### PR TITLE
fix(blocks): fixed router and evaluator block, added autofill & tests

### DIFF
--- a/sim/blocks/blocks/router.ts
+++ b/sim/blocks/blocks/router.ts
@@ -55,7 +55,7 @@ ID: ${block.id}
 Type: ${block.type}
 Title: ${block.title}
 Description: ${block.description}
-Category: ${block.category}
+System Prompt: ${JSON.stringify(block.subBlocks?.systemPrompt || '')}
 Configuration: ${JSON.stringify(block.subBlocks, null, 2)}
 ${block.currentState ? `Current State: ${JSON.stringify(block.currentState, null, 2)}` : ''}
 ---`
@@ -64,7 +64,8 @@ ${block.currentState ? `Current State: ${JSON.stringify(block.currentState, null
 
 Routing Instructions:
 1. Analyze the input request carefully against each block's:
-   - Primary purpose (from description)
+   - Primary purpose (from title, description, and system prompt)
+   - Look for keywords in the system prompt that match the user's request
    - Configuration settings
    - Current state (if available)
    - Processing capabilities

--- a/sim/executor/handlers/evaluator/evaluator-handler.ts
+++ b/sim/executor/handlers/evaluator/evaluator-handler.ts
@@ -1,6 +1,5 @@
 import { createLogger } from '@/lib/logs/console-logger'
 import { BlockOutput } from '@/blocks/types'
-import { executeProviderRequest } from '@/providers'
 import { getProviderFromModel } from '@/providers/utils'
 import { SerializedBlock } from '@/serializer/types'
 import { BlockHandler, ExecutionContext } from '../../types'
@@ -102,129 +101,162 @@ export class EvaluatorBlockHandler implements BlockHandler {
         'Evaluate the content and provide scores for each metric as JSON.'
     }
 
-    // Make sure we force JSON output in the request
-    const response = await executeProviderRequest(providerId, {
-      model: model,
-      systemPrompt: systemPromptObj.systemPrompt,
-      responseFormat: systemPromptObj.responseFormat,
-      messages: [
-        {
-          role: 'user',
-          content:
-            'Please evaluate the content provided in the system prompt. Return ONLY a valid JSON with metric scores.',
-        },
-      ],
-      temperature: inputs.temperature || 0,
-      apiKey: inputs.apiKey,
-    })
-
-    // Parse response content with robust error handling
-    let parsedContent: Record<string, any> = {}
     try {
-      const contentStr = response.content.trim()
-      let jsonStr = ''
+      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || ''
+      const url = new URL('/api/providers', baseUrl)
+      
+      // Make sure we force JSON output in the request
+      const providerRequest = {
+        provider: providerId,
+        model: model,
+        systemPrompt: systemPromptObj.systemPrompt,
+        responseFormat: systemPromptObj.responseFormat,
+        context: JSON.stringify([
+          {
+            role: 'user',
+            content: 'Please evaluate the content provided in the system prompt. Return ONLY a valid JSON with metric scores.',
+          },
+        ]),
+        temperature: inputs.temperature || 0,
+        apiKey: inputs.apiKey,
+        workflowId: context.workflowId,
+      }
+      
+      const response = await fetch(url.toString(), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(providerRequest),
+      })
 
-      // Method 1: Extract content between first { and last }
-      const fullMatch = contentStr.match(/(\{[\s\S]*\})/) // Regex to find JSON structure
-      if (fullMatch) {
-        jsonStr = fullMatch[0]
-      }
-      // Method 2: Try to find and extract just the JSON part
-      else if (contentStr.includes('{') && contentStr.includes('}')) {
-        const startIdx = contentStr.indexOf('{')
-        const endIdx = contentStr.lastIndexOf('}') + 1
-        jsonStr = contentStr.substring(startIdx, endIdx)
-      }
-      // Method 3: Just use the raw content as a last resort
-      else {
-        jsonStr = contentStr
+      if (!response.ok) {
+        // Try to extract a helpful error message
+        let errorMessage = `Provider API request failed with status ${response.status}`
+        try {
+          const errorData = await response.json()
+          if (errorData.error) {
+            errorMessage = errorData.error
+          }
+        } catch (e) {
+          // If JSON parsing fails, use the original error message
+        }
+        throw new Error(errorMessage)
       }
 
-      // Try to parse the extracted JSON
+      const result = await response.json()
+
+      // Parse response content with robust error handling
+      let parsedContent: Record<string, any> = {}
       try {
-        parsedContent = JSON.parse(jsonStr)
-      } catch (parseError) {
-        logger.error('Failed to parse extracted JSON:', parseError)
-        throw new Error('Invalid JSON in response')
+        const contentStr = result.content.trim()
+        let jsonStr = ''
+
+        // Method 1: Extract content between first { and last }
+        const fullMatch = contentStr.match(/(\{[\s\S]*\})/) // Regex to find JSON structure
+        if (fullMatch) {
+          jsonStr = fullMatch[0]
+        }
+        // Method 2: Try to find and extract just the JSON part
+        else if (contentStr.includes('{') && contentStr.includes('}')) {
+          const startIdx = contentStr.indexOf('{')
+          const endIdx = contentStr.lastIndexOf('}') + 1
+          jsonStr = contentStr.substring(startIdx, endIdx)
+        }
+        // Method 3: Just use the raw content as a last resort
+        else {
+          jsonStr = contentStr
+        }
+
+        // Try to parse the extracted JSON
+        try {
+          parsedContent = JSON.parse(jsonStr)
+        } catch (parseError) {
+          logger.error('Failed to parse extracted JSON:', parseError)
+          throw new Error('Invalid JSON in response')
+        }
+      } catch (error) {
+        logger.error('Error parsing evaluator response:', error)
+        logger.error('Raw response content:', result.content)
+
+        // Fallback to empty object
+        parsedContent = {}
       }
-    } catch (error) {
-      logger.error('Error parsing evaluator response:', error)
-      logger.error('Raw response content:', response.content)
 
-      // Fallback to empty object
-      parsedContent = {}
-    }
+      // Extract and process metric scores with proper validation
+      const metricScores: Record<string, any> = {}
 
-    // Extract and process metric scores with proper validation
-    const metricScores: Record<string, any> = {}
+      try {
+        // Ensure metrics is an array before processing
+        const validMetrics = Array.isArray(inputs.metrics) ? inputs.metrics : []
 
-    try {
-      // Ensure metrics is an array before processing
-      const validMetrics = Array.isArray(inputs.metrics) ? inputs.metrics : []
-
-      // If we have a successful parse, extract the metrics
-      if (Object.keys(parsedContent).length > 0) {
-        validMetrics.forEach((metric: any) => {
-          // Check if metric and name are valid before proceeding
-          if (!metric || !metric.name) {
-            logger.warn('Skipping invalid metric entry during score extraction:', metric)
-            return // Skip this iteration
-          }
-
-          const metricName = metric.name
-          const lowerCaseMetricName = metricName.toLowerCase()
-
-          // Try multiple possible ways the metric might be represented
-          if (parsedContent[metricName] !== undefined) {
-            metricScores[lowerCaseMetricName] = Number(parsedContent[metricName])
-          } else if (parsedContent[metricName.toLowerCase()] !== undefined) {
-            metricScores[lowerCaseMetricName] = Number(parsedContent[metricName.toLowerCase()])
-          } else if (parsedContent[metricName.toUpperCase()] !== undefined) {
-            metricScores[lowerCaseMetricName] = Number(parsedContent[metricName.toUpperCase()])
-          } else {
-            // Last resort - try to find any key that might contain this metric name
-            const matchingKey = Object.keys(parsedContent).find((key) => {
-              // Add check for key validity before calling toLowerCase()
-              return typeof key === 'string' && key.toLowerCase().includes(lowerCaseMetricName)
-            })
-
-            if (matchingKey) {
-              metricScores[lowerCaseMetricName] = Number(parsedContent[matchingKey])
-            } else {
-              logger.warn(`Metric "${metricName}" not found in LLM response`)
-              metricScores[lowerCaseMetricName] = 0
+        // If we have a successful parse, extract the metrics
+        if (Object.keys(parsedContent).length > 0) {
+          validMetrics.forEach((metric: any) => {
+            // Check if metric and name are valid before proceeding
+            if (!metric || !metric.name) {
+              logger.warn('Skipping invalid metric entry during score extraction:', metric)
+              return // Skip this iteration
             }
-          }
-        })
-      } else {
-        // If we couldn't parse any content, set all metrics to 0
-        validMetrics.forEach((metric: any) => {
-          // Ensure metric and name are valid before setting default score
-          if (metric && metric.name) {
-            metricScores[metric.name.toLowerCase()] = 0
-          } else {
-            logger.warn('Skipping invalid metric entry when setting default scores:', metric)
-          }
-        })
+
+            const metricName = metric.name
+            const lowerCaseMetricName = metricName.toLowerCase()
+
+            // Try multiple possible ways the metric might be represented
+            if (parsedContent[metricName] !== undefined) {
+              metricScores[lowerCaseMetricName] = Number(parsedContent[metricName])
+            } else if (parsedContent[metricName.toLowerCase()] !== undefined) {
+              metricScores[lowerCaseMetricName] = Number(parsedContent[metricName.toLowerCase()])
+            } else if (parsedContent[metricName.toUpperCase()] !== undefined) {
+              metricScores[lowerCaseMetricName] = Number(parsedContent[metricName.toUpperCase()])
+            } else {
+              // Last resort - try to find any key that might contain this metric name
+              const matchingKey = Object.keys(parsedContent).find((key) => {
+                // Add check for key validity before calling toLowerCase()
+                return typeof key === 'string' && key.toLowerCase().includes(lowerCaseMetricName)
+              })
+
+              if (matchingKey) {
+                metricScores[lowerCaseMetricName] = Number(parsedContent[matchingKey])
+              } else {
+                logger.warn(`Metric "${metricName}" not found in LLM response`)
+                metricScores[lowerCaseMetricName] = 0
+              }
+            }
+          })
+        } else {
+          // If we couldn't parse any content, set all metrics to 0
+          validMetrics.forEach((metric: any) => {
+            // Ensure metric and name are valid before setting default score
+            if (metric && metric.name) {
+              metricScores[metric.name.toLowerCase()] = 0
+            } else {
+              logger.warn('Skipping invalid metric entry when setting default scores:', metric)
+            }
+          })
+        }
+      } catch (e) {
+        logger.error('Error extracting metric scores:', e)
       }
-    } catch (e) {
-      logger.error('Error extracting metric scores:', e)
-    }
 
-    // Create result with metrics as direct fields for easy access
-    const result = {
-      response: {
-        content: inputs.content,
-        model: response.model,
-        tokens: {
-          prompt: response.tokens?.prompt || 0,
-          completion: response.tokens?.completion || 0,
-          total: response.tokens?.total || 0,
+      // Create result with metrics as direct fields for easy access
+      const outputResult = {
+        response: {
+          content: inputs.content,
+          model: result.model,
+          tokens: {
+            prompt: result.tokens?.prompt || 0,
+            completion: result.tokens?.completion || 0,
+            total: result.tokens?.total || 0,
+          },
+          ...metricScores,
         },
-        ...metricScores,
-      },
-    }
+      }
 
-    return result
+      return outputResult
+    } catch (error) {
+      logger.error('Evaluator execution failed:', error)
+      throw error
+    }
   }
 }


### PR DESCRIPTION
## Description

Fixed router and evaluator block, added autofill & tests. Now all provider blocks (evalautor, router, agent) all execute server-side and have autofill based on the model provider selected in the dropdown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring (no functional changes)

## How Has This Been Tested?

Tested a huge workflow manually with evaluator, router, & agent block

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`npm test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes