### PR TITLE
fix(switchWorkspace): switch workspace ordering bug fix 

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
@@ -343,11 +343,11 @@ export const WorkspaceHeader = React.memo<WorkspaceHeaderProps>(
         setActiveWorkspace(workspace)
         setWorkspaceDropdownOpen(false)
 
-        // Use full workspace switch which now handles localStorage automatically
-        switchToWorkspace(workspace.id)
-
-        // Update URL to include workspace ID
+        // Update URL first so sidebar filters use the new workspace ID
         router.push(`/workspace/${workspace.id}/w`)
+
+        // Then switch workspace which will clear workflows and fetch new ones
+        switchToWorkspace(workspace.id)
       },
       [activeWorkspace?.id, switchToWorkspace, router, setWorkspaceDropdownOpen]
     )
@@ -372,12 +372,11 @@ export const WorkspaceHeader = React.memo<WorkspaceHeaderProps>(
             setWorkspaces((prev) => [...prev, newWorkspace])
             setActiveWorkspace(newWorkspace)
 
-            // Use switchToWorkspace to properly load workflows for the new workspace
-            // This will clear existing workflows, set loading state, and fetch workflows from DB
-            switchToWorkspace(newWorkspace.id)
-
-            // Update URL to include new workspace ID
+            // Update URL first so sidebar filters use the new workspace ID
             router.push(`/workspace/${newWorkspace.id}/w`)
+
+            // Then switch workspace which will clear workflows and fetch new ones
+            switchToWorkspace(newWorkspace.id)
           }
         } catch (err) {
           logger.error('Error creating workspace:', err)


### PR DESCRIPTION
## Description

switchToWorkspace() immediately clears workflows while the URL still has the old workspaceId. The sidebar filters workflows by the URL's workspaceId, but since workflows are cleared and the URL hasn't updated yet, it shows empty state.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally and in CI (`bun run test`)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated version numbers as needed (if needed)
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [ ] My changes do not introduce any new security vulnerabilities
- [ ] I have considered the security implications of my changes

## Additional Information:

Any additional information, configuration or data that might be necessary to reproduce the issue or use the feature.
