### PR TITLE
fix(duplicate): added isWide and advacnedMode to optimistic duplicate, persist collapsed subblock state

### DIFF
--- a/apps/sim/app/api/__test-utils__/utils.ts
+++ b/apps/sim/app/api/__test-utils__/utils.ts
@@ -98,6 +98,7 @@ export const sampleWorkflowState = {
       enabled: true,
       horizontalHandles: true,
       isWide: false,
+      advancedMode: false,
       height: 95,
     },
     'agent-id': {
@@ -125,6 +126,7 @@ export const sampleWorkflowState = {
       enabled: true,
       horizontalHandles: true,
       isWide: false,
+      advancedMode: false,
       height: 680,
     },
   },

--- a/apps/sim/app/api/tools/edit-workflow/route.ts
+++ b/apps/sim/app/api/tools/edit-workflow/route.ts
@@ -175,6 +175,7 @@ export async function POST(request: NextRequest) {
         enabled: true,
         horizontalHandles: true,
         isWide: false,
+        advancedMode: false,
         height: 0,
         data: block.data || {},
       }

--- a/apps/sim/app/api/workflows/[id]/yaml/route.ts
+++ b/apps/sim/app/api/workflows/[id]/yaml/route.ts
@@ -283,6 +283,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
           enabled: true,
           horizontalHandles: true,
           isWide: false,
+          advancedMode: false,
           height: 0,
           data: block.data || {},
         }
@@ -325,6 +326,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
           enabled: true,
           horizontalHandles: true,
           isWide: false,
+          advancedMode: false,
           height: 0,
           data: block.data || {},
         }

--- a/apps/sim/app/api/workflows/route.ts
+++ b/apps/sim/app/api/workflows/route.ts
@@ -129,6 +129,7 @@ export async function POST(req: NextRequest) {
           enabled: true,
           horizontalHandles: true,
           isWide: false,
+          advancedMode: false,
           height: 95,
         },
       },
@@ -176,6 +177,7 @@ export async function POST(req: NextRequest) {
         enabled: true,
         horizontalHandles: true,
         isWide: false,
+        advancedMode: false,
         height: '95',
         subBlocks: {
           startWorkflow: {

--- a/apps/sim/app/api/workspaces/route.ts
+++ b/apps/sim/app/api/workspaces/route.ts
@@ -161,6 +161,7 @@ async function createWorkspace(userId: string, name: string) {
             enabled: true,
             horizontalHandles: true,
             isWide: false,
+            advancedMode: false,
             height: 95,
           },
         },
@@ -206,6 +207,7 @@ async function createWorkspace(userId: string, name: string) {
         enabled: true,
         horizontalHandles: true,
         isWide: false,
+        advancedMode: false,
         height: '95',
         subBlocks: {
           startWorkflow: {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
@@ -98,7 +98,6 @@ export function Code({
   const isCollapsed =
     (useSubBlockStore((state) => state.getValue(blockId, collapsedStateKey)) as boolean) ?? false
 
-  // Use collaborative subblock operations to persist collapse state
   const { collaborativeSetSubblockValue } = useCollaborativeWorkflow()
   const setCollapsedValue = (blockId: string, subblockId: string, value: any) => {
     collaborativeSetSubblockValue(blockId, subblockId, value)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
@@ -14,6 +14,7 @@ import { WandPromptBar } from '@/app/workspace/[workspaceId]/w/[workflowId]/comp
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
 import { useWand } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-wand'
 import type { GenerationType } from '@/blocks/types'
+import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
 import { useTagSelection } from '@/hooks/use-tag-selection'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 
@@ -96,7 +97,12 @@ export function Code({
   const collapsedStateKey = `${subBlockId}_collapsed`
   const isCollapsed =
     (useSubBlockStore((state) => state.getValue(blockId, collapsedStateKey)) as boolean) ?? false
-  const setCollapsedValue = useSubBlockStore((state) => state.setValue)
+
+  // Use collaborative subblock operations to persist collapse state
+  const { collaborativeSetSubblockValue } = useCollaborativeWorkflow()
+  const setCollapsedValue = (blockId: string, subblockId: string, value: any) => {
+    collaborativeSetSubblockValue(blockId, subblockId, value)
+  }
 
   const showCollapseButton =
     (subBlockId === 'responseFormat' || subBlockId === 'code') && code.split('\n').length > 5

--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -148,7 +148,7 @@ export function useCollaborativeWorkflow() {
               workflowStore.setBlockWide(payload.id, payload.isWide)
               break
             case 'update-advanced-mode':
-              workflowStore.toggleBlockAdvancedMode(payload.id)
+              workflowStore.setBlockAdvancedMode(payload.id, payload.advancedMode)
               break
             case 'toggle-handles': {
               const currentBlock = workflowStore.blocks[payload.id]
@@ -433,6 +433,7 @@ export function useCollaborativeWorkflow() {
           enabled: true,
           horizontalHandles: true,
           isWide: false,
+          advancedMode: false,
           height: 0,
           parentId,
           extent,
@@ -504,6 +505,7 @@ export function useCollaborativeWorkflow() {
         enabled: true,
         horizontalHandles: true,
         isWide: false,
+        advancedMode: false,
         height: 0, // Default height, will be set by the UI
         parentId,
         extent,
@@ -811,6 +813,7 @@ export function useCollaborativeWorkflow() {
         enabled: sourceBlock.enabled ?? true,
         horizontalHandles: sourceBlock.horizontalHandles ?? true,
         isWide: sourceBlock.isWide ?? false,
+        advancedMode: sourceBlock.advancedMode ?? false,
         height: sourceBlock.height || 0,
       }
 
@@ -821,7 +824,14 @@ export function useCollaborativeWorkflow() {
         offsetPosition,
         sourceBlock.data ? JSON.parse(JSON.stringify(sourceBlock.data)) : {},
         sourceBlock.data?.parentId,
-        sourceBlock.data?.extent
+        sourceBlock.data?.extent,
+        {
+          enabled: sourceBlock.enabled,
+          horizontalHandles: sourceBlock.horizontalHandles,
+          isWide: sourceBlock.isWide,
+          advancedMode: sourceBlock.advancedMode,
+          height: sourceBlock.height,
+        }
       )
 
       executeQueuedOperation('duplicate', 'block', duplicatedBlockData, () => {
@@ -830,7 +840,16 @@ export function useCollaborativeWorkflow() {
           sourceBlock.type,
           newName,
           offsetPosition,
-          sourceBlock.data ? JSON.parse(JSON.stringify(sourceBlock.data)) : {}
+          sourceBlock.data ? JSON.parse(JSON.stringify(sourceBlock.data)) : {},
+          sourceBlock.data?.parentId,
+          sourceBlock.data?.extent,
+          {
+            enabled: sourceBlock.enabled,
+            horizontalHandles: sourceBlock.horizontalHandles,
+            isWide: sourceBlock.isWide,
+            advancedMode: sourceBlock.advancedMode,
+            height: sourceBlock.height,
+          }
         )
 
         // Apply subblock values locally for immediate UI feedback

--- a/apps/sim/lib/workflows/db-helpers.ts
+++ b/apps/sim/lib/workflows/db-helpers.ts
@@ -146,6 +146,7 @@ export async function saveWorkflowToNormalizedTables(
           enabled: block.enabled ?? true,
           horizontalHandles: block.horizontalHandles ?? true,
           isWide: block.isWide ?? false,
+          advancedMode: block.advancedMode ?? false,
           height: String(block.height || 0),
           subBlocks: block.subBlocks || {},
           outputs: block.outputs || {},

--- a/apps/sim/scripts/insert-test-workflow.ts
+++ b/apps/sim/scripts/insert-test-workflow.ts
@@ -28,6 +28,7 @@ const testWorkflowState = {
       enabled: true,
       horizontalHandles: true,
       isWide: false,
+      advancedMode: false,
       height: 90,
     },
     'loop-block-456': {
@@ -43,6 +44,7 @@ const testWorkflowState = {
       enabled: true,
       horizontalHandles: true,
       isWide: false,
+      advancedMode: false,
       height: 0,
       data: {
         width: 400,
@@ -74,6 +76,7 @@ const testWorkflowState = {
       enabled: true,
       horizontalHandles: true,
       isWide: false,
+      advancedMode: false,
       height: 144,
       data: {
         parentId: 'loop-block-456',

--- a/apps/sim/scripts/migrate-workflow-states.ts
+++ b/apps/sim/scripts/migrate-workflow-states.ts
@@ -129,6 +129,7 @@ async function migrateWorkflowStates(specificWorkflowIds?: string[] | null) {
               enabled: block.enabled ?? true,
               horizontalHandles: block.horizontalHandles ?? true,
               isWide: block.isWide ?? false,
+              advancedMode: block.advancedMode ?? false,
               height: String(block.height || 0),
               subBlocks: block.subBlocks || {},
               outputs: block.outputs || {},

--- a/apps/sim/socket-server/database/operations.ts
+++ b/apps/sim/socket-server/database/operations.ts
@@ -268,6 +268,7 @@ async function handleBlockOperationTx(
           enabled: payload.enabled ?? true,
           horizontalHandles: payload.horizontalHandles ?? true,
           isWide: payload.isWide ?? false,
+          advancedMode: payload.advancedMode ?? false,
           height: payload.height || 0,
         }
 
@@ -617,6 +618,7 @@ async function handleBlockOperationTx(
           enabled: payload.enabled ?? true,
           horizontalHandles: payload.horizontalHandles ?? true,
           isWide: payload.isWide ?? false,
+          advancedMode: payload.advancedMode ?? false,
           height: payload.height || 0,
         }
 

--- a/apps/sim/stores/workflows/registry/store.ts
+++ b/apps/sim/stores/workflows/registry/store.ts
@@ -730,6 +730,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
               enabled: true,
               horizontalHandles: true,
               isWide: false,
+              advancedMode: false,
               height: 0,
             }
 
@@ -1105,6 +1106,7 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
             enabled: true,
             horizontalHandles: true,
             isWide: false,
+            advancedMode: false,
             height: 0,
           }
 

--- a/apps/sim/stores/workflows/workflow/store.ts
+++ b/apps/sim/stores/workflows/workflow/store.ts
@@ -95,7 +95,14 @@ export const useWorkflowStore = create<WorkflowStoreWithHistory>()(
         position: Position,
         data?: Record<string, any>,
         parentId?: string,
-        extent?: 'parent'
+        extent?: 'parent',
+        blockProperties?: {
+          enabled?: boolean
+          horizontalHandles?: boolean
+          isWide?: boolean
+          advancedMode?: boolean
+          height?: number
+        }
       ) => {
         const blockConfig = getBlock(type)
         // For custom nodes like loop and parallel that don't use BlockConfig
@@ -116,10 +123,11 @@ export const useWorkflowStore = create<WorkflowStoreWithHistory>()(
                 position,
                 subBlocks: {},
                 outputs: {},
-                enabled: true,
-                horizontalHandles: true,
-                isWide: false,
-                height: 0,
+                enabled: blockProperties?.enabled ?? true,
+                horizontalHandles: blockProperties?.horizontalHandles ?? true,
+                isWide: blockProperties?.isWide ?? false,
+                advancedMode: blockProperties?.advancedMode ?? false,
+                height: blockProperties?.height ?? 0,
                 data: nodeData,
               },
             },
@@ -165,10 +173,11 @@ export const useWorkflowStore = create<WorkflowStoreWithHistory>()(
               position,
               subBlocks,
               outputs,
-              enabled: true,
-              horizontalHandles: true,
-              isWide: false,
-              height: 0,
+              enabled: blockProperties?.enabled ?? true,
+              horizontalHandles: blockProperties?.horizontalHandles ?? true,
+              isWide: blockProperties?.isWide ?? false,
+              advancedMode: blockProperties?.advancedMode ?? false,
+              height: blockProperties?.height ?? 0,
               data: nodeData,
             },
           },

--- a/apps/sim/stores/workflows/workflow/types.ts
+++ b/apps/sim/stores/workflows/workflow/types.ts
@@ -161,7 +161,14 @@ export interface WorkflowActions {
     position: Position,
     data?: Record<string, any>,
     parentId?: string,
-    extent?: 'parent'
+    extent?: 'parent',
+    blockProperties?: {
+      enabled?: boolean
+      horizontalHandles?: boolean
+      isWide?: boolean
+      advancedMode?: boolean
+      height?: number
+    }
   ) => void
   updateBlockPosition: (id: string, position: Position) => void
   updateNodeDimensions: (id: string, dimensions: { width: number; height: number }) => void
@@ -177,6 +184,7 @@ export interface WorkflowActions {
   updateBlockName: (id: string, name: string) => void
   toggleBlockWide: (id: string) => void
   setBlockWide: (id: string, isWide: boolean) => void
+  setBlockAdvancedMode: (id: string, advancedMode: boolean) => void
   updateBlockHeight: (id: string, height: number) => void
   triggerUpdate: () => void
   updateLoopCount: (loopId: string, count: number) => void


### PR DESCRIPTION
## Summary
added isWide and advacnedMode to optimistic duplicate -> wasn't persisting additional block properties on optimistic client side update nor on the server

persist collapsed subblock state -> was using local setSubblockValue instead of collaboartive, means that it doesn't get sent to the socket sever & doesn't persist

## Type of Change
- [x] Bug fix

## Testing
Tested manually many times

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

https://github.com/user-attachments/assets/be6ad293-3966-4d2d-bc1e-e99399e0c5b4

