### PR TITLE
fix(deployed-workflow): fixed the deployment status changes across workflows.

### DIFF
--- a/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
@@ -199,6 +199,11 @@ export function DeployModal({
     }
   }, [open, workflowId])
 
+  // Log when needsRedeployment changes
+  useEffect(() => {
+    logger.debug(`DeployModal: needsRedeployment changed to ${needsRedeployment} for workflow ${workflowId}`)
+  }, [needsRedeployment, workflowId])
+
   // Fetch deployment info when the modal opens and the workflow is deployed
   useEffect(() => {
     async function fetchDeploymentInfo() {
@@ -281,6 +286,9 @@ export function DeployModal({
 
       // Reset the needs redeployment flag
       setNeedsRedeployment(false)
+      if (workflowId) {
+        useWorkflowRegistry.getState().setWorkflowNeedsRedeployment(workflowId, false)
+      }
 
       // Update the local deployment info
       const endpoint = `${env.NEXT_PUBLIC_APP_URL}/api/workflows/${workflowId}/execute`
@@ -377,6 +385,9 @@ export function DeployModal({
 
       // Reset the needs redeployment flag
       setNeedsRedeployment(false)
+      if (workflowId) {
+        useWorkflowRegistry.getState().setWorkflowNeedsRedeployment(workflowId, false)
+      }
 
       // Add a success notification
       addNotification('info', 'Workflow successfully redeployed', workflowId)

--- a/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
@@ -72,7 +72,10 @@ export function DeployModal({
 }: DeployModalProps) {
   // Store hooks
   const { addNotification } = useNotificationStore()
-  const { isDeployed, setDeploymentStatus } = useWorkflowStore()
+  // Use workflow-specific deployment status getter
+  const deploymentStatus = useWorkflowStore(state => state.getWorkflowDeploymentStatus(workflowId))
+  const isDeployed = deploymentStatus?.isDeployed || false
+  const setDeploymentStatus = useWorkflowStore(state => state.setDeploymentStatus)
 
   // Local state
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -273,7 +276,7 @@ export function DeployModal({
       const { isDeployed: newDeployStatus, deployedAt } = await response.json()
 
       // Update the store with the deployment status
-      setDeploymentStatus(newDeployStatus, deployedAt ? new Date(deployedAt) : undefined)
+      setDeploymentStatus(workflowId, newDeployStatus, deployedAt ? new Date(deployedAt) : undefined, data.apiKey)
 
       // Reset the needs redeployment flag
       setNeedsRedeployment(false)
@@ -322,7 +325,7 @@ export function DeployModal({
       }
 
       // Update deployment status in the store
-      setDeploymentStatus(false)
+      setDeploymentStatus(workflowId, false)
 
       // Reset chat deployment info
       setDeployedChatUrl(null)
@@ -366,10 +369,10 @@ export function DeployModal({
         throw new Error(errorData.error || 'Failed to redeploy workflow')
       }
 
-      const { isDeployed: newDeployStatus, deployedAt } = await response.json()
+      const { isDeployed: newDeployStatus, deployedAt, apiKey } = await response.json()
 
       // Update deployment status in the store
-      setDeploymentStatus(newDeployStatus, deployedAt ? new Date(deployedAt) : undefined)
+      setDeploymentStatus(workflowId, newDeployStatus, deployedAt ? new Date(deployedAt) : undefined, apiKey)
 
       // Reset the needs redeployment flag
       setNeedsRedeployment(false)
@@ -475,10 +478,10 @@ export function DeployModal({
           throw new Error(errorData.error || 'Failed to deploy workflow')
         }
 
-        const { isDeployed: newDeployStatus, deployedAt } = await response.json()
+        const { isDeployed: newDeployStatus, deployedAt, apiKey } = await response.json()
 
         // Update the store with the deployment status
-        setDeploymentStatus(newDeployStatus, deployedAt ? new Date(deployedAt) : undefined)
+        setDeploymentStatus(workflowId, newDeployStatus, deployedAt ? new Date(deployedAt) : undefined, apiKey)
 
         logger.info('Workflow automatically deployed for chat deployment')
       } catch (error: any) {

--- a/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
@@ -23,6 +23,7 @@ import { createLogger } from '@/lib/logs/console-logger'
 import { cn } from '@/lib/utils'
 import { useNotificationStore } from '@/stores/notifications/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
+import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 import { ChatDeploy } from '@/app/w/[id]/components/control-bar/components/deploy-modal/components/chat-deploy/chat-deploy'
 import { DeployForm } from '@/app/w/[id]/components/control-bar/components/deploy-modal/components/deploy-form/deploy-form'
@@ -72,10 +73,11 @@ export function DeployModal({
 }: DeployModalProps) {
   // Store hooks
   const { addNotification } = useNotificationStore()
-  // Use workflow-specific deployment status getter
-  const deploymentStatus = useWorkflowStore(state => state.getWorkflowDeploymentStatus(workflowId))
+  
+  // Use registry store for deployment-related functions
+  const deploymentStatus = useWorkflowRegistry(state => state.getWorkflowDeploymentStatus(workflowId))
   const isDeployed = deploymentStatus?.isDeployed || false
-  const setDeploymentStatus = useWorkflowStore(state => state.setDeploymentStatus)
+  const setDeploymentStatus = useWorkflowRegistry(state => state.setDeploymentStatus)
 
   // Local state
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -83,7 +85,6 @@ export function DeployModal({
   const [deploymentInfo, setDeploymentInfo] = useState<DeploymentInfo | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([])
-  const [isCreatingKey, setIsCreatingKey] = useState(false)
   const [keysLoaded, setKeysLoaded] = useState(false)
   const [activeTab, setActiveTab] = useState<TabView>('api')
   const [isChatDeploying, setIsChatDeploying] = useState(false)

--- a/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deploy-modal/deploy-modal.tsx
@@ -199,11 +199,6 @@ export function DeployModal({
     }
   }, [open, workflowId])
 
-  // Log when needsRedeployment changes
-  useEffect(() => {
-    logger.debug(`DeployModal: needsRedeployment changed to ${needsRedeployment} for workflow ${workflowId}`)
-  }, [needsRedeployment, workflowId])
-
   // Fetch deployment info when the modal opens and the workflow is deployed
   useEffect(() => {
     async function fetchDeploymentInfo() {

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-card.tsx
@@ -7,19 +7,16 @@ import { cn } from '@/lib/utils'
 import { WorkflowPreview } from '@/app/w/components/workflow-preview/generic-workflow-preview'
 
 interface DeployedWorkflowCardProps {
-  // Current workflow state (if any)
   currentWorkflowState?: {
     blocks: Record<string, any>
     edges: Array<any>
     loops: Record<string, any>
   }
-  // Deployed workflow state from Supabase
   deployedWorkflowState: {
     blocks: Record<string, any>
     edges: Array<any>
     loops: Record<string, any>
   }
-  // Optional className for styling
   className?: string
 }
 
@@ -28,15 +25,20 @@ export function DeployedWorkflowCard({
   deployedWorkflowState,
   className,
 }: DeployedWorkflowCardProps) {
-  // State for toggling between deployed and current workflow
   const [showingDeployed, setShowingDeployed] = useState(true)
-
-  // Determine which workflow state to show
   const workflowToShow = showingDeployed ? deployedWorkflowState : currentWorkflowState
 
   return (
-    <Card className={cn('overflow-hidden', className)}>
-      <CardHeader className="space-y-4 p-4">
+    <Card className={cn('overflow-hidden relative', className)}>
+      <CardHeader
+        className={cn(
+          'space-y-4 p-4 sticky top-0 z-10',
+          'backdrop-blur-xl',
+          'bg-background/70 dark:bg-background/50',
+          'border-b border-border/30 dark:border-border/20',
+          'shadow-sm'
+        )}
+      >
         <div className="flex items-center justify-between">
           <h3 className="font-medium">
             {showingDeployed ? 'Deployed Workflow' : 'Current Workflow'}

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-modal.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/components/deployed-workflow-modal.tsx
@@ -13,13 +13,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { mergeSubblockState } from '@/stores/workflows/utils'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
@@ -62,8 +56,6 @@ export function DeployedWorkflowModal({
       <DialogContent
         className="sm:max-w-[1100px] max-h-[100vh] overflow-y-auto"
         style={{ zIndex: 1000 }}
-        onInteractOutside={(e) => e.preventDefault()}
-        onEscapeKeyDown={(e) => e.preventDefault()}
         hideCloseButton={true}
       >
         <div className="sr-only">

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/deployment-controls.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/deployment-controls.tsx
@@ -31,9 +31,7 @@ export function DeploymentControls({
   const workflowNeedsRedeployment = deploymentStatus?.needsRedeployment !== undefined 
     ? deploymentStatus.needsRedeployment 
     : needsRedeployment
-  
-  logger.debug(`DeploymentControls: Workflow ${activeWorkflowId} - isDeployed: ${isDeployed}, needsRedeployment: ${workflowNeedsRedeployment}`)
-  
+    
   const [isDeploying, setIsDeploying] = useState(false)
   const [isModalOpen, setIsModalOpen] = useState(false)
 

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/deployment-controls.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/deployment-controls.tsx
@@ -22,7 +22,10 @@ export function DeploymentControls({
   needsRedeployment,
   setNeedsRedeployment,
 }: DeploymentControlsProps) {
-  const { isDeployed } = useWorkflowStore()
+  // Use workflow-specific deployment status
+  const deploymentStatus = useWorkflowStore(state => state.getWorkflowDeploymentStatus(activeWorkflowId))
+  const isDeployed = deploymentStatus?.isDeployed || false
+  
   const [isDeploying, setIsDeploying] = useState(false)
   const [isModalOpen, setIsModalOpen] = useState(false)
 

--- a/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/deployment-controls.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/components/deployment-controls/deployment-controls.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { createLogger } from '@/lib/logs/console-logger'
 import { cn } from '@/lib/utils'
-import { useWorkflowStore } from '@/stores/workflows/workflow/store'
+import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { DeployModal } from '../deploy-modal/deploy-modal'
 
 const logger = createLogger('DeploymentControls')
@@ -23,7 +23,8 @@ export function DeploymentControls({
   setNeedsRedeployment,
 }: DeploymentControlsProps) {
   // Use workflow-specific deployment status
-  const deploymentStatus = useWorkflowStore(state => state.getWorkflowDeploymentStatus(activeWorkflowId))
+  const deploymentStatus = useWorkflowRegistry(state => 
+    state.getWorkflowDeploymentStatus(activeWorkflowId))
   const isDeployed = deploymentStatus?.isDeployed || false
   
   const [isDeploying, setIsDeploying] = useState(false)

--- a/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
@@ -292,6 +292,7 @@ export function ControlBar() {
           const data = await response.json()
           // Update the store with the status from the API
           setDeploymentStatus(
+            activeWorkflowId, 
             data.isDeployed,
             data.deployedAt ? new Date(data.deployedAt) : undefined
           )
@@ -329,7 +330,7 @@ export function ControlBar() {
 
   // Add a manual method to update the deployment status and clear the needsRedeployment flag
   const updateDeploymentStatusAndClearFlag = (isDeployed: boolean, deployedAt?: Date) => {
-    setDeploymentStatus(isDeployed, deployedAt)
+    setDeploymentStatus(activeWorkflowId, isDeployed, deployedAt)
     setNeedsRedeployment(false)
     useWorkflowStore.getState().setNeedsRedeploymentFlag(false)
   }

--- a/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
@@ -264,7 +264,6 @@ export function ControlBar() {
     const debouncedCheck = () => {
       // Skip if the active workflow has changed
       if (effectWorkflowId !== activeWorkflowId) {
-        logger.debug(`Skipping check for changes - workflow has changed from ${effectWorkflowId} to ${activeWorkflowId}`)
         return
       }
       
@@ -309,7 +308,6 @@ export function ControlBar() {
       
       // Skip if the workflow ID has changed since this effect started
       if (effectWorkflowId !== activeWorkflowId) {
-        logger.debug(`Skipping subblock check - workflow has changed from ${effectWorkflowId} to ${activeWorkflowId}`)
         return
       }
 
@@ -331,7 +329,6 @@ export function ControlBar() {
       periodicCheckTimer = setInterval(() => {
         // Only perform the check if this is still the active workflow
         if (effectWorkflowId === activeWorkflowId) {
-          logger.debug(`Performing periodic redeployment check for workflow ${activeWorkflowId}`);
           checkForChanges();
         } else {
           // Clear the interval if the workflow has changed
@@ -369,12 +366,9 @@ export function ControlBar() {
 
           // Verify the active workflow hasn't changed while fetching
           if (requestedWorkflowId !== activeWorkflowId) {
-            logger.debug(`Ignoring status response for ${requestedWorkflowId} - no longer the active workflow`)
             return
           }
           
-          // Log the response data
-          logger.debug(`Status API response for workflow ${requestedWorkflowId}: isDeployed=${data.isDeployed}, needsRedeployment=${data.needsRedeployment}`)
           
           // Update the store with the status from the API
           setDeploymentStatus(

--- a/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/w/[id]/components/control-bar/control-bar.tsx
@@ -88,9 +88,8 @@ export function ControlBar() {
     showNotification,
     removeNotification,
   } = useNotificationStore()
-  const { history, revertToHistoryState, lastSaved, isDeployed, setDeploymentStatus } =
-    useWorkflowStore()
-  const { workflows, updateWorkflow, activeWorkflowId, removeWorkflow, duplicateWorkflow } =
+  const { history, revertToHistoryState, lastSaved } = useWorkflowStore()
+  const { workflows, updateWorkflow, activeWorkflowId, removeWorkflow, duplicateWorkflow, setDeploymentStatus } =
     useWorkflowRegistry()
   const { isExecuting, handleRunWorkflow } = useWorkflowExecution()
   const { setActiveTab } = usePanelStore()
@@ -174,6 +173,11 @@ export function ControlBar() {
     const marketplaceData = getMarketplaceData()
     return marketplaceData?.status === 'owner'
   }
+
+  // Get deployment status from registry
+  const deploymentStatus = useWorkflowRegistry(state => 
+    state.getWorkflowDeploymentStatus(activeWorkflowId))
+  const isDeployed = deploymentStatus?.isDeployed || false
 
   // Client-side only rendering for the timestamp
   useEffect(() => {

--- a/apps/sim/app/w/[id]/components/notifications/notifications.tsx
+++ b/apps/sim/app/w/[id]/components/notifications/notifications.tsx
@@ -315,7 +315,7 @@ export function NotificationAlert({ notification, isFading, onHide }: Notificati
   // Create a function to clear the redeployment flag and update deployment status
   const updateDeploymentStatus = (isDeployed: boolean, deployedAt?: Date) => {
     // Update deployment status in workflow store
-    setDeploymentStatus(isDeployed, deployedAt)
+    setDeploymentStatus(workflowId || null, isDeployed, deployedAt)
 
     // Manually update the needsRedeployment flag in workflow store
     useWorkflowStore.getState().setNeedsRedeploymentFlag(false)

--- a/apps/sim/app/w/[id]/components/notifications/notifications.tsx
+++ b/apps/sim/app/w/[id]/components/notifications/notifications.tsx
@@ -308,11 +308,10 @@ export function NotificationAlert({ notification, isFading, onHide }: Notificati
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [showApiKey, setShowApiKey] = useState(false)
   const { setDeploymentStatus } = useWorkflowRegistry()
-  const { activeWorkflowId } = useWorkflowRegistry()
-
-  // Get deployment status from registry
+  
+  // Get deployment status from registry using notification's workflowId, not activeWorkflowId
   const deploymentStatus = useWorkflowRegistry(state => 
-    state.getWorkflowDeploymentStatus(activeWorkflowId))
+    state.getWorkflowDeploymentStatus(workflowId || null))
   const isDeployed = deploymentStatus?.isDeployed || false
 
   // Create a function to clear the redeployment flag and update deployment status

--- a/apps/sim/app/w/[id]/components/notifications/notifications.tsx
+++ b/apps/sim/app/w/[id]/components/notifications/notifications.tsx
@@ -307,10 +307,13 @@ export function NotificationAlert({ notification, isFading, onHide }: Notificati
   const { id, type, message, options, workflowId } = notification
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [showApiKey, setShowApiKey] = useState(false)
-  const { setDeploymentStatus } = useWorkflowStore()
-  const { isDeployed } = useWorkflowStore((state) => ({
-    isDeployed: state.isDeployed,
-  }))
+  const { setDeploymentStatus } = useWorkflowRegistry()
+  const { activeWorkflowId } = useWorkflowRegistry()
+
+  // Get deployment status from registry
+  const deploymentStatus = useWorkflowRegistry(state => 
+    state.getWorkflowDeploymentStatus(activeWorkflowId))
+  const isDeployed = deploymentStatus?.isDeployed || false
 
   // Create a function to clear the redeployment flag and update deployment status
   const updateDeploymentStatus = (isDeployed: boolean, deployedAt?: Date) => {

--- a/apps/sim/app/w/[id]/hooks/use-deployment-change-detection.ts
+++ b/apps/sim/app/w/[id]/hooks/use-deployment-change-detection.ts
@@ -1,0 +1,285 @@
+import { useEffect, useState } from 'react'
+import { createLogger } from '@/lib/logs/console-logger'
+import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
+import { useSubBlockStore } from '@/stores/workflows/subblock/store'
+import { useWorkflowStore } from '@/stores/workflows/workflow/store'
+
+const logger = createLogger('useDeploymentChangeDetection')
+
+/**
+ * Hook to detect when a deployed workflow needs redeployment due to changes
+ * Handles debouncing, API checks, and state synchronization
+ */
+export function useDeploymentChangeDetection(activeWorkflowId: string | null, isDeployed: boolean) {
+  const [needsRedeployment, setNeedsRedeployment] = useState(false)
+
+  // Listen for workflow changes and check if redeployment is needed
+  useEffect(() => {
+    if (!activeWorkflowId || !isDeployed) return
+
+    // Create a debounced function to check for changes
+    let debounceTimer: NodeJS.Timeout | null = null
+    let lastCheckTime = 0
+    let pendingChanges = 0
+    const DEBOUNCE_DELAY = 1000
+    const THROTTLE_INTERVAL = 3000
+
+    // Store the current workflow ID when the effect runs
+    const effectWorkflowId = activeWorkflowId
+
+    // Function to check if redeployment is needed
+    const checkForChanges = async () => {
+      // No longer skip if we're already showing needsRedeployment
+      // This allows us to detect when changes have been reverted
+
+      // Reset the pending changes counter
+      pendingChanges = 0
+      lastCheckTime = Date.now()
+
+      // Store the current workflow ID to check for race conditions
+      const requestedWorkflowId = activeWorkflowId
+      logger.debug(`Checking for changes in workflow ${requestedWorkflowId}`)
+
+      try {
+        // Get the deployed state from the API
+        const response = await fetch(`/api/workflows/${requestedWorkflowId}/status`)
+        if (response.ok) {
+          const data = await response.json()
+
+          // Verify the active workflow hasn't changed while fetching
+          if (requestedWorkflowId !== activeWorkflowId) {
+            logger.debug(
+              `Ignoring changes response for ${requestedWorkflowId} - no longer the active workflow`
+            )
+            return
+          }
+
+          logger.debug(
+            `API needsRedeployment response for workflow ${requestedWorkflowId}: ${data.needsRedeployment}`
+          )
+
+          // Always update the needsRedeployment flag based on API response to handle both true and false
+          // This ensures it's updated when changes are detected and when changes are no longer detected
+          if (data.needsRedeployment) {
+            logger.info(
+              `Setting needsRedeployment flag to TRUE for workflow ${requestedWorkflowId}`
+            )
+
+            // Update local state
+            setNeedsRedeployment(true)
+
+            // Use the workflow-specific method to update the registry
+            useWorkflowRegistry.getState().setWorkflowNeedsRedeployment(requestedWorkflowId, true)
+          } else {
+            // Only update to false if the current state is true to avoid unnecessary updates
+            const currentStatus = useWorkflowRegistry
+              .getState()
+              .getWorkflowDeploymentStatus(requestedWorkflowId)
+            if (currentStatus?.needsRedeployment) {
+              logger.info(
+                `Setting needsRedeployment flag to FALSE for workflow ${requestedWorkflowId}`
+              )
+
+              // Update local state
+              setNeedsRedeployment(false)
+
+              // Use the workflow-specific method to update the registry
+              useWorkflowRegistry
+                .getState()
+                .setWorkflowNeedsRedeployment(requestedWorkflowId, false)
+            }
+          }
+        }
+      } catch (error) {
+        logger.error('Failed to check workflow change status:', { error })
+      }
+    }
+
+    // Debounced check function
+    const debouncedCheck = () => {
+      // Skip if the active workflow has changed
+      if (effectWorkflowId !== activeWorkflowId) {
+        return
+      }
+
+      // Increment the pending changes counter
+      pendingChanges++
+
+      // Clear any existing timer
+      if (debounceTimer) {
+        clearTimeout(debounceTimer)
+      }
+
+      // If we recently checked, and it's within throttle interval, wait longer
+      const timeElapsed = Date.now() - lastCheckTime
+      if (timeElapsed < THROTTLE_INTERVAL && lastCheckTime > 0) {
+        // Wait until the throttle interval has passed
+        const adjustedDelay = Math.max(THROTTLE_INTERVAL - timeElapsed, DEBOUNCE_DELAY)
+
+        debounceTimer = setTimeout(() => {
+          // Only check if we have pending changes and workflow ID hasn't changed
+          if (pendingChanges > 0 && effectWorkflowId === activeWorkflowId) {
+            checkForChanges()
+          }
+        }, adjustedDelay)
+      } else {
+        // Standard debounce delay if we haven't checked recently
+        debounceTimer = setTimeout(() => {
+          // Only check if we have pending changes and workflow ID hasn't changed
+          if (pendingChanges > 0 && effectWorkflowId === activeWorkflowId) {
+            checkForChanges()
+          }
+        }, DEBOUNCE_DELAY)
+      }
+    }
+
+    // Subscribe to workflow store changes
+    const workflowUnsubscribe = useWorkflowStore.subscribe(debouncedCheck)
+
+    // Also subscribe to subblock store changes
+    const subBlockUnsubscribe = useSubBlockStore.subscribe((state) => {
+      // Only check for the active workflow when it's deployed
+      if (!activeWorkflowId || !isDeployed) return
+
+      // Skip if the workflow ID has changed since this effect started
+      if (effectWorkflowId !== activeWorkflowId) {
+        return
+      }
+
+      // Only trigger when there is an update to the current workflow's subblocks
+      const workflowSubBlocks = state.workflowValues[effectWorkflowId]
+      if (workflowSubBlocks && Object.keys(workflowSubBlocks).length > 0) {
+        debouncedCheck()
+      }
+    })
+
+    // Set up a periodic check when needsRedeployment is true to ensure it gets set back to false
+    // when changes are reverted
+    let periodicCheckTimer: NodeJS.Timeout | null = null
+
+    if (needsRedeployment) {
+      // Check every 5 seconds when needsRedeployment is true to catch reverted changes
+      const PERIODIC_CHECK_INTERVAL = 5000 // 5 seconds
+
+      periodicCheckTimer = setInterval(() => {
+        // Only perform the check if this is still the active workflow
+        if (effectWorkflowId === activeWorkflowId) {
+          checkForChanges()
+        } else {
+          // Clear the interval if the workflow has changed
+          if (periodicCheckTimer) {
+            clearInterval(periodicCheckTimer)
+          }
+        }
+      }, PERIODIC_CHECK_INTERVAL)
+    }
+
+    return () => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer)
+      }
+      if (periodicCheckTimer) {
+        clearInterval(periodicCheckTimer)
+      }
+      workflowUnsubscribe()
+      subBlockUnsubscribe()
+    }
+  }, [activeWorkflowId, isDeployed, needsRedeployment])
+
+  // Initial check on mount or when active workflow changes
+  useEffect(() => {
+    async function checkDeploymentStatus() {
+      if (!activeWorkflowId) return
+
+      try {
+        // Store the current workflow ID to check for race conditions
+        const requestedWorkflowId = activeWorkflowId
+
+        const response = await fetch(`/api/workflows/${requestedWorkflowId}/status`)
+        if (response.ok) {
+          const data = await response.json()
+
+          // Verify the active workflow hasn't changed while fetching
+          if (requestedWorkflowId !== activeWorkflowId) {
+            return
+          }
+
+          // Update the store with the status from the API
+          useWorkflowRegistry
+            .getState()
+            .setDeploymentStatus(
+              requestedWorkflowId,
+              data.isDeployed,
+              data.deployedAt ? new Date(data.deployedAt) : undefined
+            )
+
+          // Update local state
+          setNeedsRedeployment(data.needsRedeployment)
+
+          // Use the workflow-specific method to update the registry
+          useWorkflowRegistry
+            .getState()
+            .setWorkflowNeedsRedeployment(requestedWorkflowId, data.needsRedeployment)
+        }
+      } catch (error) {
+        logger.error('Failed to check workflow status:', { error })
+      }
+    }
+    checkDeploymentStatus()
+  }, [activeWorkflowId])
+
+  // Listen for deployment status changes
+  useEffect(() => {
+    // When deployment status changes and isDeployed becomes true,
+    // that means a deployment just occurred, so reset the needsRedeployment flag
+    if (isDeployed) {
+      // Update local state
+      setNeedsRedeployment(false)
+
+      // Use the workflow-specific method to update the registry
+      if (activeWorkflowId) {
+        useWorkflowRegistry.getState().setWorkflowNeedsRedeployment(activeWorkflowId, false)
+      }
+    }
+  }, [isDeployed, activeWorkflowId])
+
+  // Add a listener for the needsRedeployment flag in the workflow store
+  useEffect(() => {
+    const unsubscribe = useWorkflowStore.subscribe((state) => {
+      // Only update local state when it's for the currently active workflow
+      if (state.needsRedeployment !== undefined) {
+        // Get the workflow-specific needsRedeployment flag for the current workflow
+        const currentWorkflowStatus = useWorkflowRegistry
+          .getState()
+          .getWorkflowDeploymentStatus(activeWorkflowId)
+
+        // Only set local state based on current workflow's status
+        if (currentWorkflowStatus?.needsRedeployment !== undefined) {
+          setNeedsRedeployment(currentWorkflowStatus.needsRedeployment)
+        } else {
+          // Fallback to global state only if we don't have workflow-specific status
+          setNeedsRedeployment(state.needsRedeployment)
+        }
+      }
+    })
+
+    return () => unsubscribe()
+  }, [activeWorkflowId])
+
+  // Function to clear the redeployment flag
+  const clearNeedsRedeployment = () => {
+    // Update local state
+    setNeedsRedeployment(false)
+
+    // Use the workflow-specific method to update the registry
+    if (activeWorkflowId) {
+      useWorkflowRegistry.getState().setWorkflowNeedsRedeployment(activeWorkflowId, false)
+    }
+  }
+
+  return {
+    needsRedeployment,
+    setNeedsRedeployment,
+    clearNeedsRedeployment,
+  }
+}

--- a/apps/sim/stores/workflows/index.ts
+++ b/apps/sim/stores/workflows/index.ts
@@ -48,7 +48,7 @@ export function getWorkflowWithValues(workflowId: string) {
       logger.warn(`No saved state found for workflow ${workflowId}`)
       return null
     }
-    
+
     // Use registry deployment status instead of relying on saved state
     workflowState = {
       ...savedState,
@@ -136,7 +136,7 @@ export function getAllWorkflowsWithValues() {
         logger.warn(`No saved state found for workflow ${id}`)
         continue
       }
-      
+
       // Use registry deployment status instead of relying on saved state
       workflowState = {
         ...savedState,
@@ -149,7 +149,7 @@ export function getAllWorkflowsWithValues() {
     const mergedBlocks = mergeSubblockState(workflowState.blocks, id)
 
     // Include the API key in the state if it exists in the deployment status
-    const apiKey = deploymentStatus?.apiKey;
+    const apiKey = deploymentStatus?.apiKey
 
     result[id] = {
       id,

--- a/apps/sim/stores/workflows/index.ts
+++ b/apps/sim/stores/workflows/index.ts
@@ -25,6 +25,9 @@ export function getWorkflowWithValues(workflowId: string) {
 
   const metadata = workflows[workflowId]
 
+  // Get deployment status from registry
+  const deploymentStatus = useWorkflowRegistry.getState().getWorkflowDeploymentStatus(workflowId)
+
   // Load the specific state for this workflow
   let workflowState: WorkflowState
 
@@ -34,8 +37,8 @@ export function getWorkflowWithValues(workflowId: string) {
       blocks: currentState.blocks,
       edges: currentState.edges,
       loops: currentState.loops,
-      isDeployed: currentState.isDeployed,
-      deployedAt: currentState.deployedAt,
+      isDeployed: deploymentStatus?.isDeployed || false,
+      deployedAt: deploymentStatus?.deployedAt,
       lastSaved: currentState.lastSaved,
     }
   } else {
@@ -45,7 +48,13 @@ export function getWorkflowWithValues(workflowId: string) {
       logger.warn(`No saved state found for workflow ${workflowId}`)
       return null
     }
-    workflowState = savedState
+    
+    // Use registry deployment status instead of relying on saved state
+    workflowState = {
+      ...savedState,
+      isDeployed: deploymentStatus?.isDeployed || savedState.isDeployed || false,
+      deployedAt: deploymentStatus?.deployedAt || savedState.deployedAt,
+    }
   }
 
   // Merge the subblock values for this specific workflow
@@ -103,6 +112,9 @@ export function getAllWorkflowsWithValues() {
       continue
     }
 
+    // Get deployment status from registry
+    const deploymentStatus = useWorkflowRegistry.getState().getWorkflowDeploymentStatus(id)
+
     // Load the specific state for this workflow
     let workflowState: WorkflowState
 
@@ -112,8 +124,8 @@ export function getAllWorkflowsWithValues() {
         blocks: currentState.blocks,
         edges: currentState.edges,
         loops: currentState.loops,
-        isDeployed: currentState.isDeployed,
-        deployedAt: currentState.deployedAt,
+        isDeployed: deploymentStatus?.isDeployed || false,
+        deployedAt: deploymentStatus?.deployedAt,
         lastSaved: currentState.lastSaved,
       }
     } else {
@@ -124,11 +136,20 @@ export function getAllWorkflowsWithValues() {
         logger.warn(`No saved state found for workflow ${id}`)
         continue
       }
-      workflowState = savedState
+      
+      // Use registry deployment status instead of relying on saved state
+      workflowState = {
+        ...savedState,
+        isDeployed: deploymentStatus?.isDeployed || savedState.isDeployed || false,
+        deployedAt: deploymentStatus?.deployedAt || savedState.deployedAt,
+      }
     }
 
     // Merge the subblock values for this specific workflow
     const mergedBlocks = mergeSubblockState(workflowState.blocks, id)
+
+    // Include the API key in the state if it exists in the deployment status
+    const apiKey = deploymentStatus?.apiKey;
 
     result[id] = {
       id,
@@ -145,6 +166,8 @@ export function getAllWorkflowsWithValues() {
         isDeployed: workflowState.isDeployed,
         deployedAt: workflowState.deployedAt,
       },
+      // Include API key if available
+      apiKey,
     }
   }
 

--- a/apps/sim/stores/workflows/registry/store.ts
+++ b/apps/sim/stores/workflows/registry/store.ts
@@ -329,12 +329,12 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
         }
 
         const { deploymentStatuses = {} } = get()
-        
+
         // First try to get from the workflow-specific deployment statuses
         if (deploymentStatuses[workflowId]) {
           return deploymentStatuses[workflowId]
         }
-        
+
         // For backward compatibility, check the workflow state in workflow store
         // This will only be relevant during the transition period
         const workflowState = loadWorkflowState(workflowId)
@@ -343,7 +343,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
           if (workflowState.deploymentStatuses?.[workflowId]) {
             return workflowState.deploymentStatuses[workflowId]
           }
-          
+
           // Fallback to legacy fields if needed
           if (workflowState.isDeployed) {
             return {
@@ -352,13 +352,18 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             }
           }
         }
-        
+
         // No deployment status found
         return null
       },
 
       // Method to set deployment status for a specific workflow
-      setDeploymentStatus: (workflowId: string | null, isDeployed: boolean, deployedAt?: Date, apiKey?: string) => {
+      setDeploymentStatus: (
+        workflowId: string | null,
+        isDeployed: boolean,
+        deployedAt?: Date,
+        apiKey?: string
+      ) => {
         if (!workflowId) {
           workflowId = get().activeWorkflowId
           if (!workflowId) return
@@ -373,10 +378,12 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
               deployedAt: deployedAt || (isDeployed ? new Date() : undefined),
               apiKey,
               // Preserve existing needsRedeployment flag if available, but reset if newly deployed
-              needsRedeployment: isDeployed ? false : 
-                (state.deploymentStatuses?.[workflowId as string] as any)?.needsRedeployment ?? false,
+              needsRedeployment: isDeployed
+                ? false
+                : ((state.deploymentStatuses?.[workflowId as string] as any)?.needsRedeployment ??
+                  false),
             },
-          }
+          },
         }))
 
         // Also update the workflow store if this is the active workflow
@@ -393,10 +400,12 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
                 isDeployed,
                 deployedAt: deployedAt || (isDeployed ? new Date() : undefined),
                 apiKey,
-                needsRedeployment: isDeployed ? false : 
-                  (state.deploymentStatuses?.[workflowId as string] as any)?.needsRedeployment ?? false,
-              }
-            }
+                needsRedeployment: isDeployed
+                  ? false
+                  : ((state.deploymentStatuses?.[workflowId as string] as any)?.needsRedeployment ??
+                    false),
+              },
+            },
           }))
         }
 
@@ -407,18 +416,22 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             ...workflowState,
             // Update both legacy and new fields for compatibility
             isDeployed: workflowId === activeWorkflowId ? isDeployed : workflowState.isDeployed,
-            deployedAt: workflowId === activeWorkflowId ? 
-              (deployedAt || (isDeployed ? new Date() : undefined)) : workflowState.deployedAt,
+            deployedAt:
+              workflowId === activeWorkflowId
+                ? deployedAt || (isDeployed ? new Date() : undefined)
+                : workflowState.deployedAt,
             deploymentStatuses: {
               ...(workflowState.deploymentStatuses || {}),
               [workflowId]: {
                 isDeployed,
                 deployedAt: deployedAt || (isDeployed ? new Date() : undefined),
                 apiKey,
-                needsRedeployment: isDeployed ? false : 
-                  (workflowState.deploymentStatuses?.[workflowId] as any)?.needsRedeployment ?? false,
-              }
-            }
+                needsRedeployment: isDeployed
+                  ? false
+                  : ((workflowState.deploymentStatuses?.[workflowId] as any)?.needsRedeployment ??
+                    false),
+              },
+            },
           })
         }
 
@@ -435,9 +448,9 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
 
         // Update the registry's deployment status for this specific workflow
         set((state) => {
-          const deploymentStatuses = state.deploymentStatuses || {};
-          const currentStatus = deploymentStatuses[workflowId as string] || { isDeployed: false };
-          
+          const deploymentStatuses = state.deploymentStatuses || {}
+          const currentStatus = deploymentStatuses[workflowId as string] || { isDeployed: false }
+
           return {
             deploymentStatuses: {
               ...deploymentStatuses,
@@ -445,9 +458,9 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
                 ...currentStatus,
                 needsRedeployment,
               },
-            }
-          };
-        });
+            },
+          }
+        })
 
         // Only update the global flag if this is the active workflow
         const { activeWorkflowId } = get()
@@ -457,9 +470,9 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
         // Save to persistent storage
         const workflowState = loadWorkflowState(workflowId)
         if (workflowState) {
-          const deploymentStatuses = workflowState.deploymentStatuses || {};
-          const currentStatus = deploymentStatuses[workflowId] || { isDeployed: false };
-          
+          const deploymentStatuses = workflowState.deploymentStatuses || {}
+          const currentStatus = deploymentStatuses[workflowId] || { isDeployed: false }
+
           saveWorkflowState(workflowId, {
             ...workflowState,
             deploymentStatuses: {
@@ -467,8 +480,8 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
               [workflowId]: {
                 ...currentStatus,
                 needsRedeployment,
-              }
-            }
+              },
+            },
           })
         }
       },
@@ -483,7 +496,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
 
         // Get current workflow ID
         const currentId = get().activeWorkflowId
-                // Save current workflow state before switching
+        // Save current workflow state before switching
         if (currentId) {
           const currentState = useWorkflowStore.getState()
 
@@ -509,27 +522,27 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
         // Load workflow state for the new active workflow
         const parsedState = loadWorkflowState(id)
         if (parsedState) {
-          const { 
-            blocks, 
-            edges, 
-            history, 
-            loops, 
-            isDeployed, 
-            deployedAt, 
+          const {
+            blocks,
+            edges,
+            history,
+            loops,
+            isDeployed,
+            deployedAt,
             deploymentStatuses,
-            needsRedeployment 
+            needsRedeployment,
           } = parsedState
 
           // Get workflow-specific deployment status
-          let workflowIsDeployed = isDeployed;
-          let workflowDeployedAt = deployedAt;
-          let workflowNeedsRedeployment = needsRedeployment;
-          
+          let workflowIsDeployed = isDeployed
+          let workflowDeployedAt = deployedAt
+          let workflowNeedsRedeployment = needsRedeployment
+
           // Check if we have a workflow-specific deployment status
           if (deploymentStatuses && deploymentStatuses[id]) {
-            workflowIsDeployed = deploymentStatuses[id].isDeployed;
-            workflowDeployedAt = deploymentStatuses[id].deployedAt;
-            workflowNeedsRedeployment = deploymentStatuses[id].needsRedeployment;
+            workflowIsDeployed = deploymentStatuses[id].isDeployed
+            workflowDeployedAt = deploymentStatuses[id].deployedAt
+            workflowNeedsRedeployment = deploymentStatuses[id].needsRedeployment
           }
 
           // Initialize subblock store with workflow values
@@ -540,12 +553,10 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             blocks,
             edges,
             loops,
-            // Set global deployment status based on this workflow's status
             isDeployed: workflowIsDeployed !== undefined ? workflowIsDeployed : false,
             deployedAt: workflowDeployedAt ? new Date(workflowDeployedAt) : undefined,
-            // Set the needsRedeployment flag from the workflow-specific status
-            needsRedeployment: workflowNeedsRedeployment !== undefined ? workflowNeedsRedeployment : false,
-            // Include the deployment statuses map
+            needsRedeployment:
+              workflowNeedsRedeployment !== undefined ? workflowNeedsRedeployment : false,
             deploymentStatuses: deploymentStatuses || {},
             hasActiveSchedule: false,
             history: history || {
@@ -572,8 +583,8 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             set((state) => ({
               deploymentStatuses: {
                 ...state.deploymentStatuses,
-                ...deploymentStatuses
-              }
+                ...deploymentStatuses,
+              },
             }))
           } else if (workflowIsDeployed !== undefined) {
             // If there's no deployment statuses object but we have legacy deployment status,
@@ -583,9 +594,9 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
                 ...state.deploymentStatuses,
                 [id]: {
                   isDeployed: workflowIsDeployed as boolean,
-                  deployedAt: workflowDeployedAt ? new Date(workflowDeployedAt) : undefined
-                }
-              }
+                  deployedAt: workflowDeployedAt ? new Date(workflowDeployedAt) : undefined,
+                },
+              },
             }))
           }
 

--- a/apps/sim/stores/workflows/registry/store.ts
+++ b/apps/sim/stores/workflows/registry/store.ts
@@ -132,6 +132,7 @@ function resetWorkflowStores() {
     loops: {},
     isDeployed: false,
     deployedAt: undefined,
+    deploymentStatuses: {}, // Reset deployment statuses map
     hasActiveSchedule: false,
     history: {
       past: [],
@@ -343,6 +344,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             history: currentState.history,
             isDeployed: currentState.isDeployed,
             deployedAt: currentState.deployedAt,
+            deploymentStatuses: currentState.deploymentStatuses,
             lastSaved: Date.now(),
           })
 
@@ -356,7 +358,17 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
         // Load workflow state for the new active workflow
         const parsedState = loadWorkflowState(id)
         if (parsedState) {
-          const { blocks, edges, history, loops, isDeployed, deployedAt } = parsedState
+          const { blocks, edges, history, loops, isDeployed, deployedAt, deploymentStatuses } = parsedState
+
+          // Get workflow-specific deployment status
+          let workflowIsDeployed = isDeployed;
+          let workflowDeployedAt = deployedAt;
+          
+          // Check if we have a workflow-specific deployment status
+          if (deploymentStatuses && deploymentStatuses[id]) {
+            workflowIsDeployed = deploymentStatuses[id].isDeployed;
+            workflowDeployedAt = deploymentStatuses[id].deployedAt;
+          }
 
           // Initialize subblock store with workflow values
           useSubBlockStore.getState().initializeFromWorkflow(id, blocks)
@@ -366,8 +378,11 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             blocks,
             edges,
             loops,
-            isDeployed: isDeployed !== undefined ? isDeployed : false,
-            deployedAt: deployedAt ? new Date(deployedAt) : undefined,
+            // Set global deployment status based on this workflow's status
+            isDeployed: workflowIsDeployed !== undefined ? workflowIsDeployed : false,
+            deployedAt: workflowDeployedAt ? new Date(workflowDeployedAt) : undefined,
+            // Include the deployment statuses map
+            deploymentStatuses: deploymentStatuses || {},
             hasActiveSchedule: false,
             history: history || {
               past: [],
@@ -376,8 +391,8 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
                   blocks,
                   edges,
                   loops: {},
-                  isDeployed: isDeployed !== undefined ? isDeployed : false,
-                  deployedAt: deployedAt,
+                  isDeployed: workflowIsDeployed !== undefined ? workflowIsDeployed : false,
+                  deployedAt: workflowDeployedAt,
                 },
                 timestamp: Date.now(),
                 action: 'Initial state',
@@ -395,6 +410,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             loops: {},
             isDeployed: false,
             deployedAt: undefined,
+            deploymentStatuses: {},
             hasActiveSchedule: false,
             history: {
               past: [],
@@ -459,6 +475,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             loops: options.marketplaceState.loops || {},
             isDeployed: false,
             deployedAt: undefined,
+            deploymentStatuses: {}, // Initialize empty deployment statuses map
             workspaceId, // Include workspace ID in the state object
             history: {
               past: [],
@@ -582,6 +599,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             loops: {},
             isDeployed: false,
             deployedAt: undefined,
+            deploymentStatuses: {}, // Initialize empty deployment statuses map
             workspaceId, // Include workspace ID in the state object
             history: {
               past: [],
@@ -776,6 +794,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
           isDeployed: false, // Reset deployment status
           deployedAt: undefined, // Reset deployment timestamp
           workspaceId, // Include workspaceId in state
+          deploymentStatuses: {}, // Start with empty deployment statuses map
           history: {
             past: [],
             present: {

--- a/apps/sim/stores/workflows/registry/store.ts
+++ b/apps/sim/stores/workflows/registry/store.ts
@@ -69,7 +69,6 @@ function cleanupLocalStorageForWorkspace(workspaceId: string): void {
               // Only remove if it belongs to the current workspace
               if (parsed.workspaceId === workspaceId) {
                 localStorage.removeItem(key)
-                logger.debug(`Removed stale localStorage data for workflow ${workflowId}`)
               }
             } catch (e) {
               // Skip if we can't parse the data
@@ -78,7 +77,6 @@ function cleanupLocalStorageForWorkspace(workspaceId: string): void {
           } else {
             // If we can't determine the workspace, remove it to be safe
             localStorage.removeItem(key)
-            logger.debug(`Removed stale localStorage data for workflow ${workflowId}`)
           }
         }
         // Case 2: Clean up workflows that reference deleted workspaces
@@ -99,9 +97,6 @@ function cleanupLocalStorageForWorkspace(workspaceId: string): void {
                       // Workspace doesn't exist, update the workflow to use current workspace
                       parsed.workspaceId = workspaceId
                       localStorage.setItem(`workflow-${workflowId}`, JSON.stringify(parsed))
-                      logger.debug(
-                        `Updated workflow ${workflowId} to use current workspace ${workspaceId}`
-                      )
                     }
                   } catch (e) {
                     // Skip if we can't parse workspaces data
@@ -438,9 +433,6 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
           if (!workflowId) return
         }
 
-        // Log the action
-        logger.debug(`Setting workflow-specific needsRedeployment=${needsRedeployment} for workflow ${workflowId}`)
-
         // Update the registry's deployment status for this specific workflow
         set((state) => {
           const deploymentStatuses = state.deploymentStatuses || {};
@@ -460,13 +452,8 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
         // Only update the global flag if this is the active workflow
         const { activeWorkflowId } = get()
         if (workflowId === activeWorkflowId) {
-          logger.debug(`Updating global needsRedeployment flag to ${needsRedeployment} for active workflow ${workflowId}`)
           useWorkflowStore.getState().setNeedsRedeploymentFlag(needsRedeployment)
-        } else {
-          // Important: Do NOT update global state for non-active workflows
-          logger.debug(`Not updating global needsRedeployment flag for non-active workflow ${workflowId}`)
         }
-
         // Save to persistent storage
         const workflowState = loadWorkflowState(workflowId)
         if (workflowState) {
@@ -496,15 +483,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
 
         // Get current workflow ID
         const currentId = get().activeWorkflowId
-        
-        // Log the current state for debugging
-        logger.debug(`Switching from workflow ${currentId} to ${id}`)
-        if (currentId) {
-          const workflowStore = useWorkflowStore.getState()
-          logger.debug(`Current workflow ${currentId} has needsRedeployment=${workflowStore.needsRedeployment}`)
-        }
-
-        // Save current workflow state before switching
+                // Save current workflow state before switching
         if (currentId) {
           const currentState = useWorkflowStore.getState()
 
@@ -540,8 +519,6 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             deploymentStatuses,
             needsRedeployment 
           } = parsedState
-
-          logger.debug(`Loaded workflow ${id} with needsRedeployment=${needsRedeployment}, isDeployed=${isDeployed}`)
 
           // Get workflow-specific deployment status
           let workflowIsDeployed = isDeployed;

--- a/apps/sim/stores/workflows/registry/store.ts
+++ b/apps/sim/stores/workflows/registry/store.ts
@@ -511,8 +511,6 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             },
             lastSaved: parsedState.lastSaved || Date.now(),
           })
-<<<<<<< HEAD
-=======
 
           // Update the deployment statuses in the registry
           if (deploymentStatuses) {
@@ -537,7 +535,6 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
           }
 
           logger.info(`Switched to workflow ${id}`)
->>>>>>> 5b406ec6 (fix: moved the deployment status logic to registry store)
         } else {
           // If no saved state, initialize with empty state
           useWorkflowStore.setState({

--- a/apps/sim/stores/workflows/registry/types.ts
+++ b/apps/sim/stores/workflows/registry/types.ts
@@ -8,6 +8,7 @@ export interface DeploymentStatus {
   isDeployed: boolean
   deployedAt?: Date
   apiKey?: string
+  needsRedeployment?: boolean
 }
 
 export interface WorkflowMetadata {
@@ -49,6 +50,7 @@ export interface WorkflowRegistryActions {
   // Add deployment-related methods
   getWorkflowDeploymentStatus: (workflowId: string | null) => DeploymentStatus | null
   setDeploymentStatus: (workflowId: string | null, isDeployed: boolean, deployedAt?: Date, apiKey?: string) => void
+  setWorkflowNeedsRedeployment: (workflowId: string | null, needsRedeployment: boolean) => void
 }
 
 export type WorkflowRegistry = WorkflowRegistryState & WorkflowRegistryActions

--- a/apps/sim/stores/workflows/registry/types.ts
+++ b/apps/sim/stores/workflows/registry/types.ts
@@ -3,6 +3,13 @@ export interface MarketplaceData {
   status: 'owner' | 'temp'
 }
 
+// Add DeploymentStatus interface directly here to avoid import
+export interface DeploymentStatus {
+  isDeployed: boolean
+  deployedAt?: Date
+  apiKey?: string
+}
+
 export interface WorkflowMetadata {
   id: string
   name: string
@@ -19,6 +26,8 @@ export interface WorkflowRegistryState {
   activeWorkspaceId: string | null
   isLoading: boolean
   error: string | null
+  // Add deployment statuses map to registry state
+  deploymentStatuses: Record<string, DeploymentStatus>
 }
 
 export interface WorkflowRegistryActions {
@@ -37,6 +46,9 @@ export interface WorkflowRegistryActions {
     workspaceId?: string
   }) => string
   duplicateWorkflow: (sourceId: string) => string | null
+  // Add deployment-related methods
+  getWorkflowDeploymentStatus: (workflowId: string | null) => DeploymentStatus | null
+  setDeploymentStatus: (workflowId: string | null, isDeployed: boolean, deployedAt?: Date, apiKey?: string) => void
 }
 
 export type WorkflowRegistry = WorkflowRegistryState & WorkflowRegistryActions

--- a/apps/sim/stores/workflows/registry/types.ts
+++ b/apps/sim/stores/workflows/registry/types.ts
@@ -3,7 +3,6 @@ export interface MarketplaceData {
   status: 'owner' | 'temp'
 }
 
-// Add DeploymentStatus interface directly here to avoid import
 export interface DeploymentStatus {
   isDeployed: boolean
   deployedAt?: Date
@@ -27,7 +26,6 @@ export interface WorkflowRegistryState {
   activeWorkspaceId: string | null
   isLoading: boolean
   error: string | null
-  // Add deployment statuses map to registry state
   deploymentStatuses: Record<string, DeploymentStatus>
 }
 
@@ -47,9 +45,13 @@ export interface WorkflowRegistryActions {
     workspaceId?: string
   }) => string
   duplicateWorkflow: (sourceId: string) => string | null
-  // Add deployment-related methods
   getWorkflowDeploymentStatus: (workflowId: string | null) => DeploymentStatus | null
-  setDeploymentStatus: (workflowId: string | null, isDeployed: boolean, deployedAt?: Date, apiKey?: string) => void
+  setDeploymentStatus: (
+    workflowId: string | null,
+    isDeployed: boolean,
+    deployedAt?: Date,
+    apiKey?: string
+  ) => void
   setWorkflowNeedsRedeployment: (workflowId: string | null, needsRedeployment: boolean) => void
 }
 

--- a/apps/sim/stores/workflows/workflow/store.ts
+++ b/apps/sim/stores/workflows/workflow/store.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import { getBlock } from '@/blocks'
 import { resolveOutputType } from '@/blocks/utils'
+import { createLogger } from '@/lib/logs/console-logger'
 import { pushHistory, withHistory, WorkflowStoreWithHistory } from '../middleware'
 import { saveWorkflowState } from '../persistence'
 import { useWorkflowRegistry } from '../registry/store'
@@ -11,6 +12,8 @@ import { markWorkflowsDirty, workflowSync } from '../sync'
 import { mergeSubblockState } from '../utils'
 import { Loop, Position, SubBlockState, SyncControl, WorkflowState } from './types'
 import { detectCycle } from './utils'
+
+const logger = createLogger('WorkflowStore')
 
 const initialState = {
   blocks: {},
@@ -81,6 +84,7 @@ export const useWorkflowStore = create<WorkflowStoreWithHistory>()(
       sync: createSyncControl(),
 
       setNeedsRedeploymentFlag: (needsRedeployment: boolean) => {
+        logger.debug(`Setting global needsRedeployment flag to ${needsRedeployment} (active workflow: ${useWorkflowRegistry.getState().activeWorkflowId})`)
         set({ needsRedeployment })
       },
 

--- a/apps/sim/stores/workflows/workflow/store.ts
+++ b/apps/sim/stores/workflows/workflow/store.ts
@@ -84,7 +84,6 @@ export const useWorkflowStore = create<WorkflowStoreWithHistory>()(
       sync: createSyncControl(),
 
       setNeedsRedeploymentFlag: (needsRedeployment: boolean) => {
-        logger.debug(`Setting global needsRedeployment flag to ${needsRedeployment} (active workflow: ${useWorkflowRegistry.getState().activeWorkflowId})`)
         set({ needsRedeployment })
       },
 

--- a/apps/sim/stores/workflows/workflow/types.ts
+++ b/apps/sim/stores/workflows/workflow/types.ts
@@ -34,14 +34,24 @@ export interface Loop {
   forEachItems?: any[] | Record<string, any> | string // Items or expression
 }
 
+// New interface for deployment status
+export interface DeploymentStatus {
+  isDeployed: boolean
+  deployedAt?: Date
+  apiKey?: string
+}
+
 export interface WorkflowState {
   blocks: Record<string, BlockState>
   edges: Edge[]
   lastSaved?: number
   loops: Record<string, Loop>
   lastUpdate?: number
+  // Legacy deployment fields (keeping for compatibility)
   isDeployed?: boolean
   deployedAt?: Date
+  // New field for per-workflow deployment status
+  deploymentStatuses?: Record<string, DeploymentStatus>
   needsRedeployment?: boolean
   hasActiveSchedule?: boolean
   hasActiveWebhook?: boolean
@@ -76,7 +86,8 @@ export interface WorkflowActions {
   updateLoopType: (loopId: string, loopType: Loop['loopType']) => void
   updateLoopForEachItems: (loopId: string, items: string) => void
   setNeedsRedeploymentFlag: (needsRedeployment: boolean) => void
-  setDeploymentStatus: (isDeployed: boolean, deployedAt?: Date) => void
+  setDeploymentStatus: (workflowId: string | null, isDeployed: boolean, deployedAt?: Date, apiKey?: string) => void
+  getWorkflowDeploymentStatus: (workflowId: string | null) => DeploymentStatus | null
   setScheduleStatus: (hasActiveSchedule: boolean) => void
   setWebhookStatus: (hasActiveWebhook: boolean) => void
   toggleBlockAdvancedMode: (id: string) => void

--- a/apps/sim/stores/workflows/workflow/types.ts
+++ b/apps/sim/stores/workflows/workflow/types.ts
@@ -34,7 +34,6 @@ export interface Loop {
   forEachItems?: any[] | Record<string, any> | string // Items or expression
 }
 
-// New interface for deployment status
 export interface DeploymentStatus {
   isDeployed: boolean
   deployedAt?: Date

--- a/apps/sim/stores/workflows/workflow/types.ts
+++ b/apps/sim/stores/workflows/workflow/types.ts
@@ -86,8 +86,6 @@ export interface WorkflowActions {
   updateLoopType: (loopId: string, loopType: Loop['loopType']) => void
   updateLoopForEachItems: (loopId: string, items: string) => void
   setNeedsRedeploymentFlag: (needsRedeployment: boolean) => void
-  setDeploymentStatus: (workflowId: string | null, isDeployed: boolean, deployedAt?: Date, apiKey?: string) => void
-  getWorkflowDeploymentStatus: (workflowId: string | null) => DeploymentStatus | null
   setScheduleStatus: (hasActiveSchedule: boolean) => void
   setWebhookStatus: (hasActiveWebhook: boolean) => void
   toggleBlockAdvancedMode: (id: string) => void

--- a/apps/sim/stores/workflows/workflow/types.ts
+++ b/apps/sim/stores/workflows/workflow/types.ts
@@ -39,6 +39,7 @@ export interface DeploymentStatus {
   isDeployed: boolean
   deployedAt?: Date
   apiKey?: string
+  needsRedeployment?: boolean
 }
 
 export interface WorkflowState {


### PR DESCRIPTION
## Description

Workflows were rendering as deployed when creating new ones, and the deployed state across workflows was getting mixed up. Added rechecks on reverted changes, handling both true/false API responses, enabling subblock change detection, adding 5s polling to auto-clear state, and cleaning up code to resolve race conditions.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Deploying new workflows, modifying existing workflows, and navigating between different workflows to observe changes in deployment status. Made sure indicator accurately reflected the current state, correctly detected changes, and reliably cleared when workflows were reverted—all without requiring a page refresh.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
