### PR TITLE
fix(gmail-webhook): gmail webhook synchronous processing fix

### DIFF
--- a/apps/sim/app/api/webhooks/trigger/[path]/route.ts
+++ b/apps/sim/app/api/webhooks/trigger/[path]/route.ts
@@ -305,49 +305,7 @@ export async function POST(
     }
   }
 
-  // For Gmail: Process with specific email handling
-  if (isGmailWebhook) {
-    try {
-      logger.info(`[${requestId}] Gmail webhook request received for webhook: ${foundWebhook.id}`)
-
-      const webhookSecret = foundWebhook.secret
-      if (webhookSecret) {
-        const secretHeader = request.headers.get('X-Webhook-Secret')
-        if (secretHeader !== webhookSecret) {
-          logger.warn(`[${requestId}] Invalid webhook secret`)
-          return new NextResponse('Unauthorized', { status: 401 })
-        }
-      }
-
-      if (body.email) {
-        logger.info(`[${requestId}] Processing Gmail email`, {
-          emailId: body.email.id,
-          subject:
-            body.email?.payload?.headers?.find((h: any) => h.name === 'Subject')?.value ||
-            'No subject',
-        })
-
-        const executionId = uuidv4()
-        logger.info(`[${requestId}] Executing workflow ${foundWorkflow.id} for Gmail email`)
-
-        return await processWebhook(
-          foundWebhook,
-          foundWorkflow,
-          body,
-          request,
-          executionId,
-          requestId
-        )
-      }
-      logger.warn(`[${requestId}] Invalid Gmail webhook payload format`)
-      return new NextResponse('Invalid payload format', { status: 400 })
-    } catch (error: any) {
-      logger.error(`[${requestId}] Error processing Gmail webhook`, error)
-      return new NextResponse(`Internal server error: ${error.message}`, { status: 500 })
-    }
-  }
-
-  // --- For all other webhook types: Use async processing with timeout ---
+  // --- For all webhook types (including Gmail): Use async processing with timeout ---
 
   // Create timeout promise for fast initial response (2.5 seconds)
   const timeoutDuration = 25000
@@ -361,7 +319,7 @@ export async function POST(
   // Create the processing promise for asynchronous execution
   const processingPromise = (async () => {
     try {
-      // Provider-specific deduplication
+      // Provider-specific validation and deduplication
       if (foundWebhook.provider === 'whatsapp') {
         const data = body?.entry?.[0]?.changes?.[0]?.value
         const messages = data?.messages || []
@@ -369,6 +327,36 @@ export async function POST(
         const whatsappDuplicateResponse = await processWhatsAppDeduplication(requestId, messages)
         if (whatsappDuplicateResponse) {
           return whatsappDuplicateResponse
+        }
+      } else if (foundWebhook.provider === 'gmail') {
+        // Gmail-specific validation and logging
+        logger.info(`[${requestId}] Gmail webhook request received for webhook: ${foundWebhook.id}`)
+
+        const webhookSecret = foundWebhook.secret
+        if (webhookSecret) {
+          const secretHeader = request.headers.get('X-Webhook-Secret')
+          if (secretHeader !== webhookSecret) {
+            logger.warn(`[${requestId}] Invalid webhook secret`)
+            return new NextResponse('Unauthorized', { status: 401 })
+          }
+        }
+
+        if (!body.email) {
+          logger.warn(`[${requestId}] Invalid Gmail webhook payload format`)
+          return new NextResponse('Invalid payload format', { status: 400 })
+        }
+
+        logger.info(`[${requestId}] Processing Gmail email`, {
+          emailId: body.email.id,
+          subject:
+            body.email?.payload?.headers?.find((h: any) => h.name === 'Subject')?.value ||
+            'No subject',
+        })
+
+        // Gmail deduplication using generic method
+        const genericDuplicateResponse = await processGenericDeduplication(requestId, path, body)
+        if (genericDuplicateResponse) {
+          return genericDuplicateResponse
         }
       } else if (foundWebhook.provider !== 'slack') {
         const genericDuplicateResponse = await processGenericDeduplication(requestId, path, body)


### PR DESCRIPTION
## Description

 Gmail webhooks waited for the entire workflow before responding, so when workflows got longer Gmail would retry, causing duplications in workflow execution. The process is now asynchronous like the other webhooks, preventing the time-related duplicate exeuctions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I had two curl commands send identical requests with the second command sent 10 seconds after the first, while a 30 second workflow was still processing. This recreated the issue where the polling would timeout which would lead to duplicate triggers. After applying the fix, the first request responded quickly and started background processing, and the second request was caught and returned "duplicate request", which is expected behaviour.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
