### PR TITLE
feat: text and markdown parsers

### DIFF
--- a/apps/sim/lib/file-parsers/index.ts
+++ b/apps/sim/lib/file-parsers/index.ts
@@ -75,6 +75,20 @@ function getParserInstances(): Record<string, FileParser> {
       } catch (error) {
         logger.error('Failed to load DOCX parser:', error)
       }
+
+      try {
+        const { TxtParser } = require('./txt-parser')
+        parserInstances.txt = new TxtParser()
+      } catch (error) {
+        logger.error('Failed to load TXT parser:', error)
+      }
+
+      try {
+        const { MdParser } = require('./md-parser')
+        parserInstances.md = new MdParser()
+      } catch (error) {
+        logger.error('Failed to load MD parser:', error)
+      }
     } catch (error) {
       logger.error('Error loading file parsers:', error)
     }

--- a/apps/sim/lib/file-parsers/md-parser.ts
+++ b/apps/sim/lib/file-parsers/md-parser.ts
@@ -28,7 +28,7 @@ export class MdParser implements FileParser {
       logger.info('Parsing buffer, size:', buffer.length)
 
       // Extract content
-      const result = await readFile(buffer, 'utf-8')
+      const result = buffer.toString('utf-8')
 
       return {
         content: result,

--- a/apps/sim/lib/file-parsers/md-parser.ts
+++ b/apps/sim/lib/file-parsers/md-parser.ts
@@ -1,0 +1,45 @@
+import { readFile } from 'fs/promises'
+import { createLogger } from '@/lib/logs/console-logger'
+import type { FileParseResult, FileParser } from './types'
+
+const logger = createLogger('MdParser')
+
+export class MdParser implements FileParser {
+  async parseFile(filePath: string): Promise<FileParseResult> {
+    try {
+      // Validate input
+      if (!filePath) {
+        throw new Error('No file path provided')
+      }
+
+      // Read the file
+      const buffer = await readFile(filePath)
+
+      // Use parseBuffer for consistent implementation
+      return this.parseBuffer(buffer)
+    } catch (error) {
+      logger.error('MD file error:', error)
+      throw new Error(`Failed to parse MD file: ${(error as Error).message}`)
+    }
+  }
+
+  async parseBuffer(buffer: Buffer): Promise<FileParseResult> {
+    try {
+      logger.info('Parsing buffer, size:', buffer.length)
+
+      // Extract content
+      const result = await readFile(buffer, 'utf-8')
+
+      return {
+        content: result,
+        metadata: {
+          characterCount: result.length,
+          tokenCount: result.length / 4,
+        },
+      }
+    } catch (error) {
+      logger.error('MD buffer parsing error:', error)
+      throw new Error(`Failed to parse MD buffer: ${(error as Error).message}`)
+    }
+  }
+}

--- a/apps/sim/lib/file-parsers/txt-parser.ts
+++ b/apps/sim/lib/file-parsers/txt-parser.ts
@@ -28,7 +28,7 @@ export class TxtParser implements FileParser {
       logger.info('Parsing buffer, size:', buffer.length)
 
       // Extract content
-      const result = await readFile(buffer, 'utf-8')
+      const result = buffer.toString('utf-8')
 
       return {
         content: result,

--- a/apps/sim/lib/file-parsers/txt-parser.ts
+++ b/apps/sim/lib/file-parsers/txt-parser.ts
@@ -1,0 +1,45 @@
+import { readFile } from 'fs/promises'
+import { createLogger } from '@/lib/logs/console-logger'
+import type { FileParseResult, FileParser } from './types'
+
+const logger = createLogger('TxtParser')
+
+export class TxtParser implements FileParser {
+  async parseFile(filePath: string): Promise<FileParseResult> {
+    try {
+      // Validate input
+      if (!filePath) {
+        throw new Error('No file path provided')
+      }
+
+      // Read the file
+      const buffer = await readFile(filePath)
+
+      // Use parseBuffer for consistent implementation
+      return this.parseBuffer(buffer)
+    } catch (error) {
+      logger.error('TXT file error:', error)
+      throw new Error(`Failed to parse TXT file: ${(error as Error).message}`)
+    }
+  }
+
+  async parseBuffer(buffer: Buffer): Promise<FileParseResult> {
+    try {
+      logger.info('Parsing buffer, size:', buffer.length)
+
+      // Extract content
+      const result = await readFile(buffer, 'utf-8')
+
+      return {
+        content: result,
+        metadata: {
+          characterCount: result.length,
+          tokenCount: result.length / 4,
+        },
+      }
+    } catch (error) {
+      logger.error('TXT buffer parsing error:', error)
+      throw new Error(`Failed to parse TXT buffer: ${(error as Error).message}`)
+    }
+  }
+}


### PR DESCRIPTION
## Description

Fixes missing text and markdown parsers since those file extensions are available for uploads but not processing.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally but got stuck at chonkie api

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally and in CI (`bun run test`)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated version numbers as needed (if needed)
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [ ] My changes do not introduce any new security vulnerabilities
- [ ] I have considered the security implications of my changes

## Additional Information:

Any additional information, configuration or data that might be necessary to reproduce the issue or use the feature.
