### PR TITLE
improvement(sockets): add batch subblock updates for duplicate to clear queue faster

### DIFF
--- a/apps/sim/contexts/socket-context.tsx
+++ b/apps/sim/contexts/socket-context.tsx
@@ -50,11 +50,17 @@ interface SocketContextType {
     value: any,
     operationId?: string
   ) => void
+  emitBatchSubblockUpdate: (
+    blockId: string,
+    subblockValues: Record<string, any>,
+    operationId?: string
+  ) => void
   emitCursorUpdate: (cursor: { x: number; y: number }) => void
   emitSelectionUpdate: (selection: { type: 'block' | 'edge' | 'none'; id?: string }) => void
   // Event handlers for receiving real-time updates
   onWorkflowOperation: (handler: (data: any) => void) => void
   onSubblockUpdate: (handler: (data: any) => void) => void
+  onBatchSubblockUpdate: (handler: (data: any) => void) => void
   onCursorUpdate: (handler: (data: any) => void) => void
   onSelectionUpdate: (handler: (data: any) => void) => void
   onUserJoined: (handler: (data: any) => void) => void
@@ -75,10 +81,12 @@ const SocketContext = createContext<SocketContextType>({
   leaveWorkflow: () => {},
   emitWorkflowOperation: () => {},
   emitSubblockUpdate: () => {},
+  emitBatchSubblockUpdate: () => {},
   emitCursorUpdate: () => {},
   emitSelectionUpdate: () => {},
   onWorkflowOperation: () => {},
   onSubblockUpdate: () => {},
+  onBatchSubblockUpdate: () => {},
   onCursorUpdate: () => {},
   onSelectionUpdate: () => {},
   onUserJoined: () => {},
@@ -111,6 +119,7 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
   const eventHandlers = useRef<{
     workflowOperation?: (data: any) => void
     subblockUpdate?: (data: any) => void
+    batchSubblockUpdate?: (data: any) => void
     cursorUpdate?: (data: any) => void
     selectionUpdate?: (data: any) => void
     userJoined?: (data: any) => void
@@ -287,6 +296,11 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
         // Subblock update events
         socketInstance.on('subblock-update', (data) => {
           eventHandlers.current.subblockUpdate?.(data)
+        })
+
+        // Batch subblock update events
+        socketInstance.on('batch-subblock-update', (data) => {
+          eventHandlers.current.batchSubblockUpdate?.(data)
         })
 
         // Workflow deletion events
@@ -694,6 +708,29 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
     [socket, currentWorkflowId]
   )
 
+  // Emit batch subblock value updates
+  const emitBatchSubblockUpdate = useCallback(
+    (blockId: string, subblockValues: Record<string, any>, operationId?: string) => {
+      // Only emit if socket is connected and we're in a valid workflow room
+      if (socket && currentWorkflowId) {
+        socket.emit('batch-subblock-update', {
+          blockId,
+          subblockValues,
+          timestamp: Date.now(),
+          operationId, // Include operation ID for queue tracking
+        })
+      } else {
+        logger.warn('Cannot emit batch subblock update: no socket connection or workflow room', {
+          hasSocket: !!socket,
+          currentWorkflowId,
+          blockId,
+          subblockCount: Object.keys(subblockValues).length,
+        })
+      }
+    },
+    [socket, currentWorkflowId]
+  )
+
   // Cursor throttling optimized for database connection health
   const lastCursorEmit = useRef(0)
   const emitCursorUpdate = useCallback(
@@ -727,6 +764,10 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
 
   const onSubblockUpdate = useCallback((handler: (data: any) => void) => {
     eventHandlers.current.subblockUpdate = handler
+  }, [])
+
+  const onBatchSubblockUpdate = useCallback((handler: (data: any) => void) => {
+    eventHandlers.current.batchSubblockUpdate = handler
   }, [])
 
   const onCursorUpdate = useCallback((handler: (data: any) => void) => {
@@ -773,10 +814,12 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
         leaveWorkflow,
         emitWorkflowOperation,
         emitSubblockUpdate,
+        emitBatchSubblockUpdate,
         emitCursorUpdate,
         emitSelectionUpdate,
         onWorkflowOperation,
         onSubblockUpdate,
+        onBatchSubblockUpdate,
         onCursorUpdate,
         onSelectionUpdate,
         onUserJoined,

--- a/apps/sim/socket-server/handlers/subblocks.ts
+++ b/apps/sim/socket-server/handlers/subblocks.ts
@@ -158,4 +158,152 @@ export function setupSubblocksHandlers(
       })
     }
   })
+
+  socket.on('batch-subblock-update', async (data) => {
+    const workflowId = roomManager.getWorkflowIdForSocket(socket.id)
+    const session = roomManager.getUserSession(socket.id)
+
+    if (!workflowId || !session) {
+      logger.debug(`Ignoring batch subblock update: socket not connected to any workflow room`, {
+        socketId: socket.id,
+        hasWorkflowId: !!workflowId,
+        hasSession: !!session,
+      })
+      return
+    }
+
+    const { blockId, subblockValues, timestamp, operationId } = data
+    const room = roomManager.getWorkflowRoom(workflowId)
+
+    if (!room) {
+      logger.debug(`Ignoring batch subblock update: workflow room not found`, {
+        socketId: socket.id,
+        workflowId,
+        blockId,
+        subblockCount: Object.keys(subblockValues).length,
+      })
+      return
+    }
+
+    try {
+      const userPresence = room.users.get(socket.id)
+      if (userPresence) {
+        userPresence.lastActivity = Date.now()
+      }
+
+      // First, verify that the workflow still exists in the database
+      const workflowExists = await db
+        .select({ id: workflow.id })
+        .from(workflow)
+        .where(eq(workflow.id, workflowId))
+        .limit(1)
+
+      if (workflowExists.length === 0) {
+        logger.warn(`Ignoring batch subblock update: workflow ${workflowId} no longer exists`, {
+          socketId: socket.id,
+          blockId,
+          subblockCount: Object.keys(subblockValues).length,
+        })
+        roomManager.cleanupUserFromRoom(socket.id, workflowId)
+        return
+      }
+
+      let updateSuccessful = false
+
+      await db.transaction(async (tx) => {
+        // Get the current block
+        const [block] = await tx
+          .select({ subBlocks: workflowBlocks.subBlocks })
+          .from(workflowBlocks)
+          .where(and(eq(workflowBlocks.id, blockId), eq(workflowBlocks.workflowId, workflowId)))
+          .limit(1)
+
+        if (!block) {
+          logger.debug(`Block ${blockId} not found in workflow ${workflowId}`)
+          return
+        }
+
+        const subBlocks = (block.subBlocks as any) || {}
+
+        // Update all subblock values in batch
+        for (const [subblockId, value] of Object.entries(subblockValues)) {
+          if (!subBlocks[subblockId]) {
+            // Create new subblock with minimal structure
+            subBlocks[subblockId] = {
+              id: subblockId,
+              type: 'unknown', // Will be corrected by next collaborative update
+              value: value,
+            }
+          } else {
+            // Preserve existing id and type, only update value
+            subBlocks[subblockId] = {
+              ...subBlocks[subblockId],
+              value: value,
+            }
+          }
+        }
+
+        await tx
+          .update(workflowBlocks)
+          .set({
+            subBlocks: subBlocks,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(workflowBlocks.id, blockId), eq(workflowBlocks.workflowId, workflowId)))
+
+        updateSuccessful = true
+      })
+
+      // Only broadcast to other clients if the update was successful
+      if (updateSuccessful) {
+        socket.to(workflowId).emit('batch-subblock-update', {
+          blockId,
+          subblockValues,
+          timestamp,
+          senderId: socket.id,
+          userId: session.userId,
+        })
+
+        // Emit confirmation if operationId is provided
+        if (operationId) {
+          socket.emit('operation-confirmed', {
+            operationId,
+            serverTimestamp: Date.now(),
+          })
+        }
+
+        logger.debug(
+          `Batch subblock update in workflow ${workflowId}: ${blockId} (${Object.keys(subblockValues).length} subblocks)`
+        )
+      } else if (operationId) {
+        // Block was deleted - notify client that operation completed (but didn't update anything)
+        socket.emit('operation-failed', {
+          operationId,
+          error: 'Block no longer exists',
+          retryable: false, // No point retrying for deleted blocks
+        })
+      }
+    } catch (error) {
+      logger.error('Error handling batch subblock update:', error)
+
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+
+      // Emit operation-failed for queue-tracked operations
+      if (operationId) {
+        socket.emit('operation-failed', {
+          operationId,
+          error: errorMessage,
+          retryable: true, // Batch subblock updates are generally retryable
+        })
+      }
+
+      // Also emit legacy operation-error for backward compatibility
+      socket.emit('operation-error', {
+        type: 'BATCH_SUBBLOCK_UPDATE_FAILED',
+        message: `Failed to update batch subblocks for ${blockId}: ${errorMessage}`,
+        operation: 'batch-subblock-update',
+        target: 'block',
+      })
+    }
+  })
 }


### PR DESCRIPTION
## Description

Batch subblock updates to clear client side queue faster for block duplications. 

## Type of change
- [x] Performance improvement

## How Has This Been Tested?

Test duplicating 10 blocks in a row.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally and in CI (`bun run test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated version numbers as needed (if needed)
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Security Considerations:

- [x] My changes do not introduce any new security vulnerabilities
- [x] I have considered the security implications of my changes