### PR TITLE
fix(agent): stringify input into user prompt for agent

### DIFF
--- a/apps/sim/executor/handlers/agent/agent-handler.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.ts
@@ -317,11 +317,13 @@ export class AgentBlockHandler implements BlockHandler {
   }
 
   private addUserPrompt(messages: Message[], userPrompt: any) {
-    let content = userPrompt
+    let content: string
     if (typeof userPrompt === 'object' && userPrompt.input) {
-      content = userPrompt.input
+      content = String(userPrompt.input)
     } else if (typeof userPrompt === 'object') {
       content = JSON.stringify(userPrompt)
+    } else {
+      content = String(userPrompt)
     }
 
     messages.push({ role: 'user', content })


### PR DESCRIPTION
## Summary
stringify input into user prompt for agent, because the user input only takes a string which results in JSONs not being able to go in directly or numbers or anything besides strings

## Type of Change
- [x] New feature  

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)