### PR TITLE
feat(executor): improve executor to allow bi-directional dependencies

### DIFF
--- a/executor/index.ts
+++ b/executor/index.ts
@@ -1020,7 +1020,7 @@ export class Executor {
     const blockById = new Map(this.workflow.blocks.map((b) => [b.id, b]))
     const blockByName = new Map(
       this.workflow.blocks.map((b) => [
-        b.metadata?.name?.toLowerCase().replace(/\s+/g, '') || '',
+        b.metadata?.name ? b.metadata.name.toLowerCase().replace(/\s+/g, '') : b.id,
         b,
       ])
     )
@@ -1035,7 +1035,8 @@ export class Executor {
             blockByName,
             context.blockStates,
             block.metadata?.name || '',
-            block.metadata?.id || ''
+            block.metadata?.id || '',
+            this.workflow.loops
           )
 
           // Resolve environment variables


### PR DESCRIPTION
## What does this PR do?
- This PR allows for blocks that are in the same loop to have bi-directional dependencies
- For example, the following workflow has agent1 referring to condition1's response in its context
![Screenshot 2025-02-18 at 4 49 20 PM](https://github.com/user-attachments/assets/1a699d49-0a95-4bc9-9fc0-5d653cce517c)
- Previously, this would error out unless we could resolve the value for condition 1 since we resolve the inputs first. Now, if the block is in the loop and it doesn't have a value in the state, then we default to '' instead of erroring. On the next pass, that value will be populated and can reference it. This allows for agents to talk to one another.
- We still error if the path cannot be resolved at all, or if that block is not in the same loop and we rely on it and can't find it, or if the block doesn't exist at all.
  - tldr: We don't fail silently if the value is never going to be non-nil, but if the expected state of that reference in the future is not nil, then we don't error and allow it if the two blocks that depend on one another are in the same loop.


## Mandatory Tasks (DO NOT REMOVE)

- [y] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [y] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [y] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Test a workflow where two agents rely on eachother's responses, and have them build on eachother's responses.