### PR TITLE
fix(sidebar): expose workflow loading state to sidebar and folder tree to resolve race condition between sidebar init and fetching workflows

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/folder-tree/folder-tree.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/folder-tree/folder-tree.tsx
@@ -171,7 +171,7 @@ export function FolderTree({
     isLoading: foldersLoading,
     clearSelection,
   } = useFolderStore()
-  const { updateWorkflow } = useWorkflowRegistry()
+  const { updateWorkflow, isWorkspaceTransitioning } = useWorkflowRegistry()
 
   // Fetch folders when workspace changes
   useEffect(() => {
@@ -226,7 +226,7 @@ export function FolderTree({
     ))
   }
 
-  const showLoading = isLoading || foldersLoading
+  const showLoading = isLoading || foldersLoading || isWorkspaceTransitioning
 
   return (
     <div

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -32,10 +32,15 @@ const IS_DEV = process.env.NODE_ENV === 'development'
 export function Sidebar() {
   useGlobalShortcuts()
 
-  const { workflows, createWorkflow, isLoading: workflowsLoading } = useWorkflowRegistry()
+  const {
+    workflows,
+    createWorkflow,
+    isLoading: workflowsLoading,
+    isWorkspaceTransitioning,
+  } = useWorkflowRegistry()
   const { isPending: sessionLoading } = useSession()
   const userPermissions = useUserPermissionsContext()
-  const isLoading = workflowsLoading || sessionLoading
+  const isLoading = workflowsLoading || sessionLoading || isWorkspaceTransitioning
   const router = useRouter()
   const params = useParams()
   const workspaceId = params.workspaceId as string

--- a/apps/sim/stores/workflows/registry/store.ts
+++ b/apps/sim/stores/workflows/registry/store.ts
@@ -224,6 +224,7 @@ function resetWorkflowStores() {
  */
 function setWorkspaceTransitioning(isTransitioning: boolean): void {
   isWorkspaceTransitioning = isTransitioning
+  useWorkflowRegistry.setState({ isWorkspaceTransitioning: isTransitioning })
 
   // Set a safety timeout to prevent permanently stuck in transition state
   if (isTransitioning) {
@@ -231,6 +232,7 @@ function setWorkspaceTransitioning(isTransitioning: boolean): void {
       if (isWorkspaceTransitioning) {
         logger.warn('Forcing workspace transition to complete due to timeout')
         isWorkspaceTransitioning = false
+        useWorkflowRegistry.setState({ isWorkspaceTransitioning: false })
       }
     }, TRANSITION_TIMEOUT)
   }
@@ -251,6 +253,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
       workflows: {},
       activeWorkflowId: null,
       isLoading: true,
+      isWorkspaceTransitioning: false,
       error: null,
       // Initialize deployment statuses
       deploymentStatuses: {},

--- a/apps/sim/stores/workflows/registry/types.ts
+++ b/apps/sim/stores/workflows/registry/types.ts
@@ -25,6 +25,7 @@ export interface WorkflowRegistryState {
   workflows: Record<string, WorkflowMetadata>
   activeWorkflowId: string | null
   isLoading: boolean
+  isWorkspaceTransitioning: boolean
   error: string | null
   deploymentStatuses: Record<string, DeploymentStatus>
 }


### PR DESCRIPTION
## Description

expose workflow loading state to sidebar and folder tree to resolve race condition between sidebar init and fetching workflows

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally and in CI (`bun run test`)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated version numbers as needed (if needed)
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [ ] My changes do not introduce any new security vulnerabilities
- [ ] I have considered the security implications of my changes

## Additional Information:

Any additional information, configuration or data that might be necessary to reproduce the issue or use the feature.
