### PR TITLE
fix(force-dynamic): revert force-dynamic for the 38 routes that we previously added it to

### DIFF
--- a/apps/sim/app/api/chat/route.ts
+++ b/apps/sim/app/api/chat/route.ts
@@ -14,8 +14,6 @@ import { chat } from '@/db/schema'
 
 const logger = createLogger('ChatAPI')
 
-export const dynamic = 'force-dynamic'
-
 const chatSchema = z.object({
   workflowId: z.string().min(1, 'Workflow ID is required'),
   subdomain: z

--- a/apps/sim/app/api/chat/subdomains/validate/route.ts
+++ b/apps/sim/app/api/chat/subdomains/validate/route.ts
@@ -2,9 +2,6 @@ import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { createErrorResponse, createSuccessResponse } from '@/app/api/workflows/utils'
 import { db } from '@/db'
 import { chat } from '@/db/schema'

--- a/apps/sim/app/api/environment/route.ts
+++ b/apps/sim/app/api/environment/route.ts
@@ -3,9 +3,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { decryptSecret, encryptSecret } from '@/lib/utils'
 import { db } from '@/db'
 import { environment } from '@/db/schema'

--- a/apps/sim/app/api/jobs/[jobId]/route.ts
+++ b/apps/sim/app/api/jobs/[jobId]/route.ts
@@ -3,11 +3,8 @@ import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-import { db } from '@/db'
-
-export const dynamic = 'force-dynamic'
-
 import { createErrorResponse } from '@/app/api/workflows/utils'
+import { db } from '@/db'
 import { apiKey as apiKeyTable } from '@/db/schema'
 
 const logger = createLogger('TaskStatusAPI')

--- a/apps/sim/app/api/knowledge/[id]/documents/[documentId]/chunks/[chunkId]/route.ts
+++ b/apps/sim/app/api/knowledge/[id]/documents/[documentId]/chunks/[chunkId]/route.ts
@@ -4,9 +4,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { checkChunkAccess } from '@/app/api/knowledge/utils'
 import { db } from '@/db'
 import { document, embedding } from '@/db/schema'

--- a/apps/sim/app/api/knowledge/[id]/documents/[documentId]/chunks/route.ts
+++ b/apps/sim/app/api/knowledge/[id]/documents/[documentId]/chunks/route.ts
@@ -4,9 +4,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { estimateTokenCount } from '@/lib/tokenization/estimators'
 import { getUserId } from '@/app/api/auth/oauth/utils'
 import {

--- a/apps/sim/app/api/knowledge/[id]/documents/[documentId]/route.ts
+++ b/apps/sim/app/api/knowledge/[id]/documents/[documentId]/route.ts
@@ -4,9 +4,6 @@ import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { TAG_SLOTS } from '@/lib/constants/knowledge'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import {
   checkDocumentAccess,
   checkDocumentWriteAccess,

--- a/apps/sim/app/api/organizations/[id]/invitations/route.ts
+++ b/apps/sim/app/api/organizations/[id]/invitations/route.ts
@@ -21,8 +21,6 @@ import { invitation, member, organization, user, workspace, workspaceInvitation 
 
 const logger = createLogger('OrganizationInvitationsAPI')
 
-export const dynamic = 'force-dynamic'
-
 interface WorkspaceInvitation {
   workspaceId: string
   permission: 'admin' | 'write' | 'read'

--- a/apps/sim/app/api/organizations/[id]/members/[memberId]/route.ts
+++ b/apps/sim/app/api/organizations/[id]/members/[memberId]/route.ts
@@ -7,8 +7,6 @@ import { member, user, userStats } from '@/db/schema'
 
 const logger = createLogger('OrganizationMemberAPI')
 
-export const dynamic = 'force-dynamic'
-
 /**
  * GET /api/organizations/[id]/members/[memberId]
  * Get individual organization member details

--- a/apps/sim/app/api/organizations/[id]/members/route.ts
+++ b/apps/sim/app/api/organizations/[id]/members/route.ts
@@ -13,8 +13,6 @@ import { invitation, member, organization, user, userStats } from '@/db/schema'
 
 const logger = createLogger('OrganizationMembersAPI')
 
-export const dynamic = 'force-dynamic'
-
 /**
  * GET /api/organizations/[id]/members
  * Get organization members with optional usage data

--- a/apps/sim/app/api/organizations/invitations/accept/route.ts
+++ b/apps/sim/app/api/organizations/invitations/accept/route.ts
@@ -9,8 +9,6 @@ import { invitation, member, permissions, workspaceInvitation } from '@/db/schem
 
 const logger = createLogger('OrganizationInvitationAcceptanceAPI')
 
-export const dynamic = 'force-dynamic'
-
 // Accept an organization invitation and any associated workspace invitations
 export async function GET(req: NextRequest) {
   const invitationId = req.nextUrl.searchParams.get('id')

--- a/apps/sim/app/api/schedules/[id]/status/route.ts
+++ b/apps/sim/app/api/schedules/[id]/status/route.ts
@@ -3,9 +3,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { getUserEntityPermissions } from '@/lib/permissions/utils'
-
-export const dynamic = 'force-dynamic'
-
 import { db } from '@/db'
 import { workflow, workflowSchedule } from '@/db/schema'
 

--- a/apps/sim/app/api/schedules/route.ts
+++ b/apps/sim/app/api/schedules/route.ts
@@ -18,8 +18,6 @@ import { workflow, workflowSchedule } from '@/db/schema'
 
 const logger = createLogger('ScheduledAPI')
 
-export const dynamic = 'force-dynamic'
-
 const ScheduleRequestSchema = z.object({
   workflowId: z.string(),
   blockId: z.string().optional(),

--- a/apps/sim/app/api/tools/custom/route.ts
+++ b/apps/sim/app/api/tools/custom/route.ts
@@ -9,9 +9,6 @@ import { customTools } from '@/db/schema'
 
 const logger = createLogger('CustomToolsAPI')
 
-export const dynamic = 'force-dynamic'
-
-// Define validation schema for custom tools
 const CustomToolSchema = z.object({
   tools: z.array(
     z.object({

--- a/apps/sim/app/api/usage-limits/route.ts
+++ b/apps/sim/app/api/usage-limits/route.ts
@@ -7,8 +7,6 @@ import { isOrganizationOwnerOrAdmin } from '@/lib/permissions/utils'
 
 const logger = createLogger('UnifiedUsageLimitsAPI')
 
-export const dynamic = 'force-dynamic'
-
 /**
  * Unified Usage Limits Endpoint
  * GET/PUT /api/usage-limits?context=user|member&userId=<id>&organizationId=<id>

--- a/apps/sim/app/api/users/me/api-keys/[id]/route.ts
+++ b/apps/sim/app/api/users/me/api-keys/[id]/route.ts
@@ -2,9 +2,6 @@ import { and, eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { db } from '@/db'
 import { apiKey } from '@/db/schema'
 

--- a/apps/sim/app/api/users/me/api-keys/route.ts
+++ b/apps/sim/app/api/users/me/api-keys/route.ts
@@ -9,8 +9,6 @@ import { apiKey } from '@/db/schema'
 
 const logger = createLogger('ApiKeysAPI')
 
-export const dynamic = 'force-dynamic'
-
 // GET /api/users/me/api-keys - Get all API keys for the current user
 export async function GET(request: NextRequest) {
   try {

--- a/apps/sim/app/api/users/me/subscription/[id]/transfer/route.ts
+++ b/apps/sim/app/api/users/me/subscription/[id]/transfer/route.ts
@@ -3,9 +3,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { db } from '@/db'
 import { member, organization, subscription } from '@/db/schema'
 

--- a/apps/sim/app/api/users/rate-limit/route.ts
+++ b/apps/sim/app/api/users/rate-limit/route.ts
@@ -2,9 +2,6 @@ import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { createErrorResponse } from '@/app/api/workflows/utils'
 import { db } from '@/db'
 import { apiKey as apiKeyTable, subscription } from '@/db/schema'

--- a/apps/sim/app/api/workflows/[id]/duplicate/route.ts
+++ b/apps/sim/app/api/workflows/[id]/duplicate/route.ts
@@ -4,9 +4,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { getUserEntityPermissions } from '@/lib/permissions/utils'
 import { db } from '@/db'
 import { workflow, workflowBlocks, workflowEdges, workflowSubflows } from '@/db/schema'

--- a/apps/sim/app/api/workflows/[id]/route.ts
+++ b/apps/sim/app/api/workflows/[id]/route.ts
@@ -12,8 +12,6 @@ import { apiKey as apiKeyTable, workflow } from '@/db/schema'
 
 const logger = createLogger('WorkflowByIdAPI')
 
-export const dynamic = 'force-dynamic'
-
 const UpdateWorkflowSchema = z.object({
   name: z.string().min(1, 'Name is required').optional(),
   description: z.string().optional(),

--- a/apps/sim/app/api/workflows/[id]/state/route.ts
+++ b/apps/sim/app/api/workflows/[id]/state/route.ts
@@ -3,9 +3,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { getUserEntityPermissions } from '@/lib/permissions/utils'
 import { saveWorkflowToNormalizedTables } from '@/lib/workflows/db-helpers'
 import { db } from '@/db'
@@ -13,7 +10,6 @@ import { workflow } from '@/db/schema'
 
 const logger = createLogger('WorkflowStateAPI')
 
-// Zod schemas for workflow state validation
 const PositionSchema = z.object({
   x: z.number(),
   y: z.number(),

--- a/apps/sim/app/api/workflows/[id]/variables/route.ts
+++ b/apps/sim/app/api/workflows/[id]/variables/route.ts
@@ -3,9 +3,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { getUserEntityPermissions } from '@/lib/permissions/utils'
 import { db } from '@/db'
 import { workflow } from '@/db/schema'

--- a/apps/sim/app/api/workflows/route.ts
+++ b/apps/sim/app/api/workflows/route.ts
@@ -8,9 +8,6 @@ import { workflow, workflowBlocks } from '@/db/schema'
 
 const logger = createLogger('WorkflowAPI')
 
-export const dynamic = 'force-dynamic'
-
-// Schema for workflow creation
 const CreateWorkflowSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   description: z.string().optional().default(''),

--- a/apps/sim/app/api/workflows/sync/route.ts
+++ b/apps/sim/app/api/workflows/sync/route.ts
@@ -3,9 +3,6 @@ import { and, eq, isNull } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-
-export const dynamic = 'force-dynamic'
-
 import { getUserEntityPermissions } from '@/lib/permissions/utils'
 import { db } from '@/db'
 import { workflow, workspace } from '@/db/schema'

--- a/apps/sim/app/api/workspaces/[id]/permissions/route.ts
+++ b/apps/sim/app/api/workspaces/[id]/permissions/route.ts
@@ -3,9 +3,6 @@ import { and, eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { getUsersWithPermissions, hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
-
-export const dynamic = 'force-dynamic'
-
 import { db } from '@/db'
 import { permissions, type permissionTypeEnum } from '@/db/schema'
 

--- a/apps/sim/app/api/workspaces/invitations/[id]/route.ts
+++ b/apps/sim/app/api/workspaces/invitations/[id]/route.ts
@@ -5,8 +5,6 @@ import { hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
 import { db } from '@/db'
 import { workspaceInvitation } from '@/db/schema'
 
-export const dynamic = 'force-dynamic'
-
 // DELETE /api/workspaces/invitations/[id] - Delete a workspace invitation
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params

--- a/apps/sim/app/api/workspaces/invitations/accept/route.ts
+++ b/apps/sim/app/api/workspaces/invitations/accept/route.ts
@@ -6,8 +6,6 @@ import { env } from '@/lib/env'
 import { db } from '@/db'
 import { permissions, user, workspace, workspaceInvitation } from '@/db/schema'
 
-export const dynamic = 'force-dynamic'
-
 // Accept an invitation via token
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token')

--- a/apps/sim/app/api/workspaces/invitations/details/route.ts
+++ b/apps/sim/app/api/workspaces/invitations/details/route.ts
@@ -4,8 +4,6 @@ import { getSession } from '@/lib/auth'
 import { db } from '@/db'
 import { workspace, workspaceInvitation } from '@/db/schema'
 
-export const dynamic = 'force-dynamic'
-
 // Get invitation details by token
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token')

--- a/apps/sim/app/api/workspaces/members/[id]/route.ts
+++ b/apps/sim/app/api/workspaces/members/[id]/route.ts
@@ -5,8 +5,6 @@ import { hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
 import { db } from '@/db'
 import { permissions } from '@/db/schema'
 
-export const dynamic = 'force-dynamic'
-
 // DELETE /api/workspaces/members/[id] - Remove a member from a workspace
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id: userId } = await params

--- a/apps/sim/app/api/workspaces/members/route.ts
+++ b/apps/sim/app/api/workspaces/members/route.ts
@@ -7,8 +7,6 @@ import { permissions, type permissionTypeEnum, user } from '@/db/schema'
 
 type PermissionType = (typeof permissionTypeEnum.enumValues)[number]
 
-export const dynamic = 'force-dynamic'
-
 // Add a member to a workspace
 export async function POST(req: Request) {
   const session = await getSession()


### PR DESCRIPTION
## Summary
revert force-dynamic for the 38 routes that we previously added it to in https://github.com/simstudioai/sim/pull/787/files since it started causing the workflow detached error, next step is to use redis for session data. For some of these routes, we had already removed it so there are <38 that we had to remove it from.

## Type of Change
- [x] Bug fix

## Testing
Tested manually everything behaves the same. Instead of forcing these routes to be dynamic, we let NextJS decide which pages to load statically.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)