### PR TITLE
fix(unload): remove beforeunload warning since we communicate via wss

### DIFF
--- a/apps/sim/stores/index.ts
+++ b/apps/sim/stores/index.ts
@@ -43,9 +43,6 @@ async function initializeApplication(): Promise<void> {
     // Mark data as initialized only after sync managers have loaded data from DB
     dataInitialized = true
 
-    // Register cleanup
-    window.addEventListener('beforeunload', handleBeforeUnload)
-
     // Log initialization timing information
     const initDuration = Date.now() - initStartTime
     logger.info(`Application initialization completed in ${initDuration}ms`)


### PR DESCRIPTION
## Description

Remove beforeunload warning since we communicate via wss. This removes the 'Are you sure you want to leave this page?' every time someone closes the simstudio tab. This is not necessary since we stream changes in realtime.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested navigating away from the tab, ensured there was no alert dialog.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes