### PR TITLE
feat(email): add customizable "FROM" email for resend

### DIFF
--- a/apps/sim/app/api/help/route.ts
+++ b/apps/sim/app/api/help/route.ts
@@ -3,6 +3,7 @@ import { Resend } from 'resend'
 import { z } from 'zod'
 import { env } from '@/lib/env'
 import { createLogger } from '@/lib/logs/console-logger'
+import { getBaseDomain } from '@/lib/urls/utils'
 
 const resend = env.RESEND_API_KEY ? new Resend(env.RESEND_API_KEY) : null
 const logger = createLogger('HelpAPI')
@@ -98,8 +99,8 @@ ${message}
 
     // Send email using Resend
     const { data, error } = await resend.emails.send({
-      from: `Sim Studio <noreply@${env.EMAIL_DOMAIN}>`,
-      to: [`help@${env.EMAIL_DOMAIN}`],
+      from: `Sim Studio <noreply@${getBaseDomain()}>`,
+      to: [`help@${getBaseDomain()}`],
       subject: `[${type.toUpperCase()}] ${subject}`,
       replyTo: email,
       text: emailText,
@@ -121,7 +122,7 @@ ${message}
     // Send confirmation email to the user
     await resend.emails
       .send({
-        from: `Sim Studio <noreply@${env.EMAIL_DOMAIN}>`,
+        from: `Sim Studio <noreply@${getBaseDomain()}>`,
         to: [email],
         subject: `Your ${type} request has been received: ${subject}`,
         text: `
@@ -137,7 +138,7 @@ ${images.length > 0 ? `You attached ${images.length} image(s).` : ''}
 Best regards,
 The Sim Studio Team
       `,
-        replyTo: `help@${env.EMAIL_DOMAIN}`,
+        replyTo: `help@${getBaseDomain()}`,
       })
       .catch((err) => {
         logger.warn(`[${requestId}] Failed to send confirmation email`, err)

--- a/apps/sim/app/api/help/route.ts
+++ b/apps/sim/app/api/help/route.ts
@@ -98,8 +98,8 @@ ${message}
 
     // Send email using Resend
     const { data, error } = await resend.emails.send({
-      from: 'Sim Studio <noreply@simstudio.ai>',
-      to: ['help@simstudio.ai'],
+      from: `Sim Studio <noreply@${env.EMAIL_DOMAIN}>`,
+      to: [`help@${env.EMAIL_DOMAIN}`],
       subject: `[${type.toUpperCase()}] ${subject}`,
       replyTo: email,
       text: emailText,
@@ -121,7 +121,7 @@ ${message}
     // Send confirmation email to the user
     await resend.emails
       .send({
-        from: 'Sim Studio <noreply@simstudio.ai>',
+        from: `Sim Studio <noreply@${env.EMAIL_DOMAIN}>`,
         to: [email],
         subject: `Your ${type} request has been received: ${subject}`,
         text: `
@@ -137,7 +137,7 @@ ${images.length > 0 ? `You attached ${images.length} image(s).` : ''}
 Best regards,
 The Sim Studio Team
       `,
-        replyTo: 'help@simstudio.ai',
+        replyTo: `help@${env.EMAIL_DOMAIN}`,
       })
       .catch((err) => {
         logger.warn(`[${requestId}] Failed to send confirmation email`, err)

--- a/apps/sim/app/api/workspaces/invitations/route.ts
+++ b/apps/sim/app/api/workspaces/invitations/route.ts
@@ -228,7 +228,7 @@ async function sendInvitationEmail({
     }
 
     await resend.emails.send({
-      from: 'noreply@simstudio.ai',
+      from: `noreply@${env.EMAIL_DOMAIN}`,
       to,
       subject: `You've been invited to join "${workspaceName}" on Sim Studio`,
       html: emailHtml,

--- a/apps/sim/app/api/workspaces/invitations/route.ts
+++ b/apps/sim/app/api/workspaces/invitations/route.ts
@@ -7,6 +7,7 @@ import { WorkspaceInvitationEmail } from '@/components/emails/workspace-invitati
 import { getSession } from '@/lib/auth'
 import { env } from '@/lib/env'
 import { createLogger } from '@/lib/logs/console-logger'
+import { getBaseDomain } from '@/lib/urls/utils'
 import { db } from '@/db'
 import { user, workspace, workspaceInvitation, workspaceMember } from '@/db/schema'
 
@@ -228,7 +229,7 @@ async function sendInvitationEmail({
     }
 
     await resend.emails.send({
-      from: `noreply@${env.EMAIL_DOMAIN}`,
+      from: `noreply@${getBaseDomain()}`,
       to,
       subject: `You've been invited to join "${workspaceName}" on Sim Studio`,
       html: emailHtml,

--- a/apps/sim/lib/auth.ts
+++ b/apps/sim/lib/auth.ts
@@ -17,6 +17,7 @@ import { createLogger } from '@/lib/logs/console-logger'
 import { db } from '@/db'
 import * as schema from '@/db/schema'
 import { env } from './env'
+import { getBaseDomain } from './urls/utils'
 
 const logger = createLogger('Auth')
 
@@ -145,7 +146,7 @@ export const auth = betterAuth({
       const html = await renderPasswordResetEmail(username, url)
 
       const result = await resend.emails.send({
-        from: `Sim Studio <team@${env.EMAIL_DOMAIN}>`,
+        from: `Sim Studio <team@${getBaseDomain()}>`,
         to: user.email,
         subject: getEmailSubject('reset-password'),
         html,
@@ -187,7 +188,7 @@ export const auth = betterAuth({
 
           // In production, send an actual email
           const result = await resend.emails.send({
-            from: `Sim Studio <onboarding@${env.EMAIL_DOMAIN}>`,
+            from: `Sim Studio <onboarding@${getBaseDomain()}>`,
             to: data.email,
             subject: getEmailSubject(data.type),
             html,
@@ -1077,7 +1078,7 @@ export const auth = betterAuth({
                 )
 
                 await resend.emails.send({
-                  from: `Sim Studio <team@${env.EMAIL_DOMAIN}>`,
+                  from: `Sim Studio <team@${getBaseDomain()}>`,
                   to: invitation.email,
                   subject: `${inviterName} has invited you to join ${organization.name} on Sim Studio`,
                   html,

--- a/apps/sim/lib/auth.ts
+++ b/apps/sim/lib/auth.ts
@@ -145,7 +145,7 @@ export const auth = betterAuth({
       const html = await renderPasswordResetEmail(username, url)
 
       const result = await resend.emails.send({
-        from: 'Sim Studio <team@simstudio.ai>',
+        from: `Sim Studio <team@${env.EMAIL_DOMAIN}>`,
         to: user.email,
         subject: getEmailSubject('reset-password'),
         html,
@@ -187,7 +187,7 @@ export const auth = betterAuth({
 
           // In production, send an actual email
           const result = await resend.emails.send({
-            from: 'Sim Studio <onboarding@simstudio.ai>',
+            from: `Sim Studio <onboarding@${env.EMAIL_DOMAIN}>`,
             to: data.email,
             subject: getEmailSubject(data.type),
             html,
@@ -1077,7 +1077,7 @@ export const auth = betterAuth({
                 )
 
                 await resend.emails.send({
-                  from: 'Sim Studio <team@simstudio.ai>',
+                  from: `Sim Studio <team@${env.EMAIL_DOMAIN}>`,
                   to: invitation.email,
                   subject: `${inviterName} has invited you to join ${organization.name} on Sim Studio`,
                   html,

--- a/apps/sim/lib/env.ts
+++ b/apps/sim/lib/env.ts
@@ -37,7 +37,6 @@ export const env = createEnv({
       .regex(/^\d+(\.\d+)?$/)
       .optional(),
     RESEND_API_KEY: z.string().min(1).optional(),
-    EMAIL_DOMAIN: z.string().min(1).optional(),
     OPENAI_API_KEY: z.string().min(1).optional(),
     OPENAI_API_KEY_1: z.string().min(1).optional(),
     OPENAI_API_KEY_2: z.string().min(1).optional(),

--- a/apps/sim/lib/env.ts
+++ b/apps/sim/lib/env.ts
@@ -37,6 +37,7 @@ export const env = createEnv({
       .regex(/^\d+(\.\d+)?$/)
       .optional(),
     RESEND_API_KEY: z.string().min(1).optional(),
+    EMAIL_DOMAIN: z.string().min(1).optional(),
     OPENAI_API_KEY: z.string().min(1).optional(),
     OPENAI_API_KEY_1: z.string().min(1).optional(),
     OPENAI_API_KEY_2: z.string().min(1).optional(),

--- a/apps/sim/lib/mailer.ts
+++ b/apps/sim/lib/mailer.ts
@@ -41,7 +41,7 @@ export async function sendEmail({
   from,
 }: EmailOptions): Promise<SendEmailResult> {
   try {
-    const senderEmail = from || 'noreply@simstudio.ai'
+    const senderEmail = from || `noreply@${env.EMAIL_DOMAIN}`
 
     if (!resend) {
       logger.info('Email not sent (Resend not configured):', {
@@ -89,7 +89,7 @@ export async function sendBatchEmails({
   emails,
 }: BatchEmailOptions): Promise<BatchSendEmailResult> {
   try {
-    const senderEmail = 'noreply@simstudio.ai'
+    const senderEmail = `noreply@${env.EMAIL_DOMAIN}`
     const results: SendEmailResult[] = []
 
     if (!resend) {

--- a/apps/sim/lib/mailer.ts
+++ b/apps/sim/lib/mailer.ts
@@ -1,6 +1,7 @@
 import { Resend } from 'resend'
 import { createLogger } from '@/lib/logs/console-logger'
 import { env } from './env'
+import { getBaseDomain } from './urls/utils'
 
 interface EmailOptions {
   to: string
@@ -41,7 +42,7 @@ export async function sendEmail({
   from,
 }: EmailOptions): Promise<SendEmailResult> {
   try {
-    const senderEmail = from || `noreply@${env.EMAIL_DOMAIN}`
+    const senderEmail = from || `noreply@${getBaseDomain()}`
 
     if (!resend) {
       logger.info('Email not sent (Resend not configured):', {
@@ -89,7 +90,7 @@ export async function sendBatchEmails({
   emails,
 }: BatchEmailOptions): Promise<BatchSendEmailResult> {
   try {
-    const senderEmail = `noreply@${env.EMAIL_DOMAIN}`
+    const senderEmail = `noreply@${getBaseDomain()}`
     const results: SendEmailResult[] = []
 
     if (!resend) {


### PR DESCRIPTION
## Description

Add customizable `FROM` email with next public app url so users can use their own verified domains to send emails

Fixes #446 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested and confirmed that we can still send emails manually. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes