### PR TITLE
fix(response-format): add response format to tag dropdown, chat panel, and chat client

### DIFF
--- a/apps/sim/app/api/chat/[subdomain]/route.ts
+++ b/apps/sim/app/api/chat/[subdomain]/route.ts
@@ -177,6 +177,26 @@ export async function GET(
       return addCorsHeaders(createErrorResponse('This chat is currently unavailable', 403), request)
     }
 
+    // Get workflow information for field selection
+    let workflowBlocks = {}
+    try {
+      const workflowResult = await db
+        .select({
+          deployedState: workflow.deployedState,
+        })
+        .from(workflow)
+        .where(eq(workflow.id, deployment.workflowId))
+        .limit(1)
+
+      if (workflowResult.length > 0 && workflowResult[0].deployedState) {
+        const deployedState = workflowResult[0].deployedState as any
+        workflowBlocks = deployedState.blocks || {}
+      }
+    } catch (error) {
+      logger.warn(`[${requestId}] Could not fetch workflow blocks:`, error)
+      // Continue without blocks - field selection will be disabled
+    }
+
     // Check for auth cookie first
     const cookieName = `chat_auth_${deployment.id}`
     const authCookie = request.cookies.get(cookieName)
@@ -194,6 +214,8 @@ export async function GET(
           description: deployment.description,
           customizations: deployment.customizations,
           authType: deployment.authType,
+          workflowBlocks,
+          outputConfigs: deployment.outputConfigs,
         }),
         request
       )
@@ -219,6 +241,8 @@ export async function GET(
         description: deployment.description,
         customizations: deployment.customizations,
         authType: deployment.authType,
+        workflowBlocks,
+        outputConfigs: deployment.outputConfigs,
       }),
       request
     )

--- a/apps/sim/app/api/chat/[subdomain]/route.ts
+++ b/apps/sim/app/api/chat/[subdomain]/route.ts
@@ -177,26 +177,6 @@ export async function GET(
       return addCorsHeaders(createErrorResponse('This chat is currently unavailable', 403), request)
     }
 
-    // Get workflow information for field selection
-    let workflowBlocks = {}
-    try {
-      const workflowResult = await db
-        .select({
-          deployedState: workflow.deployedState,
-        })
-        .from(workflow)
-        .where(eq(workflow.id, deployment.workflowId))
-        .limit(1)
-
-      if (workflowResult.length > 0 && workflowResult[0].deployedState) {
-        const deployedState = workflowResult[0].deployedState as any
-        workflowBlocks = deployedState.blocks || {}
-      }
-    } catch (error) {
-      logger.warn(`[${requestId}] Could not fetch workflow blocks:`, error)
-      // Continue without blocks - field selection will be disabled
-    }
-
     // Check for auth cookie first
     const cookieName = `chat_auth_${deployment.id}`
     const authCookie = request.cookies.get(cookieName)
@@ -214,7 +194,6 @@ export async function GET(
           description: deployment.description,
           customizations: deployment.customizations,
           authType: deployment.authType,
-          workflowBlocks,
           outputConfigs: deployment.outputConfigs,
         }),
         request
@@ -241,7 +220,6 @@ export async function GET(
         description: deployment.description,
         customizations: deployment.customizations,
         authType: deployment.authType,
-        workflowBlocks,
         outputConfigs: deployment.outputConfigs,
       }),
       request

--- a/apps/sim/app/chat/[subdomain]/chat-client.tsx
+++ b/apps/sim/app/chat/[subdomain]/chat-client.tsx
@@ -33,6 +33,8 @@ interface ChatConfig {
     headerText?: string
   }
   authType?: 'public' | 'password' | 'email'
+  workflowBlocks?: Record<string, any>
+  outputConfigs?: Array<{ blockId: string; path?: string }>
 }
 
 interface AudioStreamingOptions {
@@ -373,8 +375,16 @@ export default function ChatClient({ subdomain }: { subdomain: string }) {
                   const json = JSON.parse(line.substring(6))
                   const { blockId, chunk: contentChunk, event: eventType } = json
 
-                  if (eventType === 'final') {
+                  if (eventType === 'final' && json.data) {
                     setIsLoading(false)
+
+                    // Process final execution result for field extraction
+                    const result = json.data
+                    const nonStreamingLogs =
+                      result.logs?.filter((log: any) => !messageIdMap.has(log.blockId)) || []
+
+                    // Chat field extraction will be handled by the backend using deployment outputConfigs
+
                     return
                   }
 

--- a/apps/sim/app/chat/[subdomain]/chat-client.tsx
+++ b/apps/sim/app/chat/[subdomain]/chat-client.tsx
@@ -33,7 +33,6 @@ interface ChatConfig {
     headerText?: string
   }
   authType?: 'public' | 'password' | 'email'
-  workflowBlocks?: Record<string, any>
   outputConfigs?: Array<{ blockId: string; path?: string }>
 }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/chat/chat.tsx
@@ -60,8 +60,8 @@ export function Chat({ panelWidth, chatMessage, setChatMessage }: ChatProps) {
     const selected = selectedWorkflowOutputs[activeWorkflowId]
 
     if (!selected || selected.length === 0) {
-      const defaultSelection = outputEntries.length > 0 ? [outputEntries[0].id] : []
-      return defaultSelection
+      // Return empty array when nothing is explicitly selected
+      return []
     }
 
     // Ensure we have no duplicates in the selection
@@ -74,7 +74,7 @@ export function Chat({ panelWidth, chatMessage, setChatMessage }: ChatProps) {
     }
 
     return selected
-  }, [selectedWorkflowOutputs, activeWorkflowId, outputEntries, setSelectedWorkflowOutput])
+  }, [selectedWorkflowOutputs, activeWorkflowId, setSelectedWorkflowOutput])
 
   // Auto-scroll to bottom when new messages are added
   useEffect(() => {
@@ -159,7 +159,18 @@ export function Chat({ panelWidth, chatMessage, setChatMessage }: ChatProps) {
 
                       if (log) {
                         let outputValue: any = log.output
+
                         if (path) {
+                          // For response format, the structured data is in the content field as JSON
+                          if (outputValue.content && typeof outputValue.content === 'string') {
+                            try {
+                              const parsedContent = JSON.parse(outputValue.content)
+                              outputValue = parsedContent
+                            } catch (e) {
+                              // Fallback to original structure
+                            }
+                          }
+
                           const pathParts = path.split('.')
                           for (const part of pathParts) {
                             if (
@@ -224,29 +235,38 @@ export function Chat({ panelWidth, chatMessage, setChatMessage }: ChatProps) {
 
       if (selectedOutputs && selectedOutputs.length > 0) {
         for (const outputId of selectedOutputs) {
-          // Find the log that corresponds to the start of the outputId
-          const log = result.logs?.find(
-            (l: BlockLog) => l.blockId === outputId || outputId.startsWith(`${l.blockId}_`)
-          )
+          // Extract block ID and path using the same logic as streaming section
+          const blockIdForOutput = outputId.includes('_')
+            ? outputId.split('_')[0]
+            : outputId.split('.')[0]
+          const path = outputId.substring(blockIdForOutput.length + 1)
+          const log = result.logs?.find((l: BlockLog) => l.blockId === blockIdForOutput)
 
           if (log) {
             let output = log.output
-            // Check if there is a path to traverse
-            if (outputId.length > log.blockId.length) {
-              const path = outputId.substring(log.blockId.length + 1)
-              if (path) {
-                const pathParts = path.split('.')
-                let current = output
-                for (const part of pathParts) {
-                  if (current && typeof current === 'object' && part in current) {
-                    current = current[part]
-                  } else {
-                    current = undefined
-                    break
-                  }
+
+            if (path) {
+              // For response format, the structured data is in the content field as JSON
+              if (output.content && typeof output.content === 'string') {
+                try {
+                  const parsedContent = JSON.parse(output.content)
+                  output = parsedContent
+                } catch (e) {
+                  // Fallback to original structure
                 }
-                output = current
               }
+
+              const pathParts = path.split('.')
+              let current = output
+              for (const part of pathParts) {
+                if (current && typeof current === 'object' && part in current) {
+                  current = current[part]
+                } else {
+                  current = undefined
+                  break
+                }
+              }
+              output = current
             }
             if (output !== undefined) {
               finalOutputs.push(output)
@@ -255,10 +275,8 @@ export function Chat({ panelWidth, chatMessage, setChatMessage }: ChatProps) {
         }
       }
 
-      // If no specific outputs could be resolved, fall back to the final workflow output
-      if (finalOutputs.length === 0 && result.output) {
-        finalOutputs.push(result.output)
-      }
+      // Only show outputs if something was explicitly selected
+      // If no outputs are selected, don't show anything
 
       // Add a new message for each resolved output
       finalOutputs.forEach((output) => {
@@ -266,19 +284,8 @@ export function Chat({ panelWidth, chatMessage, setChatMessage }: ChatProps) {
         if (typeof output === 'string') {
           content = output
         } else if (output && typeof output === 'object') {
-          // Handle cases where output is { response: ... }
-          const outputObj = output as Record<string, any>
-          const response = outputObj.response
-          if (response) {
-            if (typeof response.content === 'string') {
-              content = response.content
-            } else {
-              // Pretty print for better readability
-              content = `\`\`\`json\n${JSON.stringify(response, null, 2)}\n\`\`\``
-            }
-          } else {
-            content = `\`\`\`json\n${JSON.stringify(output, null, 2)}\n\`\`\``
-          }
+          // For structured responses, pretty print the JSON
+          content = `\`\`\`json\n${JSON.stringify(output, null, 2)}\n\`\`\``
         }
 
         if (content) {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/console/components/console-entry/console-entry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/console/components/console-entry/console-entry.tsx
@@ -125,35 +125,33 @@ export function ConsoleEntry({ entry, consoleWidth }: ConsoleEntryProps) {
             <div className='flex items-start gap-2'>
               <Terminal className='mt-1 h-4 w-4 text-muted-foreground' />
               <div className='overflow-wrap-anywhere relative flex-1 whitespace-normal break-normal font-mono text-sm'>
-                {typeof entry.output === 'object' &&
-                  entry.output !== null &&
-                  hasNestedStructure(entry.output) && (
-                    <div className='absolute top-0 right-0 z-10'>
-                      <Button
-                        variant='ghost'
-                        size='sm'
-                        className='h-6 px-2 text-muted-foreground hover:text-foreground'
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setExpandAllJson(!expandAllJson)
-                        }}
-                      >
-                        <span className='flex items-center'>
-                          {expandAllJson ? (
-                            <>
-                              <ChevronUp className='mr-1 h-3 w-3' />
-                              <span className='text-xs'>Collapse</span>
-                            </>
-                          ) : (
-                            <>
-                              <ChevronDown className='mr-1 h-3 w-3' />
-                              <span className='text-xs'>Expand</span>
-                            </>
-                          )}
-                        </span>
-                      </Button>
-                    </div>
-                  )}
+                {entry.output !== undefined && entry.output !== null && (
+                  <div className='absolute top-0 right-0 z-10'>
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-6 px-2 text-muted-foreground hover:text-foreground'
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setExpandAllJson(!expandAllJson)
+                      }}
+                    >
+                      <span className='flex items-center'>
+                        {expandAllJson ? (
+                          <>
+                            <ChevronUp className='mr-1 h-3 w-3' />
+                            <span className='text-xs'>Collapse</span>
+                          </>
+                        ) : (
+                          <>
+                            <ChevronDown className='mr-1 h-3 w-3' />
+                            <span className='text-xs'>Expand</span>
+                          </>
+                        )}
+                      </span>
+                    </Button>
+                  </div>
+                )}
                 <JSONView data={entry.output} initiallyExpanded={expandAllJson} />
               </div>
             </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/console/components/console-entry/console-entry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/console/components/console-entry/console-entry.tsx
@@ -125,7 +125,7 @@ export function ConsoleEntry({ entry, consoleWidth }: ConsoleEntryProps) {
             <div className='flex items-start gap-2'>
               <Terminal className='mt-1 h-4 w-4 text-muted-foreground' />
               <div className='overflow-wrap-anywhere relative flex-1 whitespace-normal break-normal font-mono text-sm'>
-                {entry.output !== undefined && entry.output !== null && (
+                {entry.output != null && (
                   <div className='absolute top-0 right-0 z-10'>
                     <Button
                       variant='ghost'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -217,10 +217,13 @@ export function useWorkflowExecution() {
                   result.logs.forEach((log: BlockLog) => {
                     if (streamedContent.has(log.blockId)) {
                       const content = streamedContent.get(log.blockId) || ''
-                      if (log.output) {
-                        log.output.content = content
-                      }
-                      useConsoleStore.getState().updateConsole(log.blockId, content)
+                      // For console display, show the actual structured block output instead of formatted streaming content
+                      // This ensures console logs match the block state structure
+                      // Use replaceOutput to completely replace the output instead of merging
+                      useConsoleStore.getState().updateConsole(log.blockId, {
+                        replaceOutput: log.output,
+                        success: true,
+                      })
                     }
                   })
 

--- a/apps/sim/components/ui/tag-dropdown.test.tsx
+++ b/apps/sim/components/ui/tag-dropdown.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, test, vi } from 'vitest'
+import { extractFieldsFromSchema, parseResponseFormatSafely } from '@/lib/response-format'
 import type { BlockState } from '@/stores/workflows/workflow/types'
 import { generateLoopBlocks } from '@/stores/workflows/workflow/utils'
-import { checkTagTrigger, extractFieldsFromSchema } from './tag-dropdown'
+import { checkTagTrigger } from './tag-dropdown'
 
 vi.mock('@/stores/workflows/workflow/store', () => ({
   useWorkflowStore: vi.fn(() => ({
@@ -656,7 +657,6 @@ describe('TagDropdown Response Format Support', () => {
       } as any)
 
       // Test the parseResponseFormatSafely function
-      const { parseResponseFormatSafely } = await import('./tag-dropdown')
       const parsedFormat = parseResponseFormatSafely(responseFormatValue, 'agent1')
 
       expect(parsedFormat).toEqual({
@@ -677,7 +677,6 @@ describe('TagDropdown Response Format Support', () => {
       })
 
       // Test the extractFieldsFromSchema function with the parsed format
-      const { extractFieldsFromSchema } = await import('./tag-dropdown')
       const fields = extractFieldsFromSchema(parsedFormat)
 
       expect(fields).toEqual([
@@ -693,8 +692,6 @@ describe('TagDropdown Response Format Support', () => {
   it.concurrent(
     'should fallback to default outputs when response format parsing fails',
     async () => {
-      const { parseResponseFormatSafely } = await import('./tag-dropdown')
-
       // Test with invalid JSON
       const invalidFormat = parseResponseFormatSafely('invalid json', 'agent1')
       expect(invalidFormat).toBeNull()
@@ -724,7 +721,6 @@ describe('TagDropdown Response Format Support', () => {
       },
     }
 
-    const { extractFieldsFromSchema } = await import('./tag-dropdown')
     const fields = extractFieldsFromSchema(responseFormat)
 
     expect(fields).toEqual([
@@ -742,7 +738,6 @@ describe('TagDropdown Response Format Support', () => {
       },
     }
 
-    const { extractFieldsFromSchema } = await import('./tag-dropdown')
     const fields = extractFieldsFromSchema(responseFormat)
 
     expect(fields).toEqual([
@@ -761,7 +756,6 @@ describe('TagDropdown Response Format Support', () => {
       },
     }
 
-    const { parseResponseFormatSafely } = await import('./tag-dropdown')
     const result = parseResponseFormatSafely(responseFormat, 'agent1')
 
     expect(result).toEqual(responseFormat)
@@ -782,7 +776,6 @@ describe('TagDropdown Response Format Support', () => {
       },
     }
 
-    const { extractFieldsFromSchema } = await import('./tag-dropdown')
     const schemaFields = extractFieldsFromSchema(responseFormat)
 
     // Generate block tags as they would be in the component

--- a/apps/sim/components/ui/tag-dropdown.test.tsx
+++ b/apps/sim/components/ui/tag-dropdown.test.tsx
@@ -24,6 +24,15 @@ vi.mock('@/stores/panel/variables/store', () => ({
   })),
 }))
 
+vi.mock('@/stores/workflows/subblock/store', () => ({
+  useSubBlockStore: vi.fn(() => ({
+    getValue: vi.fn(() => null),
+    getState: vi.fn(() => ({
+      getValue: vi.fn(() => null),
+    })),
+  })),
+}))
+
 describe('TagDropdown Loop Suggestions', () => {
   test('should generate correct loop suggestions for forEach loops', () => {
     const blocks: Record<string, BlockState> = {
@@ -601,5 +610,190 @@ describe('TagDropdown Tag Selection Logic', () => {
       const nextCloseBracket = input.indexOf('>')
       expect(nextCloseBracket).toBe(expected)
     })
+  })
+})
+
+describe('TagDropdown Response Format Support', () => {
+  it.concurrent(
+    'should use custom schema properties when response format is specified',
+    async () => {
+      // Mock the subblock store to return a custom response format
+      const mockGetValue = vi.fn()
+      const mockUseSubBlockStore = vi.mocked(
+        await import('@/stores/workflows/subblock/store')
+      ).useSubBlockStore
+
+      // Set up the mock to return the example schema from the user
+      const responseFormatValue = JSON.stringify({
+        name: 'short_schema',
+        description: 'A minimal example schema with a single string property.',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: {
+            example_property: {
+              type: 'string',
+              description: 'A simple string property.',
+            },
+          },
+          additionalProperties: false,
+          required: ['example_property'],
+        },
+      })
+
+      mockGetValue.mockImplementation((blockId: string, subBlockId: string) => {
+        if (blockId === 'agent1' && subBlockId === 'responseFormat') {
+          return responseFormatValue
+        }
+        return null
+      })
+
+      mockUseSubBlockStore.mockReturnValue({
+        getValue: mockGetValue,
+        getState: () => ({
+          getValue: mockGetValue,
+        }),
+      } as any)
+
+      // Test the parseResponseFormatSafely function
+      const { parseResponseFormatSafely } = await import('./tag-dropdown')
+      const parsedFormat = parseResponseFormatSafely(responseFormatValue, 'agent1')
+
+      expect(parsedFormat).toEqual({
+        name: 'short_schema',
+        description: 'A minimal example schema with a single string property.',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: {
+            example_property: {
+              type: 'string',
+              description: 'A simple string property.',
+            },
+          },
+          additionalProperties: false,
+          required: ['example_property'],
+        },
+      })
+
+      // Test the extractFieldsFromSchema function with the parsed format
+      const { extractFieldsFromSchema } = await import('./tag-dropdown')
+      const fields = extractFieldsFromSchema(parsedFormat)
+
+      expect(fields).toEqual([
+        {
+          name: 'example_property',
+          type: 'string',
+          description: 'A simple string property.',
+        },
+      ])
+    }
+  )
+
+  it.concurrent(
+    'should fallback to default outputs when response format parsing fails',
+    async () => {
+      const { parseResponseFormatSafely } = await import('./tag-dropdown')
+
+      // Test with invalid JSON
+      const invalidFormat = parseResponseFormatSafely('invalid json', 'agent1')
+      expect(invalidFormat).toBeNull()
+
+      // Test with null/undefined values
+      expect(parseResponseFormatSafely(null, 'agent1')).toBeNull()
+      expect(parseResponseFormatSafely(undefined, 'agent1')).toBeNull()
+      expect(parseResponseFormatSafely('', 'agent1')).toBeNull()
+    }
+  )
+
+  it.concurrent('should handle response format with nested schema correctly', async () => {
+    const responseFormat = {
+      schema: {
+        type: 'object',
+        properties: {
+          user: {
+            type: 'object',
+            description: 'User information',
+            properties: {
+              name: { type: 'string', description: 'User name' },
+              age: { type: 'number', description: 'User age' },
+            },
+          },
+          status: { type: 'string', description: 'Response status' },
+        },
+      },
+    }
+
+    const { extractFieldsFromSchema } = await import('./tag-dropdown')
+    const fields = extractFieldsFromSchema(responseFormat)
+
+    expect(fields).toEqual([
+      { name: 'user', type: 'object', description: 'User information' },
+      { name: 'status', type: 'string', description: 'Response status' },
+    ])
+  })
+
+  it.concurrent('should handle response format without schema wrapper', async () => {
+    const responseFormat = {
+      type: 'object',
+      properties: {
+        result: { type: 'boolean', description: 'Operation result' },
+        message: { type: 'string', description: 'Status message' },
+      },
+    }
+
+    const { extractFieldsFromSchema } = await import('./tag-dropdown')
+    const fields = extractFieldsFromSchema(responseFormat)
+
+    expect(fields).toEqual([
+      { name: 'result', type: 'boolean', description: 'Operation result' },
+      { name: 'message', type: 'string', description: 'Status message' },
+    ])
+  })
+
+  it.concurrent('should return object as-is when it is already parsed', async () => {
+    const responseFormat = {
+      name: 'test_schema',
+      schema: {
+        properties: {
+          data: { type: 'string' },
+        },
+      },
+    }
+
+    const { parseResponseFormatSafely } = await import('./tag-dropdown')
+    const result = parseResponseFormatSafely(responseFormat, 'agent1')
+
+    expect(result).toEqual(responseFormat)
+  })
+
+  it.concurrent('should simulate block tag generation with custom response format', async () => {
+    // Simulate the tag generation logic that would happen in the component
+    const blockName = 'Agent 1'
+    const normalizedBlockName = blockName.replace(/\s+/g, '').toLowerCase() // 'agent1'
+
+    // Mock response format
+    const responseFormat = {
+      schema: {
+        properties: {
+          example_property: { type: 'string', description: 'A simple string property.' },
+          another_field: { type: 'number', description: 'Another field.' },
+        },
+      },
+    }
+
+    const { extractFieldsFromSchema } = await import('./tag-dropdown')
+    const schemaFields = extractFieldsFromSchema(responseFormat)
+
+    // Generate block tags as they would be in the component
+    const blockTags = schemaFields.map((field) => `${normalizedBlockName}.${field.name}`)
+
+    expect(blockTags).toEqual(['agent1.example_property', 'agent1.another_field'])
+
+    // Verify the fields extracted correctly
+    expect(schemaFields).toEqual([
+      { name: 'example_property', type: 'string', description: 'A simple string property.' },
+      { name: 'another_field', type: 'number', description: 'Another field.' },
+    ])
   })
 })

--- a/apps/sim/components/ui/tag-dropdown.tsx
+++ b/apps/sim/components/ui/tag-dropdown.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { BlockPathCalculator } from '@/lib/block-path-calculator'
-import { createLogger } from '@/lib/logs/console-logger'
+import { extractFieldsFromSchema, parseResponseFormatSafely } from '@/lib/response-format'
 import { cn } from '@/lib/utils'
 import { getBlock } from '@/blocks'
 import { Serializer } from '@/serializer'
@@ -11,75 +11,12 @@ import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
-const logger = createLogger('TagDropdown')
-
-// Type definitions for component data structures
 interface BlockTagGroup {
   blockName: string
   blockId: string
   blockType: string
   tags: string[]
   distance: number
-}
-
-interface Field {
-  name: string
-  type: string
-  description?: string
-}
-
-// Helper function to extract fields from JSON Schema
-export function extractFieldsFromSchema(schema: any): Field[] {
-  if (!schema || typeof schema !== 'object') {
-    return []
-  }
-
-  // Handle legacy format with fields array
-  if (Array.isArray(schema.fields)) {
-    return schema.fields
-  }
-
-  // Handle new JSON Schema format
-  const schemaObj = schema.schema || schema
-  if (!schemaObj || !schemaObj.properties || typeof schemaObj.properties !== 'object') {
-    return []
-  }
-
-  // Extract fields from schema properties
-  return Object.entries(schemaObj.properties).map(([name, prop]: [string, any]) => {
-    // Handle array format like ['string', 'array']
-    if (Array.isArray(prop)) {
-      return {
-        name,
-        type: prop.includes('array') ? 'array' : prop[0] || 'string',
-        description: undefined,
-      }
-    }
-
-    // Handle object format like { type: 'string', description: '...' }
-    return {
-      name,
-      type: prop.type || 'string',
-      description: prop.description,
-    }
-  })
-}
-
-// Helper function to safely parse response format
-export function parseResponseFormatSafely(responseFormatValue: any, blockId: string): any {
-  if (!responseFormatValue) {
-    return null
-  }
-
-  try {
-    if (typeof responseFormatValue === 'string') {
-      return JSON.parse(responseFormatValue)
-    }
-    return responseFormatValue
-  } catch (error) {
-    logger.warn(`Failed to parse response format for block ${blockId}:`, error)
-    return null
-  }
 }
 
 interface TagDropdownProps {
@@ -377,7 +314,7 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
     )
     let containingParallelBlockId: string | null = null
     if (containingParallel) {
-      const [parallelId, parallel] = containingParallel
+      const [parallelId] = containingParallel
       containingParallelBlockId = parallelId
       const contextualTags: string[] = ['index', 'currentItem', 'items']
 

--- a/apps/sim/executor/types.ts
+++ b/apps/sim/executor/types.ts
@@ -269,3 +269,15 @@ export interface Tool<P = any, O = Record<string, any>> {
 export interface ToolRegistry {
   [key: string]: Tool
 }
+
+/**
+ * Interface for a stream processor that can process a stream based on a response format.
+ */
+export interface ResponseFormatStreamProcessor {
+  processStream(
+    originalStream: ReadableStream,
+    blockId: string,
+    selectedOutputIds: string[],
+    responseFormat?: any
+  ): ReadableStream
+}

--- a/apps/sim/executor/utils.test.ts
+++ b/apps/sim/executor/utils.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { StreamingResponseFormatProcessor, streamingResponseFormatProcessor } from './utils'
+
+vi.mock('@/lib/logs/console-logger', () => ({
+  createLogger: vi.fn().mockReturnValue({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+describe('StreamingResponseFormatProcessor', () => {
+  let processor: StreamingResponseFormatProcessor
+
+  beforeEach(() => {
+    processor = new StreamingResponseFormatProcessor()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('processStream', () => {
+    it.concurrent('should return original stream when no response format selection', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"content": "test"}'))
+          controller.close()
+        },
+      })
+
+      const result = processor.processStream(
+        mockStream,
+        'block-1',
+        ['block-1.content'], // No underscore, not response format
+        { schema: { properties: { username: { type: 'string' } } } }
+      )
+
+      expect(result).toBe(mockStream)
+    })
+
+    it.concurrent('should return original stream when no response format provided', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"content": "test"}'))
+          controller.close()
+        },
+      })
+
+      const result = processor.processStream(
+        mockStream,
+        'block-1',
+        ['block-1_username'], // Has underscore but no response format
+        undefined
+      )
+
+      expect(result).toBe(mockStream)
+    })
+
+    it.concurrent('should process stream and extract single selected field', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"username": "alice", "age": 25}'))
+          controller.close()
+        },
+      })
+
+      const processedStream = processor.processStream(mockStream, 'block-1', ['block-1_username'], {
+        schema: { properties: { username: { type: 'string' }, age: { type: 'number' } } },
+      })
+
+      const reader = processedStream.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value)
+      }
+
+      expect(result).toBe('alice')
+    })
+
+    it.concurrent('should process stream and extract multiple selected fields', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode('{"username": "bob", "age": 30, "email": "bob@test.com"}')
+          )
+          controller.close()
+        },
+      })
+
+      const processedStream = processor.processStream(
+        mockStream,
+        'block-1',
+        ['block-1_username', 'block-1_age'],
+        { schema: { properties: { username: { type: 'string' }, age: { type: 'number' } } } }
+      )
+
+      const reader = processedStream.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value)
+      }
+
+      expect(result).toBe('bob\n30')
+    })
+
+    it.concurrent('should handle non-string field values by JSON stringifying them', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              '{"config": {"theme": "dark", "notifications": true}, "count": 42}'
+            )
+          )
+          controller.close()
+        },
+      })
+
+      const processedStream = processor.processStream(
+        mockStream,
+        'block-1',
+        ['block-1_config', 'block-1_count'],
+        { schema: { properties: { config: { type: 'object' }, count: { type: 'number' } } } }
+      )
+
+      const reader = processedStream.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value)
+      }
+
+      expect(result).toBe('{"theme":"dark","notifications":true}\n42')
+    })
+
+    it.concurrent('should handle streaming JSON that comes in chunks', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          // Simulate streaming JSON in chunks
+          controller.enqueue(new TextEncoder().encode('{"username": "charlie"'))
+          controller.enqueue(new TextEncoder().encode(', "age": 35}'))
+          controller.close()
+        },
+      })
+
+      const processedStream = processor.processStream(mockStream, 'block-1', ['block-1_username'], {
+        schema: { properties: { username: { type: 'string' }, age: { type: 'number' } } },
+      })
+
+      const reader = processedStream.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value)
+      }
+
+      expect(result).toBe('charlie')
+    })
+
+    it.concurrent('should handle missing fields gracefully', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"username": "diana"}'))
+          controller.close()
+        },
+      })
+
+      const processedStream = processor.processStream(
+        mockStream,
+        'block-1',
+        ['block-1_username', 'block-1_missing_field'],
+        { schema: { properties: { username: { type: 'string' } } } }
+      )
+
+      const reader = processedStream.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value)
+      }
+
+      expect(result).toBe('diana')
+    })
+
+    it.concurrent('should handle invalid JSON gracefully', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('invalid json'))
+          controller.close()
+        },
+      })
+
+      const processedStream = processor.processStream(mockStream, 'block-1', ['block-1_username'], {
+        schema: { properties: { username: { type: 'string' } } },
+      })
+
+      const reader = processedStream.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value)
+      }
+
+      expect(result).toBe('')
+    })
+
+    it.concurrent('should filter selected fields for correct block ID', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"username": "eve", "age": 28}'))
+          controller.close()
+        },
+      })
+
+      const processedStream = processor.processStream(
+        mockStream,
+        'block-1',
+        ['block-1_username', 'block-2_age'], // Different block ID should be filtered out
+        { schema: { properties: { username: { type: 'string' }, age: { type: 'number' } } } }
+      )
+
+      const reader = processedStream.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value)
+      }
+
+      expect(result).toBe('eve')
+    })
+
+    it.concurrent('should handle empty result when no matching fields', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"other_field": "value"}'))
+          controller.close()
+        },
+      })
+
+      const processedStream = processor.processStream(mockStream, 'block-1', ['block-1_username'], {
+        schema: { properties: { username: { type: 'string' } } },
+      })
+
+      const reader = processedStream.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value)
+      }
+
+      expect(result).toBe('')
+    })
+  })
+
+  describe('singleton instance', () => {
+    it.concurrent('should export a singleton instance', () => {
+      expect(streamingResponseFormatProcessor).toBeInstanceOf(StreamingResponseFormatProcessor)
+    })
+
+    it.concurrent('should return the same instance on multiple imports', () => {
+      const instance1 = streamingResponseFormatProcessor
+      const instance2 = streamingResponseFormatProcessor
+      expect(instance1).toBe(instance2)
+    })
+  })
+
+  describe('edge cases', () => {
+    it.concurrent('should handle empty stream', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.close()
+        },
+      })
+
+      const processedStream = processor.processStream(mockStream, 'block-1', ['block-1_username'], {
+        schema: { properties: { username: { type: 'string' } } },
+      })
+
+      const reader = processedStream.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value)
+      }
+
+      expect(result).toBe('')
+    })
+
+    it.concurrent('should handle very large JSON objects', async () => {
+      const largeObject = {
+        username: 'frank',
+        data: 'x'.repeat(10000), // Large string
+        nested: {
+          deep: {
+            value: 'test',
+          },
+        },
+      }
+
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(JSON.stringify(largeObject)))
+          controller.close()
+        },
+      })
+
+      const processedStream = processor.processStream(mockStream, 'block-1', ['block-1_username'], {
+        schema: { properties: { username: { type: 'string' } } },
+      })
+
+      const reader = processedStream.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value)
+      }
+
+      expect(result).toBe('frank')
+    })
+  })
+})

--- a/apps/sim/executor/utils.ts
+++ b/apps/sim/executor/utils.ts
@@ -1,0 +1,201 @@
+import { createLogger } from '@/lib/logs/console-logger'
+import type { ResponseFormatStreamProcessor } from './types'
+
+const logger = createLogger('ExecutorUtils')
+
+/**
+ * Processes a streaming response to extract only the selected response format fields
+ * instead of streaming the full JSON wrapper.
+ */
+export class StreamingResponseFormatProcessor implements ResponseFormatStreamProcessor {
+  processStream(
+    originalStream: ReadableStream,
+    blockId: string,
+    selectedOutputIds: string[],
+    responseFormat?: any
+  ): ReadableStream {
+    // Check if this block has response format selected outputs
+    const hasResponseFormatSelection = selectedOutputIds.some((outputId) => {
+      const blockIdForOutput = outputId.includes('_')
+        ? outputId.split('_')[0]
+        : outputId.split('.')[0]
+      return blockIdForOutput === blockId && outputId.includes('_')
+    })
+
+    // If no response format selection, return original stream unchanged
+    if (!hasResponseFormatSelection || !responseFormat) {
+      return originalStream
+    }
+
+    // Get the selected field names for this block
+    const selectedFields = selectedOutputIds
+      .filter((outputId) => {
+        const blockIdForOutput = outputId.includes('_')
+          ? outputId.split('_')[0]
+          : outputId.split('.')[0]
+        return blockIdForOutput === blockId && outputId.includes('_')
+      })
+      .map((outputId) => outputId.substring(blockId.length + 1))
+
+    logger.info('Processing streaming response format', {
+      blockId,
+      selectedFields,
+      hasResponseFormat: !!responseFormat,
+      selectedFieldsCount: selectedFields.length,
+    })
+
+    return this.createProcessedStream(originalStream, selectedFields, blockId)
+  }
+
+  private createProcessedStream(
+    originalStream: ReadableStream,
+    selectedFields: string[],
+    blockId: string
+  ): ReadableStream {
+    let buffer = ''
+    let hasProcessedComplete = false // Track if we've already processed the complete JSON
+
+    const self = this
+
+    return new ReadableStream({
+      async start(controller) {
+        const reader = originalStream.getReader()
+        const decoder = new TextDecoder()
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read()
+
+            if (done) {
+              // Handle any remaining buffer at the end only if we haven't processed complete JSON yet
+              if (buffer.trim() && !hasProcessedComplete) {
+                self.processCompleteJson(buffer, selectedFields, controller)
+              }
+              controller.close()
+              break
+            }
+
+            const chunk = decoder.decode(value, { stream: true })
+            buffer += chunk
+
+            // Try to process the current buffer only if we haven't processed complete JSON yet
+            if (!hasProcessedComplete) {
+              const processedChunk = self.processStreamingChunk(buffer, selectedFields)
+
+              if (processedChunk) {
+                controller.enqueue(new TextEncoder().encode(processedChunk))
+                hasProcessedComplete = true // Mark as processed to prevent duplicate processing
+              }
+            }
+          }
+        } catch (error) {
+          logger.error('Error processing streaming response format:', { error, blockId })
+          controller.error(error)
+        } finally {
+          reader.releaseLock()
+        }
+      },
+    })
+  }
+
+  private processStreamingChunk(buffer: string, selectedFields: string[]): string | null {
+    // For streaming response format, we need to parse the JSON as it comes in
+    // and extract only the field values we care about
+
+    // Try to parse as complete JSON first
+    try {
+      const parsed = JSON.parse(buffer.trim())
+      if (typeof parsed === 'object' && parsed !== null) {
+        // We have a complete JSON object, extract the selected fields
+        // Process all selected fields and format them properly
+        const results: string[] = []
+        for (const field of selectedFields) {
+          if (field in parsed) {
+            const value = parsed[field]
+            const formattedValue = typeof value === 'string' ? value : JSON.stringify(value)
+            results.push(formattedValue)
+          }
+        }
+
+        if (results.length > 0) {
+          // Join multiple fields with newlines for readability
+          const result = results.join('\n')
+          return result
+        }
+
+        return null
+      }
+    } catch (e) {
+      // Not complete JSON yet, continue buffering
+    }
+
+    // For real-time extraction during streaming, we'd need more sophisticated parsing
+    // For now, let's handle the case where we receive chunks that might be partial JSON
+
+    // Simple heuristic: if buffer contains what looks like a complete JSON object
+    const openBraces = (buffer.match(/\{/g) || []).length
+    const closeBraces = (buffer.match(/\}/g) || []).length
+
+    if (openBraces > 0 && openBraces === closeBraces) {
+      // Likely a complete JSON object
+      try {
+        const parsed = JSON.parse(buffer.trim())
+        if (typeof parsed === 'object' && parsed !== null) {
+          // Process all selected fields and format them properly
+          const results: string[] = []
+          for (const field of selectedFields) {
+            if (field in parsed) {
+              const value = parsed[field]
+              const formattedValue = typeof value === 'string' ? value : JSON.stringify(value)
+              results.push(formattedValue)
+            }
+          }
+
+          if (results.length > 0) {
+            // Join multiple fields with newlines for readability
+            const result = results.join('\n')
+            return result
+          }
+
+          return null
+        }
+      } catch (e) {
+        // Still not valid JSON, continue
+      }
+    }
+
+    return null
+  }
+
+  private processCompleteJson(
+    buffer: string,
+    selectedFields: string[],
+    controller: ReadableStreamDefaultController
+  ): void {
+    try {
+      const parsed = JSON.parse(buffer.trim())
+      if (typeof parsed === 'object' && parsed !== null) {
+        // Process all selected fields and format them properly
+        const results: string[] = []
+        for (const field of selectedFields) {
+          if (field in parsed) {
+            const value = parsed[field]
+            const formattedValue = typeof value === 'string' ? value : JSON.stringify(value)
+            results.push(formattedValue)
+          }
+        }
+
+        if (results.length > 0) {
+          // Join multiple fields with newlines for readability
+          const result = results.join('\n')
+          controller.enqueue(new TextEncoder().encode(result))
+        }
+      }
+    } catch (error) {
+      logger.warn('Failed to parse complete JSON in streaming processor:', { error })
+    }
+  }
+}
+
+// Create singleton instance
+export const streamingResponseFormatProcessor = new StreamingResponseFormatProcessor()

--- a/apps/sim/lib/response-format.ts
+++ b/apps/sim/lib/response-format.ts
@@ -1,0 +1,156 @@
+import { createLogger } from '@/lib/logs/console-logger'
+
+const logger = createLogger('ResponseFormatUtils')
+
+// Type definitions for component data structures
+export interface Field {
+  name: string
+  type: string
+  description?: string
+}
+
+/**
+ * Helper function to extract fields from JSON Schema
+ * Handles both legacy format with fields array and new JSON Schema format
+ */
+export function extractFieldsFromSchema(schema: any): Field[] {
+  if (!schema || typeof schema !== 'object') {
+    return []
+  }
+
+  // Handle legacy format with fields array
+  if (Array.isArray(schema.fields)) {
+    return schema.fields
+  }
+
+  // Handle new JSON Schema format
+  const schemaObj = schema.schema || schema
+  if (!schemaObj || !schemaObj.properties || typeof schemaObj.properties !== 'object') {
+    return []
+  }
+
+  // Extract fields from schema properties
+  return Object.entries(schemaObj.properties).map(([name, prop]: [string, any]) => {
+    // Handle array format like ['string', 'array']
+    if (Array.isArray(prop)) {
+      return {
+        name,
+        type: prop.includes('array') ? 'array' : prop[0] || 'string',
+        description: undefined,
+      }
+    }
+
+    // Handle object format like { type: 'string', description: '...' }
+    return {
+      name,
+      type: prop.type || 'string',
+      description: prop.description,
+    }
+  })
+}
+
+/**
+ * Helper function to safely parse response format
+ * Handles both string and object formats
+ */
+export function parseResponseFormatSafely(responseFormatValue: any, blockId: string): any {
+  if (!responseFormatValue) {
+    return null
+  }
+
+  try {
+    if (typeof responseFormatValue === 'string') {
+      return JSON.parse(responseFormatValue)
+    }
+    return responseFormatValue
+  } catch (error) {
+    logger.warn(`Failed to parse response format for block ${blockId}:`, error)
+    return null
+  }
+}
+
+/**
+ * Extract field values from a parsed JSON object based on selected output paths
+ * Used for both workspace and chat client field extraction
+ */
+export function extractFieldValues(
+  parsedContent: any,
+  selectedOutputIds: string[],
+  blockId: string
+): Record<string, any> {
+  const extractedValues: Record<string, any> = {}
+
+  for (const outputId of selectedOutputIds) {
+    // Extract block ID and path using the same logic as workspace
+    const blockIdForOutput = outputId.includes('_')
+      ? outputId.split('_')[0]
+      : outputId.split('.')[0]
+
+    if (blockIdForOutput !== blockId) {
+      continue
+    }
+
+    const path = outputId.substring(blockIdForOutput.length + 1)
+
+    if (path) {
+      const pathParts = path.split('.')
+      let current = parsedContent
+
+      for (const part of pathParts) {
+        if (current && typeof current === 'object' && part in current) {
+          current = current[part]
+        } else {
+          current = undefined
+          break
+        }
+      }
+
+      if (current !== undefined) {
+        extractedValues[path] = current
+      }
+    }
+  }
+
+  return extractedValues
+}
+
+/**
+ * Format extracted field values for display
+ * Returns formatted string representation of field values
+ */
+export function formatFieldValues(extractedValues: Record<string, any>): string {
+  const formattedValues: string[] = []
+
+  for (const [fieldName, value] of Object.entries(extractedValues)) {
+    const formattedValue = typeof value === 'string' ? value : JSON.stringify(value)
+    formattedValues.push(formattedValue)
+  }
+
+  return formattedValues.join('\n')
+}
+
+/**
+ * Check if a set of output IDs contains response format selections for a specific block
+ */
+export function hasResponseFormatSelection(selectedOutputIds: string[], blockId: string): boolean {
+  return selectedOutputIds.some((outputId) => {
+    const blockIdForOutput = outputId.includes('_')
+      ? outputId.split('_')[0]
+      : outputId.split('.')[0]
+    return blockIdForOutput === blockId && outputId.includes('_')
+  })
+}
+
+/**
+ * Get selected field names for a specific block from output IDs
+ */
+export function getSelectedFieldNames(selectedOutputIds: string[], blockId: string): string[] {
+  return selectedOutputIds
+    .filter((outputId) => {
+      const blockIdForOutput = outputId.includes('_')
+        ? outputId.split('_')[0]
+        : outputId.split('.')[0]
+      return blockIdForOutput === blockId && outputId.includes('_')
+    })
+    .map((outputId) => outputId.substring(blockId.length + 1))
+}

--- a/apps/sim/lib/tokenization/streaming.ts
+++ b/apps/sim/lib/tokenization/streaming.ts
@@ -78,7 +78,7 @@ export function processStreamingBlockLog(log: BlockLog, streamedContent: string)
     log.output.cost = result.cost
     log.output.model = result.model
 
-    logTokenizationDetails(`✅ Streaming tokenization completed for ${log.blockType}`, {
+    logTokenizationDetails(`Streaming tokenization completed for ${log.blockType}`, {
       blockId: log.blockId,
       blockType: log.blockType,
       model: result.model,
@@ -92,7 +92,7 @@ export function processStreamingBlockLog(log: BlockLog, streamedContent: string)
 
     return true
   } catch (error) {
-    logger.error(`❌ Streaming tokenization failed for block ${log.blockId}`, {
+    logger.error(`Streaming tokenization failed for block ${log.blockId}`, {
       blockType: log.blockType,
       error: error instanceof Error ? error.message : String(error),
       contentLength: streamedContent?.length || 0,

--- a/apps/sim/stores/panel/console/store.ts
+++ b/apps/sim/stores/panel/console/store.ts
@@ -193,7 +193,10 @@ export const useConsoleStore = create<ConsoleStore>()(
                   updatedEntry.output = newOutput
                 }
 
-                if (update.output !== undefined) {
+                if (update.replaceOutput !== undefined) {
+                  // Complete replacement of output
+                  updatedEntry.output = update.replaceOutput
+                } else if (update.output !== undefined) {
                   const existingOutput = entry.output || {}
                   updatedEntry.output = {
                     ...existingOutput,

--- a/apps/sim/stores/panel/console/types.ts
+++ b/apps/sim/stores/panel/console/types.ts
@@ -20,6 +20,7 @@ export interface ConsoleEntry {
 export interface ConsoleUpdate {
   content?: string
   output?: Partial<NormalizedBlockOutput>
+  replaceOutput?: NormalizedBlockOutput // New field for complete replacement
   error?: string
   warning?: string
   success?: boolean


### PR DESCRIPTION
- **add response format structure to tag dropdown**
- **handle response format outputs for chat client and chat panel, implemented the response format handling for streamed responses**

## Description

Previously, we did not reflect the response format in the tag dropdown, chat panel output selector, and chat client output selector. This was due to the fundamental reason that we we did not have the setup to support structured output + streaming, but now we do. And it reflects properly in the console logs and the logs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually, added testing.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes


https://github.com/user-attachments/assets/07083d4a-c0ca-4dff-8d17-688b3b464e5c

