### PR TITLE
feat(agent): added granular tool usage control for the model providers that support it

### DIFF
--- a/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/components/custom-tool-modal/custom-tool-modal.tsx
+++ b/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/components/custom-tool-modal/custom-tool-modal.tsx
@@ -61,7 +61,7 @@ export function CustomToolModal({
 
   // AI Code Generation Hooks
   const schemaGeneration = useCodeGeneration({
-    generationType: 'json-schema',
+    generationType: 'custom-tool-schema',
     onGeneratedContent: (content) => {
       handleJsonSchemaChange(content)
       setSchemaError(null) // Clear error on successful generation

--- a/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
+++ b/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import { PlusIcon, WrenchIcon, XIcon } from 'lucide-react'
+import { CircleSlashIcon, GaugeIcon, PlusIcon, WrenchIcon, XIcon, ZapIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import {
@@ -9,6 +9,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Toggle } from '@/components/ui/toggle'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { OAuthProvider } from '@/lib/oauth'
 import { cn } from '@/lib/utils'
 import { useCustomToolsStore } from '@/stores/custom-tools/store'
@@ -36,6 +38,7 @@ interface StoredTool {
   schema?: any // For custom tools
   code?: string // For custom tools implementation
   operation?: string // For tools with multiple operations
+  usageControl?: 'auto' | 'force' | 'none' // Control how the tool is used
 }
 
 interface ToolParam {
@@ -209,6 +212,7 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
       params: initialParams,
       isExpanded: true,
       operation: defaultOperation,
+      usageControl: 'auto',
     }
 
     // If isWide, keep tools in the same row expanded
@@ -263,6 +267,7 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
       isExpanded: true,
       schema: customTool.schema,
       code: customTool.code || '',
+      usageControl: 'auto',
     }
 
     // If isWide, keep tools in the same row expanded
@@ -379,6 +384,19 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
     )
   }
 
+  const handleUsageControlChange = (toolIndex: number, usageControl: string) => {
+    setValue(
+      selectedTools.map((tool, index) =>
+        index === toolIndex
+          ? {
+              ...tool,
+              usageControl: usageControl as 'auto' | 'force' | 'none',
+            }
+          : tool
+      )
+    )
+  }
+
   const toggleToolExpansion = (toolIndex: number) => {
     setValue(
       selectedTools.map((tool, index) =>
@@ -444,6 +462,7 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
                                 isExpanded: true,
                                 schema: customTool.schema,
                                 code: customTool.code,
+                                usageControl: 'auto',
                               }
 
                               if (isWide) {
@@ -570,6 +589,85 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
                       </span>
                     </div>
                     <div className="flex items-center gap-1">
+                      {/* TODO: CONDITIONALLY RENDER THIS BASED ON WHETHER THE PROVIDER SUPPORTS TOOL USAGE CONTROL */}
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Toggle
+                              className="group h-6 w-6 p-0 rounded-sm data-[state=on]:bg-transparent hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 flex items-center justify-center"
+                              pressed={true}
+                              onPressedChange={() => {}}
+                              onClick={(e: React.MouseEvent) => {
+                                e.stopPropagation()
+                                // Cycle through the states: auto -> force -> none -> auto
+                                const currentState = tool.usageControl || 'auto'
+                                const nextState =
+                                  currentState === 'auto'
+                                    ? 'force'
+                                    : currentState === 'force'
+                                      ? 'none'
+                                      : 'auto'
+                                handleUsageControlChange(toolIndex, nextState)
+                              }}
+                              aria-label="Toggle tool usage control"
+                            >
+                              {/* Auto - Gauge icon */}
+                              <GaugeIcon
+                                size={14}
+                                className={`absolute shrink-0 transition-all ${
+                                  tool.usageControl === 'auto'
+                                    ? 'scale-100 opacity-100 text-blue-600 dark:text-blue-400'
+                                    : 'scale-0 opacity-0'
+                                }`}
+                                aria-hidden="true"
+                              />
+
+                              {/* Force - Zap/Lightning icon */}
+                              <ZapIcon
+                                size={14}
+                                className={`absolute shrink-0 transition-all ${
+                                  tool.usageControl === 'force'
+                                    ? 'scale-100 opacity-100 text-green-600 dark:text-green-400'
+                                    : 'scale-0 opacity-0'
+                                }`}
+                                aria-hidden="true"
+                              />
+
+                              {/* None - Circle slash icon */}
+                              <CircleSlashIcon
+                                size={14}
+                                className={`absolute shrink-0 transition-all ${
+                                  tool.usageControl === 'none'
+                                    ? 'scale-100 opacity-100 text-red-600 dark:text-red-400'
+                                    : 'scale-0 opacity-0'
+                                }`}
+                                aria-hidden="true"
+                              />
+                            </Toggle>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" className="p-2 max-w-[240px]">
+                            <p className="text-xs">
+                              {tool.usageControl === 'auto' && (
+                                <span>
+                                  <span className="font-medium">Auto:</span> Let the agent decide
+                                  when to use the tool
+                                </span>
+                              )}
+                              {tool.usageControl === 'force' && (
+                                <span>
+                                  <span className="font-medium">Force:</span> Always use this tool
+                                  in the response
+                                </span>
+                              )}
+                              {tool.usageControl === 'none' && (
+                                <span>
+                                  <span className="font-medium">None:</span> Never use this tool
+                                </span>
+                              )}
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
                       <button
                         onClick={(e) => {
                           e.stopPropagation()
@@ -726,6 +824,7 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
                                   isExpanded: true,
                                   schema: customTool.schema,
                                   code: customTool.code,
+                                  usageControl: 'auto',
                                 }
 
                                 if (isWide) {

--- a/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
+++ b/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/select'
 import { Toggle } from '@/components/ui/toggle'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { createLogger } from '@/lib/logs/console-logger'
 import { OAuthProvider } from '@/lib/oauth'
 import { cn } from '@/lib/utils'
 import { useCustomToolsStore } from '@/stores/custom-tools/store'
@@ -18,12 +19,16 @@ import { useGeneralStore } from '@/stores/settings/general/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 import { getAllBlocks } from '@/blocks'
+import { supportsToolUsageControl } from '@/providers/model-capabilities'
+import { getProviderFromModel } from '@/providers/utils'
 import { getTool } from '@/tools'
 import { useSubBlockValue } from '../../hooks/use-sub-block-value'
 import { CredentialSelector } from '../credential-selector/credential-selector'
 import { ShortInput } from '../short-input'
 import { CustomTool, CustomToolModal } from './components/custom-tool-modal/custom-tool-modal'
 import { ToolCommand } from './components/tool-command/tool-command'
+
+const logger = createLogger('ToolInput')
 
 interface ToolInputProps {
   blockId: string
@@ -161,6 +166,12 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
   const customTools = useCustomToolsStore((state) => state.getAllTools())
   const subBlockStore = useSubBlockStore()
   const isAutoFillEnvVarsEnabled = useGeneralStore((state) => state.isAutoFillEnvVarsEnabled)
+
+  // Get the current model from the 'model' subblock
+  const modelValue = useSubBlockStore.getState().getValue(blockId, 'model')
+  const model = typeof modelValue === 'string' ? modelValue : ''
+  const provider = model ? getProviderFromModel(model) : ''
+  const supportsToolControl = provider ? supportsToolUsageControl(provider) : false
 
   const toolBlocks = getAllBlocks().filter((block) => block.category === 'tools')
 
@@ -589,85 +600,87 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
                       </span>
                     </div>
                     <div className="flex items-center gap-1">
-                      {/* TODO: CONDITIONALLY RENDER THIS BASED ON WHETHER THE PROVIDER SUPPORTS TOOL USAGE CONTROL */}
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Toggle
-                              className="group h-6 w-6 p-0 rounded-sm data-[state=on]:bg-transparent hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 flex items-center justify-center"
-                              pressed={true}
-                              onPressedChange={() => {}}
-                              onClick={(e: React.MouseEvent) => {
-                                e.stopPropagation()
-                                // Cycle through the states: auto -> force -> none -> auto
-                                const currentState = tool.usageControl || 'auto'
-                                const nextState =
-                                  currentState === 'auto'
-                                    ? 'force'
-                                    : currentState === 'force'
-                                      ? 'none'
-                                      : 'auto'
-                                handleUsageControlChange(toolIndex, nextState)
-                              }}
-                              aria-label="Toggle tool usage control"
-                            >
-                              {/* Auto - Gauge icon */}
-                              <GaugeIcon
-                                size={14}
-                                className={`absolute shrink-0 transition-all ${
-                                  tool.usageControl === 'auto'
-                                    ? 'scale-100 opacity-100 text-blue-600 dark:text-blue-400'
-                                    : 'scale-0 opacity-0'
-                                }`}
-                                aria-hidden="true"
-                              />
+                      {/* Only render the tool usage control if the provider supports it */}
+                      {supportsToolControl && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Toggle
+                                className="group h-6 w-6 p-0 rounded-sm data-[state=on]:bg-transparent hover:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 flex items-center justify-center"
+                                pressed={true}
+                                onPressedChange={() => {}}
+                                onClick={(e: React.MouseEvent) => {
+                                  e.stopPropagation()
+                                  // Cycle through the states: auto -> force -> none -> auto
+                                  const currentState = tool.usageControl || 'auto'
+                                  const nextState =
+                                    currentState === 'auto'
+                                      ? 'force'
+                                      : currentState === 'force'
+                                        ? 'none'
+                                        : 'auto'
+                                  handleUsageControlChange(toolIndex, nextState)
+                                }}
+                                aria-label="Toggle tool usage control"
+                              >
+                                {/* Auto - Gauge icon */}
+                                <GaugeIcon
+                                  size={14}
+                                  className={`absolute shrink-0 transition-all ${
+                                    tool.usageControl === 'auto'
+                                      ? 'scale-100 opacity-100 text-blue-600 dark:text-blue-400'
+                                      : 'scale-0 opacity-0'
+                                  }`}
+                                  aria-hidden="true"
+                                />
 
-                              {/* Force - Zap/Lightning icon */}
-                              <ZapIcon
-                                size={14}
-                                className={`absolute shrink-0 transition-all ${
-                                  tool.usageControl === 'force'
-                                    ? 'scale-100 opacity-100 text-green-600 dark:text-green-400'
-                                    : 'scale-0 opacity-0'
-                                }`}
-                                aria-hidden="true"
-                              />
+                                {/* Force - Zap/Lightning icon */}
+                                <ZapIcon
+                                  size={14}
+                                  className={`absolute shrink-0 transition-all ${
+                                    tool.usageControl === 'force'
+                                      ? 'scale-100 opacity-100 text-green-600 dark:text-green-400'
+                                      : 'scale-0 opacity-0'
+                                  }`}
+                                  aria-hidden="true"
+                                />
 
-                              {/* None - Circle slash icon */}
-                              <CircleSlashIcon
-                                size={14}
-                                className={`absolute shrink-0 transition-all ${
-                                  tool.usageControl === 'none'
-                                    ? 'scale-100 opacity-100 text-red-600 dark:text-red-400'
-                                    : 'scale-0 opacity-0'
-                                }`}
-                                aria-hidden="true"
-                              />
-                            </Toggle>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom" className="p-2 max-w-[240px]">
-                            <p className="text-xs">
-                              {tool.usageControl === 'auto' && (
-                                <span>
-                                  <span className="font-medium">Auto:</span> Let the agent decide
-                                  when to use the tool
-                                </span>
-                              )}
-                              {tool.usageControl === 'force' && (
-                                <span>
-                                  <span className="font-medium">Force:</span> Always use this tool
-                                  in the response
-                                </span>
-                              )}
-                              {tool.usageControl === 'none' && (
-                                <span>
-                                  <span className="font-medium">None:</span> Never use this tool
-                                </span>
-                              )}
-                            </p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
+                                {/* None - Circle slash icon */}
+                                <CircleSlashIcon
+                                  size={14}
+                                  className={`absolute shrink-0 transition-all ${
+                                    tool.usageControl === 'none'
+                                      ? 'scale-100 opacity-100 text-red-600 dark:text-red-400'
+                                      : 'scale-0 opacity-0'
+                                  }`}
+                                  aria-hidden="true"
+                                />
+                              </Toggle>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom" className="p-2 max-w-[240px]">
+                              <p className="text-xs">
+                                {tool.usageControl === 'auto' && (
+                                  <span>
+                                    <span className="font-medium">Auto:</span> Let the agent decide
+                                    when to use the tool
+                                  </span>
+                                )}
+                                {tool.usageControl === 'force' && (
+                                  <span>
+                                    <span className="font-medium">Force:</span> Always use this tool
+                                    in the response
+                                  </span>
+                                )}
+                                {tool.usageControl === 'none' && (
+                                  <span>
+                                    <span className="font-medium">None:</span> Never use this tool
+                                  </span>
+                                )}
+                              </p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
                       <button
                         onClick={(e) => {
                           e.stopPropagation()

--- a/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
+++ b/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
@@ -1,5 +1,13 @@
 import { useCallback, useState } from 'react'
-import { CircleSlashIcon, GaugeIcon, PlusIcon, WrenchIcon, XIcon, ZapIcon } from 'lucide-react'
+import {
+  BrainIcon,
+  CircleSlashIcon,
+  GaugeIcon,
+  PlusIcon,
+  WrenchIcon,
+  XIcon,
+  ZapIcon,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import {
@@ -623,12 +631,12 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
                                 }}
                                 aria-label="Toggle tool usage control"
                               >
-                                {/* Auto - Gauge icon */}
-                                <GaugeIcon
+                                {/* Auto - Brain icon */}
+                                <BrainIcon
                                   size={14}
                                   className={`absolute shrink-0 transition-all ${
                                     tool.usageControl === 'auto'
-                                      ? 'scale-100 opacity-100 text-blue-600 dark:text-blue-400'
+                                      ? 'scale-100 opacity-100 text-muted-foreground'
                                       : 'scale-0 opacity-0'
                                   }`}
                                   aria-hidden="true"
@@ -639,7 +647,7 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
                                   size={14}
                                   className={`absolute shrink-0 transition-all ${
                                     tool.usageControl === 'force'
-                                      ? 'scale-100 opacity-100 text-green-600 dark:text-green-400'
+                                      ? 'scale-100 opacity-100 text-muted-foreground'
                                       : 'scale-0 opacity-0'
                                   }`}
                                   aria-hidden="true"
@@ -650,7 +658,7 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
                                   size={14}
                                   className={`absolute shrink-0 transition-all ${
                                     tool.usageControl === 'none'
-                                      ? 'scale-100 opacity-100 text-red-600 dark:text-red-400'
+                                      ? 'scale-100 opacity-100 text-muted-foreground'
                                       : 'scale-0 opacity-0'
                                   }`}
                                   aria-hidden="true"

--- a/sim/blocks/blocks/agent.test.ts
+++ b/sim/blocks/blocks/agent.test.ts
@@ -145,27 +145,6 @@ describe('AgentBlock', () => {
       })
     })
 
-    it('should log which tools are filtered out', () => {
-      const params = {
-        model: 'gpt-4o',
-        systemPrompt: 'You are a helpful assistant.',
-        tools: [
-          {
-            type: 'tool-type-1',
-            title: 'Tool 1',
-            usageControl: 'auto',
-          },
-          {
-            type: 'tool-type-2',
-            title: 'Tool 2',
-            usageControl: 'none', // Should be filtered out and logged
-          },
-        ],
-      }
-
-      paramsFunction(params)
-    })
-
     it('should handle an empty tools array', () => {
       const params = {
         model: 'gpt-4o',

--- a/sim/blocks/blocks/agent.test.ts
+++ b/sim/blocks/blocks/agent.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentBlock } from './agent'
+
+vi.mock('@/blocks', () => ({
+  getAllBlocks: vi.fn(() => [
+    {
+      type: 'tool-type-1',
+      tools: {
+        access: ['tool-id-1'],
+      },
+    },
+    {
+      type: 'tool-type-2',
+      tools: {
+        access: ['tool-id-2'],
+      },
+    },
+  ]),
+}))
+
+describe('AgentBlock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const paramsFunction = AgentBlock.tools.config?.params
+
+  if (!paramsFunction) {
+    throw new Error('AgentBlock.tools.config.params function is missing')
+  }
+
+  describe('tools.config.params function', () => {
+    it('should pass through params when no tools array is provided', () => {
+      const params = {
+        model: 'gpt-4o',
+        systemPrompt: 'You are a helpful assistant.',
+        // No tools provided
+      }
+
+      const result = paramsFunction(params)
+      expect(result).toEqual(params)
+    })
+
+    it('should filter out tools with usageControl set to "none"', () => {
+      const params = {
+        model: 'gpt-4o',
+        systemPrompt: 'You are a helpful assistant.',
+        tools: [
+          {
+            type: 'tool-type-1',
+            title: 'Tool 1',
+            usageControl: 'auto',
+          },
+          {
+            type: 'tool-type-2',
+            title: 'Tool 2',
+            usageControl: 'none', // Should be filtered out
+          },
+          {
+            type: 'custom-tool',
+            title: 'Custom Tool',
+            schema: {
+              function: {
+                name: 'custom_function',
+                description: 'A custom function',
+                parameters: { type: 'object', properties: {} },
+              },
+            },
+            usageControl: 'force',
+          },
+        ],
+      }
+
+      const result = paramsFunction(params)
+
+      // Verify that transformed tools contains only the tools not set to 'none'
+      expect(result.tools.length).toBe(2)
+
+      // Verify the tool titles (custom identifiers that we can check)
+      const toolIds = result.tools.map((tool: any) => tool.name)
+      expect(toolIds).toContain('Tool 1')
+      expect(toolIds).not.toContain('Tool 2')
+      expect(toolIds).toContain('Custom Tool')
+    })
+
+    it('should set default usageControl to "auto" if not specified', () => {
+      const params = {
+        model: 'gpt-4o',
+        systemPrompt: 'You are a helpful assistant.',
+        tools: [
+          {
+            type: 'tool-type-1',
+            title: 'Tool 1',
+            // No usageControl specified, should default to 'auto'
+          },
+        ],
+      }
+
+      const result = paramsFunction(params)
+
+      // Verify that the tool has usageControl set to 'auto'
+      expect(result.tools[0].usageControl).toBe('auto')
+    })
+
+    it('should correctly transform custom tools', () => {
+      const params = {
+        model: 'gpt-4o',
+        systemPrompt: 'You are a helpful assistant.',
+        tools: [
+          {
+            type: 'custom-tool',
+            title: 'Custom Tool',
+            schema: {
+              function: {
+                name: 'custom_function',
+                description: 'A custom function description',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    param1: { type: 'string' },
+                  },
+                },
+              },
+            },
+            usageControl: 'force',
+          },
+        ],
+      }
+
+      const result = paramsFunction(params)
+
+      // Verify custom tool transformation
+      expect(result.tools[0]).toEqual({
+        id: 'custom_function',
+        name: 'Custom Tool',
+        description: 'A custom function description',
+        params: {},
+        parameters: {
+          type: 'object',
+          properties: {
+            param1: { type: 'string' },
+          },
+        },
+        usageControl: 'force',
+      })
+    })
+
+    it('should log which tools are filtered out', () => {
+      const params = {
+        model: 'gpt-4o',
+        systemPrompt: 'You are a helpful assistant.',
+        tools: [
+          {
+            type: 'tool-type-1',
+            title: 'Tool 1',
+            usageControl: 'auto',
+          },
+          {
+            type: 'tool-type-2',
+            title: 'Tool 2',
+            usageControl: 'none', // Should be filtered out and logged
+          },
+        ],
+      }
+
+      paramsFunction(params)
+    })
+
+    it('should handle an empty tools array', () => {
+      const params = {
+        model: 'gpt-4o',
+        systemPrompt: 'You are a helpful assistant.',
+        tools: [], // Empty array
+      }
+
+      const result = paramsFunction(params)
+
+      // Verify that transformed tools is an empty array
+      expect(result.tools).toEqual([])
+    })
+  })
+})

--- a/sim/blocks/blocks/agent.ts
+++ b/sim/blocks/blocks/agent.ts
@@ -1,12 +1,16 @@
 import { AgentIcon } from '@/components/icons'
 import { isHostedVersion } from '@/lib/utils'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useOllamaStore } from '@/stores/ollama/store'
+import { getAllBlocks } from '@/blocks'
 import { MODELS_TEMP_RANGE_0_1, MODELS_TEMP_RANGE_0_2 } from '@/providers/model-capabilities'
 import { getAllModelProviders, getBaseModelProviders } from '@/providers/utils'
+import { getTool } from '@/tools'
 import { ToolResponse } from '@/tools/types'
 import { BlockConfig } from '../types'
 
 const isHosted = isHostedVersion()
+const logger = createLogger('AgentBlock')
 
 interface AgentResponse extends ToolResponse {
   output: {
@@ -25,6 +29,13 @@ interface AgentResponse extends ToolResponse {
       count: number
     }
   }
+}
+
+// Helper function to get the tool ID from a block type
+const getToolIdFromBlock = (blockType: string): string | undefined => {
+  const blocks = getAllBlocks()
+  const block = blocks.find((b) => b.type === blockType)
+  return block?.tools?.access?.[0]
 }
 
 export const AgentBlock: BlockConfig<AgentResponse> = {
@@ -139,6 +150,52 @@ export const AgentBlock: BlockConfig<AgentResponse> = {
           throw new Error(`Invalid model selected: ${model}`)
         }
         return tool
+      },
+      params: (params: Record<string, any>) => {
+        // If tools array is provided, handle tool usage control
+        if (params.tools && Array.isArray(params.tools)) {
+          // Transform tools to include usageControl
+          const transformedTools = params.tools
+            // Filter out tools set to 'none' - they should never be passed to the provider
+            .filter((tool: any) => {
+              const usageControl = tool.usageControl || 'auto'
+              return usageControl !== 'none'
+            })
+            .map((tool: any) => {
+              // Get the base tool configuration
+              const toolConfig = {
+                id:
+                  tool.type === 'custom-tool'
+                    ? tool.schema?.function?.name
+                    : tool.operation || getToolIdFromBlock(tool.type),
+                name: tool.title,
+                description: tool.type === 'custom-tool' ? tool.schema?.function?.description : '',
+                params: tool.params || {},
+                parameters: tool.type === 'custom-tool' ? tool.schema?.function?.parameters : {}, // We'd need to get actual parameters for non-custom tools
+                usageControl: tool.usageControl || 'auto',
+              }
+              return toolConfig
+            })
+
+          // Log which tools are being passed and which are filtered out
+          const filteredOutTools = params.tools
+            .filter((tool: any) => (tool.usageControl || 'auto') === 'none')
+            .map((tool: any) => tool.title)
+
+          if (filteredOutTools.length > 0) {
+            logger.info('Filtered out tools set to none', { tools: filteredOutTools.join(', ') })
+          }
+
+          logger.info('Transformed tools', { tools: transformedTools })
+          if (transformedTools.length === 0) {
+            logger.info('No tools will be passed to the provider after filtering')
+          } else {
+            logger.info('Tools passed to provider', { count: transformedTools.length })
+          }
+
+          return { ...params, tools: transformedTools }
+        }
+        return params
       },
     },
   },

--- a/sim/blocks/blocks/agent.ts
+++ b/sim/blocks/blocks/agent.ts
@@ -1,11 +1,10 @@
 import { AgentIcon } from '@/components/icons'
-import { isHostedVersion } from '@/lib/utils'
 import { createLogger } from '@/lib/logs/console-logger'
+import { isHostedVersion } from '@/lib/utils'
 import { useOllamaStore } from '@/stores/ollama/store'
 import { getAllBlocks } from '@/blocks'
 import { MODELS_TEMP_RANGE_0_1, MODELS_TEMP_RANGE_0_2 } from '@/providers/model-capabilities'
 import { getAllModelProviders, getBaseModelProviders } from '@/providers/utils'
-import { getTool } from '@/tools'
 import { ToolResponse } from '@/tools/types'
 import { BlockConfig } from '../types'
 

--- a/sim/components/ui/toggle.tsx
+++ b/sim/components/ui/toggle.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import * as React from 'react'
+import * as TogglePrimitive from '@radix-ui/react-toggle'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+// TODO: FIX STYLING
+const toggleVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground',
+  {
+    variants: {
+      variant: {
+        default: 'bg-transparent',
+        outline: 'border border-input bg-transparent hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-10 px-3',
+        sm: 'h-9 px-2.5',
+        lg: 'h-11 px-5',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+))
+
+Toggle.displayName = TogglePrimitive.Root.displayName
+
+export { Toggle, toggleVariants }

--- a/sim/hooks/use-code-generation.ts
+++ b/sim/hooks/use-code-generation.ts
@@ -7,7 +7,11 @@ interface ChatMessage {
   content: string
 }
 
-type GenerationType = 'json-schema' | 'javascript-function-body' | 'typescript-function-body'
+type GenerationType =
+  | 'json-schema'
+  | 'javascript-function-body'
+  | 'typescript-function-body'
+  | 'custom-tool-schema'
 
 interface UseCodeGenerationProps {
   generationType: GenerationType

--- a/sim/package-lock.json
+++ b/sim/package-lock.json
@@ -34,6 +34,7 @@
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-switch": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.2",
+        "@radix-ui/react-toggle": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.6",
         "@react-email/components": "^0.0.34",
         "@vercel/og": "^0.6.5",
@@ -3116,6 +3117,31 @@
         "@radix-ui/react-presence": "1.1.2",
         "@radix-ui/react-primitive": "2.0.2",
         "@radix-ui/react-roving-focus": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.2.tgz",
+      "integrity": "sha512-lntKchNWx3aCHuWKiDY+8WudiegQvBpDRAYL8dKLRvKEH8VOpl0XX6SSU/bUBqIRJbcTy4+MW06Wv8vgp10rzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
         "@radix-ui/react-use-controllable-state": "1.1.0"
       },
       "peerDependencies": {

--- a/sim/package.json
+++ b/sim/package.json
@@ -48,6 +48,7 @@
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.2",
+    "@radix-ui/react-toggle": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.6",
     "@react-email/components": "^0.0.34",
     "@vercel/og": "^0.6.5",

--- a/sim/providers/anthropic/index.ts
+++ b/sim/providers/anthropic/index.ts
@@ -104,12 +104,11 @@ export const anthropicProvider: ProviderConfig = {
 
     // Handle tools and tool usage control
     if (anthropicTools?.length) {
-      const { tools: filteredTools, toolChoice: tc } = prepareToolsWithUsageControl(
-        anthropicTools,
-        request.tools,
-        logger,
-        'anthropic'
-      )
+      const {
+        tools: filteredTools,
+        toolChoice: tc,
+        forcedTools,
+      } = prepareToolsWithUsageControl(anthropicTools, request.tools, logger, 'anthropic')
 
       if (filteredTools?.length) {
         anthropicTools = filteredTools
@@ -235,6 +234,13 @@ ${fieldDescriptions}
       // Track the original tool_choice for forced tool tracking
       const originalToolChoice = payload.tool_choice
 
+      // Track forced tools and their usage
+      const forcedTools = anthropicTools?.length
+        ? prepareToolsWithUsageControl(anthropicTools, request.tools, logger, 'anthropic')
+            .forcedTools
+        : []
+      let usedForcedTools: string[] = []
+
       let currentResponse = await anthropic.messages.create(payload)
       const firstResponseTime = Date.now() - initialCallTime
 
@@ -299,9 +305,12 @@ ${fieldDescriptions}
             adaptedToolCalls,
             adaptedToolChoice,
             logger,
-            'anthropic'
+            'anthropic',
+            forcedTools,
+            usedForcedTools
           )
           hasUsedForcedTool = result.hasUsedForcedTool
+          usedForcedTools = result.usedForcedTools
         }
       }
 
@@ -398,8 +407,29 @@ ${fieldDescriptions}
             messages: currentMessages,
           }
 
-          // If we've used the forced tool, switch to 'auto' mode for subsequent requests
-          if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
+          // Update tool_choice based on which forced tools have been used
+          if (
+            typeof originalToolChoice === 'object' &&
+            hasUsedForcedTool &&
+            forcedTools.length > 0
+          ) {
+            // If we have remaining forced tools, get the next one to force
+            const remainingTools = forcedTools.filter((tool) => !usedForcedTools.includes(tool))
+
+            if (remainingTools.length > 0) {
+              // Force the next tool - use Anthropic format
+              nextPayload.tool_choice = {
+                type: 'tool',
+                name: remainingTools[0],
+              }
+              logger.info(`Forcing next tool: ${remainingTools[0]}`)
+            } else {
+              // All forced tools have been used, switch to auto by removing tool_choice
+              delete nextPayload.tool_choice
+              logger.info('All forced tools have been used, removing tool_choice parameter')
+            }
+          } else if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
+            // Handle the case of a single forced tool that was used
             delete nextPayload.tool_choice
             logger.info(
               'Removing tool_choice parameter for subsequent requests after forced tool was used'
@@ -412,10 +442,9 @@ ${fieldDescriptions}
           // Make the next request
           currentResponse = await anthropic.messages.create(nextPayload)
 
-          // Check if a forced tool was used in this response (if not already used)
+          // Check if any forced tools were used in this response
           if (
-            !hasUsedForcedTool &&
-            typeof originalToolChoice === 'object' &&
+            typeof nextPayload.tool_choice === 'object' &&
             Array.isArray(currentResponse.content)
           ) {
             const toolUses = currentResponse.content.filter((item) => item.type === 'tool_use')
@@ -428,17 +457,20 @@ ${fieldDescriptions}
 
               // Convert Anthropic tool_choice format to match OpenAI format for tracking
               const adaptedToolChoice =
-                originalToolChoice.type === 'tool'
-                  ? { function: { name: originalToolChoice.name } }
-                  : originalToolChoice
+                nextPayload.tool_choice.type === 'tool'
+                  ? { function: { name: nextPayload.tool_choice.name } }
+                  : nextPayload.tool_choice
 
               const result = trackForcedToolUsage(
                 adaptedToolCalls,
                 adaptedToolChoice,
                 logger,
-                'anthropic'
+                'anthropic',
+                forcedTools,
+                usedForcedTools
               )
-              hasUsedForcedTool = result.hasUsedForcedTool
+              hasUsedForcedTool = result.hasUsedForcedTool || hasUsedForcedTool
+              usedForcedTools = result.usedForcedTools
             }
           }
 

--- a/sim/providers/anthropic/index.ts
+++ b/sim/providers/anthropic/index.ts
@@ -2,6 +2,7 @@ import Anthropic from '@anthropic-ai/sdk'
 import { createLogger } from '@/lib/logs/console-logger'
 import { executeTool } from '@/tools'
 import { ProviderConfig, ProviderRequest, ProviderResponse, TimeSegment } from '../types'
+import { prepareToolsWithUsageControl, trackForcedToolUsage } from '../utils'
 
 const logger = createLogger('Anthropic Provider')
 
@@ -86,7 +87,7 @@ export const anthropicProvider: ProviderConfig = {
     }
 
     // Transform tools to Anthropic format if provided
-    const tools = request.tools?.length
+    let anthropicTools = request.tools?.length
       ? request.tools.map((tool) => ({
           name: tool.id,
           description: tool.description,
@@ -97,6 +98,42 @@ export const anthropicProvider: ProviderConfig = {
           },
         }))
       : undefined
+
+    // Set tool_choice based on usage control settings
+    let toolChoice: 'none' | 'auto' | { type: 'tool'; name: string } = 'auto'
+
+    // Handle tools and tool usage control
+    if (anthropicTools?.length) {
+      const { tools: filteredTools, toolChoice: tc } = prepareToolsWithUsageControl(
+        anthropicTools,
+        request.tools,
+        logger,
+        'anthropic'
+      )
+
+      if (filteredTools?.length) {
+        anthropicTools = filteredTools
+
+        // No longer need conversion since provider-specific formatting is in prepareToolsWithUsageControl
+        if (typeof tc === 'object' && tc !== null) {
+          if (tc.type === 'tool') {
+            toolChoice = tc
+            logger.info(`Using Anthropic tool_choice format: force tool "${tc.name}"`)
+          } else {
+            // Default to auto if we got a non-Anthropic object format
+            toolChoice = 'auto'
+            logger.warn(`Received non-Anthropic tool_choice format, defaulting to auto`)
+          }
+        } else if (tc === 'auto' || tc === 'none') {
+          toolChoice = tc
+          logger.info(`Using tool_choice mode: ${tc}`)
+        } else {
+          // Default to auto if we got something unexpected
+          toolChoice = 'auto'
+          logger.warn(`Unexpected tool_choice format, defaulting to auto`)
+        }
+      }
+    }
 
     // If response format is specified, add strict formatting instructions
     if (request.responseFormat) {
@@ -178,9 +215,13 @@ ${fieldDescriptions}
       temperature: parseFloat(String(request.temperature ?? 0.7)),
     }
 
-    // Add tools if provided
-    if (tools?.length) {
-      payload.tools = tools
+    // Use the tools in the payload
+    if (anthropicTools?.length) {
+      payload.tools = anthropicTools
+      // Only set tool_choice if it's not 'auto'
+      if (toolChoice !== 'auto') {
+        payload.tool_choice = toolChoice
+      }
     }
 
     // Start execution timer for the entire provider execution
@@ -190,6 +231,10 @@ ${fieldDescriptions}
     try {
       // Make the initial API request
       const initialCallTime = Date.now()
+
+      // Track the original tool_choice for forced tool tracking
+      const originalToolChoice = payload.tool_choice
+
       let currentResponse = await anthropic.messages.create(payload)
       const firstResponseTime = Date.now() - initialCallTime
 
@@ -216,6 +261,9 @@ ${fieldDescriptions}
       let iterationCount = 0
       const MAX_ITERATIONS = 10 // Prevent infinite loops
 
+      // Track if a forced tool has been used
+      let hasUsedForcedTool = false
+
       // Track time spent in model vs tools
       let modelTime = firstResponseTime
       let toolsTime = 0
@@ -230,6 +278,32 @@ ${fieldDescriptions}
           duration: firstResponseTime,
         },
       ]
+
+      // Check if a forced tool was used in the first response
+      if (typeof originalToolChoice === 'object' && Array.isArray(currentResponse.content)) {
+        const toolUses = currentResponse.content.filter((item) => item.type === 'tool_use')
+
+        if (toolUses.length > 0) {
+          // Convert Anthropic tool_use format to a format trackForcedToolUsage can understand
+          const adaptedToolCalls = toolUses.map((tool) => ({
+            name: tool.name,
+          }))
+
+          // Convert Anthropic tool_choice format to match OpenAI format for tracking
+          const adaptedToolChoice =
+            originalToolChoice.type === 'tool'
+              ? { function: { name: originalToolChoice.name } }
+              : originalToolChoice
+
+          const result = trackForcedToolUsage(
+            adaptedToolCalls,
+            adaptedToolChoice,
+            logger,
+            'anthropic'
+          )
+          hasUsedForcedTool = result.hasUsedForcedTool
+        }
+      }
 
       try {
         while (iterationCount < MAX_ITERATIONS) {
@@ -324,11 +398,49 @@ ${fieldDescriptions}
             messages: currentMessages,
           }
 
+          // If we've used the forced tool, switch to 'auto' mode for subsequent requests
+          if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
+            delete nextPayload.tool_choice
+            logger.info(
+              'Removing tool_choice parameter for subsequent requests after forced tool was used'
+            )
+          }
+
           // Time the next model call
           const nextModelStartTime = Date.now()
 
           // Make the next request
           currentResponse = await anthropic.messages.create(nextPayload)
+
+          // Check if a forced tool was used in this response (if not already used)
+          if (
+            !hasUsedForcedTool &&
+            typeof originalToolChoice === 'object' &&
+            Array.isArray(currentResponse.content)
+          ) {
+            const toolUses = currentResponse.content.filter((item) => item.type === 'tool_use')
+
+            if (toolUses.length > 0) {
+              // Convert Anthropic tool_use format to a format trackForcedToolUsage can understand
+              const adaptedToolCalls = toolUses.map((tool) => ({
+                name: tool.name,
+              }))
+
+              // Convert Anthropic tool_choice format to match OpenAI format for tracking
+              const adaptedToolChoice =
+                originalToolChoice.type === 'tool'
+                  ? { function: { name: originalToolChoice.name } }
+                  : originalToolChoice
+
+              const result = trackForcedToolUsage(
+                adaptedToolCalls,
+                adaptedToolChoice,
+                logger,
+                'anthropic'
+              )
+              hasUsedForcedTool = result.hasUsedForcedTool
+            }
+          }
 
           const nextModelEndTime = Date.now()
           const thisModelTime = nextModelEndTime - nextModelStartTime

--- a/sim/providers/cerebras/index.ts
+++ b/sim/providers/cerebras/index.ts
@@ -82,12 +82,30 @@ export const cerebrasProvider: ProviderConfig = {
 
       // Add tools if provided
       if (tools?.length) {
-        payload.tools = tools
-        payload.tool_choice = 'auto'
+        // Filter out any tools with usageControl='none', but ignore 'force' since Cerebras doesn't support it
+        const filteredTools = tools.filter((tool) => {
+          const toolId = tool.function?.name
+          const toolConfig = request.tools?.find((t) => t.id === toolId)
+          // Only filter out 'none', treat 'force' as 'auto'
+          return toolConfig?.usageControl !== 'none'
+        })
+
+        if (filteredTools?.length) {
+          payload.tools = filteredTools
+          // Always use 'auto' for Cerebras, regardless of the tool_choice setting
+          payload.tool_choice = 'auto'
+
+          logger.info(`Cerebras request configuration:`, {
+            toolCount: filteredTools.length,
+            toolChoice: 'auto', // Cerebras always uses auto
+            model: request.model,
+          })
+        }
       }
 
       // Make the initial API request
       const initialCallTime = Date.now()
+
       let currentResponse = (await client.chat.completions.create(payload)) as CerebrasResponse
       const firstResponseTime = Date.now() - initialCallTime
 
@@ -239,8 +257,10 @@ export const cerebrasProvider: ProviderConfig = {
             const finalPayload = {
               ...payload,
               messages: currentMessages,
-              tool_choice: 'none',
             }
+
+            // Use tool_choice: 'none' for the final response to avoid an infinite loop
+            finalPayload.tool_choice = 'none'
 
             const finalResponse = (await client.chat.completions.create(
               finalPayload

--- a/sim/providers/deepseek/index.ts
+++ b/sim/providers/deepseek/index.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai'
 import { createLogger } from '@/lib/logs/console-logger'
 import { executeTool } from '@/tools'
 import { ProviderConfig, ProviderRequest, ProviderResponse, TimeSegment } from '../types'
+import { prepareToolsWithUsageControl, trackForcedToolUsage } from '../utils'
 
 const logger = createLogger('Deepseek Provider')
 
@@ -74,14 +75,42 @@ export const deepseekProvider: ProviderConfig = {
       if (request.temperature !== undefined) payload.temperature = request.temperature
       if (request.maxTokens !== undefined) payload.max_tokens = request.maxTokens
 
-      // Add tools if provided
+      // Handle tools and tool usage control
       if (tools?.length) {
-        payload.tools = tools
-        payload.tool_choice = 'auto'
+        const { tools: filteredTools, toolChoice } = prepareToolsWithUsageControl(
+          tools,
+          request.tools,
+          logger,
+          'deepseek'
+        )
+
+        if (filteredTools?.length && toolChoice) {
+          payload.tools = filteredTools
+          payload.tool_choice = toolChoice
+
+          logger.info(`Deepseek request configuration:`, {
+            toolCount: filteredTools.length,
+            toolChoice:
+              typeof toolChoice === 'string'
+                ? toolChoice
+                : toolChoice.type === 'function'
+                  ? `force:${toolChoice.function.name}`
+                  : toolChoice.type === 'tool'
+                    ? `force:${toolChoice.name}`
+                    : toolChoice.type === 'any'
+                      ? `force:${toolChoice.any?.name || 'unknown'}`
+                      : 'unknown',
+            model: request.model || 'deepseek-v3',
+          })
+        }
       }
 
       // Make the initial API request
       const initialCallTime = Date.now()
+
+      // Track the original tool_choice for forced tool tracking
+      const originalToolChoice = payload.tool_choice
+
       let currentResponse = await deepseek.chat.completions.create(payload)
       const firstResponseTime = Date.now() - initialCallTime
 
@@ -106,6 +135,9 @@ export const deepseekProvider: ProviderConfig = {
       let iterationCount = 0
       const MAX_ITERATIONS = 10 // Prevent infinite loops
 
+      // Track if a forced tool has been used
+      let hasUsedForcedTool = false
+
       // Track time spent in model vs tools
       let modelTime = firstResponseTime
       let toolsTime = 0
@@ -120,6 +152,21 @@ export const deepseekProvider: ProviderConfig = {
           duration: firstResponseTime,
         },
       ]
+
+      // Check if a forced tool was used in the first response
+      if (
+        typeof originalToolChoice === 'object' &&
+        currentResponse.choices[0]?.message?.tool_calls
+      ) {
+        const toolCallsResponse = currentResponse.choices[0].message.tool_calls
+        const result = trackForcedToolUsage(
+          toolCallsResponse,
+          originalToolChoice,
+          logger,
+          'deepseek'
+        )
+        hasUsedForcedTool = result.hasUsedForcedTool
+      }
 
       try {
         while (iterationCount < MAX_ITERATIONS) {
@@ -210,11 +257,35 @@ export const deepseekProvider: ProviderConfig = {
             messages: currentMessages,
           }
 
+          // If we've used the forced tool, switch to 'auto' mode for subsequent requests
+          if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
+            nextPayload.tool_choice = 'auto'
+            logger.info(
+              'Switching to auto tool_choice for subsequent requests after forced tool was used'
+            )
+          }
+
           // Time the next model call
           const nextModelStartTime = Date.now()
 
           // Make the next request
           currentResponse = await deepseek.chat.completions.create(nextPayload)
+
+          // Check if a forced tool was used in this response (if not already used)
+          if (
+            !hasUsedForcedTool &&
+            typeof originalToolChoice === 'object' &&
+            currentResponse.choices[0]?.message?.tool_calls
+          ) {
+            const toolCallsResponse = currentResponse.choices[0].message.tool_calls
+            const result = trackForcedToolUsage(
+              toolCallsResponse,
+              originalToolChoice,
+              logger,
+              'deepseek'
+            )
+            hasUsedForcedTool = result.hasUsedForcedTool
+          }
 
           const nextModelEndTime = Date.now()
           const thisModelTime = nextModelEndTime - nextModelStartTime

--- a/sim/providers/deepseek/index.ts
+++ b/sim/providers/deepseek/index.ts
@@ -77,12 +77,11 @@ export const deepseekProvider: ProviderConfig = {
 
       // Handle tools and tool usage control
       if (tools?.length) {
-        const { tools: filteredTools, toolChoice } = prepareToolsWithUsageControl(
-          tools,
-          request.tools,
-          logger,
-          'deepseek'
-        )
+        const {
+          tools: filteredTools,
+          toolChoice,
+          forcedTools,
+        } = prepareToolsWithUsageControl(tools, request.tools, logger, 'deepseek')
 
         if (filteredTools?.length && toolChoice) {
           payload.tools = filteredTools
@@ -110,6 +109,12 @@ export const deepseekProvider: ProviderConfig = {
 
       // Track the original tool_choice for forced tool tracking
       const originalToolChoice = payload.tool_choice
+
+      // Track forced tools and their usage
+      const forcedTools = tools?.length
+        ? prepareToolsWithUsageControl(tools, request.tools, logger, 'deepseek').forcedTools
+        : []
+      let usedForcedTools: string[] = []
 
       let currentResponse = await deepseek.chat.completions.create(payload)
       const firstResponseTime = Date.now() - initialCallTime
@@ -163,9 +168,12 @@ export const deepseekProvider: ProviderConfig = {
           toolCallsResponse,
           originalToolChoice,
           logger,
-          'deepseek'
+          'deepseek',
+          forcedTools,
+          usedForcedTools
         )
         hasUsedForcedTool = result.hasUsedForcedTool
+        usedForcedTools = result.usedForcedTools
       }
 
       try {
@@ -257,12 +265,27 @@ export const deepseekProvider: ProviderConfig = {
             messages: currentMessages,
           }
 
-          // If we've used the forced tool, switch to 'auto' mode for subsequent requests
-          if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
-            nextPayload.tool_choice = 'auto'
-            logger.info(
-              'Switching to auto tool_choice for subsequent requests after forced tool was used'
-            )
+          // Update tool_choice based on which forced tools have been used
+          if (
+            typeof originalToolChoice === 'object' &&
+            hasUsedForcedTool &&
+            forcedTools.length > 0
+          ) {
+            // If we have remaining forced tools, get the next one to force
+            const remainingTools = forcedTools.filter((tool) => !usedForcedTools.includes(tool))
+
+            if (remainingTools.length > 0) {
+              // Force the next tool
+              nextPayload.tool_choice = {
+                type: 'function',
+                function: { name: remainingTools[0] },
+              }
+              logger.info(`Forcing next tool: ${remainingTools[0]}`)
+            } else {
+              // All forced tools have been used, switch to auto
+              nextPayload.tool_choice = 'auto'
+              logger.info('All forced tools have been used, switching to auto tool_choice')
+            }
           }
 
           // Time the next model call
@@ -271,20 +294,22 @@ export const deepseekProvider: ProviderConfig = {
           // Make the next request
           currentResponse = await deepseek.chat.completions.create(nextPayload)
 
-          // Check if a forced tool was used in this response (if not already used)
+          // Check if any forced tools were used in this response
           if (
-            !hasUsedForcedTool &&
-            typeof originalToolChoice === 'object' &&
+            typeof nextPayload.tool_choice === 'object' &&
             currentResponse.choices[0]?.message?.tool_calls
           ) {
             const toolCallsResponse = currentResponse.choices[0].message.tool_calls
             const result = trackForcedToolUsage(
               toolCallsResponse,
-              originalToolChoice,
+              nextPayload.tool_choice,
               logger,
-              'deepseek'
+              'deepseek',
+              forcedTools,
+              usedForcedTools
             )
-            hasUsedForcedTool = result.hasUsedForcedTool
+            hasUsedForcedTool = result.hasUsedForcedTool || hasUsedForcedTool
+            usedForcedTools = result.usedForcedTools
           }
 
           const nextModelEndTime = Date.now()

--- a/sim/providers/google/index.ts
+++ b/sim/providers/google/index.ts
@@ -2,7 +2,6 @@ import OpenAI from 'openai'
 import { createLogger } from '@/lib/logs/console-logger'
 import { executeTool } from '@/tools'
 import { ProviderConfig, ProviderRequest, ProviderResponse, TimeSegment } from '../types'
-import { prepareToolsWithUsageControl, trackForcedToolUsage } from '../utils'
 
 const logger = createLogger('Google Provider')
 
@@ -87,45 +86,14 @@ export const googleProvider: ProviderConfig = {
         }
       }
 
-      // Handle tools and tool usage control
+      // Add tools if provided
       if (tools?.length) {
-        const {
-          tools: filteredTools,
-          toolChoice,
-          forcedTools,
-        } = prepareToolsWithUsageControl(tools, request.tools, logger, 'google')
-
-        if (filteredTools?.length && toolChoice) {
-          payload.tools = filteredTools
-          payload.tool_choice = toolChoice
-
-          logger.info(`Google request configuration:`, {
-            toolCount: filteredTools.length,
-            toolChoice:
-              typeof toolChoice === 'string'
-                ? toolChoice
-                : toolChoice.type === 'function'
-                  ? `force:${toolChoice.function.name}`
-                  : toolChoice.type === 'tool'
-                    ? `force:${toolChoice.name}`
-                    : `force:${toolChoice.any?.name || 'unknown'}`,
-            model: requestedModel,
-          })
-        }
+        payload.tools = tools
+        payload.tool_choice = 'auto'
       }
 
       // Make the initial API request
       const initialCallTime = Date.now()
-
-      // Track the original tool_choice for forced tool tracking
-      const originalToolChoice = payload.tool_choice
-
-      // Track forced tools and their usage
-      const forcedTools = tools?.length
-        ? prepareToolsWithUsageControl(tools, request.tools, logger, 'google').forcedTools
-        : []
-      let usedForcedTools: string[] = []
-
       let currentResponse
       let firstResponseTime = 0
 
@@ -208,9 +176,6 @@ export const googleProvider: ProviderConfig = {
       let iterationCount = 0
       const MAX_ITERATIONS = 10 // Prevent infinite loops
 
-      // Track if a forced tool has been used
-      let hasUsedForcedTool = false
-
       // Track time spent in model vs tools
       let modelTime = firstResponseTime
       let toolsTime = 0
@@ -225,24 +190,6 @@ export const googleProvider: ProviderConfig = {
           duration: firstResponseTime,
         },
       ]
-
-      // Check if a forced tool was used in the first response
-      if (
-        typeof originalToolChoice === 'object' &&
-        currentResponse.choices[0]?.message?.tool_calls
-      ) {
-        const toolCallsResponse = currentResponse.choices[0].message.tool_calls
-        const result = trackForcedToolUsage(
-          toolCallsResponse,
-          originalToolChoice,
-          logger,
-          'google',
-          forcedTools,
-          usedForcedTools
-        )
-        hasUsedForcedTool = result.hasUsedForcedTool
-        usedForcedTools = result.usedForcedTools
-      }
 
       try {
         while (iterationCount < MAX_ITERATIONS) {
@@ -335,55 +282,11 @@ export const googleProvider: ProviderConfig = {
             messages: currentMessages,
           }
 
-          // Update tool_choice based on which forced tools have been used
-          if (
-            typeof originalToolChoice === 'object' &&
-            hasUsedForcedTool &&
-            forcedTools.length > 0
-          ) {
-            // If we have remaining forced tools, get the next one to force
-            const remainingTools = forcedTools.filter((tool) => !usedForcedTools.includes(tool))
-
-            if (remainingTools.length > 0) {
-              // Force the next tool
-              nextPayload.tool_choice = {
-                type: 'any',
-                any: {
-                  model: 'latest',
-                  name: remainingTools[0],
-                },
-              }
-              logger.info(`Forcing next tool: ${remainingTools[0]}`)
-            } else {
-              // All forced tools have been used, switch to auto
-              nextPayload.tool_choice = 'auto'
-              logger.info('All forced tools have been used, switching to auto tool_choice')
-            }
-          }
-
           // Time the next model call
           const nextModelStartTime = Date.now()
 
           // Make the next request
           currentResponse = await openai.chat.completions.create(nextPayload)
-
-          // Check if any forced tools were used in this response
-          if (
-            typeof nextPayload.tool_choice === 'object' &&
-            currentResponse.choices[0]?.message?.tool_calls
-          ) {
-            const toolCallsResponse = currentResponse.choices[0].message.tool_calls
-            const result = trackForcedToolUsage(
-              toolCallsResponse,
-              nextPayload.tool_choice,
-              logger,
-              'google',
-              forcedTools,
-              usedForcedTools
-            )
-            hasUsedForcedTool = result.hasUsedForcedTool || hasUsedForcedTool
-            usedForcedTools = result.usedForcedTools
-          }
 
           const nextModelEndTime = Date.now()
           const thisModelTime = nextModelEndTime - nextModelStartTime

--- a/sim/providers/google/index.ts
+++ b/sim/providers/google/index.ts
@@ -89,12 +89,11 @@ export const googleProvider: ProviderConfig = {
 
       // Handle tools and tool usage control
       if (tools?.length) {
-        const { tools: filteredTools, toolChoice } = prepareToolsWithUsageControl(
-          tools,
-          request.tools,
-          logger,
-          'google'
-        )
+        const {
+          tools: filteredTools,
+          toolChoice,
+          forcedTools,
+        } = prepareToolsWithUsageControl(tools, request.tools, logger, 'google')
 
         if (filteredTools?.length && toolChoice) {
           payload.tools = filteredTools
@@ -120,6 +119,12 @@ export const googleProvider: ProviderConfig = {
 
       // Track the original tool_choice for forced tool tracking
       const originalToolChoice = payload.tool_choice
+
+      // Track forced tools and their usage
+      const forcedTools = tools?.length
+        ? prepareToolsWithUsageControl(tools, request.tools, logger, 'google').forcedTools
+        : []
+      let usedForcedTools: string[] = []
 
       let currentResponse
       let firstResponseTime = 0
@@ -227,8 +232,16 @@ export const googleProvider: ProviderConfig = {
         currentResponse.choices[0]?.message?.tool_calls
       ) {
         const toolCallsResponse = currentResponse.choices[0].message.tool_calls
-        const result = trackForcedToolUsage(toolCallsResponse, originalToolChoice, logger, 'google')
+        const result = trackForcedToolUsage(
+          toolCallsResponse,
+          originalToolChoice,
+          logger,
+          'google',
+          forcedTools,
+          usedForcedTools
+        )
         hasUsedForcedTool = result.hasUsedForcedTool
+        usedForcedTools = result.usedForcedTools
       }
 
       try {
@@ -322,12 +335,30 @@ export const googleProvider: ProviderConfig = {
             messages: currentMessages,
           }
 
-          // If we've used the forced tool, switch to 'auto' mode for subsequent requests
-          if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
-            nextPayload.tool_choice = 'auto'
-            logger.info(
-              'Switching to auto tool_choice for subsequent requests after forced tool was used'
-            )
+          // Update tool_choice based on which forced tools have been used
+          if (
+            typeof originalToolChoice === 'object' &&
+            hasUsedForcedTool &&
+            forcedTools.length > 0
+          ) {
+            // If we have remaining forced tools, get the next one to force
+            const remainingTools = forcedTools.filter((tool) => !usedForcedTools.includes(tool))
+
+            if (remainingTools.length > 0) {
+              // Force the next tool
+              nextPayload.tool_choice = {
+                type: 'any',
+                any: {
+                  model: 'latest',
+                  name: remainingTools[0],
+                },
+              }
+              logger.info(`Forcing next tool: ${remainingTools[0]}`)
+            } else {
+              // All forced tools have been used, switch to auto
+              nextPayload.tool_choice = 'auto'
+              logger.info('All forced tools have been used, switching to auto tool_choice')
+            }
           }
 
           // Time the next model call
@@ -336,20 +367,22 @@ export const googleProvider: ProviderConfig = {
           // Make the next request
           currentResponse = await openai.chat.completions.create(nextPayload)
 
-          // Check if a forced tool was used in this response (if not already used)
+          // Check if any forced tools were used in this response
           if (
-            !hasUsedForcedTool &&
-            typeof originalToolChoice === 'object' &&
+            typeof nextPayload.tool_choice === 'object' &&
             currentResponse.choices[0]?.message?.tool_calls
           ) {
             const toolCallsResponse = currentResponse.choices[0].message.tool_calls
             const result = trackForcedToolUsage(
               toolCallsResponse,
-              originalToolChoice,
+              nextPayload.tool_choice,
               logger,
-              'google'
+              'google',
+              forcedTools,
+              usedForcedTools
             )
-            hasUsedForcedTool = result.hasUsedForcedTool
+            hasUsedForcedTool = result.hasUsedForcedTool || hasUsedForcedTool
+            usedForcedTools = result.usedForcedTools
           }
 
           const nextModelEndTime = Date.now()

--- a/sim/providers/google/index.ts
+++ b/sim/providers/google/index.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai'
 import { createLogger } from '@/lib/logs/console-logger'
 import { executeTool } from '@/tools'
 import { ProviderConfig, ProviderRequest, ProviderResponse, TimeSegment } from '../types'
+import { prepareToolsWithUsageControl, trackForcedToolUsage } from '../utils'
 
 const logger = createLogger('Google Provider')
 
@@ -86,14 +87,40 @@ export const googleProvider: ProviderConfig = {
         }
       }
 
-      // Add tools if provided
+      // Handle tools and tool usage control
       if (tools?.length) {
-        payload.tools = tools
-        payload.tool_choice = 'auto'
+        const { tools: filteredTools, toolChoice } = prepareToolsWithUsageControl(
+          tools,
+          request.tools,
+          logger,
+          'google'
+        )
+
+        if (filteredTools?.length && toolChoice) {
+          payload.tools = filteredTools
+          payload.tool_choice = toolChoice
+
+          logger.info(`Google request configuration:`, {
+            toolCount: filteredTools.length,
+            toolChoice:
+              typeof toolChoice === 'string'
+                ? toolChoice
+                : toolChoice.type === 'function'
+                  ? `force:${toolChoice.function.name}`
+                  : toolChoice.type === 'tool'
+                    ? `force:${toolChoice.name}`
+                    : `force:${toolChoice.any?.name || 'unknown'}`,
+            model: requestedModel,
+          })
+        }
       }
 
       // Make the initial API request
       const initialCallTime = Date.now()
+
+      // Track the original tool_choice for forced tool tracking
+      const originalToolChoice = payload.tool_choice
+
       let currentResponse
       let firstResponseTime = 0
 
@@ -176,6 +203,9 @@ export const googleProvider: ProviderConfig = {
       let iterationCount = 0
       const MAX_ITERATIONS = 10 // Prevent infinite loops
 
+      // Track if a forced tool has been used
+      let hasUsedForcedTool = false
+
       // Track time spent in model vs tools
       let modelTime = firstResponseTime
       let toolsTime = 0
@@ -190,6 +220,16 @@ export const googleProvider: ProviderConfig = {
           duration: firstResponseTime,
         },
       ]
+
+      // Check if a forced tool was used in the first response
+      if (
+        typeof originalToolChoice === 'object' &&
+        currentResponse.choices[0]?.message?.tool_calls
+      ) {
+        const toolCallsResponse = currentResponse.choices[0].message.tool_calls
+        const result = trackForcedToolUsage(toolCallsResponse, originalToolChoice, logger, 'google')
+        hasUsedForcedTool = result.hasUsedForcedTool
+      }
 
       try {
         while (iterationCount < MAX_ITERATIONS) {
@@ -282,11 +322,35 @@ export const googleProvider: ProviderConfig = {
             messages: currentMessages,
           }
 
+          // If we've used the forced tool, switch to 'auto' mode for subsequent requests
+          if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
+            nextPayload.tool_choice = 'auto'
+            logger.info(
+              'Switching to auto tool_choice for subsequent requests after forced tool was used'
+            )
+          }
+
           // Time the next model call
           const nextModelStartTime = Date.now()
 
           // Make the next request
           currentResponse = await openai.chat.completions.create(nextPayload)
+
+          // Check if a forced tool was used in this response (if not already used)
+          if (
+            !hasUsedForcedTool &&
+            typeof originalToolChoice === 'object' &&
+            currentResponse.choices[0]?.message?.tool_calls
+          ) {
+            const toolCallsResponse = currentResponse.choices[0].message.tool_calls
+            const result = trackForcedToolUsage(
+              toolCallsResponse,
+              originalToolChoice,
+              logger,
+              'google'
+            )
+            hasUsedForcedTool = result.hasUsedForcedTool
+          }
 
           const nextModelEndTime = Date.now()
           const thisModelTime = nextModelEndTime - nextModelStartTime

--- a/sim/providers/model-capabilities.test.ts
+++ b/sim/providers/model-capabilities.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getMaxTemperature,
+  PROVIDERS_WITH_TOOL_USAGE_CONTROL,
+  supportsTemperature,
+  supportsToolUsageControl,
+} from './model-capabilities'
+
+describe('supportsToolUsageControl', () => {
+  it('should return true for providers that support tool usage control', () => {
+    // Test each provider that should support tool usage control
+    for (const provider of PROVIDERS_WITH_TOOL_USAGE_CONTROL) {
+      expect(supportsToolUsageControl(provider)).toBe(true)
+    }
+  })
+
+  it('should return false for providers that do not support tool usage control', () => {
+    const unsupportedProviders = ['google', 'ollama', 'non-existent-provider']
+
+    for (const provider of unsupportedProviders) {
+      expect(supportsToolUsageControl(provider)).toBe(false)
+    }
+  })
+})
+
+describe('supportsTemperature', () => {
+  it('should return true for models that support temperature', () => {
+    const supportedModels = [
+      'gpt-4o',
+      'gemini-2.0-flash',
+      'claude-3-5-sonnet-20240620',
+      'grok-2-latest',
+    ]
+
+    for (const model of supportedModels) {
+      expect(supportsTemperature(model)).toBe(true)
+    }
+  })
+
+  it('should return false for models that do not support temperature', () => {
+    const unsupportedModels = ['unsupported-model']
+
+    for (const model of unsupportedModels) {
+      expect(supportsTemperature(model)).toBe(false)
+    }
+  })
+})
+
+describe('getMaxTemperature', () => {
+  it('should return 2 for models with temperature range 0-2', () => {
+    const models = ['gpt-4o', 'gemini-2.0-flash', 'deepseek-v3']
+
+    for (const model of models) {
+      expect(getMaxTemperature(model)).toBe(2)
+    }
+  })
+
+  it('should return 1 for models with temperature range 0-1', () => {
+    const models = ['claude-3-5-sonnet-20240620', 'claude-3-7-sonnet-20250219', 'grok-2-latest']
+
+    for (const model of models) {
+      expect(getMaxTemperature(model)).toBe(1)
+    }
+  })
+
+  it('should return undefined for models that do not support temperature', () => {
+    expect(getMaxTemperature('unsupported-model')).toBeUndefined()
+  })
+})

--- a/sim/providers/model-capabilities.ts
+++ b/sim/providers/model-capabilities.ts
@@ -26,6 +26,15 @@ export const MODELS_TEMP_RANGE_0_1 = [
 // All models that support temperature (combined list)
 export const MODELS_WITH_TEMPERATURE_SUPPORT = [...MODELS_TEMP_RANGE_0_2, ...MODELS_TEMP_RANGE_0_1]
 
+// Models and their providers that support tool usage control (force, auto, none)
+export const PROVIDERS_WITH_TOOL_USAGE_CONTROL = [
+  'openai',
+  'anthropic',
+  'google',
+  'deepseek',
+  'xai',
+]
+
 /**
  * Check if a model supports temperature parameter
  */
@@ -59,4 +68,11 @@ export function getMaxTemperature(model: string): number | undefined {
 
   // Temperature not supported
   return undefined
+}
+
+/**
+ * Check if a provider supports tool usage control
+ */
+export function supportsToolUsageControl(provider: string): boolean {
+  return PROVIDERS_WITH_TOOL_USAGE_CONTROL.includes(provider)
 }

--- a/sim/providers/model-capabilities.ts
+++ b/sim/providers/model-capabilities.ts
@@ -27,13 +27,7 @@ export const MODELS_TEMP_RANGE_0_1 = [
 export const MODELS_WITH_TEMPERATURE_SUPPORT = [...MODELS_TEMP_RANGE_0_2, ...MODELS_TEMP_RANGE_0_1]
 
 // Models and their providers that support tool usage control (force, auto, none)
-export const PROVIDERS_WITH_TOOL_USAGE_CONTROL = [
-  'openai',
-  'anthropic',
-  'google',
-  'deepseek',
-  'xai',
-]
+export const PROVIDERS_WITH_TOOL_USAGE_CONTROL = ['openai', 'anthropic', 'deepseek', 'xai']
 
 /**
  * Check if a model supports temperature parameter

--- a/sim/providers/openai/index.ts
+++ b/sim/providers/openai/index.ts
@@ -93,12 +93,11 @@ export const openaiProvider: ProviderConfig = {
 
     // Handle tools and tool usage control
     if (tools?.length) {
-      const { tools: filteredTools, toolChoice } = prepareToolsWithUsageControl(
-        tools,
-        request.tools,
-        logger,
-        'openai'
-      )
+      const {
+        tools: filteredTools,
+        toolChoice,
+        forcedTools,
+      } = prepareToolsWithUsageControl(tools, request.tools, logger, 'openai')
 
       if (filteredTools?.length && toolChoice) {
         payload.tools = filteredTools
@@ -131,6 +130,12 @@ export const openaiProvider: ProviderConfig = {
 
       // Track the original tool_choice for forced tool tracking
       const originalToolChoice = payload.tool_choice
+
+      // Track forced tools and their usage
+      const forcedTools = tools?.length
+        ? prepareToolsWithUsageControl(tools, request.tools, logger, 'openai').forcedTools
+        : []
+      let usedForcedTools: string[] = []
 
       let currentResponse = await openai.chat.completions.create(payload)
       const firstResponseTime = Date.now() - initialCallTime
@@ -171,8 +176,16 @@ export const openaiProvider: ProviderConfig = {
         currentResponse.choices[0]?.message?.tool_calls
       ) {
         const toolCallsResponse = currentResponse.choices[0].message.tool_calls
-        const result = trackForcedToolUsage(toolCallsResponse, originalToolChoice, logger, 'openai')
+        const result = trackForcedToolUsage(
+          toolCallsResponse,
+          originalToolChoice,
+          logger,
+          'openai',
+          forcedTools,
+          usedForcedTools
+        )
         hasUsedForcedTool = result.hasUsedForcedTool
+        usedForcedTools = result.usedForcedTools
       }
 
       while (iterationCount < MAX_ITERATIONS) {
@@ -270,12 +283,23 @@ export const openaiProvider: ProviderConfig = {
           messages: currentMessages,
         }
 
-        // If we've used the forced tool, switch to 'auto' mode for subsequent requests
-        if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
-          nextPayload.tool_choice = 'auto'
-          logger.info(
-            'Switching to auto tool_choice for subsequent requests after forced tool was used'
-          )
+        // Update tool_choice based on which forced tools have been used
+        if (typeof originalToolChoice === 'object' && hasUsedForcedTool && forcedTools.length > 0) {
+          // If we have remaining forced tools, get the next one to force
+          const remainingTools = forcedTools.filter((tool) => !usedForcedTools.includes(tool))
+
+          if (remainingTools.length > 0) {
+            // Force the next tool
+            nextPayload.tool_choice = {
+              type: 'function',
+              function: { name: remainingTools[0] },
+            }
+            logger.info(`Forcing next tool: ${remainingTools[0]}`)
+          } else {
+            // All forced tools have been used, switch to auto
+            nextPayload.tool_choice = 'auto'
+            logger.info('All forced tools have been used, switching to auto tool_choice')
+          }
         }
 
         // Time the next model call
@@ -284,20 +308,22 @@ export const openaiProvider: ProviderConfig = {
         // Make the next request
         currentResponse = await openai.chat.completions.create(nextPayload)
 
-        // Check if a forced tool was used in this response (if not already used)
+        // Check if any forced tools were used in this response
         if (
-          !hasUsedForcedTool &&
-          typeof originalToolChoice === 'object' &&
+          typeof nextPayload.tool_choice === 'object' &&
           currentResponse.choices[0]?.message?.tool_calls
         ) {
           const toolCallsResponse = currentResponse.choices[0].message.tool_calls
           const result = trackForcedToolUsage(
             toolCallsResponse,
-            originalToolChoice,
+            nextPayload.tool_choice,
             logger,
-            'openai'
+            'openai',
+            forcedTools,
+            usedForcedTools
           )
-          hasUsedForcedTool = result.hasUsedForcedTool
+          hasUsedForcedTool = result.hasUsedForcedTool || hasUsedForcedTool
+          usedForcedTools = result.usedForcedTools
         }
 
         const nextModelEndTime = Date.now()

--- a/sim/providers/openai/index.ts
+++ b/sim/providers/openai/index.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai'
 import { createLogger } from '@/lib/logs/console-logger'
 import { executeTool } from '@/tools'
 import { ProviderConfig, ProviderRequest, ProviderResponse, TimeSegment } from '../types'
+import { prepareToolsWithUsageControl, trackForcedToolUsage } from '../utils'
 
 const logger = createLogger('OpenAI Provider')
 
@@ -90,11 +91,34 @@ export const openaiProvider: ProviderConfig = {
       logger.info('Added JSON schema response format to request')
     }
 
-    // Add tools if provided
+    // Handle tools and tool usage control
     if (tools?.length) {
-      payload.tools = tools
-      payload.tool_choice = 'auto'
-      logger.info(`Configured ${tools.length} tools for OpenAI request`)
+      const { tools: filteredTools, toolChoice } = prepareToolsWithUsageControl(
+        tools,
+        request.tools,
+        logger,
+        'openai'
+      )
+
+      if (filteredTools?.length && toolChoice) {
+        payload.tools = filteredTools
+        payload.tool_choice = toolChoice
+
+        logger.info(`OpenAI request configuration:`, {
+          toolCount: filteredTools.length,
+          toolChoice:
+            typeof toolChoice === 'string'
+              ? toolChoice
+              : toolChoice.type === 'function'
+                ? `force:${toolChoice.function.name}`
+                : toolChoice.type === 'tool'
+                  ? `force:${toolChoice.name}`
+                  : toolChoice.type === 'any'
+                    ? `force:${toolChoice.any?.name || 'unknown'}`
+                    : 'unknown',
+          model: request.model || 'gpt-4o',
+        })
+      }
     }
 
     // Start execution timer for the entire provider execution
@@ -104,6 +128,10 @@ export const openaiProvider: ProviderConfig = {
     try {
       // Make the initial API request
       const initialCallTime = Date.now()
+
+      // Track the original tool_choice for forced tool tracking
+      const originalToolChoice = payload.tool_choice
+
       let currentResponse = await openai.chat.completions.create(payload)
       const firstResponseTime = Date.now() - initialCallTime
 
@@ -119,6 +147,9 @@ export const openaiProvider: ProviderConfig = {
       let iterationCount = 0
       const MAX_ITERATIONS = 10 // Prevent infinite loops
 
+      // Track if a forced tool has been used
+      let hasUsedForcedTool = false
+
       // Track time spent in model vs tools
       let modelTime = firstResponseTime
       let toolsTime = 0
@@ -133,6 +164,16 @@ export const openaiProvider: ProviderConfig = {
           duration: firstResponseTime,
         },
       ]
+
+      // Check if a forced tool was used in the first response
+      if (
+        typeof originalToolChoice === 'object' &&
+        currentResponse.choices[0]?.message?.tool_calls
+      ) {
+        const toolCallsResponse = currentResponse.choices[0].message.tool_calls
+        const result = trackForcedToolUsage(toolCallsResponse, originalToolChoice, logger, 'openai')
+        hasUsedForcedTool = result.hasUsedForcedTool
+      }
 
       while (iterationCount < MAX_ITERATIONS) {
         // Check for tool calls
@@ -229,11 +270,35 @@ export const openaiProvider: ProviderConfig = {
           messages: currentMessages,
         }
 
+        // If we've used the forced tool, switch to 'auto' mode for subsequent requests
+        if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
+          nextPayload.tool_choice = 'auto'
+          logger.info(
+            'Switching to auto tool_choice for subsequent requests after forced tool was used'
+          )
+        }
+
         // Time the next model call
         const nextModelStartTime = Date.now()
 
         // Make the next request
         currentResponse = await openai.chat.completions.create(nextPayload)
+
+        // Check if a forced tool was used in this response (if not already used)
+        if (
+          !hasUsedForcedTool &&
+          typeof originalToolChoice === 'object' &&
+          currentResponse.choices[0]?.message?.tool_calls
+        ) {
+          const toolCallsResponse = currentResponse.choices[0].message.tool_calls
+          const result = trackForcedToolUsage(
+            toolCallsResponse,
+            originalToolChoice,
+            logger,
+            'openai'
+          )
+          hasUsedForcedTool = result.hasUsedForcedTool
+        }
 
         const nextModelEndTime = Date.now()
         const thisModelTime = nextModelEndTime - nextModelStartTime

--- a/sim/providers/types.ts
+++ b/sim/providers/types.ts
@@ -92,6 +92,8 @@ export interface ProviderResponse {
   }
 }
 
+export type ToolUsageControl = 'auto' | 'force' | 'none'
+
 export interface ProviderToolConfig {
   id: string
   name: string
@@ -102,6 +104,7 @@ export interface ProviderToolConfig {
     properties: Record<string, any>
     required: string[]
   }
+  usageControl?: ToolUsageControl
 }
 
 export interface Message {

--- a/sim/providers/utils.ts
+++ b/sim/providers/utils.ts
@@ -515,10 +515,11 @@ export function prepareToolsWithUsageControl(
     | { type: 'any'; any: { model: string; name: string } }
     | undefined
   hasFilteredTools: boolean
+  forcedTools: string[] // Return all forced tool IDs
 } {
   // If no tools, return early
   if (!tools || tools.length === 0) {
-    return { tools: undefined, toolChoice: undefined, hasFilteredTools: false }
+    return { tools: undefined, toolChoice: undefined, hasFilteredTools: false, forcedTools: [] }
   }
 
   // Filter out tools marked with usageControl='none'
@@ -539,11 +540,12 @@ export function prepareToolsWithUsageControl(
   // If all tools were filtered out, return empty
   if (filteredTools.length === 0) {
     logger.info('All tools were filtered out due to usageControl="none"')
-    return { tools: undefined, toolChoice: undefined, hasFilteredTools: true }
+    return { tools: undefined, toolChoice: undefined, hasFilteredTools: true, forcedTools: [] }
   }
 
-  // Get tools that should be forced
+  // Get all tools that should be forced
   const forcedTools = providerTools?.filter((tool) => tool.usageControl === 'force') || []
+  const forcedToolIds = forcedTools.map((tool) => tool.id)
 
   // Determine tool_choice setting
   let toolChoice:
@@ -584,7 +586,7 @@ export function prepareToolsWithUsageControl(
 
     if (forcedTools.length > 1) {
       logger.info(
-        `Multiple tools set to 'force' mode, but only the first one (${forcedTool.id}) will be forced`
+        `Multiple tools set to 'force' mode (${forcedToolIds.join(', ')}). Will cycle through them sequentially.`
       )
     }
   } else {
@@ -597,6 +599,7 @@ export function prepareToolsWithUsageControl(
     tools: filteredTools,
     toolChoice,
     hasFilteredTools,
+    forcedTools: forcedToolIds,
   }
 }
 
@@ -607,15 +610,20 @@ export function prepareToolsWithUsageControl(
  * @param originalToolChoice The original tool_choice setting used in the request
  * @param logger Logger instance to use for logging
  * @param provider Optional provider ID to adjust format for specific providers
- * @returns Object containing hasUsedForcedTool flag and toolChoice for next request
+ * @param forcedTools Array of all tool IDs that should be forced in sequence
+ * @param usedForcedTools Array of tool IDs that have already been used
+ * @returns Object containing tracking information and next tool choice
  */
 export function trackForcedToolUsage(
   toolCallsResponse: any[] | undefined,
   originalToolChoice: any,
   logger: any,
-  provider?: string
+  provider?: string,
+  forcedTools: string[] = [],
+  usedForcedTools: string[] = []
 ): {
   hasUsedForcedTool: boolean
+  usedForcedTools: string[]
   nextToolChoice:
     | 'auto'
     | { type: 'function'; function: { name: string } }
@@ -626,6 +634,7 @@ export function trackForcedToolUsage(
   // Default to keeping the original tool_choice
   let hasUsedForcedTool = false
   let nextToolChoice = originalToolChoice
+  const updatedUsedForcedTools = [...usedForcedTools]
 
   // If we're forcing a specific tool and we have tool calls in the response
   if (
@@ -636,7 +645,7 @@ export function trackForcedToolUsage(
     toolCallsResponse &&
     toolCallsResponse.length > 0
   ) {
-    // Get the name of the forced tool
+    // Get the name of the current forced tool
     const forcedToolName =
       originalToolChoice?.function?.name ||
       originalToolChoice?.name ||
@@ -648,20 +657,52 @@ export function trackForcedToolUsage(
     if (toolNames.includes(forcedToolName)) {
       // The forced tool was used
       hasUsedForcedTool = true
+      updatedUsedForcedTools.push(forcedToolName)
 
-      // For Anthropic, we need to return null to signal deletion of the parameter
-      // For Google/Gemini, we return 'auto'
-      // For other providers, we return 'auto'
-      nextToolChoice = provider === 'anthropic' ? null : 'auto'
+      // Find the next tool to force that hasn't been used yet
+      const remainingTools = forcedTools.filter((tool) => !updatedUsedForcedTools.includes(tool))
 
-      logger.info(
-        `Forced tool ${forcedToolName} was used, switching to auto mode for future iterations`
-      )
+      if (remainingTools.length > 0) {
+        // There are still forced tools to use
+        const nextToolToForce = remainingTools[0]
+
+        // Format based on provider
+        if (provider === 'anthropic') {
+          nextToolChoice = {
+            type: 'tool',
+            name: nextToolToForce,
+          }
+        } else if (provider === 'google') {
+          nextToolChoice = {
+            type: 'any',
+            any: {
+              model: 'latest',
+              name: nextToolToForce,
+            },
+          }
+        } else {
+          // Default OpenAI format
+          nextToolChoice = {
+            type: 'function',
+            function: { name: nextToolToForce },
+          }
+        }
+
+        logger.info(
+          `Forced tool ${forcedToolName} was used, switching to next forced tool: ${nextToolToForce}`
+        )
+      } else {
+        // All forced tools have been used, switch to auto mode
+        nextToolChoice = provider === 'anthropic' ? null : 'auto'
+
+        logger.info(`All forced tools have been used, switching to auto mode for future iterations`)
+      }
     }
   }
 
   return {
     hasUsedForcedTool,
+    usedForcedTools: updatedUsedForcedTools,
     nextToolChoice: hasUsedForcedTool ? nextToolChoice : originalToolChoice,
   }
 }

--- a/sim/providers/utils.ts
+++ b/sim/providers/utils.ts
@@ -514,12 +514,22 @@ export function prepareToolsWithUsageControl(
     | { type: 'tool'; name: string }
     | { type: 'any'; any: { model: string; name: string } }
     | undefined
+  toolConfig?: {
+    // Add toolConfig for Google's format
+    mode: 'AUTO' | 'ANY' | 'NONE'
+    allowed_function_names?: string[]
+  }
   hasFilteredTools: boolean
   forcedTools: string[] // Return all forced tool IDs
 } {
   // If no tools, return early
   if (!tools || tools.length === 0) {
-    return { tools: undefined, toolChoice: undefined, hasFilteredTools: false, forcedTools: [] }
+    return {
+      tools: undefined,
+      toolChoice: undefined,
+      hasFilteredTools: false,
+      forcedTools: [],
+    }
   }
 
   // Filter out tools marked with usageControl='none'
@@ -540,7 +550,12 @@ export function prepareToolsWithUsageControl(
   // If all tools were filtered out, return empty
   if (filteredTools.length === 0) {
     logger.info('All tools were filtered out due to usageControl="none"')
-    return { tools: undefined, toolChoice: undefined, hasFilteredTools: true, forcedTools: [] }
+    return {
+      tools: undefined,
+      toolChoice: undefined,
+      hasFilteredTools: true,
+      forcedTools: [],
+    }
   }
 
   // Get all tools that should be forced
@@ -555,6 +570,14 @@ export function prepareToolsWithUsageControl(
     | { type: 'tool'; name: string }
     | { type: 'any'; any: { model: string; name: string } } = 'auto'
 
+  // For Google, we'll use a separate toolConfig object
+  let toolConfig:
+    | {
+        mode: 'AUTO' | 'ANY' | 'NONE'
+        allowed_function_names?: string[]
+      }
+    | undefined = undefined
+
   if (forcedTools.length > 0) {
     // Force the first tool that has usageControl='force'
     const forcedTool = forcedTools[0]
@@ -566,14 +589,16 @@ export function prepareToolsWithUsageControl(
         name: forcedTool.id,
       }
     } else if (provider === 'google') {
-      // Google Gemini format uses "any" type with tool name
-      toolChoice = {
-        type: 'any',
-        any: {
-          model: 'latest',
-          name: forcedTool.id,
-        },
+      // Google Gemini format uses a separate tool_config object
+      toolConfig = {
+        mode: 'ANY',
+        allowed_function_names:
+          forcedTools.length === 1
+            ? [forcedTool.id] // If only one tool, specify just that one
+            : forcedToolIds, // If multiple tools, include all of them
       }
+      // Keep toolChoice as 'auto' since we use toolConfig instead
+      toolChoice = 'auto'
     } else {
       // Default OpenAI format
       toolChoice = {
@@ -592,12 +617,16 @@ export function prepareToolsWithUsageControl(
   } else {
     // Default to auto if no forced tools
     toolChoice = 'auto'
+    if (provider === 'google') {
+      toolConfig = { mode: 'AUTO' }
+    }
     logger.info('Setting tool_choice to auto - letting model decide which tools to use')
   }
 
   return {
     tools: filteredTools,
     toolChoice,
+    toolConfig,
     hasFilteredTools,
     forcedTools: forcedToolIds,
   }
@@ -624,42 +653,65 @@ export function trackForcedToolUsage(
 ): {
   hasUsedForcedTool: boolean
   usedForcedTools: string[]
-  nextToolChoice:
+  nextToolChoice?:
     | 'auto'
     | { type: 'function'; function: { name: string } }
     | { type: 'tool'; name: string }
     | { type: 'any'; any: { model: string; name: string } }
     | null
+  nextToolConfig?: {
+    mode: 'AUTO' | 'ANY' | 'NONE'
+    allowed_function_names?: string[]
+  }
 } {
   // Default to keeping the original tool_choice
   let hasUsedForcedTool = false
   let nextToolChoice = originalToolChoice
+  let nextToolConfig:
+    | {
+        mode: 'AUTO' | 'ANY' | 'NONE'
+        allowed_function_names?: string[]
+      }
+    | undefined = undefined
+
   const updatedUsedForcedTools = [...usedForcedTools]
 
-  // If we're forcing a specific tool and we have tool calls in the response
-  if (
+  // Special handling for Google format
+  const isGoogleFormat = provider === 'google'
+
+  // Get the name of the current forced tool(s)
+  let forcedToolNames: string[] = []
+  if (isGoogleFormat && originalToolChoice?.allowed_function_names) {
+    // For Google format
+    forcedToolNames = originalToolChoice.allowed_function_names
+  } else if (
     typeof originalToolChoice === 'object' &&
     (originalToolChoice?.function?.name ||
       (originalToolChoice?.type === 'tool' && originalToolChoice?.name) ||
-      (originalToolChoice?.type === 'any' && originalToolChoice?.any?.name)) &&
-    toolCallsResponse &&
-    toolCallsResponse.length > 0
+      (originalToolChoice?.type === 'any' && originalToolChoice?.any?.name))
   ) {
-    // Get the name of the current forced tool
-    const forcedToolName =
+    // For other providers
+    forcedToolNames = [
       originalToolChoice?.function?.name ||
-      originalToolChoice?.name ||
-      originalToolChoice?.any?.name
+        originalToolChoice?.name ||
+        originalToolChoice?.any?.name,
+    ].filter(Boolean)
+  }
 
-    // Check if any of the tool calls used the forced tool
+  // If we're forcing specific tools and we have tool calls in the response
+  if (forcedToolNames.length > 0 && toolCallsResponse && toolCallsResponse.length > 0) {
+    // Check if any of the tool calls used the forced tools
     const toolNames = toolCallsResponse.map((tc) => tc.function?.name || tc.name || tc.id)
 
-    if (toolNames.includes(forcedToolName)) {
-      // The forced tool was used
-      hasUsedForcedTool = true
-      updatedUsedForcedTools.push(forcedToolName)
+    // Find any forced tools that were used
+    const usedTools = forcedToolNames.filter((toolName) => toolNames.includes(toolName))
 
-      // Find the next tool to force that hasn't been used yet
+    if (usedTools.length > 0) {
+      // At least one forced tool was used
+      hasUsedForcedTool = true
+      updatedUsedForcedTools.push(...usedTools)
+
+      // Find the next tools to force that haven't been used yet
       const remainingTools = forcedTools.filter((tool) => !updatedUsedForcedTools.includes(tool))
 
       if (remainingTools.length > 0) {
@@ -673,12 +725,12 @@ export function trackForcedToolUsage(
             name: nextToolToForce,
           }
         } else if (provider === 'google') {
-          nextToolChoice = {
-            type: 'any',
-            any: {
-              model: 'latest',
-              name: nextToolToForce,
-            },
+          nextToolConfig = {
+            mode: 'ANY',
+            allowed_function_names:
+              remainingTools.length === 1
+                ? [nextToolToForce] // If only one tool left, specify just that one
+                : remainingTools, // If multiple tools, include all remaining
           }
         } else {
           // Default OpenAI format
@@ -689,11 +741,17 @@ export function trackForcedToolUsage(
         }
 
         logger.info(
-          `Forced tool ${forcedToolName} was used, switching to next forced tool: ${nextToolToForce}`
+          `Forced tool(s) ${usedTools.join(', ')} used, switching to next forced tool(s): ${remainingTools.join(', ')}`
         )
       } else {
         // All forced tools have been used, switch to auto mode
-        nextToolChoice = provider === 'anthropic' ? null : 'auto'
+        if (provider === 'anthropic') {
+          nextToolChoice = null // Anthropic requires null to remove the parameter
+        } else if (provider === 'google') {
+          nextToolConfig = { mode: 'AUTO' }
+        } else {
+          nextToolChoice = 'auto'
+        }
 
         logger.info(`All forced tools have been used, switching to auto mode for future iterations`)
       }
@@ -704,5 +762,10 @@ export function trackForcedToolUsage(
     hasUsedForcedTool,
     usedForcedTools: updatedUsedForcedTools,
     nextToolChoice: hasUsedForcedTool ? nextToolChoice : originalToolChoice,
+    nextToolConfig: isGoogleFormat
+      ? hasUsedForcedTool
+        ? nextToolConfig
+        : originalToolChoice
+      : undefined,
   }
 }

--- a/sim/providers/utils.ts
+++ b/sim/providers/utils.ts
@@ -490,3 +490,178 @@ export function getApiKey(provider: string, model: string, userProvidedKey?: str
 
   return userProvidedKey!
 }
+
+/**
+ * Prepares tool configuration for provider requests with consistent tool usage control behavior
+ *
+ * @param tools Array of tools in provider-specific format
+ * @param providerTools Original tool configurations with usage control settings
+ * @param logger Logger instance to use for logging
+ * @param provider Optional provider ID to adjust format for specific providers
+ * @returns Object with prepared tools and tool_choice settings
+ */
+export function prepareToolsWithUsageControl(
+  tools: any[] | undefined,
+  providerTools: any[] | undefined,
+  logger: any,
+  provider?: string
+): {
+  tools: any[] | undefined
+  toolChoice:
+    | 'auto'
+    | 'none'
+    | { type: 'function'; function: { name: string } }
+    | { type: 'tool'; name: string }
+    | { type: 'any'; any: { model: string; name: string } }
+    | undefined
+  hasFilteredTools: boolean
+} {
+  // If no tools, return early
+  if (!tools || tools.length === 0) {
+    return { tools: undefined, toolChoice: undefined, hasFilteredTools: false }
+  }
+
+  // Filter out tools marked with usageControl='none'
+  const filteredTools = tools.filter((tool) => {
+    const toolId = tool.function?.name || tool.name
+    const toolConfig = providerTools?.find((t) => t.id === toolId)
+    return toolConfig?.usageControl !== 'none'
+  })
+
+  // Check if any tools were filtered out
+  const hasFilteredTools = filteredTools.length < tools.length
+  if (hasFilteredTools) {
+    logger.info(
+      `Filtered out ${tools.length - filteredTools.length} tools with usageControl='none'`
+    )
+  }
+
+  // If all tools were filtered out, return empty
+  if (filteredTools.length === 0) {
+    logger.info('All tools were filtered out due to usageControl="none"')
+    return { tools: undefined, toolChoice: undefined, hasFilteredTools: true }
+  }
+
+  // Get tools that should be forced
+  const forcedTools = providerTools?.filter((tool) => tool.usageControl === 'force') || []
+
+  // Determine tool_choice setting
+  let toolChoice:
+    | 'auto'
+    | 'none'
+    | { type: 'function'; function: { name: string } }
+    | { type: 'tool'; name: string }
+    | { type: 'any'; any: { model: string; name: string } } = 'auto'
+
+  if (forcedTools.length > 0) {
+    // Force the first tool that has usageControl='force'
+    const forcedTool = forcedTools[0]
+
+    // Adjust format based on provider
+    if (provider === 'anthropic') {
+      toolChoice = {
+        type: 'tool',
+        name: forcedTool.id,
+      }
+    } else if (provider === 'google') {
+      // Google Gemini format uses "any" type with tool name
+      toolChoice = {
+        type: 'any',
+        any: {
+          model: 'latest',
+          name: forcedTool.id,
+        },
+      }
+    } else {
+      // Default OpenAI format
+      toolChoice = {
+        type: 'function',
+        function: { name: forcedTool.id },
+      }
+    }
+
+    logger.info(`Forcing use of tool: ${forcedTool.id}`)
+
+    if (forcedTools.length > 1) {
+      logger.info(
+        `Multiple tools set to 'force' mode, but only the first one (${forcedTool.id}) will be forced`
+      )
+    }
+  } else {
+    // Default to auto if no forced tools
+    toolChoice = 'auto'
+    logger.info('Setting tool_choice to auto - letting model decide which tools to use')
+  }
+
+  return {
+    tools: filteredTools,
+    toolChoice,
+    hasFilteredTools,
+  }
+}
+
+/**
+ * Checks if a forced tool has been used in a response and manages the tool_choice accordingly
+ *
+ * @param toolCallsResponse Array of tool calls in the response
+ * @param originalToolChoice The original tool_choice setting used in the request
+ * @param logger Logger instance to use for logging
+ * @param provider Optional provider ID to adjust format for specific providers
+ * @returns Object containing hasUsedForcedTool flag and toolChoice for next request
+ */
+export function trackForcedToolUsage(
+  toolCallsResponse: any[] | undefined,
+  originalToolChoice: any,
+  logger: any,
+  provider?: string
+): {
+  hasUsedForcedTool: boolean
+  nextToolChoice:
+    | 'auto'
+    | { type: 'function'; function: { name: string } }
+    | { type: 'tool'; name: string }
+    | { type: 'any'; any: { model: string; name: string } }
+    | null
+} {
+  // Default to keeping the original tool_choice
+  let hasUsedForcedTool = false
+  let nextToolChoice = originalToolChoice
+
+  // If we're forcing a specific tool and we have tool calls in the response
+  if (
+    typeof originalToolChoice === 'object' &&
+    (originalToolChoice?.function?.name ||
+      (originalToolChoice?.type === 'tool' && originalToolChoice?.name) ||
+      (originalToolChoice?.type === 'any' && originalToolChoice?.any?.name)) &&
+    toolCallsResponse &&
+    toolCallsResponse.length > 0
+  ) {
+    // Get the name of the forced tool
+    const forcedToolName =
+      originalToolChoice?.function?.name ||
+      originalToolChoice?.name ||
+      originalToolChoice?.any?.name
+
+    // Check if any of the tool calls used the forced tool
+    const toolNames = toolCallsResponse.map((tc) => tc.function?.name || tc.name || tc.id)
+
+    if (toolNames.includes(forcedToolName)) {
+      // The forced tool was used
+      hasUsedForcedTool = true
+
+      // For Anthropic, we need to return null to signal deletion of the parameter
+      // For Google/Gemini, we return 'auto'
+      // For other providers, we return 'auto'
+      nextToolChoice = provider === 'anthropic' ? null : 'auto'
+
+      logger.info(
+        `Forced tool ${forcedToolName} was used, switching to auto mode for future iterations`
+      )
+    }
+  }
+
+  return {
+    hasUsedForcedTool,
+    nextToolChoice: hasUsedForcedTool ? nextToolChoice : originalToolChoice,
+  }
+}

--- a/sim/providers/xai/index.ts
+++ b/sim/providers/xai/index.ts
@@ -90,12 +90,11 @@ export const xAIProvider: ProviderConfig = {
 
       // Handle tools and tool usage control
       if (tools?.length) {
-        const { tools: filteredTools, toolChoice } = prepareToolsWithUsageControl(
-          tools,
-          request.tools,
-          logger,
-          'xai'
-        )
+        const {
+          tools: filteredTools,
+          toolChoice,
+          forcedTools,
+        } = prepareToolsWithUsageControl(tools, request.tools, logger, 'xai')
 
         if (filteredTools?.length && toolChoice) {
           payload.tools = filteredTools
@@ -123,6 +122,12 @@ export const xAIProvider: ProviderConfig = {
 
       // Track the original tool_choice for forced tool tracking
       const originalToolChoice = payload.tool_choice
+
+      // Track forced tools and their usage
+      const forcedTools = tools?.length
+        ? prepareToolsWithUsageControl(tools, request.tools, logger, 'xai').forcedTools
+        : []
+      let usedForcedTools: string[] = []
 
       let currentResponse = await xai.chat.completions.create(payload)
       const firstResponseTime = Date.now() - initialCallTime
@@ -163,8 +168,16 @@ export const xAIProvider: ProviderConfig = {
         currentResponse.choices[0]?.message?.tool_calls
       ) {
         const toolCallsResponse = currentResponse.choices[0].message.tool_calls
-        const result = trackForcedToolUsage(toolCallsResponse, originalToolChoice, logger, 'xai')
+        const result = trackForcedToolUsage(
+          toolCallsResponse,
+          originalToolChoice,
+          logger,
+          'xai',
+          forcedTools,
+          usedForcedTools
+        )
         hasUsedForcedTool = result.hasUsedForcedTool
+        usedForcedTools = result.usedForcedTools
       }
 
       try {
@@ -251,12 +264,27 @@ export const xAIProvider: ProviderConfig = {
             messages: currentMessages,
           }
 
-          // If we've used the forced tool, switch to 'auto' mode for subsequent requests
-          if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
-            nextPayload.tool_choice = 'auto'
-            logger.info(
-              'Switching to auto tool_choice for subsequent requests after forced tool was used'
-            )
+          // Update tool_choice based on which forced tools have been used
+          if (
+            typeof originalToolChoice === 'object' &&
+            hasUsedForcedTool &&
+            forcedTools.length > 0
+          ) {
+            // If we have remaining forced tools, get the next one to force
+            const remainingTools = forcedTools.filter((tool) => !usedForcedTools.includes(tool))
+
+            if (remainingTools.length > 0) {
+              // Force the next tool
+              nextPayload.tool_choice = {
+                type: 'function',
+                function: { name: remainingTools[0] },
+              }
+              logger.info(`Forcing next tool: ${remainingTools[0]}`)
+            } else {
+              // All forced tools have been used, switch to auto
+              nextPayload.tool_choice = 'auto'
+              logger.info('All forced tools have been used, switching to auto tool_choice')
+            }
           }
 
           // Time the next model call
@@ -264,20 +292,22 @@ export const xAIProvider: ProviderConfig = {
 
           currentResponse = await xai.chat.completions.create(nextPayload)
 
-          // Check if a forced tool was used in this response (if not already used)
+          // Check if any forced tools were used in this response
           if (
-            !hasUsedForcedTool &&
-            typeof originalToolChoice === 'object' &&
+            typeof nextPayload.tool_choice === 'object' &&
             currentResponse.choices[0]?.message?.tool_calls
           ) {
             const toolCallsResponse = currentResponse.choices[0].message.tool_calls
             const result = trackForcedToolUsage(
               toolCallsResponse,
-              originalToolChoice,
+              nextPayload.tool_choice,
               logger,
-              'xai'
+              'xai',
+              forcedTools,
+              usedForcedTools
             )
-            hasUsedForcedTool = result.hasUsedForcedTool
+            hasUsedForcedTool = result.hasUsedForcedTool || hasUsedForcedTool
+            usedForcedTools = result.usedForcedTools
           }
 
           const nextModelEndTime = Date.now()

--- a/sim/providers/xai/index.ts
+++ b/sim/providers/xai/index.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai'
 import { createLogger } from '@/lib/logs/console-logger'
 import { executeTool } from '@/tools'
 import { ProviderConfig, ProviderRequest, ProviderResponse, TimeSegment } from '../types'
+import { prepareToolsWithUsageControl, trackForcedToolUsage } from '../utils'
 
 const logger = createLogger('XAI Provider')
 
@@ -87,13 +88,42 @@ export const xAIProvider: ProviderConfig = {
         }
       }
 
+      // Handle tools and tool usage control
       if (tools?.length) {
-        payload.tools = tools
-        payload.tool_choice = 'auto'
+        const { tools: filteredTools, toolChoice } = prepareToolsWithUsageControl(
+          tools,
+          request.tools,
+          logger,
+          'xai'
+        )
+
+        if (filteredTools?.length && toolChoice) {
+          payload.tools = filteredTools
+          payload.tool_choice = toolChoice
+
+          logger.info(`XAI request configuration:`, {
+            toolCount: filteredTools.length,
+            toolChoice:
+              typeof toolChoice === 'string'
+                ? toolChoice
+                : toolChoice.type === 'function'
+                  ? `force:${toolChoice.function.name}`
+                  : toolChoice.type === 'tool'
+                    ? `force:${toolChoice.name}`
+                    : toolChoice.type === 'any'
+                      ? `force:${toolChoice.any?.name || 'unknown'}`
+                      : 'unknown',
+            model: request.model || 'grok-2-latest',
+          })
+        }
       }
 
       // Make the initial API request
       const initialCallTime = Date.now()
+
+      // Track the original tool_choice for forced tool tracking
+      const originalToolChoice = payload.tool_choice
+
       let currentResponse = await xai.chat.completions.create(payload)
       const firstResponseTime = Date.now() - initialCallTime
 
@@ -108,6 +138,9 @@ export const xAIProvider: ProviderConfig = {
       let currentMessages = [...allMessages]
       let iterationCount = 0
       const MAX_ITERATIONS = 10
+
+      // Track if a forced tool has been used
+      let hasUsedForcedTool = false
 
       // Track time spent in model vs tools
       let modelTime = firstResponseTime
@@ -124,8 +157,19 @@ export const xAIProvider: ProviderConfig = {
         },
       ]
 
+      // Check if a forced tool was used in the first response
+      if (
+        typeof originalToolChoice === 'object' &&
+        currentResponse.choices[0]?.message?.tool_calls
+      ) {
+        const toolCallsResponse = currentResponse.choices[0].message.tool_calls
+        const result = trackForcedToolUsage(toolCallsResponse, originalToolChoice, logger, 'xai')
+        hasUsedForcedTool = result.hasUsedForcedTool
+      }
+
       try {
         while (iterationCount < MAX_ITERATIONS) {
+          // Check for tool calls
           const toolCallsInResponse = currentResponse.choices[0]?.message?.tool_calls
           if (!toolCallsInResponse || toolCallsInResponse.length === 0) {
             break
@@ -207,10 +251,34 @@ export const xAIProvider: ProviderConfig = {
             messages: currentMessages,
           }
 
+          // If we've used the forced tool, switch to 'auto' mode for subsequent requests
+          if (hasUsedForcedTool && typeof originalToolChoice === 'object') {
+            nextPayload.tool_choice = 'auto'
+            logger.info(
+              'Switching to auto tool_choice for subsequent requests after forced tool was used'
+            )
+          }
+
           // Time the next model call
           const nextModelStartTime = Date.now()
 
           currentResponse = await xai.chat.completions.create(nextPayload)
+
+          // Check if a forced tool was used in this response (if not already used)
+          if (
+            !hasUsedForcedTool &&
+            typeof originalToolChoice === 'object' &&
+            currentResponse.choices[0]?.message?.tool_calls
+          ) {
+            const toolCallsResponse = currentResponse.choices[0].message.tool_calls
+            const result = trackForcedToolUsage(
+              toolCallsResponse,
+              originalToolChoice,
+              logger,
+              'xai'
+            )
+            hasUsedForcedTool = result.hasUsedForcedTool
+          }
 
           const nextModelEndTime = Date.now()
           const thisModelTime = nextModelEndTime - nextModelStartTime


### PR DESCRIPTION
- **added tool usage config to agents' tools, some more things to do**
- **allow sequential forcing of multiple tools for providers that support it**
- **remove google from the list of providers with granular tool usage control**
- **conditionally render tool usage icons if the model supports it**
- **fixed styles and added unit tests**

## Description

Added granular tool usage control for the model providers that support it. Sometimes, users want to force a tool call every time an agent is called, and this allows them that granular control. If they choose not to modify it, it is on auto like it was before and there is no change. This was only added for model providers that support it.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I tested this manually for openai, anthropic, and deepseek models which are the providers that allow this type of granular control. For the models that don't support it, we just let the model auto-select the tools as normal.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`npm test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes


## Additional Information:

May need some styling improvements.