### PR TITLE
tooltip to remove cursor not allowed

### DIFF
--- a/apps/sim/app/w/[id]/components/toolbar/components/toolbar-block/toolbar-block.tsx
+++ b/apps/sim/app/w/[id]/components/toolbar/components/toolbar-block/toolbar-block.tsx
@@ -39,7 +39,7 @@ export function ToolbarBlock({ config, disabled = false }: ToolbarBlockProps) {
       className={cn(
         'group flex items-center gap-3 rounded-lg border bg-card p-3.5 shadow-sm transition-colors',
         disabled
-          ? 'cursor-not-allowed opacity-60'
+          ? 'opacity-60'
           : 'cursor-pointer hover:bg-accent/50 active:cursor-grabbing'
       )}
     >

--- a/apps/sim/app/w/[id]/components/toolbar/components/toolbar-loop-block/toolbar-loop-block.tsx
+++ b/apps/sim/app/w/[id]/components/toolbar/components/toolbar-loop-block/toolbar-loop-block.tsx
@@ -48,7 +48,7 @@ export default function LoopToolbarItem({ disabled = false }: LoopToolbarItemPro
       className={cn(
         'group flex items-center gap-3 rounded-lg border bg-card p-3.5 shadow-sm transition-colors',
         disabled
-          ? 'cursor-not-allowed opacity-60'
+          ? 'opacity-60'
           : 'cursor-pointer hover:bg-accent/50 active:cursor-grabbing'
       )}
     >

--- a/apps/sim/app/w/[id]/components/toolbar/components/toolbar-parallel-block/toolbar-parallel-block.tsx
+++ b/apps/sim/app/w/[id]/components/toolbar/components/toolbar-parallel-block/toolbar-parallel-block.tsx
@@ -49,7 +49,7 @@ export default function ParallelToolbarItem({ disabled = false }: ParallelToolba
       className={cn(
         'group flex items-center gap-3 rounded-lg border bg-card p-3.5 shadow-sm transition-colors',
         disabled
-          ? 'cursor-not-allowed opacity-60'
+          ? 'opacity-60'
           : 'cursor-pointer hover:bg-accent/50 active:cursor-grabbing'
       )}
     >

--- a/apps/sim/app/w/[id]/components/workflow-block/components/action-bar/action-bar.tsx
+++ b/apps/sim/app/w/[id]/components/workflow-block/components/action-bar/action-bar.tsx
@@ -59,7 +59,7 @@ export function ActionBar({ blockId, blockType, disabled = false }: ActionBarPro
                 toggleBlockEnabled(blockId)
               }
             }}
-            className={cn('text-gray-500', disabled && 'cursor-not-allowed opacity-50')}
+            className={cn('text-gray-500', disabled && 'opacity-50')}
             disabled={disabled}
           >
             {isEnabled ? <Circle className='h-4 w-4' /> : <CircleOff className='h-4 w-4' />}
@@ -103,7 +103,7 @@ export function ActionBar({ blockId, blockType, disabled = false }: ActionBarPro
                 toggleBlockHandles(blockId)
               }
             }}
-            className={cn('text-gray-500', disabled && 'cursor-not-allowed opacity-50')}
+            className={cn('text-gray-500', disabled && 'opacity-50')}
             disabled={disabled}
           >
             {horizontalHandles ? (
@@ -131,7 +131,7 @@ export function ActionBar({ blockId, blockType, disabled = false }: ActionBarPro
               }}
               className={cn(
                 'text-gray-500 hover:text-red-600',
-                disabled && 'cursor-not-allowed opacity-50'
+                disabled && 'opacity-50'
               )}
               disabled={disabled}
             >

--- a/apps/sim/app/w/[id]/workflow.tsx
+++ b/apps/sim/app/w/[id]/workflow.tsx
@@ -49,6 +49,49 @@ import {
 
 const logger = createLogger('Workflow')
 
+// Cursor tooltip component for read-only mode
+const CursorTooltip = ({ isVisible }: { isVisible: boolean }) => {
+  const [position, setPosition] = useState({ x: 0, y: 0 })
+  const [isHoveringReactFlow, setIsHoveringReactFlow] = useState(false)
+
+  useEffect(() => {
+    if (!isVisible) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      setPosition({ x: e.clientX, y: e.clientY })
+
+      // Check if mouse is over ReactFlow container
+      const reactFlowElement = document.querySelector('.workflow-container')
+      if (reactFlowElement) {
+        const rect = reactFlowElement.getBoundingClientRect()
+        const isOverReactFlow =
+          e.clientX >= rect.left &&
+          e.clientX <= rect.right &&
+          e.clientY >= rect.top &&
+          e.clientY <= rect.bottom
+        setIsHoveringReactFlow(isOverReactFlow)
+      }
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    return () => document.removeEventListener('mousemove', handleMouseMove)
+  }, [isVisible])
+
+  if (!isVisible || !isHoveringReactFlow) return null
+
+  return (
+    <div
+      className="fixed z-[9999] pointer-events-none bg-gray-900 text-white text-xs px-2 py-1 rounded shadow-lg"
+      style={{
+        left: position.x + 10,
+        top: position.y - 30,
+      }}
+    >
+      Can't edit in read-only mode. Please contact your workspace admin for edit permissions.
+    </div>
+  )
+}
+
 // Define custom node and edge types
 const nodeTypes: NodeTypes = {
   workflowBlock: WorkflowBlock,
@@ -1448,6 +1491,7 @@ const WorkflowContent = React.memo(() => {
             <Background />
           </div>
         </div>
+        <CursorTooltip isVisible={!userPermissions.canEdit} />
       </div>
     )
   }
@@ -1515,6 +1559,7 @@ const WorkflowContent = React.memo(() => {
           <Background />
         </ReactFlow>
       </div>
+      <CursorTooltip isVisible={!userPermissions.canEdit} />
     </div>
   )
 })


### PR DESCRIPTION
adding a tooltip when you're hovering over the reactflow component and in read-only mode, that tells you that you are in read-only mode. likely needs some additional QA on staging, but seemed to work on my end.


https://github.com/user-attachments/assets/9c225de4-453d-4b9e-80a8-08e41d5ae69c

