### PR TITLE
fix(folders): modified folder deletion to delete subfolders & workflows in it instead of moving to root

### DIFF
--- a/apps/sim/app/api/folders/[id]/route.test.ts
+++ b/apps/sim/app/api/folders/[id]/route.test.ts
@@ -5,6 +5,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  type CapturedFolderValues,
   createMockRequest,
   type MockUser,
   mockAuth,
@@ -12,8 +13,14 @@ import {
   setupCommonApiMocks,
 } from '@/app/api/__test-utils__/utils'
 
+interface FolderDbMockOptions {
+  folderLookupResult?: any
+  updateResult?: any[]
+  throwError?: boolean
+  circularCheckResults?: any[]
+}
+
 describe('Individual Folder API Route', () => {
-  // Test data constants
   const TEST_USER: MockUser = {
     id: 'user-123',
     email: 'test@example.com',
@@ -34,14 +41,7 @@ describe('Individual Folder API Route', () => {
 
   const { mockAuthenticatedUser, mockUnauthenticated } = mockAuth(TEST_USER)
 
-  function createFolderDbMock(
-    options: {
-      folderLookupResult?: any
-      updateResult?: any[]
-      throwError?: boolean
-      circularCheckResults?: any[]
-    } = {}
-  ) {
+  function createFolderDbMock(options: FolderDbMockOptions = {}) {
     const {
       folderLookupResult = mockFolder,
       updateResult = [{ ...mockFolder, name: 'Updated Folder' }],
@@ -206,7 +206,7 @@ describe('Individual Folder API Route', () => {
     it('should trim folder name when updating', async () => {
       mockAuthenticatedUser()
 
-      let capturedUpdates: any = null
+      let capturedUpdates: CapturedFolderValues | null = null
       const dbMock = createFolderDbMock({
         updateResult: [{ ...mockFolder, name: 'Folder With Spaces' }],
       })
@@ -231,7 +231,8 @@ describe('Individual Folder API Route', () => {
 
       await PUT(req, { params })
 
-      expect(capturedUpdates.name).toBe('Folder With Spaces')
+      expect(capturedUpdates).not.toBeNull()
+      expect(capturedUpdates!.name).toBe('Folder With Spaces')
     })
 
     it('should handle database errors gracefully', async () => {

--- a/apps/sim/app/api/folders/route.test.ts
+++ b/apps/sim/app/api/folders/route.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Tests for folders API route
+ *
+ * @vitest-environment node
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createMockRequest,
+  mockAuth,
+  mockLogger,
+  setupCommonApiMocks,
+} from '@/app/api/__test-utils__/utils'
+
+describe('Folders API Route', () => {
+  const mockFolders = [
+    {
+      id: 'folder-1',
+      name: 'Test Folder 1',
+      userId: 'user-123',
+      workspaceId: 'workspace-123',
+      parentId: null,
+      color: '#6B7280',
+      isExpanded: true,
+      sortOrder: 0,
+      createdAt: new Date('2023-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2023-01-01T00:00:00.000Z'),
+    },
+    {
+      id: 'folder-2',
+      name: 'Test Folder 2',
+      userId: 'user-123',
+      workspaceId: 'workspace-123',
+      parentId: 'folder-1',
+      color: '#EF4444',
+      isExpanded: false,
+      sortOrder: 1,
+      createdAt: new Date('2023-01-02T00:00:00.000Z'),
+      updatedAt: new Date('2023-01-02T00:00:00.000Z'),
+    },
+  ]
+
+  const { mockAuthenticatedUser, mockUnauthenticated } = mockAuth()
+  const mockUUID = 'mock-uuid-12345678-90ab-cdef-1234-567890abcdef'
+
+  const mockSelect = vi.fn()
+  const mockFrom = vi.fn()
+  const mockWhere = vi.fn()
+  const mockOrderBy = vi.fn()
+  const mockInsert = vi.fn()
+  const mockValues = vi.fn()
+  const mockReturning = vi.fn()
+  const mockTransaction = vi.fn()
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    vi.stubGlobal('crypto', {
+      randomUUID: vi.fn().mockReturnValue(mockUUID),
+    })
+
+    setupCommonApiMocks()
+
+    mockSelect.mockReturnValue({ from: mockFrom })
+    mockFrom.mockReturnValue({ where: mockWhere })
+    mockWhere.mockReturnValue({ orderBy: mockOrderBy })
+    mockOrderBy.mockReturnValue(mockFolders)
+
+    mockInsert.mockReturnValue({ values: mockValues })
+    mockValues.mockReturnValue({ returning: mockReturning })
+    mockReturning.mockReturnValue([mockFolders[0]])
+
+    vi.doMock('@/db', () => ({
+      db: {
+        select: mockSelect,
+        insert: mockInsert,
+        transaction: mockTransaction,
+      },
+    }))
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('GET /api/folders', () => {
+    it('should return folders for a valid workspace', async () => {
+      mockAuthenticatedUser()
+
+      const mockRequest = createMockRequest('GET')
+      Object.defineProperty(mockRequest, 'url', {
+        value: 'http://localhost:3000/api/folders?workspaceId=workspace-123',
+      })
+
+      const { GET } = await import('./route')
+      const response = await GET(mockRequest)
+
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data).toHaveProperty('folders')
+      expect(data.folders).toHaveLength(2)
+      expect(data.folders[0]).toMatchObject({
+        id: 'folder-1',
+        name: 'Test Folder 1',
+        workspaceId: 'workspace-123',
+      })
+    })
+
+    it('should return 401 for unauthenticated requests', async () => {
+      mockUnauthenticated()
+
+      const mockRequest = createMockRequest('GET')
+      Object.defineProperty(mockRequest, 'url', {
+        value: 'http://localhost:3000/api/folders?workspaceId=workspace-123',
+      })
+
+      const { GET } = await import('./route')
+      const response = await GET(mockRequest)
+
+      expect(response.status).toBe(401)
+
+      const data = await response.json()
+      expect(data).toHaveProperty('error', 'Unauthorized')
+    })
+
+    it('should return 400 when workspaceId is missing', async () => {
+      mockAuthenticatedUser()
+
+      const mockRequest = createMockRequest('GET')
+      Object.defineProperty(mockRequest, 'url', {
+        value: 'http://localhost:3000/api/folders',
+      })
+
+      const { GET } = await import('./route')
+      const response = await GET(mockRequest)
+
+      expect(response.status).toBe(400)
+
+      const data = await response.json()
+      expect(data).toHaveProperty('error', 'Workspace ID is required')
+    })
+
+    it('should handle database errors gracefully', async () => {
+      mockAuthenticatedUser()
+
+      mockSelect.mockImplementationOnce(() => {
+        throw new Error('Database connection failed')
+      })
+
+      const mockRequest = createMockRequest('GET')
+      Object.defineProperty(mockRequest, 'url', {
+        value: 'http://localhost:3000/api/folders?workspaceId=workspace-123',
+      })
+
+      const { GET } = await import('./route')
+      const response = await GET(mockRequest)
+
+      expect(response.status).toBe(500)
+
+      const data = await response.json()
+      expect(data).toHaveProperty('error', 'Internal server error')
+      expect(mockLogger.error).toHaveBeenCalledWith('Error fetching folders:', {
+        error: expect.any(Error),
+      })
+    })
+  })
+
+  describe('POST /api/folders', () => {
+    it('should create a new folder successfully', async () => {
+      mockAuthenticatedUser()
+
+      mockTransaction.mockImplementationOnce(async (callback: any) => {
+        const tx = {
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue([]), // No existing folders
+                }),
+              }),
+            }),
+          }),
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockReturnValue({
+              returning: vi.fn().mockReturnValue([mockFolders[0]]),
+            }),
+          }),
+        }
+        return await callback(tx)
+      })
+
+      const req = createMockRequest('POST', {
+        name: 'New Test Folder',
+        workspaceId: 'workspace-123',
+        color: '#6B7280',
+      })
+
+      const { POST } = await import('./route')
+      const response = await POST(req)
+
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data).toHaveProperty('folder')
+      expect(data.folder).toMatchObject({
+        id: 'folder-1',
+        name: 'Test Folder 1',
+        workspaceId: 'workspace-123',
+      })
+    })
+
+    it('should create folder with correct sort order', async () => {
+      mockAuthenticatedUser()
+
+      mockTransaction.mockImplementationOnce(async (callback: any) => {
+        const tx = {
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue([{ sortOrder: 5 }]), // Existing folder with sort order 5
+                }),
+              }),
+            }),
+          }),
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockReturnValue({
+              returning: vi.fn().mockReturnValue([{ ...mockFolders[0], sortOrder: 6 }]),
+            }),
+          }),
+        }
+        return await callback(tx)
+      })
+
+      const req = createMockRequest('POST', {
+        name: 'New Test Folder',
+        workspaceId: 'workspace-123',
+      })
+
+      const { POST } = await import('./route')
+      const response = await POST(req)
+
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.folder).toMatchObject({
+        sortOrder: 6,
+      })
+    })
+
+    it('should create subfolder with parent reference', async () => {
+      mockAuthenticatedUser()
+
+      mockTransaction.mockImplementationOnce(async (callback: any) => {
+        const tx = {
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue([]),
+                }),
+              }),
+            }),
+          }),
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockReturnValue({
+              returning: vi.fn().mockReturnValue([{ ...mockFolders[1] }]),
+            }),
+          }),
+        }
+        return await callback(tx)
+      })
+
+      const req = createMockRequest('POST', {
+        name: 'Subfolder',
+        workspaceId: 'workspace-123',
+        parentId: 'folder-1',
+      })
+
+      const { POST } = await import('./route')
+      const response = await POST(req)
+
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.folder).toMatchObject({
+        parentId: 'folder-1',
+      })
+    })
+
+    it('should return 401 for unauthenticated requests', async () => {
+      mockUnauthenticated()
+
+      const req = createMockRequest('POST', {
+        name: 'Test Folder',
+        workspaceId: 'workspace-123',
+      })
+
+      const { POST } = await import('./route')
+      const response = await POST(req)
+
+      expect(response.status).toBe(401)
+
+      const data = await response.json()
+      expect(data).toHaveProperty('error', 'Unauthorized')
+    })
+
+    it('should return 400 when required fields are missing', async () => {
+      const testCases = [
+        { name: '', workspaceId: 'workspace-123' }, // Missing name
+        { name: 'Test Folder', workspaceId: '' }, // Missing workspaceId
+        { workspaceId: 'workspace-123' }, // Missing name entirely
+        { name: 'Test Folder' }, // Missing workspaceId entirely
+      ]
+
+      for (const body of testCases) {
+        mockAuthenticatedUser()
+
+        const req = createMockRequest('POST', body)
+
+        const { POST } = await import('./route')
+        const response = await POST(req)
+
+        expect(response.status).toBe(400)
+
+        const data = await response.json()
+        expect(data).toHaveProperty('error', 'Name and workspace ID are required')
+      }
+    })
+
+    it('should handle database errors gracefully', async () => {
+      mockAuthenticatedUser()
+
+      // Make transaction throw an error
+      mockTransaction.mockImplementationOnce(() => {
+        throw new Error('Database transaction failed')
+      })
+
+      const req = createMockRequest('POST', {
+        name: 'Test Folder',
+        workspaceId: 'workspace-123',
+      })
+
+      const { POST } = await import('./route')
+      const response = await POST(req)
+
+      expect(response.status).toBe(500)
+
+      const data = await response.json()
+      expect(data).toHaveProperty('error', 'Internal server error')
+      expect(mockLogger.error).toHaveBeenCalledWith('Error creating folder:', {
+        error: expect.any(Error),
+      })
+    })
+
+    it('should trim folder name when creating', async () => {
+      mockAuthenticatedUser()
+
+      let capturedValues: any = null
+
+      mockTransaction.mockImplementationOnce(async (callback: any) => {
+        const tx = {
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue([]),
+                }),
+              }),
+            }),
+          }),
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockImplementation((values) => {
+              capturedValues = values
+              return {
+                returning: vi.fn().mockReturnValue([mockFolders[0]]),
+              }
+            }),
+          }),
+        }
+        return await callback(tx)
+      })
+
+      const req = createMockRequest('POST', {
+        name: '  Test Folder With Spaces  ',
+        workspaceId: 'workspace-123',
+      })
+
+      const { POST } = await import('./route')
+      await POST(req)
+
+      expect(capturedValues.name).toBe('Test Folder With Spaces')
+    })
+
+    it('should use default color when not provided', async () => {
+      mockAuthenticatedUser()
+
+      let capturedValues: any = null
+
+      mockTransaction.mockImplementationOnce(async (callback: any) => {
+        const tx = {
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue([]),
+                }),
+              }),
+            }),
+          }),
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockImplementation((values) => {
+              capturedValues = values
+              return {
+                returning: vi.fn().mockReturnValue([mockFolders[0]]),
+              }
+            }),
+          }),
+        }
+        return await callback(tx)
+      })
+
+      const req = createMockRequest('POST', {
+        name: 'Test Folder',
+        workspaceId: 'workspace-123',
+      })
+
+      const { POST } = await import('./route')
+      await POST(req)
+
+      expect(capturedValues.color).toBe('#6B7280')
+    })
+  })
+})

--- a/apps/sim/app/w/components/sidebar/components/folder-tree/components/folder-item.tsx
+++ b/apps/sim/app/w/components/sidebar/components/folder-tree/components/folder-item.tsx
@@ -133,7 +133,8 @@ export function FolderItem({
             <AlertDialogHeader>
               <AlertDialogTitle>Are you sure you want to delete "{folder.name}"?</AlertDialogTitle>
               <AlertDialogDescription>
-                Child folders and workflows will be moved to the parent folder.
+                This will permanently delete the folder and all its contents, including subfolders
+                and workflows. This action cannot be undone.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
@@ -143,7 +144,7 @@ export function FolderItem({
                 disabled={isDeleting}
                 className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
               >
-                {isDeleting ? 'Deleting...' : 'Delete'}
+                {isDeleting ? 'Deleting...' : 'Delete Forever'}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
@@ -197,7 +198,8 @@ export function FolderItem({
           <AlertDialogHeader>
             <AlertDialogTitle>Are you sure you want to delete "{folder.name}"?</AlertDialogTitle>
             <AlertDialogDescription>
-              Child folders and workflows will be moved to the parent folder.
+              This will permanently delete the folder and all its contents, including subfolders and
+              workflows. This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -207,7 +209,7 @@ export function FolderItem({
               disabled={isDeleting}
               className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
             >
-              {isDeleting ? 'Deleting...' : 'Delete'}
+              {isDeleting ? 'Deleting...' : 'Delete Forever'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/sim/lib/variables/variable-manager.ts
+++ b/apps/sim/lib/variables/variable-manager.ts
@@ -6,7 +6,6 @@ import type { VariableType } from '@/stores/panel/variables/types'
  * to minimize type conversion issues and ensure predictable behavior.
  */
 
-// biome-ignore lint: false positive
 export class VariableManager {
   /**
    * Core method to convert any value to its appropriate native JavaScript type

--- a/apps/sim/stores/folders/store.ts
+++ b/apps/sim/stores/folders/store.ts
@@ -5,6 +5,16 @@ import { useWorkflowRegistry } from '../workflows/registry/store'
 
 const logger = createLogger('FoldersStore')
 
+export interface Workflow {
+  id: string
+  folderId?: string | null
+  name?: string
+  description?: string
+  userId?: string
+  workspaceId?: string
+  [key: string]: any // For additional properties
+}
+
 export interface WorkflowFolder {
   id: string
   name: string
@@ -64,7 +74,7 @@ interface FolderState {
   deleteFolder: (id: string) => Promise<void>
 
   // Helper functions
-  isWorkflowInDeletedSubfolder: (workflow: any, deletedFolderId: string) => boolean
+  isWorkflowInDeletedSubfolder: (workflow: Workflow, deletedFolderId: string) => boolean
   removeSubfoldersRecursively: (parentFolderId: string) => void
 }
 
@@ -318,11 +328,11 @@ export const useFolderStore = create<FolderState>()(
           try {
             const workflows = Object.values(workflowRegistry.workflows)
             const workflowsToDelete = workflows.filter(
-              (workflow: any) =>
+              (workflow) =>
                 workflow.folderId === id || get().isWorkflowInDeletedSubfolder(workflow, id)
             )
 
-            workflowsToDelete.forEach((workflow: any) => {
+            workflowsToDelete.forEach((workflow) => {
               workflowRegistry.removeWorkflow(workflow.id)
             })
 
@@ -342,11 +352,11 @@ export const useFolderStore = create<FolderState>()(
         }
       },
 
-      isWorkflowInDeletedSubfolder: (workflow: any, deletedFolderId: string) => {
+      isWorkflowInDeletedSubfolder: (workflow: Workflow, deletedFolderId: string) => {
         if (!workflow.folderId) return false
 
         const folders = get().folders
-        let currentFolderId = workflow.folderId
+        let currentFolderId: string | null = workflow.folderId
 
         while (currentFolderId && folders[currentFolderId]) {
           if (currentFolderId === deletedFolderId) {

--- a/apps/sim/stores/workflows/registry/store.ts
+++ b/apps/sim/stores/workflows/registry/store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import { createLogger } from '@/lib/logs/console-logger'
 import { clearWorkflowVariablesTracking } from '@/stores/panel/variables/store'
-import { API_ENDPOINTS, STORAGE_KEYS } from '../../constants'
+import { STORAGE_KEYS } from '../../constants'
 import {
   loadWorkflowState,
   removeFromStorage,
@@ -1083,19 +1083,6 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
           removeFromStorage(STORAGE_KEYS.WORKFLOW(id))
           removeFromStorage(STORAGE_KEYS.SUBBLOCK(id))
           saveRegistry(newWorkflows)
-
-          // Ensure any schedule for this workflow is cancelled
-          // The API will handle the deletion of the schedule
-          fetch(API_ENDPOINTS.SCHEDULE, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              workflowId: id,
-              state: { blocks: {} }, // Empty blocks will signal to cancel the schedule
-            }),
-          }).catch((error) => {
-            logger.error(`Error cancelling schedule for deleted workflow ${id}:`, { error })
-          })
 
           // Mark as dirty to ensure sync
           useWorkflowStore.getState().sync.markDirty()

--- a/biome.json
+++ b/biome.json
@@ -133,7 +133,8 @@
       },
       "complexity": {
         "noForEach": "off",
-        "noUselessFragments": "off"
+        "noUselessFragments": "off",
+        "noStaticOnlyClass": "off"
       },
       "performance": {
         "noAccumulatingSpread": "off",


### PR DESCRIPTION
## Description

modified folder deletion to delete subfolders & workflows in it instead of moving to root, more intuitive for user as long as delete message is clear

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested deleted a subfolder, all of its contents were deleted. Also tested deleting a folder with subfolders & workflows, also confirmed it deleted successfully.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes