### PR TITLE
fix(logs): improve timeline resizing behavior in trace spans

### DIFF
--- a/apps/sim/app/w/logs/components/trace-spans/trace-spans-display.tsx
+++ b/apps/sim/app/w/logs/components/trace-spans/trace-spans-display.tsx
@@ -408,9 +408,9 @@ function TraceSpanItem({
             <span className='block text-muted-foreground text-xs'>{formatDuration(duration)}</span>
           </div>
 
-          <div className='ml-auto flex flex-shrink-0 items-center gap-2'>
+          <div className='ml-auto flex flex-shrink-0 items-center gap-2 w-[40%]'>
             {/* Timeline visualization - responsive width based on container size */}
-            <div className='relative hidden h-2 flex-shrink-0 overflow-hidden rounded-full bg-accent/40 sm:block sm:w-24 md:w-32 lg:w-40 xl:w-56'>
+            <div className='relative hidden h-2 flex-shrink-0 overflow-hidden rounded-full bg-accent/40 sm:block flex-1 min-w-[15%]'>
               <div
                 className='absolute h-full rounded-full'
                 style={{


### PR DESCRIPTION
## Description

Fixed styling issues in the logs panel where the timeline visualisation would slide off the page during panel resizing/closing operations.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested by opening/closing logs panel, browser window resizing, and confirmed timeline stays visible and properly sized.

Before:

https://github.com/user-attachments/assets/8b8eec7e-7550-4160-9754-e034e415e0bd

After:

https://github.com/user-attachments/assets/570cd8d9-98e4-43b2-9bd3-a6383fe8505a



## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All tests pass locally and in CI (`bun run test`)
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have updated version numbers as needed (if needed)
- [X] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [X] My changes do not introduce any new security vulnerabilities
- [X] I have considered the security implications of my changes

## Additional Information:

Any additional information, configuration or data that might be necessary to reproduce the issue or use the feature.
