### PR TITLE
improvement(sockets conn): sockets connection refresh warning 

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
@@ -689,7 +689,7 @@ export function ControlBar({ hasValidationErrors = false }: ControlBarProps) {
         {hasConnectionWarning && (
           <div className='ml-3 flex items-center gap-2 rounded-md bg-destructive/10 px-2 py-1 text-destructive text-sm'>
             <AlertTriangle className='h-4 w-4' />
-            <span>Connection issues detected. Please refresh to ensure data consistency.</span>
+            <span>Connection issues detected. Please refresh to make sure changes are saved.</span>
           </div>
         )}
         <UserAvatarStack className='ml-3' />

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import {
-  AlertTriangle,
   Bell,
   Bug,
   ChevronDown,
@@ -42,7 +41,7 @@ import { useSession } from '@/lib/auth-client'
 import { createLogger } from '@/lib/logs/console-logger'
 import { cn } from '@/lib/utils'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/w/components/providers/workspace-permissions-provider'
-import { useSocket } from '@/contexts/socket-context'
+import { SocketConnectionWarning } from '@/components/socket-connection-warning'
 import { useExecutionStore } from '@/stores/execution/store'
 import { useFolderStore } from '@/stores/folders/store'
 import { useNotificationStore } from '@/stores/notifications/store'
@@ -113,7 +112,7 @@ export function ControlBar({ hasValidationErrors = false }: ControlBarProps) {
   const { isExecuting, handleRunWorkflow } = useWorkflowExecution()
   const { setActiveTab } = usePanelStore()
   const { getFolderTree, expandedFolders } = useFolderStore()
-  const { hasConnectionWarning } = useSocket()
+
 
   // Get current workflow and workspace ID for permissions
   const currentWorkflow = activeWorkflowId ? workflows[activeWorkflowId] : null
@@ -686,12 +685,7 @@ export function ControlBar({ hasValidationErrors = false }: ControlBarProps) {
             </p>
           )}
         </div>
-        {hasConnectionWarning && (
-          <div className='ml-3 flex items-center gap-2 rounded-md bg-destructive/10 px-2 py-1 text-destructive text-sm'>
-            <AlertTriangle className='h-4 w-4' />
-            <span>Connection issues detected. Please refresh to make sure changes are saved.</span>
-          </div>
-        )}
+        <SocketConnectionWarning className='ml-3' />
         <UserAvatarStack className='ml-3' />
       </div>
     )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
@@ -42,6 +42,7 @@ import { useSession } from '@/lib/auth-client'
 import { createLogger } from '@/lib/logs/console-logger'
 import { cn } from '@/lib/utils'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/w/components/providers/workspace-permissions-provider'
+import { useSocket } from '@/contexts/socket-context'
 import { useExecutionStore } from '@/stores/execution/store'
 import { useFolderStore } from '@/stores/folders/store'
 import { useNotificationStore } from '@/stores/notifications/store'
@@ -61,7 +62,6 @@ import { HistoryDropdownItem } from './components/history-dropdown-item/history-
 import { MarketplaceModal } from './components/marketplace-modal/marketplace-modal'
 import { NotificationDropdownItem } from './components/notification-dropdown-item/notification-dropdown-item'
 import { UserAvatarStack } from './components/user-avatar-stack/user-avatar-stack'
-import { useSocket } from '@/contexts/socket-context'
 
 const logger = createLogger('ControlBar')
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
@@ -17,6 +17,7 @@ import {
   X,
 } from 'lucide-react'
 import { useParams, useRouter } from 'next/navigation'
+import { SocketConnectionWarning } from '@/components/socket-connection-warning'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -41,7 +42,6 @@ import { useSession } from '@/lib/auth-client'
 import { createLogger } from '@/lib/logs/console-logger'
 import { cn } from '@/lib/utils'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/w/components/providers/workspace-permissions-provider'
-import { SocketConnectionWarning } from '@/components/socket-connection-warning'
 import { useExecutionStore } from '@/stores/execution/store'
 import { useFolderStore } from '@/stores/folders/store'
 import { useNotificationStore } from '@/stores/notifications/store'
@@ -112,7 +112,6 @@ export function ControlBar({ hasValidationErrors = false }: ControlBarProps) {
   const { isExecuting, handleRunWorkflow } = useWorkflowExecution()
   const { setActiveTab } = usePanelStore()
   const { getFolderTree, expandedFolders } = useFolderStore()
-
 
   // Get current workflow and workspace ID for permissions
   const currentWorkflow = activeWorkflowId ? workflows[activeWorkflowId] : null

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import {
+  AlertTriangle,
   Bell,
   Bug,
   ChevronDown,
@@ -60,6 +61,7 @@ import { HistoryDropdownItem } from './components/history-dropdown-item/history-
 import { MarketplaceModal } from './components/marketplace-modal/marketplace-modal'
 import { NotificationDropdownItem } from './components/notification-dropdown-item/notification-dropdown-item'
 import { UserAvatarStack } from './components/user-avatar-stack/user-avatar-stack'
+import { useSocket } from '@/contexts/socket-context'
 
 const logger = createLogger('ControlBar')
 
@@ -111,6 +113,7 @@ export function ControlBar({ hasValidationErrors = false }: ControlBarProps) {
   const { isExecuting, handleRunWorkflow } = useWorkflowExecution()
   const { setActiveTab } = usePanelStore()
   const { getFolderTree, expandedFolders } = useFolderStore()
+  const { hasConnectionWarning } = useSocket()
 
   // Get current workflow and workspace ID for permissions
   const currentWorkflow = activeWorkflowId ? workflows[activeWorkflowId] : null
@@ -683,6 +686,12 @@ export function ControlBar({ hasValidationErrors = false }: ControlBarProps) {
             </p>
           )}
         </div>
+        {hasConnectionWarning && (
+          <div className='ml-3 flex items-center gap-2 rounded-md bg-destructive/10 px-2 py-1 text-destructive text-sm'>
+            <AlertTriangle className='h-4 w-4' />
+            <span>Connection issues detected. Please refresh to ensure data consistency.</span>
+          </div>
+        )}
         <UserAvatarStack className='ml-3' />
       </div>
     )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value.ts
@@ -6,12 +6,13 @@ import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 // Helper function to dispatch collaborative subblock updates
-const dispatchSubblockUpdate = (blockId: string, subBlockId: string, value: any) => {
+const dispatchSubblockUpdate = (blockId: string, subBlockId: string, value: any, isUserAction: boolean = false) => {
   const event = new CustomEvent('update-subblock-value', {
     detail: {
       blockId,
       subBlockId,
       value,
+      isUserAction,
     },
   })
   window.dispatchEvent(event)
@@ -232,11 +233,13 @@ export function useSubBlockValue<T = any>(
         useSubBlockStore.getState().setValue(blockId, subBlockId, valueCopy)
 
         // Dispatch event to trigger socket emission only (not store update)
+        // Mark as user action since setValue is called by user interactions
         const event = new CustomEvent('update-subblock-value', {
           detail: {
             blockId,
             subBlockId,
             value: valueCopy,
+            isUserAction: true, // setValue is called by user interactions
           },
         })
         window.dispatchEvent(event)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value.ts
@@ -6,7 +6,12 @@ import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 // Helper function to dispatch collaborative subblock updates
-const dispatchSubblockUpdate = (blockId: string, subBlockId: string, value: any, isUserAction: boolean = false) => {
+const dispatchSubblockUpdate = (
+  blockId: string,
+  subBlockId: string,
+  value: any,
+  isUserAction = false
+) => {
   const event = new CustomEvent('update-subblock-value', {
     detail: {
       blockId,

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/sub-block.tsx
@@ -308,6 +308,7 @@ export function SubBlock({
                     blockId,
                     subBlockId: config.id,
                     value,
+                    isUserAction: true, // User selecting OAuth credential
                   },
                 })
                 window.dispatchEvent(event)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -1457,12 +1457,12 @@ const WorkflowContent = React.memo(() => {
   // Handle sub-block value updates from custom events
   useEffect(() => {
     const handleSubBlockValueUpdate = (event: CustomEvent) => {
-      const { blockId, subBlockId, value } = event.detail
+      const { blockId, subBlockId, value, isUserAction } = event.detail
       if (blockId && subBlockId) {
         // Only emit the socket update, don't update the store again
         // The store was already updated in the setValue function
-        // Let the socket context handle all connection checking and warnings
-        emitSubblockUpdate(blockId, subBlockId, value)
+        // Pass through the isUserAction flag to show warnings only for user actions
+        emitSubblockUpdate(blockId, subBlockId, value, isUserAction || false)
       }
     }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -1461,9 +1461,8 @@ const WorkflowContent = React.memo(() => {
       if (blockId && subBlockId) {
         // Only emit the socket update, don't update the store again
         // The store was already updated in the setValue function
-        if (isConnected && currentWorkflowId && activeWorkflowId === currentWorkflowId) {
-          emitSubblockUpdate(blockId, subBlockId, value)
-        }
+        // Let the socket context handle all connection checking and warnings
+        emitSubblockUpdate(blockId, subBlockId, value)
       }
     }
 

--- a/apps/sim/components/socket-connection-warning.tsx
+++ b/apps/sim/components/socket-connection-warning.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { useSocket } from '@/contexts/socket-context'
+
+interface SocketConnectionWarningProps {
+  className?: string
+}
+
+export function SocketConnectionWarning({ className }: SocketConnectionWarningProps) {
+  // Local state that resets on every page load/refresh
+  const [showWarning, setShowWarning] = useState(false)
+  
+  const { socket } = useSocket()
+
+  useEffect(() => {
+    // Listen for custom connection error events from socket context
+    const handleConnectionError = (event: CustomEvent) => {
+      console.error('Socket connection error detected:', event.detail.error)
+      setShowWarning(true)
+    }
+
+    // Listen for custom events dispatched by socket context
+    window.addEventListener('socket-connection-error', handleConnectionError as EventListener)
+
+    // Also listen for actual socket errors if socket is available
+    if (socket) {
+      const handleSocketError = (error: any) => {
+        console.error('Socket error detected:', error)
+        setShowWarning(true)
+      }
+
+      const handleOperationError = (error: any) => {
+        console.error('Socket operation error detected:', error)
+        setShowWarning(true)
+      }
+
+      const handleOperationForbidden = (error: any) => {
+        console.warn('Socket operation forbidden:', error)
+        setShowWarning(true)
+      }
+
+      const handleDisconnect = (reason: string) => {
+        // Only show warning for unexpected disconnections, not normal ones
+        if (reason === 'io server disconnect' || reason === 'transport close' || reason === 'transport error') {
+          console.warn('Socket disconnected unexpectedly:', reason)
+          setShowWarning(true)
+        }
+      }
+
+      // Attach socket event listeners
+      socket.on('error', handleSocketError)
+      socket.on('operation-error', handleOperationError)
+      socket.on('operation-forbidden', handleOperationForbidden)
+      socket.on('disconnect', handleDisconnect)
+
+      // Cleanup socket listeners
+      return () => {
+        window.removeEventListener('socket-connection-error', handleConnectionError as EventListener)
+        socket.off('error', handleSocketError)
+        socket.off('operation-error', handleOperationError)
+        socket.off('operation-forbidden', handleOperationForbidden)
+        socket.off('disconnect', handleDisconnect)
+      }
+    }
+
+    // Cleanup custom event listener if no socket
+    return () => {
+      window.removeEventListener('socket-connection-error', handleConnectionError as EventListener)
+    }
+  }, [socket])
+
+  // Warning should persist until page refresh - don't auto-clear on successful connection
+  // This ensures users know they should refresh to ensure data consistency
+
+  if (!showWarning) return null
+
+  return (
+    <div className={`flex items-center gap-2 rounded-md bg-destructive/10 px-2 py-1 text-destructive text-sm ${className || ''}`}>
+      <AlertTriangle className='h-4 w-4' />
+      <span>Connection issues detected. Please refresh to make sure changes are saved.</span>
+    </div>
+  )
+}

--- a/apps/sim/components/socket-connection-warning.tsx
+++ b/apps/sim/components/socket-connection-warning.tsx
@@ -11,7 +11,7 @@ interface SocketConnectionWarningProps {
 export function SocketConnectionWarning({ className }: SocketConnectionWarningProps) {
   // Local state that resets on every page load/refresh
   const [showWarning, setShowWarning] = useState(false)
-  
+
   const { socket } = useSocket()
 
   useEffect(() => {
@@ -43,7 +43,11 @@ export function SocketConnectionWarning({ className }: SocketConnectionWarningPr
 
       const handleDisconnect = (reason: string) => {
         // Only show warning for unexpected disconnections, not normal ones
-        if (reason === 'io server disconnect' || reason === 'transport close' || reason === 'transport error') {
+        if (
+          reason === 'io server disconnect' ||
+          reason === 'transport close' ||
+          reason === 'transport error'
+        ) {
           console.warn('Socket disconnected unexpectedly:', reason)
           setShowWarning(true)
         }
@@ -57,7 +61,10 @@ export function SocketConnectionWarning({ className }: SocketConnectionWarningPr
 
       // Cleanup socket listeners
       return () => {
-        window.removeEventListener('socket-connection-error', handleConnectionError as EventListener)
+        window.removeEventListener(
+          'socket-connection-error',
+          handleConnectionError as EventListener
+        )
         socket.off('error', handleSocketError)
         socket.off('operation-error', handleOperationError)
         socket.off('operation-forbidden', handleOperationForbidden)
@@ -77,7 +84,9 @@ export function SocketConnectionWarning({ className }: SocketConnectionWarningPr
   if (!showWarning) return null
 
   return (
-    <div className={`flex items-center gap-2 rounded-md bg-destructive/10 px-2 py-1 text-destructive text-sm ${className || ''}`}>
+    <div
+      className={`flex items-center gap-2 rounded-md bg-destructive/10 px-2 py-1 text-destructive text-sm ${className || ''}`}
+    >
       <AlertTriangle className='h-4 w-4' />
       <span>Connection issues detected. Please refresh to make sure changes are saved.</span>
     </div>

--- a/apps/sim/contexts/socket-context.tsx
+++ b/apps/sim/contexts/socket-context.tsx
@@ -453,14 +453,8 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
   const emitWorkflowOperation = useCallback(
     (operation: string, target: string, payload: any) => {
       // Check if socket is available and connected
-      if (!socket || !currentWorkflowId) {
-        logger.warn('Cannot emit workflow operation: no socket connection or workflow room')
-        setHasConnectionWarning(true)
-        return
-      }
-
-      if (!socket.connected) {
-        logger.warn('Cannot emit workflow operation: socket not connected')
+      if (!socket || !currentWorkflowId || !socket.connected) {
+        logger.warn('Cannot emit workflow operation: socket not available or connected')
         setHasConnectionWarning(true)
         return
       }
@@ -523,7 +517,7 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
     (blockId: string, subblockId: string, value: any) => {
       // Check if socket is available and connected
       if (!socket || !currentWorkflowId || !socket.connected) {
-        logger.warn('Cannot emit subblock update: no socket connection or workflow room', {
+        logger.warn('Cannot emit subblock update: socket not available or connected', {
           hasSocket: !!socket,
           currentWorkflowId,
           blockId,

--- a/apps/sim/contexts/socket-context.tsx
+++ b/apps/sim/contexts/socket-context.tsx
@@ -37,8 +37,18 @@ interface SocketContextType {
   presenceUsers: PresenceUser[]
   joinWorkflow: (workflowId: string) => void
   leaveWorkflow: () => void
-  emitWorkflowOperation: (operation: string, target: string, payload: any, isUserAction?: boolean) => void
-  emitSubblockUpdate: (blockId: string, subblockId: string, value: any, isUserAction?: boolean) => void
+  emitWorkflowOperation: (
+    operation: string,
+    target: string,
+    payload: any,
+    isUserAction?: boolean
+  ) => void
+  emitSubblockUpdate: (
+    blockId: string,
+    subblockId: string,
+    value: any,
+    isUserAction?: boolean
+  ) => void
   emitCursorUpdate: (cursor: { x: number; y: number }) => void
   emitSelectionUpdate: (selection: { type: 'block' | 'edge' | 'none'; id?: string }) => void
   // Event handlers for receiving real-time updates
@@ -432,23 +442,25 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
     }
   }, [socket, currentWorkflowId])
 
-
-
   // Light throttling for position updates to ensure smooth collaborative movement
   const positionUpdateTimeouts = useRef<Map<string, number>>(new Map())
   const pendingPositionUpdates = useRef<Map<string, any>>(new Map())
 
   // Emit workflow operations (blocks, edges, subflows)
   const emitWorkflowOperation = useCallback(
-    (operation: string, target: string, payload: any, isUserAction: boolean = false) => {
+    (operation: string, target: string, payload: any, isUserAction = false) => {
       // Check if socket is available and connected
       if (!socket || !currentWorkflowId || !socket.connected) {
         logger.warn('Cannot emit workflow operation: socket not available or connected')
         // Only show warning for user-initiated actions, not automatic operations
         if (isUserAction) {
-          window.dispatchEvent(new CustomEvent('socket-connection-error', {
-            detail: { error: 'Cannot emit workflow operation: socket not available or connected' }
-          }))
+          window.dispatchEvent(
+            new CustomEvent('socket-connection-error', {
+              detail: {
+                error: 'Cannot emit workflow operation: socket not available or connected',
+              },
+            })
+          )
         }
         return
       }
@@ -480,9 +492,11 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
               // Position update failed due to disconnection
               // Only show warning for user-initiated position updates
               if (isUserAction) {
-                window.dispatchEvent(new CustomEvent('socket-connection-error', {
-                  detail: { error: 'Position update failed: socket disconnected' }
-                }))
+                window.dispatchEvent(
+                  new CustomEvent('socket-connection-error', {
+                    detail: { error: 'Position update failed: socket disconnected' },
+                  })
+                )
               }
               pendingPositionUpdates.current.delete(blockId)
             }
@@ -505,9 +519,11 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
             logger.error('Workflow operation failed:', response.error)
             // Only show warning for user-initiated actions
             if (isUserAction) {
-              window.dispatchEvent(new CustomEvent('socket-connection-error', {
-                detail: { error: `Workflow operation failed: ${response.error}` }
-              }))
+              window.dispatchEvent(
+                new CustomEvent('socket-connection-error', {
+                  detail: { error: `Workflow operation failed: ${response.error}` },
+                })
+              )
             }
           }
         })
@@ -518,7 +534,7 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
 
   // Emit subblock value updates
   const emitSubblockUpdate = useCallback(
-    (blockId: string, subblockId: string, value: any, isUserAction: boolean = false) => {
+    (blockId: string, subblockId: string, value: any, isUserAction = false) => {
       // Check if socket is available and connected
       if (!socket || !currentWorkflowId || !socket.connected) {
         logger.warn('Cannot emit subblock update: socket not available or connected', {
@@ -529,9 +545,11 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
         })
         // Only show warning for user-initiated actions, not automatic operations
         if (isUserAction) {
-          window.dispatchEvent(new CustomEvent('socket-connection-error', {
-            detail: { error: 'Cannot emit subblock update: socket not available or connected' }
-          }))
+          window.dispatchEvent(
+            new CustomEvent('socket-connection-error', {
+              detail: { error: 'Cannot emit subblock update: socket not available or connected' },
+            })
+          )
         }
         return
       }

--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -313,7 +313,7 @@ export function useCollaborativeWorkflow() {
 
         // Then broadcast to other clients with complete block data
         if (!isApplyingRemoteChange.current) {
-          emitWorkflowOperation('add', 'block', completeBlockData)
+          emitWorkflowOperation('add', 'block', completeBlockData, true) // User action
         }
         return
       }
@@ -361,7 +361,7 @@ export function useCollaborativeWorkflow() {
 
       // Then broadcast to other clients with complete block data
       if (!isApplyingRemoteChange.current) {
-        emitWorkflowOperation('add', 'block', completeBlockData)
+        emitWorkflowOperation('add', 'block', completeBlockData, true) // User action
       }
     },
     [workflowStore, emitWorkflowOperation]
@@ -374,7 +374,7 @@ export function useCollaborativeWorkflow() {
 
       // Then broadcast to other clients
       if (!isApplyingRemoteChange.current) {
-        emitWorkflowOperation('remove', 'block', { id })
+        emitWorkflowOperation('remove', 'block', { id }, true) // User action
       }
     },
     [workflowStore, emitWorkflowOperation]
@@ -387,7 +387,7 @@ export function useCollaborativeWorkflow() {
 
       // Then broadcast to other clients
       if (!isApplyingRemoteChange.current) {
-        emitWorkflowOperation('update-position', 'block', { id, position })
+        emitWorkflowOperation('update-position', 'block', { id, position }, true) // User action
       }
     },
     [workflowStore, emitWorkflowOperation]
@@ -589,7 +589,7 @@ export function useCollaborativeWorkflow() {
 
       // Then broadcast to other clients
       if (!isApplyingRemoteChange.current) {
-        emitWorkflowOperation('add', 'edge', edge)
+        emitWorkflowOperation('add', 'edge', edge, true) // User action
       }
     },
     [workflowStore, emitWorkflowOperation]
@@ -602,7 +602,7 @@ export function useCollaborativeWorkflow() {
 
       // Then broadcast to other clients
       if (!isApplyingRemoteChange.current) {
-        emitWorkflowOperation('remove', 'edge', { id: edgeId })
+        emitWorkflowOperation('remove', 'edge', { id: edgeId }, true) // User action
       }
     },
     [workflowStore, emitWorkflowOperation]
@@ -620,7 +620,7 @@ export function useCollaborativeWorkflow() {
         currentWorkflowId &&
         activeWorkflowId === currentWorkflowId
       ) {
-        emitSubblockUpdate(blockId, subblockId, value)
+        emitSubblockUpdate(blockId, subblockId, value, true) // User action
       } else if (!isConnected || !currentWorkflowId || activeWorkflowId !== currentWorkflowId) {
         logger.debug('Skipping subblock update broadcast', {
           isConnected,


### PR DESCRIPTION
## Description

Show sockets refresh warning if sockets connection goes down for some reason to make sure user knows changes not being persisted.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Turn Sockets Server Off and make a change on the workflow -- should get the warning immediately. 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes

## Additional Information:

Any additional information, configuration or data that might be necessary to reproduce the issue or use the feature.
