### PR TITLE
fix(precommit-hook): fixed pre commit hook to use lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bun lint
+bunx lint-staged

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "biome check --files-ignore-unknown=true"
+      "biome check --write --files-ignore-unknown=true"
     ],
     "!.github/*.md": []
   }


### PR DESCRIPTION
## Description

Previously, when we committed it would re-stage files that got changed on commit. Now, we run lint-staged to ensure that biome only runs on staged files, we automatically stage any files that biome modiifes, and we complete the commit with all the changes included.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue

## How Has This Been Tested?

Tested manually by creating a file that had bad formatting, staged & committed and made sure that it ranter linter on staged files & added them to commit

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes