### PR TITLE
fix(qdrant): kebab case to camel case for icon properties

### DIFF
--- a/apps/docs/content/docs/tools/qdrant.mdx
+++ b/apps/docs/content/docs/tools/qdrant.mdx
@@ -13,51 +13,51 @@ import { BlockInfoCard } from "@/components/ui/block-info-card"
       <g clip-path='url(#b)'>
         <path
           d='m38.489 51.477-1.1167-30.787-2.0223-8.1167 13.498 1.429v37.242l-8.2456 4.7589-2.1138-4.5259z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#24386C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m48.847 14-8.2457 4.7622-17.016-3.7326-19.917 8.1094-3.3183-9.139 12.122-7 12.126-7 12.123 7 12.126 7z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#7589BE'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m0.34961 13.999 8.2457 4.7622 4.7798 14.215 16.139 12.913-4.9158 10.109-12.126-7.0004-12.123-7v-28z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#B2BFE8'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m30.066 38.421-5.4666 8.059v9.5207l7.757-4.4756 3.9968-5.9681'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#24386C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m24.602 36.962-7.7603-13.436 1.6715-4.4531 6.3544-3.0809 7.488 7.5343-7.7536 13.436z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#7589BE'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m16.843 23.525 7.7569 4.4756v8.9585l-7.1741 0.3087-4.3397-5.5412 3.7569-8.2016z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#B2BFE8'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m24.6 28 7.757-4.4752 5.2792 8.7903-6.3886 5.2784-6.6476-0.6346v-8.9589z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#24386C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m32.355 51.524 8.2457 4.476v-37.238l-8.0032-4.6189-7.9995-4.6189-8.0031 4.6189-7.9995 4.6189v18.479l7.9995 4.6189 8.0031 4.6193 7.757-4.4797v9.5244zm0-19.045-7.757 4.4793-7.7569-4.4793v-8.9549l7.7569-4.4792 7.757 4.4792v8.9549z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#DC244C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path d='m24.603 46.483v-9.5222l-7.7166-4.4411v9.5064l7.7166 4.4569z' fill='url(#a)' />
       </g>
@@ -70,8 +70,8 @@ import { BlockInfoCard } from "@/components/ui/block-info-card"
           y2='38.781'
           gradientUnits='userSpaceOnUse'
         >
-          <stop stop-color='#FF3364' offset='0' />
-          <stop stop-color='#C91540' stop-opacity='0' offset='1' />
+          <stop stopColor='#FF3364' offset='0' />
+          <stop stopColor='#C91540' stopOpacity='0' offset='1' />
         </linearGradient>
         <clipPath id='b'>
           <rect transform='translate(.34961)'   fill='#fff' />

--- a/apps/sim/app/(landing)/components/sections/integrations.tsx
+++ b/apps/sim/app/(landing)/components/sections/integrations.tsx
@@ -523,51 +523,51 @@ const Icons = {
       <g clipPath='url(#b)'>
         <path
           d='m38.489 51.477-1.1167-30.787-2.0223-8.1167 13.498 1.429v37.242l-8.2456 4.7589-2.1138-4.5259z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#24386C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m48.847 14-8.2457 4.7622-17.016-3.7326-19.917 8.1094-3.3183-9.139 12.122-7 12.126-7 12.123 7 12.126 7z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#7589BE'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m0.34961 13.999 8.2457 4.7622 4.7798 14.215 16.139 12.913-4.9158 10.109-12.126-7.0004-12.123-7v-28z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#B2BFE8'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m30.066 38.421-5.4666 8.059v9.5207l7.757-4.4756 3.9968-5.9681'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#24386C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m24.602 36.962-7.7603-13.436 1.6715-4.4531 6.3544-3.0809 7.488 7.5343-7.7536 13.436z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#7589BE'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m16.843 23.525 7.7569 4.4756v8.9585l-7.1741 0.3087-4.3397-5.5412 3.7569-8.2016z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#B2BFE8'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m24.6 28 7.757-4.4752 5.2792 8.7903-6.3886 5.2784-6.6476-0.6346v-8.9589z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#24386C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m32.355 51.524 8.2457 4.476v-37.238l-8.0032-4.6189-7.9995-4.6189-8.0031 4.6189-7.9995 4.6189v18.479l7.9995 4.6189 8.0031 4.6193 7.757-4.4797v9.5244zm0-19.045-7.757 4.4793-7.7569-4.4793v-8.9549l7.7569-4.4792 7.757 4.4792v8.9549z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#DC244C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path d='m24.603 46.483v-9.5222l-7.7166-4.4411v9.5064l7.7166 4.4569z' fill='url(#a)' />
       </g>
@@ -580,8 +580,8 @@ const Icons = {
           y2='38.781'
           gradientUnits='userSpaceOnUse'
         >
-          <stop stop-color='#FF3364' offset='0' />
-          <stop stop-color='#C91540' stop-opacity='0' offset='1' />
+          <stop stopColor='#FF3364' offset='0' />
+          <stop stopColor='#C91540' stopOpacity='0' offset='1' />
         </linearGradient>
         <clipPath id='b'>
           <rect transform='translate(.34961)' width='48.3' height='56' fill='#fff' />

--- a/apps/sim/components/icons.tsx
+++ b/apps/sim/components/icons.tsx
@@ -3037,54 +3037,54 @@ export function ScheduleIcon(props: SVGProps<SVGSVGElement>) {
 export function QdrantIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg {...props} fill='none' viewBox='0 0 49 56' xmlns='http://www.w3.org/2000/svg'>
-      <g clip-path='url(#b)'>
+      <g clipPath='url(#b)'>
         <path
           d='m38.489 51.477-1.1167-30.787-2.0223-8.1167 13.498 1.429v37.242l-8.2456 4.7589-2.1138-4.5259z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#24386C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m48.847 14-8.2457 4.7622-17.016-3.7326-19.917 8.1094-3.3183-9.139 12.122-7 12.126-7 12.123 7 12.126 7z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#7589BE'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m0.34961 13.999 8.2457 4.7622 4.7798 14.215 16.139 12.913-4.9158 10.109-12.126-7.0004-12.123-7v-28z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#B2BFE8'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m30.066 38.421-5.4666 8.059v9.5207l7.757-4.4756 3.9968-5.9681'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#24386C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m24.602 36.962-7.7603-13.436 1.6715-4.4531 6.3544-3.0809 7.488 7.5343-7.7536 13.436z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#7589BE'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m16.843 23.525 7.7569 4.4756v8.9585l-7.1741 0.3087-4.3397-5.5412 3.7569-8.2016z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#B2BFE8'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m24.6 28 7.757-4.4752 5.2792 8.7903-6.3886 5.2784-6.6476-0.6346v-8.9589z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#24386C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path
           d='m32.355 51.524 8.2457 4.476v-37.238l-8.0032-4.6189-7.9995-4.6189-8.0031 4.6189-7.9995 4.6189v18.479l7.9995 4.6189 8.0031 4.6193 7.757-4.4797v9.5244zm0-19.045-7.757 4.4793-7.7569-4.4793v-8.9549l7.7569-4.4792 7.757 4.4792v8.9549z'
-          clip-rule='evenodd'
+          clipRule='evenodd'
           fill='#DC244C'
-          fill-rule='evenodd'
+          fillRule='evenodd'
         />
         <path d='m24.603 46.483v-9.5222l-7.7166-4.4411v9.5064l7.7166 4.4569z' fill='url(#a)' />
       </g>
@@ -3097,8 +3097,8 @@ export function QdrantIcon(props: SVGProps<SVGSVGElement>) {
           y2='38.781'
           gradientUnits='userSpaceOnUse'
         >
-          <stop stop-color='#FF3364' offset='0' />
-          <stop stop-color='#C91540' stop-opacity='0' offset='1' />
+          <stop stopColor='#FF3364' offset='0' />
+          <stop stopColor='#C91540' stopOpacity='0' offset='1' />
         </linearGradient>
         <clipPath id='b'>
           <rect transform='translate(.34961)' width='48.3' height='56' fill='#fff' />


### PR DESCRIPTION
## Description

Local linter issues with kebab case styling. E.g. fill-rule --> fillRule

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
