### PR TITLE
Upgraded better-auth dependency to ^1.2.3 to patch ATO vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@radix-ui/react-tooltip": "^1.1.6",
         "@vercel/og": "^0.6.5",
         "@webcontainer/api": "^1.5.1-internal.9",
-        "better-auth": "^1.1.18",
+        "better-auth": "^1.2.3",
         "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -598,7 +598,9 @@
       }
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.12"
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.15.tgz",
+      "integrity": "sha512-0Bl8YYj1f8qCTNHeSn5+1DWv2hy7rLBrQ8rS8Y9XYloiwZEfc3k4yspIG0llRxafxqhGCwlGRg+F8q1HZRCMXA=="
     },
     "node_modules/@cerebras/cerebras_cloud_sdk": {
       "version": "1.23.0",
@@ -4510,29 +4512,34 @@
       "license": "MIT"
     },
     "node_modules/better-auth": {
-      "version": "1.1.18",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.2.3.tgz",
+      "integrity": "sha512-y97/ah2SOWaW81IRg36m7xMSMVl7ATaHie/nhQ0in/reVlEX/6juVPszNqq0gcTwQtFsB8oe15wQKgdf4yHP9Q==",
       "dependencies": {
         "@better-auth/utils": "0.2.3",
-        "@better-fetch/fetch": "1.1.12",
+        "@better-fetch/fetch": "^1.1.15",
         "@noble/ciphers": "^0.6.0",
         "@noble/hashes": "^1.6.1",
         "@simplewebauthn/browser": "^13.0.0",
         "@simplewebauthn/server": "^13.0.0",
-        "better-call": "0.3.3",
+        "better-call": "^1.0.3",
         "defu": "^6.1.4",
         "jose": "^5.9.6",
         "kysely": "^0.27.4",
         "nanostores": "^0.11.3",
+        "valibot": "1.0.0-beta.15",
         "zod": "^3.24.1"
       }
     },
     "node_modules/better-call": {
-      "version": "0.3.3",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.0.4.tgz",
+      "integrity": "sha512-NdAihYdkS0IOz1mtz8mw1gWacCxR9r921U8YqB+VB6++rt8edMG13vVL16Y4TBL4XkjMK/DUewEsOOFkw9LJYQ==",
       "dependencies": {
         "@better-fetch/fetch": "^1.1.4",
         "rou3": "^0.5.1",
-        "uncrypto": "^0.1.3",
-        "zod": "^3.24.1"
+        "set-cookie-parser": "^2.7.1",
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/binary-extensions": {
@@ -12437,6 +12444,8 @@
     },
     "node_modules/rou3": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.5.1.tgz",
+      "integrity": "sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ==",
       "license": "MIT"
     },
     "node_modules/run-applescript": {
@@ -12646,6 +12655,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.33.5",
@@ -13876,6 +13891,20 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0-beta.15.tgz",
+      "integrity": "sha512-BKy8XosZkDHWmYC+cJG74LBzP++Gfntwi33pP3D3RKztz2XV9jmFWnkOi21GoqARP8wAWARwhV6eTr1JcWzjGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@radix-ui/react-tooltip": "^1.1.6",
     "@vercel/og": "^0.6.5",
     "@webcontainer/api": "^1.5.1-internal.9",
-    "better-auth": "^1.1.18",
+    "better-auth": "^1.2.3",
     "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
# Update better-auth dependency to version 1.2.3

## What does this PR do?

This PR updates the better-auth dependency from version 1.1.18 to 1.2.3 in package.json. This update addresses critical security vulnerabilities present in the older version and ensures we're using the latest version with bug fixes and improvements.

- Fixes security vulnerabilities:
  - GHSA-vp58-j275-797x (Critical): Bypass of trustedOrigins protection leading to Account Takeover (ATO)
  - CVE-2025-27143 / GHSA-hjpm-7mrm-26w8 (Moderate): Open redirect vulnerability via scheme-less callback parameter

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. (N/A - No documentation changes needed for this dependency update)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (N/A - This is a dependency version update only)

## How should this be tested?

- Run `npm install` to update the package-lock.json file with the new version
- Verify the application builds successfully with `npm run build`
- Test the authentication functionality to ensure it works properly with the updated version
- Verify that the security vulnerabilities are fixed:
  - Test that trustedOrigins protection cannot be bypassed with payloads like `/\/example.com`
  - Test that scheme-less URLs (e.g., `//malicious-site.com`) are properly blocked in callback parameters

## Checklist

- I have read the [contributing guide](https://github.com/simstudioai/sim-studio/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings
- I have checked if my changes generate no new errors