### PR TITLE
fix(sockets): delete block edge case 

### DIFF
--- a/apps/sim/socket-server/handlers/subblocks.ts
+++ b/apps/sim/socket-server/handlers/subblocks.ts
@@ -125,9 +125,16 @@ export function setupSubblocksHandlers(
             serverTimestamp: Date.now(),
           })
         }
-      }
 
-      logger.debug(`Subblock update in workflow ${workflowId}: ${blockId}.${subblockId}`)
+        logger.debug(`Subblock update in workflow ${workflowId}: ${blockId}.${subblockId}`)
+      } else if (operationId) {
+        // Block was deleted - notify client that operation completed (but didn't update anything)
+        socket.emit('operation-failed', {
+          operationId,
+          error: 'Block no longer exists',
+          retryable: false, // No point retrying for deleted blocks
+        })
+      }
     } catch (error) {
       logger.error('Error handling subblock update:', error)
 


### PR DESCRIPTION
## Description

Remove all pending operations related to deleted block from queue so others can run without these retries blocking the queue and triggering connection warning.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Delete a block with and edge that goes into it and out of it. And do other stuff after like adding a new block. Connection warning will trigger until cascading failures are all out of the queue. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
