### PR TITLE
feat(rate-limits): make rate limits configurable via environment variables

### DIFF
--- a/apps/sim/lib/env.ts
+++ b/apps/sim/lib/env.ts
@@ -110,6 +110,18 @@ export const env = createEnv({
     // Data Retention
     FREE_PLAN_LOG_RETENTION_DAYS:         z.string().optional(),                // Log retention days for free plan users
 
+    // Rate Limiting Configuration
+    RATE_LIMIT_WINDOW_MS:                 z.string().optional().default('60000'), // Rate limit window duration in milliseconds (default: 1 minute)
+    MANUAL_EXECUTION_LIMIT:               z.string().optional().default('999999'), // Manual execution bypass value (effectively unlimited)
+    RATE_LIMIT_FREE_SYNC:                 z.string().optional().default('10'),   // Free tier sync API executions per minute
+    RATE_LIMIT_FREE_ASYNC:                z.string().optional().default('50'),   // Free tier async API executions per minute
+    RATE_LIMIT_PRO_SYNC:                  z.string().optional().default('25'),   // Pro tier sync API executions per minute
+    RATE_LIMIT_PRO_ASYNC:                 z.string().optional().default('200'),  // Pro tier async API executions per minute
+    RATE_LIMIT_TEAM_SYNC:                 z.string().optional().default('75'),   // Team tier sync API executions per minute
+    RATE_LIMIT_TEAM_ASYNC:                z.string().optional().default('500'),  // Team tier async API executions per minute
+    RATE_LIMIT_ENTERPRISE_SYNC:           z.string().optional().default('150'),  // Enterprise tier sync API executions per minute
+    RATE_LIMIT_ENTERPRISE_ASYNC:          z.string().optional().default('1000'), // Enterprise tier async API executions per minute
+
     // Real-time Communication
     SOCKET_SERVER_URL:                    z.string().url().optional(),          // WebSocket server URL for real-time features
     SOCKET_PORT:                          z.number().optional(),                // Port for WebSocket server

--- a/apps/sim/services/queue/RateLimiter.test.ts
+++ b/apps/sim/services/queue/RateLimiter.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { RateLimiter } from '@/services/queue/RateLimiter'
-import { RATE_LIMITS } from '@/services/queue/types'
+import { MANUAL_EXECUTION_LIMIT, RATE_LIMITS } from '@/services/queue/types'
 
 // Mock the database module
 vi.mock('@/db', () => ({
@@ -34,7 +34,7 @@ describe('RateLimiter', () => {
       const result = await rateLimiter.checkRateLimit(testUserId, 'free', 'manual', false)
 
       expect(result.allowed).toBe(true)
-      expect(result.remaining).toBe(999999)
+      expect(result.remaining).toBe(MANUAL_EXECUTION_LIMIT)
       expect(result.resetAt).toBeInstanceOf(Date)
       expect(db.select).not.toHaveBeenCalled()
     })
@@ -144,8 +144,8 @@ describe('RateLimiter', () => {
       const status = await rateLimiter.getRateLimitStatus(testUserId, 'free', 'manual', false)
 
       expect(status.used).toBe(0)
-      expect(status.limit).toBe(999999)
-      expect(status.remaining).toBe(999999)
+      expect(status.limit).toBe(MANUAL_EXECUTION_LIMIT)
+      expect(status.remaining).toBe(MANUAL_EXECUTION_LIMIT)
       expect(status.resetAt).toBeInstanceOf(Date)
     })
 

--- a/apps/sim/services/queue/types.ts
+++ b/apps/sim/services/queue/types.ts
@@ -1,4 +1,5 @@
 import type { InferSelectModel } from 'drizzle-orm'
+import { env } from '@/lib/env'
 import type { userRateLimits } from '@/db/schema'
 
 // Database types
@@ -16,22 +17,28 @@ export interface RateLimitConfig {
   asyncApiExecutionsPerMinute: number
 }
 
+// Rate limit window duration in milliseconds
+export const RATE_LIMIT_WINDOW_MS = Number.parseInt(env.RATE_LIMIT_WINDOW_MS)
+
+// Manual execution bypass value (effectively unlimited)
+export const MANUAL_EXECUTION_LIMIT = Number.parseInt(env.MANUAL_EXECUTION_LIMIT)
+
 export const RATE_LIMITS: Record<SubscriptionPlan, RateLimitConfig> = {
   free: {
-    syncApiExecutionsPerMinute: 10,
-    asyncApiExecutionsPerMinute: 50,
+    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_FREE_SYNC),
+    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_FREE_ASYNC),
   },
   pro: {
-    syncApiExecutionsPerMinute: 25,
-    asyncApiExecutionsPerMinute: 200,
+    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_PRO_SYNC),
+    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_PRO_ASYNC),
   },
   team: {
-    syncApiExecutionsPerMinute: 75,
-    asyncApiExecutionsPerMinute: 500,
+    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_TEAM_SYNC),
+    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_TEAM_ASYNC),
   },
   enterprise: {
-    syncApiExecutionsPerMinute: 150,
-    asyncApiExecutionsPerMinute: 1000,
+    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_ENTERPRISE_SYNC),
+    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_ENTERPRISE_ASYNC),
   },
 }
 

--- a/apps/sim/services/queue/types.ts
+++ b/apps/sim/services/queue/types.ts
@@ -18,27 +18,27 @@ export interface RateLimitConfig {
 }
 
 // Rate limit window duration in milliseconds
-export const RATE_LIMIT_WINDOW_MS = Number.parseInt(env.RATE_LIMIT_WINDOW_MS)
+export const RATE_LIMIT_WINDOW_MS = Number.parseInt(env.RATE_LIMIT_WINDOW_MS) || 60000
 
 // Manual execution bypass value (effectively unlimited)
-export const MANUAL_EXECUTION_LIMIT = Number.parseInt(env.MANUAL_EXECUTION_LIMIT)
+export const MANUAL_EXECUTION_LIMIT = Number.parseInt(env.MANUAL_EXECUTION_LIMIT) || 999999
 
 export const RATE_LIMITS: Record<SubscriptionPlan, RateLimitConfig> = {
   free: {
-    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_FREE_SYNC),
-    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_FREE_ASYNC),
+    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_FREE_SYNC) || 10,
+    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_FREE_ASYNC) || 50,
   },
   pro: {
-    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_PRO_SYNC),
-    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_PRO_ASYNC),
+    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_PRO_SYNC) || 25,
+    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_PRO_ASYNC) || 200,
   },
   team: {
-    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_TEAM_SYNC),
-    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_TEAM_ASYNC),
+    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_TEAM_SYNC) || 75,
+    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_TEAM_ASYNC) || 500,
   },
   enterprise: {
-    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_ENTERPRISE_SYNC),
-    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_ENTERPRISE_ASYNC),
+    syncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_ENTERPRISE_SYNC) || 150,
+    asyncApiExecutionsPerMinute: Number.parseInt(env.RATE_LIMIT_ENTERPRISE_ASYNC) || 1000,
   },
 }
 

--- a/helm/sim/values.yaml
+++ b/helm/sim/values.yaml
@@ -87,6 +87,18 @@ app:
     NEXT_PUBLIC_DOCUMENTATION_URL: ""                    # Documentation URL (leave empty for none)
     NEXT_PUBLIC_TERMS_URL: ""                            # Terms of service URL (leave empty for none)
     NEXT_PUBLIC_PRIVACY_URL: ""                          # Privacy policy URL (leave empty for none)
+    
+    # Rate Limiting Configuration
+    RATE_LIMIT_WINDOW_MS: "60000"                        # Rate limit window in milliseconds (1 minute)
+    MANUAL_EXECUTION_LIMIT: "999999"                     # Manual execution limit (effectively unlimited)
+    RATE_LIMIT_FREE_SYNC: "10"                          # Free tier sync API executions per minute
+    RATE_LIMIT_FREE_ASYNC: "50"                         # Free tier async API executions per minute
+    RATE_LIMIT_PRO_SYNC: "25"                           # Pro tier sync API executions per minute
+    RATE_LIMIT_PRO_ASYNC: "200"                         # Pro tier async API executions per minute
+    RATE_LIMIT_TEAM_SYNC: "75"                          # Team tier sync API executions per minute
+    RATE_LIMIT_TEAM_ASYNC: "500"                        # Team tier async API executions per minute
+    RATE_LIMIT_ENTERPRISE_SYNC: "150"                   # Enterprise tier sync API executions per minute
+    RATE_LIMIT_ENTERPRISE_ASYNC: "1000"                 # Enterprise tier async API executions per minute
   
   # Service configuration
   service:


### PR DESCRIPTION
## Summary
Make rate limits configurable via environment variables, default values are what we had before as magic number so no need to set them anywhere

## Type of Change
- [x] New feature  

## Testing
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)