### PR TITLE
fix(workflow-block): improvements to pulsing effect, active execution state, and running workflow blocks in parallel

### DIFF
--- a/apps/sim/executor/handlers/workflow/workflow-handler.ts
+++ b/apps/sim/executor/handlers/workflow/workflow-handler.ts
@@ -116,8 +116,8 @@ export class WorkflowBlockHandler implements BlockHandler {
       )
 
       // If the child workflow failed, throw an error to trigger proper error handling in the parent
-      if (mappedResult.success === false) {
-        const childError = mappedResult.error || 'Unknown error'
+      if ((mappedResult as any).success === false) {
+        const childError = (mappedResult as any).error || 'Unknown error'
         throw new Error(`Error in child workflow "${childWorkflowName}": ${childError}`)
       }
 
@@ -229,7 +229,7 @@ export class WorkflowBlockHandler implements BlockHandler {
     childWorkflowId: string,
     childWorkflowName: string,
     duration: number
-  ): Record<string, any> {
+  ): BlockOutput {
     const success = childResult.success !== false
 
     // If child workflow failed, return minimal output

--- a/apps/sim/executor/handlers/workflow/workflow-handler.ts
+++ b/apps/sim/executor/handlers/workflow/workflow-handler.ts
@@ -46,8 +46,8 @@ export class WorkflowBlockHandler implements BlockHandler {
         throw new Error(`Maximum workflow nesting depth of ${MAX_WORKFLOW_DEPTH} exceeded`)
       }
 
-      // Check for cycles
-      const executionId = `${context.workflowId}_sub_${workflowId}`
+      // Check for cycles - include block ID to differentiate parallel executions
+      const executionId = `${context.workflowId}_sub_${workflowId}_${block.id}`
       if (WorkflowBlockHandler.executionStack.has(executionId)) {
         throw new Error(`Cyclic workflow dependency detected: ${executionId}`)
       }
@@ -110,7 +110,7 @@ export class WorkflowBlockHandler implements BlockHandler {
       logger.error(`Error executing child workflow ${workflowId}:`, error)
 
       // Clean up execution stack in case of error
-      const executionId = `${context.workflowId}_sub_${workflowId}`
+      const executionId = `${context.workflowId}_sub_${workflowId}_${block.id}`
       WorkflowBlockHandler.executionStack.delete(executionId)
 
       // Get workflow name for error reporting

--- a/apps/sim/executor/handlers/workflow/workflow-handler.ts
+++ b/apps/sim/executor/handlers/workflow/workflow-handler.ts
@@ -90,6 +90,9 @@ export class WorkflowBlockHandler implements BlockHandler {
         workflowInput: childWorkflowInput,
         envVarValues: context.environmentVariables,
         workflowVariables: childWorkflow.variables || {},
+        contextExtensions: {
+          isChildExecution: true, // Prevent child executor from managing global state
+        },
       })
 
       const startTime = performance.now()


### PR DESCRIPTION
## Summary
- same child workflow executing in parallel with workflow block
  - would previously cause cyclical dependency error
- fixed run button prematurely showing completion before child workflows completed
  - would previously show the run was completed before all the child workflows had actually completed 
- prevent child worklfows from touching the activeBlocks & layer logic in the parent executor
  - would not show pulsing since child workflows executor was touching the global activeBlocks set
- surface errors from child workflows
  - child workflow errors do not get surfaced to the main workflow

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

https://github.com/user-attachments/assets/d8b70dd7-1bd9-4b3d-b8bb-b4e172a2d940

<img width="4077" height="2551" alt="image" src="https://github.com/user-attachments/assets/54069031-38e4-4f7b-b19a-8c44cff90070" />
