### PR TITLE
fix(sockets): added debouncing for sub-block values to prevent overloading socket server, fixed persistence issue during streaming back from LLM response format, removed unused events

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
@@ -73,8 +73,21 @@ export function Code({
     }
   }, [generationType])
 
-  // State management
-  const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlockId)
+  const [storeValue, setStoreValue, { isStreaming }] = useSubBlockValue(
+    blockId,
+    subBlockId,
+    false,
+    {
+      debounceMs: 150,
+      onStreamingStart: () => {
+        logger.debug('Streaming started for code editing', { blockId, subBlockId })
+      },
+      onStreamingEnd: () => {
+        logger.debug('Streaming ended for code editing', { blockId, subBlockId })
+      },
+    }
+  )
+
   const [code, setCode] = useState<string>('')
   const [_lineCount, setLineCount] = useState(1)
   const [showTags, setShowTags] = useState(false)
@@ -104,8 +117,7 @@ export function Code({
   // AI Code Generation Hook
   const handleStreamStart = () => {
     setCode('')
-    // Optionally clear the store value too, though handleStreamChunk will update it
-    // setStoreValue('')
+    // No need to manually manage streaming - it's automatic now
   }
 
   const handleGeneratedContent = (generatedCode: string) => {
@@ -120,6 +132,7 @@ export function Code({
     setCode((currentCode) => {
       const newCode = currentCode + chunk
       if (!isPreview && !disabled) {
+        // Just update the value - streaming detection is automatic
         setStoreValue(newCode)
       }
       return newCode

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/response/response-format.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/response/response-format.tsx
@@ -50,14 +50,9 @@ export function ResponseFormat({
   isPreview = false,
   previewValue,
 }: ResponseFormatProps) {
+  // useSubBlockValue now includes debouncing by default
   const [storeValue, setStoreValue] = useSubBlockValue<JSONProperty[]>(blockId, subBlockId, false, {
     debounceMs: 200, // Slightly longer debounce for complex structures
-    onStreamingStart: () => {
-      console.debug('Starting bulk property operation', { blockId, subBlockId })
-    },
-    onStreamingEnd: () => {
-      console.debug('Ending bulk property operation', { blockId, subBlockId })
-    },
   })
 
   const [showPreview, setShowPreview] = useState(false)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/response/response-format.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/response/response-format.tsx
@@ -50,7 +50,16 @@ export function ResponseFormat({
   isPreview = false,
   previewValue,
 }: ResponseFormatProps) {
-  const [storeValue, setStoreValue] = useSubBlockValue<JSONProperty[]>(blockId, subBlockId)
+  const [storeValue, setStoreValue] = useSubBlockValue<JSONProperty[]>(blockId, subBlockId, false, {
+    debounceMs: 200, // Slightly longer debounce for complex structures
+    onStreamingStart: () => {
+      console.debug('Starting bulk property operation', { blockId, subBlockId })
+    },
+    onStreamingEnd: () => {
+      console.debug('Ending bulk property operation', { blockId, subBlockId })
+    },
+  })
+
   const [showPreview, setShowPreview] = useState(false)
 
   const value = isPreview ? previewValue : storeValue

--- a/apps/sim/socket-server/handlers/connection.ts
+++ b/apps/sim/socket-server/handlers/connection.ts
@@ -28,7 +28,5 @@ export function setupConnectionHandlers(
       roomManager.cleanupUserFromRoom(socket.id, workflowId)
       roomManager.broadcastPresenceUpdate(workflowId)
     }
-
-    roomManager.clearPendingOperations(socket.id)
   })
 }

--- a/apps/sim/socket-server/rooms/manager.ts
+++ b/apps/sim/socket-server/rooms/manager.ts
@@ -75,11 +75,6 @@ export class RoomManager {
     this.userSessions.delete(socketId)
   }
 
-  // This would be used if we implement operation queuing
-  clearPendingOperations(socketId: string) {
-    logger.debug(`Cleared pending operations for socket ${socketId}`)
-  }
-
   handleWorkflowDeletion(workflowId: string) {
     logger.info(`Handling workflow deletion notification for ${workflowId}`)
 


### PR DESCRIPTION
## Description

Added debouncing for sub-block values to prevent overloading socket server, fixed persistence issue during streaming back from LLM response format, removed unused events

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## How Has This Been Tested?

Tested manually to ensure response format streaming was a single event once the LLM was done streaming, large pastes and large deletes are also single events, and that this doesn't disrupt the user experience.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
