### PR TITLE
fix(loading): fix workflow detached on first load

### DIFF
--- a/apps/sim/stores/workflows/registry/store.ts
+++ b/apps/sim/stores/workflows/registry/store.ts
@@ -426,8 +426,12 @@ export const useWorkflowRegistry = create<WorkflowRegistry>()(
       setActiveWorkflow: async (id: string) => {
         const { workflows, activeWorkflowId } = get()
 
-        if (activeWorkflowId === id) {
-          logger.info(`Already active workflow ${id}, skipping switch`)
+        // Check if workflow is already active AND has data loaded
+        const workflowStoreState = useWorkflowStore.getState()
+        const hasWorkflowData = Object.keys(workflowStoreState.blocks).length > 0
+
+        if (activeWorkflowId === id && hasWorkflowData) {
+          logger.info(`Already active workflow ${id} with data loaded, skipping switch`)
           return
         }
 


### PR DESCRIPTION
## Summary
-  fix workflow detached on first load
  - we set the activeWorkflowId immediately, and the check in the store checked only that and not if the workflow data was loaded in, now we modified it to check if the active workflow id matched the id provided, and that we have the workflow data then leave the loading state

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

https://github.com/user-attachments/assets/74222c1c-1f40-47fe-89d7-4ed484411d2c