### PR TITLE
fix(logs): forgot dependency for logs breaking pagination

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
@@ -324,7 +324,7 @@ export default function Logs() {
         fetchLogs(nextPage, true)
       }, 50)
     }
-  }, [isFetchingMore, hasMore, page])
+  }, [fetchLogs, isFetchingMore, hasMore, page])
 
   useEffect(() => {
     if (loading || !hasMore) return


### PR DESCRIPTION
## Summary

Pagination broke because of removed dependency in previous PR. This patches that. 

## Type of Change
- [x] Bug fix

## Testing

Manually load logs with more than one page of entries and monitor network tab for new logs call with offset set to 50. 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
