### PR TITLE
fix(tag-dropdown): last char dropped bug

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/subflows/components/iteration-badges/iteration-badges.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/subflows/components/iteration-badges/iteration-badges.tsx
@@ -158,19 +158,23 @@ export function IterationBadges({ nodeId, data, iterationType }: IterationBadges
   const handleEditorChange = useCallback(
     (value: string) => {
       if (isPreview) return
-      collaborativeUpdateIterationCollection(nodeId, iterationType, value)
 
-      const textarea = editorContainerRef.current?.querySelector('textarea')
+      // Capture cursor first to minimize staleness in dropdown logic
+      const textarea = editorContainerRef.current?.querySelector(
+        'textarea'
+      ) as HTMLTextAreaElement | null
+      const cursorPos = textarea?.selectionStart ?? cursorPosition
       if (textarea) {
         textareaRef.current = textarea
-        const cursorPos = textarea.selectionStart || 0
-        setCursorPosition(cursorPos)
-
-        const triggerCheck = checkTagTrigger(value, cursorPos)
-        setShowTagDropdown(triggerCheck.show)
       }
+      setCursorPosition(cursorPos)
+
+      collaborativeUpdateIterationCollection(nodeId, iterationType, value)
+
+      const triggerCheck = checkTagTrigger(value, cursorPos)
+      setShowTagDropdown(triggerCheck.show)
     },
-    [nodeId, iterationType, collaborativeUpdateIterationCollection, isPreview]
+    [nodeId, iterationType, collaborativeUpdateIterationCollection, isPreview, cursorPosition]
   )
 
   // Handle tag selection

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
@@ -446,24 +446,25 @@ export function Code({
             value={code}
             onValueChange={(newCode) => {
               if (!isCollapsed && !isAiStreaming && !isPreview && !disabled) {
+                // Capture cursor first to minimize staleness in dropdown logic
+                const textarea = editorRef.current?.querySelector(
+                  'textarea'
+                ) as HTMLTextAreaElement | null
+                const pos = textarea?.selectionStart ?? cursorPosition
+                setCursorPosition(pos)
+
                 setCode(newCode)
                 setStoreValue(newCode)
 
-                const textarea = editorRef.current?.querySelector('textarea')
-                if (textarea) {
-                  const pos = textarea.selectionStart
-                  setCursorPosition(pos)
-
-                  const tagTrigger = checkTagTrigger(newCode, pos)
-                  setShowTags(tagTrigger.show)
-                  if (!tagTrigger.show) {
-                    setActiveSourceBlockId(null)
-                  }
-
-                  const envVarTrigger = checkEnvVarTrigger(newCode, pos)
-                  setShowEnvVars(envVarTrigger.show)
-                  setSearchTerm(envVarTrigger.show ? envVarTrigger.searchTerm : '')
+                const tagTrigger = checkTagTrigger(newCode, pos)
+                setShowTags(tagTrigger.show)
+                if (!tagTrigger.show) {
+                  setActiveSourceBlockId(null)
                 }
+
+                const envVarTrigger = checkEnvVarTrigger(newCode, pos)
+                setShowEnvVars(envVarTrigger.show)
+                setSearchTerm(envVarTrigger.show ? envVarTrigger.searchTerm : '')
               }
             }}
             onKeyDown={(e) => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/combobox.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/combobox.tsx
@@ -150,12 +150,13 @@ export function ComboBox({
     const newValue = e.target.value
     const newCursorPosition = e.target.selectionStart ?? 0
 
+    // Update cursor first to reduce staleness for dropdown logic
+    setCursorPosition(newCursorPosition)
+
     // Update store value immediately (allow free text)
     if (!isPreview) {
       setStoreValue(newValue)
     }
-
-    setCursorPosition(newCursorPosition)
 
     // Check for environment variables trigger
     const envVarTrigger = checkEnvVarTrigger(newValue, newCursorPosition)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/long-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/long-input.tsx
@@ -148,6 +148,9 @@ export function LongInput({
     const newValue = e.target.value
     const newCursorPosition = e.target.selectionStart ?? 0
 
+    // Update cursor first to minimize state staleness for dropdown selection logic
+    setCursorPosition(newCursorPosition)
+
     // Update local content immediately
     setLocalContent(newValue)
 
@@ -157,8 +160,6 @@ export function LongInput({
       // Only update store when not in preview mode
       setStoreValue(newValue)
     }
-
-    setCursorPosition(newCursorPosition)
 
     // Check for environment variables trigger
     const envVarTrigger = checkEnvVarTrigger(newValue, newCursorPosition)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/short-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/short-input.tsx
@@ -106,14 +106,15 @@ export function ShortInput({
     const newValue = e.target.value
     const newCursorPosition = e.target.selectionStart ?? 0
 
+    // Update cursor first to minimize state staleness for dropdown selection logic
+    setCursorPosition(newCursorPosition)
+
     if (onChange) {
       onChange(newValue)
     } else if (!isPreview) {
       // Only update store when not in preview mode
       setStoreValue(newValue)
     }
-
-    setCursorPosition(newCursorPosition)
 
     // Check for environment variables trigger
     const envVarTrigger = checkEnvVarTrigger(newValue, newCursorPosition)


### PR DESCRIPTION
## Summary

The closing bracket ('>') was triggering an effect to close the tag dropdown, that was racing with the entry of the last character. Could be the cause of the bug. Use live dom tracking in the tag dropdown to prevent this. Also move set cursor before store value setter for extra precaution.

## Type of Change
- [x] Bug fix

## Testing
Tested manually typing out variable values.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
