### PR TITLE
fix(docs): fixed docs script to reflect the new output format for all blocks

### DIFF
--- a/apps/docs/content/docs/blocks/function.mdx
+++ b/apps/docs/content/docs/blocks/function.mdx
@@ -88,9 +88,8 @@ For security and performance reasons, function execution has certain limitations
 
 ### Outputs
 
-- **Result**: The value returned by your function
-- **Standard Output**: Any console output from your function
-- **Execution Time**: The time taken to execute your function (in milliseconds)
+- **result**: The value returned by your function
+- **stdout**: Any console output from your function
 
 ## Example Usage
 

--- a/apps/docs/content/docs/blocks/response.mdx
+++ b/apps/docs/content/docs/blocks/response.mdx
@@ -115,14 +115,9 @@ Headers are configured as key-value pairs:
   </Tab>
   <Tab>
     <ul className="list-disc space-y-2 pl-6">
-      <li>
-        <strong>response</strong>: Complete response object containing:
-        <ul className="list-disc space-y-1 pl-6 mt-2">
-          <li><strong>data</strong>: The response body data</li>
-          <li><strong>status</strong>: HTTP status code</li>
-          <li><strong>headers</strong>: Response headers</li>
-        </ul>
-      </li>
+      <li><strong>data</strong>: The response body data</li>
+      <li><strong>status</strong>: HTTP status code</li>
+      <li><strong>headers</strong>: Response headers</li>
     </ul>
   </Tab>
 </Tabs>

--- a/apps/docs/content/docs/tools/airtable.mdx
+++ b/apps/docs/content/docs/tools/airtable.mdx
@@ -182,10 +182,9 @@ Update multiple existing records in an Airtable table
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `records` | json | records of the response |
-| ↳ `record` | json | record of the response |
-| ↳ `metadata` | json | metadata of the response |
+| `records` | json | records output from the block |
+| `record` | json | record output from the block |
+| `metadata` | json | metadata output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/autoblocks.mdx
+++ b/apps/docs/content/docs/tools/autoblocks.mdx
@@ -174,11 +174,10 @@ Manage and render prompts using Autoblocks prompt management system
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `promptId` | string | promptId of the response |
-| ↳ `version` | string | version of the response |
-| ↳ `renderedPrompt` | string | renderedPrompt of the response |
-| ↳ `templates` | json | templates of the response |
+| `promptId` | string | promptId output from the block |
+| `version` | string | version output from the block |
+| `renderedPrompt` | string | renderedPrompt output from the block |
+| `templates` | json | templates output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/browser_use.mdx
+++ b/apps/docs/content/docs/tools/browser_use.mdx
@@ -102,11 +102,10 @@ Runs a browser automation task using BrowserUse
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `id` | string | id of the response |
-| ↳ `success` | boolean | success of the response |
-| ↳ `output` | any | output of the response |
-| ↳ `steps` | json | steps of the response |
+| `id` | string | id output from the block |
+| `success` | boolean | success output from the block |
+| `output` | any | output output from the block |
+| `steps` | json | steps output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/clay.mdx
+++ b/apps/docs/content/docs/tools/clay.mdx
@@ -238,8 +238,7 @@ Populate Clay with data from a JSON file. Enables direct communication and notif
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `data` | any | data of the response |
+| `data` | any | data output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/confluence.mdx
+++ b/apps/docs/content/docs/tools/confluence.mdx
@@ -113,12 +113,11 @@ Update a Confluence page using the Confluence API.
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `ts` | string | ts of the response |
-| ↳ `pageId` | string | pageId of the response |
-| ↳ `content` | string | content of the response |
-| ↳ `title` | string | title of the response |
-| ↳ `success` | boolean | success of the response |
+| `ts` | string | ts output from the block |
+| `pageId` | string | pageId output from the block |
+| `content` | string | content output from the block |
+| `title` | string | title output from the block |
+| `success` | boolean | success output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/discord.mdx
+++ b/apps/docs/content/docs/tools/discord.mdx
@@ -150,9 +150,8 @@ Retrieve information about a Discord user
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `message` | string | message of the response |
-| ↳ `data` | any | data of the response |
+| `message` | string | message output from the block |
+| `data` | any | data output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/elevenlabs.mdx
+++ b/apps/docs/content/docs/tools/elevenlabs.mdx
@@ -80,8 +80,7 @@ Convert TTS using ElevenLabs voices
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `audioUrl` | string | audioUrl of the response |
+| `audioUrl` | string | audioUrl output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/exa.mdx
+++ b/apps/docs/content/docs/tools/exa.mdx
@@ -158,11 +158,10 @@ Get an AI-generated answer to a question with citations from the web using Exa A
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `results` | json | results of the response |
-| ↳ `similarLinks` | json | similarLinks of the response |
-| ↳ `answer` | string | answer of the response |
-| ↳ `citations` | json | citations of the response |
+| `results` | json | results output from the block |
+| `similarLinks` | json | similarLinks output from the block |
+| `answer` | string | answer output from the block |
+| `citations` | json | citations output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/file.mdx
+++ b/apps/docs/content/docs/tools/file.mdx
@@ -87,9 +87,8 @@ This tool does not produce any outputs.
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `files` | json | files of the response |
-| ↳ `combinedContent` | string | combinedContent of the response |
+| `files` | json | files output from the block |
+| `combinedContent` | string | combinedContent output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/firecrawl.mdx
+++ b/apps/docs/content/docs/tools/firecrawl.mdx
@@ -111,12 +111,11 @@ Search for information on the web using Firecrawl
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `markdown` | string | markdown of the response |
-| ↳ `html` | any | html of the response |
-| ↳ `metadata` | json | metadata of the response |
-| ↳ `data` | json | data of the response |
-| ↳ `warning` | any | warning of the response |
+| `markdown` | string | markdown output from the block |
+| `html` | any | html output from the block |
+| `metadata` | json | metadata output from the block |
+| `data` | json | data output from the block |
+| `warning` | any | warning output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/github.mdx
+++ b/apps/docs/content/docs/tools/github.mdx
@@ -174,9 +174,8 @@ Retrieve the latest commit from a GitHub repository
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `metadata` | json | metadata of the response |
+| `content` | string | content output from the block |
+| `metadata` | json | metadata output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/gmail.mdx
+++ b/apps/docs/content/docs/tools/gmail.mdx
@@ -130,9 +130,8 @@ No configuration parameters required.
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `metadata` | json | metadata of the response |
+| `content` | string | content output from the block |
+| `metadata` | json | metadata output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/google_calendar.mdx
+++ b/apps/docs/content/docs/tools/google_calendar.mdx
@@ -228,9 +228,8 @@ Invite attendees to an existing Google Calendar event
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `metadata` | json | metadata of the response |
+| `content` | string | content output from the block |
+| `metadata` | json | metadata output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/google_docs.mdx
+++ b/apps/docs/content/docs/tools/google_docs.mdx
@@ -159,10 +159,9 @@ Create a new Google Docs document
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `metadata` | json | metadata of the response |
-| ↳ `updatedContent` | boolean | updatedContent of the response |
+| `content` | string | content output from the block |
+| `metadata` | json | metadata output from the block |
+| `updatedContent` | boolean | updatedContent output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/google_drive.mdx
+++ b/apps/docs/content/docs/tools/google_drive.mdx
@@ -177,9 +177,8 @@ List files and folders in Google Drive
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `file` | json | file of the response |
-| ↳ `files` | json | files of the response |
+| `file` | json | file output from the block |
+| `files` | json | files output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/google_search.mdx
+++ b/apps/docs/content/docs/tools/google_search.mdx
@@ -101,7 +101,11 @@ Search the web with the Custom Search API
 
 ### Outputs
 
-This block does not produce any outputs.
+| Output | Type | Description |
+| ------ | ---- | ----------- |
+| `items` | json | items output from the block |
+| `searchInformation` | json | searchInformation output from the block |
+
 
 ## Notes
 

--- a/apps/docs/content/docs/tools/google_sheets.mdx
+++ b/apps/docs/content/docs/tools/google_sheets.mdx
@@ -212,14 +212,13 @@ Append data to the end of a Google Sheets spreadsheet
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `data` | json | data of the response |
-| ↳ `metadata` | json | metadata of the response |
-| ↳ `updatedRange` | string | updatedRange of the response |
-| ↳ `updatedRows` | number | updatedRows of the response |
-| ↳ `updatedColumns` | number | updatedColumns of the response |
-| ↳ `updatedCells` | number | updatedCells of the response |
-| ↳ `tableRange` | string | tableRange of the response |
+| `data` | json | data output from the block |
+| `metadata` | json | metadata output from the block |
+| `updatedRange` | string | updatedRange output from the block |
+| `updatedRows` | number | updatedRows output from the block |
+| `updatedColumns` | number | updatedColumns output from the block |
+| `updatedCells` | number | updatedCells output from the block |
+| `tableRange` | string | tableRange output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/guesty.mdx
+++ b/apps/docs/content/docs/tools/guesty.mdx
@@ -107,15 +107,14 @@ Search for guests in Guesty by phone number
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `id` | string | id of the response |
-| ↳ `guest` | json | guest of the response |
-| ↳ `checkIn` | string | checkIn of the response |
-| ↳ `checkOut` | string | checkOut of the response |
-| ↳ `status` | string | status of the response |
-| ↳ `listing` | json | listing of the response |
-| ↳ `money` | json | money of the response |
-| ↳ `guests` | json | guests of the response |
+| `id` | string | id output from the block |
+| `guest` | json | guest output from the block |
+| `checkIn` | string | checkIn output from the block |
+| `checkOut` | string | checkOut output from the block |
+| `status` | string | status output from the block |
+| `listing` | json | listing output from the block |
+| `money` | json | money output from the block |
+| `guests` | json | guests output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/huggingface.mdx
+++ b/apps/docs/content/docs/tools/huggingface.mdx
@@ -115,10 +115,9 @@ Generate completions using Hugging Face Inference API
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `model` | string | model of the response |
-| ↳ `usage` | json | usage of the response |
+| `content` | string | content output from the block |
+| `model` | string | model output from the block |
+| `usage` | json | usage output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/image_generator.mdx
+++ b/apps/docs/content/docs/tools/image_generator.mdx
@@ -93,10 +93,9 @@ Generate images using OpenAI
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `image` | string | image of the response |
-| ↳ `metadata` | json | metadata of the response |
+| `content` | string | content output from the block |
+| `image` | string | image output from the block |
+| `metadata` | json | metadata output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/jina.mdx
+++ b/apps/docs/content/docs/tools/jina.mdx
@@ -101,8 +101,7 @@ Extract and process web content into clean, LLM-friendly text using Jina AI Read
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
+| `content` | string | content output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/jira.mdx
+++ b/apps/docs/content/docs/tools/jira.mdx
@@ -165,15 +165,14 @@ Retrieve multiple Jira issues in bulk
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `ts` | string | ts of the response |
-| ↳ `issueKey` | string | issueKey of the response |
-| ↳ `summary` | string | summary of the response |
-| ↳ `description` | string | description of the response |
-| ↳ `created` | string | created of the response |
-| ↳ `updated` | string | updated of the response |
-| ↳ `success` | boolean | success of the response |
-| ↳ `url` | string | url of the response |
+| `ts` | string | ts output from the block |
+| `issueKey` | string | issueKey output from the block |
+| `summary` | string | summary output from the block |
+| `description` | string | description output from the block |
+| `created` | string | created output from the block |
+| `updated` | string | updated output from the block |
+| `success` | boolean | success output from the block |
+| `url` | string | url output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/knowledge.mdx
+++ b/apps/docs/content/docs/tools/knowledge.mdx
@@ -66,6 +66,13 @@ Search for similar content in one or more knowledge bases using vector similarit
 | `knowledgeBaseIds` | string | Yes | ID of the knowledge base to search in, or comma-separated IDs for multiple knowledge bases |
 | `query` | string | Yes | Search query text |
 | `topK` | number | No | Number of most similar results to return \(1-100\) |
+| `tag1` | string | No | Filter by tag 1 value |
+| `tag2` | string | No | Filter by tag 2 value |
+| `tag3` | string | No | Filter by tag 3 value |
+| `tag4` | string | No | Filter by tag 4 value |
+| `tag5` | string | No | Filter by tag 5 value |
+| `tag6` | string | No | Filter by tag 6 value |
+| `tag7` | string | No | Filter by tag 7 value |
 
 #### Output
 
@@ -74,6 +81,7 @@ Search for similar content in one or more knowledge bases using vector similarit
 | `results` | string |
 | `query` | string |
 | `totalResults` | string |
+| `cost` | string |
 
 ### `knowledge_upload_chunk`
 
@@ -111,6 +119,13 @@ Create a new document in a knowledge base
 | `knowledgeBaseId` | string | Yes | ID of the knowledge base containing the document |
 | `name` | string | Yes | Name of the document |
 | `content` | string | Yes | Content of the document |
+| `tag1` | string | No | Tag 1 value for the document |
+| `tag2` | string | No | Tag 2 value for the document |
+| `tag3` | string | No | Tag 3 value for the document |
+| `tag4` | string | No | Tag 4 value for the document |
+| `tag5` | string | No | Tag 5 value for the document |
+| `tag6` | string | No | Tag 6 value for the document |
+| `tag7` | string | No | Tag 7 value for the document |
 
 #### Output
 
@@ -135,10 +150,9 @@ Create a new document in a knowledge base
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `results` | json | results of the response |
-| ↳ `query` | string | query of the response |
-| ↳ `totalResults` | number | totalResults of the response |
+| `results` | json | results output from the block |
+| `query` | string | query output from the block |
+| `totalResults` | number | totalResults output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/knowledge.mdx
+++ b/apps/docs/content/docs/tools/knowledge.mdx
@@ -81,7 +81,6 @@ Search for similar content in one or more knowledge bases using vector similarit
 | `results` | string |
 | `query` | string |
 | `totalResults` | string |
-| `cost` | string |
 
 ### `knowledge_upload_chunk`
 

--- a/apps/docs/content/docs/tools/linear.mdx
+++ b/apps/docs/content/docs/tools/linear.mdx
@@ -105,9 +105,8 @@ Create a new issue in Linear
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `issues` | json | issues of the response |
-| ↳ `issue` | json | issue of the response |
+| `issues` | json | issues output from the block |
+| `issue` | json | issue output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/linkup.mdx
+++ b/apps/docs/content/docs/tools/linkup.mdx
@@ -92,9 +92,8 @@ Search the web for information using Linkup
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `answer` | string | answer of the response |
-| ↳ `sources` | json | sources of the response |
+| `answer` | string | answer output from the block |
+| `sources` | json | sources output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/mem0.mdx
+++ b/apps/docs/content/docs/tools/mem0.mdx
@@ -126,10 +126,9 @@ Retrieve memories from Mem0 by ID or filter criteria
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `ids` | any | ids of the response |
-| ↳ `memories` | any | memories of the response |
-| ↳ `searchResults` | any | searchResults of the response |
+| `ids` | any | ids output from the block |
+| `memories` | any | memories output from the block |
+| `searchResults` | any | searchResults output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/memory.mdx
+++ b/apps/docs/content/docs/tools/memory.mdx
@@ -124,9 +124,8 @@ Delete a specific memory by its ID
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `memories` | any | memories of the response |
-| ↳ `id` | string | id of the response |
+| `memories` | any | memories output from the block |
+| `id` | string | id output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/microsoft_excel.mdx
+++ b/apps/docs/content/docs/tools/microsoft_excel.mdx
@@ -180,15 +180,14 @@ Add new rows to a Microsoft Excel table
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `data` | json | data of the response |
-| ↳ `metadata` | json | metadata of the response |
-| ↳ `updatedRange` | string | updatedRange of the response |
-| ↳ `updatedRows` | number | updatedRows of the response |
-| ↳ `updatedColumns` | number | updatedColumns of the response |
-| ↳ `updatedCells` | number | updatedCells of the response |
-| ↳ `index` | number | index of the response |
-| ↳ `values` | json | values of the response |
+| `data` | json | data output from the block |
+| `metadata` | json | metadata output from the block |
+| `updatedRange` | string | updatedRange output from the block |
+| `updatedRows` | number | updatedRows output from the block |
+| `updatedColumns` | number | updatedColumns output from the block |
+| `updatedCells` | number | updatedCells output from the block |
+| `index` | number | index output from the block |
+| `values` | json | values output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/microsoft_teams.mdx
+++ b/apps/docs/content/docs/tools/microsoft_teams.mdx
@@ -205,10 +205,9 @@ Write or send a message to a Microsoft Teams channel
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `metadata` | json | metadata of the response |
-| ↳ `updatedContent` | boolean | updatedContent of the response |
+| `content` | string | content output from the block |
+| `metadata` | json | metadata output from the block |
+| `updatedContent` | boolean | updatedContent output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/mistral_parse.mdx
+++ b/apps/docs/content/docs/tools/mistral_parse.mdx
@@ -122,9 +122,8 @@ This tool does not produce any outputs.
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `metadata` | json | metadata of the response |
+| `content` | string | content output from the block |
+| `metadata` | json | metadata output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/notion.mdx
+++ b/apps/docs/content/docs/tools/notion.mdx
@@ -117,9 +117,8 @@ Create a new page in Notion
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `metadata` | any | metadata of the response |
+| `content` | string | content output from the block |
+| `metadata` | any | metadata output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/openai.mdx
+++ b/apps/docs/content/docs/tools/openai.mdx
@@ -88,10 +88,9 @@ Generate embeddings from text using OpenAI
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `embeddings` | json | embeddings of the response |
-| ↳ `model` | string | model of the response |
-| ↳ `usage` | json | usage of the response |
+| `embeddings` | json | embeddings output from the block |
+| `model` | string | model output from the block |
+| `usage` | json | usage output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/outlook.mdx
+++ b/apps/docs/content/docs/tools/outlook.mdx
@@ -225,9 +225,8 @@ Read emails from Outlook
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `message` | string | message of the response |
-| ↳ `results` | json | results of the response |
+| `message` | string | message output from the block |
+| `results` | json | results output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/perplexity.mdx
+++ b/apps/docs/content/docs/tools/perplexity.mdx
@@ -83,10 +83,9 @@ Generate completions using Perplexity AI chat models
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `model` | string | model of the response |
-| ↳ `usage` | json | usage of the response |
+| `content` | string | content output from the block |
+| `model` | string | model output from the block |
+| `usage` | json | usage output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/pinecone.mdx
+++ b/apps/docs/content/docs/tools/pinecone.mdx
@@ -181,13 +181,12 @@ Fetch vectors by ID from a Pinecone index
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `matches` | any | matches of the response |
-| ↳ `upsertedCount` | any | upsertedCount of the response |
-| ↳ `data` | any | data of the response |
-| ↳ `model` | any | model of the response |
-| ↳ `vector_type` | any | vector_type of the response |
-| ↳ `usage` | any | usage of the response |
+| `matches` | any | matches output from the block |
+| `upsertedCount` | any | upsertedCount output from the block |
+| `data` | any | data output from the block |
+| `model` | any | model output from the block |
+| `vector_type` | any | vector_type output from the block |
+| `usage` | any | usage output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/reddit.mdx
+++ b/apps/docs/content/docs/tools/reddit.mdx
@@ -129,11 +129,10 @@ Fetch comments from a specific Reddit post
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `subreddit` | string | subreddit of the response |
-| ↳ `posts` | json | posts of the response |
-| ↳ `post` | json | post of the response |
-| ↳ `comments` | json | comments of the response |
+| `subreddit` | string | subreddit output from the block |
+| `posts` | json | posts output from the block |
+| `post` | json | post output from the block |
+| `comments` | json | comments output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/s3.mdx
+++ b/apps/docs/content/docs/tools/s3.mdx
@@ -89,9 +89,8 @@ Retrieve an object from an AWS S3 bucket
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `url` | string | url of the response |
-| ↳ `metadata` | json | metadata of the response |
+| `url` | string | url output from the block |
+| `metadata` | json | metadata output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/serper.mdx
+++ b/apps/docs/content/docs/tools/serper.mdx
@@ -121,8 +121,7 @@ A powerful web search tool that provides access to Google search results through
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `searchResults` | json | searchResults of the response |
+| `searchResults` | json | searchResults output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/slack.mdx
+++ b/apps/docs/content/docs/tools/slack.mdx
@@ -98,9 +98,8 @@ Send messages to Slack channels or users through the Slack API. Supports Slack m
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `ts` | string | ts of the response |
-| ↳ `channel` | string | channel of the response |
+| `ts` | string | ts output from the block |
+| `channel` | string | channel output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/stagehand.mdx
+++ b/apps/docs/content/docs/tools/stagehand.mdx
@@ -232,8 +232,7 @@ Extract structured data from a webpage using Stagehand
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `data` | json | data of the response |
+| `data` | json | data output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/stagehand_agent.mdx
+++ b/apps/docs/content/docs/tools/stagehand_agent.mdx
@@ -240,9 +240,8 @@ Run an autonomous web agent to complete tasks and extract structured data
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `agentResult` | json | agentResult of the response |
-| ↳ `structuredOutput` | any | structuredOutput of the response |
+| `agentResult` | json | agentResult output from the block |
+| `structuredOutput` | any | structuredOutput output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/supabase.mdx
+++ b/apps/docs/content/docs/tools/supabase.mdx
@@ -127,9 +127,8 @@ Insert data into a Supabase table
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `message` | string | message of the response |
-| ↳ `results` | json | results of the response |
+| `message` | string | message output from the block |
+| `results` | json | results output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/tavily.mdx
+++ b/apps/docs/content/docs/tools/tavily.mdx
@@ -121,13 +121,12 @@ Extract raw content from multiple web pages simultaneously using Tavily
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `results` | json | results of the response |
-| ↳ `answer` | any | answer of the response |
-| ↳ `query` | string | query of the response |
-| ↳ `content` | string | content of the response |
-| ↳ `title` | string | title of the response |
-| ↳ `url` | string | url of the response |
+| `results` | json | results output from the block |
+| `answer` | any | answer output from the block |
+| `query` | string | query output from the block |
+| `content` | string | content output from the block |
+| `title` | string | title output from the block |
+| `url` | string | url output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/telegram.mdx
+++ b/apps/docs/content/docs/tools/telegram.mdx
@@ -121,9 +121,8 @@ Send messages to Telegram channels or users through the Telegram Bot API. Enable
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `ok` | boolean | ok of the response |
-| ↳ `result` | json | result of the response |
+| `ok` | boolean | ok output from the block |
+| `result` | json | result output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/thinking.mdx
+++ b/apps/docs/content/docs/tools/thinking.mdx
@@ -87,8 +87,7 @@ Processes a provided thought/instruction, making it available for subsequent ste
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `acknowledgedThought` | string | acknowledgedThought of the response |
+| `acknowledgedThought` | string | acknowledgedThought output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/translate.mdx
+++ b/apps/docs/content/docs/tools/translate.mdx
@@ -95,10 +95,9 @@ This tool does not produce any outputs.
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `model` | string | model of the response |
-| ↳ `tokens` | any | tokens of the response |
+| `content` | string | content output from the block |
+| `model` | string | model output from the block |
+| `tokens` | any | tokens output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/twilio_sms.mdx
+++ b/apps/docs/content/docs/tools/twilio_sms.mdx
@@ -78,11 +78,10 @@ Send text messages to single or multiple recipients using the Twilio API.
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `success` | boolean | success of the response |
-| ↳ `messageId` | any | messageId of the response |
-| ↳ `status` | any | status of the response |
-| ↳ `error` | any | error of the response |
+| `success` | boolean | success output from the block |
+| `messageId` | any | messageId output from the block |
+| `status` | any | status output from the block |
+| `error` | any | error output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/typeform.mdx
+++ b/apps/docs/content/docs/tools/typeform.mdx
@@ -126,10 +126,9 @@ This tool does not produce any outputs.
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `total_items` | number | total_items of the response |
-| ↳ `page_count` | number | page_count of the response |
-| ↳ `items` | json | items of the response |
+| `total_items` | number | total_items output from the block |
+| `page_count` | number | page_count output from the block |
+| `items` | json | items output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/vision.mdx
+++ b/apps/docs/content/docs/tools/vision.mdx
@@ -90,10 +90,9 @@ Process and analyze images using advanced vision models. Capable of understandin
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `content` | string | content of the response |
-| ↳ `model` | any | model of the response |
-| ↳ `tokens` | any | tokens of the response |
+| `content` | string | content output from the block |
+| `model` | any | model output from the block |
+| `tokens` | any | tokens output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/whatsapp.mdx
+++ b/apps/docs/content/docs/tools/whatsapp.mdx
@@ -79,10 +79,9 @@ Send WhatsApp messages
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `success` | boolean | success of the response |
-| ↳ `messageId` | any | messageId of the response |
-| ↳ `error` | any | error of the response |
+| `success` | boolean | success output from the block |
+| `messageId` | any | messageId output from the block |
+| `error` | any | error output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/x.mdx
+++ b/apps/docs/content/docs/tools/x.mdx
@@ -145,15 +145,14 @@ Get user profile information
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `tweet` | json | tweet of the response |
-| ↳ `replies` | any | replies of the response |
-| ↳ `context` | any | context of the response |
-| ↳ `tweets` | json | tweets of the response |
-| ↳ `includes` | any | includes of the response |
-| ↳ `meta` | json | meta of the response |
-| ↳ `user` | json | user of the response |
-| ↳ `recentTweets` | any | recentTweets of the response |
+| `tweet` | json | tweet output from the block |
+| `replies` | any | replies output from the block |
+| `context` | any | context output from the block |
+| `tweets` | json | tweets output from the block |
+| `includes` | any | includes output from the block |
+| `meta` | json | meta output from the block |
+| `user` | json | user output from the block |
+| `recentTweets` | any | recentTweets output from the block |
 
 
 ## Notes

--- a/apps/docs/content/docs/tools/youtube.mdx
+++ b/apps/docs/content/docs/tools/youtube.mdx
@@ -82,9 +82,8 @@ Search for videos on YouTube using the YouTube Data API.
 
 | Output | Type | Description |
 | ------ | ---- | ----------- |
-| `response` | object | Output from response |
-| ↳ `items` | json | items of the response |
-| ↳ `totalResults` | number | totalResults of the response |
+| `items` | json | items output from the block |
+| `totalResults` | number | totalResults output from the block |
 
 
 ## Notes

--- a/scripts/generate-block-docs.ts
+++ b/scripts/generate-block-docs.ts
@@ -356,7 +356,30 @@ function extractOutputs(content: string): Record<string, any> {
     const outputsContent = outputsMatch[1].trim()
     const outputs: Record<string, any> = {}
 
-    // Try to extract fields from the outputs object
+    // First try to handle the new flat format: fieldName: 'type'
+    const flatFieldMatches = outputsContent.match(/(\w+)\s*:\s*['"]([^'"]+)['"]/g)
+
+    if (flatFieldMatches && flatFieldMatches.length > 0) {
+      flatFieldMatches.forEach((fieldMatch) => {
+        const fieldParts = fieldMatch.match(/(\w+)\s*:\s*['"]([^'"]+)['"]/)
+        if (fieldParts) {
+          const fieldName = fieldParts[1]
+          const fieldType = fieldParts[2]
+
+          outputs[fieldName] = {
+            type: fieldType,
+            description: `${fieldName} output from the block`,
+          }
+        }
+      })
+
+      // If we found flat fields, return them
+      if (Object.keys(outputs).length > 0) {
+        return outputs
+      }
+    }
+
+    // Fallback: Try to extract fields from the old nested format
     const fieldMatches = outputsContent.match(/(\w+)\s*:\s*{([^}]+)}/g)
 
     if (fieldMatches && fieldMatches.length > 0) {


### PR DESCRIPTION
- **fix(docs): fixed tool docs generator script to match new output structure from blocks**
- **updated outdated docs**

## Description

fixed docs script to reflect the new output format for all blocks, since we got rid of the `response` wrapper

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## How Has This Been Tested?

Ran the script and ensured that all outputs were not corrupted, but just reflected the new output structure

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes