### PR TITLE
improvement(oauth): credentials sharing for workflows

### DIFF
--- a/apps/sim/app/api/auth/oauth/credentials/route.test.ts
+++ b/apps/sim/app/api/auth/oauth/credentials/route.test.ts
@@ -125,7 +125,7 @@ describe('OAuth Credentials API Route', () => {
     })
     expect(data.credentials[1]).toMatchObject({
       id: 'credential-2',
-      provider: 'google-email',
+      provider: 'google-default',
       isDefault: true,
     })
   })
@@ -158,7 +158,7 @@ describe('OAuth Credentials API Route', () => {
     const data = await response.json()
 
     expect(response.status).toBe(400)
-    expect(data.error).toBe('Provider is required')
+    expect(data.error).toBe('Provider or credentialId is required')
     expect(mockLogger.warn).toHaveBeenCalled()
   })
 

--- a/apps/sim/app/api/auth/oauth/credentials/route.ts
+++ b/apps/sim/app/api/auth/oauth/credentials/route.ts
@@ -6,7 +6,7 @@ import { createLogger } from '@/lib/logs/console/logger'
 import type { OAuthService } from '@/lib/oauth/oauth'
 import { parseProvider } from '@/lib/oauth/oauth'
 import { db } from '@/db'
-import { account, user } from '@/db/schema'
+import { account, user, workflow } from '@/db/schema'
 
 export const dynamic = 'force-dynamic'
 
@@ -25,36 +25,59 @@ export async function GET(request: NextRequest) {
   const requestId = crypto.randomUUID().slice(0, 8)
 
   try {
-    // Get the session
-    const session = await getSession()
-
-    // Check if the user is authenticated
-    if (!session?.user?.id) {
-      logger.warn(`[${requestId}] Unauthenticated credentials request rejected`)
-      return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
-    }
-
-    // Get the provider from the query params
+    // Get query params
     const { searchParams } = new URL(request.url)
-    const provider = searchParams.get('provider') as OAuthService | null
+    const providerParam = searchParams.get('provider') as OAuthService | null
+    const workflowId = searchParams.get('workflowId')
+    const credentialId = searchParams.get('credentialId')
 
-    if (!provider) {
-      logger.warn(`[${requestId}] Missing provider parameter`)
-      return NextResponse.json({ error: 'Provider is required' }, { status: 400 })
+    // Resolve effective user id: workflow owner if workflowId provided; else session user
+    let effectiveUserId: string | undefined
+    if (workflowId) {
+      const rows = await db
+        .select({ userId: workflow.userId })
+        .from(workflow)
+        .where(eq(workflow.id, workflowId))
+        .limit(1)
+      effectiveUserId = rows[0]?.userId
     }
 
-    // Parse the provider to get base provider and feature type
-    const { baseProvider } = parseProvider(provider)
+    if (!effectiveUserId) {
+      const session = await getSession()
+      if (!session?.user?.id) {
+        logger.warn(`[${requestId}] Unauthenticated credentials request rejected`)
+        return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
+      }
+      effectiveUserId = session.user.id
+    }
 
-    // Get all accounts for this user and provider
-    const accounts = await db
-      .select()
-      .from(account)
-      .where(and(eq(account.userId, session.user.id), eq(account.providerId, provider)))
+    if (!providerParam && !credentialId) {
+      logger.warn(`[${requestId}] Missing provider parameter`)
+      return NextResponse.json({ error: 'Provider or credentialId is required' }, { status: 400 })
+    }
+
+    // Parse the provider to get base provider and feature type (if provider is present)
+    const { baseProvider } = parseProvider(providerParam || 'google-default')
+
+    let accountsData
+
+    if (credentialId) {
+      // Fetch a single credential by id for the effective user
+      accountsData = await db
+        .select()
+        .from(account)
+        .where(and(eq(account.userId, effectiveUserId), eq(account.id, credentialId)))
+    } else {
+      // Fetch all credentials for provider and effective user
+      accountsData = await db
+        .select()
+        .from(account)
+        .where(and(eq(account.userId, effectiveUserId), eq(account.providerId, providerParam!)))
+    }
 
     // Transform accounts into credentials
     const credentials = await Promise.all(
-      accounts.map(async (acc) => {
+      accountsData.map(async (acc) => {
         // Extract the feature type from providerId (e.g., 'google-default' -> 'default')
         const [_, featureType = 'default'] = acc.providerId.split('-')
 
@@ -109,7 +132,7 @@ export async function GET(request: NextRequest) {
         return {
           id: acc.id,
           name: displayName,
-          provider,
+          provider: acc.providerId,
           lastUsed: acc.updatedAt.toISOString(),
           isDefault: featureType === 'default',
         }

--- a/apps/sim/app/api/tools/jira/issues/route.ts
+++ b/apps/sim/app/api/tools/jira/issues/route.ts
@@ -110,6 +110,7 @@ export async function GET(request: Request) {
     const accessToken = url.searchParams.get('accessToken')
     const providedCloudId = url.searchParams.get('cloudId')
     const query = url.searchParams.get('query') || ''
+    const projectId = url.searchParams.get('projectId') || ''
 
     if (!domain) {
       return NextResponse.json({ error: 'Domain is required' }, { status: 400 })
@@ -131,35 +132,69 @@ export async function GET(request: Request) {
       params.append('query', query)
     }
 
-    // Use the correct Jira Cloud OAuth endpoint structure
-    const apiUrl = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/picker?${params.toString()}`
+    let data: any
 
-    logger.info(`Fetching Jira issue suggestions from: ${apiUrl}`)
-
-    const response = await fetch(apiUrl, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        Accept: 'application/json',
-      },
-    })
-
-    logger.info('Response status:', response.status, response.statusText)
-
-    if (!response.ok) {
-      logger.error(`Jira API error: ${response.status} ${response.statusText}`)
-      let errorMessage
-      try {
-        const errorData = await response.json()
-        logger.error('Error details:', errorData)
-        errorMessage = errorData.message || `Failed to fetch issue suggestions (${response.status})`
-      } catch (_e) {
-        errorMessage = `Failed to fetch issue suggestions: ${response.status} ${response.statusText}`
+    if (query) {
+      const apiUrl = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/picker?${params.toString()}`
+      logger.info(`Fetching Jira issue suggestions from: ${apiUrl}`)
+      const response = await fetch(apiUrl, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: 'application/json',
+        },
+      })
+      logger.info('Response status:', response.status, response.statusText)
+      if (!response.ok) {
+        logger.error(`Jira API error: ${response.status} ${response.statusText}`)
+        let errorMessage
+        try {
+          const errorData = await response.json()
+          logger.error('Error details:', errorData)
+          errorMessage =
+            errorData.message || `Failed to fetch issue suggestions (${response.status})`
+        } catch (_e) {
+          errorMessage = `Failed to fetch issue suggestions: ${response.status} ${response.statusText}`
+        }
+        return NextResponse.json({ error: errorMessage }, { status: response.status })
       }
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      data = await response.json()
+    } else if (projectId) {
+      // When no query, list latest issues for the selected project using Search API
+      const searchParams = new URLSearchParams()
+      searchParams.append('jql', `project=${projectId} ORDER BY updated DESC`)
+      searchParams.append('maxResults', '25')
+      searchParams.append('fields', 'summary,key')
+      const searchUrl = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search?${searchParams.toString()}`
+      logger.info(`Fetching Jira issues via search from: ${searchUrl}`)
+      const response = await fetch(searchUrl, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: 'application/json',
+        },
+      })
+      if (!response.ok) {
+        let errorMessage
+        try {
+          const errorData = await response.json()
+          logger.error('Jira Search API error details:', errorData)
+          errorMessage =
+            errorData.errorMessages?.[0] || `Failed to fetch issues (${response.status})`
+        } catch (_e) {
+          errorMessage = `Failed to fetch issues: ${response.status} ${response.statusText}`
+        }
+        return NextResponse.json({ error: errorMessage }, { status: response.status })
+      }
+      const searchData = await response.json()
+      const issues = (searchData.issues || []).map((it: any) => ({
+        key: it.key,
+        summary: it.fields?.summary || it.key,
+      }))
+      data = { sections: [{ issues }], cloudId }
+    } else {
+      data = { sections: [], cloudId }
     }
-
-    const data = await response.json()
 
     return NextResponse.json({
       ...data,

--- a/apps/sim/app/api/tools/linear/teams/route.ts
+++ b/apps/sim/app/api/tools/linear/teams/route.ts
@@ -1,9 +1,12 @@
 import type { Team } from '@linear/sdk'
 import { LinearClient } from '@linear/sdk'
+import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
+import { db } from '@/db'
+import { account } from '@/db/schema'
 
 export const dynamic = 'force-dynamic'
 
@@ -20,15 +23,39 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Credential is required' }, { status: 400 })
     }
 
-    const userId = session?.user?.id || ''
-    if (!userId) {
+    const requesterUserId = session?.user?.id || ''
+    if (!requesterUserId) {
       logger.error('No user ID found in session')
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
     }
 
-    const accessToken = await refreshAccessTokenIfNeeded(credential, userId, workflowId)
+    // Look up credential to determine owner
+    const creds = await db.select().from(account).where(eq(account.id, credential)).limit(1)
+    if (!creds.length) {
+      logger.error('Credential not found for Linear API', { credential })
+      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
+    }
+    const credentialOwnerUserId = creds[0].userId
+
+    // If requester does not own the credential, allow only if workflowId present (collab context)
+    if (credentialOwnerUserId !== requesterUserId && !workflowId) {
+      logger.warn('Unauthorized Linear credential access attempt without workflow context', {
+        credentialOwnerUserId,
+        requesterUserId,
+      })
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+
+    const accessToken = await refreshAccessTokenIfNeeded(
+      credential,
+      credentialOwnerUserId,
+      workflowId || 'linear'
+    )
     if (!accessToken) {
-      logger.error('Failed to get access token', { credentialId: credential, userId })
+      logger.error('Failed to get access token', {
+        credentialId: credential,
+        userId: credentialOwnerUserId,
+      })
       return NextResponse.json(
         {
           error: 'Could not retrieve access token',

--- a/apps/sim/app/api/tools/microsoft-teams/chats/route.ts
+++ b/apps/sim/app/api/tools/microsoft-teams/chats/route.ts
@@ -1,7 +1,10 @@
+import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
+import { db } from '@/db'
+import { account } from '@/db/schema'
 
 export const dynamic = 'force-dynamic'
 
@@ -118,7 +121,7 @@ export async function POST(request: Request) {
     const session = await getSession()
     const body = await request.json()
 
-    const { credential } = body
+    const { credential, workflowId } = body
 
     if (!credential) {
       logger.error('Missing credential in request')
@@ -126,15 +129,18 @@ export async function POST(request: Request) {
     }
 
     try {
-      // Get the userId either from the session or from the workflowId
       const userId = session?.user?.id || ''
-
       if (!userId) {
         logger.error('No user ID found in session')
         return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
       }
-
-      const accessToken = await refreshAccessTokenIfNeeded(credential, userId, body.workflowId)
+      const creds = await db.select().from(account).where(eq(account.id, credential)).limit(1)
+      if (!creds.length) {
+        return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
+      }
+      const ownerUserId = creds[0].userId
+      // Allow read-only resolution when a workflowId is present
+      const accessToken = await refreshAccessTokenIfNeeded(credential, ownerUserId, 'TeamsChatsAPI')
 
       if (!accessToken) {
         logger.error('Failed to get access token', { credentialId: credential, userId })

--- a/apps/sim/app/api/tools/microsoft-teams/teams/route.ts
+++ b/apps/sim/app/api/tools/microsoft-teams/teams/route.ts
@@ -1,7 +1,10 @@
+import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
+import { db } from '@/db'
+import { account } from '@/db/schema'
 
 export const dynamic = 'force-dynamic'
 
@@ -20,15 +23,24 @@ export async function POST(request: Request) {
     }
 
     try {
-      // Get the userId either from the session or from the workflowId
       const userId = session?.user?.id || ''
-
       if (!userId) {
         logger.error('No user ID found in session')
         return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
       }
+      // Resolve credential owner
+      const creds = await db.select().from(account).where(eq(account.id, credential)).limit(1)
+      if (!creds.length) {
+        return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
+      }
+      const ownerUserId = creds[0].userId
+      // If session doesn't own it and no workflow context, reject
+      if (ownerUserId !== userId && !workflowId) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+      }
+      // Allow read-only resolution when a workflowId is present, even if session user isn't the owner
 
-      const accessToken = await refreshAccessTokenIfNeeded(credential, userId, workflowId)
+      const accessToken = await refreshAccessTokenIfNeeded(credential, ownerUserId, 'TeamsTeamsAPI')
 
       if (!accessToken) {
         logger.error('Failed to get access token', { credentialId: credential, userId })

--- a/apps/sim/app/api/webhooks/route.ts
+++ b/apps/sim/app/api/webhooks/route.ts
@@ -329,7 +329,8 @@ export async function POST(request: NextRequest) {
       logger.info(`[${requestId}] Gmail provider detected. Setting up Gmail webhook configuration.`)
       try {
         const { configureGmailPolling } = await import('@/lib/webhooks/utils')
-        const success = await configureGmailPolling(userId, savedWebhook, requestId)
+        // Use workflow owner for OAuth lookups to support collaborator-saved credentials
+        const success = await configureGmailPolling(workflowRecord.userId, savedWebhook, requestId)
 
         if (!success) {
           logger.error(`[${requestId}] Failed to configure Gmail polling`)
@@ -363,7 +364,12 @@ export async function POST(request: NextRequest) {
       )
       try {
         const { configureOutlookPolling } = await import('@/lib/webhooks/utils')
-        const success = await configureOutlookPolling(userId, savedWebhook, requestId)
+        // Use workflow owner for OAuth lookups to support collaborator-saved credentials
+        const success = await configureOutlookPolling(
+          workflowRecord.userId,
+          savedWebhook,
+          requestId
+        )
 
         if (!success) {
           logger.error(`[${requestId}] Failed to configure Outlook polling`)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
@@ -84,7 +84,7 @@ export function CredentialSelector({
       const response = await fetch(`/api/auth/oauth/credentials?provider=${effectiveProviderId}`)
       if (response.ok) {
         const data = await response.json()
-        let creds = data.credentials as Credential[]
+        const creds = data.credentials as Credential[]
         let foreignMetaFound = false
 
         // If persisted selection is not among viewer's credentials, attempt to fetch its metadata
@@ -100,7 +100,7 @@ export function CredentialSelector({
             if (metaResp.ok) {
               const meta = await metaResp.json()
               if (meta.credentials?.length) {
-                creds = [meta.credentials[0], ...(creds || [])]
+                // Mark as foreign, but do NOT merge into list to avoid leaking owner email
                 foreignMetaFound = true
               }
             }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
@@ -149,7 +149,7 @@ export function CredentialSelector({
         if (aborted) return
         if (metaResp.ok) {
           const meta = await metaResp.json()
-          setHasForeignMeta(!!(meta.credentials && meta.credentials.length))
+          setHasForeignMeta(!!meta.credentials?.length)
         }
       } catch {
         // ignore

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
@@ -83,36 +83,7 @@ export function CredentialSelector({
         const data = await response.json()
         setCredentials(data.credentials)
 
-        // If we have a value but it's not in the credentials, reset it
-        if (selectedId && !data.credentials.some((cred: Credential) => cred.id === selectedId)) {
-          setSelectedId('')
-          if (!isPreview) {
-            setStoreValue('')
-          }
-        }
-
-        // Auto-select logic:
-        // 1. If we already have a valid selection, keep it
-        // 2. If there's a default credential, select it
-        // 3. If there's only one credential, select it
-        if (
-          (!selectedId || !data.credentials.some((cred: Credential) => cred.id === selectedId)) &&
-          data.credentials.length > 0
-        ) {
-          const defaultCred = data.credentials.find((cred: Credential) => cred.isDefault)
-          if (defaultCred) {
-            setSelectedId(defaultCred.id)
-            if (!isPreview) {
-              setStoreValue(defaultCred.id)
-            }
-          } else if (data.credentials.length === 1) {
-            // If only one credential, select it
-            setSelectedId(data.credentials[0].id)
-            if (!isPreview) {
-              setStoreValue(data.credentials[0].id)
-            }
-          }
-        }
+        // Do not auto-select or reset. We only show what's persisted.
       }
     } catch (error) {
       logger.error('Error fetching credentials:', { error })
@@ -156,6 +127,7 @@ export function CredentialSelector({
 
   // Get the selected credential
   const selectedCredential = credentials.find((cred) => cred.id === selectedId)
+  const isForeign = !!(selectedId && !selectedCredential)
 
   // Handle selection
   const handleSelect = (credentialId: string) => {
@@ -214,11 +186,17 @@ export function CredentialSelector({
           >
             <div className='flex max-w-[calc(100%-20px)] items-center gap-2 overflow-hidden'>
               {getProviderIcon(provider)}
-              {selectedCredential ? (
-                <span className='truncate font-normal'>{selectedCredential.name}</span>
-              ) : (
-                <span className='truncate text-muted-foreground'>{label}</span>
-              )}
+              <span
+                className={
+                  selectedCredential ? 'truncate font-normal' : 'truncate text-muted-foreground'
+                }
+              >
+                {selectedCredential
+                  ? selectedCredential.name
+                  : isForeign
+                    ? 'Saved by collaborator'
+                    : label}
+              </span>
             </div>
             <ChevronDown className='absolute right-3 h-4 w-4 shrink-0 opacity-50' />
           </Button>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/confluence-file-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/confluence-file-selector.tsx
@@ -45,6 +45,7 @@ interface ConfluenceFileSelectorProps {
   domain: string
   showPreview?: boolean
   onFileInfoChange?: (fileInfo: ConfluenceFileInfo | null) => void
+  credentialId?: string
 }
 
 export function ConfluenceFileSelector({
@@ -58,11 +59,12 @@ export function ConfluenceFileSelector({
   domain,
   showPreview = true,
   onFileInfoChange,
+  credentialId,
 }: ConfluenceFileSelectorProps) {
   const [open, setOpen] = useState(false)
   const [credentials, setCredentials] = useState<Credential[]>([])
   const [files, setFiles] = useState<ConfluenceFileInfo[]>([])
-  const [selectedCredentialId, setSelectedCredentialId] = useState<string>('')
+  const [selectedCredentialId, setSelectedCredentialId] = useState<string>(credentialId || '')
   const [selectedFileId, setSelectedFileId] = useState(value)
   const [selectedFile, setSelectedFile] = useState<ConfluenceFileInfo | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -120,25 +122,6 @@ export function ConfluenceFileSelector({
       if (response.ok) {
         const data = await response.json()
         setCredentials(data.credentials)
-
-        // Auto-select logic for credentials
-        if (data.credentials.length > 0) {
-          // If we already have a selected credential ID, check if it's valid
-          if (
-            selectedCredentialId &&
-            data.credentials.some((cred: Credential) => cred.id === selectedCredentialId)
-          ) {
-            // Keep the current selection
-          } else {
-            // Otherwise, select the default or first credential
-            const defaultCred = data.credentials.find((cred: Credential) => cred.isDefault)
-            if (defaultCred) {
-              setSelectedCredentialId(defaultCred.id)
-            } else if (data.credentials.length === 1) {
-              setSelectedCredentialId(data.credentials[0].id)
-            }
-          }
-        }
       }
     } catch (error) {
       logger.error('Error fetching credentials:', error)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-calendar-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-calendar-selector.tsx
@@ -35,6 +35,7 @@ interface GoogleCalendarSelectorProps {
   showPreview?: boolean
   onCalendarInfoChange?: (info: GoogleCalendarInfo | null) => void
   credentialId: string
+  workflowId?: string
 }
 
 export function GoogleCalendarSelector({
@@ -45,6 +46,7 @@ export function GoogleCalendarSelector({
   showPreview = true,
   onCalendarInfoChange,
   credentialId,
+  workflowId,
 }: GoogleCalendarSelectorProps) {
   const [open, setOpen] = useState(false)
   const [calendars, setCalendars] = useState<GoogleCalendarInfo[]>([])
@@ -62,6 +64,9 @@ export function GoogleCalendarSelector({
     const queryParams = new URLSearchParams({
       credentialId: credentialId,
     })
+    if (workflowId) {
+      queryParams.set('workflowId', workflowId)
+    }
 
     const response = await fetch(`/api/tools/google_calendar/calendars?${queryParams.toString()}`)
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-drive-picker.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-drive-picker.tsx
@@ -248,7 +248,6 @@ export function GoogleDrivePicker({
       const url = new URL('/api/auth/oauth/token', window.location.origin)
       url.searchParams.set('credentialId', selectedCredentialId)
       // include workflowId if available via global registry (server adds session owner otherwise)
-      // We cannot import store here; picker runs client-side, so let server rely on session for GET; prefer POST when possible
       const response = await fetch(url.toString())
 
       if (!response.ok) {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-drive-picker.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-drive-picker.tsx
@@ -54,6 +54,8 @@ interface GoogleDrivePickerProps {
   onFileInfoChange?: (fileInfo: FileInfo | null) => void
   clientId: string
   apiKey: string
+  credentialId?: string
+  workflowId?: string
 }
 
 export function GoogleDrivePicker({
@@ -69,6 +71,8 @@ export function GoogleDrivePicker({
   onFileInfoChange,
   clientId,
   apiKey,
+  credentialId,
+  workflowId,
 }: GoogleDrivePickerProps) {
   const [open, setOpen] = useState(false)
   const [credentials, setCredentials] = useState<Credential[]>([])
@@ -105,25 +109,7 @@ export function GoogleDrivePicker({
       if (response.ok) {
         const data = await response.json()
         setCredentials(data.credentials)
-
-        // Auto-select logic for credentials
-        if (data.credentials.length > 0) {
-          // If we already have a selected credential ID, check if it's valid
-          if (
-            selectedCredentialId &&
-            data.credentials.some((cred: Credential) => cred.id === selectedCredentialId)
-          ) {
-            // Keep the current selection
-          } else {
-            // Otherwise, select the default or first credential
-            const defaultCred = data.credentials.find((cred: Credential) => cred.isDefault)
-            if (defaultCred) {
-              setSelectedCredentialId(defaultCred.id)
-            } else if (data.credentials.length === 1) {
-              setSelectedCredentialId(data.credentials[0].id)
-            }
-          }
-        }
+        // Do not auto-select. Respect persisted credential via prop when provided.
       }
     } catch (error) {
       logger.error('Error fetching credentials:', { error })
@@ -132,6 +118,13 @@ export function GoogleDrivePicker({
       setCredentialsLoaded(true)
     }
   }, [provider, getProviderId, selectedCredentialId])
+
+  // Prefer persisted credentialId if provided
+  useEffect(() => {
+    if (credentialId && credentialId !== selectedCredentialId) {
+      setSelectedCredentialId(credentialId)
+    }
+  }, [credentialId, selectedCredentialId])
 
   // Fetch a single file by ID when we have a selectedFileId but no metadata
   const fetchFileById = useCallback(
@@ -145,6 +138,7 @@ export function GoogleDrivePicker({
           credentialId: selectedCredentialId,
           fileId: fileId,
         })
+        if (workflowId) queryParams.set('workflowId', workflowId)
 
         const response = await fetch(`/api/tools/drive/file?${queryParams.toString()}`)
 
@@ -251,7 +245,11 @@ export function GoogleDrivePicker({
 
     setIsLoading(true)
     try {
-      const response = await fetch(`/api/auth/oauth/token?credentialId=${selectedCredentialId}`)
+      const url = new URL('/api/auth/oauth/token', window.location.origin)
+      url.searchParams.set('credentialId', selectedCredentialId)
+      // include workflowId if available via global registry (server adds session owner otherwise)
+      // We cannot import store here; picker runs client-side, so let server rely on session for GET; prefer POST when possible
+      const response = await fetch(url.toString())
 
       if (!response.ok) {
         throw new Error(`Failed to fetch access token: ${response.status}`)
@@ -500,10 +498,7 @@ export function GoogleDrivePicker({
                     </div>
                   ) : (
                     <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>Ready to select files.</p>
-                      <p className='text-muted-foreground text-xs'>
-                        Click the button below to open the file picker.
-                      </p>
+                      <p className='font-medium text-sm'>No documents available.</p>
                     </div>
                   )}
                 </CommandEmpty>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
@@ -47,6 +47,7 @@ interface JiraIssueSelectorProps {
   onIssueInfoChange?: (issueInfo: JiraIssueInfo | null) => void
   projectId?: string
   credentialId?: string
+  isForeignCredential?: boolean
 }
 
 export function JiraIssueSelector({
@@ -367,13 +368,12 @@ export function JiraIssueSelector({
     ]
   )
 
-  // Fetch credentials on initial mount
+  // Fetch credentials when the dropdown opens (avoid fetching on mount with no credential)
   useEffect(() => {
-    if (!initialFetchRef.current) {
+    if (open) {
       fetchCredentials()
-      initialFetchRef.current = true
     }
-  }, [fetchCredentials])
+  }, [open, fetchCredentials])
 
   // Handle open change
   const handleOpenChange = (isOpen: boolean) => {
@@ -443,7 +443,7 @@ export function JiraIssueSelector({
               role='combobox'
               aria-expanded={open}
               className='h-10 w-full min-w-0 justify-between'
-              disabled={disabled || !domain}
+              disabled={disabled || !domain || !selectedCredentialId}
             >
               <div className='flex min-w-0 items-center gap-2 overflow-hidden'>
                 {selectedIssue ? (

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
@@ -46,6 +46,7 @@ interface JiraIssueSelectorProps {
   showPreview?: boolean
   onIssueInfoChange?: (issueInfo: JiraIssueInfo | null) => void
   projectId?: string
+  credentialId?: string
 }
 
 export function JiraIssueSelector({
@@ -60,11 +61,12 @@ export function JiraIssueSelector({
   showPreview = true,
   onIssueInfoChange,
   projectId,
+  credentialId,
 }: JiraIssueSelectorProps) {
   const [open, setOpen] = useState(false)
   const [credentials, setCredentials] = useState<Credential[]>([])
   const [issues, setIssues] = useState<JiraIssueInfo[]>([])
-  const [selectedCredentialId, setSelectedCredentialId] = useState<string>('')
+  const [selectedCredentialId, setSelectedCredentialId] = useState<string>(credentialId || '')
   const [selectedIssueId, setSelectedIssueId] = useState(value)
   const [selectedIssue, setSelectedIssue] = useState<JiraIssueInfo | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -124,25 +126,6 @@ export function JiraIssueSelector({
       if (response.ok) {
         const data = await response.json()
         setCredentials(data.credentials)
-
-        // Auto-select logic for credentials
-        if (data.credentials.length > 0) {
-          // If we already have a selected credential ID, check if it's valid
-          if (
-            selectedCredentialId &&
-            data.credentials.some((cred: Credential) => cred.id === selectedCredentialId)
-          ) {
-            // Keep the current selection
-          } else {
-            // Otherwise, select the default or first credential
-            const defaultCred = data.credentials.find((cred: Credential) => cred.isDefault)
-            if (defaultCred) {
-              setSelectedCredentialId(defaultCred.id)
-            } else if (data.credentials.length === 1) {
-              setSelectedCredentialId(data.credentials[0].id)
-            }
-          }
-        }
       }
     } catch (error) {
       logger.error('Error fetching credentials:', error)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
@@ -406,6 +406,14 @@ export function JiraIssueSelector({
     if (value !== selectedIssueId) {
       setSelectedIssueId(value)
     }
+    // When the upstream value is cleared (e.g., project changed or remote user cleared),
+    // clear local selection and preview immediately
+    if (!value) {
+      setSelectedIssue(null)
+      setIssues([])
+      setError(null)
+      onIssueInfoChange?.(null)
+    }
   }, [value])
 
   // Handle issue selection

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
@@ -234,6 +234,11 @@ export function JiraIssueSelector({
   const fetchIssues = useCallback(
     async (searchQuery?: string) => {
       if (!selectedCredentialId || !domain) return
+      // If no search query is provided, require a projectId before fetching
+      if (!searchQuery && !projectId) {
+        setIssues([])
+        return
+      }
 
       // Validate domain format
       const trimmedDomain = domain.trim().toLowerCase()
@@ -376,7 +381,10 @@ export function JiraIssueSelector({
 
     // Only fetch recent/default issues when opening the dropdown
     if (isOpen && selectedCredentialId && domain && domain.includes('.')) {
-      fetchIssues('') // Pass empty string to get recent or default issues
+      // Only fetch on open when a project is selected; otherwise wait for user search
+      if (projectId) {
+        fetchIssues('')
+      }
     }
   }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
@@ -75,6 +75,15 @@ export function JiraIssueSelector({
   const [error, setError] = useState<string | null>(null)
   const [cloudId, setCloudId] = useState<string | null>(null)
 
+  // Keep local credential state in sync with persisted credentialId prop
+  useEffect(() => {
+    if (credentialId && credentialId !== selectedCredentialId) {
+      setSelectedCredentialId(credentialId)
+    } else if (!credentialId && selectedCredentialId) {
+      setSelectedCredentialId('')
+    }
+  }, [credentialId, selectedCredentialId])
+
   // Handle search with debounce
   const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -109,6 +109,7 @@ export function FileSelectorInput({
   const isMicrosoftPlanner = provider === 'microsoft-planner'
   // For Confluence and Jira, we need the domain and credentials
   const domain = isConfluence || isJira ? (getValue(blockId, 'domain') as string) || '' : ''
+  const jiraCredential = isJira ? (getValue(blockId, 'credential') as string) || '' : ''
   // For Discord, we need the bot token and server ID
   const botToken = isDiscord ? (getValue(blockId, 'botToken') as string) || '' : ''
   const serverId = isDiscord ? (getValue(blockId, 'serverId') as string) || '' : ''
@@ -325,7 +326,7 @@ export function FileSelectorInput({
   }
 
   if (isJira) {
-    const credential = (getValue(blockId, 'credential') as string) || ''
+    const credential = jiraCredential
     return (
       <TooltipProvider>
         <Tooltip>
@@ -347,18 +348,28 @@ export function FileSelectorInput({
                 requiredScopes={subBlock.requiredScopes || []}
                 serviceId={subBlock.serviceId}
                 label={subBlock.placeholder || 'Select Jira issue'}
-                disabled={disabled || !domain}
+                disabled={
+                  disabled || !domain || !credential || !(getValue(blockId, 'projectId') as string)
+                }
                 showPreview={true}
                 onIssueInfoChange={setIssueInfo as (info: JiraIssueInfo | null) => void}
                 credentialId={credential}
               />
             </div>
           </TooltipTrigger>
-          {!domain && (
+          {!domain ? (
             <TooltipContent side='top'>
               <p>Please enter a Jira domain first</p>
             </TooltipContent>
-          )}
+          ) : !credential ? (
+            <TooltipContent side='top'>
+              <p>Please select Jira credentials first</p>
+            </TooltipContent>
+          ) : !(getValue(blockId, 'projectId') as string) ? (
+            <TooltipContent side='top'>
+              <p>Please select a Jira project first</p>
+            </TooltipContent>
+          ) : null}
         </Tooltip>
       </TooltipProvider>
     )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -117,59 +117,53 @@ export function FileSelectorInput({
   // Use preview value when in preview mode, otherwise use store value
   const value = isPreview ? previewValue : storeValue
 
-  // Get the current value from the store or prop value if in preview mode
+  // Keep local selection in sync with store value (and preview)
   useEffect(() => {
-    if (isPreview && previewValue !== undefined) {
-      const value = previewValue
-      if (value && typeof value === 'string') {
-        if (isJira) {
-          setSelectedIssueId(value)
-        } else if (isDiscord) {
-          setSelectedChannelId(value)
-        } else if (isMicrosoftTeams) {
-          setSelectedMessageId(value)
-        } else if (isGoogleCalendar) {
-          setSelectedCalendarId(value)
-        } else if (isWealthbox) {
-          setSelectedWealthboxItemId(value)
-        } else if (isMicrosoftSharePoint) {
-          setSelectedFileId(value)
-        } else {
-          setSelectedFileId(value)
-        }
+    const effective = isPreview && previewValue !== undefined ? previewValue : storeValue
+    if (typeof effective === 'string' && effective !== '') {
+      if (isJira) {
+        setSelectedIssueId(effective)
+      } else if (isDiscord) {
+        setSelectedChannelId(effective)
+      } else if (isMicrosoftTeams) {
+        setSelectedMessageId(effective)
+      } else if (isGoogleCalendar) {
+        setSelectedCalendarId(effective)
+      } else if (isWealthbox) {
+        setSelectedWealthboxItemId(effective)
+      } else if (isMicrosoftSharePoint) {
+        setSelectedFileId(effective)
+      } else {
+        setSelectedFileId(effective)
       }
     } else {
-      const value = getValue(blockId, subBlock.id)
-      if (value && typeof value === 'string') {
-        if (isJira) {
-          setSelectedIssueId(value)
-        } else if (isDiscord) {
-          setSelectedChannelId(value)
-        } else if (isMicrosoftTeams) {
-          setSelectedMessageId(value)
-        } else if (isGoogleCalendar) {
-          setSelectedCalendarId(value)
-        } else if (isWealthbox) {
-          setSelectedWealthboxItemId(value)
-        } else if (isMicrosoftSharePoint) {
-          setSelectedFileId(value)
-        } else {
-          setSelectedFileId(value)
-        }
+      // Clear when value becomes empty
+      if (isJira) {
+        setSelectedIssueId('')
+      } else if (isDiscord) {
+        setSelectedChannelId('')
+      } else if (isMicrosoftTeams) {
+        setSelectedMessageId('')
+      } else if (isGoogleCalendar) {
+        setSelectedCalendarId('')
+      } else if (isWealthbox) {
+        setSelectedWealthboxItemId('')
+      } else if (isMicrosoftSharePoint) {
+        setSelectedFileId('')
+      } else {
+        setSelectedFileId('')
       }
     }
   }, [
-    blockId,
-    subBlock.id,
-    getValue,
+    isPreview,
+    previewValue,
+    storeValue,
     isJira,
     isDiscord,
     isMicrosoftTeams,
     isGoogleCalendar,
     isWealthbox,
     isMicrosoftSharePoint,
-    isPreview,
-    previewValue,
   ])
 
   // Handle file selection

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -355,6 +355,7 @@ export function FileSelectorInput({
                 onIssueInfoChange={setIssueInfo as (info: JiraIssueInfo | null) => void}
                 credentialId={credential}
                 projectId={(getValue(blockId, 'projectId') as string) || ''}
+                isForeignCredential={isForeignCredential}
               />
             </div>
           </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -354,6 +354,7 @@ export function FileSelectorInput({
                 showPreview={true}
                 onIssueInfoChange={setIssueInfo as (info: JiraIssueInfo | null) => void}
                 credentialId={credential}
+                projectId={(getValue(blockId, 'projectId') as string) || ''}
               />
             </div>
           </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -183,6 +183,10 @@ export function FileSelectorInput({
     if (isJira) {
       collaborativeSetSubblockValue(blockId, 'summary', '')
       collaborativeSetSubblockValue(blockId, 'description', '')
+      if (!issueKey) {
+        // Also clear the manual issue key when cleared
+        collaborativeSetSubblockValue(blockId, 'manualIssueKey', '')
+      }
     }
   }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
@@ -49,6 +49,7 @@ interface JiraProjectSelectorProps {
   showPreview?: boolean
   onProjectInfoChange?: (projectInfo: JiraProjectInfo | null) => void
   credentialId?: string
+  isForeignCredential?: boolean
 }
 
 export function JiraProjectSelector({

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
@@ -126,25 +126,7 @@ export function JiraProjectSelector({
       if (response.ok) {
         const data = await response.json()
         setCredentials(data.credentials)
-
-        // Auto-select logic for credentials
-        if (data.credentials.length > 0) {
-          // If we already have a selected credential ID, check if it's valid
-          if (
-            selectedCredentialId &&
-            data.credentials.some((cred: Credential) => cred.id === selectedCredentialId)
-          ) {
-            // Keep the current selection
-          } else {
-            // Otherwise, select the default or first credential
-            const defaultCred = data.credentials.find((cred: Credential) => cred.isDefault)
-            if (defaultCred) {
-              setSelectedCredentialId(defaultCred.id)
-            } else if (data.credentials.length === 1) {
-              setSelectedCredentialId(data.credentials[0].id)
-            }
-          }
-        }
+        // Do not auto-select credentials. Only use the credentialId provided by the parent.
       }
     } catch (error) {
       logger.error('Error fetching credentials:', error)
@@ -335,13 +317,12 @@ export function JiraProjectSelector({
     ]
   )
 
-  // Fetch credentials on initial mount
+  // Fetch credentials list when dropdown opens (for account switching UI), not on mount
   useEffect(() => {
-    if (!initialFetchRef.current) {
+    if (open) {
       fetchCredentials()
-      initialFetchRef.current = true
     }
-  }, [fetchCredentials])
+  }, [open, fetchCredentials])
 
   // Keep local credential state in sync with persisted credential
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
@@ -48,6 +48,7 @@ interface JiraProjectSelectorProps {
   domain: string
   showPreview?: boolean
   onProjectInfoChange?: (projectInfo: JiraProjectInfo | null) => void
+  credentialId?: string
 }
 
 export function JiraProjectSelector({
@@ -61,11 +62,12 @@ export function JiraProjectSelector({
   domain,
   showPreview = true,
   onProjectInfoChange,
+  credentialId,
 }: JiraProjectSelectorProps) {
   const [open, setOpen] = useState(false)
   const [credentials, setCredentials] = useState<Credential[]>([])
   const [projects, setProjects] = useState<JiraProjectInfo[]>([])
-  const [selectedCredentialId, setSelectedCredentialId] = useState<string>('')
+  const [selectedCredentialId, setSelectedCredentialId] = useState<string>(credentialId || '')
   const [selectedProjectId, setSelectedProjectId] = useState(value)
   const [selectedProject, setSelectedProject] = useState<JiraProjectInfo | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -337,6 +339,13 @@ export function JiraProjectSelector({
     }
   }, [fetchCredentials])
 
+  // Keep local credential state in sync with persisted credential
+  useEffect(() => {
+    if (credentialId && credentialId !== selectedCredentialId) {
+      setSelectedCredentialId(credentialId)
+    }
+  }, [credentialId, selectedCredentialId])
+
   // Fetch the selected project metadata once credentials are ready or changed
   useEffect(() => {
     if (value && selectedCredentialId && !selectedProject && domain && domain.includes('.')) {
@@ -394,7 +403,7 @@ export function JiraProjectSelector({
               role='combobox'
               aria-expanded={open}
               className='w-full justify-between'
-              disabled={disabled || !domain}
+              disabled={disabled || !domain || !selectedCredentialId}
             >
               {selectedProject ? (
                 <div className='flex items-center gap-2 overflow-hidden'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
@@ -348,8 +348,9 @@ export function JiraProjectSelector({
   // Handle open change
   const handleOpenChange = (isOpen: boolean) => {
     setOpen(isOpen)
+    // Only fetch projects when a credential is present; otherwise, do nothing
     if (isOpen && selectedCredentialId && domain && domain.includes('.')) {
-      fetchProjects('') // Pass empty string to get all projects
+      fetchProjects('')
     }
   }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
@@ -334,7 +334,13 @@ export function JiraProjectSelector({
 
   // Fetch the selected project metadata once credentials are ready or changed
   useEffect(() => {
-    if (value && selectedCredentialId && !selectedProject && domain && domain.includes('.')) {
+    if (
+      value &&
+      selectedCredentialId &&
+      domain &&
+      domain.includes('.') &&
+      (!selectedProject || selectedProject.id !== value)
+    ) {
       fetchProjectInfo(value)
     }
   }, [value, selectedCredentialId, selectedProject, domain, fetchProjectInfo])
@@ -396,6 +402,11 @@ export function JiraProjectSelector({
                 <div className='flex items-center gap-2 overflow-hidden'>
                   <JiraIcon className='h-4 w-4' />
                   <span className='truncate font-normal'>{selectedProject.name}</span>
+                </div>
+              ) : selectedProjectId ? (
+                <div className='flex items-center gap-2 overflow-hidden'>
+                  <JiraIcon className='h-4 w-4' />
+                  <span className='truncate font-normal'>{selectedProjectId}</span>
                 </div>
               ) : (
                 <div className='flex items-center gap-2'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/linear-project-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/linear-project-selector.tsx
@@ -24,6 +24,7 @@ interface LinearProjectSelectorProps {
   teamId: string
   label?: string
   disabled?: boolean
+  workflowId?: string
 }
 
 export function LinearProjectSelector({
@@ -33,6 +34,7 @@ export function LinearProjectSelector({
   teamId,
   label = 'Select Linear project',
   disabled = false,
+  workflowId,
 }: LinearProjectSelectorProps) {
   const [projects, setProjects] = useState<LinearProjectInfo[]>([])
   const [loading, setLoading] = useState(false)
@@ -49,7 +51,7 @@ export function LinearProjectSelector({
     fetch('/api/tools/linear/projects', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ credential, teamId }),
+      body: JSON.stringify({ credential, teamId, workflowId }),
       signal: controller.signal,
     })
       .then(async (res) => {
@@ -80,7 +82,7 @@ export function LinearProjectSelector({
       })
       .finally(() => setLoading(false))
     return () => controller.abort()
-  }, [credential, teamId, value])
+  }, [credential, teamId, value, workflowId])
 
   // Sync selected project with value prop
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/linear-team-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/linear-team-selector.tsx
@@ -23,6 +23,7 @@ interface LinearTeamSelectorProps {
   credential: string
   label?: string
   disabled?: boolean
+  workflowId?: string
   showPreview?: boolean
 }
 
@@ -32,6 +33,7 @@ export function LinearTeamSelector({
   credential,
   label = 'Select Linear team',
   disabled = false,
+  workflowId,
 }: LinearTeamSelectorProps) {
   const [teams, setTeams] = useState<LinearTeamInfo[]>([])
   const [loading, setLoading] = useState(false)
@@ -48,7 +50,7 @@ export function LinearTeamSelector({
     fetch('/api/tools/linear/teams', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ credential }),
+      body: JSON.stringify({ credential, workflowId }),
       signal: controller.signal,
     })
       .then((res) => {
@@ -76,7 +78,7 @@ export function LinearTeamSelector({
       })
       .finally(() => setLoading(false))
     return () => controller.abort()
-  }, [credential, value])
+  }, [credential, value, workflowId])
 
   // Sync selected team with value prop
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
@@ -47,6 +47,12 @@ export function ProjectSelectorInput({
 
   // Use the proper hook to get the current value and setter
   const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlock.id)
+  // Local setters for related Jira fields to ensure immediate UI clearing
+  const [_issueKeyValue, setIssueKeyValue] = useSubBlockValue<string>(blockId, 'issueKey')
+  const [_manualIssueKeyValue, setManualIssueKeyValue] = useSubBlockValue<string>(
+    blockId,
+    'manualIssueKey'
+  )
   // Reactive dependencies from store for Linear
   const [linearCredential] = useSubBlockValue(blockId, 'credential')
   const [linearTeamId] = useSubBlockValue(blockId, 'teamId')
@@ -118,6 +124,9 @@ export function ProjectSelectorInput({
       // Clear both the basic and advanced issue key fields to ensure UI resets
       collaborativeSetSubblockValue(blockId, 'issueKey', '')
       collaborativeSetSubblockValue(blockId, 'manualIssueKey', '')
+      // Also clear locally for immediate UI feedback on this client
+      setIssueKeyValue('')
+      setManualIssueKeyValue('')
     } else if (provider === 'discord') {
       collaborativeSetSubblockValue(blockId, 'channelId', '')
     } else if (provider === 'linear') {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
@@ -21,6 +21,7 @@ import {
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
 import type { SubBlockConfig } from '@/blocks/types'
 import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
+import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 
 interface ProjectSelectorInputProps {
   blockId: string
@@ -48,6 +49,7 @@ export function ProjectSelectorInput({
   // Reactive dependencies from store for Linear
   const [linearCredential] = useSubBlockValue(blockId, 'credential')
   const [linearTeamId] = useSubBlockValue(blockId, 'teamId')
+  const activeWorkflowId = useWorkflowRegistry((s) => s.activeWorkflowId) as string | null
 
   // Get provider-specific values
   const provider = subBlock.provider || 'jira'
@@ -143,6 +145,7 @@ export function ProjectSelectorInput({
                   label={subBlock.placeholder || 'Select Linear team'}
                   disabled={disabled || !(linearCredential as string)}
                   showPreview={true}
+                  workflowId={activeWorkflowId || ''}
                 />
               ) : (
                 (() => {
@@ -159,6 +162,7 @@ export function ProjectSelectorInput({
                       teamId={teamId}
                       label={subBlock.placeholder || 'Select Linear project'}
                       disabled={isDisabled}
+                      workflowId={activeWorkflowId || ''}
                     />
                   )
                 })()

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
@@ -202,11 +202,15 @@ export function ProjectSelectorInput({
             />
           </div>
         </TooltipTrigger>
-        {!domain && (
+        {!domain ? (
           <TooltipContent side='top'>
             <p>Please enter a Jira domain first</p>
           </TooltipContent>
-        )}
+        ) : !(jiraCredential as string) ? (
+          <TooltipContent side='top'>
+            <p>Please select a Jira account first</p>
+          </TooltipContent>
+        ) : null}
       </Tooltip>
     </TooltipProvider>
   )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
@@ -115,7 +115,9 @@ export function ProjectSelectorInput({
     if (provider === 'jira') {
       collaborativeSetSubblockValue(blockId, 'summary', '')
       collaborativeSetSubblockValue(blockId, 'description', '')
+      // Clear both the basic and advanced issue key fields to ensure UI resets
       collaborativeSetSubblockValue(blockId, 'issueKey', '')
+      collaborativeSetSubblockValue(blockId, 'manualIssueKey', '')
     } else if (provider === 'discord') {
       collaborativeSetSubblockValue(blockId, 'channelId', '')
     } else if (provider === 'linear') {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
@@ -56,8 +56,10 @@ export function ProjectSelectorInput({
   const isDiscord = provider === 'discord'
   const isLinear = provider === 'linear'
 
-  // For Jira and Discord, we can keep existing behavior (not part of this fix)
-  const domain = ''
+  // Jira/Discord upstream fields
+  const [jiraDomain] = useSubBlockValue(blockId, 'domain')
+  const [jiraCredential] = useSubBlockValue(blockId, 'credential')
+  const domain = (jiraDomain as string) || ''
   const botToken = ''
 
   // Get the current value from the store or prop value if in preview mode
@@ -193,9 +195,10 @@ export function ProjectSelectorInput({
               requiredScopes={subBlock.requiredScopes || []}
               serviceId={subBlock.serviceId}
               label={subBlock.placeholder || 'Select Jira project'}
-              disabled={disabled}
+              disabled={disabled || !domain || !(jiraCredential as string)}
               showPreview={true}
               onProjectInfoChange={setProjectInfo}
+              credentialId={(jiraCredential as string) || ''}
             />
           </div>
         </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/trigger-config/trigger-config.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/trigger-config/trigger-config.tsx
@@ -124,9 +124,20 @@ export function TriggerConfig({
   }, [refreshWebhookState])
 
   // Re-check when collaborative store updates trigger fields (so other users' changes reflect)
+  // Avoid overriding local edits while the modal is open or when saving/deleting
   useEffect(() => {
-    refreshWebhookState()
-  }, [storeTriggerId, storeTriggerPath, storeTriggerConfig, refreshWebhookState])
+    if (!isModalOpen && !isSaving && !isDeleting) {
+      refreshWebhookState()
+    }
+  }, [
+    storeTriggerId,
+    storeTriggerPath,
+    storeTriggerConfig,
+    isModalOpen,
+    isSaving,
+    isDeleting,
+    refreshWebhookState,
+  ])
 
   const handleOpenModal = () => {
     if (isPreview || disabled) return

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/trigger-config/trigger-config.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/trigger-config/trigger-config.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ExternalLink } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
@@ -66,59 +66,67 @@ export function TriggerConfig({
   const [actualTriggerId, setActualTriggerId] = useState<string | null>(null)
 
   // Check if webhook exists in the database (using existing webhook API)
-  useEffect(() => {
+  const refreshWebhookState = useCallback(async () => {
     // Skip API calls in preview mode
-    if (isPreview) {
+    if (isPreview || !effectiveTriggerId) {
       setIsLoading(false)
       return
     }
 
-    const checkWebhook = async () => {
-      setIsLoading(true)
-      try {
-        // Check if there's a webhook for this specific block
-        const response = await fetch(`/api/webhooks?workflowId=${workflowId}&blockId=${blockId}`)
-        if (response.ok) {
-          const data = await response.json()
-          if (data.webhooks && data.webhooks.length > 0) {
-            const webhook = data.webhooks[0].webhook
-            setTriggerId(webhook.id)
-            setActualTriggerId(webhook.provider)
+    setIsLoading(true)
+    try {
+      const response = await fetch(`/api/webhooks?workflowId=${workflowId}&blockId=${blockId}`)
+      if (response.ok) {
+        const data = await response.json()
+        if (data.webhooks && data.webhooks.length > 0) {
+          const webhook = data.webhooks[0].webhook
+          setTriggerId(webhook.id)
+          setActualTriggerId(webhook.provider)
 
-            // Update the path in the block state if it's different
-            if (webhook.path && webhook.path !== triggerPath) {
-              setTriggerPath(webhook.path)
-            }
+          if (webhook.path && webhook.path !== triggerPath) {
+            setTriggerPath(webhook.path)
+          }
 
-            // Update trigger config (from webhook providerConfig)
-            if (webhook.providerConfig) {
-              setTriggerConfig(webhook.providerConfig)
-            }
-          } else {
-            setTriggerId(null)
-            setActualTriggerId(null)
+          if (webhook.providerConfig) {
+            setTriggerConfig(webhook.providerConfig)
+          }
+        } else {
+          setTriggerId(null)
+          setActualTriggerId(null)
 
-            // Clear stale trigger data from store when no webhook found in database
-            if (triggerPath) {
-              setTriggerPath('')
-              logger.info('Cleared stale trigger path on page refresh - no webhook in database', {
-                blockId,
-                clearedPath: triggerPath,
-              })
-            }
+          if (triggerPath) {
+            setTriggerPath('')
+            logger.info('Cleared stale trigger path on page refresh - no webhook in database', {
+              blockId,
+              clearedPath: triggerPath,
+            })
           }
         }
-      } catch (error) {
-        logger.error('Error checking webhook:', { error })
-      } finally {
-        setIsLoading(false)
       }
+    } catch (error) {
+      logger.error('Error checking webhook:', { error })
+    } finally {
+      setIsLoading(false)
     }
+  }, [
+    isPreview,
+    effectiveTriggerId,
+    workflowId,
+    blockId,
+    triggerPath,
+    setTriggerPath,
+    setTriggerConfig,
+  ])
 
-    if (effectiveTriggerId) {
-      checkWebhook()
-    }
-  }, [workflowId, blockId, isPreview, effectiveTriggerId])
+  // Initial load
+  useEffect(() => {
+    refreshWebhookState()
+  }, [refreshWebhookState])
+
+  // Re-check when collaborative store updates trigger fields (so other users' changes reflect)
+  useEffect(() => {
+    refreshWebhookState()
+  }, [storeTriggerId, storeTriggerPath, storeTriggerConfig, refreshWebhookState])
 
   const handleOpenModal = () => {
     if (isPreview || disabled) return

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -157,28 +157,24 @@ export function WorkflowBlock({ id, data }: NodeProps<WorkflowBlockProps>) {
     collaborativeToggleBlockWide,
     collaborativeToggleBlockAdvancedMode,
     collaborativeToggleBlockTriggerMode,
+    collaborativeSetSubblockValue,
   } = useCollaborativeWorkflow()
 
   // Clear credential-dependent fields when credential changes
+  const prevCredRef = useRef<string | undefined>(undefined)
   useEffect(() => {
     const activeWorkflowId = useWorkflowRegistry.getState().activeWorkflowId
     if (!activeWorkflowId) return
     const current = useSubBlockStore.getState().workflowValues[activeWorkflowId]?.[id]
     if (!current) return
     const cred = current.credential?.value as string | undefined
-    const prevRefKey = `__prevCredIdRef_${id}`
-    const anyGlobal = globalThis as any
-    const prevRef = anyGlobal[prevRefKey] || { current: cred }
-    anyGlobal[prevRefKey] = prevRef
-    if (prevRef.current !== cred) {
-      prevRef.current = cred
-      // naive clear: remove known dependent keys if present
+    if (prevCredRef.current !== cred) {
+      prevCredRef.current = cred
       const keys = Object.keys(current)
       const dependentKeys = keys.filter((k) => k !== 'credential')
-      const { collaborativeSetSubblockValue } = useCollaborativeWorkflow()
       dependentKeys.forEach((k) => collaborativeSetSubblockValue(id, k, ''))
     }
-  }, [id])
+  }, [id, collaborativeSetSubblockValue])
 
   // Workflow store actions
   const updateBlockHeight = useWorkflowStore((state) => state.updateBlockHeight)

--- a/apps/sim/tools/index.ts
+++ b/apps/sim/tools/index.ts
@@ -111,19 +111,15 @@ export async function executeTool(
       try {
         const baseUrl = getBaseUrl()
 
-        const isServerSide = typeof window === 'undefined'
-
         // Prepare the token payload
         const tokenPayload: OAuthTokenPayload = {
           credentialId: contextParams.credential,
         }
 
-        // Add workflowId if it exists in params or context (only server-side)
-        if (isServerSide) {
-          const workflowId = contextParams.workflowId || contextParams._context?.workflowId
-          if (workflowId) {
-            tokenPayload.workflowId = workflowId
-          }
+        // Add workflowId if it exists in params or context
+        const workflowId = contextParams.workflowId || contextParams._context?.workflowId
+        if (workflowId) {
+          tokenPayload.workflowId = workflowId
         }
 
         logger.info(`[${requestId}] Fetching access token from ${baseUrl}/api/auth/oauth/token`)


### PR DESCRIPTION
## Summary

Auto-selection of credentials was overwriting what the other user had causing deselection of "credential dependent" subblocks -- document ids, file ids, etc. 

This fixes that by having a owner credential vs foreign credential distinguishing check. And also having the UX clearly indicate to the user who's credentials the workflow is running on. 

## Type of Change
- [x] Bug fix

## Testing

Tested all webhooks + Oauth blocks with @aadamgough. E.g. 

https://github.com/user-attachments/assets/3d1875e5-5da9-40a9-8b06-01469267280c


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)