### PR TITLE
fix(tag-dropdown): fix values for parallel & loop blocks

### DIFF
--- a/apps/sim/components/ui/tag-dropdown.tsx
+++ b/apps/sim/components/ui/tag-dropdown.tsx
@@ -539,8 +539,6 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
       const containingLoopBlock = blocks[loopId]
       if (containingLoopBlock) {
         const loopBlockName = containingLoopBlock.name || containingLoopBlock.type
-        const normalizedLoopBlockName = normalizeBlockName(loopBlockName)
-        contextualTags.push(`${normalizedLoopBlockName}.results`)
 
         loopBlockGroup = {
           blockName: loopBlockName,
@@ -565,8 +563,6 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
       const containingParallelBlock = blocks[parallelId]
       if (containingParallelBlock) {
         const parallelBlockName = containingParallelBlock.name || containingParallelBlock.type
-        const normalizedParallelBlockName = normalizeBlockName(parallelBlockName)
-        contextualTags.push(`${normalizedParallelBlockName}.results`)
 
         parallelBlockGroup = {
           blockName: parallelBlockName,
@@ -803,11 +799,23 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
           })
         } else {
           const path = tagParts.slice(1).join('.')
-          directTags.push({
-            key: path || group.blockName,
-            display: path || group.blockName,
-            fullTag: tag,
-          })
+          // Handle contextual tags for loop/parallel blocks (single words like 'index', 'currentItem')
+          if (
+            (group.blockType === 'loop' || group.blockType === 'parallel') &&
+            tagParts.length === 1
+          ) {
+            directTags.push({
+              key: tag,
+              display: tag,
+              fullTag: tag,
+            })
+          } else {
+            directTags.push({
+              key: path || group.blockName,
+              display: path || group.blockName,
+              fullTag: tag,
+            })
+          }
         }
       })
 


### PR DESCRIPTION
## Summary
fix values for parallel & loop blocks, was not showing index and currentItem

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Before:
<img width="526" height="519" alt="Screenshot 2025-08-10 at 11 55 20 AM" src="https://github.com/user-attachments/assets/e4b29290-9187-411a-9575-cb513eaf1072" />

After:
<img width="454" height="461" alt="Screenshot 2025-08-10 at 11 54 56 AM" src="https://github.com/user-attachments/assets/7d8bc0bd-ef5c-4bf7-aff0-d0c2841844c5" />
