### PR TITLE
fix(config): add t3 to list of transpiled packages to ensure that envvars are picked up correctly

### DIFF
--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -43,7 +43,13 @@ const nextConfig: NextConfig = {
     ],
     outputFileTracingRoot: path.join(__dirname, '../../'),
   }),
-  transpilePackages: ['prettier', '@react-email/components', '@react-email/render'],
+  transpilePackages: [
+    'prettier',
+    '@react-email/components',
+    '@react-email/render',
+    '@t3-oss/env-nextjs',
+    '@t3-oss/env-core',
+  ],
   async headers() {
     return [
       {


### PR DESCRIPTION
## Description

We had an issue where the NEXT_PUBLIC_SOCKET_URL was not being picked up properly and this is because t3-oss was not transpiled in the standalone build, and the runtime envvars were undefined and led to fallbacks. This worked if you didn't have a remote socket server url, but didn't used to work if you had the socket server running elsewhere with a standalone build.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually with a script to ensure that we were grabbing the correct socket url.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
