### PR TITLE
fix(gmail-webhook): gmail credential injection issue with webhook block

### DIFF
--- a/apps/sim/blocks/blocks/webhook.ts
+++ b/apps/sim/blocks/blocks/webhook.ts
@@ -79,6 +79,21 @@ export const WebhookBlock: BlockConfig = {
       value: () => 'generic',
     },
     {
+      id: 'gmailCredential',
+      title: 'Gmail Account',
+      type: 'oauth-input',
+      layout: 'full',
+      provider: 'google-email',
+      serviceId: 'gmail',
+      requiredScopes: [
+        'https://www.googleapis.com/auth/gmail.modify',
+        'https://www.googleapis.com/auth/gmail.labels',
+      ],
+      placeholder: 'Select Gmail account',
+      condition: { field: 'webhookProvider', value: 'gmail' },
+      required: true,
+    },
+    {
       id: 'webhookConfig',
       title: 'Webhook Configuration',
       type: 'webhook-config',


### PR DESCRIPTION
## Summary


Gmail credential should have been persisted + injected using subblock system -- not through webhook provider config. 

This previously affected the case where credentials already existed but were not actually connected via a webhook block itself. 

## Type of Change
- [x] Bug fix

## Testing
Tested by using ngrok + manually triggering gmail polling job.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
