### PR TITLE
fix(refresh-token): refresh token fix for some providers

### DIFF
--- a/apps/sim/app/api/tools/linear/projects/route.ts
+++ b/apps/sim/app/api/tools/linear/projects/route.ts
@@ -10,6 +10,8 @@ export const dynamic = 'force-dynamic'
 const logger = createLogger('LinearProjects')
 
 export async function POST(request: Request) {
+  const requestId = crypto.randomUUID().slice(0, 8)
+  
   try {
     const session = await getSession()
     const body = await request.json()
@@ -26,7 +28,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
     }
 
-    const accessToken = await refreshAccessTokenIfNeeded(credential, userId, workflowId)
+    const accessToken = await refreshAccessTokenIfNeeded(credential, userId, requestId)
     if (!accessToken) {
       logger.error('Failed to get access token', { credentialId: credential, userId })
       return NextResponse.json(

--- a/apps/sim/app/api/tools/linear/projects/route.ts
+++ b/apps/sim/app/api/tools/linear/projects/route.ts
@@ -11,7 +11,7 @@ const logger = createLogger('LinearProjects')
 
 export async function POST(request: Request) {
   const requestId = crypto.randomUUID().slice(0, 8)
-  
+
   try {
     const session = await getSession()
     const body = await request.json()

--- a/apps/sim/app/api/tools/linear/teams/route.ts
+++ b/apps/sim/app/api/tools/linear/teams/route.ts
@@ -10,6 +10,8 @@ export const dynamic = 'force-dynamic'
 const logger = createLogger('LinearTeams')
 
 export async function POST(request: Request) {
+  const requestId = crypto.randomUUID().slice(0, 8)
+  
   try {
     const session = await getSession()
     const body = await request.json()
@@ -26,7 +28,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
     }
 
-    const accessToken = await refreshAccessTokenIfNeeded(credential, userId, workflowId)
+    const accessToken = await refreshAccessTokenIfNeeded(credential, userId, requestId)
     if (!accessToken) {
       logger.error('Failed to get access token', { credentialId: credential, userId })
       return NextResponse.json(

--- a/apps/sim/app/api/tools/linear/teams/route.ts
+++ b/apps/sim/app/api/tools/linear/teams/route.ts
@@ -11,7 +11,7 @@ const logger = createLogger('LinearTeams')
 
 export async function POST(request: Request) {
   const requestId = crypto.randomUUID().slice(0, 8)
-  
+
   try {
     const session = await getSession()
     const body = await request.json()

--- a/apps/sim/app/api/tools/microsoft-teams/channels/route.ts
+++ b/apps/sim/app/api/tools/microsoft-teams/channels/route.ts
@@ -8,6 +8,8 @@ export const dynamic = 'force-dynamic'
 const logger = createLogger('TeamsChannelsAPI')
 
 export async function POST(request: Request) {
+  const requestId = crypto.randomUUID().slice(0, 8)
+  
   try {
     const session = await getSession()
     const body = await request.json()
@@ -33,7 +35,7 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
       }
 
-      const accessToken = await refreshAccessTokenIfNeeded(credential, userId, workflowId)
+      const accessToken = await refreshAccessTokenIfNeeded(credential, userId, requestId)
 
       if (!accessToken) {
         logger.error('Failed to get access token', { credentialId: credential, userId })

--- a/apps/sim/app/api/tools/microsoft-teams/channels/route.ts
+++ b/apps/sim/app/api/tools/microsoft-teams/channels/route.ts
@@ -9,7 +9,7 @@ const logger = createLogger('TeamsChannelsAPI')
 
 export async function POST(request: Request) {
   const requestId = crypto.randomUUID().slice(0, 8)
-  
+
   try {
     const session = await getSession()
     const body = await request.json()

--- a/apps/sim/app/api/tools/microsoft-teams/chats/route.ts
+++ b/apps/sim/app/api/tools/microsoft-teams/chats/route.ts
@@ -114,6 +114,8 @@ const getChatDisplayName = async (
 }
 
 export async function POST(request: Request) {
+  const requestId = crypto.randomUUID().slice(0, 8)
+  
   try {
     const session = await getSession()
     const body = await request.json()
@@ -134,7 +136,7 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
       }
 
-      const accessToken = await refreshAccessTokenIfNeeded(credential, userId, body.workflowId)
+      const accessToken = await refreshAccessTokenIfNeeded(credential, userId, requestId)
 
       if (!accessToken) {
         logger.error('Failed to get access token', { credentialId: credential, userId })

--- a/apps/sim/app/api/tools/microsoft-teams/chats/route.ts
+++ b/apps/sim/app/api/tools/microsoft-teams/chats/route.ts
@@ -115,7 +115,7 @@ const getChatDisplayName = async (
 
 export async function POST(request: Request) {
   const requestId = crypto.randomUUID().slice(0, 8)
-  
+
   try {
     const session = await getSession()
     const body = await request.json()

--- a/apps/sim/app/api/tools/microsoft-teams/teams/route.ts
+++ b/apps/sim/app/api/tools/microsoft-teams/teams/route.ts
@@ -9,7 +9,7 @@ const logger = createLogger('teams-teams')
 
 export async function POST(request: Request) {
   const requestId = crypto.randomUUID().slice(0, 8)
-  
+
   try {
     const session = await getSession()
     const body = await request.json()

--- a/apps/sim/app/api/tools/microsoft-teams/teams/route.ts
+++ b/apps/sim/app/api/tools/microsoft-teams/teams/route.ts
@@ -8,6 +8,8 @@ export const dynamic = 'force-dynamic'
 const logger = createLogger('teams-teams')
 
 export async function POST(request: Request) {
+  const requestId = crypto.randomUUID().slice(0, 8)
+  
   try {
     const session = await getSession()
     const body = await request.json()
@@ -28,7 +30,7 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
       }
 
-      const accessToken = await refreshAccessTokenIfNeeded(credential, userId, workflowId)
+      const accessToken = await refreshAccessTokenIfNeeded(credential, userId, requestId)
 
       if (!accessToken) {
         logger.error('Failed to get access token', { credentialId: credential, userId })

--- a/apps/sim/app/api/tools/slack/channels/route.ts
+++ b/apps/sim/app/api/tools/slack/channels/route.ts
@@ -17,7 +17,7 @@ interface SlackChannel {
 
 export async function POST(request: Request) {
   const requestId = crypto.randomUUID().slice(0, 8)
-  
+
   try {
     const session = await getSession()
     const body = await request.json()

--- a/apps/sim/app/api/tools/slack/channels/route.ts
+++ b/apps/sim/app/api/tools/slack/channels/route.ts
@@ -16,6 +16,8 @@ interface SlackChannel {
 }
 
 export async function POST(request: Request) {
+  const requestId = crypto.randomUUID().slice(0, 8)
+  
   try {
     const session = await getSession()
     const body = await request.json()
@@ -40,7 +42,7 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
       }
 
-      const resolvedToken = await refreshAccessTokenIfNeeded(credential, userId, workflowId)
+      const resolvedToken = await refreshAccessTokenIfNeeded(credential, userId, requestId)
       if (!resolvedToken) {
         logger.error('Failed to get access token', { credentialId: credential, userId })
         return NextResponse.json(


### PR DESCRIPTION
## Description

Some providers refresh token wasn't working. I changed the refresh logic to what we have for the other providers to be using requestId and not workflowId

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually changed expiration in supabase to test refresh.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
