### PR TITLE
fix(executions): fix async executions when envvars are not set

### DIFF
--- a/apps/sim/app/api/schedules/execute/route.ts
+++ b/apps/sim/app/api/schedules/execute/route.ts
@@ -155,6 +155,7 @@ export async function GET(req: NextRequest) {
 
         const mergedStates = mergeSubblockState(blocks)
 
+        // Retrieve environment variables for this user (if any).
         const [userEnv] = await db
           .select()
           .from(environment)
@@ -162,13 +163,12 @@ export async function GET(req: NextRequest) {
           .limit(1)
 
         if (!userEnv) {
-          logger.error(
-            `[${requestId}] No environment variables found for user ${workflowRecord.userId}`
+          logger.debug(
+            `[${requestId}] No environment record found for user ${workflowRecord.userId}. Proceeding with empty variables.`
           )
-          throw new Error('No environment variables found for this user')
         }
 
-        const variables = EnvVarsSchema.parse(userEnv.variables)
+        const variables = EnvVarsSchema.parse(userEnv?.variables ?? {})
 
         const currentBlockStates = await Object.entries(mergedStates).reduce(
           async (accPromise, [id, block]) => {

--- a/apps/sim/app/api/workflows/[id]/execute/route.ts
+++ b/apps/sim/app/api/workflows/[id]/execute/route.ts
@@ -102,7 +102,7 @@ async function executeWorkflow(workflow: any, requestId: string, input?: any) {
     // Use the same execution flow as in scheduled executions
     const mergedStates = mergeSubblockState(blocks)
 
-    // Retrieve environment variables for this user
+    // Fetch the user's environment variables (if any)
     const [userEnv] = await db
       .select()
       .from(environment)
@@ -110,12 +110,13 @@ async function executeWorkflow(workflow: any, requestId: string, input?: any) {
       .limit(1)
 
     if (!userEnv) {
-      logger.error(`[${requestId}] No environment variables found for user: ${workflow.userId}`)
-      throw new Error('No environment variables found for this user')
+      logger.debug(
+        `[${requestId}] No environment record found for user ${workflow.userId}. Proceeding with empty variables.`
+      )
     }
 
-    // Parse and validate environment variables
-    const variables = EnvVarsSchema.parse(userEnv.variables)
+    // Parse and validate environment variables.
+    const variables = EnvVarsSchema.parse(userEnv?.variables ?? {})
 
     // Replace environment variables in the block states
     const currentBlockStates = await Object.entries(mergedStates).reduce(


### PR DESCRIPTION
## Description

Fix async executions when envvars are not set. We were previously mandating that the user have envvars set, but sometimes a user will have a workflow that does not rely on envvars and we should allow them to execute asynchronously.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually to ensure that we could execute just fine without any envvars set.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes