### PR TITLE
fix(race-cond): for auto-connect rare race condition between adding edge + block

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -442,7 +442,7 @@ const WorkflowContent = React.memo(() => {
 
         // Auto-connect logic for container nodes
         const isAutoConnectEnabled = useGeneralStore.getState().isAutoConnectEnabled
-        let autoConnectEdge = undefined
+        let autoConnectEdge
         if (isAutoConnectEnabled) {
           const closestBlock = findClosestOutput(centerPosition)
           if (closestBlock) {
@@ -461,11 +461,20 @@ const WorkflowContent = React.memo(() => {
         }
 
         // Add the container node directly to canvas with default dimensions and auto-connect edge
-        addBlock(id, type, name, centerPosition, {
-          width: 500,
-          height: 300,
-          type: type === 'loop' ? 'loopNode' : 'parallelNode',
-        }, undefined, undefined, autoConnectEdge)
+        addBlock(
+          id,
+          type,
+          name,
+          centerPosition,
+          {
+            width: 500,
+            height: 300,
+            type: type === 'loop' ? 'loopNode' : 'parallelNode',
+          },
+          undefined,
+          undefined,
+          autoConnectEdge
+        )
 
         return
       }
@@ -491,7 +500,7 @@ const WorkflowContent = React.memo(() => {
       // Auto-connect logic
       const isAutoConnectEnabled = useGeneralStore.getState().isAutoConnectEnabled
       console.log('🔗 Auto-connect enabled:', isAutoConnectEnabled, 'type:', type)
-      let autoConnectEdge = undefined
+      let autoConnectEdge
       if (isAutoConnectEnabled && type !== 'starter') {
         const closestBlock = findClosestOutput(centerPosition)
         console.log('🎯 Closest block found:', closestBlock)
@@ -591,7 +600,7 @@ const WorkflowContent = React.memo(() => {
           } else {
             // Auto-connect the container to the closest node on the canvas
             const isAutoConnectEnabled = useGeneralStore.getState().isAutoConnectEnabled
-            let autoConnectEdge = undefined
+            let autoConnectEdge
             if (isAutoConnectEnabled) {
               const closestBlock = findClosestOutput(position)
               if (closestBlock) {
@@ -609,11 +618,20 @@ const WorkflowContent = React.memo(() => {
             }
 
             // Add the container node directly to canvas with default dimensions and auto-connect edge
-            addBlock(id, data.type, name, position, {
-              width: 500,
-              height: 300,
-              type: data.type === 'loop' ? 'loopNode' : 'parallelNode',
-            }, undefined, undefined, autoConnectEdge)
+            addBlock(
+              id,
+              data.type,
+              name,
+              position,
+              {
+                width: 500,
+                height: 300,
+                type: data.type === 'loop' ? 'loopNode' : 'parallelNode',
+              },
+              undefined,
+              undefined,
+              autoConnectEdge
+            )
           }
 
           return
@@ -715,7 +733,7 @@ const WorkflowContent = React.memo(() => {
         } else {
           // Regular auto-connect logic
           const isAutoConnectEnabled = useGeneralStore.getState().isAutoConnectEnabled
-          let autoConnectEdge = undefined
+          let autoConnectEdge
           if (isAutoConnectEnabled && data.type !== 'starter') {
             const closestBlock = findClosestOutput(position)
             if (closestBlock) {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -419,6 +419,7 @@ const WorkflowContent = React.memo(() => {
       }
 
       const { type } = event.detail
+      console.log('🛠️ Adding block from toolbar:', type)
 
       if (!type) return
       if (type === 'connectionBlock') return
@@ -439,31 +440,32 @@ const WorkflowContent = React.memo(() => {
           y: window.innerHeight / 2,
         })
 
-        // Add the container node directly to canvas with default dimensions
-        addBlock(id, type, name, centerPosition, {
-          width: 500,
-          height: 300,
-          type: type === 'loop' ? 'loopNode' : 'parallelNode',
-        })
-
         // Auto-connect logic for container nodes
         const isAutoConnectEnabled = useGeneralStore.getState().isAutoConnectEnabled
+        let autoConnectEdge = undefined
         if (isAutoConnectEnabled) {
           const closestBlock = findClosestOutput(centerPosition)
           if (closestBlock) {
             // Get appropriate source handle
             const sourceHandle = determineSourceHandle(closestBlock)
 
-            addEdge({
+            autoConnectEdge = {
               id: crypto.randomUUID(),
               source: closestBlock.id,
               target: id,
               sourceHandle,
               targetHandle: 'target',
               type: 'workflowEdge',
-            })
+            }
           }
         }
+
+        // Add the container node directly to canvas with default dimensions and auto-connect edge
+        addBlock(id, type, name, centerPosition, {
+          width: 500,
+          height: 300,
+          type: type === 'loop' ? 'loopNode' : 'parallelNode',
+        }, undefined, undefined, autoConnectEdge)
 
         return
       }
@@ -486,27 +488,31 @@ const WorkflowContent = React.memo(() => {
         Object.values(blocks).filter((b) => b.type === type).length + 1
       }`
 
-      // Add the block to the workflow
-      addBlock(id, type, name, centerPosition)
-
       // Auto-connect logic
       const isAutoConnectEnabled = useGeneralStore.getState().isAutoConnectEnabled
+      console.log('🔗 Auto-connect enabled:', isAutoConnectEnabled, 'type:', type)
+      let autoConnectEdge = undefined
       if (isAutoConnectEnabled && type !== 'starter') {
         const closestBlock = findClosestOutput(centerPosition)
+        console.log('🎯 Closest block found:', closestBlock)
         if (closestBlock) {
           // Get appropriate source handle
           const sourceHandle = determineSourceHandle(closestBlock)
 
-          addEdge({
+          autoConnectEdge = {
             id: crypto.randomUUID(),
             source: closestBlock.id,
             target: id,
             sourceHandle,
             targetHandle: 'target',
             type: 'workflowEdge',
-          })
+          }
+          console.log('✅ Auto-connect edge created:', autoConnectEdge)
         }
       }
+
+      // Add the block to the workflow with auto-connect edge
+      addBlock(id, type, name, centerPosition, undefined, undefined, undefined, autoConnectEdge)
     }
 
     window.addEventListener('add-block-from-toolbar', handleAddBlockFromToolbar as EventListener)
@@ -583,30 +589,31 @@ const WorkflowContent = React.memo(() => {
             // Resize the parent container to fit the new child container
             resizeLoopNodesWrapper()
           } else {
-            // Add the container node directly to canvas with default dimensions
-            addBlock(id, data.type, name, position, {
-              width: 500,
-              height: 300,
-              type: data.type === 'loop' ? 'loopNode' : 'parallelNode',
-            })
-
             // Auto-connect the container to the closest node on the canvas
             const isAutoConnectEnabled = useGeneralStore.getState().isAutoConnectEnabled
+            let autoConnectEdge = undefined
             if (isAutoConnectEnabled) {
               const closestBlock = findClosestOutput(position)
               if (closestBlock) {
                 const sourceHandle = determineSourceHandle(closestBlock)
 
-                addEdge({
+                autoConnectEdge = {
                   id: crypto.randomUUID(),
                   source: closestBlock.id,
                   target: id,
                   sourceHandle,
                   targetHandle: 'target',
                   type: 'workflowEdge',
-                })
+                }
               }
             }
+
+            // Add the container node directly to canvas with default dimensions and auto-connect edge
+            addBlock(id, data.type, name, position, {
+              width: 500,
+              height: 300,
+              type: data.type === 'loop' ? 'loopNode' : 'parallelNode',
+            }, undefined, undefined, autoConnectEdge)
           }
 
           return
@@ -706,26 +713,27 @@ const WorkflowContent = React.memo(() => {
             }
           }
         } else {
-          // Regular canvas drop
-          addBlock(id, data.type, name, position)
-
           // Regular auto-connect logic
           const isAutoConnectEnabled = useGeneralStore.getState().isAutoConnectEnabled
+          let autoConnectEdge = undefined
           if (isAutoConnectEnabled && data.type !== 'starter') {
             const closestBlock = findClosestOutput(position)
             if (closestBlock) {
               const sourceHandle = determineSourceHandle(closestBlock)
 
-              addEdge({
+              autoConnectEdge = {
                 id: crypto.randomUUID(),
                 source: closestBlock.id,
                 target: id,
                 sourceHandle,
                 targetHandle: 'target',
                 type: 'workflowEdge',
-              })
+              }
             }
           }
+
+          // Regular canvas drop with auto-connect edge
+          addBlock(id, data.type, name, position, undefined, undefined, undefined, autoConnectEdge)
         }
       } catch (err) {
         logger.error('Error dropping block:', { err })

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -499,7 +499,6 @@ const WorkflowContent = React.memo(() => {
 
       // Auto-connect logic
       const isAutoConnectEnabled = useGeneralStore.getState().isAutoConnectEnabled
-      console.log('🔗 Auto-connect enabled:', isAutoConnectEnabled, 'type:', type)
       let autoConnectEdge
       if (isAutoConnectEnabled && type !== 'starter') {
         const closestBlock = findClosestOutput(centerPosition)

--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -373,10 +373,8 @@ export function useCollaborativeWorkflow() {
       // Apply locally first
       workflowStore.addBlock(id, type, name, position, data, parentId, extent)
       if (autoConnectEdge) {
-        console.log('🚀 Adding auto-connect edge locally:', autoConnectEdge)
+        if (autoConnectEdge) {
         workflowStore.addEdge(autoConnectEdge)
-      } else {
-        console.log('❌ No auto-connect edge to add')
       }
 
       // Then broadcast to other clients with complete block data

--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -373,7 +373,6 @@ export function useCollaborativeWorkflow() {
       // Apply locally first
       workflowStore.addBlock(id, type, name, position, data, parentId, extent)
       if (autoConnectEdge) {
-        if (autoConnectEdge) {
         workflowStore.addEdge(autoConnectEdge)
       }
 

--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -91,6 +91,10 @@ export function useCollaborativeWorkflow() {
                 payload.parentId,
                 payload.extent
               )
+              // Handle auto-connect edge if present
+              if (payload.autoConnectEdge) {
+                workflowStore.addEdge(payload.autoConnectEdge)
+              }
               break
             case 'update-position': {
               // Apply position update only if it's newer than the last applied timestamp
@@ -164,6 +168,10 @@ export function useCollaborativeWorkflow() {
                 payload.parentId,
                 payload.extent
               )
+              // Handle auto-connect edge if present
+              if (payload.autoConnectEdge) {
+                workflowStore.addEdge(payload.autoConnectEdge)
+              }
               break
           }
         } else if (target === 'edge') {
@@ -284,7 +292,8 @@ export function useCollaborativeWorkflow() {
       position: Position,
       data?: Record<string, any>,
       parentId?: string,
-      extent?: 'parent'
+      extent?: 'parent',
+      autoConnectEdge?: Edge
     ) => {
       // Create complete block data upfront using the same logic as the store
       const blockConfig = getBlock(type)
@@ -306,10 +315,14 @@ export function useCollaborativeWorkflow() {
           height: 0,
           parentId,
           extent,
+          autoConnectEdge, // Include edge data for atomic operation
         }
 
         // Apply locally first
         workflowStore.addBlock(id, type, name, position, data, parentId, extent)
+        if (autoConnectEdge) {
+          workflowStore.addEdge(autoConnectEdge)
+        }
 
         // Then broadcast to other clients with complete block data
         if (!isApplyingRemoteChange.current) {
@@ -354,10 +367,17 @@ export function useCollaborativeWorkflow() {
         height: 0, // Default height, will be set by the UI
         parentId,
         extent,
+        autoConnectEdge, // Include edge data for atomic operation
       }
 
       // Apply locally first
       workflowStore.addBlock(id, type, name, position, data, parentId, extent)
+      if (autoConnectEdge) {
+        console.log('🚀 Adding auto-connect edge locally:', autoConnectEdge)
+        workflowStore.addEdge(autoConnectEdge)
+      } else {
+        console.log('❌ No auto-connect edge to add')
+      }
 
       // Then broadcast to other clients with complete block data
       if (!isApplyingRemoteChange.current) {

--- a/apps/sim/socket-server/database/operations.ts
+++ b/apps/sim/socket-server/database/operations.ts
@@ -29,6 +29,34 @@ const db = socketDb
 // Constants
 const DEFAULT_LOOP_ITERATIONS = 5
 
+/**
+ * Shared function to handle auto-connect edge insertion
+ * @param tx - Database transaction
+ * @param workflowId - The workflow ID
+ * @param autoConnectEdge - The auto-connect edge data
+ * @param logger - Logger instance
+ */
+async function insertAutoConnectEdge(
+  tx: any,
+  workflowId: string,
+  autoConnectEdge: any,
+  logger: any
+) {
+  if (!autoConnectEdge) return
+
+  await tx.insert(workflowEdges).values({
+    id: autoConnectEdge.id,
+    workflowId,
+    sourceBlockId: autoConnectEdge.source,
+    targetBlockId: autoConnectEdge.target,
+    sourceHandle: autoConnectEdge.sourceHandle || null,
+    targetHandle: autoConnectEdge.targetHandle || null,
+  })
+  logger.debug(
+    `Added auto-connect edge ${autoConnectEdge.id}: ${autoConnectEdge.source} -> ${autoConnectEdge.target}`
+  )
+}
+
 // Enum for subflow types
 enum SubflowType {
   LOOP = 'loop',
@@ -248,18 +276,7 @@ async function handleBlockOperationTx(
         await tx.insert(workflowBlocks).values(insertData)
 
         // Handle auto-connect edge if present
-        if (payload.autoConnectEdge) {
-          const edge = payload.autoConnectEdge
-          await tx.insert(workflowEdges).values({
-            id: edge.id,
-            workflowId,
-            sourceBlockId: edge.source,
-            targetBlockId: edge.target,
-            sourceHandle: edge.sourceHandle || null,
-            targetHandle: edge.targetHandle || null,
-          })
-          logger.info(`Added auto-connect edge ${edge.id}: ${edge.source} -> ${edge.target}`)
-        }
+        await insertAutoConnectEdge(tx, workflowId, payload.autoConnectEdge, logger)
       } catch (insertError) {
         logger.error(`[SERVER] ❌ Failed to insert block ${payload.id}:`, insertError)
         throw insertError
@@ -608,18 +625,7 @@ async function handleBlockOperationTx(
         await tx.insert(workflowBlocks).values(insertData)
 
         // Handle auto-connect edge if present
-        if (payload.autoConnectEdge) {
-          const edge = payload.autoConnectEdge
-          await tx.insert(workflowEdges).values({
-            id: edge.id,
-            workflowId,
-            sourceBlockId: edge.source,
-            targetBlockId: edge.target,
-            sourceHandle: edge.sourceHandle || null,
-            targetHandle: edge.targetHandle || null,
-          })
-          logger.debug(`Added auto-connect edge ${edge.id}: ${edge.source} -> ${edge.target}`)
-        }
+        await insertAutoConnectEdge(tx, workflowId, payload.autoConnectEdge, logger)
       } catch (insertError) {
         logger.error(`[SERVER] ❌ Failed to insert duplicated block ${payload.id}:`, insertError)
         throw insertError

--- a/apps/sim/socket-server/database/operations.ts
+++ b/apps/sim/socket-server/database/operations.ts
@@ -246,6 +246,20 @@ async function handleBlockOperationTx(
         }
 
         await tx.insert(workflowBlocks).values(insertData)
+
+        // Handle auto-connect edge if present
+        if (payload.autoConnectEdge) {
+          const edge = payload.autoConnectEdge
+          await tx.insert(workflowEdges).values({
+            id: edge.id,
+            workflowId,
+            sourceBlockId: edge.source,
+            targetBlockId: edge.target,
+            sourceHandle: edge.sourceHandle || null,
+            targetHandle: edge.targetHandle || null,
+          })
+          logger.info(`Added auto-connect edge ${edge.id}: ${edge.source} -> ${edge.target}`)
+        }
       } catch (insertError) {
         logger.error(`[SERVER] ❌ Failed to insert block ${payload.id}:`, insertError)
         throw insertError
@@ -592,6 +606,20 @@ async function handleBlockOperationTx(
         }
 
         await tx.insert(workflowBlocks).values(insertData)
+
+        // Handle auto-connect edge if present
+        if (payload.autoConnectEdge) {
+          const edge = payload.autoConnectEdge
+          await tx.insert(workflowEdges).values({
+            id: edge.id,
+            workflowId,
+            sourceBlockId: edge.source,
+            targetBlockId: edge.target,
+            sourceHandle: edge.sourceHandle || null,
+            targetHandle: edge.targetHandle || null,
+          })
+          logger.debug(`Added auto-connect edge ${edge.id}: ${edge.source} -> ${edge.target}`)
+        }
       } catch (insertError) {
         logger.error(`[SERVER] ❌ Failed to insert duplicated block ${payload.id}:`, insertError)
         throw insertError

--- a/apps/sim/socket-server/index.test.ts
+++ b/apps/sim/socket-server/index.test.ts
@@ -279,6 +279,32 @@ describe('Socket Server Index Integration', () => {
       expect(() => WorkflowOperationSchema.parse(validOperation)).not.toThrow()
     })
 
+    it.concurrent('should validate block operations with autoConnectEdge', async () => {
+      const { WorkflowOperationSchema } = await import('./validation/schemas')
+
+      const validOperationWithAutoEdge = {
+        operation: 'add',
+        target: 'block',
+        payload: {
+          id: 'test-block',
+          type: 'action',
+          name: 'Test Block',
+          position: { x: 100, y: 200 },
+          autoConnectEdge: {
+            id: 'auto-edge-123',
+            source: 'source-block',
+            target: 'test-block',
+            sourceHandle: 'output',
+            targetHandle: 'target',
+            type: 'workflowEdge',
+          },
+        },
+        timestamp: Date.now(),
+      }
+
+      expect(() => WorkflowOperationSchema.parse(validOperationWithAutoEdge)).not.toThrow()
+    })
+
     it.concurrent('should validate edge operations', async () => {
       const { WorkflowOperationSchema } = await import('./validation/schemas')
 

--- a/apps/sim/socket-server/validation/schemas.ts
+++ b/apps/sim/socket-server/validation/schemas.ts
@@ -5,6 +5,16 @@ const PositionSchema = z.object({
   y: z.number(),
 })
 
+// Schema for auto-connect edge data
+const AutoConnectEdgeSchema = z.object({
+  id: z.string(),
+  source: z.string(),
+  target: z.string(),
+  sourceHandle: z.string().nullable().optional(),
+  targetHandle: z.string().nullable().optional(),
+  type: z.string().optional(),
+})
+
 export const BlockOperationSchema = z.object({
   operation: z.enum([
     'add',
@@ -35,6 +45,7 @@ export const BlockOperationSchema = z.object({
     isWide: z.boolean().optional(),
     advancedMode: z.boolean().optional(),
     height: z.number().optional(),
+    autoConnectEdge: AutoConnectEdgeSchema.optional(), // Add support for auto-connect edges
   }),
   timestamp: z.number(),
 })
@@ -69,4 +80,4 @@ export const WorkflowOperationSchema = z.union([
   SubflowOperationSchema,
 ])
 
-export { PositionSchema }
+export { PositionSchema, AutoConnectEdgeSchema }


### PR DESCRIPTION
## Description

When you drag and drop -- it adds a block + edge. These are currently sent as separate socket events. But sometimes the edge db call finishes before the block -- and errors since target block doesn't exist yet. 

This autoEdge mode makes sure the block addition is awaited. New sockets event for this. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Test dragging and dropping blocks onto canvas and refresh. Also add edges normally and refresh. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes

## Additional Information:

Any additional information, configuration or data that might be necessary to reproduce the issue or use the feature.
