### PR TITLE
fix(autocomplete): fixed extra closing tag on tag dropdown autocomplete

### DIFF
--- a/apps/sim/components/ui/tag-dropdown.tsx
+++ b/apps/sim/components/ui/tag-dropdown.tsx
@@ -475,7 +475,23 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
         }
       }
 
-      const newValue = `${textBeforeCursor.slice(0, lastOpenBracket)}<${processedTag}>${textAfterCursor}`
+      // Check if there's a closing bracket in textAfterCursor that belongs to the current tag
+      // Find the first '>' in textAfterCursor (if any)
+      const nextCloseBracket = textAfterCursor.indexOf('>')
+      let remainingTextAfterCursor = textAfterCursor
+
+      // If there's a '>' right after the cursor or with only whitespace/tag content in between,
+      // it's likely part of the existing tag being edited, so we should skip it
+      if (nextCloseBracket !== -1) {
+        const textBetween = textAfterCursor.slice(0, nextCloseBracket)
+        // If the text between cursor and '>' contains only tag-like characters (letters, dots, numbers)
+        // then it's likely part of the current tag being edited
+        if (/^[a-zA-Z0-9._]*$/.test(textBetween)) {
+          remainingTextAfterCursor = textAfterCursor.slice(nextCloseBracket + 1)
+        }
+      }
+
+      const newValue = `${textBeforeCursor.slice(0, lastOpenBracket)}<${processedTag}>${remainingTextAfterCursor}`
 
       onSelect(newValue)
       onClose?.()


### PR DESCRIPTION
## Description

Fixed extra closing tag on tag dropdown autocomplete

Fixes #509 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added unit tests to test regex logic, ensured that we are not adding an extra closing tag irregardless of the cursor position.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes