### PR TITLE
feat(TagImprovement): Improved tag dropdown and outputselect

### DIFF
--- a/apps/sim/blocks/types.ts
+++ b/apps/sim/blocks/types.ts
@@ -78,7 +78,20 @@ export type BlockOutput =
 // Output field definition with optional description
 export type OutputFieldDefinition =
   | PrimitiveValueType
-  | { type: PrimitiveValueType; description?: string }
+  | {
+      type: PrimitiveValueType;
+      description?: string;
+      condition?: {
+        field: string
+        value: string | number | boolean | Array<string | number | boolean>
+        not?: boolean
+        and?: {
+          field: string
+          value: string | number | boolean | Array<string | number | boolean> | undefined
+          not?: boolean
+        }
+      }
+    }
 
 // Parameter validation rules
 export interface ParamConfig {


### PR DESCRIPTION
## Summary
Previously we could not filter outputs based on user inputs. From now on outputs of a tool will also support a condition field.

Example: `arxiv`

Instead of using comments to separate different types of responses like this:
```ts
  outputs: {
    // Search output
    papers: { type: 'json', description: 'Found papers data' },
    totalResults: { type: 'number', description: 'Total results count' },
    // Get Paper Details output
    paper: { type: 'json', description: 'Paper details' },
    // Get Author Papers output
    authorPapers: { type: 'json', description: 'Author papers list' },
  },
```
we can say:
```ts
    papers: { type: 'json', description: 'Found papers data', condition: {field: 'operation', value: 'arxiv_search'} },
    totalResults: { type: 'number', description: 'Total results count', condition: {field: 'operation', value: 'arxiv_search'} },
```

Fixes #(issue)

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
It is not a breaking change but you can focus on checking the functionality in the app.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->

Solves #905
