### PR TITLE
fix(sockets): permissions to align with normal perms system

### DIFF
--- a/apps/sim/socket-server/middleware/permissions.ts
+++ b/apps/sim/socket-server/middleware/permissions.ts
@@ -41,10 +41,12 @@ export async function verifyWorkflowAccess(
 
     const { userId: workflowUserId, workspaceId, name: workflowName } = workflowData[0]
 
-    // Check if user owns the workflow
+    // Check if user owns the workflow - treat as admin
     if (workflowUserId === userId) {
-      logger.debug(`User ${userId} has owner access to workflow ${workflowId} (${workflowName})`)
-      return { hasAccess: true, role: 'owner', workspaceId: workspaceId || undefined }
+      logger.debug(
+        `User ${userId} has admin access to workflow ${workflowId} (${workflowName}) as owner`
+      )
+      return { hasAccess: true, role: 'admin', workspaceId: workspaceId || undefined }
     }
 
     // Check workspace membership if workflow belongs to a workspace
@@ -90,19 +92,6 @@ export async function verifyOperationPermission(
 
     // Define operation permissions based on role
     const rolePermissions = {
-      owner: [
-        'add',
-        'remove',
-        'update',
-        'update-position',
-        'update-name',
-        'toggle-enabled',
-        'update-parent',
-        'update-wide',
-        'update-advanced-mode',
-        'toggle-handles',
-        'duplicate',
-      ],
       admin: [
         'add',
         'remove',
@@ -116,7 +105,7 @@ export async function verifyOperationPermission(
         'toggle-handles',
         'duplicate',
       ],
-      member: [
+      write: [
         'add',
         'remove',
         'update',
@@ -129,7 +118,7 @@ export async function verifyOperationPermission(
         'toggle-handles',
         'duplicate',
       ],
-      viewer: ['update-position'], // Viewers can only move things around
+      read: ['update-position'], // Read-only users can only move things around
     }
 
     const allowedOperations = rolePermissions[accessInfo.role as keyof typeof rolePermissions] || []


### PR DESCRIPTION
## Description

Sockets perms system still used old perms -- which caused issues for shared workspaces. Now uses read, write, admin like rest of the platform.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Shared between two users. If a user has write perms -- they can do all write ops. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
