### PR TITLE
fix(persistence): persist collapsed state for responseFormat code subblock

### DIFF
--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/code.tsx
@@ -72,7 +72,7 @@ export function Code({
 
   const collapsedStateKey = `${subBlockId}_collapsed`
   const isCollapsed =
-    useSubBlockStore((state) => state.getValue(blockId, collapsedStateKey)) ?? false
+    (useSubBlockStore((state) => state.getValue(blockId, collapsedStateKey)) as boolean) ?? false
   const setCollapsedValue = useSubBlockStore((state) => state.setValue)
 
   const showCollapseButton = subBlockId === 'responseFormat' && code.split('\n').length > 5

--- a/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/sub-block/components/code.tsx
@@ -12,6 +12,7 @@ import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
 import { createLogger } from '@/lib/logs/console-logger'
 import { cn } from '@/lib/utils'
 import { useCodeGeneration } from '@/app/w/[id]/hooks/use-code-generation'
+import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { CodePromptBar } from '../../../../code-prompt-bar/code-prompt-bar'
 import { useSubBlockValue } from '../hooks/use-sub-block-value'
 
@@ -68,9 +69,20 @@ export function Code({
   const [cursorPosition, setCursorPosition] = useState(0)
   const [activeSourceBlockId, setActiveSourceBlockId] = useState<string | null>(null)
   const [visualLineHeights, setVisualLineHeights] = useState<number[]>([])
-  const [isCollapsed, setIsCollapsed] = useState(false)
+
+  const collapsedStateKey = `${subBlockId}_collapsed`
+  const isCollapsed =
+    useSubBlockStore((state) => state.getValue(blockId, collapsedStateKey)) ?? false
+  const setCollapsedValue = useSubBlockStore((state) => state.setValue)
+
+  const showCollapseButton = subBlockId === 'responseFormat' && code.split('\n').length > 5
 
   const editorRef = useRef<HTMLDivElement>(null)
+
+  // Function to toggle collapsed state
+  const toggleCollapsed = () => {
+    setCollapsedValue(blockId, collapsedStateKey, !isCollapsed)
+  }
 
   // AI Code Generation Hook
   const handleStreamStart = () => {
@@ -311,11 +323,11 @@ export function Code({
             </Button>
           )}
 
-          {code.split('\n').length > 5 && !isAiStreaming && (
+          {showCollapseButton && !isAiStreaming && (
             <Button
               variant='ghost'
               size='sm'
-              onClick={() => setIsCollapsed(!isCollapsed)}
+              onClick={toggleCollapsed}
               aria-label={isCollapsed ? 'Expand code' : 'Collapse code'}
               className='h-8 px-2 text-muted-foreground hover:text-foreground'
             >


### PR DESCRIPTION
## Description

Persist collapsed state for responseFormat code subblock. On a block-level, we persist the horizontal handles, wide, etc. For the sub-block level, we did not persist when we collapsed the sub-block, and therefore every time we refresh it would re-initialize as expanded, causing a bad UX.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually by collapsing the sub-block state and refreshing, ensuring it persisted in the state/store.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes