### PR TITLE
fix(workflow-preview): fixed the workflow preview to pull from state

### DIFF
--- a/apps/sim/app/api/workflows/[id]/deployed/route.ts
+++ b/apps/sim/app/api/workflows/[id]/deployed/route.ts
@@ -17,7 +17,7 @@ function addNoCacheHeaders(response: NextResponse): NextResponse {
   return response
 }
 
-export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   const requestId = crypto.randomUUID().slice(0, 8)
   const { id } = await params
 

--- a/apps/sim/app/api/workflows/[id]/deployed/route.ts
+++ b/apps/sim/app/api/workflows/[id]/deployed/route.ts
@@ -6,7 +6,7 @@ import { workflow } from '@/db/schema'
 import { validateWorkflowAccess } from '../../middleware'
 import { createErrorResponse, createSuccessResponse } from '../../utils'
 
-const logger = createLogger('WorkflowDeployedAPI')
+const logger = createLogger('WorkflowDeployedStateAPI')
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return createErrorResponse(validation.error.message, validation.error.status)
     }
 
-    // Fetch just the deployed state
+    // Fetch the workflow's deployed state
     const result = await db
       .select({
         deployedState: workflow.deployedState,
@@ -46,17 +46,16 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       logger.info(`[${requestId}] No deployed state available for workflow: ${id}`)
       return createSuccessResponse({
         deployedState: null,
-        isDeployed: false,
+        message: 'Workflow is not deployed or has no deployed state',
       })
     }
 
-    logger.info(`[${requestId}] Successfully retrieved DEPLOYED state: ${id}`)
+    logger.info(`[${requestId}] Successfully retrieved deployed state for: ${id}`)
     return createSuccessResponse({
       deployedState: workflowData.deployedState,
-      isDeployed: true,
     })
   } catch (error: any) {
     logger.error(`[${requestId}] Error fetching deployed state: ${id}`, error)
     return createErrorResponse(error.message || 'Failed to fetch deployed state', 500)
   }
-}
+} 

--- a/apps/sim/app/api/workflows/[id]/deployed/route.ts
+++ b/apps/sim/app/api/workflows/[id]/deployed/route.ts
@@ -17,7 +17,7 @@ function addNoCacheHeaders(response: NextResponse): NextResponse {
   return response
 }
 
-export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const requestId = crypto.randomUUID().slice(0, 8)
   const { id } = await params
 

--- a/apps/sim/app/api/workflows/[id]/deployed/route.ts
+++ b/apps/sim/app/api/workflows/[id]/deployed/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { eq } from 'drizzle-orm'
 import { createLogger } from '@/lib/logs/console-logger'
 import { db } from '@/db'
@@ -11,6 +11,12 @@ const logger = createLogger('WorkflowDeployedStateAPI')
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
+// Helper function to add Cache-Control headers to NextResponse
+function addNoCacheHeaders(response: NextResponse): NextResponse {
+  response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+  return response
+}
+
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const requestId = crypto.randomUUID().slice(0, 8)
   const { id } = await params
@@ -21,7 +27,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     if (validation.error) {
       logger.warn(`[${requestId}] Failed to fetch deployed state: ${validation.error.message}`)
-      return createErrorResponse(validation.error.message, validation.error.status)
+      const response = createErrorResponse(validation.error.message, validation.error.status)
+      return addNoCacheHeaders(response)
     }
 
     // Fetch the workflow's deployed state
@@ -36,7 +43,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     if (result.length === 0) {
       logger.warn(`[${requestId}] Workflow not found: ${id}`)
-      return createErrorResponse('Workflow not found', 404)
+      const response = createErrorResponse('Workflow not found', 404)
+      return addNoCacheHeaders(response)
     }
 
     const workflowData = result[0]
@@ -44,18 +52,21 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     // If the workflow is not deployed, return appropriate response
     if (!workflowData.isDeployed || !workflowData.deployedState) {
       logger.info(`[${requestId}] No deployed state available for workflow: ${id}`)
-      return createSuccessResponse({
+      const response = createSuccessResponse({
         deployedState: null,
         message: 'Workflow is not deployed or has no deployed state',
       })
+      return addNoCacheHeaders(response)
     }
 
     logger.info(`[${requestId}] Successfully retrieved deployed state for: ${id}`)
-    return createSuccessResponse({
+    const response = createSuccessResponse({
       deployedState: workflowData.deployedState,
     })
+    return addNoCacheHeaders(response)
   } catch (error: any) {
     logger.error(`[${requestId}] Error fetching deployed state: ${id}`, error)
-    return createErrorResponse(error.message || 'Failed to fetch deployed state', 500)
+    const response = createErrorResponse(error.message || 'Failed to fetch deployed state', 500)
+    return addNoCacheHeaders(response)
   }
 } 

--- a/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/components/deployment-info/deployment-info.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/components/deployment-info/deployment-info.tsx
@@ -39,7 +39,6 @@ interface DeploymentInfoProps {
   onUndeploy: () => void
   isSubmitting: boolean
   isUndeploying: boolean
-  needsRedeployment: boolean
   workflowId: string | null
   deployedState: any
   isLoadingDeployedState: boolean
@@ -52,7 +51,6 @@ export function DeploymentInfo({
   onUndeploy,
   isSubmitting,
   isUndeploying,
-  needsRedeployment,
   workflowId,
   deployedState,
   isLoadingDeployedState
@@ -71,7 +69,7 @@ export function DeploymentInfo({
       logger.info(`Using cached deployed state for workflow: ${workflowId}`)
       setIsViewingDeployed(true)
       return
-    } else {
+    } else if (!isLoadingDeployedState) {
       logger.debug(`[${workflowId}] No deployed state found`)
       addNotification('error', 'Cannot view deployment: No deployed state available', workflowId)
     }

--- a/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/components/deployment-info/deployment-info.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/components/deployment-info/deployment-info.tsx
@@ -21,9 +21,12 @@ import { ApiKey } from '@/app/w/[id]/components/control-bar/components/deploy-mo
 import { DeployStatus } from '@/app/w/[id]/components/control-bar/components/deploy-modal/components/deployment-info/components/deploy-status/deploy-status'
 import { ExampleCommand } from '@/app/w/[id]/components/control-bar/components/deploy-modal/components/deployment-info/components/example-command/example-command'
 import { DeployedWorkflowModal } from '../../../deployment-controls/components/deployed-workflow-modal'
+import { createLogger } from '@/lib/logs/console-logger'
+
+const logger = createLogger('DeploymentInfo')
 
 interface DeploymentInfoProps {
-  isLoading: boolean
+  isLoading?: boolean
   deploymentInfo: {
     isDeployed: boolean
     deployedAt?: string
@@ -36,7 +39,10 @@ interface DeploymentInfoProps {
   onUndeploy: () => void
   isSubmitting: boolean
   isUndeploying: boolean
-  workflowId?: string
+  needsRedeployment: boolean
+  workflowId: string | null
+  deployedState: any
+  isLoadingDeployedState: boolean
 }
 
 export function DeploymentInfo({
@@ -46,10 +52,12 @@ export function DeploymentInfo({
   onUndeploy,
   isSubmitting,
   isUndeploying,
+  needsRedeployment,
   workflowId,
+  deployedState,
+  isLoadingDeployedState
 }: DeploymentInfoProps) {
   const [isViewingDeployed, setIsViewingDeployed] = useState(false)
-  const [deployedWorkflowState, setDeployedWorkflowState] = useState<any>(null)
   const { addNotification } = useNotificationStore()
 
   const handleViewDeployed = async () => {
@@ -57,29 +65,15 @@ export function DeploymentInfo({
       addNotification('error', 'Cannot view deployment: Workflow ID is missing', null)
       return
     }
-
-    try {
-      const response = await fetch(`/api/workflows/${workflowId}/deployed`)
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch deployed workflow')
-      }
-
-      const data = await response.json()
-
-      if (data && data.deployedState) {
-        setDeployedWorkflowState(data.deployedState)
-        setIsViewingDeployed(true)
-      } else {
-        addNotification('error', 'Failed to view deployment: No deployment state found', workflowId)
-      }
-    } catch (error) {
-      console.error('Error fetching deployed workflow:', error)
-      addNotification(
-        'error',
-        `Failed to fetch deployed workflow: ${(error as Error).message}`,
-        workflowId
-      )
+    
+    // If deployedState is already loaded, use it directly
+    if (deployedState) {
+      logger.info(`Using cached deployed state for workflow: ${workflowId}`)
+      setIsViewingDeployed(true)
+      return
+    } else {
+      logger.debug(`[${workflowId}] No deployed state found`)
+      addNotification('error', 'Cannot view deployment: No deployed state available', workflowId)
     }
   }
 
@@ -168,11 +162,11 @@ export function DeploymentInfo({
         </div>
       </div>
 
-      {deployedWorkflowState && (
+      {deployedState && (
         <DeployedWorkflowModal
           isOpen={isViewingDeployed}
           onClose={() => setIsViewingDeployed(false)}
-          deployedWorkflowState={deployedWorkflowState}
+          deployedWorkflowState={deployedState}
         />
       )}
     </>

--- a/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
@@ -35,6 +35,8 @@ interface DeployModalProps {
   workflowId: string | null
   needsRedeployment: boolean
   setNeedsRedeployment: (value: boolean) => void
+  deployedState: any
+  isLoadingDeployedState: boolean
 }
 
 interface ApiKey {
@@ -68,6 +70,8 @@ export function DeployModal({
   workflowId,
   needsRedeployment,
   setNeedsRedeployment,
+  deployedState,
+  isLoadingDeployedState,
 }: DeployModalProps) {
   // Store hooks
   const { addNotification } = useNotificationStore()
@@ -589,7 +593,10 @@ export function DeployModal({
                       onUndeploy={handleUndeploy}
                       isSubmitting={isSubmitting}
                       isUndeploying={isUndeploying}
-                      workflowId={workflowId || undefined}
+                      needsRedeployment={needsRedeployment}
+                      workflowId={workflowId}
+                      deployedState={deployedState}
+                      isLoadingDeployedState={isLoadingDeployedState}
                     />
                   ) : (
                     <>

--- a/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
@@ -37,6 +37,7 @@ interface DeployModalProps {
   setNeedsRedeployment: (value: boolean) => void
   deployedState: any
   isLoadingDeployedState: boolean
+  refetchDeployedState: () => Promise<void>
 }
 
 interface ApiKey {
@@ -72,6 +73,7 @@ export function DeployModal({
   setNeedsRedeployment,
   deployedState,
   isLoadingDeployedState,
+  refetchDeployedState,
 }: DeployModalProps) {
   // Store hooks
   const { addNotification } = useNotificationStore()
@@ -296,6 +298,10 @@ export function DeployModal({
 
       setDeploymentInfo(newDeploymentInfo)
 
+      // Fetch the updated deployed state after deployment
+      logger.info('Deployment successful, fetching initial deployed state')
+      await refetchDeployedState()
+
       // No notification on successful deploy
     } catch (error: any) {
       logger.error('Error deploying workflow:', { error })
@@ -376,6 +382,10 @@ export function DeployModal({
 
       // Reset the needs redeployment flag
       setNeedsRedeployment(false)
+
+      // Fetch the updated deployed state after redeployment
+      logger.info('Redeployment successful, fetching updated deployed state')
+      await refetchDeployedState()
 
       // Add a success notification
       addNotification('info', 'Workflow successfully redeployed', workflowId)

--- a/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
@@ -603,7 +603,6 @@ export function DeployModal({
                       onUndeploy={handleUndeploy}
                       isSubmitting={isSubmitting}
                       isUndeploying={isUndeploying}
-                      needsRedeployment={needsRedeployment}
                       workflowId={workflowId}
                       deployedState={deployedState}
                       isLoadingDeployedState={isLoadingDeployedState}

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
-import { WorkflowPreview } from '@/app/w/components/workflow-preview/generic-workflow-preview'
+import { WorkflowPreview } from '@/app/w/components/workflow-preview/workflow-preview'
 
 interface DeployedWorkflowCardProps {
   // Current workflow state (if any)
@@ -33,6 +33,7 @@ export function DeployedWorkflowCard({
 
   // Determine which workflow state to show
   const workflowToShow = showingDeployed ? deployedWorkflowState : currentWorkflowState
+  console.log('workflowToShow', workflowToShow)
 
   return (
     <Card className={cn('overflow-hidden', className)}>

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
 import { createLogger } from '@/lib/logs/console-logger'
 import { WorkflowPreview } from '@/app/w/components/workflow-preview/workflow-preview'
@@ -112,16 +114,22 @@ export function DeployedWorkflowCard({
             {showingDeployed ? 'Deployed Workflow' : 'Current Workflow'}
           </h3>
           {/* Controls */}
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
             {/* Version toggle - only show if there's a current version */}
             {currentWorkflowState && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowingDeployed(!showingDeployed)}
-              >
-                {showingDeployed ? 'Show Current' : 'Show Deployed'}
-              </Button>
+              <div className="flex items-center space-x-2">
+                <Label htmlFor="workflow-version-toggle" className="text-sm text-muted-foreground">
+                  Current
+                </Label>
+                <Switch 
+                  id="workflow-version-toggle"
+                  checked={showingDeployed} 
+                  onCheckedChange={setShowingDeployed}
+                />
+                <Label htmlFor="workflow-version-toggle" className="text-sm text-muted-foreground">
+                  Deployed
+                </Label>
+              </div>
             )}
           </div>
         </div>

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
@@ -1,10 +1,13 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
+import { createLogger } from '@/lib/logs/console-logger'
 import { WorkflowPreview } from '@/app/w/components/workflow-preview/workflow-preview'
+
+const logger = createLogger('DeployedWorkflowCard')
 
 interface DeployedWorkflowCardProps {
   // Current workflow state (if any)
@@ -35,6 +38,72 @@ export function DeployedWorkflowCard({
   const workflowToShow = showingDeployed ? deployedWorkflowState : currentWorkflowState
   console.log('workflowToShow', workflowToShow)
 
+  // Add detailed logging for debugging
+  useEffect(() => {
+    if (workflowToShow) {
+      // Log basic stats
+      const blockCount = Object.keys(workflowToShow.blocks || {}).length;
+      const blocksWithSubBlocks = Object.values(workflowToShow.blocks || {})
+        .filter(block => block.subBlocks && Object.keys(block.subBlocks).length > 0);
+      
+      logger.info(`[WORKFLOW-STATE] ${showingDeployed ? 'Deployed' : 'Current'} workflow with ${blockCount} blocks`, {
+        type: showingDeployed ? 'deployed' : 'current',
+        blockCount,
+        blocksWithSubBlocksCount: blocksWithSubBlocks.length,
+        // Log a sample of a block with subblocks if any exist
+        sampleBlock: blocksWithSubBlocks.length > 0 
+          ? {
+              id: blocksWithSubBlocks[0].id,
+              type: blocksWithSubBlocks[0].type,
+              subBlocksCount: Object.keys(blocksWithSubBlocks[0].subBlocks || {}).length,
+              subBlocksSample: Object.entries(blocksWithSubBlocks[0].subBlocks || {}).slice(0, 2)
+            }
+          : null
+      });
+      
+      // For deep debug, log each block's subblocks (limited data for readability)
+      Object.entries(workflowToShow.blocks || {}).forEach(([blockId, block]) => {
+        if (block.subBlocks && Object.keys(block.subBlocks).length > 0) {
+          logger.info(`[BLOCK-SUBBLOCKS] ${showingDeployed ? 'Deployed' : 'Current'} block ${blockId}`, {
+            blockId,
+            blockType: block.type,
+            subBlocksCount: Object.keys(block.subBlocks).length,
+            // Just log IDs to avoid huge logs, but include a couple of values as examples
+            subBlockIds: Object.keys(block.subBlocks),
+            sampleValues: Object.entries(block.subBlocks).slice(0, 2).map(([id, value]) => ({ id, value }))
+          });
+        }
+      });
+    }
+  }, [workflowToShow, showingDeployed]);
+  
+  // Create sanitized workflow state
+  const sanitizedWorkflowState = useMemo(() => {
+    if (!workflowToShow) return null;
+    
+    // Filter out invalid blocks and make deep clone to avoid reference issues
+    return {
+      blocks: Object.fromEntries(
+        Object.entries(workflowToShow.blocks || {})
+          .filter(([_, block]) => block && block.type) // Filter out invalid blocks
+          .map(([id, block]) => {
+            // Deep clone the block to avoid any reference sharing
+            const clonedBlock = JSON.parse(JSON.stringify(block));
+            return [id, clonedBlock];
+          })
+      ),
+      edges: workflowToShow.edges ? JSON.parse(JSON.stringify(workflowToShow.edges)) : [],
+      loops: workflowToShow.loops ? JSON.parse(JSON.stringify(workflowToShow.loops)) : {}
+    };
+  }, [workflowToShow]);
+
+  // Generate a unique key for the workflow preview
+  const previewKey = useMemo(() => {
+    return `${showingDeployed ? 'deployed' : 'current'}-preview-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+  }, [showingDeployed]);
+
+  {console.log('sanitizedWorkflowState', sanitizedWorkflowState)}
+
   return (
     <Card className={cn('overflow-hidden', className)}>
       <CardHeader className="space-y-4 p-4">
@@ -61,10 +130,10 @@ export function DeployedWorkflowCard({
       <CardContent className="p-0">
         {/* Workflow preview with fixed height */}
         <div className="h-[500px] w-full">
-          {workflowToShow ? (
+          {sanitizedWorkflowState ? (
             <WorkflowPreview
-              key={showingDeployed ? 'deployed-preview' : 'current-preview'} 
-              workflowState={workflowToShow}
+              key={previewKey}
+              workflowState={sanitizedWorkflowState}
               showSubBlocks={true}
               height="100%"
               width="100%"

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
@@ -38,46 +38,6 @@ export function DeployedWorkflowCard({
 
   // Determine which workflow state to show
   const workflowToShow = showingDeployed ? deployedWorkflowState : currentWorkflowState
-  console.log('workflowToShow', workflowToShow)
-
-  // Add detailed logging for debugging
-  useEffect(() => {
-    if (workflowToShow) {
-      // Log basic stats
-      const blockCount = Object.keys(workflowToShow.blocks || {}).length;
-      const blocksWithSubBlocks = Object.values(workflowToShow.blocks || {})
-        .filter(block => block.subBlocks && Object.keys(block.subBlocks).length > 0);
-      
-      logger.info(`[WORKFLOW-STATE] ${showingDeployed ? 'Deployed' : 'Current'} workflow with ${blockCount} blocks`, {
-        type: showingDeployed ? 'deployed' : 'current',
-        blockCount,
-        blocksWithSubBlocksCount: blocksWithSubBlocks.length,
-        // Log a sample of a block with subblocks if any exist
-        sampleBlock: blocksWithSubBlocks.length > 0 
-          ? {
-              id: blocksWithSubBlocks[0].id,
-              type: blocksWithSubBlocks[0].type,
-              subBlocksCount: Object.keys(blocksWithSubBlocks[0].subBlocks || {}).length,
-              subBlocksSample: Object.entries(blocksWithSubBlocks[0].subBlocks || {}).slice(0, 2)
-            }
-          : null
-      });
-      
-      // For deep debug, log each block's subblocks (limited data for readability)
-      Object.entries(workflowToShow.blocks || {}).forEach(([blockId, block]) => {
-        if (block.subBlocks && Object.keys(block.subBlocks).length > 0) {
-          logger.info(`[BLOCK-SUBBLOCKS] ${showingDeployed ? 'Deployed' : 'Current'} block ${blockId}`, {
-            blockId,
-            blockType: block.type,
-            subBlocksCount: Object.keys(block.subBlocks).length,
-            // Just log IDs to avoid huge logs, but include a couple of values as examples
-            subBlockIds: Object.keys(block.subBlocks),
-            sampleValues: Object.entries(block.subBlocks).slice(0, 2).map(([id, value]) => ({ id, value }))
-          });
-        }
-      });
-    }
-  }, [workflowToShow, showingDeployed]);
   
   // Create sanitized workflow state
   const sanitizedWorkflowState = useMemo(() => {
@@ -103,8 +63,6 @@ export function DeployedWorkflowCard({
   const previewKey = useMemo(() => {
     return `${showingDeployed ? 'deployed' : 'current'}-preview-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
   }, [showingDeployed]);
-
-  {console.log('sanitizedWorkflowState', sanitizedWorkflowState)}
 
   return (
     <Card className={cn('overflow-hidden', className)}>

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
@@ -62,6 +62,7 @@ export function DeployedWorkflowCard({
         <div className="h-[500px] w-full">
           {workflowToShow ? (
             <WorkflowPreview
+              key={showingDeployed ? 'deployed-preview' : 'current-preview'} 
               workflowState={workflowToShow}
               showSubBlocks={true}
               height="100%"

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
@@ -61,7 +61,7 @@ export function DeployedWorkflowCard({
 
   // Generate a unique key for the workflow preview
   const previewKey = useMemo(() => {
-    return `${showingDeployed ? 'deployed' : 'current'}-preview-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+    return `${showingDeployed ? 'deployed' : 'current'}-preview`;
   }, [showingDeployed]);
 
   return (

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -65,6 +65,45 @@ export function DeployedWorkflowModal({
     edges: state.edges,
     loops: state.loops,
   }))
+  
+  // Sanitize states to ensure no invalid blocks are passed to components
+  const sanitizedCurrentState = useMemo(() => {
+    if (!currentWorkflowState) return undefined;
+    
+    return {
+      blocks: Object.fromEntries(
+        Object.entries(currentWorkflowState.blocks || {})
+          .filter(([_, block]) => block && block.type)
+          .map(([id, block]) => {
+            // Deep clone the block to avoid any reference sharing
+            return [id, JSON.parse(JSON.stringify(block))];
+          })
+      ),
+      edges: currentWorkflowState.edges ? [...currentWorkflowState.edges] : [],
+      loops: currentWorkflowState.loops ? {...currentWorkflowState.loops} : {}
+    };
+  }, [currentWorkflowState]);
+  
+  const sanitizedDeployedState = useMemo(() => {
+    if (!deployedWorkflowState) return {
+      blocks: {},
+      edges: [],
+      loops: {}
+    };
+    
+    return {
+      blocks: Object.fromEntries(
+        Object.entries(deployedWorkflowState.blocks || {})
+          .filter(([_, block]) => block && block.type)
+          .map(([id, block]) => {
+            // Deep clone the block to avoid any reference sharing
+            return [id, JSON.parse(JSON.stringify(block))];
+          })
+      ),
+      edges: deployedWorkflowState.edges ? [...deployedWorkflowState.edges] : [],
+      loops: deployedWorkflowState.loops ? {...deployedWorkflowState.loops} : {}
+    };
+  }, [deployedWorkflowState]);
 
   const handleRevert = () => {
     if (activeWorkflowId) {
@@ -96,8 +135,8 @@ export function DeployedWorkflowModal({
           </div>
         ) : (
           <DeployedWorkflowCard
-            currentWorkflowState={currentWorkflowState}
-            deployedWorkflowState={deployedWorkflowState}
+            currentWorkflowState={sanitizedCurrentState}
+            deployedWorkflowState={sanitizedDeployedState}
           />
         )}
 

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-modal.tsx
@@ -97,7 +97,7 @@ export function DeployedWorkflowModal({
   const handleRevert = () => {
     if (activeWorkflowId) {
       logger.info(`Reverting to deployed state for workflow: ${activeWorkflowId}`)
-      revertToDeployedState(deployedWorkflowState)
+      revertToDeployedState(sanitizedDeployedState)
       setShowRevertDialog(false)
       onClose()
     }

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -47,17 +47,6 @@ export function DeployedWorkflowModal({
   const [isLoading, setIsLoading] = useState(false)
   const { revertToDeployedState } = useWorkflowStore()
   const activeWorkflowId = useWorkflowRegistry((state) => state.activeWorkflowId)
-
-  // Add debug logging to check deployedWorkflowState
-  useEffect(() => {
-    if (isOpen) {
-      if (deployedWorkflowState) {
-        logger.info(`DeployedWorkflowModal received state with ${Object.keys(deployedWorkflowState.blocks || {}).length} blocks`)
-      } else {
-        logger.warn('DeployedWorkflowModal opened but deployedWorkflowState is null or undefined')
-      }
-    }
-  }, [isOpen, deployedWorkflowState]);
 
   // Get current workflow state to compare with deployed state
   const currentWorkflowState = useWorkflowStore((state) => ({

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/deployment-controls.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/deployment-controls.tsx
@@ -15,12 +15,16 @@ interface DeploymentControlsProps {
   activeWorkflowId: string | null
   needsRedeployment: boolean
   setNeedsRedeployment: (value: boolean) => void
+  deployedState: any
+  isLoadingDeployedState: boolean
 }
 
 export function DeploymentControls({
   activeWorkflowId,
   needsRedeployment,
   setNeedsRedeployment,
+  deployedState,
+  isLoadingDeployedState,
 }: DeploymentControlsProps) {
   const { isDeployed } = useWorkflowStore()
   const [isDeploying, setIsDeploying] = useState(false)
@@ -74,6 +78,8 @@ export function DeploymentControls({
         workflowId={activeWorkflowId}
         needsRedeployment={needsRedeployment}
         setNeedsRedeployment={setNeedsRedeployment}
+        deployedState={deployedState}
+        isLoadingDeployedState={isLoadingDeployedState}
       />
     </>
   )

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/deployment-controls.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/deployment-controls.tsx
@@ -17,6 +17,7 @@ interface DeploymentControlsProps {
   setNeedsRedeployment: (value: boolean) => void
   deployedState: any
   isLoadingDeployedState: boolean
+  refetchDeployedState: () => Promise<void>
 }
 
 export function DeploymentControls({
@@ -25,6 +26,7 @@ export function DeploymentControls({
   setNeedsRedeployment,
   deployedState,
   isLoadingDeployedState,
+  refetchDeployedState,
 }: DeploymentControlsProps) {
   const { isDeployed } = useWorkflowStore()
   const [isDeploying, setIsDeploying] = useState(false)
@@ -80,6 +82,7 @@ export function DeploymentControls({
         setNeedsRedeployment={setNeedsRedeployment}
         deployedState={deployedState}
         isLoadingDeployedState={isLoadingDeployedState}
+        refetchDeployedState={refetchDeployedState}
       />
     </>
   )

--- a/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
@@ -104,6 +104,10 @@ export function ControlBar() {
   const [mounted, setMounted] = useState(false)
   const [, forceUpdate] = useState({})
 
+  // Add deployedState management
+  const [deployedState, setDeployedState] = useState<any>(null)
+  const [isLoadingDeployedState, setIsLoadingDeployedState] = useState<boolean>(false)
+
   // Workflow name editing state
   const [isEditing, setIsEditing] = useState(false)
   const [editedName, setEditedName] = useState('')
@@ -685,6 +689,8 @@ export function ControlBar() {
       activeWorkflowId={activeWorkflowId}
       needsRedeployment={needsRedeployment}
       setNeedsRedeployment={setNeedsRedeployment}
+      deployedState={deployedState}
+      isLoadingDeployedState={isLoadingDeployedState}
     />
   )
 
@@ -1119,6 +1125,63 @@ export function ControlBar() {
       </div>
     </div>
   )
+
+  // Fetch deployed state when the workflow ID changes or deployment status changes
+  useEffect(() => {
+    async function fetchDeployedState() {
+      if (!activeWorkflowId || !isDeployed) {
+        setDeployedState(null)
+        return
+      }
+
+      try {
+        setIsLoadingDeployedState(true)
+        logger.info(`[CENTRAL] Fetching deployed state for workflow: ${activeWorkflowId} (Control Bar - Single Source of Truth)`)
+        
+        const response = await fetch(`/api/workflows/${activeWorkflowId}/deployed`)
+        if (!response.ok) {
+          throw new Error(`Failed to fetch deployed state: ${response.status}`)
+        }
+        
+        const data = await response.json()
+        
+        if (data.deployedState) {
+          logger.info('Successfully fetched deployed state from DB - This is the only place that should fetch deployed state')
+          // Create a deep clone to ensure no reference sharing with current state
+          const deepClonedState = JSON.parse(JSON.stringify(data.deployedState))
+          setDeployedState(deepClonedState)
+        } else {
+          logger.warn('No deployed state found in the database')
+          setDeployedState(null)
+        }
+      } catch (error) {
+        logger.error('Error fetching deployed state:', error)
+        setDeployedState(null)
+      } finally {
+        setIsLoadingDeployedState(false)
+      }
+    }
+    
+    fetchDeployedState()
+  }, [activeWorkflowId, isDeployed])
+
+  // Listen for deployment status changes
+  useEffect(() => {
+    // When deployment status changes and isDeployed becomes true,
+    // that means a deployment just occurred, so reset the needsRedeployment flag
+    if (isDeployed) {
+      setNeedsRedeployment(false)
+      useWorkflowStore.getState().setNeedsRedeploymentFlag(false)
+      
+      // When a workflow is newly deployed, we need to fetch the deployed state
+      if (activeWorkflowId && deployedState === null) {
+        // We'll fetch the deployed state in the other useEffect
+      }
+    } else {
+      // If workflow is undeployed, clear the deployed state
+      setDeployedState(null)
+    }
+  }, [isDeployed, activeWorkflowId])
 
   return (
     <div className="flex h-16 w-full items-center justify-between bg-background border-b">

--- a/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
@@ -173,12 +173,6 @@ export function ControlBar() {
     return !!marketplaceData
   }
 
-  // Check if the current user is the owner of the published workflow
-  const isWorkflowOwner = () => {
-    const marketplaceData = getMarketplaceData()
-    return marketplaceData?.status === 'owner'
-  }
-
   // Client-side only rendering for the timestamp
   useEffect(() => {
     setMounted(true)
@@ -320,6 +314,100 @@ export function ControlBar() {
     }
     checkStatus()
   }, [activeWorkflowId, setDeploymentStatus])
+
+  // Add a function to explicitly fetch deployed state that can be called after redeployment
+  const refetchDeployedState = async () => {
+    if (!activeWorkflowId || !isDeployed) {
+      setDeployedState(null)
+      return;
+    }
+
+    try {
+      setIsLoadingDeployedState(true);
+      logger.info(`[CENTRAL] Explicitly refetching deployed state for workflow: ${activeWorkflowId}`);
+      
+      const response = await fetch(`/api/workflows/${activeWorkflowId}/deployed`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch deployed state: ${response.status}`);
+      }
+      
+      const data = await response.json();
+      
+      if (data.deployedState) {
+        logger.info('Successfully refetched deployed state from DB after redeployment');
+        // Create a deep clone to ensure no reference sharing with current state
+        const deepClonedState = JSON.parse(JSON.stringify(data.deployedState));
+        logger.info('deepClonedState', deepClonedState)
+        setDeployedState(deepClonedState);
+      } else {
+        logger.warn('No deployed state found in the database after refetch');
+        setDeployedState(null);
+      }
+    } catch (error) {
+      logger.error('Error refetching deployed state:', error);
+      setDeployedState(null);
+    } finally {
+      setIsLoadingDeployedState(false);
+    }
+  };
+
+  // Fetch deployed state when the workflow ID changes or deployment status changes
+  useEffect(() => {
+    async function fetchDeployedState() {
+      if (!activeWorkflowId || !isDeployed) {
+        setDeployedState(null)
+        return
+      }
+
+      try {
+        setIsLoadingDeployedState(true)
+        logger.info(`[CENTRAL] Fetching deployed state for workflow: ${activeWorkflowId} (Control Bar - Single Source of Truth)`)
+        
+        const response = await fetch(`/api/workflows/${activeWorkflowId}/deployed`)
+        if (!response.ok) {
+          throw new Error(`Failed to fetch deployed state: ${response.status}`)
+        }
+        
+        const data = await response.json()
+        
+        if (data.deployedState) {
+          logger.info('Successfully fetched deployed state from DB - This is the only place that should fetch deployed state')
+          // Create a deep clone to ensure no reference sharing with current state
+          const deepClonedState = JSON.parse(JSON.stringify(data.deployedState))
+          logger.info('deepClonedState', deepClonedState)
+          setDeployedState(deepClonedState)
+        } else {
+          logger.warn('No deployed state found in the database')
+          setDeployedState(null)
+        }
+      } catch (error) {
+        logger.error('Error fetching deployed state:', error)
+        setDeployedState(null)
+      } finally {
+        setIsLoadingDeployedState(false)
+      }
+    }
+    
+    fetchDeployedState()
+  }, [activeWorkflowId, isDeployed])
+
+  // Listen for deployment status changes
+  useEffect(() => {
+    // When deployment status changes and isDeployed becomes true,
+    // that means a deployment just occurred, so reset the needsRedeployment flag
+    if (isDeployed) {
+      setNeedsRedeployment(false)
+      useWorkflowStore.getState().setNeedsRedeploymentFlag(false)
+      
+      // When a workflow is newly deployed, we need to fetch the deployed state
+      if (activeWorkflowId && deployedState === null) {
+        // We'll fetch the deployed state in the other useEffect
+      }
+    } else {
+      // If workflow is undeployed, clear the deployed state
+      setDeployedState(null)
+    }
+  }, [isDeployed, activeWorkflowId])
 
   // Listen for deployment status changes
   useEffect(() => {
@@ -691,6 +779,7 @@ export function ControlBar() {
       setNeedsRedeployment={setNeedsRedeployment}
       deployedState={deployedState}
       isLoadingDeployedState={isLoadingDeployedState}
+      refetchDeployedState={refetchDeployedState}
     />
   )
 
@@ -1125,63 +1214,6 @@ export function ControlBar() {
       </div>
     </div>
   )
-
-  // Fetch deployed state when the workflow ID changes or deployment status changes
-  useEffect(() => {
-    async function fetchDeployedState() {
-      if (!activeWorkflowId || !isDeployed) {
-        setDeployedState(null)
-        return
-      }
-
-      try {
-        setIsLoadingDeployedState(true)
-        logger.info(`[CENTRAL] Fetching deployed state for workflow: ${activeWorkflowId} (Control Bar - Single Source of Truth)`)
-        
-        const response = await fetch(`/api/workflows/${activeWorkflowId}/deployed`)
-        if (!response.ok) {
-          throw new Error(`Failed to fetch deployed state: ${response.status}`)
-        }
-        
-        const data = await response.json()
-        
-        if (data.deployedState) {
-          logger.info('Successfully fetched deployed state from DB - This is the only place that should fetch deployed state')
-          // Create a deep clone to ensure no reference sharing with current state
-          const deepClonedState = JSON.parse(JSON.stringify(data.deployedState))
-          setDeployedState(deepClonedState)
-        } else {
-          logger.warn('No deployed state found in the database')
-          setDeployedState(null)
-        }
-      } catch (error) {
-        logger.error('Error fetching deployed state:', error)
-        setDeployedState(null)
-      } finally {
-        setIsLoadingDeployedState(false)
-      }
-    }
-    
-    fetchDeployedState()
-  }, [activeWorkflowId, isDeployed])
-
-  // Listen for deployment status changes
-  useEffect(() => {
-    // When deployment status changes and isDeployed becomes true,
-    // that means a deployment just occurred, so reset the needsRedeployment flag
-    if (isDeployed) {
-      setNeedsRedeployment(false)
-      useWorkflowStore.getState().setNeedsRedeploymentFlag(false)
-      
-      // When a workflow is newly deployed, we need to fetch the deployed state
-      if (activeWorkflowId && deployedState === null) {
-        // We'll fetch the deployed state in the other useEffect
-      }
-    } else {
-      // If workflow is undeployed, clear the deployed state
-      setDeployedState(null)
-    }
-  }, [isDeployed, activeWorkflowId])
 
   return (
     <div className="flex h-16 w-full items-center justify-between bg-background border-b">

--- a/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
@@ -315,16 +315,27 @@ export function ControlBar() {
     checkStatus()
   }, [activeWorkflowId, setDeploymentStatus])
 
-  // Add a function to explicitly fetch deployed state that can be called after redeployment
-  const refetchDeployedState = async () => {
-    if (!activeWorkflowId || !isDeployed) {
-      setDeployedState(null)
+  /**
+   * Fetches the deployed state of the workflow from the server
+   * This is the single source of truth for deployed workflow state
+   * @param options.forceRefetch Force a refetch even if conditions wouldn't normally trigger it
+   * @returns Promise that resolves when the deployed state is fetched
+   */
+  const fetchDeployedState = async (options = { forceRefetch: false }) => {
+    // Skip fetching if we don't have an active workflow ID or it's not deployed
+    // unless we're explicitly forcing a refetch
+    if ((!activeWorkflowId || !isDeployed) && !options.forceRefetch) {
+      setDeployedState(null);
       return;
     }
 
     try {
       setIsLoadingDeployedState(true);
-      logger.info(`[CENTRAL] Explicitly refetching deployed state for workflow: ${activeWorkflowId}`);
+      const logMessage = options.forceRefetch 
+        ? `[CENTRAL] Explicitly refetching deployed state for workflow: ${activeWorkflowId}`
+        : `[CENTRAL] Fetching deployed state for workflow: ${activeWorkflowId} (Control Bar - Single Source of Truth)`;
+      
+      logger.info(logMessage);
       
       const response = await fetch(`/api/workflows/${activeWorkflowId}/deployed`);
       if (!response.ok) {
@@ -334,62 +345,39 @@ export function ControlBar() {
       const data = await response.json();
       
       if (data.deployedState) {
-        logger.info('Successfully refetched deployed state from DB after redeployment');
+        const successMessage = options.forceRefetch
+          ? 'Successfully refetched deployed state from DB after redeployment'
+          : 'Successfully fetched deployed state from DB - This is the only place that should fetch deployed state';
+        
+        logger.info(successMessage);
+        
         // Create a deep clone to ensure no reference sharing with current state
         const deepClonedState = JSON.parse(JSON.stringify(data.deployedState));
-        logger.info('deepClonedState', deepClonedState)
+        logger.info('deepClonedState', deepClonedState);
         setDeployedState(deepClonedState);
       } else {
-        logger.warn('No deployed state found in the database after refetch');
+        const warningMessage = options.forceRefetch
+          ? 'No deployed state found in the database after refetch'
+          : 'No deployed state found in the database';
+        
+        logger.warn(warningMessage);
         setDeployedState(null);
       }
     } catch (error) {
-      logger.error('Error refetching deployed state:', error);
+      logger.error('Error fetching deployed state:', error);
       setDeployedState(null);
     } finally {
       setIsLoadingDeployedState(false);
     }
   };
 
+  // Alias for clarity when explicitly triggering a refetch
+  const refetchDeployedState = () => fetchDeployedState({ forceRefetch: true });
+
   // Fetch deployed state when the workflow ID changes or deployment status changes
   useEffect(() => {
-    async function fetchDeployedState() {
-      if (!activeWorkflowId || !isDeployed) {
-        setDeployedState(null)
-        return
-      }
-
-      try {
-        setIsLoadingDeployedState(true)
-        logger.info(`[CENTRAL] Fetching deployed state for workflow: ${activeWorkflowId} (Control Bar - Single Source of Truth)`)
-        
-        const response = await fetch(`/api/workflows/${activeWorkflowId}/deployed`)
-        if (!response.ok) {
-          throw new Error(`Failed to fetch deployed state: ${response.status}`)
-        }
-        
-        const data = await response.json()
-        
-        if (data.deployedState) {
-          logger.info('Successfully fetched deployed state from DB - This is the only place that should fetch deployed state')
-          // Create a deep clone to ensure no reference sharing with current state
-          const deepClonedState = JSON.parse(JSON.stringify(data.deployedState))
-          logger.info('deepClonedState', deepClonedState)
-          setDeployedState(deepClonedState)
-        } else {
-          logger.warn('No deployed state found in the database')
-          setDeployedState(null)
-        }
-      } catch (error) {
-        logger.error('Error fetching deployed state:', error)
-        setDeployedState(null)
-      } finally {
-        setIsLoadingDeployedState(false)
-      }
-    }
-    
-    fetchDeployedState()
-  }, [activeWorkflowId, isDeployed])
+    fetchDeployedState();
+  }, [activeWorkflowId, isDeployed]);
 
   // Listen for deployment status changes
   useEffect(() => {
@@ -408,16 +396,6 @@ export function ControlBar() {
       setDeployedState(null)
     }
   }, [isDeployed, activeWorkflowId])
-
-  // Listen for deployment status changes
-  useEffect(() => {
-    // When deployment status changes and isDeployed becomes true,
-    // that means a deployment just occurred, so reset the needsRedeployment flag
-    if (isDeployed) {
-      setNeedsRedeployment(false)
-      useWorkflowStore.getState().setNeedsRedeploymentFlag(false)
-    }
-  }, [isDeployed])
 
   // Add a listener for the needsRedeployment flag in the workflow store
   useEffect(() => {

--- a/apps/sim/app/w/[id]/components/panel/components/chat/components/output-select/output-select.tsx
+++ b/apps/sim/app/w/[id]/components/panel/components/chat/components/output-select/output-select.tsx
@@ -42,7 +42,10 @@ export function OutputSelect({
       // Skip starter/start blocks
       if (block.type === 'starter') return
 
-      const blockName = block.name.replace(/\s+/g, '').toLowerCase()
+      // Add defensive check to ensure block.name exists and is a string
+      const blockName = block.name && typeof block.name === 'string' 
+        ? block.name.replace(/\s+/g, '').toLowerCase() 
+        : `block-${block.id}`;
 
       // Add response outputs
       if (block.outputs && typeof block.outputs === 'object') {
@@ -60,7 +63,7 @@ export function OutputSelect({
               id: `${block.id}_${fullPath}`,
               label: `${blockName}.${fullPath}`,
               blockId: block.id,
-              blockName: block.name,
+              blockName: block.name || `Block ${block.id}`,
               blockType: block.type,
               path: fullPath,
             })
@@ -93,7 +96,11 @@ export function OutputSelect({
     if (validOutputs.length === 1) {
       const output = workflowOutputs.find((o) => o.id === validOutputs[0])
       if (output) {
-        return `${output.blockName.replace(/\s+/g, '').toLowerCase()}.${output.path}`
+        // Add defensive check for output.blockName
+        const blockNameText = output.blockName && typeof output.blockName === 'string'
+          ? output.blockName.replace(/\s+/g, '').toLowerCase()
+          : `block-${output.blockId}`;
+        return `${blockNameText}.${output.path}`
       }
       return placeholder
     }

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/checkbox-list.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/checkbox-list.tsx
@@ -1,7 +1,10 @@
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
+
+const logger = createLogger('CheckboxList')
 
 interface CheckboxListProps {
   blockId: string
@@ -9,13 +12,39 @@ interface CheckboxListProps {
   title: string
   options: { label: string; id: string }[]
   layout?: 'full' | 'half'
+  isPreview?: boolean
+  value?: Record<string, boolean>
 }
 
-export function CheckboxList({ blockId, subBlockId, title, options, layout }: CheckboxListProps) {
+export function CheckboxList({ 
+  blockId, 
+  subBlockId, 
+  title, 
+  options, 
+  layout,
+  isPreview = false,
+  value: propValues
+}: CheckboxListProps) {
   return (
     <div className={cn('grid gap-4', layout === 'half' ? 'grid-cols-2' : 'grid-cols-1', 'pt-1')}>
       {options.map((option) => {
-        const [value, setValue] = useSubBlockValue(blockId, option.id)
+        const [value, setValue] = useSubBlockValue(
+          blockId, 
+          option.id, 
+          false, 
+          isPreview, 
+          propValues?.[option.id]
+        )
+        
+        // Log when in preview mode to verify it's working
+        if (isPreview) {
+          logger.info(`[PREVIEW] CheckboxList option ${option.id} for ${blockId}`, {
+            isPreview,
+            propValue: propValues?.[option.id],
+            value
+          });
+        }
+        
         return (
           <div key={option.id} className="flex items-center space-x-2">
             <Checkbox

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/checkbox-list.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/checkbox-list.tsx
@@ -1,10 +1,8 @@
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
 
-const logger = createLogger('CheckboxList')
 
 interface CheckboxListProps {
   blockId: string
@@ -35,15 +33,6 @@ export function CheckboxList({
           isPreview, 
           propValues?.[option.id]
         )
-        
-        // Log when in preview mode to verify it's working
-        if (isPreview) {
-          logger.info(`[PREVIEW] CheckboxList option ${option.id} for ${blockId}`, {
-            isPreview,
-            propValue: propValues?.[option.id],
-            value
-          });
-        }
         
         return (
           <div key={option.id} className="flex items-center space-x-2">

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/code.tsx
@@ -188,18 +188,7 @@ export function Code({
       clearTimeout(timeoutId)
       resizeObserver.disconnect()
     }
-  }, [code])
-
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] Code for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        storeValue
-      });
-    }
-  }, [isPreview, propValue, storeValue, blockId, subBlockId]);
+  }, [code])  
 
   // Handlers
   const handleDrop = (e: React.DragEvent) => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/code.tsx
@@ -23,6 +23,8 @@ interface CodeProps {
   placeholder?: string
   language?: 'javascript' | 'json'
   generationType?: 'javascript-function-body' | 'json-schema'
+  isPreview?: boolean
+  value?: string
 }
 
 if (typeof document !== 'undefined') {
@@ -50,6 +52,8 @@ export function Code({
   placeholder = 'Write JavaScript...',
   language = 'javascript',
   generationType = 'javascript-function-body',
+  isPreview = false,
+  value: propValue
 }: CodeProps) {
   // Determine the AI prompt placeholder based on language
   const aiPromptPlaceholder =
@@ -58,7 +62,7 @@ export function Code({
       : 'Describe the JavaScript code to generate...'
 
   // State management
-  const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlockId)
+  const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlockId, false, isPreview, propValue)
   const [code, setCode] = useState<string>('')
   const [lineCount, setLineCount] = useState(1)
   const [showTags, setShowTags] = useState(false)
@@ -185,6 +189,17 @@ export function Code({
       resizeObserver.disconnect()
     }
   }, [code])
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] Code for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        storeValue
+      });
+    }
+  }, [isPreview, propValue, storeValue, blockId, subBlockId]);
 
   // Handlers
   const handleDrop = (e: React.DragEvent) => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/condition-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/condition-input.tsx
@@ -516,15 +516,15 @@ export function ConditionInput({ blockId, subBlockId, isConnecting, isPreview = 
   }, [conditionalBlocks.length])
 
   // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] ConditionInput for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        storeValue
-      });
-    }
-  }, [isPreview, propValue, storeValue, blockId, subBlockId]);
+  // useEffect(() => {
+  //   if (isPreview) {
+  //     logger.info(`[PREVIEW] ConditionInput for ${blockId}:${subBlockId}`, {
+  //       isPreview,
+  //       propValue,
+  //       storeValue
+  //     });
+  //   }
+  // }, [isPreview, propValue, storeValue, blockId, subBlockId]);
 
   // Show loading or empty state if not ready or no blocks
   if (!isReady || conditionalBlocks.length === 0) {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/condition-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/condition-input.tsx
@@ -32,6 +32,8 @@ interface ConditionInputProps {
   blockId: string
   subBlockId: string
   isConnecting: boolean
+  isPreview?: boolean
+  value?: string
 }
 
 // Generate a stable ID based on the blockId and a suffix
@@ -39,8 +41,8 @@ const generateStableId = (blockId: string, suffix: string): string => {
   return `${blockId}-${suffix}`
 }
 
-export function ConditionInput({ blockId, subBlockId, isConnecting }: ConditionInputProps) {
-  const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlockId)
+export function ConditionInput({ blockId, subBlockId, isConnecting, isPreview = false, value: propValue }: ConditionInputProps) {
+  const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlockId, false, isPreview, propValue)
   const editorRef = useRef<HTMLDivElement>(null)
   const [visualLineHeights, setVisualLineHeights] = useState<{
     [key: string]: number[]
@@ -512,6 +514,17 @@ export function ConditionInput({ blockId, subBlockId, isConnecting }: ConditionI
       }
     })
   }, [conditionalBlocks.length])
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] ConditionInput for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        storeValue
+      });
+    }
+  }, [isPreview, propValue, storeValue, blockId, subBlockId]);
 
   // Show loading or empty state if not ready or no blocks
   if (!isReady || conditionalBlocks.length === 0) {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/condition-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/condition-input.tsx
@@ -515,17 +515,6 @@ export function ConditionInput({ blockId, subBlockId, isConnecting, isPreview = 
     })
   }, [conditionalBlocks.length])
 
-  // Log when in preview mode to verify it's working
-  // useEffect(() => {
-  //   if (isPreview) {
-  //     logger.info(`[PREVIEW] ConditionInput for ${blockId}:${subBlockId}`, {
-  //       isPreview,
-  //       propValue,
-  //       storeValue
-  //     });
-  //   }
-  // }, [isPreview, propValue, storeValue, blockId, subBlockId]);
-
   // Show loading or empty state if not ready or no blocks
   if (!isReady || conditionalBlocks.length === 0) {
     return (

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/date-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/date-input.tsx
@@ -7,19 +7,35 @@ import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useNotificationStore } from '@/stores/notifications/store'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
+
+const logger = createLogger('DateInput')
 
 interface DateInputProps {
   blockId: string
   subBlockId: string
   placeholder?: string
+  isPreview?: boolean
+  value?: string
 }
 
-export function DateInput({ blockId, subBlockId, placeholder }: DateInputProps) {
-  const [value, setValue] = useSubBlockValue<string>(blockId, subBlockId, true)
+export function DateInput({ blockId, subBlockId, placeholder, isPreview = false, value: propValue }: DateInputProps) {
+  const [value, setValue] = useSubBlockValue<string>(blockId, subBlockId, true, isPreview, propValue)
   const addNotification = useNotificationStore((state) => state.addNotification)
   const date = value ? new Date(value) : undefined
+
+  // Log when in preview mode to verify it's working
+  React.useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] DateInput for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        value
+      });
+    }
+  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   const isPastDate = React.useMemo(() => {
     if (!date) return false

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/date-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/date-input.tsx
@@ -7,11 +7,9 @@ import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useNotificationStore } from '@/stores/notifications/store'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
 
-const logger = createLogger('DateInput')
 
 interface DateInputProps {
   blockId: string
@@ -25,17 +23,6 @@ export function DateInput({ blockId, subBlockId, placeholder, isPreview = false,
   const [value, setValue] = useSubBlockValue<string>(blockId, subBlockId, true, isPreview, propValue)
   const addNotification = useNotificationStore((state) => state.addNotification)
   const date = value ? new Date(value) : undefined
-
-  // Log when in preview mode to verify it's working
-  React.useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] DateInput for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        value
-      });
-    }
-  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   const isPastDate = React.useMemo(() => {
     if (!date) return false

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/dropdown.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/dropdown.tsx
@@ -6,7 +6,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
+
+const logger = createLogger('Dropdown')
 
 interface DropdownProps {
   options:
@@ -15,11 +18,31 @@ interface DropdownProps {
   defaultValue?: string
   blockId: string
   subBlockId: string
+  isPreview?: boolean
+  value?: string
 }
 
-export function Dropdown({ options, defaultValue, blockId, subBlockId }: DropdownProps) {
-  const [value, setValue] = useSubBlockValue<string>(blockId, subBlockId, true)
+export function Dropdown({ 
+  options, 
+  defaultValue, 
+  blockId, 
+  subBlockId,
+  isPreview = false,
+  value: propValue
+}: DropdownProps) {
+  const [value, setValue] = useSubBlockValue<string>(blockId, subBlockId, true, isPreview, propValue)
   const [storeInitialized, setStoreInitialized] = useState(false)
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] Dropdown for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        value
+      });
+    }
+  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   // Evaluate options if it's a function
   const evaluatedOptions = useMemo(() => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/dropdown.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/dropdown.tsx
@@ -33,17 +33,6 @@ export function Dropdown({
   const [value, setValue] = useSubBlockValue<string>(blockId, subBlockId, true, isPreview, propValue)
   const [storeInitialized, setStoreInitialized] = useState(false)
 
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] Dropdown for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        value
-      });
-    }
-  }, [isPreview, propValue, value, blockId, subBlockId]);
-
   // Evaluate options if it's a function
   const evaluatedOptions = useMemo(() => {
     return typeof options === 'function' ? options() : options

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/eval-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/eval-input.tsx
@@ -3,7 +3,10 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
+
+const logger = createLogger('EvalInput')
 
 interface EvalMetric {
   id: string
@@ -18,6 +21,8 @@ interface EvalMetric {
 interface EvalInputProps {
   blockId: string
   subBlockId: string
+  isPreview?: boolean
+  value?: EvalMetric[]
 }
 
 // Default values
@@ -28,10 +33,19 @@ const DEFAULT_METRIC: EvalMetric = {
   range: { min: 0, max: 1 },
 }
 
-export function EvalInput({ blockId, subBlockId }: EvalInputProps) {
+export function EvalInput({ blockId, subBlockId, isPreview = false, value: propValue }: EvalInputProps) {
   // State hooks
-  const [value, setValue] = useSubBlockValue<EvalMetric[]>(blockId, subBlockId)
+  const [value, setValue] = useSubBlockValue<EvalMetric[]>(blockId, subBlockId, false, isPreview, propValue)
   const metrics = value || [DEFAULT_METRIC]
+
+  // Log when in preview mode to verify it's working
+  if (isPreview) {
+    logger.info(`[PREVIEW] EvalInput for ${blockId}:${subBlockId}`, {
+      isPreview,
+      propValue,
+      value
+    });
+  }
 
   // Metric operations
   const addMetric = () => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/eval-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/eval-input.tsx
@@ -3,10 +3,8 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
 
-const logger = createLogger('EvalInput')
 
 interface EvalMetric {
   id: string
@@ -37,15 +35,6 @@ export function EvalInput({ blockId, subBlockId, isPreview = false, value: propV
   // State hooks
   const [value, setValue] = useSubBlockValue<EvalMetric[]>(blockId, subBlockId, false, isPreview, propValue)
   const metrics = value || [DEFAULT_METRIC]
-
-  // Log when in preview mode to verify it's working
-  if (isPreview) {
-    logger.info(`[PREVIEW] EvalInput for ${blockId}:${subBlockId}`, {
-      isPreview,
-      propValue,
-      value
-    });
-  }
 
   // Metric operations
   const addMetric = () => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { SubBlockConfig } from '@/blocks/types'
 import { ConfluenceFileInfo, ConfluenceFileSelector } from './components/confluence-file-selector'
@@ -9,13 +10,23 @@ import { DiscordChannelInfo, DiscordChannelSelector } from './components/discord
 import { FileInfo, GoogleDrivePicker } from './components/google-drive-picker'
 import { JiraIssueInfo, JiraIssueSelector } from './components/jira-issue-selector'
 
+const logger = createLogger('FileSelectorInput')
+
 interface FileSelectorInputProps {
   blockId: string
   subBlock: SubBlockConfig
   disabled?: boolean
+  isPreview?: boolean
+  value?: string
 }
 
-export function FileSelectorInput({ blockId, subBlock, disabled = false }: FileSelectorInputProps) {
+export function FileSelectorInput({ 
+  blockId, 
+  subBlock, 
+  disabled = false,
+  isPreview = false,
+  value: propValue
+}: FileSelectorInputProps) {
   const { getValue, setValue } = useSubBlockStore()
   const [selectedFileId, setSelectedFileId] = useState<string>('')
   const [fileInfo, setFileInfo] = useState<FileInfo | ConfluenceFileInfo | null>(null)
@@ -23,6 +34,16 @@ export function FileSelectorInput({ blockId, subBlock, disabled = false }: FileS
   const [issueInfo, setIssueInfo] = useState<JiraIssueInfo | null>(null)
   const [selectedChannelId, setSelectedChannelId] = useState<string>('')
   const [channelInfo, setChannelInfo] = useState<DiscordChannelInfo | null>(null)
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] FileSelectorInput for ${blockId}:${subBlock.id}`, {
+        isPreview,
+        propValue
+      });
+    }
+  }, [isPreview, propValue, blockId, subBlock.id]);
 
   // Get provider-specific values
   const provider = subBlock.provider || 'google-drive'
@@ -38,19 +59,32 @@ export function FileSelectorInput({ blockId, subBlock, disabled = false }: FileS
   const botToken = isDiscord ? (getValue(blockId, 'botToken') as string) || '' : ''
   const serverId = isDiscord ? (getValue(blockId, 'serverId') as string) || '' : ''
 
-  // Get the current value from the store
+  // Get the current value from the store or prop value if in preview mode
   useEffect(() => {
-    const value = getValue(blockId, subBlock.id)
-    if (value && typeof value === 'string') {
-      if (isJira) {
-        setSelectedIssueId(value)
-      } else if (isDiscord) {
-        setSelectedChannelId(value)
-      } else {
-        setSelectedFileId(value)
+    if (isPreview && propValue !== undefined) {
+      const value = propValue;
+      if (value && typeof value === 'string') {
+        if (isJira) {
+          setSelectedIssueId(value);
+        } else if (isDiscord) {
+          setSelectedChannelId(value);
+        } else {
+          setSelectedFileId(value);
+        }
+      }
+    } else {
+      const value = getValue(blockId, subBlock.id);
+      if (value && typeof value === 'string') {
+        if (isJira) {
+          setSelectedIssueId(value);
+        } else if (isDiscord) {
+          setSelectedChannelId(value);
+        } else {
+          setSelectedFileId(value);
+        }
       }
     }
-  }, [blockId, subBlock.id, getValue, isJira, isDiscord])
+  }, [blockId, subBlock.id, getValue, isJira, isDiscord, isPreview, propValue]);
 
   // Handle file selection
   const handleFileChange = (fileId: string, info?: any) => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { SubBlockConfig } from '@/blocks/types'
 import { ConfluenceFileInfo, ConfluenceFileSelector } from './components/confluence-file-selector'
@@ -10,7 +9,6 @@ import { DiscordChannelInfo, DiscordChannelSelector } from './components/discord
 import { FileInfo, GoogleDrivePicker } from './components/google-drive-picker'
 import { JiraIssueInfo, JiraIssueSelector } from './components/jira-issue-selector'
 
-const logger = createLogger('FileSelectorInput')
 
 interface FileSelectorInputProps {
   blockId: string
@@ -34,16 +32,6 @@ export function FileSelectorInput({
   const [issueInfo, setIssueInfo] = useState<JiraIssueInfo | null>(null)
   const [selectedChannelId, setSelectedChannelId] = useState<string>('')
   const [channelInfo, setChannelInfo] = useState<DiscordChannelInfo | null>(null)
-
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] FileSelectorInput for ${blockId}:${subBlock.id}`, {
-        isPreview,
-        propValue
-      });
-    }
-  }, [isPreview, propValue, blockId, subBlock.id]);
 
   // Get provider-specific values
   const provider = subBlock.provider || 'google-drive'

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/file-upload.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/file-upload.tsx
@@ -4,14 +4,12 @@ import { useEffect, useRef, useState } from 'react'
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Progress } from '@/components/ui/progress'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useNotificationStore } from '@/stores/notifications/store'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
 
-const logger = createLogger('FileUpload')
 
 interface FileUploadProps {
   blockId: string
@@ -65,17 +63,6 @@ export function FileUpload({
   // Stores
   const { addNotification } = useNotificationStore()
   const { activeWorkflowId } = useWorkflowRegistry()
-
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] FileUpload for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        value
-      });
-    }
-  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   /**
    * Opens file dialog

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/folder-selector/components/folder-selector-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/folder-selector/components/folder-selector-input.tsx
@@ -1,12 +1,9 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { SubBlockConfig } from '@/blocks/types'
 import { FolderInfo, FolderSelector } from '../folder-selector'
-
-const logger = createLogger('FolderSelectorInput')
 
 interface FolderSelectorInputProps {
   blockId: string
@@ -26,16 +23,6 @@ export function FolderSelectorInput({
   const { getValue, setValue } = useSubBlockStore()
   const [selectedFolderId, setSelectedFolderId] = useState<string>('')
   const [folderInfo, setFolderInfo] = useState<FolderInfo | null>(null)
-
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] FolderSelectorInput for ${blockId}:${subBlock.id}`, {
-        isPreview,
-        propValue
-      });
-    }
-  }, [isPreview, propValue, blockId, subBlock.id]);
 
   // Get the current value from the store or prop value if in preview mode
   useEffect(() => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/folder-selector/components/folder-selector-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/folder-selector/components/folder-selector-input.tsx
@@ -1,42 +1,67 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { SubBlockConfig } from '@/blocks/types'
 import { FolderInfo, FolderSelector } from '../folder-selector'
+
+const logger = createLogger('FolderSelectorInput')
 
 interface FolderSelectorInputProps {
   blockId: string
   subBlock: SubBlockConfig
   disabled?: boolean
+  isPreview?: boolean
+  value?: string
 }
 
 export function FolderSelectorInput({
   blockId,
   subBlock,
   disabled = false,
+  isPreview = false,
+  value: propValue
 }: FolderSelectorInputProps) {
   const { getValue, setValue } = useSubBlockStore()
   const [selectedFolderId, setSelectedFolderId] = useState<string>('')
   const [folderInfo, setFolderInfo] = useState<FolderInfo | null>(null)
 
-  // Get the current value from the store
+  // Log when in preview mode to verify it's working
   useEffect(() => {
-    const value = getValue(blockId, subBlock.id)
-    if (value && typeof value === 'string') {
-      setSelectedFolderId(value)
-    } else {
-      const defaultValue = 'INBOX'
-      setSelectedFolderId(defaultValue)
-      setValue(blockId, subBlock.id, defaultValue)
+    if (isPreview) {
+      logger.info(`[PREVIEW] FolderSelectorInput for ${blockId}:${subBlock.id}`, {
+        isPreview,
+        propValue
+      });
     }
-  }, [blockId, subBlock.id, getValue, setValue])
+  }, [isPreview, propValue, blockId, subBlock.id]);
+
+  // Get the current value from the store or prop value if in preview mode
+  useEffect(() => {
+    if (isPreview && propValue !== undefined) {
+      setSelectedFolderId(propValue);
+    } else {
+      const value = getValue(blockId, subBlock.id);
+      if (value && typeof value === 'string') {
+        setSelectedFolderId(value);
+      } else {
+        const defaultValue = 'INBOX';
+        setSelectedFolderId(defaultValue);
+        if (!isPreview) {
+          setValue(blockId, subBlock.id, defaultValue);
+        }
+      }
+    }
+  }, [blockId, subBlock.id, getValue, setValue, isPreview, propValue]);
 
   // Handle folder selection
   const handleFolderChange = (folderId: string, info?: FolderInfo) => {
-    setSelectedFolderId(folderId)
-    setFolderInfo(info || null)
-    setValue(blockId, subBlock.id, folderId)
+    setSelectedFolderId(folderId);
+    setFolderInfo(info || null);
+    if (!isPreview) {
+      setValue(blockId, subBlock.id, folderId);
+    }
   }
 
   return (

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/long-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/long-input.tsx
@@ -48,17 +48,6 @@ export function LongInput({
   const [activeSourceBlockId, setActiveSourceBlockId] = useState<string | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] LongInput for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        value
-      });
-    }
-  }, [isPreview, propValue, value, blockId, subBlockId]);
-
   // Calculate initial height based on rows prop with reasonable defaults
   const getInitialHeight = () => {
     // Use provided rows or default, then convert to pixels with a minimum

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/long-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/long-input.tsx
@@ -19,6 +19,8 @@ interface LongInputProps {
   isConnecting: boolean
   config: SubBlockConfig
   rows?: number
+  isPreview?: boolean
+  value?: string
 }
 
 // Constants
@@ -33,8 +35,10 @@ export function LongInput({
   isConnecting,
   config,
   rows,
+  isPreview = false,
+  value: propValue,
 }: LongInputProps) {
-  const [value, setValue] = useSubBlockValue(blockId, subBlockId)
+  const [value, setValue] = useSubBlockValue(blockId, subBlockId, false, isPreview, propValue)
   const [showEnvVars, setShowEnvVars] = useState(false)
   const [showTags, setShowTags] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
@@ -43,6 +47,17 @@ export function LongInput({
   const overlayRef = useRef<HTMLDivElement>(null)
   const [activeSourceBlockId, setActiveSourceBlockId] = useState<string | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] LongInput for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        value
+      });
+    }
+  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   // Calculate initial height based on rows prop with reasonable defaults
   const getInitialHeight = () => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
@@ -2,13 +2,11 @@
 
 import { useEffect, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { SubBlockConfig } from '@/blocks/types'
 import { DiscordServerInfo, DiscordServerSelector } from './components/discord-server-selector'
 import { JiraProjectInfo, JiraProjectSelector } from './components/jira-project-selector'
 
-const logger = createLogger('ProjectSelectorInput')
 
 interface ProjectSelectorInputProps {
   blockId: string
@@ -30,16 +28,6 @@ export function ProjectSelectorInput({
   const { getValue, setValue } = useSubBlockStore()
   const [selectedProjectId, setSelectedProjectId] = useState<string>('')
   const [projectInfo, setProjectInfo] = useState<JiraProjectInfo | DiscordServerInfo | null>(null)
-
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] ProjectSelectorInput for ${blockId}:${subBlock.id}`, {
-        isPreview,
-        propValue
-      });
-    }
-  }, [isPreview, propValue, blockId, subBlock.id]);
 
   // Get provider-specific values
   const provider = subBlock.provider || 'jira'

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/schedule/schedule-config.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/schedule/schedule-config.tsx
@@ -57,18 +57,6 @@ export function ScheduleConfig({
   const [startWorkflow, setStartWorkflow] = useSubBlockValue(blockId, 'startWorkflow', false, isPreview, propValue?.startWorkflow)
   const isScheduleEnabled = startWorkflow === 'schedule'
 
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] ScheduleConfig for ${blockId}`, {
-        isPreview,
-        propValue,
-        scheduleType,
-        startWorkflow
-      });
-    }
-  }, [isPreview, propValue, scheduleType, startWorkflow, blockId]);
-
   // Function to check if schedule exists in the database
   const checkSchedule = async () => {
     setIsLoading(true)

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/schedule/schedule-config.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/schedule/schedule-config.tsx
@@ -19,9 +19,17 @@ interface ScheduleConfigProps {
   blockId: string
   subBlockId?: string
   isConnecting: boolean
+  isPreview?: boolean
+  value?: any
 }
 
-export function ScheduleConfig({ blockId, subBlockId, isConnecting }: ScheduleConfigProps) {
+export function ScheduleConfig({ 
+  blockId, 
+  subBlockId, 
+  isConnecting, 
+  isPreview = false,
+  value: propValue 
+}: ScheduleConfigProps) {
   const [error, setError] = useState<string | null>(null)
   const [scheduleId, setScheduleId] = useState<string | null>(null)
   const [nextRunAt, setNextRunAt] = useState<string | null>(null)
@@ -42,12 +50,24 @@ export function ScheduleConfig({ blockId, subBlockId, isConnecting }: ScheduleCo
   const setScheduleStatus = useWorkflowStore((state) => state.setScheduleStatus)
 
   // Get the schedule type from the block state
-  const [scheduleType] = useSubBlockValue(blockId, 'scheduleType')
+  const [scheduleType] = useSubBlockValue(blockId, 'scheduleType', false, isPreview, propValue?.scheduleType)
 
   // Get the startWorkflow value to determine if scheduling is enabled
   // and expose the setter so we can update it
-  const [startWorkflow, setStartWorkflow] = useSubBlockValue(blockId, 'startWorkflow')
+  const [startWorkflow, setStartWorkflow] = useSubBlockValue(blockId, 'startWorkflow', false, isPreview, propValue?.startWorkflow)
   const isScheduleEnabled = startWorkflow === 'schedule'
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] ScheduleConfig for ${blockId}`, {
+        isPreview,
+        propValue,
+        scheduleType,
+        startWorkflow
+      });
+    }
+  }, [isPreview, propValue, scheduleType, startWorkflow, blockId]);
 
   // Function to check if schedule exists in the database
   const checkSchedule = async () => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/short-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/short-input.tsx
@@ -20,6 +20,7 @@ interface ShortInputProps {
   config: SubBlockConfig
   value?: string
   onChange?: (value: string) => void
+  isPreview?: boolean
 }
 
 export function ShortInput({
@@ -31,11 +32,18 @@ export function ShortInput({
   config,
   value: propValue,
   onChange,
+  isPreview = false,
 }: ShortInputProps) {
   const [isFocused, setIsFocused] = useState(false)
   const [showEnvVars, setShowEnvVars] = useState(false)
   const [showTags, setShowTags] = useState(false)
-  const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlockId)
+  const [storeValue, setStoreValue] = useSubBlockValue(
+    blockId, 
+    subBlockId, 
+    false, // No workflow update needed
+    isPreview, 
+    propValue
+  )
   const [searchTerm, setSearchTerm] = useState('')
   const [cursorPosition, setCursorPosition] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -45,8 +53,10 @@ export function ShortInput({
   // Get ReactFlow instance for zoom control
   const reactFlowInstance = useReactFlow()
 
-  // Use either controlled or uncontrolled value
-  const value = propValue !== undefined ? propValue : storeValue
+  // Use either controlled or uncontrolled value, prioritizing the direct value if in preview mode
+  const value = isPreview && propValue !== undefined 
+    ? propValue 
+    : (propValue !== undefined ? propValue : storeValue)
 
   // Check if this input is API key related
   const isApiKeyField = useMemo(() => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/slider-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/slider-input.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo } from 'react'
 import { Slider } from '@/components/ui/slider'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
+
+const logger = createLogger('SliderInput')
 
 interface SliderInputProps {
   min?: number
@@ -10,6 +13,8 @@ interface SliderInputProps {
   subBlockId: string
   step?: number
   integer?: boolean
+  isPreview?: boolean
+  value?: number
 }
 
 export function SliderInput({
@@ -20,8 +25,21 @@ export function SliderInput({
   subBlockId,
   step = 0.1,
   integer = false,
+  isPreview = false,
+  value: propValue
 }: SliderInputProps) {
-  const [value, setValue] = useSubBlockValue<number>(blockId, subBlockId)
+  const [value, setValue] = useSubBlockValue<number>(blockId, subBlockId, false, isPreview, propValue)
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] SliderInput for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        value
+      });
+    }
+  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   // Clamp the value within bounds while preserving relative position when possible
   const normalizedValue = useMemo(() => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/slider-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/slider-input.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { Slider } from '@/components/ui/slider'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
 
-const logger = createLogger('SliderInput')
 
 interface SliderInputProps {
   min?: number
@@ -29,17 +27,6 @@ export function SliderInput({
   value: propValue
 }: SliderInputProps) {
   const [value, setValue] = useSubBlockValue<number>(blockId, subBlockId, false, isPreview, propValue)
-
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] SliderInput for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        value
-      });
-    }
-  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   // Clamp the value within bounds while preserving relative position when possible
   const normalizedValue = useMemo(() => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/starter/input-format.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/starter/input-format.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react'
 import { ChevronDown, Plus, Trash } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/starter/input-format.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/starter/input-format.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { ChevronDown, Plus, Trash } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -10,7 +11,10 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../../hooks/use-sub-block-value'
+
+const logger = createLogger('InputFormat')
 
 interface InputField {
   id: string
@@ -22,6 +26,8 @@ interface InputField {
 interface InputFormatProps {
   blockId: string
   subBlockId: string
+  isPreview?: boolean
+  value?: InputField[]
 }
 
 // Default values
@@ -32,10 +38,21 @@ const DEFAULT_FIELD: InputField = {
   collapsed: true,
 }
 
-export function InputFormat({ blockId, subBlockId }: InputFormatProps) {
+export function InputFormat({ blockId, subBlockId, isPreview = false, value: propValue }: InputFormatProps) {
   // State hooks
-  const [value, setValue] = useSubBlockValue<InputField[]>(blockId, subBlockId)
+  const [value, setValue] = useSubBlockValue<InputField[]>(blockId, subBlockId, false, isPreview, propValue)
   const fields = value || [DEFAULT_FIELD]
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] InputFormat for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        value
+      });
+    }
+  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   // Field operations
   const addField = () => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/starter/input-format.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/starter/input-format.tsx
@@ -11,10 +11,8 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../../hooks/use-sub-block-value'
 
-const logger = createLogger('InputFormat')
 
 interface InputField {
   id: string
@@ -42,17 +40,6 @@ export function InputFormat({ blockId, subBlockId, isPreview = false, value: pro
   // State hooks
   const [value, setValue] = useSubBlockValue<InputField[]>(blockId, subBlockId, false, isPreview, propValue)
   const fields = value || [DEFAULT_FIELD]
-
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] InputFormat for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        value
-      });
-    }
-  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   // Field operations
   const addField = () => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/switch.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/switch.tsx
@@ -1,15 +1,38 @@
+import { useEffect } from 'react'
 import { Label } from '@/components/ui/label'
 import { Switch as UISwitch } from '@/components/ui/switch'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
+
+const logger = createLogger('Switch')
 
 interface SwitchProps {
   blockId: string
   subBlockId: string
   title: string
+  isPreview?: boolean
+  value?: boolean
 }
 
-export function Switch({ blockId, subBlockId, title }: SwitchProps) {
-  const [value, setValue] = useSubBlockValue(blockId, subBlockId)
+export function Switch({ 
+  blockId, 
+  subBlockId, 
+  title, 
+  isPreview = false,
+  value: propValue 
+}: SwitchProps) {
+  const [value, setValue] = useSubBlockValue(blockId, subBlockId, false, isPreview, propValue)
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] Switch for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        value
+      });
+    }
+  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   return (
     <div className="flex flex-col gap-2">

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/switch.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/switch.tsx
@@ -1,10 +1,8 @@
 import { useEffect } from 'react'
 import { Label } from '@/components/ui/label'
 import { Switch as UISwitch } from '@/components/ui/switch'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
 
-const logger = createLogger('Switch')
 
 interface SwitchProps {
   blockId: string
@@ -22,17 +20,6 @@ export function Switch({
   value: propValue 
 }: SwitchProps) {
   const [value, setValue] = useSubBlockValue(blockId, subBlockId, false, isPreview, propValue)
-
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] Switch for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        value
-      });
-    }
-  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   return (
     <div className="flex flex-col gap-2">

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/table.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/table.tsx
@@ -5,13 +5,18 @@ import { checkEnvVarTrigger, EnvVarDropdown } from '@/components/ui/env-var-drop
 import { formatDisplayText } from '@/components/ui/formatted-text'
 import { Input } from '@/components/ui/input'
 import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
+import { createLogger } from '@/lib/logs/console-logger'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
+
+const logger = createLogger('Table')
 
 interface TableProps {
   columns: string[]
   blockId: string
   subBlockId: string
+  isPreview?: boolean
+  value?: TableRow[]
 }
 
 interface TableRow {
@@ -19,8 +24,19 @@ interface TableRow {
   cells: Record<string, string>
 }
 
-export function Table({ columns, blockId, subBlockId }: TableProps) {
-  const [value, setValue] = useSubBlockValue(blockId, subBlockId)
+export function Table({ columns, blockId, subBlockId, isPreview = false, value: propValue }: TableProps) {
+  const [value, setValue] = useSubBlockValue(blockId, subBlockId, false, isPreview, propValue)
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] Table for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        value
+      });
+    }
+  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   // Create refs for input elements
   const inputRefs = useRef<Map<string, HTMLInputElement>>(new Map())

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/table.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/table.tsx
@@ -5,11 +5,9 @@ import { checkEnvVarTrigger, EnvVarDropdown } from '@/components/ui/env-var-drop
 import { formatDisplayText } from '@/components/ui/formatted-text'
 import { Input } from '@/components/ui/input'
 import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
-import { createLogger } from '@/lib/logs/console-logger'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
 
-const logger = createLogger('Table')
 
 interface TableProps {
   columns: string[]
@@ -26,17 +24,6 @@ interface TableRow {
 
 export function Table({ columns, blockId, subBlockId, isPreview = false, value: propValue }: TableProps) {
   const [value, setValue] = useSubBlockValue(blockId, subBlockId, false, isPreview, propValue)
-
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] Table for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        value
-      });
-    }
-  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   // Create refs for input elements
   const inputRefs = useRef<Map<string, HTMLInputElement>>(new Map())

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/time-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/time-input.tsx
@@ -5,19 +5,42 @@ import { Clock } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { createLogger } from '@/lib/logs/console-logger'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
+
+const logger = createLogger('TimeInput')
 
 interface TimeInputProps {
   blockId: string
   subBlockId: string
   placeholder?: string
   className?: string
+  isPreview?: boolean
+  value?: string
 }
 
-export function TimeInput({ blockId, subBlockId, placeholder, className }: TimeInputProps) {
-  const [value, setValue] = useSubBlockValue<string>(blockId, subBlockId, true)
+export function TimeInput({ 
+  blockId, 
+  subBlockId, 
+  placeholder, 
+  className,
+  isPreview = false,
+  value: propValue
+}: TimeInputProps) {
+  const [value, setValue] = useSubBlockValue<string>(blockId, subBlockId, true, isPreview, propValue)
   const [isOpen, setIsOpen] = React.useState(false)
+
+  // Log when in preview mode to verify it's working
+  React.useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] TimeInput for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        value
+      });
+    }
+  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   // Convert 24h time string to display format (12h with AM/PM)
   const formatDisplayTime = (time: string) => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/time-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/time-input.tsx
@@ -5,11 +5,9 @@ import { Clock } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { createLogger } from '@/lib/logs/console-logger'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
 
-const logger = createLogger('TimeInput')
 
 interface TimeInputProps {
   blockId: string
@@ -30,17 +28,6 @@ export function TimeInput({
 }: TimeInputProps) {
   const [value, setValue] = useSubBlockValue<string>(blockId, subBlockId, true, isPreview, propValue)
   const [isOpen, setIsOpen] = React.useState(false)
-
-  // Log when in preview mode to verify it's working
-  React.useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] TimeInput for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        value
-      });
-    }
-  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   // Convert 24h time string to display format (12h with AM/PM)
   const formatDisplayTime = (time: string) => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { PlusIcon, WrenchIcon, XIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -33,6 +33,8 @@ const logger = createLogger('ToolInput')
 interface ToolInputProps {
   blockId: string
   subBlockId: string
+  isPreview?: boolean
+  value?: StoredTool[]
 }
 
 interface StoredTool {
@@ -240,8 +242,8 @@ const formatParamId = (paramId: string): string => {
   return paramId.charAt(0).toUpperCase() + paramId.slice(1)
 }
 
-export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
-  const [value, setValue] = useSubBlockValue(blockId, subBlockId)
+export function ToolInput({ blockId, subBlockId, isPreview = false, value: propValue }: ToolInputProps) {
+  const [value, setValue] = useSubBlockValue(blockId, subBlockId, false, isPreview, propValue)
   const [open, setOpen] = useState(false)
   const [customToolModalOpen, setCustomToolModalOpen] = useState(false)
   const [editingToolIndex, setEditingToolIndex] = useState<number | null>(null)
@@ -544,6 +546,17 @@ export function ToolInput({ blockId, subBlockId }: ToolInputProps) {
     if (!Icon) return null
     return <Icon className={className} />
   }
+
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] ToolInput for ${blockId}:${subBlockId}`, {
+        isPreview,
+        propValue,
+        value
+      });
+    }
+  }, [isPreview, propValue, value, blockId, subBlockId]);
 
   return (
     <div className="w-full">

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
@@ -547,17 +547,6 @@ export function ToolInput({ blockId, subBlockId, isPreview = false, value: propV
     return <Icon className={className} />
   }
 
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] ToolInput for ${blockId}:${subBlockId}`, {
-        isPreview,
-        propValue,
-        value
-      });
-    }
-  }, [isPreview, propValue, value, blockId, subBlockId]);
-
   return (
     <div className="w-full">
       {selectedTools.length === 0 ? (

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/webhook/webhook.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/webhook/webhook.tsx
@@ -316,19 +316,6 @@ export function WebhookConfig({
 
   // Store provider-specific configuration
   const [providerConfig, setProviderConfig] = useSubBlockValue(blockId, 'providerConfig', false, isPreview, propValue?.providerConfig)
-
-  // Log when in preview mode to verify it's working
-  useEffect(() => {
-    if (isPreview) {
-      logger.info(`[PREVIEW] WebhookConfig for ${blockId}`, {
-        isPreview,
-        propValue,
-        webhookProvider,
-        webhookPath,
-        providerConfig
-      });
-    }
-  }, [isPreview, propValue, webhookProvider, webhookPath, providerConfig, blockId]);
   
   // Reset provider config when provider changes
   useEffect(() => {

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/webhook/webhook.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/webhook/webhook.tsx
@@ -284,9 +284,17 @@ interface WebhookConfigProps {
   blockId: string
   subBlockId?: string
   isConnecting: boolean
+  isPreview?: boolean
+  value?: any
 }
 
-export function WebhookConfig({ blockId, subBlockId, isConnecting }: WebhookConfigProps) {
+export function WebhookConfig({ 
+  blockId, 
+  subBlockId, 
+  isConnecting, 
+  isPreview = false, 
+  value: propValue 
+}: WebhookConfigProps) {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -301,21 +309,34 @@ export function WebhookConfig({ blockId, subBlockId, isConnecting }: WebhookConf
   const setWebhookStatus = useWorkflowStore((state) => state.setWebhookStatus)
 
   // Get the webhook provider from the block state
-  const [webhookProvider, setWebhookProvider] = useSubBlockValue(blockId, 'webhookProvider')
+  const [webhookProvider, setWebhookProvider] = useSubBlockValue(blockId, 'webhookProvider', false, isPreview, propValue?.webhookProvider)
 
   // Store the webhook path
-  const [webhookPath, setWebhookPath] = useSubBlockValue(blockId, 'webhookPath')
+  const [webhookPath, setWebhookPath] = useSubBlockValue(blockId, 'webhookPath', false, isPreview, propValue?.webhookPath)
 
   // Store provider-specific configuration
-  const [providerConfig, setProviderConfig] = useSubBlockValue(blockId, 'providerConfig')
+  const [providerConfig, setProviderConfig] = useSubBlockValue(blockId, 'providerConfig', false, isPreview, propValue?.providerConfig)
 
+  // Log when in preview mode to verify it's working
+  useEffect(() => {
+    if (isPreview) {
+      logger.info(`[PREVIEW] WebhookConfig for ${blockId}`, {
+        isPreview,
+        propValue,
+        webhookProvider,
+        webhookPath,
+        providerConfig
+      });
+    }
+  }, [isPreview, propValue, webhookProvider, webhookPath, providerConfig, blockId]);
+  
   // Reset provider config when provider changes
   useEffect(() => {
-    if (webhookProvider) {
+    if (webhookProvider && !isPreview) {
       // Reset the provider config when the provider changes
       setProviderConfig({})
     }
-  }, [webhookProvider, setProviderConfig])
+  }, [webhookProvider, setProviderConfig, isPreview])
 
   // Store the actual provider from the database
   const [actualProvider, setActualProvider] = useState<string | null>(null)

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/hooks/use-sub-block-value.ts
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/hooks/use-sub-block-value.ts
@@ -233,10 +233,6 @@ export function useSubBlockValue<T = any>(
               // Update valueRef directly to use the preview value
               valueRef.current = directValue;
               
-              logger.info(`[PREVIEW-DOM] Using direct subblock value for ${blockId}:${subBlockId}`, {
-                directValue,
-                storeValue
-              });
             }
           }
         } else {
@@ -248,48 +244,6 @@ export function useSubBlockValue<T = any>(
       // Ignore errors in preview detection
     }
   }, [blockId, subBlockId, isPreview, directValue, storeValue]);
-
-  // Add logging to trace where values are coming from
-  useEffect(() => {
-    // Skip if we've already determined we're in preview mode
-    if (previewDataRef.current.isInPreview) return;
-    
-    // Check if we're in preview context
-    let isPreviewContext = false;
-    let directSubBlockValue = null;
-    
-    try {
-      // Try to find if this component is within a preview parent
-      const parentBlock = document.querySelector(`[data-id="${blockId}"]`);
-      if (parentBlock) {
-        isPreviewContext = parentBlock.closest('.preview-mode') != null;
-        
-        // Try to find the parent data to see if subBlockValues was passed directly
-        const dataProps = parentBlock.getAttribute('data-props');
-        if (dataProps) {
-          const parsedProps = JSON.parse(dataProps);
-          directSubBlockValue = parsedProps?.data?.subBlockValues?.[subBlockId];
-        }
-      }
-      
-      logger.info(`[DATA-TRACE] SubBlock value source for ${blockId}:${subBlockId}`, {
-        blockId,
-        subBlockId, 
-        storeValueExists: storeValue !== undefined,
-        initialValueExists: initialValue !== null,
-        isPreviewContext,
-        hasDirectSubBlockValue: directSubBlockValue !== undefined && directSubBlockValue !== null,
-        valueFromStore: storeValue,
-        valueFromInitial: initialValue,
-        valueFromDirect: directSubBlockValue,
-        actuallyUsing: previewDataRef.current.isInPreview ? 'directValue' : 
-                       (storeValue !== undefined ? 'globalStore' : 
-                       (initialValue !== null ? 'initialValue' : 'null')),
-      });
-    } catch (e) {
-      // Ignore errors - this is just diagnostic logging
-    }
-  }, [blockId, subBlockId, storeValue, initialValue]);
 
   // Check if this is an API key field that could be auto-filled
   const isApiKey =

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/hooks/use-sub-block-value.ts
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/hooks/use-sub-block-value.ts
@@ -201,49 +201,11 @@ export function useSubBlockValue<T = any>(
         directValue,
         isPreview
       });
+    } else if (!isPreview && previewDataRef.current.isInPreview) {
+      // Reset preview flag when isPreview prop changes to false
+      previewDataRef.current.isInPreview = false;
     }
   }, [isPreview, directValue, blockId, subBlockId]);
-
-  // Check for preview mode first and get direct subblock values if available
-  useEffect(() => {
-    // Skip DOM-based detection if already in preview mode with direct values
-    if (isPreview && directValue !== undefined) return;
-    
-    try {
-      // Try to find if this component is within a preview parent
-      const parentBlock = document.querySelector(`[data-id="${blockId}"]`);
-      if (parentBlock) {
-        const isPreviewContext = parentBlock.closest('.preview-mode') != null;
-        
-        // Get direct subblock values from parent's data props if in preview mode
-        if (isPreviewContext) {
-          const dataProps = parentBlock.getAttribute('data-props');
-          if (dataProps) {
-            const parsedProps = JSON.parse(dataProps);
-            const directValue = parsedProps?.data?.subBlockValues?.[subBlockId];
-            
-            // If we have direct values in preview mode, use them
-            if (directValue !== undefined && directValue !== null) {
-              // Save the values in our ref
-              previewDataRef.current = {
-                isInPreview: true,
-                directValue: directValue
-              };
-              
-              // Update valueRef directly to use the preview value
-              valueRef.current = directValue;
-              
-            }
-          }
-        } else {
-          // Reset preview flag if we're no longer in preview mode
-          previewDataRef.current.isInPreview = false;
-        }
-      }
-    } catch (e) {
-      // Ignore errors in preview detection
-    }
-  }, [blockId, subBlockId, isPreview, directValue, storeValue]);
 
   // Check if this is an API key field that could be auto-filled
   const isApiKey =
@@ -273,7 +235,7 @@ export function useSubBlockValue<T = any>(
       // Otherwise use the store value or initial value
       valueRef.current = storeValue !== undefined ? storeValue : initialValue;
     }
-  }, [])
+  }, [storeValue, initialValue])
 
   // Update the ref if the store value changes
   // This ensures we're always working with the latest value

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/hooks/use-sub-block-value.ts
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/hooks/use-sub-block-value.ts
@@ -1,9 +1,13 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { isEqual } from 'lodash'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useGeneralStore } from '@/stores/settings/general/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 import { getProviderFromModel } from '@/providers/utils'
+
+// Add logger for diagnostic logging
+const logger = createLogger('useSubBlockValue')
 
 /**
  * Helper to handle API key auto-fill for provider-based blocks
@@ -142,12 +146,16 @@ function storeApiKeyValue(
  * @param blockId The ID of the block containing the sub-block
  * @param subBlockId The ID of the sub-block
  * @param triggerWorkflowUpdate Whether to trigger a workflow update when the value changes
+ * @param isPreview Whether this is being used in preview mode
+ * @param directValue The direct value to use when in preview mode
  * @returns A tuple containing the current value and a setter function
  */
 export function useSubBlockValue<T = any>(
   blockId: string,
   subBlockId: string,
-  triggerWorkflowUpdate: boolean = false
+  triggerWorkflowUpdate: boolean = false,
+  isPreview: boolean = false,
+  directValue?: T
 ): readonly [T | null, (value: T) => void] {
   const blockType = useWorkflowStore(
     useCallback((state) => state.blocks?.[blockId]?.type, [blockId])
@@ -165,11 +173,123 @@ export function useSubBlockValue<T = any>(
 
   // Previous model reference for detecting model changes
   const prevModelRef = useRef<string | null>(null)
+  
+  // Ref to track if we're in preview mode and have direct values
+  const previewDataRef = useRef<{
+    isInPreview: boolean,
+    directValue: T | null
+  }>({
+    isInPreview: isPreview,
+    directValue: directValue as T || null
+  })
 
   // Get value from subblock store - always call this hook unconditionally
   const storeValue = useSubBlockStore(
     useCallback((state) => state.getValue(blockId, subBlockId), [blockId, subBlockId])
   )
+
+  // Directly update preview data when props change
+  useEffect(() => {
+    if (isPreview && directValue !== undefined) {
+      previewDataRef.current = {
+        isInPreview: true,
+        directValue: directValue as T || null
+      };
+      valueRef.current = directValue as T || null;
+      
+      logger.info(`[PREVIEW-DIRECT] Using direct value for ${blockId}:${subBlockId}`, {
+        directValue,
+        isPreview
+      });
+    }
+  }, [isPreview, directValue, blockId, subBlockId]);
+
+  // Check for preview mode first and get direct subblock values if available
+  useEffect(() => {
+    // Skip DOM-based detection if already in preview mode with direct values
+    if (isPreview && directValue !== undefined) return;
+    
+    try {
+      // Try to find if this component is within a preview parent
+      const parentBlock = document.querySelector(`[data-id="${blockId}"]`);
+      if (parentBlock) {
+        const isPreviewContext = parentBlock.closest('.preview-mode') != null;
+        
+        // Get direct subblock values from parent's data props if in preview mode
+        if (isPreviewContext) {
+          const dataProps = parentBlock.getAttribute('data-props');
+          if (dataProps) {
+            const parsedProps = JSON.parse(dataProps);
+            const directValue = parsedProps?.data?.subBlockValues?.[subBlockId];
+            
+            // If we have direct values in preview mode, use them
+            if (directValue !== undefined && directValue !== null) {
+              // Save the values in our ref
+              previewDataRef.current = {
+                isInPreview: true,
+                directValue: directValue
+              };
+              
+              // Update valueRef directly to use the preview value
+              valueRef.current = directValue;
+              
+              logger.info(`[PREVIEW-DOM] Using direct subblock value for ${blockId}:${subBlockId}`, {
+                directValue,
+                storeValue
+              });
+            }
+          }
+        } else {
+          // Reset preview flag if we're no longer in preview mode
+          previewDataRef.current.isInPreview = false;
+        }
+      }
+    } catch (e) {
+      // Ignore errors in preview detection
+    }
+  }, [blockId, subBlockId, isPreview, directValue, storeValue]);
+
+  // Add logging to trace where values are coming from
+  useEffect(() => {
+    // Skip if we've already determined we're in preview mode
+    if (previewDataRef.current.isInPreview) return;
+    
+    // Check if we're in preview context
+    let isPreviewContext = false;
+    let directSubBlockValue = null;
+    
+    try {
+      // Try to find if this component is within a preview parent
+      const parentBlock = document.querySelector(`[data-id="${blockId}"]`);
+      if (parentBlock) {
+        isPreviewContext = parentBlock.closest('.preview-mode') != null;
+        
+        // Try to find the parent data to see if subBlockValues was passed directly
+        const dataProps = parentBlock.getAttribute('data-props');
+        if (dataProps) {
+          const parsedProps = JSON.parse(dataProps);
+          directSubBlockValue = parsedProps?.data?.subBlockValues?.[subBlockId];
+        }
+      }
+      
+      logger.info(`[DATA-TRACE] SubBlock value source for ${blockId}:${subBlockId}`, {
+        blockId,
+        subBlockId, 
+        storeValueExists: storeValue !== undefined,
+        initialValueExists: initialValue !== null,
+        isPreviewContext,
+        hasDirectSubBlockValue: directSubBlockValue !== undefined && directSubBlockValue !== null,
+        valueFromStore: storeValue,
+        valueFromInitial: initialValue,
+        valueFromDirect: directSubBlockValue,
+        actuallyUsing: previewDataRef.current.isInPreview ? 'directValue' : 
+                       (storeValue !== undefined ? 'globalStore' : 
+                       (initialValue !== null ? 'initialValue' : 'null')),
+      });
+    } catch (e) {
+      // Ignore errors - this is just diagnostic logging
+    }
+  }, [blockId, subBlockId, storeValue, initialValue]);
 
   // Check if this is an API key field that could be auto-filled
   const isApiKey =
@@ -190,10 +310,46 @@ export function useSubBlockValue<T = any>(
   // Compute the modelValue based on block type
   const modelValue = isProviderBasedBlock ? (modelSubBlockValue as string) : null
 
-  // Hook to set a value in the subblock store
-  const setValue = useCallback(
+  // Initialize valueRef on first render
+  useEffect(() => {
+    // If we're in preview mode with direct values, use those
+    if (previewDataRef.current.isInPreview) {
+      valueRef.current = previewDataRef.current.directValue;
+    } else {
+      // Otherwise use the store value or initial value
+      valueRef.current = storeValue !== undefined ? storeValue : initialValue;
+    }
+  }, [])
+
+  // Update the ref if the store value changes
+  // This ensures we're always working with the latest value
+  useEffect(() => {
+    // Skip updates from global store if we're using preview values
+    if (previewDataRef.current.isInPreview) return;
+    
+    // Use deep comparison for objects to prevent unnecessary updates
+    if (!isEqual(valueRef.current, storeValue)) {
+      valueRef.current = storeValue !== undefined ? storeValue : initialValue
+    }
+  }, [storeValue, initialValue])
+
+  // Create a preview-aware setValue function
+  const setValueWithPreview = useCallback(
     (newValue: T) => {
-      // Use deep comparison to avoid unnecessary updates for complex objects
+      // If we're in preview mode, just update the local valueRef for display
+      // but don't update the global store
+      if (previewDataRef.current.isInPreview) {
+        // Only update if the value has changed
+        if (!isEqual(valueRef.current, newValue)) {
+          valueRef.current = newValue;
+          // Update the ref as well
+          previewDataRef.current.directValue = newValue;
+        }
+        // Return early without updating global state
+        return;
+      }
+      
+      // For non-preview mode, use the normal setValue logic
       if (!isEqual(valueRef.current, newValue)) {
         valueRef.current = newValue
 
@@ -221,11 +377,6 @@ export function useSubBlockValue<T = any>(
     },
     [blockId, subBlockId, blockType, isApiKey, storeValue, triggerWorkflowUpdate, modelValue]
   )
-
-  // Initialize valueRef on first render
-  useEffect(() => {
-    valueRef.current = storeValue !== undefined ? storeValue : initialValue
-  }, [])
 
   // When component mounts, check for existing API key in toolParamsStore
   useEffect(() => {
@@ -297,14 +448,5 @@ export function useSubBlockValue<T = any>(
     isProviderBasedBlock,
   ])
 
-  // Update the ref if the store value changes
-  // This ensures we're always working with the latest value
-  useEffect(() => {
-    // Use deep comparison for objects to prevent unnecessary updates
-    if (!isEqual(valueRef.current, storeValue)) {
-      valueRef.current = storeValue !== undefined ? storeValue : initialValue
-    }
-  }, [storeValue, initialValue])
-
-  return [valueRef.current as T | null, setValue] as const
+  return [valueRef.current as T | null, setValueWithPreview] as const
 }

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/sub-block.tsx
@@ -3,7 +3,6 @@ import { Info } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
-import { createLogger } from '@/lib/logs/console-logger'
 import { getBlock } from '@/blocks/index'
 import { SubBlockConfig } from '@/blocks/types'
 import { CheckboxList } from './components/checkbox-list'
@@ -28,8 +27,6 @@ import { TimeInput } from './components/time-input'
 import { ToolInput } from './components/tool-input/tool-input'
 import { WebhookConfig } from './components/webhook/webhook'
 
-// Add logger
-const logger = createLogger('SubBlock')
 
 interface SubBlockProps {
   blockId: string
@@ -46,17 +43,6 @@ export function SubBlock({
   isPreview = false, 
   previewValue = undefined 
 }: SubBlockProps) {
-  // Add debugging logs to trace parent context
-  useEffect(() => {
-    logger.info(`[TRACE] SubBlock ${config.id} for block ${blockId}`, {
-      blockId,
-      subBlockId: config.id,
-      subBlockTitle: config.title,
-      isPreview: isPreview,
-      previewValue: previewValue,
-      usingGlobalStore: !isPreview
-    });
-  }, [blockId, config.id, config.title, isPreview, previewValue]);
 
   const handleMouseDown = (e: React.MouseEvent) => {
     e.stopPropagation()

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/sub-block.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from 'react'
 import { Info } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
+import { createLogger } from '@/lib/logs/console-logger'
 import { getBlock } from '@/blocks/index'
 import { SubBlockConfig } from '@/blocks/types'
 import { CheckboxList } from './components/checkbox-list'
@@ -26,13 +28,36 @@ import { TimeInput } from './components/time-input'
 import { ToolInput } from './components/tool-input/tool-input'
 import { WebhookConfig } from './components/webhook/webhook'
 
+// Add logger
+const logger = createLogger('SubBlock')
+
 interface SubBlockProps {
   blockId: string
   config: SubBlockConfig
   isConnecting: boolean
+  isPreview?: boolean
+  previewValue?: any
 }
 
-export function SubBlock({ blockId, config, isConnecting }: SubBlockProps) {
+export function SubBlock({ 
+  blockId, 
+  config, 
+  isConnecting, 
+  isPreview = false, 
+  previewValue = undefined 
+}: SubBlockProps) {
+  // Add debugging logs to trace parent context
+  useEffect(() => {
+    logger.info(`[TRACE] SubBlock ${config.id} for block ${blockId}`, {
+      blockId,
+      subBlockId: config.id,
+      subBlockTitle: config.title,
+      isPreview: isPreview,
+      previewValue: previewValue,
+      usingGlobalStore: !isPreview
+    });
+  }, [blockId, config.id, config.title, isPreview, previewValue]);
+
   const handleMouseDown = (e: React.MouseEvent) => {
     e.stopPropagation()
   }
@@ -48,6 +73,9 @@ export function SubBlock({ blockId, config, isConnecting }: SubBlockProps) {
   }
 
   const renderInput = () => {
+    // Get the subblock value from the config if available
+    const directValue = isPreview ? previewValue : undefined;
+    
     switch (config.type) {
       case 'short-input':
         return (
@@ -58,6 +86,8 @@ export function SubBlock({ blockId, config, isConnecting }: SubBlockProps) {
             password={config.password}
             isConnecting={isConnecting}
             config={config}
+            isPreview={isPreview}
+            value={directValue}
           />
         )
       case 'long-input':
@@ -69,6 +99,8 @@ export function SubBlock({ blockId, config, isConnecting }: SubBlockProps) {
             isConnecting={isConnecting}
             rows={config.rows}
             config={config}
+            isPreview={isPreview}
+            value={directValue}
           />
         )
       case 'dropdown':
@@ -78,6 +110,8 @@ export function SubBlock({ blockId, config, isConnecting }: SubBlockProps) {
               blockId={blockId}
               subBlockId={config.id}
               options={config.options as string[]}
+              isPreview={isPreview}
+              value={directValue}
             />
           </div>
         )

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/sub-block.tsx
@@ -1,7 +1,6 @@
 import { Info } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 import { getBlock } from '@/blocks/index'
 import { SubBlockConfig } from '@/blocks/types'
@@ -37,8 +36,6 @@ export function SubBlock({ blockId, config, isConnecting }: SubBlockProps) {
   const handleMouseDown = (e: React.MouseEvent) => {
     e.stopPropagation()
   }
-
-  const { getValue } = useSubBlockStore()
 
   const isFieldRequired = () => {
     const blockType = useWorkflowStore.getState().blocks[blockId]?.type

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/sub-block.tsx
@@ -125,10 +125,18 @@ export function SubBlock({
             defaultValue={(config.min || 0) + ((config.max || 100) - (config.min || 0)) / 2}
             step={config.step}
             integer={config.integer}
+            isPreview={isPreview}
+            value={directValue}
           />
         )
       case 'table':
-        return <Table blockId={blockId} subBlockId={config.id} columns={config.columns ?? []} />
+        return <Table 
+          blockId={blockId} 
+          subBlockId={config.id} 
+          columns={config.columns ?? []} 
+          isPreview={isPreview}
+          value={directValue}
+        />
       case 'code':
         return (
           <Code
@@ -138,12 +146,25 @@ export function SubBlock({
             placeholder={config.placeholder}
             language={config.language}
             generationType={config.generationType}
+            isPreview={isPreview}
+            value={directValue}
           />
         )
       case 'switch':
-        return <Switch blockId={blockId} subBlockId={config.id} title={config.title ?? ''} />
+        return <Switch 
+          blockId={blockId} 
+          subBlockId={config.id} 
+          title={config.title ?? ''} 
+          isPreview={isPreview}
+          value={directValue}
+        />
       case 'tool-input':
-        return <ToolInput blockId={blockId} subBlockId={config.id} />
+        return <ToolInput 
+          blockId={blockId} 
+          subBlockId={config.id}
+          isPreview={isPreview}
+          value={directValue}
+        />
       case 'checkbox-list':
         return (
           <CheckboxList
@@ -152,21 +173,46 @@ export function SubBlock({
             title={config.title ?? ''}
             options={config.options as { label: string; id: string }[]}
             layout={config.layout}
+            isPreview={isPreview}
+            value={directValue}
           />
         )
       case 'condition-input':
         return (
-          <ConditionInput blockId={blockId} subBlockId={config.id} isConnecting={isConnecting} />
+          <ConditionInput 
+            blockId={blockId} 
+            subBlockId={config.id} 
+            isConnecting={isConnecting}
+            isPreview={isPreview}
+            value={directValue}
+          />
         )
       case 'eval-input':
-        return <EvalInput blockId={blockId} subBlockId={config.id} />
+        return <EvalInput 
+          blockId={blockId} 
+          subBlockId={config.id}
+          isPreview={isPreview}
+          value={directValue}
+        />
       case 'date-input':
         return (
-          <DateInput blockId={blockId} subBlockId={config.id} placeholder={config.placeholder} />
+          <DateInput 
+            blockId={blockId} 
+            subBlockId={config.id} 
+            placeholder={config.placeholder}
+            isPreview={isPreview}
+            value={directValue}
+          />
         )
       case 'time-input':
         return (
-          <TimeInput blockId={blockId} subBlockId={config.id} placeholder={config.placeholder} />
+          <TimeInput 
+            blockId={blockId} 
+            subBlockId={config.id} 
+            placeholder={config.placeholder}
+            isPreview={isPreview}
+            value={directValue}
+          />
         )
       case 'file-upload':
         return (
@@ -176,20 +222,34 @@ export function SubBlock({
             acceptedTypes={config.acceptedTypes || '*'}
             multiple={config.multiple === true}
             maxSize={config.maxSize}
+            isPreview={isPreview}
+            value={directValue}
           />
         )
       case 'webhook-config':
         return (
-          <WebhookConfig blockId={blockId} subBlockId={config.id} isConnecting={isConnecting} />
+          <WebhookConfig 
+            blockId={blockId} 
+            subBlockId={config.id} 
+            isConnecting={isConnecting} 
+            isPreview={isPreview}
+            value={directValue}
+          />
         )
       case 'schedule-config':
         return (
-          <ScheduleConfig blockId={blockId} subBlockId={config.id} isConnecting={isConnecting} />
+          <ScheduleConfig 
+            blockId={blockId} 
+            subBlockId={config.id} 
+            isConnecting={isConnecting}
+            isPreview={isPreview}
+            value={directValue}
+          />
         )
       case 'oauth-input':
         return (
           <CredentialSelector
-            value={typeof config.value === 'string' ? config.value : ''}
+            value={isPreview && directValue ? directValue : (typeof config.value === 'string' ? config.value : '')}
             onChange={(value) => {
               // Use the workflow store to update the value
               const event = new CustomEvent('update-subblock-value', {
@@ -208,13 +268,36 @@ export function SubBlock({
           />
         )
       case 'file-selector':
-        return <FileSelectorInput blockId={blockId} subBlock={config} disabled={isConnecting} />
+        return <FileSelectorInput 
+          blockId={blockId} 
+          subBlock={config} 
+          disabled={isConnecting}
+          isPreview={isPreview}
+          value={directValue}
+        />
       case 'project-selector':
-        return <ProjectSelectorInput blockId={blockId} subBlock={config} disabled={isConnecting} />
+        return <ProjectSelectorInput 
+          blockId={blockId} 
+          subBlock={config} 
+          disabled={isConnecting}
+          isPreview={isPreview}
+          value={directValue}
+        />
       case 'folder-selector':
-        return <FolderSelectorInput blockId={blockId} subBlock={config} disabled={isConnecting} />
+        return <FolderSelectorInput 
+          blockId={blockId} 
+          subBlock={config} 
+          disabled={isConnecting}
+          isPreview={isPreview}
+          value={directValue}
+        />
       case 'input-format':
-        return <InputFormat blockId={blockId} subBlockId={config.id} />
+        return <InputFormat 
+          blockId={blockId} 
+          subBlockId={config.id}
+          isPreview={isPreview}
+          value={directValue}
+        />
       default:
         return <div>Unknown input type: {config.type}</div>
     }

--- a/apps/sim/app/w/[id]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/workflow-block.tsx
@@ -7,14 +7,19 @@ import { Card } from '@/components/ui/card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { parseCronToHumanReadable } from '@/lib/schedules/utils'
 import { cn, formatDateTime } from '@/lib/utils'
+import { createLogger } from '@/lib/logs/console-logger'
 import { useExecutionStore } from '@/stores/execution/store'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { mergeSubblockState } from '@/stores/workflows/utils'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
+import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { BlockConfig, SubBlockConfig } from '@/blocks/types'
 import { ActionBar } from './components/action-bar/action-bar'
 import { ConnectionBlocks } from './components/connection-blocks/connection-blocks'
 import { SubBlock } from './components/sub-block/sub-block'
+
+// Add logger for diagnostic logging
+const logger = createLogger('WorkflowBlock')
 
 interface WorkflowBlockProps {
   type: string
@@ -22,11 +27,28 @@ interface WorkflowBlockProps {
   name: string
   isActive?: boolean
   isPending?: boolean
+  isPreview?: boolean
+  isReadOnly?: boolean
+  subBlockValues?: Record<string, any>
+  blockState?: any
 }
 
 // Combine both interfaces into a single component
 export function WorkflowBlock({ id, data }: NodeProps<WorkflowBlockProps>) {
   const { type, config, name, isActive: dataIsActive, isPending } = data
+
+  // Add logging for debug purposes
+  useEffect(() => {
+    if (data.isPreview === true) {
+      logger.info(`[PREVIEW-RENDER] Block ${id} rendering in preview mode`, {
+        blockId: id,
+        blockType: type,
+        subBlockValues: data.subBlockValues ? Object.keys(data.subBlockValues) : [],
+        hasDirectSubBlocks: Boolean(data.subBlockValues && Object.keys(data.subBlockValues).length > 0),
+        isReadOnly: data.isReadOnly,
+      });
+    }
+  }, [id, type, data.isPreview, data.subBlockValues, data.isReadOnly]);
 
   // State management
   const [isConnecting, setIsConnecting] = useState(false)
@@ -253,10 +275,14 @@ export function WorkflowBlock({ id, data }: NodeProps<WorkflowBlockProps>) {
     let currentRow: SubBlockConfig[] = []
     let currentRowWidth = 0
 
-    // Get merged state for this block
+    // Get merged state for this block - use direct props if in preview mode
     const blocks = useWorkflowStore.getState().blocks
     const activeWorkflowId = useWorkflowRegistry.getState().activeWorkflowId || undefined
-    const mergedState = mergeSubblockState(blocks, activeWorkflowId, blockId)[blockId]
+    
+    // If in preview mode with direct subBlockValues, use those instead of global state
+    const mergedState = data.isPreview && data.subBlockValues 
+      ? { [blockId]: { subBlocks: data.subBlockValues } }
+      : mergeSubblockState(blocks, activeWorkflowId, blockId)
 
     // Filter visible blocks and those that meet their conditions
     const visibleSubBlocks = subBlocks.filter((block) => {
@@ -266,9 +292,9 @@ export function WorkflowBlock({ id, data }: NodeProps<WorkflowBlockProps>) {
       if (!block.condition) return true
 
       // Get the values of the fields this block depends on from merged state
-      const fieldValue = mergedState?.subBlocks[block.condition.field]?.value
+      const fieldValue = mergedState?.[blockId]?.subBlocks[block.condition.field]?.value
       const andFieldValue = block.condition.and
-        ? mergedState?.subBlocks[block.condition.and.field]?.value
+        ? mergedState?.[blockId]?.subBlocks[block.condition.and.field]?.value
         : undefined
 
       // Check if the condition value is an array
@@ -374,6 +400,15 @@ export function WorkflowBlock({ id, data }: NodeProps<WorkflowBlockProps>) {
           isPending && 'ring-2 ring-amber-500',
           'z-[20]'
         )}
+        data-id={id}
+        data-props={data.isPreview ? JSON.stringify({
+          isPreview: data.isPreview,
+          isReadOnly: data.isReadOnly,
+          blockType: type,
+          data: {
+            subBlockValues: data.subBlockValues
+          }
+        }) : undefined}
       >
         {/* Show debug indicator for pending blocks */}
         {isPending && (
@@ -653,7 +688,14 @@ export function WorkflowBlock({ id, data }: NodeProps<WorkflowBlockProps>) {
                       key={`${id}-${rowIndex}-${blockIndex}`}
                       className={cn('space-y-1', subBlock.layout === 'half' ? 'flex-1' : 'w-full')}
                     >
-                      <SubBlock blockId={id} config={subBlock} isConnecting={isConnecting} />
+                      <SubBlock 
+                        blockId={id} 
+                        config={subBlock} 
+                        isConnecting={isConnecting} 
+                        isPreview={data.isPreview} 
+                        previewValue={data.isPreview && data.subBlockValues ? 
+                          (data.subBlockValues[subBlock.id]?.value || null) : null} 
+                      />
                     </div>
                   ))}
                 </div>

--- a/apps/sim/app/w/[id]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/workflow-block.tsx
@@ -7,19 +7,15 @@ import { Card } from '@/components/ui/card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { parseCronToHumanReadable } from '@/lib/schedules/utils'
 import { cn, formatDateTime } from '@/lib/utils'
-import { createLogger } from '@/lib/logs/console-logger'
 import { useExecutionStore } from '@/stores/execution/store'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { mergeSubblockState } from '@/stores/workflows/utils'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
-import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { BlockConfig, SubBlockConfig } from '@/blocks/types'
 import { ActionBar } from './components/action-bar/action-bar'
 import { ConnectionBlocks } from './components/connection-blocks/connection-blocks'
 import { SubBlock } from './components/sub-block/sub-block'
 
-// Add logger for diagnostic logging
-const logger = createLogger('WorkflowBlock')
 
 interface WorkflowBlockProps {
   type: string
@@ -36,19 +32,6 @@ interface WorkflowBlockProps {
 // Combine both interfaces into a single component
 export function WorkflowBlock({ id, data }: NodeProps<WorkflowBlockProps>) {
   const { type, config, name, isActive: dataIsActive, isPending } = data
-
-  // Add logging for debug purposes
-  useEffect(() => {
-    if (data.isPreview === true) {
-      logger.info(`[PREVIEW-RENDER] Block ${id} rendering in preview mode`, {
-        blockId: id,
-        blockType: type,
-        subBlockValues: data.subBlockValues ? Object.keys(data.subBlockValues) : [],
-        hasDirectSubBlocks: Boolean(data.subBlockValues && Object.keys(data.subBlockValues).length > 0),
-        isReadOnly: data.isReadOnly,
-      });
-    }
-  }, [id, type, data.isPreview, data.subBlockValues, data.isReadOnly]);
 
   // State management
   const [isConnecting, setIsConnecting] = useState(false)

--- a/apps/sim/app/w/components/workflow-preview/generic-workflow-preview.tsx
+++ b/apps/sim/app/w/components/workflow-preview/generic-workflow-preview.tsx
@@ -8,21 +8,21 @@ import ReactFlow, {
   EdgeTypes,
   Handle,
   Node,
-  NodeProps,
   NodeTypes,
   Position,
   ReactFlowProvider,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
-import { Card } from '@/components/ui/card'
-import { Label } from '@/components/ui/label'
-import { cn } from '@/lib/utils'
+import { createLogger } from '@/lib/logs/console-logger'
+import { WorkflowBlock } from '@/app/w/[id]/components/workflow-block/workflow-block'
 import { WorkflowEdge } from '@/app/w/[id]/components/workflow-edge/workflow-edge'
 import { LoopInput } from '@/app/w/[id]/components/workflow-loop/components/loop-input/loop-input'
 import { LoopLabel } from '@/app/w/[id]/components/workflow-loop/components/loop-label/loop-label'
 import { createLoopNode } from '@/app/w/[id]/components/workflow-loop/workflow-loop'
 import { getBlock } from '@/blocks'
-import { SubBlockConfig } from '@/blocks/types'
+import { useEffect } from 'react'
+
+const logger = createLogger('WorkflowPreview')
 
 interface WorkflowPreviewProps {
   // The workflow state to render
@@ -49,13 +49,9 @@ interface WorkflowPreviewProps {
   defaultZoom?: number
 }
 
-interface ExtendedSubBlockConfig extends SubBlockConfig {
-  value?: any
-}
-
-// Define node types
+// Define node types - using the actual workflow components
 const nodeTypes: NodeTypes = {
-  workflowBlock: PreviewWorkflowBlock,
+  workflowBlock: WorkflowBlock,
   loopLabel: LoopLabel,
   loopInput: LoopInput,
 }
@@ -63,439 +59,6 @@ const nodeTypes: NodeTypes = {
 // Define edge types
 const edgeTypes: EdgeTypes = {
   workflowEdge: WorkflowEdge,
-}
-
-/**
- * Prepares subblocks by combining block state with block configuration
- */
-function prepareSubBlocks(blockSubBlocks: Record<string, any> = {}, blockConfig: any) {
-  const configSubBlocks = blockConfig?.subBlocks || []
-
-  return Object.entries(blockSubBlocks)
-    .map(([id, subBlock]) => {
-      const matchingConfig = configSubBlocks.find((config: any) => config.id === id)
-
-      const value = subBlock.value
-      const hasValue = value !== undefined && value !== null && value !== ''
-
-      if (!hasValue) return null
-
-      return {
-        ...matchingConfig,
-        ...subBlock,
-        id,
-      }
-    })
-    .filter(Boolean)
-}
-
-/**
- * Groups subblocks into rows for layout
- */
-function groupSubBlocks(subBlocks: ExtendedSubBlockConfig[]) {
-  const rows: ExtendedSubBlockConfig[][] = []
-  let currentRow: ExtendedSubBlockConfig[] = []
-  let currentRowWidth = 0
-
-  const visibleSubBlocks = subBlocks.filter((block) => !block.hidden)
-
-  visibleSubBlocks.forEach((block) => {
-    const blockWidth = block.layout === 'half' ? 0.5 : 1
-    if (currentRowWidth + blockWidth > 1) {
-      if (currentRow.length > 0) {
-        rows.push([...currentRow])
-      }
-      currentRow = [block]
-      currentRowWidth = blockWidth
-    } else {
-      currentRow.push(block)
-      currentRowWidth += blockWidth
-    }
-  })
-
-  if (currentRow.length > 0) {
-    rows.push(currentRow)
-  }
-
-  return rows
-}
-
-/**
- * PreviewSubBlock component - Renders a simplified version of a subblock input
- * @param config - The configuration for the subblock
- */
-function PreviewSubBlock({ config }: { config: ExtendedSubBlockConfig }) {
-  /**
-   * Renders a simplified input based on the subblock type
-   * Creates visual representations of different input types
-   */
-  const renderSimplifiedInput = () => {
-    switch (config.type) {
-      case 'short-input':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1.5 text-xs text-muted-foreground">
-            {config.password
-              ? '**********************'
-              : config.id === 'providerConfig' && config.value && typeof config.value === 'object'
-                ? Object.keys(config.value).length === 0
-                  ? 'Webhook pending configuration'
-                  : 'Webhook configured'
-                : config.value || config.placeholder || 'Text input'}
-          </div>
-        )
-      case 'long-input':
-        return (
-          <div className="h-16 rounded-md border border-input bg-background p-2 text-xs text-muted-foreground">
-            {typeof config.value === 'string'
-              ? config.value.length > 50
-                ? `${config.value.substring(0, 50)}...`
-                : config.value
-              : config.placeholder || 'Text area'}
-          </div>
-        )
-      case 'dropdown':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground flex items-center justify-between">
-            <span>
-              {config.value ||
-                (Array.isArray(config.options) ? config.options[0] : 'Select option')}
-            </span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="ml-2"
-            >
-              <path d="m6 9 6 6 6-6" />
-            </svg>
-          </div>
-        )
-      case 'switch':
-        return (
-          <div className="flex items-center space-x-2">
-            <div
-              className={`h-4 w-8 rounded-full ${config.value ? 'bg-primary' : 'bg-muted'} flex items-center`}
-            >
-              <div
-                className={`h-3 w-3 rounded-full bg-background transition-all ${config.value ? 'ml-4' : 'ml-0.5'}`}
-              ></div>
-            </div>
-            <span className="text-xs">{config.title}</span>
-          </div>
-        )
-      case 'checkbox-list':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground">
-            Checkbox list
-          </div>
-        )
-      case 'code':
-        return (
-          <div className="h-12 rounded-md border border-input bg-background p-2 text-xs font-mono text-muted-foreground">
-            {typeof config.value === 'string'
-              ? 'Code content'
-              : config.placeholder || 'Code editor'}
-          </div>
-        )
-      case 'tool-input':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground">
-            Tool configuration
-          </div>
-        )
-      case 'oauth-input':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground flex items-center justify-between">
-            <span>
-              {config.value ? 'Connected account' : config.placeholder || 'Select account'}
-            </span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="ml-2"
-            >
-              <path d="m6 9 6 6 6-6" />
-            </svg>
-          </div>
-        )
-      case 'file-selector':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground flex items-center justify-between">
-            <span>{config.value ? 'File selected' : config.placeholder || 'Select file'}</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="ml-2"
-            >
-              <path d="m6 9 6 6 6-6" />
-            </svg>
-          </div>
-        )
-      case 'folder-selector':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground flex items-center justify-between">
-            <span>{config.value ? 'Folder selected' : config.placeholder || 'Select folder'}</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="ml-2"
-            >
-              <path d="m6 9 6 6 6-6" />
-            </svg>
-          </div>
-        )
-      case 'project-selector':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground flex items-center justify-between">
-            <span>
-              {config.value ? 'Project selected' : config.placeholder || 'Select project'}
-            </span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="ml-2"
-            >
-              <path d="m6 9 6 6 6-6" />
-            </svg>
-          </div>
-        )
-      case 'condition-input':
-        return (
-          <div className="h-16 rounded-md border border-input bg-background p-2 text-xs text-muted-foreground">
-            Condition configuration
-          </div>
-        )
-      case 'eval-input':
-        return (
-          <div className="h-12 rounded-md border border-input bg-background p-2 text-xs font-mono text-muted-foreground">
-            Eval expression
-          </div>
-        )
-      case 'date-input':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground flex items-center justify-between">
-            <span>{config.value || config.placeholder || 'Select date'}</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="ml-2"
-            >
-              <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
-              <line x1="16" x2="16" y1="2" y2="6" />
-              <line x1="8" x2="8" y1="2" y2="6" />
-              <line x1="3" x2="21" y1="10" y2="10" />
-            </svg>
-          </div>
-        )
-      case 'time-input':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground flex items-center justify-between">
-            <span>{config.value || config.placeholder || 'Select time'}</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="ml-2"
-            >
-              <circle cx="12" cy="12" r="10" />
-              <polyline points="12 6 12 12 16 14" />
-            </svg>
-          </div>
-        )
-      case 'file-upload':
-        return (
-          <div className="h-7 rounded-md border border-dashed border-input bg-background px-3 py-1 text-xs text-muted-foreground flex items-center justify-center">
-            {config.value ? 'File uploaded' : 'Upload file'}
-          </div>
-        )
-      case 'webhook-config':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground">
-            Webhook configuration
-          </div>
-        )
-      case 'schedule-config':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground">
-            Schedule configuration
-          </div>
-        )
-      case 'input-format':
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground">
-            Input format configuration
-          </div>
-        )
-      case 'slider':
-        return (
-          <div className="h-7 px-1 py-2">
-            <div className="relative h-2 w-full rounded-full bg-muted">
-              <div
-                className="absolute h-2 rounded-full bg-primary"
-                style={{ width: `${((config.value || 50) / 100) * 100}%` }}
-              />
-              <div
-                className="absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-primary bg-background"
-                style={{ left: `${((config.value || 50) / 100) * 100}%` }}
-              />
-            </div>
-          </div>
-        )
-      default:
-        return (
-          <div className="h-7 rounded-md border border-input bg-background px-3 py-1 text-xs text-muted-foreground">
-            {config.value !== undefined ? String(config.value) : config.title || 'Input field'}
-          </div>
-        )
-    }
-  }
-
-  return (
-    <div className="space-y-1">
-      {config.type !== 'switch' && <Label className="text-xs">{config.title}</Label>}
-      {renderSimplifiedInput()}
-    </div>
-  )
-}
-
-function PreviewWorkflowBlock({ id, data }: NodeProps<any>) {
-  const { type, config, name, blockState, showSubBlocks = true } = data
-
-  // Only prepare subblocks if they should be shown
-  const preparedSubBlocks = useMemo(() => {
-    if (!showSubBlocks) return []
-    return prepareSubBlocks(blockState?.subBlocks, config)
-  }, [blockState?.subBlocks, config, showSubBlocks])
-
-  // Group subblocks for layout
-  const subBlockRows = useMemo(() => {
-    return groupSubBlocks(preparedSubBlocks)
-  }, [preparedSubBlocks])
-
-  return (
-    <div className="relative">
-      <Card
-        className={cn(
-          'shadow-md select-none relative',
-          'transition-ring transition-block-bg',
-          blockState?.isWide ? 'w-[400px]' : 'w-[260px]'
-        )}
-      >
-        {/* Block Header */}
-        <div className="flex items-center justify-between p-2 border-b">
-          <div className="flex items-center gap-2">
-            <div
-              className="flex items-center justify-center w-6 h-6 rounded"
-              style={{ backgroundColor: config.bgColor }}
-            >
-              <config.icon className="w-4 h-4 text-white" />
-            </div>
-            <span className="font-medium text-sm truncate max-w-[180px]" title={name}>
-              {name}
-            </span>
-          </div>
-        </div>
-
-        {/* Block Content */}
-        {showSubBlocks && (
-          <div className="px-3 py-2 space-y-2">
-            {subBlockRows.length > 0 ? (
-              subBlockRows.map((row, rowIndex) => (
-                <div key={`row-${rowIndex}`} className="flex gap-2">
-                  {row.map((subBlock, blockIndex) => (
-                    <div
-                      key={`${id}-${rowIndex}-${blockIndex}`}
-                      className={cn('space-y-1', subBlock.layout === 'half' ? 'flex-1' : 'w-full')}
-                    >
-                      <PreviewSubBlock config={subBlock} />
-                    </div>
-                  ))}
-                </div>
-              ))
-            ) : (
-              <div className="text-xs text-muted-foreground py-2">No configured items</div>
-            )}
-          </div>
-        )}
-
-        {/* Handles */}
-        {type !== 'starter' && (
-          <Handle
-            type="target"
-            position={blockState?.horizontalHandles ? Position.Left : Position.Top}
-            id="target"
-            className={cn(
-              '!w-3 !h-3',
-              '!bg-white !rounded-full !border !border-gray-200',
-              blockState?.horizontalHandles ? '!left-[-6px]' : '!top-[-6px]'
-            )}
-            isConnectable={false}
-          />
-        )}
-
-        {type !== 'condition' && (
-          <Handle
-            type="source"
-            position={blockState?.horizontalHandles ? Position.Right : Position.Bottom}
-            id="source"
-            className={cn(
-              '!w-3 !h-3',
-              '!bg-white !rounded-full !border !border-gray-200',
-              blockState?.horizontalHandles ? '!right-[-6px]' : '!bottom-[-6px]'
-            )}
-            isConnectable={false}
-          />
-        )}
-      </Card>
-    </div>
-  )
 }
 
 function WorkflowPreviewContent({
@@ -529,28 +92,33 @@ function WorkflowPreviewContent({
       }
     })
 
-    // Add block nodes
+    // Add block nodes using the same approach as workflow.tsx
     Object.entries(workflowState.blocks).forEach(([blockId, block]) => {
       const blockConfig = getBlock(block.type)
-      if (!blockConfig) return
+      if (!blockConfig) {
+        logger.error(`No configuration found for block type: ${block.type}`, { blockId })
+        return
+      }
 
       nodeArray.push({
         id: blockId,
         type: 'workflowBlock',
         position: block.position,
+        draggable: false,
         data: {
           type: block.type,
           config: blockConfig,
           name: block.name,
           blockState: block,
+          isReadOnly: true, // Set read-only mode for preview
+          isPreview: true, // Indicate this is a preview
           showSubBlocks,
         },
-        draggable: false,
       })
     })
 
     return nodeArray
-  }, [workflowState.blocks, workflowState.loops, showSubBlocks])
+  }, [JSON.stringify(workflowState.blocks), JSON.stringify(workflowState.loops), showSubBlocks])
 
   // Transform edges
   const edges: Edge[] = useMemo(() => {
@@ -562,7 +130,11 @@ function WorkflowPreviewContent({
       targetHandle: edge.targetHandle,
       type: 'workflowEdge',
     }))
-  }, [workflowState.edges])
+  }, [JSON.stringify(workflowState.edges)])
+
+  useEffect(() => {
+    logger.info('Rendering workflow state', { workflowState })
+  }, [workflowState])
 
   return (
     <div style={{ height, width }} className={className}>
@@ -585,6 +157,9 @@ function WorkflowPreviewContent({
         minZoom={0.1}
         maxZoom={2}
         proOptions={{ hideAttribution: true }}
+        elementsSelectable={false}
+        nodesDraggable={false}
+        nodesConnectable={false}
       >
         <Background />
       </ReactFlow>

--- a/apps/sim/app/w/components/workflow-preview/workflow-preview.tsx
+++ b/apps/sim/app/w/components/workflow-preview/workflow-preview.tsx
@@ -20,6 +20,7 @@ import { LoopInput } from '@/app/w/[id]/components/workflow-loop/components/loop
 import { LoopLabel } from '@/app/w/[id]/components/workflow-loop/components/loop-label/loop-label'
 import { createLoopNode } from '@/app/w/[id]/components/workflow-loop/workflow-loop'
 import { getBlock } from '@/blocks'
+import { cn } from '@/lib/utils'
 
 const logger = createLogger('WorkflowPreview')
 
@@ -74,6 +75,14 @@ export function WorkflowPreview({
   defaultPosition,
   defaultZoom,
 }: WorkflowPreviewProps) {
+  // Use effect to log the workflow state once outside of useMemo
+  useEffect(() => {
+    logger.info('WorkflowPreview received new state', {
+      blockCount: Object.keys(workflowState?.blocks || {}).length,
+      withSubBlocks: Object.values(workflowState?.blocks || {}).filter(b => b.subBlocks && Object.keys(b.subBlocks).length > 0).length,
+    });
+  }, [workflowState]);
+  
   // Transform blocks and loops into ReactFlow nodes
   const nodes: Node[] = useMemo(() => {
     const nodeArray: Node[] = []
@@ -97,11 +106,19 @@ export function WorkflowPreview({
 
     // Add block nodes using the same approach as workflow.tsx
     Object.entries(workflowState.blocks).forEach(([blockId, block]) => {
+      if (!block || !block.type) {
+        logger.warn(`Skipping invalid block: ${blockId}`);
+        return;
+      }
+    
       const blockConfig = getBlock(block.type)
       if (!blockConfig) {
         logger.error(`No configuration found for block type: ${block.type}`, { blockId })
-        return
+        return;
       }
+
+      // Create a deep clone of subBlocks to avoid any references to the original state
+      const subBlocksClone = block.subBlocks ? JSON.parse(JSON.stringify(block.subBlocks)) : {};
 
       nodeArray.push({
         id: blockId,
@@ -115,9 +132,13 @@ export function WorkflowPreview({
           blockState: block,
           isReadOnly: true, // Set read-only mode for preview
           isPreview: true, // Indicate this is a preview
-          subBlockValues: block.subBlocks || {}, // Use empty object as fallback
+          subBlockValues: subBlocksClone, // Use the deep clone to avoid reference issues
         },
       })
+      logger.info(`Preview node created: ${blockId}`, { 
+        blockType: block.type,
+        hasSubBlocks: block.subBlocks && Object.keys(block.subBlocks).length > 0
+      });
     })
 
     return nodeArray
@@ -141,7 +162,7 @@ export function WorkflowPreview({
 
   return (
     <ReactFlowProvider>
-      <div style={{ height, width }} className={className}>
+      <div style={{ height, width }} className={cn(className, 'preview-mode')}>
         <ReactFlow
           nodes={nodes}
           edges={edges}

--- a/apps/sim/app/w/components/workflow-preview/workflow-preview.tsx
+++ b/apps/sim/app/w/components/workflow-preview/workflow-preview.tsx
@@ -115,7 +115,7 @@ export function WorkflowPreview({
           blockState: block,
           isReadOnly: true, // Set read-only mode for preview
           isPreview: true, // Indicate this is a preview
-          showSubBlocks,
+          subBlockValues: block.subBlocks || {}, // Use empty object as fallback
         },
       })
     })

--- a/apps/sim/app/w/components/workflow-preview/workflow-preview.tsx
+++ b/apps/sim/app/w/components/workflow-preview/workflow-preview.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useEffect } from 'react'
+import { cloneDeep } from 'lodash'
 import ReactFlow, {
   Background,
   ConnectionLineType,
@@ -118,7 +119,7 @@ export function WorkflowPreview({
       }
 
       // Create a deep clone of subBlocks to avoid any references to the original state
-      const subBlocksClone = block.subBlocks ? JSON.parse(JSON.stringify(block.subBlocks)) : {};
+      const subBlocksClone = block.subBlocks ? cloneDeep(block.subBlocks) : {};
 
       nodeArray.push({
         id: blockId,

--- a/apps/sim/app/w/components/workflow-preview/workflow-preview.tsx
+++ b/apps/sim/app/w/components/workflow-preview/workflow-preview.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useEffect } from 'react'
 import ReactFlow, {
   Background,
   ConnectionLineType,
@@ -20,7 +20,6 @@ import { LoopInput } from '@/app/w/[id]/components/workflow-loop/components/loop
 import { LoopLabel } from '@/app/w/[id]/components/workflow-loop/components/loop-label/loop-label'
 import { createLoopNode } from '@/app/w/[id]/components/workflow-loop/workflow-loop'
 import { getBlock } from '@/blocks'
-import { useEffect } from 'react'
 
 const logger = createLogger('WorkflowPreview')
 
@@ -61,7 +60,11 @@ const edgeTypes: EdgeTypes = {
   workflowEdge: WorkflowEdge,
 }
 
-function WorkflowPreviewContent({
+// The subblocks should be getting passed from the state and not the subBlockStore. 
+// Create optional parameter boolan isPreview to pass in the block state to know how to render
+// the subblocks
+
+export function WorkflowPreview({
   workflowState,
   showSubBlocks = true,
   className,
@@ -137,40 +140,34 @@ function WorkflowPreviewContent({
   }, [workflowState])
 
   return (
-    <div style={{ height, width }} className={className}>
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        connectionLineType={ConnectionLineType.SmoothStep}
-        fitView
-        panOnScroll={false}
-        panOnDrag={isPannable}
-        zoomOnScroll={false}
-        draggable={false}
-        defaultViewport={{
-          x: defaultPosition?.x ?? 0,
-          y: defaultPosition?.y ?? 0,
-          zoom: defaultZoom ?? 1,
-        }}
-        minZoom={0.1}
-        maxZoom={2}
-        proOptions={{ hideAttribution: true }}
-        elementsSelectable={false}
-        nodesDraggable={false}
-        nodesConnectable={false}
-      >
-        <Background />
-      </ReactFlow>
-    </div>
-  )
-}
-
-export function WorkflowPreview(props: WorkflowPreviewProps) {
-  return (
     <ReactFlowProvider>
-      <WorkflowPreviewContent {...props} />
+      <div style={{ height, width }} className={className}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          connectionLineType={ConnectionLineType.SmoothStep}
+          fitView
+          panOnScroll={false}
+          panOnDrag={isPannable}
+          zoomOnScroll={false}
+          draggable={false}
+          defaultViewport={{
+            x: defaultPosition?.x ?? 0,
+            y: defaultPosition?.y ?? 0,
+            zoom: defaultZoom ?? 1,
+          }}
+          minZoom={0.1}
+          maxZoom={2}
+          proOptions={{ hideAttribution: true }}
+          elementsSelectable={false}
+          nodesDraggable={false}
+          nodesConnectable={false}
+        >
+          <Background />
+        </ReactFlow>
+      </div>
     </ReactFlowProvider>
   )
 }

--- a/apps/sim/app/w/marketplace/components/workflow-card.tsx
+++ b/apps/sim/app/w/marketplace/components/workflow-card.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { Eye } from 'lucide-react'
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
-import { WorkflowPreview } from '@/app/w/components/workflow-preview/generic-workflow-preview'
+import { WorkflowPreview } from '@/app/w/components/workflow-preview/workflow-preview'
 import { Workflow } from '../marketplace'
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,6 +170,8 @@
     },
     "apps/sim/node_modules/@types/node": {
       "version": "20.17.46",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.46.tgz",
+      "integrity": "sha512-0PQHLhZPWOxGW4auogW0eOQAuNIlCYvibIpG67ja0TOJ6/sehu+1en7sfceUn+QQtx4Rk3GxbLNwPh0Cav7TWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -192,6 +194,8 @@
     },
     "apps/sim/node_modules/tailwind-merge": {
       "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -200,6 +204,8 @@
     },
     "apps/sim/node_modules/tailwindcss": {
       "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -233,13 +239,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "apps/sim/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.2",
@@ -320,9 +319,9 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "1.2.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.18.tgz",
-      "integrity": "sha512-8B70+i+uB12Ae6Sn6B9Oc6W0W/XorGgc88Nx0pyUrcxFOdytHBaAVhTPqYsO3LLClfjYN8pQ9GMxd5cpGEnUcA==",
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.17.tgz",
+      "integrity": "sha512-mLFLDMCJaDK+j1nvoqeNszazSZIyeSMPi5X+fs5Wh3xWZljGGE0WmFg32RNkFujRB+UnM63EnhPG70WdqOx/MA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -807,35 +806,35 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.810.0.tgz",
-      "integrity": "sha512-wM8M0BrqRkbZ9fGaLmAl24CUgVmmLjiKuNTqGOHsdCIc7RV+IGv5CnGK7ciOltAttrFBxvDlhy2lg5F8gNw8Bg==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.806.0.tgz",
+      "integrity": "sha512-kQaBBBxEBU/IJ2wKG+LL2BK+uvBwpdvOA9jy1WhW+U2/DIMwMrjVs7M/ZvTlmVOJwhZaONcJbgQqsN4Yirjj4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/credential-provider-node": "3.810.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
+        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/credential-provider-node": "3.806.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.806.0",
         "@aws-sdk/middleware-expect-continue": "3.804.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.810.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.806.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-location-constraint": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-sdk-s3": "3.810.0",
+        "@aws-sdk/middleware-sdk-s3": "3.806.0",
         "@aws-sdk/middleware-ssec": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.810.0",
-        "@aws-sdk/region-config-resolver": "3.808.0",
-        "@aws-sdk/signature-v4-multi-region": "3.810.0",
+        "@aws-sdk/middleware-user-agent": "3.806.0",
+        "@aws-sdk/region-config-resolver": "3.806.0",
+        "@aws-sdk/signature-v4-multi-region": "3.806.0",
         "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-endpoints": "3.806.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.810.0",
+        "@aws-sdk/util-user-agent-node": "3.806.0",
         "@aws-sdk/xml-builder": "3.804.0",
-        "@smithy/config-resolver": "^4.1.2",
-        "@smithy/core": "^3.3.3",
+        "@smithy/config-resolver": "^4.1.1",
+        "@smithy/core": "^3.3.1",
         "@smithy/eventstream-serde-browser": "^4.0.2",
         "@smithy/eventstream-serde-config-resolver": "^4.1.0",
         "@smithy/eventstream-serde-node": "^4.0.2",
@@ -846,22 +845,22 @@
         "@smithy/invalid-dependency": "^4.0.2",
         "@smithy/md5-js": "^4.0.2",
         "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.6",
-        "@smithy/middleware-retry": "^4.1.7",
-        "@smithy/middleware-serde": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.3",
+        "@smithy/middleware-retry": "^4.1.4",
+        "@smithy/middleware-serde": "^4.0.3",
         "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-config-provider": "^4.1.0",
         "@smithy/node-http-handler": "^4.0.4",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/smithy-client": "^4.2.3",
         "@smithy/types": "^4.2.0",
         "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.14",
-        "@smithy/util-defaults-mode-node": "^4.0.14",
-        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-defaults-mode-browser": "^4.0.11",
+        "@smithy/util-defaults-mode-node": "^4.0.11",
+        "@smithy/util-endpoints": "^3.0.3",
         "@smithy/util-middleware": "^4.0.2",
         "@smithy/util-retry": "^4.0.3",
         "@smithy/util-stream": "^4.2.0",
@@ -874,45 +873,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.810.0.tgz",
-      "integrity": "sha512-Txp/3jHqkfA4BTklQEOGiZ1yTUxg+hITislfaWEzJ904vlDt4DvAljTlhfaz7pceCLA2+LhRlYZYSv7t5b0Ltw==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.806.0.tgz",
+      "integrity": "sha512-X0p/9/u9e6b22rlQqKucdtjdqmjSNB4c/8zDEoD5MvgYAAbMF9HNE0ST2xaA/WsJ7uE0jFfhPY2/00pslL1DqQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.806.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.810.0",
-        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/middleware-user-agent": "3.806.0",
+        "@aws-sdk/region-config-resolver": "3.806.0",
         "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-endpoints": "3.806.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.810.0",
-        "@smithy/config-resolver": "^4.1.2",
-        "@smithy/core": "^3.3.3",
+        "@aws-sdk/util-user-agent-node": "3.806.0",
+        "@smithy/config-resolver": "^4.1.1",
+        "@smithy/core": "^3.3.1",
         "@smithy/fetch-http-handler": "^5.0.2",
         "@smithy/hash-node": "^4.0.2",
         "@smithy/invalid-dependency": "^4.0.2",
         "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.6",
-        "@smithy/middleware-retry": "^4.1.7",
-        "@smithy/middleware-serde": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.3",
+        "@smithy/middleware-retry": "^4.1.4",
+        "@smithy/middleware-serde": "^4.0.3",
         "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-config-provider": "^4.1.0",
         "@smithy/node-http-handler": "^4.0.4",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/smithy-client": "^4.2.3",
         "@smithy/types": "^4.2.0",
         "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.14",
-        "@smithy/util-defaults-mode-node": "^4.0.14",
-        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-defaults-mode-browser": "^4.0.11",
+        "@smithy/util-defaults-mode-node": "^4.0.11",
+        "@smithy/util-endpoints": "^3.0.3",
         "@smithy/util-middleware": "^4.0.2",
         "@smithy/util-retry": "^4.0.3",
         "@smithy/util-utf8": "^4.0.0",
@@ -923,18 +922,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.810.0.tgz",
-      "integrity": "sha512-s2IJk+qa/15YZcv3pbdQNATDR+YdYnHf94MrAeVAWubtRLnzD8JciC+gh4LSPp7JzrWSvVOg2Ut1S+0y89xqCg==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.806.0.tgz",
+      "integrity": "sha512-HJRINPncdjPK0iL3f6cBpqCMaxVwq2oDbRCzOx04tsLZ0tNgRACBfT3d/zNVRvMt6fnOVKXoN1LAtQaw50pjEA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
-        "@smithy/core": "^3.3.3",
-        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/core": "^3.3.1",
+        "@smithy/node-config-provider": "^4.1.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/signature-v4": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/smithy-client": "^4.2.3",
         "@smithy/types": "^4.2.0",
         "@smithy/util-middleware": "^4.0.2",
         "fast-xml-parser": "4.4.1",
@@ -945,12 +944,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.810.0.tgz",
-      "integrity": "sha512-iwHqF+KryKONfbdFk3iKhhPk4fHxh5QP5fXXR//jhYwmszaLOwc7CLCE9AxhgiMzAs+kV8nBFQZvdjFpPzVGOA==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.806.0.tgz",
+      "integrity": "sha512-nbPwmZn0kt6Q1XI2FaJWP6AhF9tro4cO5HlmZQx8NU+B0H1y9WMo659Q5zLLY46BXgoQVIJEsPSZpcZk27O4aw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.806.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -961,18 +960,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.810.0.tgz",
-      "integrity": "sha512-SKzjLd+8ugif7yy9sOAAdnPE1vCBHQe6jKgs2AadMpCmWm34DiHz/KuulHdvURUGMIi7CvmaC8aH77twDPYbtg==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.806.0.tgz",
+      "integrity": "sha512-e/gB2iJQQ4ZpecOVpEFhEvjGwuTqNCzhVaVsFYVc49FPfR1seuN7qBGYe1MO7mouGDQFInzJgcNup0DnYUrLiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.806.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/fetch-http-handler": "^5.0.2",
         "@smithy/node-http-handler": "^4.0.4",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/smithy-client": "^4.2.3",
         "@smithy/types": "^4.2.0",
         "@smithy/util-stream": "^4.2.0",
         "tslib": "^2.6.2"
@@ -982,20 +981,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.810.0.tgz",
-      "integrity": "sha512-H2QCSnxWJ/mj8HTcyHmCmyQ5bO/+imRi4mlBIpUyKjiYKro52WD3gXlGgPIDo2q3UFIHq37kmYvS00i+qIY9tw==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.806.0.tgz",
+      "integrity": "sha512-FogfbuYSEZgFxbNy0QcsBZHHe5mSv5HV3+JyB5n0kCyjOISCVCZD7gwxKdXjt8O1hXq5k5SOdQvydGULlB6rew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/credential-provider-env": "3.810.0",
-        "@aws-sdk/credential-provider-http": "3.810.0",
-        "@aws-sdk/credential-provider-process": "3.810.0",
-        "@aws-sdk/credential-provider-sso": "3.810.0",
-        "@aws-sdk/credential-provider-web-identity": "3.810.0",
-        "@aws-sdk/nested-clients": "3.810.0",
+        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/credential-provider-env": "3.806.0",
+        "@aws-sdk/credential-provider-http": "3.806.0",
+        "@aws-sdk/credential-provider-process": "3.806.0",
+        "@aws-sdk/credential-provider-sso": "3.806.0",
+        "@aws-sdk/credential-provider-web-identity": "3.806.0",
+        "@aws-sdk/nested-clients": "3.806.0",
         "@aws-sdk/types": "3.804.0",
-        "@smithy/credential-provider-imds": "^4.0.4",
+        "@smithy/credential-provider-imds": "^4.0.2",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -1006,19 +1005,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.810.0.tgz",
-      "integrity": "sha512-9E3Chv3x+RBM3N1bwLCyvXxoiPAckCI74wG7ePN4F3b/7ieIkbEl/3Hd67j1fnt62Xa1cjUHRu2tz5pdEv5G1Q==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.806.0.tgz",
+      "integrity": "sha512-fZX8xP2Kf0k70kDTog/87fh/M+CV0E2yujSw1cUBJhDSwDX3RlUahiJk7TpB/KGw6hEFESMd6+7kq3UzYuw3rg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.810.0",
-        "@aws-sdk/credential-provider-http": "3.810.0",
-        "@aws-sdk/credential-provider-ini": "3.810.0",
-        "@aws-sdk/credential-provider-process": "3.810.0",
-        "@aws-sdk/credential-provider-sso": "3.810.0",
-        "@aws-sdk/credential-provider-web-identity": "3.810.0",
+        "@aws-sdk/credential-provider-env": "3.806.0",
+        "@aws-sdk/credential-provider-http": "3.806.0",
+        "@aws-sdk/credential-provider-ini": "3.806.0",
+        "@aws-sdk/credential-provider-process": "3.806.0",
+        "@aws-sdk/credential-provider-sso": "3.806.0",
+        "@aws-sdk/credential-provider-web-identity": "3.806.0",
         "@aws-sdk/types": "3.804.0",
-        "@smithy/credential-provider-imds": "^4.0.4",
+        "@smithy/credential-provider-imds": "^4.0.2",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -1029,12 +1028,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.810.0.tgz",
-      "integrity": "sha512-42kE6MLdsmMGp1id3Gisal4MbMiF7PIc0tAznTeIuE8r7cIF8yeQWw/PBOIvjyI57DxbyKzLUAMEJuigUpApCw==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.806.0.tgz",
+      "integrity": "sha512-8Y8GYEw/1e5IZRDQL02H6nsTDcRWid/afRMeWg+93oLQmbHcTtdm48tjis+7Xwqy+XazhMDmkbUht11QPTDJcQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.806.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -1046,14 +1045,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.810.0.tgz",
-      "integrity": "sha512-8WjX6tz+FCvM93Y33gsr13p/HiiTJmVn5AK1O8PTkvHBclQDzmtAW5FdPqTpAJGswLW2FB0xRqdsSMN2dQEjNw==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.806.0.tgz",
+      "integrity": "sha512-hT9OBwCxWMPBydNhXm2gdNNzx5AJNheS9RglwDDvXWzQ9qDuRztjuMBilMSUMb0HF9K4IqQjYzGqczMuktz4qQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.810.0",
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/token-providers": "3.810.0",
+        "@aws-sdk/client-sso": "3.806.0",
+        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/token-providers": "3.806.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -1065,13 +1064,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.810.0.tgz",
-      "integrity": "sha512-uKQJY0AcPyrvMmfGLo36semgjqJ4vmLTqOSW9u40qQDspRnG73/P09lAO2ntqKlhwvMBt3XfcNnOpyyhKRcOfA==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.806.0.tgz",
+      "integrity": "sha512-XxaSY9Zd3D4ClUGENYMvi52ac5FuJPPAsvRtEfyrSdEpf6QufbMpnexWBZMYRF31h/VutgqtJwosGgNytpxMEg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
-        "@aws-sdk/nested-clients": "3.810.0",
+        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/nested-clients": "3.806.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -1082,14 +1081,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.808.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.808.0.tgz",
-      "integrity": "sha512-wEPlNcs8dir9lXbuviEGtSzYSxG/NRKQrJk5ybOc7OpPGHovsN+QhDOdY3lcjOFdwMTiMIG9foUkPz3zBpLB1A==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.806.0.tgz",
+      "integrity": "sha512-ACjuyKJw9OZl8z8HzPEaqn1o7ElVW94mowyoZvyUIDouwAPGqPGJbJ5V35qx1oDTFSAJX+N3O3AO6RyFc8nUhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-arn-parser": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-config-provider": "^4.1.0",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "@smithy/util-config-provider": "^4.0.0",
@@ -1115,18 +1114,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.810.0.tgz",
-      "integrity": "sha512-lF5fse+26hluElOtDZMsi5EH50G13OEqglFgpSc6xWnqNhbDc+CnPQRMwTVlOJBDR1/YVbJ15LOKf4pkat46Eg==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.806.0.tgz",
+      "integrity": "sha512-YEmuU2Nr/+blhi70gS38fnCe2IoL6OVVZXMp4MbzqZRUqeBbnxZhHQrd5YOiboJz7iq+g98xwFebHY167iejcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.806.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-config-provider": "^4.1.0",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "@smithy/util-middleware": "^4.0.2",
@@ -1197,19 +1196,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.810.0.tgz",
-      "integrity": "sha512-CmQHPVopJYDiGQOmqn5AcmhksQ9qNETF0VgU251Q4tsP9s3R9nBR1r2bZwLt5+dCtf9UCa7cBw4jXKHtH38JTg==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.806.0.tgz",
+      "integrity": "sha512-K1ssdovHH/kPN9EUS1LznwzoL+r89Cx8qAkp0K8MqdCQuBjZ0KRnjvo9nx69Vg5d/rg01VYTxomFUPXfcPtVXw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.806.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-arn-parser": "3.804.0",
-        "@smithy/core": "^3.3.3",
-        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/core": "^3.3.1",
+        "@smithy/node-config-provider": "^4.1.0",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/signature-v4": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/smithy-client": "^4.2.3",
         "@smithy/types": "^4.2.0",
         "@smithy/util-config-provider": "^4.0.0",
         "@smithy/util-middleware": "^4.0.2",
@@ -1236,15 +1235,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.810.0.tgz",
-      "integrity": "sha512-gLMJcqgIq7k9skX8u0Yyi+jil4elbsmLf3TuDuqNdlqiZ44/AKdDFfU3mU5tRUtMfP42a3gvb2U3elP0BIeybQ==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.806.0.tgz",
+      "integrity": "sha512-XoIromVffgXnc+/mjlR2EVzQVIei3bPVtafIZNsHuEmUvIWJXiWsa2eJpt3BUqa0HF9YPknK7ommNEhqRb8ucg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.806.0",
         "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.808.0",
-        "@smithy/core": "^3.3.3",
+        "@aws-sdk/util-endpoints": "3.806.0",
+        "@smithy/core": "^3.3.1",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
@@ -1254,45 +1253,45 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.810.0.tgz",
-      "integrity": "sha512-w+tGXFSQjzvJ3j2sQ4GJRdD+YXLTgwLd9eG/A+7pjrv2yLLV70M4HqRrFqH06JBjqT5rsOxonc/QSjROyxk+IA==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.806.0.tgz",
+      "integrity": "sha512-ua2gzpfQ9MF8Rny+tOAivowOWWvqEusez2rdcQK8jdBjA1ANd/0xzToSZjZh0ziN8Kl8jOhNnHbQJ0v6dT6+hg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/core": "3.806.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.810.0",
-        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/middleware-user-agent": "3.806.0",
+        "@aws-sdk/region-config-resolver": "3.806.0",
         "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-endpoints": "3.806.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.810.0",
-        "@smithy/config-resolver": "^4.1.2",
-        "@smithy/core": "^3.3.3",
+        "@aws-sdk/util-user-agent-node": "3.806.0",
+        "@smithy/config-resolver": "^4.1.1",
+        "@smithy/core": "^3.3.1",
         "@smithy/fetch-http-handler": "^5.0.2",
         "@smithy/hash-node": "^4.0.2",
         "@smithy/invalid-dependency": "^4.0.2",
         "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.6",
-        "@smithy/middleware-retry": "^4.1.7",
-        "@smithy/middleware-serde": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.3",
+        "@smithy/middleware-retry": "^4.1.4",
+        "@smithy/middleware-serde": "^4.0.3",
         "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-config-provider": "^4.1.0",
         "@smithy/node-http-handler": "^4.0.4",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/smithy-client": "^4.2.3",
         "@smithy/types": "^4.2.0",
         "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.14",
-        "@smithy/util-defaults-mode-node": "^4.0.14",
-        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-defaults-mode-browser": "^4.0.11",
+        "@smithy/util-defaults-mode-node": "^4.0.11",
+        "@smithy/util-endpoints": "^3.0.3",
         "@smithy/util-middleware": "^4.0.2",
         "@smithy/util-retry": "^4.0.3",
         "@smithy/util-utf8": "^4.0.0",
@@ -1303,13 +1302,13 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.808.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.808.0.tgz",
-      "integrity": "sha512-9x2QWfphkARZY5OGkl9dJxZlSlYM2l5inFeo2bKntGuwg4A4YUe5h7d5yJ6sZbam9h43eBrkOdumx03DAkQF9A==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.806.0.tgz",
+      "integrity": "sha512-cuv5pX55JOlzKC/iLsB5nZ9eUyVgncim3VhhWHZA/KYPh7rLMjOEfZ+xyaE9uLJXGmzOJboFH7+YdTRdIcOgrg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-config-provider": "^4.1.0",
         "@smithy/types": "^4.2.0",
         "@smithy/util-config-provider": "^4.0.0",
         "@smithy/util-middleware": "^4.0.2",
@@ -1320,17 +1319,17 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.810.0.tgz",
-      "integrity": "sha512-/6TISQT3HUOoY3Gli1EvQVISNGp8XawGKD4igJqwyF3l35VvajzaAfhwk+Tm5TKTCkFh8EFnqWeT+mId5AaUbA==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.806.0.tgz",
+      "integrity": "sha512-/LjdkoMAr6T0EIIWVt444CJlaOCpYwjKxhTgZODSeRUPhKQxidBehg0TmXgQUc3oGUhGFPGCuQtFgLT0xvOSnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.810.0",
+        "@aws-sdk/signature-v4-multi-region": "3.806.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-format-url": "3.804.0",
-        "@smithy/middleware-endpoint": "^4.1.6",
+        "@smithy/middleware-endpoint": "^4.1.3",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/smithy-client": "^4.2.3",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -1339,12 +1338,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.810.0.tgz",
-      "integrity": "sha512-6F6evHRrA0OG/H67YuZBcI7EH4A0O5dIhczo2N0AK9z495uSIv+0xUrSrDhFTZxZjo6gkADIXroRjP1kwqK6ew==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.806.0.tgz",
+      "integrity": "sha512-IrbEnpKvG8d9rUWAvsF28g8qBlQ02FaOxn4cGXtTs0b0BGMK1M+cGQrYjJ7Ak08kIXDxBqsdIlZGsKYr+Ds9+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.810.0",
+        "@aws-sdk/middleware-sdk-s3": "3.806.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/signature-v4": "^5.1.0",
@@ -1356,12 +1355,12 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.810.0.tgz",
-      "integrity": "sha512-fdgHRCDpnzsD+0km7zuRbHRysJECfS8o9T9/pZ6XAr1z2FNV/UveHtnUYq0j6XpDMrIm0/suvXbshIjQU+a+sw==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.806.0.tgz",
+      "integrity": "sha512-I6SxcsvV7yinJZmPgGullFHS0tsTKa7K3jEc5dmyCz8X+kZPfsWNffZmtmnCvWXPqMXWBvK6hVaxwomx79yeHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/nested-clients": "3.810.0",
+        "@aws-sdk/nested-clients": "3.806.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -1398,14 +1397,14 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.808.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.808.0.tgz",
-      "integrity": "sha512-N6Lic98uc4ADB7fLWlzx+1uVnq04VgVjngZvwHoujcRg9YDhIg9dUDiTzD5VZv13g1BrPYmvYP1HhsildpGV6w==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.806.0.tgz",
+      "integrity": "sha512-3YRRgZ+qFuWDdm5uAbxKsr65UAil4KkrFKua9f4m7Be3v24ETiFOOqhanFUIk9/WOtvzF7oFEiDjYKDGlwV2xg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
         "@smithy/types": "^4.2.0",
-        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-endpoints": "^3.0.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1452,14 +1451,14 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.810.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.810.0.tgz",
-      "integrity": "sha512-T56/ANEGNuvhqVoWZdr+0ZY2hjV93cH2OfGHIlVTVSAMACWG54XehDPESEso1CJNhJGYZPsE+FE42HGCk/XDMg==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.806.0.tgz",
+      "integrity": "sha512-Az2e4/gmPZ4BpB7QRj7U76I+fctXhNcxlcgsaHnMhvt+R30nvzM2EhsyBUvsWl8+r9bnLeYt9BpvEZeq2ANDzA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/middleware-user-agent": "3.806.0",
         "@aws-sdk/types": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-config-provider": "^4.1.0",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -2881,9 +2880,9 @@
       }
     },
     "node_modules/@fastify/otel": {
-      "version": "0.8.0",
-      "resolved": "https://codeload.github.com/getsentry/fastify-otel/tar.gz/ae3088d65e286bdc94ac5d722573537d6a6671bb",
-      "integrity": "sha512-8Mb0z6LsLb8krU+G/s29Gi5iPPf7em2RG3Sn50yLHVDP3Cz382MMBy790Q2zAS+iJ3hX9Fv7SKBy8Zil4DZQZQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.6.0.tgz",
+      "integrity": "sha512-lL+36KwGcFiAMcsPOLLsR+GV8ZpQuz5RLVstlgqmecTdQLTXVOe9Z8uwpMg9ktPcV++Ugp3dzzpBKNFWWWelYg==",
       "funding": [
         {
           "type": "github",
@@ -2896,69 +2895,27 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/core": "^1.30.1",
-        "@opentelemetry/instrumentation": "^0.57.2",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
-        "minimatch": "^9"
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.200.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0"
       }
     },
-    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@fastify/otel/node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.57.2",
-        "@types/shimmer": "^1.2.0",
-        "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@fastify/otel/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -4023,13 +3980,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-2.0.1.tgz",
-      "integrity": "sha512-FeHtOp2XMhYxzYhC8sXhsc3gMeoDzjI+CGuPX+vRSyUdHZHDKTMoY9jRfk8ObmZsZDTWmd63Yqcf4X472YtHeA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-2.0.0.tgz",
+      "integrity": "sha512-vXUHL9Oy5gBY+CtrLQQm254ek5jGSImLTzp51ZVC5hVOTDf9dbkymMrGU/3MYDUC8MZzPqwKnAfMPpCcjdqV5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/sdk-trace-base": "2.0.1",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
         "jaeger-client": "^3.15.0"
       },
@@ -4041,9 +3998,9 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4056,13 +4013,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
-      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -4177,22 +4134,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
@@ -4247,22 +4188,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
       "version": "0.200.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.200.0.tgz",
@@ -4295,22 +4220,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
@@ -4348,22 +4257,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-prometheus": {
       "version": "0.200.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.200.0.tgz",
@@ -4394,22 +4287,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
@@ -4446,22 +4323,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
@@ -4515,22 +4376,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
@@ -4582,22 +4427,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
@@ -4646,22 +4475,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/sdk-trace-base": {
@@ -4913,9 +4726,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-document-load/node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6063,9 +5876,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-user-interaction/node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6177,22 +5990,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
@@ -6280,12 +6077,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
-      "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/core": "2.0.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -6296,9 +6093,9 @@
       }
     },
     "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6340,22 +6137,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
@@ -6433,22 +6214,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-node": {
       "version": "0.200.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.200.0.tgz",
@@ -6498,22 +6263,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-base": {
@@ -6608,22 +6357,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
@@ -6642,13 +6375,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.0.1.tgz",
-      "integrity": "sha512-R4/i0rISvAujG4Zwk3s6ySyrWG+Db3SerZVM4jZ2lEzjrNylF7nRAy1hVvWe8gTbwIxX+6w6ZvZwdtl2C7UQHQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.0.0.tgz",
+      "integrity": "sha512-2IeDP1k2fipeCH6OcTSg3HgaSvTTqgUNld5GIPGXWspynZSK85YjUDazEYpSVIyaMeQY6+ZHEaD5cwsRaq3dWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/sdk-trace-base": "2.0.1"
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -6658,9 +6392,9 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6673,13 +6407,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
-      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -6803,6 +6537,14 @@
         "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -8795,50 +8537,50 @@
       }
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.19.0.tgz",
-      "integrity": "sha512-DlEHX4eIHe5yIuh/cFu9OiaFuk1CTnFK95zj61I7Q2fxmN43dIwC3xAAGJ/Hy+GDQi7kU+BiS2sudSHSTq81BA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.17.0.tgz",
+      "integrity": "sha512-37n6NXtkUfdK7YiP3L5DJvhA/iusOmnjHQdX1e2VwI6a29xHCl/vRqLR3XNr5K4m+49al+3fWo2ltcKsfV+0xw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.19.0"
+        "@sentry/core": "9.17.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.19.0.tgz",
-      "integrity": "sha512-yixRrv4NfpjhFW56AuUTjVwZlignB9FWAXXyrmRP3SsFeJCFrAsSD8HOxV9RXNr9ePYl7MEU0Agi43YWhJsiAw==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.17.0.tgz",
+      "integrity": "sha512-C2jBlGgYVGm8eXK38wlYQyd6NsHKaQlENg5fx8TDFMKWMNmLf6BmnPZ+y73OsFwcUtBz04CwZteybYB2GgYrvQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.19.0"
+        "@sentry/core": "9.17.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.19.0.tgz",
-      "integrity": "sha512-i/X9brRchbAF25yjxLTI7E8eoESRPBgIyQOWoWRXXt2n51iBRTjLXSaEfGvjdN+qrMq/yd6nC1/UqJVxXHeIhA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.17.0.tgz",
+      "integrity": "sha512-oH4NolXkEpe73eRP9r3K6WpERYItZisYQudsNrtkUBQL5M/uENiE7YTOvL5osD8AWmU0hCKY3Oua+qDi2lB+8g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "9.19.0",
-        "@sentry/core": "9.19.0"
+        "@sentry-internal/browser-utils": "9.17.0",
+        "@sentry/core": "9.17.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.19.0.tgz",
-      "integrity": "sha512-YC8yrOjuKSfQgGniJnzkdbFsWEPTlNpzeeYPTxS4ouH1FwfGrSkPmcddjor2YHaLfiuHHqQ/Vvq70n+zruJH7A==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.17.0.tgz",
+      "integrity": "sha512-w9AxBJIa+MbxDngvwnqouoJ/ezb7wNjxzFXtmaVtGp7hbC4yme/TOTNtFYg2J/ceQf3GMc8AfW5tsP6zU0R7gg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "9.19.0",
-        "@sentry/core": "9.19.0"
+        "@sentry-internal/replay": "9.17.0",
+        "@sentry/core": "9.17.0"
       },
       "engines": {
         "node": ">=18"
@@ -8854,16 +8596,16 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.19.0.tgz",
-      "integrity": "sha512-efKfPQ0yQkdIkC7qJ5TIHxnecLNENGUYl1YD/TC8yyzW2JRf/3OYo5yg1hY2rhsP5RwQShXlT7uA03ABVIkA4A==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.17.0.tgz",
+      "integrity": "sha512-3e/Q5bv06Q+XYV2cKmUgfMfnJtBY8MZKufpcwQ2ab2eMrastqau9KjYeWXapskDm179oPLfzLcDCSlDSTcvqpQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "9.19.0",
-        "@sentry-internal/feedback": "9.19.0",
-        "@sentry-internal/replay": "9.19.0",
-        "@sentry-internal/replay-canvas": "9.19.0",
-        "@sentry/core": "9.19.0"
+        "@sentry-internal/browser-utils": "9.17.0",
+        "@sentry-internal/feedback": "9.17.0",
+        "@sentry-internal/replay": "9.17.0",
+        "@sentry-internal/replay-canvas": "9.17.0",
+        "@sentry/core": "9.17.0"
       },
       "engines": {
         "node": ">=18"
@@ -9045,29 +8787,29 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.19.0.tgz",
-      "integrity": "sha512-I41rKpMJHHZb0z0Nja+Lxto6IkEEmX3uWjnECypF8Z1HIjeJB0+PXl8p/7TeaKYqw2J2GYcRTg7jQZDmvKle1w==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.17.0.tgz",
+      "integrity": "sha512-9f1A93/kY9lLH06L1thPx94IhyLjEP3aRxYAtjtBfzId8UtubSpwP92sbxgslodD73R4tURwWJj7nYZ9HLYBUg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/nextjs": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-9.19.0.tgz",
-      "integrity": "sha512-VE8xCIHaJBNF7DdiaG3MhBvUn5EWSJyCrrbtEkY5cvlo5pc19tBaxDwGJQfK63Z0DuZCuG9lwih7jCdmCXziwA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-9.17.0.tgz",
+      "integrity": "sha512-BTTUnHt2sFMQ081Fz+00JCiyHHXbujNFkezSeB5EoNIat7VErWh3fGJFjxv34ICfidscGQGeEHbbkyixb29J4w==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/semantic-conventions": "^1.30.0",
         "@rollup/plugin-commonjs": "28.0.1",
-        "@sentry-internal/browser-utils": "9.19.0",
-        "@sentry/core": "9.19.0",
-        "@sentry/node": "9.19.0",
-        "@sentry/opentelemetry": "9.19.0",
-        "@sentry/react": "9.19.0",
-        "@sentry/vercel-edge": "9.19.0",
+        "@sentry-internal/browser-utils": "9.17.0",
+        "@sentry/core": "9.17.0",
+        "@sentry/node": "9.17.0",
+        "@sentry/opentelemetry": "9.17.0",
+        "@sentry/react": "9.17.0",
+        "@sentry/vercel-edge": "9.17.0",
         "@sentry/webpack-plugin": "3.3.1",
         "chalk": "3.0.0",
         "resolve": "1.22.8",
@@ -9081,67 +8823,178 @@
         "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0"
       }
     },
-    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
+        "@opentelemetry/api": "^1.3.0"
       },
       "engines": {
-        "node": "^18.19.0 || >=20.6.0"
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
-      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
-        "node": "^18.19.0 || >=20.6.0"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sentry/nextjs/node_modules/@sentry/opentelemetry": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.19.0.tgz",
-      "integrity": "sha512-Js6153kW5mNjjukk6TVb04D/8DDhA9MO++WRzXWzNP+FiPi5zwtvm+Je2TvTeAjSH74f6o2JpfECdrfPYHWopA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.17.0.tgz",
+      "integrity": "sha512-hrQ5SwW3pUwQ+ORBILqQqFj9ZLoKqo12OWuTwR8fxCErVJGeezuNvIpyNfkdtEW7X6N0AQnEfAg3umDAt/TAGw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.19.0"
+        "@sentry/core": "9.17.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/instrumentation": "^0.57.1 || ^0.200.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.30.0"
+        "@opentelemetry/context-async-hooks": "^1.30.1",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.28.0"
+      }
+    },
+    "node_modules/@sentry/nextjs/node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.19.0.tgz",
-      "integrity": "sha512-WKVcUBy5Zc+LGvfV/CfGPBDfnmEOSxLCMYzXIhx0gUxf2+8WpMMc/8yW/25zbXMo3eC4oST4GBDSpTfNdMBz1w==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.17.0.tgz",
+      "integrity": "sha512-TQkQOEjf4kww15mtt6KJ0s/5+ZNt4zjR0grH3zbuBbp2jca4vbR4/Z8alFsnJv5Rp0ppBfxoNyn9JHKbquvPYw==",
       "license": "MIT",
       "dependencies": {
-        "@fastify/otel": "https://codeload.github.com/getsentry/fastify-otel/tar.gz/ae3088d65e286bdc94ac5d722573537d6a6671bb",
+        "@fastify/otel": "0.6.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^1.30.1",
         "@opentelemetry/core": "^1.30.1",
@@ -9172,9 +9025,9 @@
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.30.0",
         "@prisma/instrumentation": "6.7.0",
-        "@sentry/core": "9.19.0",
-        "@sentry/opentelemetry": "9.19.0",
-        "import-in-the-middle": "^1.13.1"
+        "@sentry/core": "9.17.0",
+        "@sentry/opentelemetry": "9.17.0",
+        "import-in-the-middle": "^1.13.0"
       },
       "engines": {
         "node": ">=18"
@@ -9300,33 +9153,33 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/opentelemetry": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.19.0.tgz",
-      "integrity": "sha512-Js6153kW5mNjjukk6TVb04D/8DDhA9MO++WRzXWzNP+FiPi5zwtvm+Je2TvTeAjSH74f6o2JpfECdrfPYHWopA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.17.0.tgz",
+      "integrity": "sha512-hrQ5SwW3pUwQ+ORBILqQqFj9ZLoKqo12OWuTwR8fxCErVJGeezuNvIpyNfkdtEW7X6N0AQnEfAg3umDAt/TAGw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.19.0"
+        "@sentry/core": "9.17.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/instrumentation": "^0.57.1 || ^0.200.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.30.0"
+        "@opentelemetry/context-async-hooks": "^1.30.1",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-9.19.0.tgz",
-      "integrity": "sha512-tHuzPVbqKsONlFQsy7FqqGjBaujQoLRIDBLlPPMNoiGvP3rodBl6t1v5zoNAq4m47i3MhvpLEYf6C00j1w5UMQ==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-9.17.0.tgz",
+      "integrity": "sha512-hJOVUheFoUKr5e4vHxyKiu72FRgqmMTFIUG9myim8PH8mJYDqab7Z7cOt4dsBR86soKanaRB5PJq5jGFuipLfg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "9.19.0",
-        "@sentry/core": "9.19.0",
+        "@sentry/browser": "9.17.0",
+        "@sentry/core": "9.17.0",
         "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
@@ -9337,13 +9190,13 @@
       }
     },
     "node_modules/@sentry/vercel-edge": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-9.19.0.tgz",
-      "integrity": "sha512-oPWFCYMYvzaEyyR/HDS42RniHoQA+p32UysAa6yW3HrTs5139d41R8+qaX1TUVKlcNVVTePajCz/V37fBBaPpA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-9.17.0.tgz",
+      "integrity": "sha512-nNmID71yR71tYh0yhHeLFVuF3p+ANq4LejoOeCYlfRukJdO4sVTR7x3L5iZl75wf4K5o7mvr1xXmRfMn7Ck6dg==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@sentry/core": "9.19.0"
+        "@sentry/core": "9.17.0"
       },
       "engines": {
         "node": ">=18"
@@ -9380,84 +9233,84 @@
       }
     },
     "node_modules/@shikijs/core": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.4.1.tgz",
-      "integrity": "sha512-GCqSd3KXRTKX1sViP7fIyyyf6do2QVg+fTd4IT00ucYCVSKiSN8HbFbfyjGsoZePNKWcQqXe4U4rrz2IVldG5A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-0YOzTSRDn/IAfQWtK791gs1u8v87HNGToU6IwcA3K7nPoVOrS2Dh6X6A6YfXgPTSkTwR5y6myk0MnI0htjnwrA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.1",
+        "@shikijs/types": "3.4.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.4.1.tgz",
-      "integrity": "sha512-oGvRqN3Bsk+cGzmCb/5Kt/LfD7uyA8vCUUawyqmLti/AYNV7++zIZFEW8JwW5PrpPNWWx9RcZ/chnYLedzlVIQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.4.0.tgz",
+      "integrity": "sha512-1ywDoe+z/TPQKj9Jw0eU61B003J9DqUFRfH+DVSzdwPUFhR7yOmfyLzUrFz0yw8JxFg/NgzXoQyyykXgO21n5Q==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.1",
+        "@shikijs/types": "3.4.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.3"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.1.tgz",
-      "integrity": "sha512-p8I5KWgEDUcXRif9JjJUZtNeqCyxZ8xcslecDJMigsqSZfokwqQIsH4aGpdjzmDf8LIWvT+C3TCxnJQVaPmCbQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.0.tgz",
+      "integrity": "sha512-zwcWlZ4OQuJ/+1t32ClTtyTU1AiDkK1lhtviRWoq/hFqPjCNyLj22bIg9rB7BfoZKOEOfrsGz7No33BPCf+WlQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.1",
+        "@shikijs/types": "3.4.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.1.tgz",
-      "integrity": "sha512-v5A5ApJYcrcPLHcwAi0bViUU+Unh67UaXU9gGX3qfr2z3AqlqSZbC00W/3J4+tfGJASzwrWDro2R1er6SsCL1Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.0.tgz",
+      "integrity": "sha512-bQkR+8LllaM2duU9BBRQU0GqFTx7TuF5kKlw/7uiGKoK140n1xlLAwCgXwSxAjJ7Htk9tXTFwnnsJTCU5nDPXQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.1"
+        "@shikijs/types": "3.4.0"
       }
     },
     "node_modules/@shikijs/rehype": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-3.4.1.tgz",
-      "integrity": "sha512-pJnQQjCAM5H+VE6Cwrjf9wkRWavloqmrIalMbRSlckKZeaASA4HITo+hyG3l4jTQCCUgsY5+GuGv8xDHy4YXzA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-3.4.0.tgz",
+      "integrity": "sha512-wm7RTSmrcmjZg+F9JRrsH0Brwi36joUMXkUWIDmBGW+XExNEi8Xjmmp2NOBXa3DujZtnL6Dbcg7V6gtZabGoXw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.1",
+        "@shikijs/types": "3.4.0",
         "@types/hast": "^3.0.4",
         "hast-util-to-string": "^3.0.1",
-        "shiki": "3.4.1",
+        "shiki": "3.4.0",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.1.tgz",
-      "integrity": "sha512-XOJgs55mVVMZtNVJx1NVmdcfXG9HIyZGh7qpCw/Ok5UMjWgkmb8z15TgcmF3ItvHItijiIMl9BLcNO/tFSGl1w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.0.tgz",
+      "integrity": "sha512-YPP4PKNFcFGLxItpbU0ZW1Osyuk8AyZ24YEFaq04CFsuCbcqydMvMUTi40V2dkc0qs1U2uZFrnU6s5zI6IH+uA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.1"
+        "@shikijs/types": "3.4.0"
       }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.4.1.tgz",
-      "integrity": "sha512-Z3lbVQXHiXLC0bjDuGqsF3AAvvv4lQMoAXqIINZiOBgsk6CrnPZy0E2A+QUqv/MUaqp5qtYGsKDUJWbFE+buXw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.4.0.tgz",
+      "integrity": "sha512-GrGaOj1/I6h75IU0VvjdWDpqGCynx0bqHzd1rErBTGxrcmusYIBhrV7aEySWyJ6HHb9figeXfcNxUFS1HKUfBw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.4.1",
-        "@shikijs/types": "3.4.1"
+        "@shikijs/core": "3.4.0",
+        "@shikijs/types": "3.4.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.1.tgz",
-      "integrity": "sha512-4flT+pToGqRBb0UhGqXTV7rCqUS3fhc8z3S2Djc3E5USKhXwadeKGFVNB2rKXfohlrEozNJMtMiZaN8lfdj/ZQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.0.tgz",
+      "integrity": "sha512-EUT/0lGiE//7j5N/yTMNMT3eCWNcHJLrRKxT0NDXWIfdfSmFJKfPX7nMmRBrQnWboAzIsUziCThrYMMhjbMS1A==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -9565,12 +9418,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.3.3.tgz",
-      "integrity": "sha512-CiJNc0b/WdnttAfQ6uMkxPQ3Z8hG/ba8wF89x9KtBBLDdZk6CX52K4F8hbe94uNbc8LDUuZFtbqfdhM3T21naw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.3.1.tgz",
+      "integrity": "sha512-W7AppgQD3fP1aBmo8wWo0id5zeR2/aYRy067vZsDVaa6v/mdhkg6DxXwEVuSPjZl+ZnvWAQbUMCd5ckw38+tHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.5",
+        "@smithy/middleware-serde": "^4.0.3",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "@smithy/util-body-length-browser": "^4.0.0",
@@ -9783,13 +9636,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.6.tgz",
-      "integrity": "sha512-Zdieg07c3ua3ap5ungdcyNnY1OsxmsXXtKDTk28+/YbwIPju0Z1ZX9X5AnkjmDE3+AbqgvhtC/ZuCMSr6VSfPw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.4.tgz",
+      "integrity": "sha512-qWyYvszzvDjT2AxRvEpNhnMTo8QX9MCAtuSA//kYbXewb+2mEGQCk1UL4dNIrKLcF5KT11dOJtxFYT0kzajq5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.3.3",
-        "@smithy/middleware-serde": "^4.0.5",
+        "@smithy/core": "^3.3.1",
+        "@smithy/middleware-serde": "^4.0.3",
         "@smithy/node-config-provider": "^4.1.1",
         "@smithy/shared-ini-file-loader": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -9802,15 +9655,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.7.tgz",
-      "integrity": "sha512-lFIFUJ0E/4I0UaIDY5usNUzNKAghhxO0lDH4TZktXMmE+e4ActD9F154Si0Unc01aCPzcwd+NcOwQw6AfXXRRQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.5.tgz",
+      "integrity": "sha512-eQguCTA2TRGyg4P7gDuhRjL2HtN5OKJXysq3Ufj0EppZe4XBmSyKIvVX9ws9KkD3lkJskw1tfE96wMFsiUShaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.1",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/service-error-classification": "^4.0.3",
-        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/smithy-client": "^4.2.4",
         "@smithy/types": "^4.2.0",
         "@smithy/util-middleware": "^4.0.2",
         "@smithy/util-retry": "^4.0.3",
@@ -9835,12 +9688,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.5.tgz",
-      "integrity": "sha512-yREC3q/HXqQigq29xX3hiy6tFi+kjPKXoYUQmwQdgPORLbQ0n6V2Z/Iw9Nnlu66da9fM/WhDtGvYvqwecrCljQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
+      "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -9990,13 +9842,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.6.tgz",
-      "integrity": "sha512-WEqP0wQ1N/lVS4pwNK1Vk+0i6QIr66cq/xbu1dVy1tM0A0qYwAYyz0JhbquzM5pMa8s89lyDBtoGKxo7iG74GA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.4.tgz",
+      "integrity": "sha512-oolSEpr/ABUtVmFMdNgi6sSXsK4csV9n4XM9yXgvDJGRa32tQDUdv9s+ztFZKccay1AiTWLSGsyDj2xy1gsv7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.3.3",
-        "@smithy/middleware-endpoint": "^4.1.6",
+        "@smithy/core": "^3.3.1",
+        "@smithy/middleware-endpoint": "^4.1.4",
         "@smithy/middleware-stack": "^4.0.2",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
@@ -10097,13 +9949,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.14.tgz",
-      "integrity": "sha512-l7QnMX8VcDOH6n/fBRu4zqguSlOBZxFzWqp58dXFSARFBjNlmEDk5G/z4T7BMGr+rI0Pg8MkhmMUfEtHFgpy2g==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.12.tgz",
+      "integrity": "sha512-0vPKiC+rXWMq397tsa/RFcO/kJ1UsibgNCXScMsRwzm9WMT4QjGf43zVPWZ5hPLu3z/1XddiZFIlKcu2j/yUuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/smithy-client": "^4.2.4",
         "@smithy/types": "^4.2.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -10113,16 +9965,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.14.tgz",
-      "integrity": "sha512-Ujs1gsWDo3m/T63VWBTBmHLTD2UlU6J6FEokLCEp7OZQv45jcjLHoxTwgWsi8ULpsYozvH4MTWkRP+bhwr0vDg==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.12.tgz",
+      "integrity": "sha512-zCx9noceM3Pw2jvcJ3w3RbvKnPe3lCo6txH9ksZj6CeRZPkvRZPLXmKVSOvDr9QQP3VRq/WnBLd+LTZAL7+0IQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.1.2",
         "@smithy/credential-provider-imds": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.1",
         "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/smithy-client": "^4.2.4",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -10302,25 +10154,35 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.7.tgz",
-      "integrity": "sha512-9rsOpdY9idRI2NH6CL4wORFY0+Q6fnx9XP9Ju+iq/0wJwGD5IByIgFmwVbyy4ymuyprj8Qh4ErxMKTUL4uNh3g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.6.tgz",
+      "integrity": "sha512-ed6zQbgmKsjsVvodAS1q1Ld2BolEuxJOSyyNc+vhkjdmfNUDCmQnlXBfQkHrlzNmslxHsQU/bFmzcEbv4xXsLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "enhanced-resolve": "^5.18.1",
         "jiti": "^2.4.2",
-        "lightningcss": "1.30.1",
+        "lightningcss": "1.29.2",
         "magic-string": "^0.30.17",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.1.7"
+        "tailwindcss": "4.1.6"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.7.tgz",
-      "integrity": "sha512-5SF95Ctm9DFiUyjUPnDGkoKItPX/k+xifcQhcqX5RA85m50jw1pT/KzjdvlqxRja45Y52nR4MR9fD1JYd7f8NQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.6.tgz",
+      "integrity": "sha512-0bpEBQiGx+227fW4G0fLQ8vuvyy5rsB1YIYNapTq3aRsJ9taF3f5cCaovDjN5pUGKKzcpMrZst/mhNaKAPOHOA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -10332,24 +10194,24 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.7",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.7",
-        "@tailwindcss/oxide-darwin-x64": "4.1.7",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.7",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.7",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.7",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.7",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.7",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.7",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.7",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.7",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.7"
+        "@tailwindcss/oxide-android-arm64": "4.1.6",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.6",
+        "@tailwindcss/oxide-darwin-x64": "4.1.6",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.6",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.6",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.6",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.6",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.6",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.6",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.6",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.6",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.6"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.7.tgz",
-      "integrity": "sha512-IWA410JZ8fF7kACus6BrUwY2Z1t1hm0+ZWNEzykKmMNM09wQooOcN/VXr0p/WJdtHZ90PvJf2AIBS/Ceqx1emg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.6.tgz",
+      "integrity": "sha512-VHwwPiwXtdIvOvqT/0/FLH/pizTVu78FOnI9jQo64kSAikFSZT7K4pjyzoDpSMaveJTGyAKvDjuhxJxKfmvjiQ==",
       "cpu": [
         "arm64"
       ],
@@ -10364,9 +10226,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.7.tgz",
-      "integrity": "sha512-81jUw9To7fimGGkuJ2W5h3/oGonTOZKZ8C2ghm/TTxbwvfSiFSDPd6/A/KE2N7Jp4mv3Ps9OFqg2fEKgZFfsvg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.6.tgz",
+      "integrity": "sha512-weINOCcqv1HVBIGptNrk7c6lWgSFFiQMcCpKM4tnVi5x8OY2v1FrV76jwLukfT6pL1hyajc06tyVmZFYXoxvhQ==",
       "cpu": [
         "arm64"
       ],
@@ -10381,9 +10243,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.7.tgz",
-      "integrity": "sha512-q77rWjEyGHV4PdDBtrzO0tgBBPlQWKY7wZK0cUok/HaGgbNKecegNxCGikuPJn5wFAlIywC3v+WMBt0PEBtwGw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.6.tgz",
+      "integrity": "sha512-3FzekhHG0ww1zQjQ1lPoq0wPrAIVXAbUkWdWM8u5BnYFZgb9ja5ejBqyTgjpo5mfy0hFOoMnMuVDI+7CXhXZaQ==",
       "cpu": [
         "x64"
       ],
@@ -10398,9 +10260,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.7.tgz",
-      "integrity": "sha512-RfmdbbK6G6ptgF4qqbzoxmH+PKfP4KSVs7SRlTwcbRgBwezJkAO3Qta/7gDy10Q2DcUVkKxFLXUQO6J3CRvBGw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.6.tgz",
+      "integrity": "sha512-4m5F5lpkBZhVQJq53oe5XgJ+aFYWdrgkMwViHjRsES3KEu2m1udR21B1I77RUqie0ZYNscFzY1v9aDssMBZ/1w==",
       "cpu": [
         "x64"
       ],
@@ -10415,9 +10277,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.7.tgz",
-      "integrity": "sha512-OZqsGvpwOa13lVd1z6JVwQXadEobmesxQ4AxhrwRiPuE04quvZHWn/LnihMg7/XkN+dTioXp/VMu/p6A5eZP3g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.6.tgz",
+      "integrity": "sha512-qU0rHnA9P/ZoaDKouU1oGPxPWzDKtIfX7eOGi5jOWJKdxieUJdVV+CxWZOpDWlYTd4N3sFQvcnVLJWJ1cLP5TA==",
       "cpu": [
         "arm"
       ],
@@ -10432,9 +10294,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.7.tgz",
-      "integrity": "sha512-voMvBTnJSfKecJxGkoeAyW/2XRToLZ227LxswLAwKY7YslG/Xkw9/tJNH+3IVh5bdYzYE7DfiaPbRkSHFxY1xA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.6.tgz",
+      "integrity": "sha512-jXy3TSTrbfgyd3UxPQeXC3wm8DAgmigzar99Km9Sf6L2OFfn/k+u3VqmpgHQw5QNfCpPe43em6Q7V76Wx7ogIQ==",
       "cpu": [
         "arm64"
       ],
@@ -10449,9 +10311,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.7.tgz",
-      "integrity": "sha512-PjGuNNmJeKHnP58M7XyjJyla8LPo+RmwHQpBI+W/OxqrwojyuCQ+GUtygu7jUqTEexejZHr/z3nBc/gTiXBj4A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.6.tgz",
+      "integrity": "sha512-8kjivE5xW0qAQ9HX9reVFmZj3t+VmljDLVRJpVBEoTR+3bKMnvC7iLcoSGNIUJGOZy1mLVq7x/gerVg0T+IsYw==",
       "cpu": [
         "arm64"
       ],
@@ -10466,9 +10328,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.7.tgz",
-      "integrity": "sha512-HMs+Va+ZR3gC3mLZE00gXxtBo3JoSQxtu9lobbZd+DmfkIxR54NO7Z+UQNPsa0P/ITn1TevtFxXTpsRU7qEvWg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.6.tgz",
+      "integrity": "sha512-A4spQhwnWVpjWDLXnOW9PSinO2PTKJQNRmL/aIl2U/O+RARls8doDfs6R41+DAXK0ccacvRyDpR46aVQJJCoCg==",
       "cpu": [
         "x64"
       ],
@@ -10483,9 +10345,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.7.tgz",
-      "integrity": "sha512-MHZ6jyNlutdHH8rd+YTdr3QbXrHXqwIhHw9e7yXEBcQdluGwhpQY2Eku8UZK6ReLaWtQ4gijIv5QoM5eE+qlsA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.6.tgz",
+      "integrity": "sha512-YRee+6ZqdzgiQAHVSLfl3RYmqeeaWVCk796MhXhLQu2kJu2COHBkqlqsqKYx3p8Hmk5pGCQd2jTAoMWWFeyG2A==",
       "cpu": [
         "x64"
       ],
@@ -10500,9 +10362,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.7.tgz",
-      "integrity": "sha512-ANaSKt74ZRzE2TvJmUcbFQ8zS201cIPxUDm5qez5rLEwWkie2SkGtA4P+GPTj+u8N6JbPrC8MtY8RmJA35Oo+A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.6.tgz",
+      "integrity": "sha512-qAp4ooTYrBQ5pk5jgg54/U1rCJ/9FLYOkkQ/nTE+bVMseMfB6O7J8zb19YTpWuu4UdfRf5zzOrNKfl6T64MNrQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -10530,9 +10392,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.7.tgz",
-      "integrity": "sha512-HUiSiXQ9gLJBAPCMVRk2RT1ZrBjto7WvqsPBwUrNK2BcdSxMnk19h4pjZjI7zgPhDxlAbJSumTC4ljeA9y0tEw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.6.tgz",
+      "integrity": "sha512-nqpDWk0Xr8ELO/nfRUDjk1pc9wDJ3ObeDdNMHLaymc4PJBWj11gdPCWZFKSK2AVKjJQC7J2EfmSmf47GN7OuLg==",
       "cpu": [
         "arm64"
       ],
@@ -10547,9 +10409,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.7.tgz",
-      "integrity": "sha512-rYHGmvoHiLJ8hWucSfSOEmdCBIGZIq7SpkPRSqLsH2Ab2YUNgKeAPT1Fi2cx3+hnYOrAb0jp9cRyode3bBW4mQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.6.tgz",
+      "integrity": "sha512-5k9xF33xkfKpo9wCvYcegQ21VwIBU1/qEbYlVukfEIyQbEA47uK8AAwS7NVjNE3vHzcmxMYwd0l6L4pPjjm1rQ==",
       "cpu": [
         "x64"
       ],
@@ -10564,17 +10426,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.7.tgz",
-      "integrity": "sha512-88g3qmNZn7jDgrrcp3ZXEQfp9CVox7xjP1HN2TFKI03CltPVd/c61ydn5qJJL8FYunn0OqBaW5HNUga0kmPVvw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.6.tgz",
+      "integrity": "sha512-ELq+gDMBuRXPJlpE3PEen+1MhnHAQQrh2zF0dI1NXOlEWfr2qWf2CQdr5jl9yANv8RErQaQ2l6nIFO9OSCVq/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.1.7",
-        "@tailwindcss/oxide": "4.1.7",
+        "@tailwindcss/node": "4.1.6",
+        "@tailwindcss/oxide": "4.1.6",
         "postcss": "^8.4.41",
-        "tailwindcss": "4.1.7"
+        "tailwindcss": "4.1.6"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -11243,9 +11105,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
-      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
+      "version": "22.15.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
+      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -11260,6 +11122,12 @@
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -11295,18 +11163,18 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.4.tgz",
-      "integrity": "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==",
+      "version": "19.1.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
+      "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
-      "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
+      "version": "19.1.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
+      "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
@@ -12436,9 +12304,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001717",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
+      "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
       "funding": [
         {
           "type": "opencollective",
@@ -13318,9 +13186,9 @@
       }
     },
     "node_modules/debounce": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
-      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.0.0.tgz",
+      "integrity": "sha512-xRetU6gL1VJbs85Mc4FoEGSjQxzpdxRyFhe3lmWFyy2EzydIcD4xzUvRJMD+NPDfMwKNhxa3PvsIOU32luIWeA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13331,9 +13199,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -13774,9 +13642,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.155",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
-      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
+      "version": "1.5.151",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.151.tgz",
+      "integrity": "sha512-Rl6uugut2l9sLojjS4H4SAr3A4IgACMLgpuEMPYCVcKydzfyPrn5absNRju38IhQOf/NwjJY8OGWjlteqYeBCA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -13888,6 +13756,20 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/environment": {
@@ -14552,12 +14434,12 @@
       "license": "MIT"
     },
     "node_modules/framer-motion": {
-      "version": "12.11.4",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.11.4.tgz",
-      "integrity": "sha512-kyE5oWZCUxhDb7LtpEyyadNThJJvoE8a6bfUTBqz++zw3XxDOosPAvw1lqNhYbjOgy57YuAlJ5qG/Cx5BigiEQ==",
+      "version": "12.10.5",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.10.5.tgz",
+      "integrity": "sha512-p6VF1YkwWvNDFzg5IQ5lqPx11Td4TQ6LqDnshV7sWj0Nrp4dwz2/aEzmgh9WA9ridcTIJ625Fr0oiuhgqIoFwQ==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.11.4",
+        "motion-dom": "^12.10.5",
         "motion-utils": "^12.9.4",
         "tslib": "^2.4.0"
       },
@@ -14684,9 +14566,9 @@
       }
     },
     "node_modules/fumadocs-core": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-15.3.2.tgz",
-      "integrity": "sha512-wrOSzYjA7EdL83SDPaN7Af4snVqB9QFxEBU3YIw66q58F64Y48C0rMqsYOLQVyL5gvq4ymXoKY+1jZJ8KYd1TQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-15.3.0.tgz",
+      "integrity": "sha512-6+j2qGntJknzQUyes5BQI3U5EE4GCIb1Pi31eAYZ8GLxMP1p1bh8nAyEeW6oZNZmqfstJoVLQNnw+vwuHJJHUw==",
       "license": "MIT",
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.6.1",
@@ -14802,9 +14684,9 @@
       }
     },
     "node_modules/fumadocs-ui": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/fumadocs-ui/-/fumadocs-ui-15.3.2.tgz",
-      "integrity": "sha512-2FEe3Y53h6hxq3JvBVC0B/dnf3m+wNtCX8CrZo57S9dst+PJ5VrwnA+paOgfHWMmaNfW15YcGB9oqCeKA2VBHQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/fumadocs-ui/-/fumadocs-ui-15.3.0.tgz",
+      "integrity": "sha512-jQeaKWD+rGoZMXuH3FA73p6N7f11Lmhyn31bn9Jtl1VdIopq7EaXhseUqw586wSNgGKO3qmfPOXCBvvuu6gDTw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.10",
@@ -14818,7 +14700,7 @@
         "@radix-ui/react-slot": "^1.2.2",
         "@radix-ui/react-tabs": "^1.1.11",
         "class-variance-authority": "^0.7.1",
-        "fumadocs-core": "15.3.2",
+        "fumadocs-core": "15.3.0",
         "lodash.merge": "^4.6.2",
         "next-themes": "^0.4.6",
         "postcss-selector-parser": "^7.1.0",
@@ -14923,6 +14805,56 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/gel": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gel/-/gel-2.1.0.tgz",
+      "integrity": "sha512-HCeRqInCt6BjbMmeghJ6BKeYwOj7WJT5Db6IWWAA3IMUUa7or7zJfTUEkUWCxiOtoXnwnm96sFK9Fr47Yh2hOA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@petamoriken/float16": "^3.8.7",
+        "debug": "^4.3.4",
+        "env-paths": "^3.0.0",
+        "semver": "^7.6.2",
+        "shell-quote": "^1.8.1",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "gel": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/gel/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/gel/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/gensync": {
@@ -15071,21 +15003,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause",
       "peer": true
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -15628,9 +15545,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.2.tgz",
-      "integrity": "sha512-Yjp9X7s2eHSXvZYQ0aye6UvwYPrVB5C2k47fuXjFKnYinAByaDZjh4t9MT2wEga9775n6WaIqyHnQhBxYtX2mg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz",
+      "integrity": "sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -16102,13 +16019,13 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "jiti": "lib/jiti-cli.mjs"
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/jose": {
@@ -16362,9 +16279,9 @@
       }
     },
     "node_modules/lenis": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.3.tgz",
-      "integrity": "sha512-DOopj/UKHS54E9l2g4BOpDUvsyvkd1zkv+ECtHxQ9Fto8ozzKSz7MccqT+KOyG0ABA/OHXZ7l9INx0peUoQ8rQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.1.tgz",
+      "integrity": "sha512-OGRlQk7EkGUtjDdnH+U49Mp26G/wGJFHuyYJ8ZwATllwHQZOKYbeuVaPWYQ4lK0gHfAnk2m0u8qN8Y4dtrHaHw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -16397,9 +16314,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
-      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.2.tgz",
+      "integrity": "sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -16413,22 +16330,22 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.30.1",
-        "lightningcss-darwin-x64": "1.30.1",
-        "lightningcss-freebsd-x64": "1.30.1",
-        "lightningcss-linux-arm-gnueabihf": "1.30.1",
-        "lightningcss-linux-arm64-gnu": "1.30.1",
-        "lightningcss-linux-arm64-musl": "1.30.1",
-        "lightningcss-linux-x64-gnu": "1.30.1",
-        "lightningcss-linux-x64-musl": "1.30.1",
-        "lightningcss-win32-arm64-msvc": "1.30.1",
-        "lightningcss-win32-x64-msvc": "1.30.1"
+        "lightningcss-darwin-arm64": "1.29.2",
+        "lightningcss-darwin-x64": "1.29.2",
+        "lightningcss-freebsd-x64": "1.29.2",
+        "lightningcss-linux-arm-gnueabihf": "1.29.2",
+        "lightningcss-linux-arm64-gnu": "1.29.2",
+        "lightningcss-linux-arm64-musl": "1.29.2",
+        "lightningcss-linux-x64-gnu": "1.29.2",
+        "lightningcss-linux-x64-musl": "1.29.2",
+        "lightningcss-win32-arm64-msvc": "1.29.2",
+        "lightningcss-win32-x64-msvc": "1.29.2"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
-      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.2.tgz",
+      "integrity": "sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==",
       "cpu": [
         "arm64"
       ],
@@ -16448,9 +16365,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
-      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.2.tgz",
+      "integrity": "sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==",
       "cpu": [
         "x64"
       ],
@@ -16470,9 +16387,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
-      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.2.tgz",
+      "integrity": "sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==",
       "cpu": [
         "x64"
       ],
@@ -16492,9 +16409,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
-      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.2.tgz",
+      "integrity": "sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==",
       "cpu": [
         "arm"
       ],
@@ -16514,9 +16431,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
-      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.2.tgz",
+      "integrity": "sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==",
       "cpu": [
         "arm64"
       ],
@@ -16536,9 +16453,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
-      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.2.tgz",
+      "integrity": "sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==",
       "cpu": [
         "arm64"
       ],
@@ -16558,9 +16475,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
-      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.2.tgz",
+      "integrity": "sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==",
       "cpu": [
         "x64"
       ],
@@ -16580,9 +16497,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
-      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.2.tgz",
+      "integrity": "sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==",
       "cpu": [
         "x64"
       ],
@@ -16602,9 +16519,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
-      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.2.tgz",
+      "integrity": "sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==",
       "cpu": [
         "arm64"
       ],
@@ -16624,9 +16541,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
-      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.2.tgz",
+      "integrity": "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==",
       "cpu": [
         "x64"
       ],
@@ -18194,9 +18111,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -18272,9 +18189,9 @@
       "license": "MIT"
     },
     "node_modules/motion-dom": {
-      "version": "12.11.4",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.11.4.tgz",
-      "integrity": "sha512-1z/qYsrDjSx5QjOH8GfJ2RfFBvEzI2gdAEt2zNW+f7QkLlqjM3sQieESJr5+QtVmvD81qPANM7t97ROixKIt9Q==",
+      "version": "12.10.5",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.10.5.tgz",
+      "integrity": "sha512-F7XKmhxXEH/y3aWWf0N2w69wNSN+6PcJ1seqR1WolClmXpPhj+xwzs9j5CpsMFzeHR1D7irl3JcWMToPRwX6Hg==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.9.4"
@@ -19200,9 +19117,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.0.tgz",
-      "integrity": "sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.9.5.tgz",
+      "integrity": "sha512-DYTWtWpfd5FOro3UnAfwvhD8jh59r2ig8bPtc9H8Ds7MscE/9NYruUQWFAOuraRl29jwcT2kyMFQ3MxeaVjUhg==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -19776,9 +19693,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.2.tgz",
-      "integrity": "sha512-f2ls6rpO6G153Cy+o2XQ+Y0sARLOZ17+OGVLHrc3VUKcLHYKEKWbkSujdBWQXM7gKn5NTfp0XnRPZn1MIu8n9w==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.1.tgz",
+      "integrity": "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -20683,17 +20600,20 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -20986,9 +20906,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -21092,18 +21012,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/shiki": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.4.1.tgz",
-      "integrity": "sha512-PSnoczt+iWIOB4iRQ+XVPFtTuN1FcmuYzPgUBZTSv5pC6CozssIx2M4O5n4S9gJlUu9A3FxMU0ZPaHflky/6LA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.4.0.tgz",
+      "integrity": "sha512-Ni80XHcqhOEXv5mmDAvf5p6PAJqbUc/RzFeaOqk+zP5DLvTPS3j0ckvA+MI87qoxTQ5RGJDVTbdl/ENLSyyAnQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.4.1",
-        "@shikijs/engine-javascript": "3.4.1",
-        "@shikijs/engine-oniguruma": "3.4.1",
-        "@shikijs/langs": "3.4.1",
-        "@shikijs/themes": "3.4.1",
-        "@shikijs/types": "3.4.1",
+        "@shikijs/core": "3.4.0",
+        "@shikijs/engine-javascript": "3.4.0",
+        "@shikijs/engine-oniguruma": "3.4.0",
+        "@shikijs/langs": "3.4.0",
+        "@shikijs/themes": "3.4.0",
+        "@shikijs/types": "3.4.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
@@ -21843,6 +21777,22 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/sucrase/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sucrase/node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -21898,9 +21848,9 @@
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.0.tgz",
-      "integrity": "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.2.0.tgz",
+      "integrity": "sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -21908,9 +21858,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.7.tgz",
-      "integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.6.tgz",
+      "integrity": "sha512-j0cGLTreM6u4OWzBeLBpycK0WIh8w7kSwcUsQZoGLHZ7xDTdM69lN64AgoIEEwFi0tnhs4wSykUa5YWxAzgFYg==",
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -21970,14 +21920,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.2.tgz",
-      "integrity": "sha512-yEPUmWve+VA78bI71BW70Dh0TuV4HHd+I5SHOAfS1+QBOmvmCiiffgjR8ryyEd3KIfvPGFqoADt8LdQ6XpXIvg==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -22080,6 +22030,22 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/test-exclude/node_modules/minipass": {
@@ -22477,9 +22443,10 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-trie": {
@@ -23324,16 +23291,16 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14.6"
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {
@@ -23461,9 +23428,9 @@
       "peer": true
     },
     "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.6.tgz",
+      "integrity": "sha512-ibr/n1hBzLLj5Y+yUcU7dYw8p6WnIVzdJbnX+1YpaScvZVF2ziugqHs+LAmHw4lWO9c/zRj+K1ncgWDQuthEdQ==",
       "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "^1.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,8 +170,6 @@
     },
     "apps/sim/node_modules/@types/node": {
       "version": "20.17.46",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.46.tgz",
-      "integrity": "sha512-0PQHLhZPWOxGW4auogW0eOQAuNIlCYvibIpG67ja0TOJ6/sehu+1en7sfceUn+QQtx4Rk3GxbLNwPh0Cav7TWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -194,8 +192,6 @@
     },
     "apps/sim/node_modules/tailwind-merge": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
-      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -204,8 +200,6 @@
     },
     "apps/sim/node_modules/tailwindcss": {
       "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -239,6 +233,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "apps/sim/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.2",
@@ -319,9 +320,9 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.17.tgz",
-      "integrity": "sha512-mLFLDMCJaDK+j1nvoqeNszazSZIyeSMPi5X+fs5Wh3xWZljGGE0WmFg32RNkFujRB+UnM63EnhPG70WdqOx/MA==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.18.tgz",
+      "integrity": "sha512-8B70+i+uB12Ae6Sn6B9Oc6W0W/XorGgc88Nx0pyUrcxFOdytHBaAVhTPqYsO3LLClfjYN8pQ9GMxd5cpGEnUcA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -806,35 +807,35 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.806.0.tgz",
-      "integrity": "sha512-kQaBBBxEBU/IJ2wKG+LL2BK+uvBwpdvOA9jy1WhW+U2/DIMwMrjVs7M/ZvTlmVOJwhZaONcJbgQqsN4Yirjj4g==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.810.0.tgz",
+      "integrity": "sha512-wM8M0BrqRkbZ9fGaLmAl24CUgVmmLjiKuNTqGOHsdCIc7RV+IGv5CnGK7ciOltAttrFBxvDlhy2lg5F8gNw8Bg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/credential-provider-node": "3.806.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/credential-provider-node": "3.810.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
         "@aws-sdk/middleware-expect-continue": "3.804.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.806.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.810.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-location-constraint": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-sdk-s3": "3.806.0",
+        "@aws-sdk/middleware-sdk-s3": "3.810.0",
         "@aws-sdk/middleware-ssec": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.806.0",
-        "@aws-sdk/region-config-resolver": "3.806.0",
-        "@aws-sdk/signature-v4-multi-region": "3.806.0",
+        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/signature-v4-multi-region": "3.810.0",
         "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.806.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.806.0",
+        "@aws-sdk/util-user-agent-node": "3.810.0",
         "@aws-sdk/xml-builder": "3.804.0",
-        "@smithy/config-resolver": "^4.1.1",
-        "@smithy/core": "^3.3.1",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.3",
         "@smithy/eventstream-serde-browser": "^4.0.2",
         "@smithy/eventstream-serde-config-resolver": "^4.1.0",
         "@smithy/eventstream-serde-node": "^4.0.2",
@@ -845,22 +846,22 @@
         "@smithy/invalid-dependency": "^4.0.2",
         "@smithy/md5-js": "^4.0.2",
         "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.3",
-        "@smithy/middleware-retry": "^4.1.4",
-        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-endpoint": "^4.1.6",
+        "@smithy/middleware-retry": "^4.1.7",
+        "@smithy/middleware-serde": "^4.0.5",
         "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/node-http-handler": "^4.0.4",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/smithy-client": "^4.2.6",
         "@smithy/types": "^4.2.0",
         "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.11",
-        "@smithy/util-defaults-mode-node": "^4.0.11",
-        "@smithy/util-endpoints": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^4.0.14",
+        "@smithy/util-defaults-mode-node": "^4.0.14",
+        "@smithy/util-endpoints": "^3.0.4",
         "@smithy/util-middleware": "^4.0.2",
         "@smithy/util-retry": "^4.0.3",
         "@smithy/util-stream": "^4.2.0",
@@ -873,45 +874,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.806.0.tgz",
-      "integrity": "sha512-X0p/9/u9e6b22rlQqKucdtjdqmjSNB4c/8zDEoD5MvgYAAbMF9HNE0ST2xaA/WsJ7uE0jFfhPY2/00pslL1DqQ==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.810.0.tgz",
+      "integrity": "sha512-Txp/3jHqkfA4BTklQEOGiZ1yTUxg+hITislfaWEzJ904vlDt4DvAljTlhfaz7pceCLA2+LhRlYZYSv7t5b0Ltw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.806.0",
-        "@aws-sdk/region-config-resolver": "3.806.0",
+        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
         "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.806.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.806.0",
-        "@smithy/config-resolver": "^4.1.1",
-        "@smithy/core": "^3.3.1",
+        "@aws-sdk/util-user-agent-node": "3.810.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.3",
         "@smithy/fetch-http-handler": "^5.0.2",
         "@smithy/hash-node": "^4.0.2",
         "@smithy/invalid-dependency": "^4.0.2",
         "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.3",
-        "@smithy/middleware-retry": "^4.1.4",
-        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-endpoint": "^4.1.6",
+        "@smithy/middleware-retry": "^4.1.7",
+        "@smithy/middleware-serde": "^4.0.5",
         "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/node-http-handler": "^4.0.4",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/smithy-client": "^4.2.6",
         "@smithy/types": "^4.2.0",
         "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.11",
-        "@smithy/util-defaults-mode-node": "^4.0.11",
-        "@smithy/util-endpoints": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^4.0.14",
+        "@smithy/util-defaults-mode-node": "^4.0.14",
+        "@smithy/util-endpoints": "^3.0.4",
         "@smithy/util-middleware": "^4.0.2",
         "@smithy/util-retry": "^4.0.3",
         "@smithy/util-utf8": "^4.0.0",
@@ -922,18 +923,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.806.0.tgz",
-      "integrity": "sha512-HJRINPncdjPK0iL3f6cBpqCMaxVwq2oDbRCzOx04tsLZ0tNgRACBfT3d/zNVRvMt6fnOVKXoN1LAtQaw50pjEA==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.810.0.tgz",
+      "integrity": "sha512-s2IJk+qa/15YZcv3pbdQNATDR+YdYnHf94MrAeVAWubtRLnzD8JciC+gh4LSPp7JzrWSvVOg2Ut1S+0y89xqCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
-        "@smithy/core": "^3.3.1",
-        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/core": "^3.3.3",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/signature-v4": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/smithy-client": "^4.2.6",
         "@smithy/types": "^4.2.0",
         "@smithy/util-middleware": "^4.0.2",
         "fast-xml-parser": "4.4.1",
@@ -944,12 +945,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.806.0.tgz",
-      "integrity": "sha512-nbPwmZn0kt6Q1XI2FaJWP6AhF9tro4cO5HlmZQx8NU+B0H1y9WMo659Q5zLLY46BXgoQVIJEsPSZpcZk27O4aw==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.810.0.tgz",
+      "integrity": "sha512-iwHqF+KryKONfbdFk3iKhhPk4fHxh5QP5fXXR//jhYwmszaLOwc7CLCE9AxhgiMzAs+kV8nBFQZvdjFpPzVGOA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -960,18 +961,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.806.0.tgz",
-      "integrity": "sha512-e/gB2iJQQ4ZpecOVpEFhEvjGwuTqNCzhVaVsFYVc49FPfR1seuN7qBGYe1MO7mouGDQFInzJgcNup0DnYUrLiw==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.810.0.tgz",
+      "integrity": "sha512-SKzjLd+8ugif7yy9sOAAdnPE1vCBHQe6jKgs2AadMpCmWm34DiHz/KuulHdvURUGMIi7CvmaC8aH77twDPYbtg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/fetch-http-handler": "^5.0.2",
         "@smithy/node-http-handler": "^4.0.4",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/smithy-client": "^4.2.6",
         "@smithy/types": "^4.2.0",
         "@smithy/util-stream": "^4.2.0",
         "tslib": "^2.6.2"
@@ -981,20 +982,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.806.0.tgz",
-      "integrity": "sha512-FogfbuYSEZgFxbNy0QcsBZHHe5mSv5HV3+JyB5n0kCyjOISCVCZD7gwxKdXjt8O1hXq5k5SOdQvydGULlB6rew==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.810.0.tgz",
+      "integrity": "sha512-H2QCSnxWJ/mj8HTcyHmCmyQ5bO/+imRi4mlBIpUyKjiYKro52WD3gXlGgPIDo2q3UFIHq37kmYvS00i+qIY9tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/credential-provider-env": "3.806.0",
-        "@aws-sdk/credential-provider-http": "3.806.0",
-        "@aws-sdk/credential-provider-process": "3.806.0",
-        "@aws-sdk/credential-provider-sso": "3.806.0",
-        "@aws-sdk/credential-provider-web-identity": "3.806.0",
-        "@aws-sdk/nested-clients": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/credential-provider-env": "3.810.0",
+        "@aws-sdk/credential-provider-http": "3.810.0",
+        "@aws-sdk/credential-provider-process": "3.810.0",
+        "@aws-sdk/credential-provider-sso": "3.810.0",
+        "@aws-sdk/credential-provider-web-identity": "3.810.0",
+        "@aws-sdk/nested-clients": "3.810.0",
         "@aws-sdk/types": "3.804.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/credential-provider-imds": "^4.0.4",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -1005,19 +1006,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.806.0.tgz",
-      "integrity": "sha512-fZX8xP2Kf0k70kDTog/87fh/M+CV0E2yujSw1cUBJhDSwDX3RlUahiJk7TpB/KGw6hEFESMd6+7kq3UzYuw3rg==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.810.0.tgz",
+      "integrity": "sha512-9E3Chv3x+RBM3N1bwLCyvXxoiPAckCI74wG7ePN4F3b/7ieIkbEl/3Hd67j1fnt62Xa1cjUHRu2tz5pdEv5G1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.806.0",
-        "@aws-sdk/credential-provider-http": "3.806.0",
-        "@aws-sdk/credential-provider-ini": "3.806.0",
-        "@aws-sdk/credential-provider-process": "3.806.0",
-        "@aws-sdk/credential-provider-sso": "3.806.0",
-        "@aws-sdk/credential-provider-web-identity": "3.806.0",
+        "@aws-sdk/credential-provider-env": "3.810.0",
+        "@aws-sdk/credential-provider-http": "3.810.0",
+        "@aws-sdk/credential-provider-ini": "3.810.0",
+        "@aws-sdk/credential-provider-process": "3.810.0",
+        "@aws-sdk/credential-provider-sso": "3.810.0",
+        "@aws-sdk/credential-provider-web-identity": "3.810.0",
         "@aws-sdk/types": "3.804.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/credential-provider-imds": "^4.0.4",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -1028,12 +1029,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.806.0.tgz",
-      "integrity": "sha512-8Y8GYEw/1e5IZRDQL02H6nsTDcRWid/afRMeWg+93oLQmbHcTtdm48tjis+7Xwqy+XazhMDmkbUht11QPTDJcQ==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.810.0.tgz",
+      "integrity": "sha512-42kE6MLdsmMGp1id3Gisal4MbMiF7PIc0tAznTeIuE8r7cIF8yeQWw/PBOIvjyI57DxbyKzLUAMEJuigUpApCw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -1045,14 +1046,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.806.0.tgz",
-      "integrity": "sha512-hT9OBwCxWMPBydNhXm2gdNNzx5AJNheS9RglwDDvXWzQ9qDuRztjuMBilMSUMb0HF9K4IqQjYzGqczMuktz4qQ==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.810.0.tgz",
+      "integrity": "sha512-8WjX6tz+FCvM93Y33gsr13p/HiiTJmVn5AK1O8PTkvHBclQDzmtAW5FdPqTpAJGswLW2FB0xRqdsSMN2dQEjNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.806.0",
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/token-providers": "3.806.0",
+        "@aws-sdk/client-sso": "3.810.0",
+        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/token-providers": "3.810.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -1064,13 +1065,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.806.0.tgz",
-      "integrity": "sha512-XxaSY9Zd3D4ClUGENYMvi52ac5FuJPPAsvRtEfyrSdEpf6QufbMpnexWBZMYRF31h/VutgqtJwosGgNytpxMEg==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.810.0.tgz",
+      "integrity": "sha512-uKQJY0AcPyrvMmfGLo36semgjqJ4vmLTqOSW9u40qQDspRnG73/P09lAO2ntqKlhwvMBt3XfcNnOpyyhKRcOfA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/nested-clients": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
+        "@aws-sdk/nested-clients": "3.810.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -1081,14 +1082,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.806.0.tgz",
-      "integrity": "sha512-ACjuyKJw9OZl8z8HzPEaqn1o7ElVW94mowyoZvyUIDouwAPGqPGJbJ5V35qx1oDTFSAJX+N3O3AO6RyFc8nUhw==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.808.0.tgz",
+      "integrity": "sha512-wEPlNcs8dir9lXbuviEGtSzYSxG/NRKQrJk5ybOc7OpPGHovsN+QhDOdY3lcjOFdwMTiMIG9foUkPz3zBpLB1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-arn-parser": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "@smithy/util-config-provider": "^4.0.0",
@@ -1114,18 +1115,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.806.0.tgz",
-      "integrity": "sha512-YEmuU2Nr/+blhi70gS38fnCe2IoL6OVVZXMp4MbzqZRUqeBbnxZhHQrd5YOiboJz7iq+g98xwFebHY167iejcg==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.810.0.tgz",
+      "integrity": "sha512-lF5fse+26hluElOtDZMsi5EH50G13OEqglFgpSc6xWnqNhbDc+CnPQRMwTVlOJBDR1/YVbJ15LOKf4pkat46Eg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "@smithy/util-middleware": "^4.0.2",
@@ -1196,19 +1197,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.806.0.tgz",
-      "integrity": "sha512-K1ssdovHH/kPN9EUS1LznwzoL+r89Cx8qAkp0K8MqdCQuBjZ0KRnjvo9nx69Vg5d/rg01VYTxomFUPXfcPtVXw==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.810.0.tgz",
+      "integrity": "sha512-CmQHPVopJYDiGQOmqn5AcmhksQ9qNETF0VgU251Q4tsP9s3R9nBR1r2bZwLt5+dCtf9UCa7cBw4jXKHtH38JTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-arn-parser": "3.804.0",
-        "@smithy/core": "^3.3.1",
-        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/core": "^3.3.3",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/signature-v4": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/smithy-client": "^4.2.6",
         "@smithy/types": "^4.2.0",
         "@smithy/util-config-provider": "^4.0.0",
         "@smithy/util-middleware": "^4.0.2",
@@ -1235,15 +1236,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.806.0.tgz",
-      "integrity": "sha512-XoIromVffgXnc+/mjlR2EVzQVIei3bPVtafIZNsHuEmUvIWJXiWsa2eJpt3BUqa0HF9YPknK7ommNEhqRb8ucg==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.810.0.tgz",
+      "integrity": "sha512-gLMJcqgIq7k9skX8u0Yyi+jil4elbsmLf3TuDuqNdlqiZ44/AKdDFfU3mU5tRUtMfP42a3gvb2U3elP0BIeybQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
         "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.806.0",
-        "@smithy/core": "^3.3.1",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@smithy/core": "^3.3.3",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
@@ -1253,45 +1254,45 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.806.0.tgz",
-      "integrity": "sha512-ua2gzpfQ9MF8Rny+tOAivowOWWvqEusez2rdcQK8jdBjA1ANd/0xzToSZjZh0ziN8Kl8jOhNnHbQJ0v6dT6+hg==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.810.0.tgz",
+      "integrity": "sha512-w+tGXFSQjzvJ3j2sQ4GJRdD+YXLTgwLd9eG/A+7pjrv2yLLV70M4HqRrFqH06JBjqT5rsOxonc/QSjROyxk+IA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/core": "3.810.0",
         "@aws-sdk/middleware-host-header": "3.804.0",
         "@aws-sdk/middleware-logger": "3.804.0",
         "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.806.0",
-        "@aws-sdk/region-config-resolver": "3.806.0",
+        "@aws-sdk/middleware-user-agent": "3.810.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
         "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.806.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
         "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.806.0",
-        "@smithy/config-resolver": "^4.1.1",
-        "@smithy/core": "^3.3.1",
+        "@aws-sdk/util-user-agent-node": "3.810.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.3",
         "@smithy/fetch-http-handler": "^5.0.2",
         "@smithy/hash-node": "^4.0.2",
         "@smithy/invalid-dependency": "^4.0.2",
         "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.3",
-        "@smithy/middleware-retry": "^4.1.4",
-        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-endpoint": "^4.1.6",
+        "@smithy/middleware-retry": "^4.1.7",
+        "@smithy/middleware-serde": "^4.0.5",
         "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/node-http-handler": "^4.0.4",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/smithy-client": "^4.2.6",
         "@smithy/types": "^4.2.0",
         "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.11",
-        "@smithy/util-defaults-mode-node": "^4.0.11",
-        "@smithy/util-endpoints": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^4.0.14",
+        "@smithy/util-defaults-mode-node": "^4.0.14",
+        "@smithy/util-endpoints": "^3.0.4",
         "@smithy/util-middleware": "^4.0.2",
         "@smithy/util-retry": "^4.0.3",
         "@smithy/util-utf8": "^4.0.0",
@@ -1302,13 +1303,13 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.806.0.tgz",
-      "integrity": "sha512-cuv5pX55JOlzKC/iLsB5nZ9eUyVgncim3VhhWHZA/KYPh7rLMjOEfZ+xyaE9uLJXGmzOJboFH7+YdTRdIcOgrg==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.808.0.tgz",
+      "integrity": "sha512-9x2QWfphkARZY5OGkl9dJxZlSlYM2l5inFeo2bKntGuwg4A4YUe5h7d5yJ6sZbam9h43eBrkOdumx03DAkQF9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/types": "^4.2.0",
         "@smithy/util-config-provider": "^4.0.0",
         "@smithy/util-middleware": "^4.0.2",
@@ -1319,17 +1320,17 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.806.0.tgz",
-      "integrity": "sha512-/LjdkoMAr6T0EIIWVt444CJlaOCpYwjKxhTgZODSeRUPhKQxidBehg0TmXgQUc3oGUhGFPGCuQtFgLT0xvOSnw==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.810.0.tgz",
+      "integrity": "sha512-/6TISQT3HUOoY3Gli1EvQVISNGp8XawGKD4igJqwyF3l35VvajzaAfhwk+Tm5TKTCkFh8EFnqWeT+mId5AaUbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.806.0",
+        "@aws-sdk/signature-v4-multi-region": "3.810.0",
         "@aws-sdk/types": "3.804.0",
         "@aws-sdk/util-format-url": "3.804.0",
-        "@smithy/middleware-endpoint": "^4.1.3",
+        "@smithy/middleware-endpoint": "^4.1.6",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/smithy-client": "^4.2.6",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -1338,12 +1339,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.806.0.tgz",
-      "integrity": "sha512-IrbEnpKvG8d9rUWAvsF28g8qBlQ02FaOxn4cGXtTs0b0BGMK1M+cGQrYjJ7Ak08kIXDxBqsdIlZGsKYr+Ds9+w==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.810.0.tgz",
+      "integrity": "sha512-6F6evHRrA0OG/H67YuZBcI7EH4A0O5dIhczo2N0AK9z495uSIv+0xUrSrDhFTZxZjo6gkADIXroRjP1kwqK6ew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.806.0",
+        "@aws-sdk/middleware-sdk-s3": "3.810.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/signature-v4": "^5.1.0",
@@ -1355,12 +1356,12 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.806.0.tgz",
-      "integrity": "sha512-I6SxcsvV7yinJZmPgGullFHS0tsTKa7K3jEc5dmyCz8X+kZPfsWNffZmtmnCvWXPqMXWBvK6hVaxwomx79yeHA==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.810.0.tgz",
+      "integrity": "sha512-fdgHRCDpnzsD+0km7zuRbHRysJECfS8o9T9/pZ6XAr1z2FNV/UveHtnUYq0j6XpDMrIm0/suvXbshIjQU+a+sw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/nested-clients": "3.806.0",
+        "@aws-sdk/nested-clients": "3.810.0",
         "@aws-sdk/types": "3.804.0",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/shared-ini-file-loader": "^4.0.2",
@@ -1397,14 +1398,14 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.806.0.tgz",
-      "integrity": "sha512-3YRRgZ+qFuWDdm5uAbxKsr65UAil4KkrFKua9f4m7Be3v24ETiFOOqhanFUIk9/WOtvzF7oFEiDjYKDGlwV2xg==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.808.0.tgz",
+      "integrity": "sha512-N6Lic98uc4ADB7fLWlzx+1uVnq04VgVjngZvwHoujcRg9YDhIg9dUDiTzD5VZv13g1BrPYmvYP1HhsildpGV6w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
         "@smithy/types": "^4.2.0",
-        "@smithy/util-endpoints": "^3.0.3",
+        "@smithy/util-endpoints": "^3.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1451,14 +1452,14 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.806.0.tgz",
-      "integrity": "sha512-Az2e4/gmPZ4BpB7QRj7U76I+fctXhNcxlcgsaHnMhvt+R30nvzM2EhsyBUvsWl8+r9bnLeYt9BpvEZeq2ANDzA==",
+      "version": "3.810.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.810.0.tgz",
+      "integrity": "sha512-T56/ANEGNuvhqVoWZdr+0ZY2hjV93cH2OfGHIlVTVSAMACWG54XehDPESEso1CJNhJGYZPsE+FE42HGCk/XDMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.806.0",
+        "@aws-sdk/middleware-user-agent": "3.810.0",
         "@aws-sdk/types": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -2880,9 +2881,9 @@
       }
     },
     "node_modules/@fastify/otel": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.6.0.tgz",
-      "integrity": "sha512-lL+36KwGcFiAMcsPOLLsR+GV8ZpQuz5RLVstlgqmecTdQLTXVOe9Z8uwpMg9ktPcV++Ugp3dzzpBKNFWWWelYg==",
+      "version": "0.8.0",
+      "resolved": "https://codeload.github.com/getsentry/fastify-otel/tar.gz/ae3088d65e286bdc94ac5d722573537d6a6671bb",
+      "integrity": "sha512-8Mb0z6LsLb8krU+G/s29Gi5iPPf7em2RG3Sn50yLHVDP3Cz382MMBy790Q2zAS+iJ3hX9Fv7SKBy8Zil4DZQZQ==",
       "funding": [
         {
           "type": "github",
@@ -2895,27 +2896,69 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.200.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0"
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.2",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "minimatch": "^9"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0"
       }
     },
-    "node_modules/@fastify/otel/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
+        "@opentelemetry/api": "^1.3.0"
       },
       "engines": {
-        "node": "^18.19.0 || >=20.6.0"
+        "node": ">=14"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3980,13 +4023,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-2.0.0.tgz",
-      "integrity": "sha512-vXUHL9Oy5gBY+CtrLQQm254ek5jGSImLTzp51ZVC5hVOTDf9dbkymMrGU/3MYDUC8MZzPqwKnAfMPpCcjdqV5A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-2.0.1.tgz",
+      "integrity": "sha512-FeHtOp2XMhYxzYhC8sXhsc3gMeoDzjI+CGuPX+vRSyUdHZHDKTMoY9jRfk8ObmZsZDTWmd63Yqcf4X472YtHeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/sdk-trace-base": "2.0.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0",
         "jaeger-client": "^3.15.0"
       },
@@ -3998,9 +4041,9 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4013,13 +4056,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
-      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
+      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -4134,6 +4177,22 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
@@ -4188,6 +4247,22 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
       "version": "0.200.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.200.0.tgz",
@@ -4220,6 +4295,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
@@ -4257,6 +4348,22 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-prometheus": {
       "version": "0.200.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.200.0.tgz",
@@ -4287,6 +4394,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
@@ -4323,6 +4446,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
@@ -4376,6 +4515,22 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
@@ -4427,6 +4582,22 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
@@ -4475,6 +4646,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/sdk-trace-base": {
@@ -4726,9 +4913,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-document-load/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -5876,9 +6063,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-user-interaction/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -5990,6 +6177,22 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
@@ -6077,12 +6280,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
+      "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/core": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -6093,9 +6296,9 @@
       }
     },
     "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6137,6 +6340,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
@@ -6214,6 +6433,22 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-node": {
       "version": "0.200.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.200.0.tgz",
@@ -6263,6 +6498,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-base": {
@@ -6357,6 +6608,22 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
@@ -6375,14 +6642,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.0.0.tgz",
-      "integrity": "sha512-2IeDP1k2fipeCH6OcTSg3HgaSvTTqgUNld5GIPGXWspynZSK85YjUDazEYpSVIyaMeQY6+ZHEaD5cwsRaq3dWA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.0.1.tgz",
+      "integrity": "sha512-R4/i0rISvAujG4Zwk3s6ySyrWG+Db3SerZVM4jZ2lEzjrNylF7nRAy1hVvWe8gTbwIxX+6w6ZvZwdtl2C7UQHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/sdk-trace-base": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/sdk-trace-base": "2.0.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -6392,9 +6658,9 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6407,13 +6673,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
-      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
+      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -6537,14 +6803,6 @@
         "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
-    },
-    "node_modules/@petamoriken/float16": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
-      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -8537,50 +8795,50 @@
       }
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.17.0.tgz",
-      "integrity": "sha512-37n6NXtkUfdK7YiP3L5DJvhA/iusOmnjHQdX1e2VwI6a29xHCl/vRqLR3XNr5K4m+49al+3fWo2ltcKsfV+0xw==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.19.0.tgz",
+      "integrity": "sha512-DlEHX4eIHe5yIuh/cFu9OiaFuk1CTnFK95zj61I7Q2fxmN43dIwC3xAAGJ/Hy+GDQi7kU+BiS2sudSHSTq81BA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.17.0"
+        "@sentry/core": "9.19.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.17.0.tgz",
-      "integrity": "sha512-C2jBlGgYVGm8eXK38wlYQyd6NsHKaQlENg5fx8TDFMKWMNmLf6BmnPZ+y73OsFwcUtBz04CwZteybYB2GgYrvQ==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.19.0.tgz",
+      "integrity": "sha512-yixRrv4NfpjhFW56AuUTjVwZlignB9FWAXXyrmRP3SsFeJCFrAsSD8HOxV9RXNr9ePYl7MEU0Agi43YWhJsiAw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.17.0"
+        "@sentry/core": "9.19.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.17.0.tgz",
-      "integrity": "sha512-oH4NolXkEpe73eRP9r3K6WpERYItZisYQudsNrtkUBQL5M/uENiE7YTOvL5osD8AWmU0hCKY3Oua+qDi2lB+8g==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.19.0.tgz",
+      "integrity": "sha512-i/X9brRchbAF25yjxLTI7E8eoESRPBgIyQOWoWRXXt2n51iBRTjLXSaEfGvjdN+qrMq/yd6nC1/UqJVxXHeIhA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "9.17.0",
-        "@sentry/core": "9.17.0"
+        "@sentry-internal/browser-utils": "9.19.0",
+        "@sentry/core": "9.19.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.17.0.tgz",
-      "integrity": "sha512-w9AxBJIa+MbxDngvwnqouoJ/ezb7wNjxzFXtmaVtGp7hbC4yme/TOTNtFYg2J/ceQf3GMc8AfW5tsP6zU0R7gg==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.19.0.tgz",
+      "integrity": "sha512-YC8yrOjuKSfQgGniJnzkdbFsWEPTlNpzeeYPTxS4ouH1FwfGrSkPmcddjor2YHaLfiuHHqQ/Vvq70n+zruJH7A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "9.17.0",
-        "@sentry/core": "9.17.0"
+        "@sentry-internal/replay": "9.19.0",
+        "@sentry/core": "9.19.0"
       },
       "engines": {
         "node": ">=18"
@@ -8596,16 +8854,16 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.17.0.tgz",
-      "integrity": "sha512-3e/Q5bv06Q+XYV2cKmUgfMfnJtBY8MZKufpcwQ2ab2eMrastqau9KjYeWXapskDm179oPLfzLcDCSlDSTcvqpQ==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.19.0.tgz",
+      "integrity": "sha512-efKfPQ0yQkdIkC7qJ5TIHxnecLNENGUYl1YD/TC8yyzW2JRf/3OYo5yg1hY2rhsP5RwQShXlT7uA03ABVIkA4A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "9.17.0",
-        "@sentry-internal/feedback": "9.17.0",
-        "@sentry-internal/replay": "9.17.0",
-        "@sentry-internal/replay-canvas": "9.17.0",
-        "@sentry/core": "9.17.0"
+        "@sentry-internal/browser-utils": "9.19.0",
+        "@sentry-internal/feedback": "9.19.0",
+        "@sentry-internal/replay": "9.19.0",
+        "@sentry-internal/replay-canvas": "9.19.0",
+        "@sentry/core": "9.19.0"
       },
       "engines": {
         "node": ">=18"
@@ -8787,29 +9045,29 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.17.0.tgz",
-      "integrity": "sha512-9f1A93/kY9lLH06L1thPx94IhyLjEP3aRxYAtjtBfzId8UtubSpwP92sbxgslodD73R4tURwWJj7nYZ9HLYBUg==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.19.0.tgz",
+      "integrity": "sha512-I41rKpMJHHZb0z0Nja+Lxto6IkEEmX3uWjnECypF8Z1HIjeJB0+PXl8p/7TeaKYqw2J2GYcRTg7jQZDmvKle1w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/nextjs": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-9.17.0.tgz",
-      "integrity": "sha512-BTTUnHt2sFMQ081Fz+00JCiyHHXbujNFkezSeB5EoNIat7VErWh3fGJFjxv34ICfidscGQGeEHbbkyixb29J4w==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-9.19.0.tgz",
+      "integrity": "sha512-VE8xCIHaJBNF7DdiaG3MhBvUn5EWSJyCrrbtEkY5cvlo5pc19tBaxDwGJQfK63Z0DuZCuG9lwih7jCdmCXziwA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/semantic-conventions": "^1.30.0",
         "@rollup/plugin-commonjs": "28.0.1",
-        "@sentry-internal/browser-utils": "9.17.0",
-        "@sentry/core": "9.17.0",
-        "@sentry/node": "9.17.0",
-        "@sentry/opentelemetry": "9.17.0",
-        "@sentry/react": "9.17.0",
-        "@sentry/vercel-edge": "9.17.0",
+        "@sentry-internal/browser-utils": "9.19.0",
+        "@sentry/core": "9.19.0",
+        "@sentry/node": "9.19.0",
+        "@sentry/opentelemetry": "9.19.0",
+        "@sentry/react": "9.19.0",
+        "@sentry/vercel-edge": "9.19.0",
         "@sentry/webpack-plugin": "3.3.1",
         "chalk": "3.0.0",
         "resolve": "1.22.8",
@@ -8823,178 +9081,67 @@
         "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0"
       }
     },
-    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/api-logs": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
-      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@sentry/nextjs/node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.57.2",
-        "@types/shimmer": "^1.2.0",
-        "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/resources": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@sentry/nextjs/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
-      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
+      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/resources": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@sentry/nextjs/node_modules/@sentry/opentelemetry": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.17.0.tgz",
-      "integrity": "sha512-hrQ5SwW3pUwQ+ORBILqQqFj9ZLoKqo12OWuTwR8fxCErVJGeezuNvIpyNfkdtEW7X6N0AQnEfAg3umDAt/TAGw==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.19.0.tgz",
+      "integrity": "sha512-Js6153kW5mNjjukk6TVb04D/8DDhA9MO++WRzXWzNP+FiPi5zwtvm+Je2TvTeAjSH74f6o2JpfECdrfPYHWopA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.17.0"
+        "@sentry/core": "9.19.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1",
-        "@opentelemetry/core": "^1.30.1",
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/sdk-trace-base": "^1.30.1",
-        "@opentelemetry/semantic-conventions": "^1.28.0"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/instrumentation": "^0.57.1 || ^0.200.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.17.0.tgz",
-      "integrity": "sha512-TQkQOEjf4kww15mtt6KJ0s/5+ZNt4zjR0grH3zbuBbp2jca4vbR4/Z8alFsnJv5Rp0ppBfxoNyn9JHKbquvPYw==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.19.0.tgz",
+      "integrity": "sha512-WKVcUBy5Zc+LGvfV/CfGPBDfnmEOSxLCMYzXIhx0gUxf2+8WpMMc/8yW/25zbXMo3eC4oST4GBDSpTfNdMBz1w==",
       "license": "MIT",
       "dependencies": {
-        "@fastify/otel": "0.6.0",
+        "@fastify/otel": "https://codeload.github.com/getsentry/fastify-otel/tar.gz/ae3088d65e286bdc94ac5d722573537d6a6671bb",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^1.30.1",
         "@opentelemetry/core": "^1.30.1",
@@ -9025,9 +9172,9 @@
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.30.0",
         "@prisma/instrumentation": "6.7.0",
-        "@sentry/core": "9.17.0",
-        "@sentry/opentelemetry": "9.17.0",
-        "import-in-the-middle": "^1.13.0"
+        "@sentry/core": "9.19.0",
+        "@sentry/opentelemetry": "9.19.0",
+        "import-in-the-middle": "^1.13.1"
       },
       "engines": {
         "node": ">=18"
@@ -9153,33 +9300,33 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/opentelemetry": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.17.0.tgz",
-      "integrity": "sha512-hrQ5SwW3pUwQ+ORBILqQqFj9ZLoKqo12OWuTwR8fxCErVJGeezuNvIpyNfkdtEW7X6N0AQnEfAg3umDAt/TAGw==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.19.0.tgz",
+      "integrity": "sha512-Js6153kW5mNjjukk6TVb04D/8DDhA9MO++WRzXWzNP+FiPi5zwtvm+Je2TvTeAjSH74f6o2JpfECdrfPYHWopA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.17.0"
+        "@sentry/core": "9.19.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1",
-        "@opentelemetry/core": "^1.30.1",
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/sdk-trace-base": "^1.30.1",
-        "@opentelemetry/semantic-conventions": "^1.28.0"
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/instrumentation": "^0.57.1 || ^0.200.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-9.17.0.tgz",
-      "integrity": "sha512-hJOVUheFoUKr5e4vHxyKiu72FRgqmMTFIUG9myim8PH8mJYDqab7Z7cOt4dsBR86soKanaRB5PJq5jGFuipLfg==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-9.19.0.tgz",
+      "integrity": "sha512-tHuzPVbqKsONlFQsy7FqqGjBaujQoLRIDBLlPPMNoiGvP3rodBl6t1v5zoNAq4m47i3MhvpLEYf6C00j1w5UMQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "9.17.0",
-        "@sentry/core": "9.17.0",
+        "@sentry/browser": "9.19.0",
+        "@sentry/core": "9.19.0",
         "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
@@ -9190,13 +9337,13 @@
       }
     },
     "node_modules/@sentry/vercel-edge": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-9.17.0.tgz",
-      "integrity": "sha512-nNmID71yR71tYh0yhHeLFVuF3p+ANq4LejoOeCYlfRukJdO4sVTR7x3L5iZl75wf4K5o7mvr1xXmRfMn7Ck6dg==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-9.19.0.tgz",
+      "integrity": "sha512-oPWFCYMYvzaEyyR/HDS42RniHoQA+p32UysAa6yW3HrTs5139d41R8+qaX1TUVKlcNVVTePajCz/V37fBBaPpA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@sentry/core": "9.17.0"
+        "@sentry/core": "9.19.0"
       },
       "engines": {
         "node": ">=18"
@@ -9233,84 +9380,84 @@
       }
     },
     "node_modules/@shikijs/core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.4.0.tgz",
-      "integrity": "sha512-0YOzTSRDn/IAfQWtK791gs1u8v87HNGToU6IwcA3K7nPoVOrS2Dh6X6A6YfXgPTSkTwR5y6myk0MnI0htjnwrA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.4.1.tgz",
+      "integrity": "sha512-GCqSd3KXRTKX1sViP7fIyyyf6do2QVg+fTd4IT00ucYCVSKiSN8HbFbfyjGsoZePNKWcQqXe4U4rrz2IVldG5A==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.0",
+        "@shikijs/types": "3.4.1",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.4.0.tgz",
-      "integrity": "sha512-1ywDoe+z/TPQKj9Jw0eU61B003J9DqUFRfH+DVSzdwPUFhR7yOmfyLzUrFz0yw8JxFg/NgzXoQyyykXgO21n5Q==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.4.1.tgz",
+      "integrity": "sha512-oGvRqN3Bsk+cGzmCb/5Kt/LfD7uyA8vCUUawyqmLti/AYNV7++zIZFEW8JwW5PrpPNWWx9RcZ/chnYLedzlVIQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.0",
+        "@shikijs/types": "3.4.1",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.3"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.0.tgz",
-      "integrity": "sha512-zwcWlZ4OQuJ/+1t32ClTtyTU1AiDkK1lhtviRWoq/hFqPjCNyLj22bIg9rB7BfoZKOEOfrsGz7No33BPCf+WlQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.1.tgz",
+      "integrity": "sha512-p8I5KWgEDUcXRif9JjJUZtNeqCyxZ8xcslecDJMigsqSZfokwqQIsH4aGpdjzmDf8LIWvT+C3TCxnJQVaPmCbQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.0",
+        "@shikijs/types": "3.4.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.0.tgz",
-      "integrity": "sha512-bQkR+8LllaM2duU9BBRQU0GqFTx7TuF5kKlw/7uiGKoK140n1xlLAwCgXwSxAjJ7Htk9tXTFwnnsJTCU5nDPXQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.1.tgz",
+      "integrity": "sha512-v5A5ApJYcrcPLHcwAi0bViUU+Unh67UaXU9gGX3qfr2z3AqlqSZbC00W/3J4+tfGJASzwrWDro2R1er6SsCL1Q==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.0"
+        "@shikijs/types": "3.4.1"
       }
     },
     "node_modules/@shikijs/rehype": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-3.4.0.tgz",
-      "integrity": "sha512-wm7RTSmrcmjZg+F9JRrsH0Brwi36joUMXkUWIDmBGW+XExNEi8Xjmmp2NOBXa3DujZtnL6Dbcg7V6gtZabGoXw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-3.4.1.tgz",
+      "integrity": "sha512-pJnQQjCAM5H+VE6Cwrjf9wkRWavloqmrIalMbRSlckKZeaASA4HITo+hyG3l4jTQCCUgsY5+GuGv8xDHy4YXzA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.0",
+        "@shikijs/types": "3.4.1",
         "@types/hast": "^3.0.4",
         "hast-util-to-string": "^3.0.1",
-        "shiki": "3.4.0",
+        "shiki": "3.4.1",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.0.tgz",
-      "integrity": "sha512-YPP4PKNFcFGLxItpbU0ZW1Osyuk8AyZ24YEFaq04CFsuCbcqydMvMUTi40V2dkc0qs1U2uZFrnU6s5zI6IH+uA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.1.tgz",
+      "integrity": "sha512-XOJgs55mVVMZtNVJx1NVmdcfXG9HIyZGh7qpCw/Ok5UMjWgkmb8z15TgcmF3ItvHItijiIMl9BLcNO/tFSGl1w==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.0"
+        "@shikijs/types": "3.4.1"
       }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.4.0.tgz",
-      "integrity": "sha512-GrGaOj1/I6h75IU0VvjdWDpqGCynx0bqHzd1rErBTGxrcmusYIBhrV7aEySWyJ6HHb9figeXfcNxUFS1HKUfBw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.4.1.tgz",
+      "integrity": "sha512-Z3lbVQXHiXLC0bjDuGqsF3AAvvv4lQMoAXqIINZiOBgsk6CrnPZy0E2A+QUqv/MUaqp5qtYGsKDUJWbFE+buXw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.4.0",
-        "@shikijs/types": "3.4.0"
+        "@shikijs/core": "3.4.1",
+        "@shikijs/types": "3.4.1"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.0.tgz",
-      "integrity": "sha512-EUT/0lGiE//7j5N/yTMNMT3eCWNcHJLrRKxT0NDXWIfdfSmFJKfPX7nMmRBrQnWboAzIsUziCThrYMMhjbMS1A==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.1.tgz",
+      "integrity": "sha512-4flT+pToGqRBb0UhGqXTV7rCqUS3fhc8z3S2Djc3E5USKhXwadeKGFVNB2rKXfohlrEozNJMtMiZaN8lfdj/ZQ==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -9418,12 +9565,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-W7AppgQD3fP1aBmo8wWo0id5zeR2/aYRy067vZsDVaa6v/mdhkg6DxXwEVuSPjZl+ZnvWAQbUMCd5ckw38+tHQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.3.3.tgz",
+      "integrity": "sha512-CiJNc0b/WdnttAfQ6uMkxPQ3Z8hG/ba8wF89x9KtBBLDdZk6CX52K4F8hbe94uNbc8LDUuZFtbqfdhM3T21naw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-serde": "^4.0.5",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "@smithy/util-body-length-browser": "^4.0.0",
@@ -9636,13 +9783,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.4.tgz",
-      "integrity": "sha512-qWyYvszzvDjT2AxRvEpNhnMTo8QX9MCAtuSA//kYbXewb+2mEGQCk1UL4dNIrKLcF5KT11dOJtxFYT0kzajq5g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.6.tgz",
+      "integrity": "sha512-Zdieg07c3ua3ap5ungdcyNnY1OsxmsXXtKDTk28+/YbwIPju0Z1ZX9X5AnkjmDE3+AbqgvhtC/ZuCMSr6VSfPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.3.1",
-        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/core": "^3.3.3",
+        "@smithy/middleware-serde": "^4.0.5",
         "@smithy/node-config-provider": "^4.1.1",
         "@smithy/shared-ini-file-loader": "^4.0.2",
         "@smithy/types": "^4.2.0",
@@ -9655,15 +9802,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.5.tgz",
-      "integrity": "sha512-eQguCTA2TRGyg4P7gDuhRjL2HtN5OKJXysq3Ufj0EppZe4XBmSyKIvVX9ws9KkD3lkJskw1tfE96wMFsiUShaw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.7.tgz",
+      "integrity": "sha512-lFIFUJ0E/4I0UaIDY5usNUzNKAghhxO0lDH4TZktXMmE+e4ActD9F154Si0Unc01aCPzcwd+NcOwQw6AfXXRRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.1",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/service-error-classification": "^4.0.3",
-        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/smithy-client": "^4.2.6",
         "@smithy/types": "^4.2.0",
         "@smithy/util-middleware": "^4.0.2",
         "@smithy/util-retry": "^4.0.3",
@@ -9688,11 +9835,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
-      "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.5.tgz",
+      "integrity": "sha512-yREC3q/HXqQigq29xX3hiy6tFi+kjPKXoYUQmwQdgPORLbQ0n6V2Z/Iw9Nnlu66da9fM/WhDtGvYvqwecrCljQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -9842,13 +9990,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.4.tgz",
-      "integrity": "sha512-oolSEpr/ABUtVmFMdNgi6sSXsK4csV9n4XM9yXgvDJGRa32tQDUdv9s+ztFZKccay1AiTWLSGsyDj2xy1gsv7Q==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.6.tgz",
+      "integrity": "sha512-WEqP0wQ1N/lVS4pwNK1Vk+0i6QIr66cq/xbu1dVy1tM0A0qYwAYyz0JhbquzM5pMa8s89lyDBtoGKxo7iG74GA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.3.1",
-        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/core": "^3.3.3",
+        "@smithy/middleware-endpoint": "^4.1.6",
         "@smithy/middleware-stack": "^4.0.2",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
@@ -9949,13 +10097,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.12.tgz",
-      "integrity": "sha512-0vPKiC+rXWMq397tsa/RFcO/kJ1UsibgNCXScMsRwzm9WMT4QjGf43zVPWZ5hPLu3z/1XddiZFIlKcu2j/yUuQ==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.14.tgz",
+      "integrity": "sha512-l7QnMX8VcDOH6n/fBRu4zqguSlOBZxFzWqp58dXFSARFBjNlmEDk5G/z4T7BMGr+rI0Pg8MkhmMUfEtHFgpy2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/smithy-client": "^4.2.6",
         "@smithy/types": "^4.2.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -9965,16 +10113,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.12.tgz",
-      "integrity": "sha512-zCx9noceM3Pw2jvcJ3w3RbvKnPe3lCo6txH9ksZj6CeRZPkvRZPLXmKVSOvDr9QQP3VRq/WnBLd+LTZAL7+0IQ==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.14.tgz",
+      "integrity": "sha512-Ujs1gsWDo3m/T63VWBTBmHLTD2UlU6J6FEokLCEp7OZQv45jcjLHoxTwgWsi8ULpsYozvH4MTWkRP+bhwr0vDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.1.2",
         "@smithy/credential-provider-imds": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.1",
         "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/smithy-client": "^4.2.6",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -10154,35 +10302,25 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.6.tgz",
-      "integrity": "sha512-ed6zQbgmKsjsVvodAS1q1Ld2BolEuxJOSyyNc+vhkjdmfNUDCmQnlXBfQkHrlzNmslxHsQU/bFmzcEbv4xXsLg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.7.tgz",
+      "integrity": "sha512-9rsOpdY9idRI2NH6CL4wORFY0+Q6fnx9XP9Ju+iq/0wJwGD5IByIgFmwVbyy4ymuyprj8Qh4ErxMKTUL4uNh3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "enhanced-resolve": "^5.18.1",
         "jiti": "^2.4.2",
-        "lightningcss": "1.29.2",
+        "lightningcss": "1.30.1",
         "magic-string": "^0.30.17",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.1.6"
-      }
-    },
-    "node_modules/@tailwindcss/node/node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
+        "tailwindcss": "4.1.7"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.6.tgz",
-      "integrity": "sha512-0bpEBQiGx+227fW4G0fLQ8vuvyy5rsB1YIYNapTq3aRsJ9taF3f5cCaovDjN5pUGKKzcpMrZst/mhNaKAPOHOA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.7.tgz",
+      "integrity": "sha512-5SF95Ctm9DFiUyjUPnDGkoKItPX/k+xifcQhcqX5RA85m50jw1pT/KzjdvlqxRja45Y52nR4MR9fD1JYd7f8NQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -10194,24 +10332,24 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.6",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.6",
-        "@tailwindcss/oxide-darwin-x64": "4.1.6",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.6",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.6",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.6",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.6",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.6",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.6",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.6",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.6",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.6"
+        "@tailwindcss/oxide-android-arm64": "4.1.7",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.7",
+        "@tailwindcss/oxide-darwin-x64": "4.1.7",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.7",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.7",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.7",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.7",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.7",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.7",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.7",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.7",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.7"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.6.tgz",
-      "integrity": "sha512-VHwwPiwXtdIvOvqT/0/FLH/pizTVu78FOnI9jQo64kSAikFSZT7K4pjyzoDpSMaveJTGyAKvDjuhxJxKfmvjiQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.7.tgz",
+      "integrity": "sha512-IWA410JZ8fF7kACus6BrUwY2Z1t1hm0+ZWNEzykKmMNM09wQooOcN/VXr0p/WJdtHZ90PvJf2AIBS/Ceqx1emg==",
       "cpu": [
         "arm64"
       ],
@@ -10226,9 +10364,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.6.tgz",
-      "integrity": "sha512-weINOCcqv1HVBIGptNrk7c6lWgSFFiQMcCpKM4tnVi5x8OY2v1FrV76jwLukfT6pL1hyajc06tyVmZFYXoxvhQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.7.tgz",
+      "integrity": "sha512-81jUw9To7fimGGkuJ2W5h3/oGonTOZKZ8C2ghm/TTxbwvfSiFSDPd6/A/KE2N7Jp4mv3Ps9OFqg2fEKgZFfsvg==",
       "cpu": [
         "arm64"
       ],
@@ -10243,9 +10381,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.6.tgz",
-      "integrity": "sha512-3FzekhHG0ww1zQjQ1lPoq0wPrAIVXAbUkWdWM8u5BnYFZgb9ja5ejBqyTgjpo5mfy0hFOoMnMuVDI+7CXhXZaQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.7.tgz",
+      "integrity": "sha512-q77rWjEyGHV4PdDBtrzO0tgBBPlQWKY7wZK0cUok/HaGgbNKecegNxCGikuPJn5wFAlIywC3v+WMBt0PEBtwGw==",
       "cpu": [
         "x64"
       ],
@@ -10260,9 +10398,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.6.tgz",
-      "integrity": "sha512-4m5F5lpkBZhVQJq53oe5XgJ+aFYWdrgkMwViHjRsES3KEu2m1udR21B1I77RUqie0ZYNscFzY1v9aDssMBZ/1w==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.7.tgz",
+      "integrity": "sha512-RfmdbbK6G6ptgF4qqbzoxmH+PKfP4KSVs7SRlTwcbRgBwezJkAO3Qta/7gDy10Q2DcUVkKxFLXUQO6J3CRvBGw==",
       "cpu": [
         "x64"
       ],
@@ -10277,9 +10415,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.6.tgz",
-      "integrity": "sha512-qU0rHnA9P/ZoaDKouU1oGPxPWzDKtIfX7eOGi5jOWJKdxieUJdVV+CxWZOpDWlYTd4N3sFQvcnVLJWJ1cLP5TA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.7.tgz",
+      "integrity": "sha512-OZqsGvpwOa13lVd1z6JVwQXadEobmesxQ4AxhrwRiPuE04quvZHWn/LnihMg7/XkN+dTioXp/VMu/p6A5eZP3g==",
       "cpu": [
         "arm"
       ],
@@ -10294,9 +10432,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.6.tgz",
-      "integrity": "sha512-jXy3TSTrbfgyd3UxPQeXC3wm8DAgmigzar99Km9Sf6L2OFfn/k+u3VqmpgHQw5QNfCpPe43em6Q7V76Wx7ogIQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.7.tgz",
+      "integrity": "sha512-voMvBTnJSfKecJxGkoeAyW/2XRToLZ227LxswLAwKY7YslG/Xkw9/tJNH+3IVh5bdYzYE7DfiaPbRkSHFxY1xA==",
       "cpu": [
         "arm64"
       ],
@@ -10311,9 +10449,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.6.tgz",
-      "integrity": "sha512-8kjivE5xW0qAQ9HX9reVFmZj3t+VmljDLVRJpVBEoTR+3bKMnvC7iLcoSGNIUJGOZy1mLVq7x/gerVg0T+IsYw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.7.tgz",
+      "integrity": "sha512-PjGuNNmJeKHnP58M7XyjJyla8LPo+RmwHQpBI+W/OxqrwojyuCQ+GUtygu7jUqTEexejZHr/z3nBc/gTiXBj4A==",
       "cpu": [
         "arm64"
       ],
@@ -10328,9 +10466,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.6.tgz",
-      "integrity": "sha512-A4spQhwnWVpjWDLXnOW9PSinO2PTKJQNRmL/aIl2U/O+RARls8doDfs6R41+DAXK0ccacvRyDpR46aVQJJCoCg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.7.tgz",
+      "integrity": "sha512-HMs+Va+ZR3gC3mLZE00gXxtBo3JoSQxtu9lobbZd+DmfkIxR54NO7Z+UQNPsa0P/ITn1TevtFxXTpsRU7qEvWg==",
       "cpu": [
         "x64"
       ],
@@ -10345,9 +10483,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.6.tgz",
-      "integrity": "sha512-YRee+6ZqdzgiQAHVSLfl3RYmqeeaWVCk796MhXhLQu2kJu2COHBkqlqsqKYx3p8Hmk5pGCQd2jTAoMWWFeyG2A==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.7.tgz",
+      "integrity": "sha512-MHZ6jyNlutdHH8rd+YTdr3QbXrHXqwIhHw9e7yXEBcQdluGwhpQY2Eku8UZK6ReLaWtQ4gijIv5QoM5eE+qlsA==",
       "cpu": [
         "x64"
       ],
@@ -10362,9 +10500,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.6.tgz",
-      "integrity": "sha512-qAp4ooTYrBQ5pk5jgg54/U1rCJ/9FLYOkkQ/nTE+bVMseMfB6O7J8zb19YTpWuu4UdfRf5zzOrNKfl6T64MNrQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.7.tgz",
+      "integrity": "sha512-ANaSKt74ZRzE2TvJmUcbFQ8zS201cIPxUDm5qez5rLEwWkie2SkGtA4P+GPTj+u8N6JbPrC8MtY8RmJA35Oo+A==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -10392,9 +10530,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.6.tgz",
-      "integrity": "sha512-nqpDWk0Xr8ELO/nfRUDjk1pc9wDJ3ObeDdNMHLaymc4PJBWj11gdPCWZFKSK2AVKjJQC7J2EfmSmf47GN7OuLg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.7.tgz",
+      "integrity": "sha512-HUiSiXQ9gLJBAPCMVRk2RT1ZrBjto7WvqsPBwUrNK2BcdSxMnk19h4pjZjI7zgPhDxlAbJSumTC4ljeA9y0tEw==",
       "cpu": [
         "arm64"
       ],
@@ -10409,9 +10547,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.6.tgz",
-      "integrity": "sha512-5k9xF33xkfKpo9wCvYcegQ21VwIBU1/qEbYlVukfEIyQbEA47uK8AAwS7NVjNE3vHzcmxMYwd0l6L4pPjjm1rQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.7.tgz",
+      "integrity": "sha512-rYHGmvoHiLJ8hWucSfSOEmdCBIGZIq7SpkPRSqLsH2Ab2YUNgKeAPT1Fi2cx3+hnYOrAb0jp9cRyode3bBW4mQ==",
       "cpu": [
         "x64"
       ],
@@ -10426,17 +10564,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.6.tgz",
-      "integrity": "sha512-ELq+gDMBuRXPJlpE3PEen+1MhnHAQQrh2zF0dI1NXOlEWfr2qWf2CQdr5jl9yANv8RErQaQ2l6nIFO9OSCVq/g==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.7.tgz",
+      "integrity": "sha512-88g3qmNZn7jDgrrcp3ZXEQfp9CVox7xjP1HN2TFKI03CltPVd/c61ydn5qJJL8FYunn0OqBaW5HNUga0kmPVvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.1.6",
-        "@tailwindcss/oxide": "4.1.6",
+        "@tailwindcss/node": "4.1.7",
+        "@tailwindcss/oxide": "4.1.7",
         "postcss": "^8.4.41",
-        "tailwindcss": "4.1.6"
+        "tailwindcss": "4.1.7"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -11105,9 +11243,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
-      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
+      "version": "22.15.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
+      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -11122,12 +11260,6 @@
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
-    },
-    "node_modules/@types/node/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -11163,18 +11295,18 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
-      "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
+      "version": "19.1.4",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.4.tgz",
+      "integrity": "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
-      "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
+      "version": "19.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
+      "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
@@ -12304,9 +12436,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001717",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-      "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -13186,9 +13318,9 @@
       }
     },
     "node_modules/debounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.0.0.tgz",
-      "integrity": "sha512-xRetU6gL1VJbs85Mc4FoEGSjQxzpdxRyFhe3lmWFyy2EzydIcD4xzUvRJMD+NPDfMwKNhxa3PvsIOU32luIWeA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
+      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13199,9 +13331,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -13642,9 +13774,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.151",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.151.tgz",
-      "integrity": "sha512-Rl6uugut2l9sLojjS4H4SAr3A4IgACMLgpuEMPYCVcKydzfyPrn5absNRju38IhQOf/NwjJY8OGWjlteqYeBCA==",
+      "version": "1.5.155",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
+      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -13756,20 +13888,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/environment": {
@@ -14434,12 +14552,12 @@
       "license": "MIT"
     },
     "node_modules/framer-motion": {
-      "version": "12.10.5",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.10.5.tgz",
-      "integrity": "sha512-p6VF1YkwWvNDFzg5IQ5lqPx11Td4TQ6LqDnshV7sWj0Nrp4dwz2/aEzmgh9WA9ridcTIJ625Fr0oiuhgqIoFwQ==",
+      "version": "12.11.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.11.4.tgz",
+      "integrity": "sha512-kyE5oWZCUxhDb7LtpEyyadNThJJvoE8a6bfUTBqz++zw3XxDOosPAvw1lqNhYbjOgy57YuAlJ5qG/Cx5BigiEQ==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.10.5",
+        "motion-dom": "^12.11.4",
         "motion-utils": "^12.9.4",
         "tslib": "^2.4.0"
       },
@@ -14566,9 +14684,9 @@
       }
     },
     "node_modules/fumadocs-core": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-15.3.0.tgz",
-      "integrity": "sha512-6+j2qGntJknzQUyes5BQI3U5EE4GCIb1Pi31eAYZ8GLxMP1p1bh8nAyEeW6oZNZmqfstJoVLQNnw+vwuHJJHUw==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-15.3.2.tgz",
+      "integrity": "sha512-wrOSzYjA7EdL83SDPaN7Af4snVqB9QFxEBU3YIw66q58F64Y48C0rMqsYOLQVyL5gvq4ymXoKY+1jZJ8KYd1TQ==",
       "license": "MIT",
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.6.1",
@@ -14684,9 +14802,9 @@
       }
     },
     "node_modules/fumadocs-ui": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/fumadocs-ui/-/fumadocs-ui-15.3.0.tgz",
-      "integrity": "sha512-jQeaKWD+rGoZMXuH3FA73p6N7f11Lmhyn31bn9Jtl1VdIopq7EaXhseUqw586wSNgGKO3qmfPOXCBvvuu6gDTw==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/fumadocs-ui/-/fumadocs-ui-15.3.2.tgz",
+      "integrity": "sha512-2FEe3Y53h6hxq3JvBVC0B/dnf3m+wNtCX8CrZo57S9dst+PJ5VrwnA+paOgfHWMmaNfW15YcGB9oqCeKA2VBHQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.10",
@@ -14700,7 +14818,7 @@
         "@radix-ui/react-slot": "^1.2.2",
         "@radix-ui/react-tabs": "^1.1.11",
         "class-variance-authority": "^0.7.1",
-        "fumadocs-core": "15.3.0",
+        "fumadocs-core": "15.3.2",
         "lodash.merge": "^4.6.2",
         "next-themes": "^0.4.6",
         "postcss-selector-parser": "^7.1.0",
@@ -14805,56 +14923,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/gel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gel/-/gel-2.1.0.tgz",
-      "integrity": "sha512-HCeRqInCt6BjbMmeghJ6BKeYwOj7WJT5Db6IWWAA3IMUUa7or7zJfTUEkUWCxiOtoXnwnm96sFK9Fr47Yh2hOA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@petamoriken/float16": "^3.8.7",
-        "debug": "^4.3.4",
-        "env-paths": "^3.0.0",
-        "semver": "^7.6.2",
-        "shell-quote": "^1.8.1",
-        "which": "^4.0.0"
-      },
-      "bin": {
-        "gel": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/gel/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/gel/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/gensync": {
@@ -15003,6 +15071,21 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause",
       "peer": true
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -15545,9 +15628,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz",
-      "integrity": "sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.2.tgz",
+      "integrity": "sha512-Yjp9X7s2eHSXvZYQ0aye6UvwYPrVB5C2k47fuXjFKnYinAByaDZjh4t9MT2wEga9775n6WaIqyHnQhBxYtX2mg==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -16019,13 +16102,13 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jose": {
@@ -16279,9 +16362,9 @@
       }
     },
     "node_modules/lenis": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.1.tgz",
-      "integrity": "sha512-OGRlQk7EkGUtjDdnH+U49Mp26G/wGJFHuyYJ8ZwATllwHQZOKYbeuVaPWYQ4lK0gHfAnk2m0u8qN8Y4dtrHaHw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.3.tgz",
+      "integrity": "sha512-DOopj/UKHS54E9l2g4BOpDUvsyvkd1zkv+ECtHxQ9Fto8ozzKSz7MccqT+KOyG0ABA/OHXZ7l9INx0peUoQ8rQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -16314,9 +16397,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.2.tgz",
-      "integrity": "sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -16330,22 +16413,22 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.29.2",
-        "lightningcss-darwin-x64": "1.29.2",
-        "lightningcss-freebsd-x64": "1.29.2",
-        "lightningcss-linux-arm-gnueabihf": "1.29.2",
-        "lightningcss-linux-arm64-gnu": "1.29.2",
-        "lightningcss-linux-arm64-musl": "1.29.2",
-        "lightningcss-linux-x64-gnu": "1.29.2",
-        "lightningcss-linux-x64-musl": "1.29.2",
-        "lightningcss-win32-arm64-msvc": "1.29.2",
-        "lightningcss-win32-x64-msvc": "1.29.2"
+        "lightningcss-darwin-arm64": "1.30.1",
+        "lightningcss-darwin-x64": "1.30.1",
+        "lightningcss-freebsd-x64": "1.30.1",
+        "lightningcss-linux-arm-gnueabihf": "1.30.1",
+        "lightningcss-linux-arm64-gnu": "1.30.1",
+        "lightningcss-linux-arm64-musl": "1.30.1",
+        "lightningcss-linux-x64-gnu": "1.30.1",
+        "lightningcss-linux-x64-musl": "1.30.1",
+        "lightningcss-win32-arm64-msvc": "1.30.1",
+        "lightningcss-win32-x64-msvc": "1.30.1"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.2.tgz",
-      "integrity": "sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
       "cpu": [
         "arm64"
       ],
@@ -16365,9 +16448,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.2.tgz",
-      "integrity": "sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
       "cpu": [
         "x64"
       ],
@@ -16387,9 +16470,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.2.tgz",
-      "integrity": "sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
       "cpu": [
         "x64"
       ],
@@ -16409,9 +16492,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.2.tgz",
-      "integrity": "sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
       "cpu": [
         "arm"
       ],
@@ -16431,9 +16514,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.2.tgz",
-      "integrity": "sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
       "cpu": [
         "arm64"
       ],
@@ -16453,9 +16536,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.2.tgz",
-      "integrity": "sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
       "cpu": [
         "arm64"
       ],
@@ -16475,9 +16558,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.2.tgz",
-      "integrity": "sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
       "cpu": [
         "x64"
       ],
@@ -16497,9 +16580,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.2.tgz",
-      "integrity": "sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
       "cpu": [
         "x64"
       ],
@@ -16519,9 +16602,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.2.tgz",
-      "integrity": "sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
       "cpu": [
         "arm64"
       ],
@@ -16541,9 +16624,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.2.tgz",
-      "integrity": "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
       "cpu": [
         "x64"
       ],
@@ -18111,9 +18194,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -18189,9 +18272,9 @@
       "license": "MIT"
     },
     "node_modules/motion-dom": {
-      "version": "12.10.5",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.10.5.tgz",
-      "integrity": "sha512-F7XKmhxXEH/y3aWWf0N2w69wNSN+6PcJ1seqR1WolClmXpPhj+xwzs9j5CpsMFzeHR1D7irl3JcWMToPRwX6Hg==",
+      "version": "12.11.4",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.11.4.tgz",
+      "integrity": "sha512-1z/qYsrDjSx5QjOH8GfJ2RfFBvEzI2gdAEt2zNW+f7QkLlqjM3sQieESJr5+QtVmvD81qPANM7t97ROixKIt9Q==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.9.4"
@@ -19117,9 +19200,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.9.5.tgz",
-      "integrity": "sha512-DYTWtWpfd5FOro3UnAfwvhD8jh59r2ig8bPtc9H8Ds7MscE/9NYruUQWFAOuraRl29jwcT2kyMFQ3MxeaVjUhg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.0.tgz",
+      "integrity": "sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -19693,9 +19776,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.1.tgz",
-      "integrity": "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.2.tgz",
+      "integrity": "sha512-f2ls6rpO6G153Cy+o2XQ+Y0sARLOZ17+OGVLHrc3VUKcLHYKEKWbkSujdBWQXM7gKn5NTfp0XnRPZn1MIu8n9w==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -20600,20 +20683,17 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -20906,9 +20986,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -21012,32 +21092,18 @@
         "node": ">=8"
       }
     },
-    "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/shiki": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.4.0.tgz",
-      "integrity": "sha512-Ni80XHcqhOEXv5mmDAvf5p6PAJqbUc/RzFeaOqk+zP5DLvTPS3j0ckvA+MI87qoxTQ5RGJDVTbdl/ENLSyyAnQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.4.1.tgz",
+      "integrity": "sha512-PSnoczt+iWIOB4iRQ+XVPFtTuN1FcmuYzPgUBZTSv5pC6CozssIx2M4O5n4S9gJlUu9A3FxMU0ZPaHflky/6LA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.4.0",
-        "@shikijs/engine-javascript": "3.4.0",
-        "@shikijs/engine-oniguruma": "3.4.0",
-        "@shikijs/langs": "3.4.0",
-        "@shikijs/themes": "3.4.0",
-        "@shikijs/types": "3.4.0",
+        "@shikijs/core": "3.4.1",
+        "@shikijs/engine-javascript": "3.4.1",
+        "@shikijs/engine-oniguruma": "3.4.1",
+        "@shikijs/langs": "3.4.1",
+        "@shikijs/themes": "3.4.1",
+        "@shikijs/types": "3.4.1",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
@@ -21777,22 +21843,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/sucrase/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/sucrase/node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -21848,9 +21898,9 @@
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.2.0.tgz",
-      "integrity": "sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.0.tgz",
+      "integrity": "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -21858,9 +21908,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.6.tgz",
-      "integrity": "sha512-j0cGLTreM6u4OWzBeLBpycK0WIh8w7kSwcUsQZoGLHZ7xDTdM69lN64AgoIEEwFi0tnhs4wSykUa5YWxAzgFYg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.7.tgz",
+      "integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==",
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -21920,14 +21970,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+      "version": "5.39.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.2.tgz",
+      "integrity": "sha512-yEPUmWve+VA78bI71BW70Dh0TuV4HHd+I5SHOAfS1+QBOmvmCiiffgjR8ryyEd3KIfvPGFqoADt8LdQ6XpXIvg==",
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.14.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -22030,22 +22080,6 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/test-exclude/node_modules/minipass": {
@@ -22443,10 +22477,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unicode-trie": {
@@ -23291,16 +23324,16 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/yargs": {
@@ -23428,9 +23461,9 @@
       "peer": true
     },
     "node_modules/zustand": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.6.tgz",
-      "integrity": "sha512-ibr/n1hBzLLj5Y+yUcU7dYw8p6WnIVzdJbnX+1YpaScvZVF2ziugqHs+LAmHw4lWO9c/zRj+K1ncgWDQuthEdQ==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
       "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "^1.2.2"


### PR DESCRIPTION
## Description

Fixed the workflow preview display to pull directly from the state instead of rendering new blocks and subBlocks. Additionally, added logic to pull the subblock values directly from the state and not from the subBlock store, which was resulting in the deployed state UI getting overridden with the current state subBlock values.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Added block and subBlock values to the current state, reverted back to the deployed state, changed every type of subBlock value to verify correctness, and undeployed and redeployed to confirm that the deployed preview and current preview were displayed as expected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`npm test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
