### PR TITLE
fix(sockets): add sockets event for tag / env var dropdown selections

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
@@ -14,6 +14,7 @@ import { WandPromptBar } from '@/app/workspace/[workspaceId]/w/[workflowId]/comp
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
 import { useWand } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-wand'
 import type { GenerationType } from '@/blocks/types'
+import { useTagSelection } from '@/hooks/use-tag-selection'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 
 const logger = createLogger('Code')
@@ -164,6 +165,8 @@ export function Code({
     },
   })
 
+  const emitTagSelection = useTagSelection(blockId, subBlockId)
+
   // Use preview value when in preview mode, otherwise use store value or prop value
   const value = isPreview ? previewValue : propValue !== undefined ? propValue : storeValue
 
@@ -306,7 +309,7 @@ export function Code({
   const handleTagSelect = (newValue: string) => {
     if (!isPreview) {
       setCode(newValue)
-      setStoreValue(newValue)
+      emitTagSelection(newValue)
     }
     setShowTags(false)
     setActiveSourceBlockId(null)
@@ -319,7 +322,7 @@ export function Code({
   const handleEnvVarSelect = (newValue: string) => {
     if (!isPreview) {
       setCode(newValue)
-      setStoreValue(newValue)
+      emitTagSelection(newValue)
     }
     setShowEnvVars(false)
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/combobox.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/combobox.tsx
@@ -10,6 +10,7 @@ import { createLogger } from '@/lib/logs/console/logger'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
 import type { SubBlockConfig } from '@/blocks/types'
+import { useTagSelection } from '@/hooks/use-tag-selection'
 
 const logger = createLogger('ComboBox')
 
@@ -52,6 +53,8 @@ export function ComboBox({
   const [cursorPosition, setCursorPosition] = useState(0)
   const [activeSourceBlockId, setActiveSourceBlockId] = useState<string | null>(null)
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
+
+  const emitTagSelection = useTagSelection(blockId, subBlockId)
 
   const inputRef = useRef<HTMLInputElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
@@ -330,7 +333,7 @@ export function ComboBox({
   // Environment variable and tag selection handler
   const handleEnvVarSelect = (newValue: string) => {
     if (!isPreview) {
-      setStoreValue(newValue)
+      emitTagSelection(newValue)
     }
   }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/long-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/long-input.tsx
@@ -12,6 +12,7 @@ import { WandPromptBar } from '@/app/workspace/[workspaceId]/w/[workflowId]/comp
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
 import { useWand } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-wand'
 import type { SubBlockConfig } from '@/blocks/types'
+import { useTagSelection } from '@/hooks/use-tag-selection'
 
 const logger = createLogger('LongInput')
 
@@ -78,6 +79,8 @@ export function LongInput({
       logger.debug('Wand streaming ended, value persisted', { blockId, subBlockId })
     },
   })
+
+  const emitTagSelection = useTagSelection(blockId, subBlockId)
 
   const [showEnvVars, setShowEnvVars] = useState(false)
   const [showTags, setShowTags] = useState(false)
@@ -428,7 +431,7 @@ export function LongInput({
             if (onChange) {
               onChange(newValue)
             } else if (!isPreview) {
-              setStoreValue(newValue)
+              emitTagSelection(newValue)
             }
           }}
           searchTerm={searchTerm}
@@ -445,7 +448,7 @@ export function LongInput({
             if (onChange) {
               onChange(newValue)
             } else if (!isPreview) {
-              setStoreValue(newValue)
+              emitTagSelection(newValue)
             }
           }}
           blockId={blockId}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/short-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/short-input.tsx
@@ -8,6 +8,7 @@ import { createLogger } from '@/lib/logs/console/logger'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
 import type { SubBlockConfig } from '@/blocks/types'
+import { useTagSelection } from '@/hooks/use-tag-selection'
 
 const logger = createLogger('ShortInput')
 
@@ -56,6 +57,8 @@ export function ShortInput({
   const inputRef = useRef<HTMLInputElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
   const [activeSourceBlockId, setActiveSourceBlockId] = useState<string | null>(null)
+
+  const emitTagSelection = useTagSelection(blockId, subBlockId)
 
   // Get ReactFlow instance for zoom control
   const reactFlowInstance = useReactFlow()
@@ -288,8 +291,7 @@ export function ShortInput({
     if (onChange) {
       onChange(newValue)
     } else if (!isPreview) {
-      // Only update store when not in preview mode
-      setStoreValue(newValue)
+      emitTagSelection(newValue)
     }
   }
 

--- a/apps/sim/hooks/use-tag-selection.ts
+++ b/apps/sim/hooks/use-tag-selection.ts
@@ -1,0 +1,25 @@
+import { useCallback } from 'react'
+import { useSocket } from '@/contexts/socket-context'
+import { useSubBlockStore } from '@/stores/workflows/subblock/store'
+
+/**
+ * Hook for handling immediate tag dropdown selections
+ * This bypasses the debounced operation queue system for instant feedback
+ */
+export function useTagSelection(blockId: string, subblockId: string) {
+  const { emitTagSelection } = useSocket()
+  const subBlockStore = useSubBlockStore()
+
+  const emitTagSelectionValue = useCallback(
+    (value: any) => {
+      // Update local store immediately for instant feedback
+      subBlockStore.setValue(blockId, subblockId, value)
+
+      // Emit to server immediately (no debouncing)
+      emitTagSelection(blockId, subblockId, value)
+    },
+    [blockId, subblockId, emitTagSelection, subBlockStore]
+  )
+
+  return emitTagSelectionValue
+}

--- a/apps/sim/socket-server/handlers/subblocks.ts
+++ b/apps/sim/socket-server/handlers/subblocks.ts
@@ -158,4 +158,119 @@ export function setupSubblocksHandlers(
       })
     }
   })
+
+  // Handle immediate tag/dropdown selections (no database persistence, just broadcast)
+  socket.on('tag-selection', async (data) => {
+    const workflowId = roomManager.getWorkflowIdForSocket(socket.id)
+    const session = roomManager.getUserSession(socket.id)
+
+    if (!workflowId || !session) {
+      logger.debug(`Ignoring tag selection: socket not connected to any workflow room`, {
+        socketId: socket.id,
+        hasWorkflowId: !!workflowId,
+        hasSession: !!session,
+      })
+      return
+    }
+
+    const { blockId, subblockId, value, timestamp } = data
+    const room = roomManager.getWorkflowRoom(workflowId)
+
+    if (!room) {
+      logger.debug(`Ignoring tag selection: workflow room not found`, {
+        socketId: socket.id,
+        workflowId,
+        blockId,
+        subblockId,
+      })
+      return
+    }
+
+    try {
+      const userPresence = room.users.get(socket.id)
+      if (userPresence) {
+        userPresence.lastActivity = Date.now()
+      }
+
+      // First, verify that the workflow still exists in the database
+      const workflowExists = await db
+        .select({ id: workflow.id })
+        .from(workflow)
+        .where(eq(workflow.id, workflowId))
+        .limit(1)
+
+      if (workflowExists.length === 0) {
+        logger.warn(`Ignoring tag selection: workflow ${workflowId} no longer exists`, {
+          socketId: socket.id,
+          blockId,
+          subblockId,
+        })
+        roomManager.cleanupUserFromRoom(socket.id, workflowId)
+        return
+      }
+
+      // Persist to database immediately (same logic as subblock-update but without operation tracking)
+      let updateSuccessful = false
+      await db.transaction(async (tx) => {
+        const [block] = await tx
+          .select({ subBlocks: workflowBlocks.subBlocks })
+          .from(workflowBlocks)
+          .where(and(eq(workflowBlocks.id, blockId), eq(workflowBlocks.workflowId, workflowId)))
+          .limit(1)
+
+        if (!block) {
+          // Block was deleted - this is a normal race condition in collaborative editing
+          logger.debug(
+            `Ignoring tag selection for deleted block: ${workflowId}/${blockId}.${subblockId}`
+          )
+          return
+        }
+
+        const subBlocks = (block.subBlocks as any) || {}
+
+        if (!subBlocks[subblockId]) {
+          // Create new subblock with minimal structure
+          subBlocks[subblockId] = {
+            id: subblockId,
+            type: 'unknown', // Will be corrected by next collaborative update
+            value: value,
+          }
+        } else {
+          // Preserve existing id and type, only update value
+          subBlocks[subblockId] = {
+            ...subBlocks[subblockId],
+            value: value,
+          }
+        }
+
+        await tx
+          .update(workflowBlocks)
+          .set({
+            subBlocks: subBlocks,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(workflowBlocks.id, blockId), eq(workflowBlocks.workflowId, workflowId)))
+
+        updateSuccessful = true
+      })
+
+      // Broadcast to other clients if the update was successful
+      if (updateSuccessful) {
+        socket.to(workflowId).emit('tag-selection', {
+          blockId,
+          subblockId,
+          value,
+          timestamp,
+          senderId: socket.id,
+          userId: session.userId,
+        })
+
+        logger.debug(
+          `Tag selection persisted and broadcast in workflow ${workflowId}: ${blockId}.${subblockId}`
+        )
+      }
+    } catch (error) {
+      logger.error('Error handling tag selection:', error)
+    }
+  })
 }


### PR DESCRIPTION
## Summary

Tag dropdown / Env Var selections were going through debounce system and were getting overwritten occasionally. Making it a atomic op by adding socket event. 

## Type of Change
- [x] Bug fix

## Testing
Pick out variables from tag dropdown / environment variable selection drop downs and refresh quickly -- should always persist. 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)