### PR TITLE
fix(drive): ensure list tool only shows files from selected folder

### DIFF
--- a/sim/blocks/blocks/drive.ts
+++ b/sim/blocks/blocks/drive.ts
@@ -89,7 +89,7 @@ export const GoogleDriveBlock: BlockConfig<GoogleDriveResponse> = {
     },
     // List Fields - Folder Selector
     {
-      id: 'folderSelector',
+      id: 'folderId',
       title: 'Select Folder',
       type: 'file-selector',
       layout: 'full',
@@ -110,7 +110,7 @@ export const GoogleDriveBlock: BlockConfig<GoogleDriveResponse> = {
       condition: {
         field: 'operation',
         value: 'list',
-        and: { field: 'folderSelector', value: '' },
+        and: { field: 'folderId', value: '' },
       },
     },
     {
@@ -146,21 +146,13 @@ export const GoogleDriveBlock: BlockConfig<GoogleDriveResponse> = {
         }
       },
       params: (params) => {
-        const { credential, folderSelector, folderId, ...rest } = params
-
-        // Convert pageSize to number if it exists
-        const pageSize = rest.pageSize ? parseInt(rest.pageSize as string, 10) : undefined
-
-        // Use the selected folder ID or the manually entered one
-        // If folderSelector is provided, it's from the file selector and contains the folder ID
-        // If not, fall back to manually entered ID
-        const effectiveFolderId = (folderSelector || folderId || '').trim()
+        const { credential, folderId, ...rest } = params
 
         return {
+          accessToken: credential,
+          folderId: folderId?.trim() || '',
+          pageSize: rest.pageSize ? parseInt(rest.pageSize as string, 10) : undefined,
           ...rest,
-          folderId: effectiveFolderId,
-          pageSize,
-          credential,
         }
       },
     },
@@ -175,7 +167,6 @@ export const GoogleDriveBlock: BlockConfig<GoogleDriveResponse> = {
     // Download operation inputs
     fileId: { type: 'string', required: false },
     // List operation inputs
-    folderSelector: { type: 'string', required: false },
     folderId: { type: 'string', required: false },
     query: { type: 'string', required: false },
     pageSize: { type: 'number', required: false },

--- a/sim/tools/drive/list.ts
+++ b/sim/tools/drive/list.ts
@@ -26,13 +26,19 @@ export const listTool: ToolConfig<GoogleDriveToolParams, GoogleDriveListResponse
         'files(id,name,mimeType,webViewLink,webContentLink,size,createdTime,modifiedTime,parents),nextPageToken'
       )
 
+      // Build the query conditions
+      const conditions = ['trashed = false'] // Always exclude trashed files
       if (params.folderId) {
-        url.searchParams.append('q', `'${params.folderId}' in parents`)
+        conditions.push(`'${params.folderId}' in parents`)
       }
+
+      // Combine all conditions with AND
+      url.searchParams.append('q', conditions.join(' and '))
+
       if (params.query) {
         const existingQ = url.searchParams.get('q')
         const queryPart = `name contains '${params.query}'`
-        url.searchParams.set('q', existingQ ? `${existingQ} and ${queryPart}` : queryPart)
+        url.searchParams.set('q', `${existingQ} and ${queryPart}`)
       }
       if (params.pageSize) {
         url.searchParams.append('pageSize', params.pageSize.toString())


### PR DESCRIPTION
# Fix Google Drive list tool folder selection

Previously, the list tool was showing files from outside the selected folder. Modified the query parameters to properly filter files by the selected folder ID. Also added 'trashed = false' condition to exclude deleted items from results.

Fixes #139

## Description
The Google Drive list tool was not properly filtering files by the selected folder, showing files from other locations. This fix ensures that:
- Only files from the specifically selected folder are shown
- Trashed files are excluded from results
- The folder selection feature works as intended

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested by:
1. Selecting a specific folder containing one video file
2. Verifying that only files from that folder are displayed
3. Verifying that trashed files are not included in the results
4. Confirming the correct folder ID is being passed to the API

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes