### PR TITLE
feat(worfklow): added cancellation after launching manual execution

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
@@ -91,7 +91,7 @@ export function ControlBar({ hasValidationErrors = false }: ControlBarProps) {
     setDeploymentStatus,
     isLoading: isRegistryLoading,
   } = useWorkflowRegistry()
-  const { isExecuting, handleRunWorkflow } = useWorkflowExecution()
+  const { isExecuting, handleRunWorkflow, handleCancelExecution } = useWorkflowExecution()
   const { setActiveTab, togglePanel, isOpen } = usePanelStore()
   const { getFolderTree, expandedFolders } = useFolderStore()
 
@@ -785,12 +785,36 @@ export function ControlBar({ hasValidationErrors = false }: ControlBarProps) {
   }
 
   /**
-   * Render run workflow button
+   * Render run workflow button or cancel button when executing
    */
   const renderRunButton = () => {
     const canRun = userPermissions.canRead // Running only requires read permissions
     const isLoadingPermissions = userPermissions.isLoading
-    const isButtonDisabled = isWorkflowBlocked || (!canRun && !isLoadingPermissions)
+    const isButtonDisabled =
+      !isExecuting && (isWorkflowBlocked || (!canRun && !isLoadingPermissions))
+
+    // If currently executing, show cancel button
+    if (isExecuting) {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              className={cn(
+                'gap-2 font-medium',
+                'bg-red-500 hover:bg-red-600',
+                'shadow-[0_0_0_0_#ef4444] hover:shadow-[0_0_0_4px_rgba(239,68,68,0.15)]',
+                'text-white transition-all duration-200',
+                'h-12 rounded-[11px] px-4 py-2'
+              )}
+              onClick={handleCancelExecution}
+            >
+              <X className={cn('h-3.5 w-3.5')} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Cancel execution</TooltipContent>
+        </Tooltip>
+      )
+    }
 
     const getTooltipContent = () => {
       if (hasValidationErrors) {
@@ -843,8 +867,6 @@ export function ControlBar({ hasValidationErrors = false }: ControlBarProps) {
               'bg-[#701FFC] hover:bg-[#6518E6]',
               'shadow-[0_0_0_0_#701FFC] hover:shadow-[0_0_0_4px_rgba(127,47,255,0.15)]',
               'text-white transition-all duration-200',
-              isExecuting &&
-                'relative after:absolute after:inset-0 after:animate-pulse after:bg-white/20',
               'disabled:opacity-50 disabled:hover:bg-[#701FFC] disabled:hover:shadow-none',
               'h-12 rounded-[11px] px-4 py-2'
             )}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -315,7 +315,7 @@ export function useWorkflowExecution() {
               ) {
                 controller.enqueue(
                   encoder.encode(
-                    `data: ${JSON.stringify({ event: 'cancelled', data: result })}\\n\\n`
+                    `data: ${JSON.stringify({ event: 'cancelled', data: result })}\n\n`
                   )
                 )
                 return

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -306,6 +306,20 @@ export function useWorkflowExecution() {
             try {
               const result = await executeWorkflow(workflowInput, onStream, executionId)
 
+              // Check if execution was cancelled
+              if (
+                result &&
+                !result.success &&
+                result.error === 'Workflow execution was cancelled'
+              ) {
+                controller.enqueue(
+                  encoder.encode(
+                    `data: ${JSON.stringify({ event: 'cancelled', data: result })}\\n\\n`
+                  )
+                )
+                return
+              }
+
               await Promise.all(streamReadingPromises)
 
               if (result && 'success' in result) {
@@ -737,6 +751,28 @@ export function useWorkflowExecution() {
     resetDebugState()
   }, [resetDebugState])
 
+  /**
+   * Handles cancelling the current workflow execution
+   */
+  const handleCancelExecution = useCallback(() => {
+    logger.info('Workflow execution cancellation requested')
+
+    // Cancel the executor if it exists
+    if (executor) {
+      executor.cancel()
+    }
+
+    // Reset execution state
+    setIsExecuting(false)
+    setIsDebugging(false)
+    setActiveBlocks(new Set())
+
+    // If in debug mode, also reset debug state
+    if (isDebugging) {
+      resetDebugState()
+    }
+  }, [executor, isDebugging, resetDebugState, setIsExecuting, setIsDebugging, setActiveBlocks])
+
   return {
     isExecuting,
     isDebugging,
@@ -746,5 +782,6 @@ export function useWorkflowExecution() {
     handleStepDebug,
     handleResumeDebug,
     handleCancelDebug,
+    handleCancelExecution,
   }
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -309,6 +309,7 @@ export function useWorkflowExecution() {
               // Check if execution was cancelled
               if (
                 result &&
+                'success' in result &&
                 !result.success &&
                 result.error === 'Workflow execution was cancelled'
               ) {

--- a/apps/sim/executor/index.ts
+++ b/apps/sim/executor/index.ts
@@ -70,6 +70,7 @@ export class Executor {
   private isDebugging = false
   private contextExtensions: any = {}
   private actualWorkflow: SerializedWorkflow
+  private isCancelled = false
 
   constructor(
     private workflowParam:
@@ -164,6 +165,15 @@ export class Executor {
   }
 
   /**
+   * Cancels the current workflow execution.
+   * Sets the cancellation flag to stop further execution.
+   */
+  public cancel(): void {
+    logger.info('Workflow execution cancelled')
+    this.isCancelled = true
+  }
+
+  /**
    * Executes the workflow and returns the result.
    *
    * @param workflowId - Unique identifier for the workflow execution
@@ -201,7 +211,7 @@ export class Executor {
       let iteration = 0
       const maxIterations = 100 // Safety limit for infinite loops
 
-      while (hasMoreLayers && iteration < maxIterations) {
+      while (hasMoreLayers && iteration < maxIterations && !this.isCancelled) {
         const nextLayer = this.getNextExecutionLayer(context)
 
         if (this.isDebugging) {
@@ -414,6 +424,24 @@ export class Executor {
         iteration++
       }
 
+      // Handle cancellation
+      if (this.isCancelled) {
+        trackWorkflowTelemetry('workflow_execution_cancelled', {
+          workflowId,
+          duration: Date.now() - startTime.getTime(),
+          blockCount: this.actualWorkflow.blocks.length,
+          executedBlockCount: context.executedBlocks.size,
+          startTime: startTime.toISOString(),
+        })
+
+        return {
+          success: false,
+          output: finalOutput,
+          error: 'Workflow execution was cancelled',
+          logs: context.blockLogs,
+        }
+      }
+
       const endTime = new Date()
       context.metadata.endTime = endTime.toISOString()
       const duration = endTime.getTime() - startTime.getTime()
@@ -477,6 +505,16 @@ export class Executor {
   async continueExecution(blockIds: string[], context: ExecutionContext): Promise<ExecutionResult> {
     const { setPendingBlocks } = useExecutionStore.getState()
     let finalOutput: NormalizedBlockOutput = {}
+
+    // Check for cancellation
+    if (this.isCancelled) {
+      return {
+        success: false,
+        output: finalOutput,
+        error: 'Workflow execution was cancelled',
+        logs: context.blockLogs,
+      }
+    }
 
     try {
       // Execute the current layer - using the original context, not a clone


### PR DESCRIPTION
## Description

Added the ability to cancel a run once its been launched. This prevents users with longer workflows from having to wait until the entire run is complete. Speeds up iteration.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes



https://github.com/user-attachments/assets/933771a6-1a7e-4cc7-9d0f-4c0bd8b79699


