### PR TITLE
fix(drizzle): use migrate instead of push for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
         working-directory: ./apps/sim
         env:
           DATABASE_URL: ${{ github.ref == 'refs/heads/main' && secrets.DATABASE_URL || secrets.STAGING_DATABASE_URL }}
-        run: bunx drizzle-kit push
+        run: bunx drizzle-kit migrate


### PR DESCRIPTION
## Description

- use migrate instead of push for ci
- marked 0-58 as applied in personal, staging, & prod so ci will just apply 59 and then when we use migrate moving forward, it will mark it as applied when the ci runs migrate
- This prevents us from the interactive terminal issue when running push

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested manually in personal & dev.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes