### PR TITLE
fix(webhook-modal): on copy do not change webhook url, fix auth to use regular perms system

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/webhook/components/webhook-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/webhook/components/webhook-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -392,8 +392,9 @@ export function WebhookModal({
     microsoftTeamsHmacSecret,
   ])
 
-  // Use the provided path or generate a UUID-based path
-  const formattedPath = webhookPath && webhookPath.trim() !== '' ? webhookPath : crypto.randomUUID()
+  const formattedPath = useMemo(() => {
+    return webhookPath && webhookPath.trim() !== '' ? webhookPath : crypto.randomUUID()
+  }, [webhookPath])
 
   // Construct the full webhook URL
   const baseUrl =


### PR DESCRIPTION
## Description

- On copying before saving -- a re-render caused webhook url to be regenerated. This PR fixes that bug. 
- Auth checks were just ownership -- didn't check permissions table. Also fixed in this PR. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Open up webhook modal -- and click on copy url button - should not generate a new URL each time. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes
