### PR TITLE
fix(deletions): folder deletions were hanging + use cascade deletions throughout 

### DIFF
--- a/apps/sim/app/api/folders/[id]/route.ts
+++ b/apps/sim/app/api/folders/[id]/route.ts
@@ -160,6 +160,7 @@ async function deleteFolderRecursively(
   }
 
   // Delete all workflows in this folder (workspace-scoped, not user-scoped)
+  // The database cascade will handle deleting related workflow_blocks, workflow_edges, workflow_subflows
   const workflowsInFolder = await db
     .select({ id: workflow.id })
     .from(workflow)

--- a/apps/sim/app/api/workflows/[id]/route.ts
+++ b/apps/sim/app/api/workflows/[id]/route.ts
@@ -7,7 +7,7 @@ import { createLogger } from '@/lib/logs/console-logger'
 import { getUserEntityPermissions, hasAdminPermission } from '@/lib/permissions/utils'
 import { loadWorkflowFromNormalizedTables } from '@/lib/workflows/db-helpers'
 import { db } from '@/db'
-import { workflow, workflowBlocks, workflowEdges, workflowSubflows } from '@/db/schema'
+import { workflow } from '@/db/schema'
 
 const logger = createLogger('WorkflowByIdAPI')
 
@@ -206,16 +206,7 @@ export async function DELETE(
       return NextResponse.json({ error: 'Access denied' }, { status: 403 })
     }
 
-    // Delete workflow and all related data in a transaction
-    await db.transaction(async (tx) => {
-      // Delete from normalized tables first (foreign key constraints)
-      await tx.delete(workflowSubflows).where(eq(workflowSubflows.workflowId, workflowId))
-      await tx.delete(workflowEdges).where(eq(workflowEdges.workflowId, workflowId))
-      await tx.delete(workflowBlocks).where(eq(workflowBlocks.workflowId, workflowId))
-
-      // Delete the main workflow record
-      await tx.delete(workflow).where(eq(workflow.id, workflowId))
-    })
+    await db.delete(workflow).where(eq(workflow.id, workflowId))
 
     const elapsed = Date.now() - startTime
     logger.info(`[${requestId}] Successfully deleted workflow ${workflowId} in ${elapsed}ms`)

--- a/apps/sim/app/api/workspaces/[id]/route.ts
+++ b/apps/sim/app/api/workspaces/[id]/route.ts
@@ -2,13 +2,7 @@ import { and, eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console-logger'
-import {
-  workflow,
-  workflowBlocks,
-  workflowEdges,
-  workflowSubflows,
-  workspaceMember,
-} from '@/db/schema'
+import { workflow, workspaceMember } from '@/db/schema'
 
 const logger = createLogger('WorkspaceByIdAPI')
 
@@ -126,20 +120,10 @@ export async function DELETE(
 
     // Delete workspace and all related data in a transaction
     await db.transaction(async (tx) => {
-      // Get all workflows in this workspace
-      const workspaceWorkflows = await tx
-        .select({ id: workflow.id })
-        .from(workflow)
-        .where(eq(workflow.workspaceId, workspaceId))
-
-      // Delete all workflow-related data for each workflow
-      for (const wf of workspaceWorkflows) {
-        await tx.delete(workflowSubflows).where(eq(workflowSubflows.workflowId, wf.id))
-        await tx.delete(workflowEdges).where(eq(workflowEdges.workflowId, wf.id))
-        await tx.delete(workflowBlocks).where(eq(workflowBlocks.workflowId, wf.id))
-      }
-
-      // Delete all workflows in the workspace
+      // Delete all workflows in the workspace - database cascade will handle all workflow-related data
+      // The database cascade will handle deleting related workflow_blocks, workflow_edges, workflow_subflows,
+      // workflow_logs, workflow_execution_snapshots, workflow_execution_logs, workflow_execution_trace_spans,
+      // workflow_schedule, webhook, marketplace, chat, and memory records
       await tx.delete(workflow).where(eq(workflow.workspaceId, workspaceId))
 
       // Delete workspace members

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/folder-context-menu/folder-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/folder-context-menu/folder-context-menu.tsx
@@ -63,12 +63,17 @@ export function FolderContextMenu({
     setShowRenameDialog(true)
   }
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (onDelete) {
       onDelete(folderId)
     } else {
-      // Default delete behavior
-      deleteFolder(folderId, workspaceId)
+      // Default delete behavior with proper error handling
+      try {
+        await deleteFolder(folderId, workspaceId)
+        logger.info(`Successfully deleted folder from context menu: ${folderName}`)
+      } catch (error) {
+        logger.error('Failed to delete folder from context menu:', { error, folderId, folderName })
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Use cascade deletions for workspaces, workflows, and normalized tables. 

Fix client side code bug calling switchWorkspace on folder deletion causing hang. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## How Has This Been Tested?

https://github.com/user-attachments/assets/8b9341e8-a23e-432b-ab13-88459d98b356



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
