### PR TITLE
fix(picker-ui): picker UI confusing when credential not set + Microsoft OAuth Fixes

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/channel-selector/channel-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/channel-selector/channel-selector-input.tsx
@@ -33,6 +33,10 @@ export function ChannelSelectorInput({
 
   // Use the proper hook to get the current value and setter (same as file-selector)
   const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlock.id)
+  // Reactive upstream fields
+  const [authMethod] = useSubBlockValue(blockId, 'authMethod')
+  const [botToken] = useSubBlockValue(blockId, 'botToken')
+  const [connectedCredential] = useSubBlockValue(blockId, 'credential')
   const [selectedChannelId, setSelectedChannelId] = useState<string>('')
   const [_channelInfo, setChannelInfo] = useState<SlackChannelInfo | null>(null)
 
@@ -40,17 +44,14 @@ export function ChannelSelectorInput({
   const provider = subBlock.provider || 'slack'
   const isSlack = provider === 'slack'
 
-  // Get the credential for the provider - use provided credential or fall back to store
-  const authMethod = getValue(blockId, 'authMethod') as string
-  const botToken = getValue(blockId, 'botToken') as string
-
+  // Get the credential for the provider - use provided credential or fall back to reactive values
   let credential: string
   if (providedCredential) {
     credential = providedCredential
-  } else if (authMethod === 'bot_token' && botToken) {
-    credential = botToken
+  } else if ((authMethod as string) === 'bot_token' && (botToken as string)) {
+    credential = botToken as string
   } else {
-    credential = (getValue(blockId, 'credential') as string) || ''
+    credential = (connectedCredential as string) || ''
   }
 
   // Use preview value when in preview mode, otherwise use store value
@@ -58,18 +59,11 @@ export function ChannelSelectorInput({
 
   // Get the current value from the store or prop value if in preview mode (same pattern as file-selector)
   useEffect(() => {
-    if (isPreview && previewValue !== undefined) {
-      const value = previewValue
-      if (value && typeof value === 'string') {
-        setSelectedChannelId(value)
-      }
-    } else {
-      const value = getValue(blockId, subBlock.id)
-      if (value && typeof value === 'string') {
-        setSelectedChannelId(value)
-      }
+    const val = isPreview && previewValue !== undefined ? previewValue : storeValue
+    if (val && typeof val === 'string') {
+      setSelectedChannelId(val)
     }
-  }, [blockId, subBlock.id, getValue, isPreview, previewValue])
+  }, [isPreview, previewValue, storeValue])
 
   // Handle channel selection (same pattern as file-selector)
   const handleChannelChange = (channelId: string, info?: SlackChannelInfo) => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
@@ -124,12 +124,10 @@ export function CredentialSelector({
     }
   }, [effectiveProviderId, selectedId, activeWorkflowId])
 
-  // Fetch credentials on initial mount
+  // Fetch credentials on initial mount and whenever the subblock value changes externally
   useEffect(() => {
     fetchCredentials()
-    // This effect should only run once on mount, so empty dependency array
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [fetchCredentials, effectiveValue])
 
   // When the selectedId changes (e.g., collaborator saved a credential), determine if it's foreign
   useEffect(() => {
@@ -180,6 +178,19 @@ export function CredentialSelector({
     }
   }, [fetchCredentials])
 
+  // Also handle BFCache restores (back/forward navigation) where visibility change may not fire reliably
+  useEffect(() => {
+    const handlePageShow = (event: any) => {
+      if (event && event.persisted) {
+        fetchCredentials()
+      }
+    }
+    window.addEventListener('pageshow', handlePageShow)
+    return () => {
+      window.removeEventListener('pageshow', handlePageShow)
+    }
+  }, [fetchCredentials])
+
   // Handle popover open to fetch fresh credentials
   const handleOpenChange = (isOpen: boolean) => {
     setOpen(isOpen)
@@ -192,6 +203,13 @@ export function CredentialSelector({
   // Get the selected credential
   const selectedCredential = credentials.find((cred) => cred.id === selectedId)
   const isForeign = !!(selectedId && !selectedCredential && hasForeignMeta)
+
+  // If the list doesn’t contain the effective value but meta says it exists, synthesize a non-leaky placeholder to render stable UI
+  const displayName = selectedCredential
+    ? selectedCredential.name
+    : isForeign
+      ? 'Saved by collaborator'
+      : undefined
 
   // Handle selection
   const handleSelect = (credentialId: string) => {
@@ -263,15 +281,9 @@ export function CredentialSelector({
             <div className='flex max-w-[calc(100%-20px)] items-center gap-2 overflow-hidden'>
               {getProviderIcon(provider)}
               <span
-                className={
-                  selectedCredential ? 'truncate font-normal' : 'truncate text-muted-foreground'
-                }
+                className={displayName ? 'truncate font-normal' : 'truncate text-muted-foreground'}
               >
-                {selectedCredential
-                  ? selectedCredential.name
-                  : isForeign
-                    ? 'Saved by collaborator'
-                    : label}
+                {displayName || label}
               </span>
             </div>
             <ChevronDown className='absolute right-3 h-4 w-4 shrink-0 opacity-50' />

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
@@ -181,7 +181,7 @@ export function CredentialSelector({
   // Also handle BFCache restores (back/forward navigation) where visibility change may not fire reliably
   useEffect(() => {
     const handlePageShow = (event: any) => {
-      if (event && event.persisted) {
+      if (event?.persisted) {
         fetchCredentials()
       }
     }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/confluence-file-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/confluence-file-selector.tsx
@@ -200,6 +200,18 @@ export function ConfluenceFileSelector({
         if (data.file) {
           setSelectedFile(data.file)
           onFileInfoChange?.(data.file)
+        } else {
+          const fileInfo: ConfluenceFileInfo = {
+            id: data.id || pageId,
+            name: data.title || `Page ${pageId}`,
+            mimeType: 'confluence/page',
+            webViewLink: undefined,
+            modifiedTime: undefined,
+            spaceId: undefined,
+            url: undefined,
+          }
+          setSelectedFile(fileInfo)
+          onFileInfoChange?.(fileInfo)
         }
       } catch (error) {
         logger.error('Error fetching page info:', error)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/confluence-file-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/confluence-file-selector.tsx
@@ -46,6 +46,8 @@ interface ConfluenceFileSelectorProps {
   showPreview?: boolean
   onFileInfoChange?: (fileInfo: ConfluenceFileInfo | null) => void
   credentialId?: string
+  workflowId?: string
+  isForeignCredential?: boolean
 }
 
 export function ConfluenceFileSelector({
@@ -60,6 +62,8 @@ export function ConfluenceFileSelector({
   showPreview = true,
   onFileInfoChange,
   credentialId,
+  workflowId,
+  isForeignCredential = false,
 }: ConfluenceFileSelectorProps) {
   const [open, setOpen] = useState(false)
   const [credentials, setCredentials] = useState<Credential[]>([])
@@ -156,6 +160,7 @@ export function ConfluenceFileSelector({
           },
           body: JSON.stringify({
             credentialId: selectedCredentialId,
+            workflowId,
           }),
         })
 
@@ -197,13 +202,14 @@ export function ConfluenceFileSelector({
         setIsLoading(false)
       }
     },
-    [selectedCredentialId, domain, onFileInfoChange]
+    [selectedCredentialId, domain, onFileInfoChange, workflowId]
   )
 
   // Fetch pages from Confluence
   const fetchFiles = useCallback(
     async (searchQuery?: string) => {
       if (!selectedCredentialId || !domain) return
+      if (isForeignCredential) return
 
       // Validate domain format
       const trimmedDomain = domain.trim().toLowerCase()
@@ -228,6 +234,7 @@ export function ConfluenceFileSelector({
           },
           body: JSON.stringify({
             credentialId: selectedCredentialId,
+            workflowId,
           }),
         })
 
@@ -267,6 +274,12 @@ export function ConfluenceFileSelector({
 
         if (!response.ok) {
           const errorData = await response.json()
+          if (response.status === 401 || response.status === 403) {
+            logger.info('Confluence pages fetch unauthorized (expected for collaborator)')
+            setFiles([])
+            setIsLoading(false)
+            return
+          }
           logger.error('Confluence API error:', errorData)
           throw new Error(errorData.error || 'Failed to fetch pages')
         }
@@ -294,7 +307,15 @@ export function ConfluenceFileSelector({
         setIsLoading(false)
       }
     },
-    [selectedCredentialId, domain, selectedFileId, onFileInfoChange, fetchPageInfo]
+    [
+      selectedCredentialId,
+      domain,
+      selectedFileId,
+      onFileInfoChange,
+      fetchPageInfo,
+      workflowId,
+      isForeignCredential,
+    ]
   )
 
   // Fetch credentials on initial mount
@@ -310,7 +331,7 @@ export function ConfluenceFileSelector({
     setOpen(isOpen)
 
     // Only fetch files when opening the dropdown and if we have valid credentials and domain
-    if (isOpen && selectedCredentialId && domain && domain.includes('.')) {
+    if (isOpen && !isForeignCredential && selectedCredentialId && domain && domain.includes('.')) {
       fetchFiles()
     }
   }
@@ -320,7 +341,15 @@ export function ConfluenceFileSelector({
     if (value && selectedCredentialId && !selectedFile && domain && domain.includes('.')) {
       fetchPageInfo(value)
     }
-  }, [value, selectedCredentialId, selectedFile, domain, fetchPageInfo])
+  }, [
+    value,
+    selectedCredentialId,
+    selectedFile,
+    domain,
+    fetchPageInfo,
+    workflowId,
+    isForeignCredential,
+  ])
 
   // Keep internal selectedFileId in sync with the value prop
   useEffect(() => {
@@ -363,7 +392,7 @@ export function ConfluenceFileSelector({
               role='combobox'
               aria-expanded={open}
               className='h-10 w-full min-w-0 justify-between'
-              disabled={disabled || !domain}
+              disabled={disabled || !domain || isForeignCredential}
             >
               <div className='flex min-w-0 items-center gap-2 overflow-hidden'>
                 {selectedFile ? (
@@ -381,118 +410,122 @@ export function ConfluenceFileSelector({
               <ChevronDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
             </Button>
           </PopoverTrigger>
-          <PopoverContent className='w-[300px] p-0' align='start'>
-            {/* Current account indicator */}
-            {selectedCredentialId && credentials.length > 0 && (
-              <div className='flex items-center justify-between border-b px-3 py-2'>
-                <div className='flex items-center gap-2'>
-                  <ConfluenceIcon className='h-4 w-4' />
-                  <span className='text-muted-foreground text-xs'>
-                    {credentials.find((cred) => cred.id === selectedCredentialId)?.name ||
-                      'Unknown'}
-                  </span>
-                </div>
-                {credentials.length > 1 && (
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    className='h-6 px-2 text-xs'
-                    onClick={() => setOpen(true)}
-                  >
-                    Switch
-                  </Button>
-                )}
-              </div>
-            )}
-
-            <Command>
-              <CommandInput placeholder='Search pages...' onValueChange={handleSearch} />
-              <CommandList>
-                <CommandEmpty>
-                  {isLoading ? (
-                    <div className='flex items-center justify-center p-4'>
-                      <RefreshCw className='h-4 w-4 animate-spin' />
-                      <span className='ml-2'>Loading pages...</span>
-                    </div>
-                  ) : error ? (
-                    <div className='p-4 text-center'>
-                      <p className='text-destructive text-sm'>{error}</p>
-                    </div>
-                  ) : credentials.length === 0 ? (
-                    <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>No accounts connected.</p>
-                      <p className='text-muted-foreground text-xs'>
-                        Connect a Confluence account to continue.
-                      </p>
-                    </div>
-                  ) : (
-                    <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>No pages found.</p>
-                      <p className='text-muted-foreground text-xs'>
-                        Try a different search or account.
-                      </p>
-                    </div>
+          {!isForeignCredential && (
+            <PopoverContent className='w-[300px] p-0' align='start'>
+              {/* Current account indicator */}
+              {selectedCredentialId && credentials.length > 0 && (
+                <div className='flex items-center justify-between border-b px-3 py-2'>
+                  <div className='flex items-center gap-2'>
+                    <ConfluenceIcon className='h-4 w-4' />
+                    <span className='text-muted-foreground text-xs'>
+                      {credentials.find((cred) => cred.id === selectedCredentialId)?.name ||
+                        'Unknown'}
+                    </span>
+                  </div>
+                  {credentials.length > 1 && (
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-6 px-2 text-xs'
+                      onClick={() => setOpen(true)}
+                    >
+                      Switch
+                    </Button>
                   )}
-                </CommandEmpty>
+                </div>
+              )}
 
-                {/* Account selection - only show if we have multiple accounts */}
-                {credentials.length > 1 && (
-                  <CommandGroup>
-                    <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
-                      Switch Account
-                    </div>
-                    {credentials.map((cred) => (
-                      <CommandItem
-                        key={cred.id}
-                        value={`account-${cred.id}`}
-                        onSelect={() => setSelectedCredentialId(cred.id)}
-                      >
-                        <div className='flex items-center gap-2'>
-                          <ConfluenceIcon className='h-4 w-4' />
-                          <span className='font-normal'>{cred.name}</span>
-                        </div>
-                        {cred.id === selectedCredentialId && <Check className='ml-auto h-4 w-4' />}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-
-                {/* Files list */}
-                {files.length > 0 && (
-                  <CommandGroup>
-                    <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
-                      Pages
-                    </div>
-                    {files.map((file) => (
-                      <CommandItem
-                        key={file.id}
-                        value={`file-${file.id}-${file.name}`}
-                        onSelect={() => handleSelectFile(file)}
-                      >
-                        <div className='flex items-center gap-2 overflow-hidden'>
-                          <ConfluenceIcon className='h-4 w-4' />
-                          <span className='truncate font-normal'>{file.name}</span>
-                        </div>
-                        {file.id === selectedFileId && <Check className='ml-auto h-4 w-4' />}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-
-                {/* Connect account option - only show if no credentials */}
-                {credentials.length === 0 && (
-                  <CommandGroup>
-                    <CommandItem onSelect={handleAddCredential}>
-                      <div className='flex items-center gap-2 text-primary'>
-                        <ConfluenceIcon className='h-4 w-4' />
-                        <span>Connect Confluence account</span>
+              <Command>
+                <CommandInput placeholder='Search pages...' onValueChange={handleSearch} />
+                <CommandList>
+                  <CommandEmpty>
+                    {isLoading ? (
+                      <div className='flex items-center justify-center p-4'>
+                        <RefreshCw className='h-4 w-4 animate-spin' />
+                        <span className='ml-2'>Loading pages...</span>
                       </div>
-                    </CommandItem>
-                  </CommandGroup>
-                )}
-              </CommandList>
-            </Command>
-          </PopoverContent>
+                    ) : error ? (
+                      <div className='p-4 text-center'>
+                        <p className='text-destructive text-sm'>{error}</p>
+                      </div>
+                    ) : credentials.length === 0 ? (
+                      <div className='p-4 text-center'>
+                        <p className='font-medium text-sm'>No accounts connected.</p>
+                        <p className='text-muted-foreground text-xs'>
+                          Connect a Confluence account to continue.
+                        </p>
+                      </div>
+                    ) : (
+                      <div className='p-4 text-center'>
+                        <p className='font-medium text-sm'>No pages found.</p>
+                        <p className='text-muted-foreground text-xs'>
+                          Try a different search or account.
+                        </p>
+                      </div>
+                    )}
+                  </CommandEmpty>
+
+                  {/* Account selection - only show if we have multiple accounts */}
+                  {credentials.length > 1 && (
+                    <CommandGroup>
+                      <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
+                        Switch Account
+                      </div>
+                      {credentials.map((cred) => (
+                        <CommandItem
+                          key={cred.id}
+                          value={`account-${cred.id}`}
+                          onSelect={() => setSelectedCredentialId(cred.id)}
+                        >
+                          <div className='flex items-center gap-2'>
+                            <ConfluenceIcon className='h-4 w-4' />
+                            <span className='font-normal'>{cred.name}</span>
+                          </div>
+                          {cred.id === selectedCredentialId && (
+                            <Check className='ml-auto h-4 w-4' />
+                          )}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+
+                  {/* Files list */}
+                  {files.length > 0 && (
+                    <CommandGroup>
+                      <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
+                        Pages
+                      </div>
+                      {files.map((file) => (
+                        <CommandItem
+                          key={file.id}
+                          value={`file-${file.id}-${file.name}`}
+                          onSelect={() => handleSelectFile(file)}
+                        >
+                          <div className='flex items-center gap-2 overflow-hidden'>
+                            <ConfluenceIcon className='h-4 w-4' />
+                            <span className='truncate font-normal'>{file.name}</span>
+                          </div>
+                          {file.id === selectedFileId && <Check className='ml-auto h-4 w-4' />}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+
+                  {/* Connect account option - only show if no credentials */}
+                  {credentials.length === 0 && (
+                    <CommandGroup>
+                      <CommandItem onSelect={handleAddCredential}>
+                        <div className='flex items-center gap-2 text-primary'>
+                          <ConfluenceIcon className='h-4 w-4' />
+                          <span>Connect Confluence account</span>
+                        </div>
+                      </CommandItem>
+                    </CommandGroup>
+                  )}
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          )}
         </Popover>
 
         {/* File preview */}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/confluence-file-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/confluence-file-selector.tsx
@@ -75,6 +75,12 @@ export function ConfluenceFileSelector({
   const [showOAuthModal, setShowOAuthModal] = useState(false)
   const initialFetchRef = useRef(false)
   const [error, setError] = useState<string | null>(null)
+  // Keep internal credential in sync with prop (handles late arrival and BFCache restores)
+  useEffect(() => {
+    if (credentialId && credentialId !== selectedCredentialId) {
+      setSelectedCredentialId(credentialId)
+    }
+  }, [credentialId, selectedCredentialId])
 
   // Handle search with debounce
   const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-drive-picker.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-drive-picker.tsx
@@ -1,18 +1,11 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Check, ChevronDown, ExternalLink, FileIcon, FolderIcon, RefreshCw, X } from 'lucide-react'
+import { ChevronDown, ExternalLink, FileIcon, FolderIcon, RefreshCw, X } from 'lucide-react'
 import useDrivePicker from 'react-google-drive-picker'
 import { GoogleDocsIcon, GoogleSheetsIcon } from '@/components/icons'
 import { Button } from '@/components/ui/button'
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+// Removed dropdown/command imports as the picker opens directly
 import { getEnv } from '@/lib/env'
 import { createLogger } from '@/lib/logs/console/logger'
 import {
@@ -74,7 +67,7 @@ export function GoogleDrivePicker({
   credentialId,
   workflowId,
 }: GoogleDrivePickerProps) {
-  const [open, setOpen] = useState(false)
+  // Dropdown removed; we only keep credential and picker logic
   const [credentials, setCredentials] = useState<Credential[]>([])
   const [selectedCredentialId, setSelectedCredentialId] = useState<string>('')
   const [selectedFileId, setSelectedFileId] = useState(value)
@@ -237,8 +230,9 @@ export function GoogleDrivePicker({
   ])
 
   // Fetch the access token for the selected credential
-  const fetchAccessToken = async (): Promise<string | null> => {
-    if (!selectedCredentialId) {
+  const fetchAccessToken = async (credentialOverrideId?: string): Promise<string | null> => {
+    const effectiveCredentialId = credentialOverrideId || selectedCredentialId
+    if (!effectiveCredentialId) {
       logger.error('No credential ID selected for Google Drive Picker')
       return null
     }
@@ -246,7 +240,7 @@ export function GoogleDrivePicker({
     setIsLoading(true)
     try {
       const url = new URL('/api/auth/oauth/token', window.location.origin)
-      url.searchParams.set('credentialId', selectedCredentialId)
+      url.searchParams.set('credentialId', effectiveCredentialId)
       // include workflowId if available via global registry (server adds session owner otherwise)
       const response = await fetch(url.toString())
 
@@ -265,10 +259,10 @@ export function GoogleDrivePicker({
   }
 
   // Handle opening the Google Drive Picker
-  const handleOpenPicker = async () => {
+  const handleOpenPicker = async (credentialOverrideId?: string) => {
     try {
       // First, get the access token for the selected credential
-      const accessToken = await fetchAccessToken()
+      const accessToken = await fetchAccessToken(credentialOverrideId)
 
       if (!accessToken) {
         logger.error('Failed to get access token for Google Drive Picker')
@@ -335,7 +329,6 @@ export function GoogleDrivePicker({
   const handleAddCredential = () => {
     // Show the OAuth modal
     setShowOAuthModal(true)
-    setOpen(false)
   }
 
   // Clear selection
@@ -426,136 +419,48 @@ export function GoogleDrivePicker({
   return (
     <>
       <div className='space-y-2'>
-        <Popover open={open} onOpenChange={setOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              variant='outline'
-              role='combobox'
-              aria-expanded={open}
-              className='h-10 w-full min-w-0 justify-between'
-              disabled={disabled}
-            >
-              <div className='flex min-w-0 items-center gap-2 overflow-hidden'>
-                {selectedFile ? (
-                  <>
-                    {getFileIcon(selectedFile, 'sm')}
-                    <span className='truncate font-normal'>{selectedFile.name}</span>
-                  </>
-                ) : selectedFileId && isLoadingSelectedFile && selectedCredentialId ? (
-                  <>
-                    <RefreshCw className='h-4 w-4 animate-spin' />
-                    <span className='truncate text-muted-foreground'>Loading document...</span>
-                  </>
-                ) : (
-                  <>
-                    {getProviderIcon(provider)}
-                    <span className='truncate text-muted-foreground'>{label}</span>
-                  </>
-                )}
-              </div>
-              <ChevronDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className='w-[300px] p-0' align='start'>
-            {/* Current account indicator */}
-            {selectedCredentialId && credentials.length > 0 && (
-              <div className='flex items-center justify-between border-b px-3 py-2'>
-                <div className='flex items-center gap-2'>
-                  {getProviderIcon(provider)}
-                  <span className='text-muted-foreground text-xs'>
-                    {credentials.find((cred) => cred.id === selectedCredentialId)?.name ||
-                      'Unknown'}
-                  </span>
-                </div>
-                {credentials.length > 1 && (
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    className='h-6 px-2 text-xs'
-                    onClick={() => setOpen(true)}
-                  >
-                    Switch
-                  </Button>
-                )}
-              </div>
+        <Button
+          variant='outline'
+          role='combobox'
+          className='h-10 w-full min-w-0 justify-between'
+          disabled={disabled || isLoading}
+          onClick={async () => {
+            // Decide which credential to use
+            let idToUse = selectedCredentialId
+            if (!idToUse && credentials.length === 1) {
+              idToUse = credentials[0].id
+              setSelectedCredentialId(idToUse)
+            }
+
+            if (!idToUse) {
+              // No credentials — prompt OAuth
+              handleAddCredential()
+              return
+            }
+
+            await handleOpenPicker(idToUse)
+          }}
+        >
+          <div className='flex min-w-0 items-center gap-2 overflow-hidden'>
+            {selectedFile ? (
+              <>
+                {getFileIcon(selectedFile, 'sm')}
+                <span className='truncate font-normal'>{selectedFile.name}</span>
+              </>
+            ) : selectedFileId && isLoadingSelectedFile && selectedCredentialId ? (
+              <>
+                <RefreshCw className='h-4 w-4 animate-spin' />
+                <span className='truncate text-muted-foreground'>Loading document...</span>
+              </>
+            ) : (
+              <>
+                {getProviderIcon(provider)}
+                <span className='truncate text-muted-foreground'>{label}</span>
+              </>
             )}
-
-            <Command>
-              <CommandList>
-                <CommandEmpty>
-                  {isLoading ? (
-                    <div className='flex items-center justify-center p-4'>
-                      <RefreshCw className='h-4 w-4 animate-spin' />
-                      <span className='ml-2'>Loading...</span>
-                    </div>
-                  ) : credentials.length === 0 ? (
-                    <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>No accounts connected.</p>
-                      <p className='text-muted-foreground text-xs'>
-                        Connect a {getProviderName(provider)} account to continue.
-                      </p>
-                    </div>
-                  ) : (
-                    <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>No documents available.</p>
-                    </div>
-                  )}
-                </CommandEmpty>
-
-                {/* Account selection - only show if we have multiple accounts */}
-                {credentials.length > 1 && (
-                  <CommandGroup>
-                    <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
-                      Switch Account
-                    </div>
-                    {credentials.map((cred) => (
-                      <CommandItem
-                        key={cred.id}
-                        value={`account-${cred.id}`}
-                        onSelect={() => setSelectedCredentialId(cred.id)}
-                      >
-                        <div className='flex items-center gap-2'>
-                          {getProviderIcon(cred.provider)}
-                          <span className='font-normal'>{cred.name}</span>
-                        </div>
-                        {cred.id === selectedCredentialId && <Check className='ml-auto h-4 w-4' />}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-
-                {/* Open picker button - only show if we have credentials */}
-                {credentials.length > 0 && selectedCredentialId && (
-                  <CommandGroup>
-                    <div className='p-2'>
-                      <Button
-                        className='w-full'
-                        onClick={() => {
-                          setOpen(false)
-                          handleOpenPicker()
-                        }}
-                      >
-                        Open Google Drive Picker
-                      </Button>
-                    </div>
-                  </CommandGroup>
-                )}
-
-                {/* Connect account option - only show if no credentials */}
-                {credentials.length === 0 && (
-                  <CommandGroup>
-                    <CommandItem onSelect={handleAddCredential}>
-                      <div className='flex items-center gap-2 text-primary'>
-                        {getProviderIcon(provider)}
-                        <span>Connect {getProviderName(provider)} account</span>
-                      </div>
-                    </CommandItem>
-                  </CommandGroup>
-                )}
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
+          </div>
+          <ChevronDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
+        </Button>
 
         {/* File preview */}
         {showPreview && selectedFile && (

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-drive-picker.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-drive-picker.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ChevronDown, ExternalLink, FileIcon, FolderIcon, RefreshCw, X } from 'lucide-react'
+import { ExternalLink, FileIcon, FolderIcon, RefreshCw, X } from 'lucide-react'
 import useDrivePicker from 'react-google-drive-picker'
 import { GoogleDocsIcon, GoogleSheetsIcon } from '@/components/icons'
 import { Button } from '@/components/ui/button'
@@ -457,7 +457,6 @@ export function GoogleDrivePicker({
               </>
             )}
           </div>
-          <ChevronDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
         </Button>
 
         {/* File preview */}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-drive-picker.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/google-drive-picker.tsx
@@ -5,7 +5,6 @@ import { ChevronDown, ExternalLink, FileIcon, FolderIcon, RefreshCw, X } from 'l
 import useDrivePicker from 'react-google-drive-picker'
 import { GoogleDocsIcon, GoogleSheetsIcon } from '@/components/icons'
 import { Button } from '@/components/ui/button'
-// Removed dropdown/command imports as the picker opens directly
 import { getEnv } from '@/lib/env'
 import { createLogger } from '@/lib/logs/console/logger'
 import {
@@ -67,7 +66,6 @@ export function GoogleDrivePicker({
   credentialId,
   workflowId,
 }: GoogleDrivePickerProps) {
-  // Dropdown removed; we only keep credential and picker logic
   const [credentials, setCredentials] = useState<Credential[]>([])
   const [selectedCredentialId, setSelectedCredentialId] = useState<string>('')
   const [selectedFileId, setSelectedFileId] = useState(value)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
@@ -63,6 +63,7 @@ export function JiraIssueSelector({
   onIssueInfoChange,
   projectId,
   credentialId,
+  isForeignCredential = false,
 }: JiraIssueSelectorProps) {
   const [open, setOpen] = useState(false)
   const [credentials, setCredentials] = useState<Credential[]>([])
@@ -377,6 +378,10 @@ export function JiraIssueSelector({
 
   // Handle open change
   const handleOpenChange = (isOpen: boolean) => {
+    if (disabled || isForeignCredential) {
+      setOpen(false)
+      return
+    }
     setOpen(isOpen)
 
     // Only fetch recent/default issues when opening the dropdown
@@ -451,7 +456,7 @@ export function JiraIssueSelector({
               role='combobox'
               aria-expanded={open}
               className='h-10 w-full min-w-0 justify-between'
-              disabled={disabled || !domain || !selectedCredentialId}
+              disabled={disabled || !domain || !selectedCredentialId || isForeignCredential}
             >
               <div className='flex min-w-0 items-center gap-2 overflow-hidden'>
                 {selectedIssue ? (
@@ -469,118 +474,122 @@ export function JiraIssueSelector({
               <ChevronDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
             </Button>
           </PopoverTrigger>
-          <PopoverContent className='w-[300px] p-0' align='start'>
-            {/* Current account indicator */}
-            {selectedCredentialId && credentials.length > 0 && (
-              <div className='flex items-center justify-between border-b px-3 py-2'>
-                <div className='flex items-center gap-2'>
-                  <JiraIcon className='h-4 w-4' />
-                  <span className='text-muted-foreground text-xs'>
-                    {credentials.find((cred) => cred.id === selectedCredentialId)?.name ||
-                      'Unknown'}
-                  </span>
-                </div>
-                {credentials.length > 1 && (
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    className='h-6 px-2 text-xs'
-                    onClick={() => setOpen(true)}
-                  >
-                    Switch
-                  </Button>
-                )}
-              </div>
-            )}
-
-            <Command>
-              <CommandInput placeholder='Search issues...' onValueChange={handleSearch} />
-              <CommandList>
-                <CommandEmpty>
-                  {isLoading ? (
-                    <div className='flex items-center justify-center p-4'>
-                      <RefreshCw className='h-4 w-4 animate-spin' />
-                      <span className='ml-2'>Loading issues...</span>
-                    </div>
-                  ) : error ? (
-                    <div className='p-4 text-center'>
-                      <p className='text-destructive text-sm'>{error}</p>
-                    </div>
-                  ) : credentials.length === 0 ? (
-                    <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>No accounts connected.</p>
-                      <p className='text-muted-foreground text-xs'>
-                        Connect a Jira account to continue.
-                      </p>
-                    </div>
-                  ) : (
-                    <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>No issues found.</p>
-                      <p className='text-muted-foreground text-xs'>
-                        Try a different search or account.
-                      </p>
-                    </div>
+          {!isForeignCredential && (
+            <PopoverContent className='w-[300px] p-0' align='start'>
+              {/* Current account indicator */}
+              {selectedCredentialId && credentials.length > 0 && (
+                <div className='flex items-center justify-between border-b px-3 py-2'>
+                  <div className='flex items-center gap-2'>
+                    <JiraIcon className='h-4 w-4' />
+                    <span className='text-muted-foreground text-xs'>
+                      {credentials.find((cred) => cred.id === selectedCredentialId)?.name ||
+                        'Unknown'}
+                    </span>
+                  </div>
+                  {credentials.length > 1 && (
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-6 px-2 text-xs'
+                      onClick={() => setOpen(true)}
+                    >
+                      Switch
+                    </Button>
                   )}
-                </CommandEmpty>
+                </div>
+              )}
 
-                {/* Account selection - only show if we have multiple accounts */}
-                {credentials.length > 1 && (
-                  <CommandGroup>
-                    <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
-                      Switch Account
-                    </div>
-                    {credentials.map((cred) => (
-                      <CommandItem
-                        key={cred.id}
-                        value={`account-${cred.id}`}
-                        onSelect={() => setSelectedCredentialId(cred.id)}
-                      >
-                        <div className='flex items-center gap-2'>
-                          <JiraIcon className='h-4 w-4' />
-                          <span className='font-normal'>{cred.name}</span>
-                        </div>
-                        {cred.id === selectedCredentialId && <Check className='ml-auto h-4 w-4' />}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-
-                {/* Issues list */}
-                {issues.length > 0 && (
-                  <CommandGroup>
-                    <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
-                      Issues
-                    </div>
-                    {issues.map((issue) => (
-                      <CommandItem
-                        key={issue.id}
-                        value={`issue-${issue.id}-${issue.name}`}
-                        onSelect={() => handleSelectIssue(issue)}
-                      >
-                        <div className='flex items-center gap-2 overflow-hidden'>
-                          <JiraIcon className='h-4 w-4' />
-                          <span className='truncate font-normal'>{issue.name}</span>
-                        </div>
-                        {issue.id === selectedIssueId && <Check className='ml-auto h-4 w-4' />}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-
-                {/* Connect account option - only show if no credentials */}
-                {credentials.length === 0 && (
-                  <CommandGroup>
-                    <CommandItem onSelect={handleAddCredential}>
-                      <div className='flex items-center gap-2 text-primary'>
-                        <JiraIcon className='h-4 w-4' />
-                        <span>Connect Jira account</span>
+              <Command>
+                <CommandInput placeholder='Search issues...' onValueChange={handleSearch} />
+                <CommandList>
+                  <CommandEmpty>
+                    {isLoading ? (
+                      <div className='flex items-center justify-center p-4'>
+                        <RefreshCw className='h-4 w-4 animate-spin' />
+                        <span className='ml-2'>Loading issues...</span>
                       </div>
-                    </CommandItem>
-                  </CommandGroup>
-                )}
-              </CommandList>
-            </Command>
-          </PopoverContent>
+                    ) : error ? (
+                      <div className='p-4 text-center'>
+                        <p className='text-destructive text-sm'>{error}</p>
+                      </div>
+                    ) : credentials.length === 0 ? (
+                      <div className='p-4 text-center'>
+                        <p className='font-medium text-sm'>No accounts connected.</p>
+                        <p className='text-muted-foreground text-xs'>
+                          Connect a Jira account to continue.
+                        </p>
+                      </div>
+                    ) : (
+                      <div className='p-4 text-center'>
+                        <p className='font-medium text-sm'>No issues found.</p>
+                        <p className='text-muted-foreground text-xs'>
+                          Try a different search or account.
+                        </p>
+                      </div>
+                    )}
+                  </CommandEmpty>
+
+                  {/* Account selection - only show if we have multiple accounts */}
+                  {credentials.length > 1 && (
+                    <CommandGroup>
+                      <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
+                        Switch Account
+                      </div>
+                      {credentials.map((cred) => (
+                        <CommandItem
+                          key={cred.id}
+                          value={`account-${cred.id}`}
+                          onSelect={() => setSelectedCredentialId(cred.id)}
+                        >
+                          <div className='flex items-center gap-2'>
+                            <JiraIcon className='h-4 w-4' />
+                            <span className='font-normal'>{cred.name}</span>
+                          </div>
+                          {cred.id === selectedCredentialId && (
+                            <Check className='ml-auto h-4 w-4' />
+                          )}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+
+                  {/* Issues list */}
+                  {issues.length > 0 && (
+                    <CommandGroup>
+                      <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
+                        Issues
+                      </div>
+                      {issues.map((issue) => (
+                        <CommandItem
+                          key={issue.id}
+                          value={`issue-${issue.id}-${issue.name}`}
+                          onSelect={() => handleSelectIssue(issue)}
+                        >
+                          <div className='flex items-center gap-2 overflow-hidden'>
+                            <JiraIcon className='h-4 w-4' />
+                            <span className='truncate font-normal'>{issue.name}</span>
+                          </div>
+                          {issue.id === selectedIssueId && <Check className='ml-auto h-4 w-4' />}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+
+                  {/* Connect account option - only show if no credentials */}
+                  {credentials.length === 0 && (
+                    <CommandGroup>
+                      <CommandItem onSelect={handleAddCredential}>
+                        <div className='flex items-center gap-2 text-primary'>
+                          <JiraIcon className='h-4 w-4' />
+                          <span>Connect Jira account</span>
+                        </div>
+                      </CommandItem>
+                    </CommandGroup>
+                  )}
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          )}
         </Popover>
 
         {/* Issue preview */}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
@@ -48,6 +48,7 @@ interface JiraIssueSelectorProps {
   projectId?: string
   credentialId?: string
   isForeignCredential?: boolean
+  workflowId?: string
 }
 
 export function JiraIssueSelector({
@@ -64,6 +65,7 @@ export function JiraIssueSelector({
   projectId,
   credentialId,
   isForeignCredential = false,
+  workflowId,
 }: JiraIssueSelectorProps) {
   const [open, setOpen] = useState(false)
   const [credentials, setCredentials] = useState<Credential[]>([])
@@ -162,7 +164,9 @@ export function JiraIssueSelector({
 
       try {
         // Get the access token from the selected credential
-        const tokenResponse = await fetch('/api/auth/oauth/token', {
+        const tokenUrl = new URL('/api/auth/oauth/token', window.location.origin)
+        if (workflowId) tokenUrl.searchParams.set('workflowId', workflowId)
+        const tokenResponse = await fetch(tokenUrl.toString(), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -258,7 +262,9 @@ export function JiraIssueSelector({
 
       try {
         // Get the access token from the selected credential
-        const tokenResponse = await fetch('/api/auth/oauth/token', {
+        const tokenUrl = new URL('/api/auth/oauth/token', window.location.origin)
+        if (workflowId) tokenUrl.searchParams.set('workflowId', workflowId)
+        const tokenResponse = await fetch(tokenUrl.toString(), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/jira-issue-selector.tsx
@@ -164,15 +164,14 @@ export function JiraIssueSelector({
 
       try {
         // Get the access token from the selected credential
-        const tokenUrl = new URL('/api/auth/oauth/token', window.location.origin)
-        if (workflowId) tokenUrl.searchParams.set('workflowId', workflowId)
-        const tokenResponse = await fetch(tokenUrl.toString(), {
+        const tokenResponse = await fetch('/api/auth/oauth/token', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
             credentialId: selectedCredentialId,
+            workflowId,
           }),
         })
 
@@ -262,15 +261,14 @@ export function JiraIssueSelector({
 
       try {
         // Get the access token from the selected credential
-        const tokenUrl = new URL('/api/auth/oauth/token', window.location.origin)
-        if (workflowId) tokenUrl.searchParams.set('workflowId', workflowId)
-        const tokenResponse = await fetch(tokenUrl.toString(), {
+        const tokenResponse = await fetch('/api/auth/oauth/token', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
             credentialId: selectedCredentialId,
+            workflowId,
           }),
         })
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/microsoft-file-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components/microsoft-file-selector.tsx
@@ -496,10 +496,7 @@ export function MicrosoftFileSelector({
       selectedCredentialId &&
       credentialsLoaded &&
       !selectedFile &&
-      !isLoadingSelectedFile &&
-      serviceId !== 'microsoft-planner' &&
-      serviceId !== 'sharepoint' &&
-      serviceId !== 'onedrive'
+      !isLoadingSelectedFile
     ) {
       fetchFileById(value)
     }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -500,6 +500,9 @@ export function FileSelectorInput({
                 disabled={disabled || !credential}
                 showPreview={true}
                 onFileInfoChange={setFileInfo as (info: MicrosoftFileInfo | null) => void}
+                workflowId={activeWorkflowId || ''}
+                credentialId={credential}
+                isForeignCredential={isForeignCredential}
               />
             </div>
           </TooltipTrigger>
@@ -532,6 +535,9 @@ export function FileSelectorInput({
                 disabled={disabled || !credential}
                 showPreview={true}
                 onFileInfoChange={setFileInfo as (info: MicrosoftFileInfo | null) => void}
+                workflowId={activeWorkflowId || ''}
+                credentialId={credential}
+                isForeignCredential={isForeignCredential}
               />
             </div>
           </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -697,32 +697,47 @@ export function FileSelectorInput({
   }
 
   // Default to Google Drive picker
-  return (
-    <GoogleDrivePicker
-      value={coerceToIdString(
-        (isPreview && previewValue !== undefined ? previewValue : storeValue) as any
-      )}
-      onChange={(val, info) => {
-        setSelectedFileId(val)
-        setFileInfo(info || null)
-        collaborativeSetSubblockValue(blockId, subBlock.id, val)
-      }}
-      provider={provider}
-      requiredScopes={subBlock.requiredScopes || []}
-      label={subBlock.placeholder || 'Select file'}
-      disabled={disabled}
-      serviceId={subBlock.serviceId}
-      mimeTypeFilter={subBlock.mimeType}
-      showPreview={true}
-      onFileInfoChange={setFileInfo}
-      clientId={clientId}
-      apiKey={apiKey}
-      credentialId={
-        ((isPreview && previewContextValues?.credential?.value) ||
-          (getValue(blockId, 'credential') as string) ||
-          '') as string
-      }
-      workflowId={workflowIdFromUrl}
-    />
-  )
+  {
+    const credential = ((isPreview && previewContextValues?.credential?.value) ||
+      (getValue(blockId, 'credential') as string) ||
+      '') as string
+
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className='w-full'>
+              <GoogleDrivePicker
+                value={coerceToIdString(
+                  (isPreview && previewValue !== undefined ? previewValue : storeValue) as any
+                )}
+                onChange={(val, info) => {
+                  setSelectedFileId(val)
+                  setFileInfo(info || null)
+                  collaborativeSetSubblockValue(blockId, subBlock.id, val)
+                }}
+                provider={provider}
+                requiredScopes={subBlock.requiredScopes || []}
+                label={subBlock.placeholder || 'Select file'}
+                disabled={disabled || !credential}
+                serviceId={subBlock.serviceId}
+                mimeTypeFilter={subBlock.mimeType}
+                showPreview={true}
+                onFileInfoChange={setFileInfo}
+                clientId={clientId}
+                apiKey={apiKey}
+                credentialId={credential}
+                workflowId={workflowIdFromUrl}
+              />
+            </div>
+          </TooltipTrigger>
+          {!credential && (
+            <TooltipContent side='top'>
+              <p>Please select Google Drive credentials first</p>
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
+    )
+  }
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -432,6 +432,7 @@ export function FileSelectorInput({
                 disabled={disabled || !credential}
                 showPreview={true}
                 onFileInfoChange={setFileInfo as (info: MicrosoftFileInfo | null) => void}
+                workflowId={activeWorkflowId || ''}
               />
             </div>
           </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -347,6 +347,8 @@ export function FileSelectorInput({
                 showPreview={true}
                 onFileInfoChange={setFileInfo as (info: ConfluenceFileInfo | null) => void}
                 credentialId={credential}
+                workflowId={workflowIdFromUrl}
+                isForeignCredential={isForeignCredential}
               />
             </div>
           </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -566,6 +566,9 @@ export function FileSelectorInput({
                 showPreview={true}
                 onFileInfoChange={setFileInfo as (info: MicrosoftFileInfo | null) => void}
                 planId={planId}
+                workflowId={activeWorkflowId || ''}
+                credentialId={credential}
+                isForeignCredential={isForeignCredential}
               />
             </div>
           </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -391,6 +391,7 @@ export function FileSelectorInput({
                 credentialId={credential}
                 projectId={(getValue(blockId, 'projectId') as string) || ''}
                 isForeignCredential={isForeignCredential}
+                workflowId={activeWorkflowId || ''}
               />
             </div>
           </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -433,6 +433,8 @@ export function FileSelectorInput({
                 showPreview={true}
                 onFileInfoChange={setFileInfo as (info: MicrosoftFileInfo | null) => void}
                 workflowId={activeWorkflowId || ''}
+                credentialId={credential}
+                isForeignCredential={isForeignCredential}
               />
             </div>
           </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -22,6 +22,7 @@ import {
   WealthboxFileSelector,
   type WealthboxItemInfo,
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/components'
+import { useForeignCredential } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-foreign-credential'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
 import type { SubBlockConfig } from '@/blocks/types'
 import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
@@ -85,33 +86,10 @@ export function FileSelectorInput({
   const [wealthboxItemInfo, setWealthboxItemInfo] = useState<WealthboxItemInfo | null>(null)
 
   // Determine if the persisted credential belongs to the current viewer
-  const [isForeignCredential, setIsForeignCredential] = useState<boolean>(false)
-  useEffect(() => {
-    const cred = (connectedCredential as string) || ''
-    if (!cred) {
-      setIsForeignCredential(false)
-      return
-    }
-    let aborted = false
-    ;(async () => {
-      try {
-        const resp = await fetch(`/api/auth/oauth/credentials?credentialId=${cred}`)
-        if (aborted) return
-        if (!resp.ok) {
-          setIsForeignCredential(true)
-          return
-        }
-        const data = await resp.json()
-        // If credential not returned for this session user, it's foreign
-        setIsForeignCredential(!(data.credentials && data.credentials.length === 1))
-      } catch {
-        setIsForeignCredential(true)
-      }
-    })()
-    return () => {
-      aborted = true
-    }
-  }, [blockId, connectedCredential])
+  const { isForeignCredential } = useForeignCredential(
+    subBlock.provider || subBlock.serviceId || '',
+    (connectedCredential as string) || ''
+  )
 
   // Get provider-specific values
   const provider = subBlock.provider || 'google-drive'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-selector/file-selector-input.tsx
@@ -70,6 +70,7 @@ export function FileSelectorInput({
 
   // Use the proper hook to get the current value and setter
   const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlock.id)
+  const [connectedCredential] = useSubBlockValue(blockId, 'credential')
   const [selectedFileId, setSelectedFileId] = useState<string>('')
   const [_fileInfo, setFileInfo] = useState<FileInfo | ConfluenceFileInfo | null>(null)
   const [selectedIssueId, setSelectedIssueId] = useState<string>('')
@@ -86,7 +87,7 @@ export function FileSelectorInput({
   // Determine if the persisted credential belongs to the current viewer
   const [isForeignCredential, setIsForeignCredential] = useState<boolean>(false)
   useEffect(() => {
-    const cred = (getValue(blockId, 'credential') as string) || ''
+    const cred = (connectedCredential as string) || ''
     if (!cred) {
       setIsForeignCredential(false)
       return
@@ -110,8 +111,7 @@ export function FileSelectorInput({
     return () => {
       aborted = true
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockId, getValue(blockId, 'credential')])
+  }, [blockId, connectedCredential])
 
   // Get provider-specific values
   const provider = subBlock.provider || 'google-drive'
@@ -254,7 +254,7 @@ export function FileSelectorInput({
 
   // Render Google Calendar selector
   if (isGoogleCalendar) {
-    const credential = (getValue(blockId, 'credential') as string) || ''
+    const credential = (connectedCredential as string) || ''
 
     return (
       <TooltipProvider>
@@ -321,7 +321,7 @@ export function FileSelectorInput({
 
   // Render the appropriate picker based on provider
   if (isConfluence) {
-    const credential = (getValue(blockId, 'credential') as string) || ''
+    const credential = (connectedCredential as string) || ''
     return (
       <TooltipProvider>
         <Tooltip>
@@ -361,7 +361,7 @@ export function FileSelectorInput({
   }
 
   if (isJira) {
-    const credential = jiraCredential
+    const credential = (connectedCredential as string) || ''
     return (
       <TooltipProvider>
         <Tooltip>
@@ -413,8 +413,8 @@ export function FileSelectorInput({
   }
 
   if (isMicrosoftExcel) {
-    // Get credential using the same pattern as other tools
-    const credential = (getValue(blockId, 'credential') as string) || ''
+    // Get credential reactively
+    const credential = (connectedCredential as string) || ''
 
     return (
       <TooltipProvider>
@@ -446,8 +446,8 @@ export function FileSelectorInput({
 
   // Handle Microsoft Word selector
   if (isMicrosoftWord) {
-    // Get credential using the same pattern as other tools
-    const credential = (getValue(blockId, 'credential') as string) || ''
+    // Get credential reactively
+    const credential = (connectedCredential as string) || ''
 
     return (
       <TooltipProvider>
@@ -479,7 +479,7 @@ export function FileSelectorInput({
 
   // Handle Microsoft OneDrive selector
   if (isMicrosoftOneDrive) {
-    const credential = (getValue(blockId, 'credential') as string) || ''
+    const credential = (connectedCredential as string) || ''
 
     return (
       <TooltipProvider>
@@ -511,7 +511,7 @@ export function FileSelectorInput({
 
   // Handle Microsoft SharePoint selector
   if (isMicrosoftSharePoint) {
-    const credential = (getValue(blockId, 'credential') as string) || ''
+    const credential = (connectedCredential as string) || ''
 
     return (
       <TooltipProvider>
@@ -543,7 +543,7 @@ export function FileSelectorInput({
 
   // Handle Microsoft Planner task selector
   if (isMicrosoftPlanner) {
-    const credential = (getValue(blockId, 'credential') as string) || ''
+    const credential = (connectedCredential as string) || ''
     const planId = (getValue(blockId, 'planId') as string) || ''
 
     return (
@@ -582,7 +582,7 @@ export function FileSelectorInput({
   // Handle Microsoft Teams selector
   if (isMicrosoftTeams) {
     // Get credential using the same pattern as other tools
-    const credential = (getValue(blockId, 'credential') as string) || ''
+    const credential = (connectedCredential as string) || ''
 
     // Determine the selector type based on the subBlock ID
     let selectionType: 'team' | 'channel' | 'chat' = 'team'
@@ -633,6 +633,7 @@ export function FileSelectorInput({
                 selectionType={selectionType}
                 initialTeamId={selectedTeamId}
                 workflowId={activeWorkflowId || ''}
+                isForeignCredential={isForeignCredential}
               />
             </div>
           </TooltipTrigger>
@@ -648,8 +649,8 @@ export function FileSelectorInput({
 
   // Render Wealthbox selector
   if (isWealthbox) {
-    // Get credential using the same pattern as other tools
-    const credential = (getValue(blockId, 'credential') as string) || ''
+    // Get credential reactively
+    const credential = (connectedCredential as string) || ''
 
     // Only handle contacts now - both notes and tasks use short-input
     if (subBlock.id === 'contactId') {
@@ -699,7 +700,7 @@ export function FileSelectorInput({
   // Default to Google Drive picker
   {
     const credential = ((isPreview && previewContextValues?.credential?.value) ||
-      (getValue(blockId, 'credential') as string) ||
+      (connectedCredential as string) ||
       '') as string
 
     return (

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/folder-selector/components/folder-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/folder-selector/components/folder-selector-input.tsx
@@ -8,6 +8,7 @@ import {
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
 import type { SubBlockConfig } from '@/blocks/types'
 import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
+import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 
 interface FolderSelectorInputProps {
   blockId: string
@@ -25,7 +26,9 @@ export function FolderSelectorInput({
   previewValue,
 }: FolderSelectorInputProps) {
   const [storeValue, _setStoreValue] = useSubBlockValue(blockId, subBlock.id)
+  const [connectedCredential] = useSubBlockValue(blockId, 'credential')
   const { collaborativeSetSubblockValue } = useCollaborativeWorkflow()
+  const { activeWorkflowId } = useWorkflowRegistry()
   const [selectedFolderId, setSelectedFolderId] = useState<string>('')
   const [_folderInfo, setFolderInfo] = useState<FolderInfo | null>(null)
 
@@ -67,6 +70,8 @@ export function FolderSelectorInput({
       disabled={disabled}
       serviceId={subBlock.serviceId}
       onFolderInfoChange={setFolderInfo}
+      credentialId={(connectedCredential as string) || ''}
+      workflowId={activeWorkflowId || ''}
     />
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/folder-selector/components/folder-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/folder-selector/components/folder-selector-input.tsx
@@ -5,6 +5,7 @@ import {
   type FolderInfo,
   FolderSelector,
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/folder-selector/folder-selector'
+import { useForeignCredential } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-foreign-credential'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
 import type { SubBlockConfig } from '@/blocks/types'
 import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
@@ -31,31 +32,10 @@ export function FolderSelectorInput({
   const { activeWorkflowId } = useWorkflowRegistry()
   const [selectedFolderId, setSelectedFolderId] = useState<string>('')
   const [_folderInfo, setFolderInfo] = useState<FolderInfo | null>(null)
-  const [isForeignCredential, setIsForeignCredential] = useState<boolean>(false)
-
-  // Determine if credential is foreign so we can gate the dropdown
-  useEffect(() => {
-    const checkForeign = async () => {
-      try {
-        const cred = (connectedCredential as string) || ''
-        if (!cred) {
-          setIsForeignCredential(false)
-          return
-        }
-        const res = await fetch(`/api/auth/oauth/credentials?provider=${subBlock.provider}`)
-        if (!res.ok) {
-          setIsForeignCredential(true)
-          return
-        }
-        const data = await res.json()
-        const isOwn = (data.credentials || []).some((c: any) => c.id === cred)
-        setIsForeignCredential(!isOwn)
-      } catch {
-        setIsForeignCredential(true)
-      }
-    }
-    void checkForeign()
-  }, [connectedCredential, subBlock.provider])
+  const { isForeignCredential } = useForeignCredential(
+    subBlock.provider || subBlock.serviceId || 'outlook',
+    (connectedCredential as string) || ''
+  )
 
   // Get the current value from the store or prop value if in preview mode
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/folder-selector/folder-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/folder-selector/folder-selector.tsx
@@ -38,6 +38,9 @@ interface FolderSelectorProps {
   onFolderInfoChange?: (folderInfo: FolderInfo | null) => void
   isPreview?: boolean
   previewValue?: any | null
+  credentialId?: string
+  workflowId?: string
+  isForeignCredential?: boolean
 }
 
 export function FolderSelector({
@@ -51,11 +54,16 @@ export function FolderSelector({
   onFolderInfoChange,
   isPreview = false,
   previewValue,
+  credentialId,
+  workflowId,
+  isForeignCredential = false,
 }: FolderSelectorProps) {
   const [open, setOpen] = useState(false)
   const [credentials, setCredentials] = useState<Credential[]>([])
   const [folders, setFolders] = useState<FolderInfo[]>([])
-  const [selectedCredentialId, setSelectedCredentialId] = useState<string>('')
+  const [selectedCredentialId, setSelectedCredentialId] = useState<Credential['id'] | ''>(
+    credentialId || ''
+  )
   const [selectedFolderId, setSelectedFolderId] = useState('')
   const [selectedFolder, setSelectedFolder] = useState<FolderInfo | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -71,6 +79,13 @@ export function FolderSelector({
       setSelectedFolderId(value)
     }
   }, [value, isPreview, previewValue])
+
+  // Keep internal credential in sync with prop
+  useEffect(() => {
+    if (credentialId && credentialId !== selectedCredentialId) {
+      setSelectedCredentialId(credentialId)
+    }
+  }, [credentialId, selectedCredentialId])
 
   // Determine the appropriate service ID based on provider and scopes
   const getServiceId = (): string => {
@@ -124,18 +139,43 @@ export function FolderSelector({
   // Fetch a single folder by ID when we have a selectedFolderId but no metadata
   const fetchFolderById = useCallback(
     async (folderId: string) => {
-      if (!selectedCredentialId || !folderId || provider === 'outlook') return null
+      if (!selectedCredentialId || !folderId) return null
 
       setIsLoadingSelectedFolder(true)
       try {
-        // Construct query parameters
+        if (provider === 'outlook') {
+          // Resolve Outlook folder name with owner-scoped token
+          const tokenRes = await fetch('/api/auth/oauth/token', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ credentialId: selectedCredentialId, workflowId }),
+          })
+          if (!tokenRes.ok) return null
+          const { accessToken } = await tokenRes.json()
+          if (!accessToken) return null
+          const resp = await fetch(
+            `https://graph.microsoft.com/v1.0/me/mailFolders/${encodeURIComponent(folderId)}`,
+            { headers: { Authorization: `Bearer ${accessToken}` } }
+          )
+          if (!resp.ok) return null
+          const folder = await resp.json()
+          const folderInfo: FolderInfo = {
+            id: folder.id,
+            name: folder.displayName,
+            type: 'folder',
+            messagesTotal: folder.totalItemCount,
+            messagesUnread: folder.unreadItemCount,
+          }
+          setSelectedFolder(folderInfo)
+          onFolderInfoChange?.(folderInfo)
+          return folderInfo
+        }
+        // Gmail label resolution
         const queryParams = new URLSearchParams({
           credentialId: selectedCredentialId,
           labelId: folderId,
         })
-
         const response = await fetch(`/api/tools/gmail/label?${queryParams.toString()}`)
-
         if (response.ok) {
           const data = await response.json()
           if (data.label) {
@@ -156,7 +196,7 @@ export function FolderSelector({
         setIsLoadingSelectedFolder(false)
       }
     },
-    [selectedCredentialId, onFolderInfoChange, provider]
+    [selectedCredentialId, onFolderInfoChange, provider, workflowId]
   )
 
   // Fetch folders from Gmail or Outlook
@@ -178,6 +218,12 @@ export function FolderSelector({
         // Determine the API endpoint based on provider
         let apiEndpoint: string
         if (provider === 'outlook') {
+          // Skip list fetch for collaborators; only show selected
+          if (isForeignCredential) {
+            setFolders([])
+            setIsLoading(false)
+            return
+          }
           apiEndpoint = `/api/tools/outlook/folders?${queryParams.toString()}`
         } else {
           // Default to Gmail
@@ -206,9 +252,12 @@ export function FolderSelector({
             }
           }
         } else {
-          logger.error('Error fetching folders:', {
-            error: await response.text(),
-          })
+          const text = await response.text()
+          if (response.status === 401 || response.status === 403) {
+            logger.info('Folder list fetch unauthorized (expected for collaborator)')
+          } else {
+            logger.warn('Error fetching folders', { status: response.status, text })
+          }
           setFolders([])
         }
       } catch (error) {
@@ -218,7 +267,14 @@ export function FolderSelector({
         setIsLoading(false)
       }
     },
-    [selectedCredentialId, selectedFolderId, onFolderInfoChange, fetchFolderById, provider]
+    [
+      selectedCredentialId,
+      selectedFolderId,
+      onFolderInfoChange,
+      fetchFolderById,
+      provider,
+      isForeignCredential,
+    ]
   )
 
   // Fetch credentials on initial mount
@@ -317,7 +373,7 @@ export function FolderSelector({
               role='combobox'
               aria-expanded={open}
               className='w-full justify-between'
-              disabled={disabled}
+              disabled={disabled || isForeignCredential}
             >
               {selectedFolder ? (
                 <div className='flex items-center gap-2 overflow-hidden'>
@@ -333,114 +389,120 @@ export function FolderSelector({
               <ChevronDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
             </Button>
           </PopoverTrigger>
-          <PopoverContent className='w-[300px] p-0' align='start'>
-            {/* Current account indicator */}
-            {selectedCredentialId && credentials.length > 0 && (
-              <div className='flex items-center justify-between border-b px-3 py-2'>
-                <div className='flex items-center gap-2'>
-                  <span className='text-muted-foreground text-xs'>
-                    {credentials.find((cred) => cred.id === selectedCredentialId)?.name ||
-                      'Unknown'}
-                  </span>
-                </div>
-                {credentials.length > 1 && (
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    className='h-6 px-2 text-xs'
-                    onClick={() => setOpen(true)}
-                  >
-                    Switch
-                  </Button>
-                )}
-              </div>
-            )}
-
-            <Command>
-              <CommandInput
-                placeholder={`Search ${getFolderLabel()}...`}
-                onValueChange={handleSearch}
-              />
-              <CommandList>
-                <CommandEmpty>
-                  {isLoading ? (
-                    <div className='flex items-center justify-center p-4'>
-                      <RefreshCw className='h-4 w-4 animate-spin' />
-                      <span className='ml-2'>Loading {getFolderLabel()}...</span>
-                    </div>
-                  ) : credentials.length === 0 ? (
-                    <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>No accounts connected.</p>
-                      <p className='text-muted-foreground text-xs'>
-                        Connect a {getProviderName()} account to continue.
-                      </p>
-                    </div>
-                  ) : (
-                    <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>No {getFolderLabel()} found.</p>
-                      <p className='text-muted-foreground text-xs'>
-                        Try a different search or account.
-                      </p>
-                    </div>
+          {!isForeignCredential && (
+            <PopoverContent className='w-[300px] p-0' align='start'>
+              {/* Current account indicator */}
+              {selectedCredentialId && credentials.length > 0 && (
+                <div className='flex items-center justify-between border-b px-3 py-2'>
+                  <div className='flex items-center gap-2'>
+                    <span className='text-muted-foreground text-xs'>
+                      {credentials.find((cred) => cred.id === selectedCredentialId)?.name ||
+                        'Unknown'}
+                    </span>
+                  </div>
+                  {credentials.length > 1 && (
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-6 px-2 text-xs'
+                      onClick={() => setOpen(true)}
+                    >
+                      Switch
+                    </Button>
                   )}
-                </CommandEmpty>
+                </div>
+              )}
 
-                {/* Account selection - only show if we have multiple accounts */}
-                {credentials.length > 1 && (
-                  <CommandGroup>
-                    <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
-                      Switch Account
-                    </div>
-                    {credentials.map((cred) => (
-                      <CommandItem
-                        key={cred.id}
-                        value={`account-${cred.id}`}
-                        onSelect={() => setSelectedCredentialId(cred.id)}
-                      >
-                        <div className='flex items-center gap-2'>
-                          <span className='font-normal'>{cred.name}</span>
-                        </div>
-                        {cred.id === selectedCredentialId && <Check className='ml-auto h-4 w-4' />}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-
-                {/* Folders list */}
-                {folders.length > 0 && (
-                  <CommandGroup>
-                    <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
-                      {getFolderLabel().charAt(0).toUpperCase() + getFolderLabel().slice(1)}
-                    </div>
-                    {folders.map((folder) => (
-                      <CommandItem
-                        key={folder.id}
-                        value={`folder-${folder.id}-${folder.name}`}
-                        onSelect={() => handleSelectFolder(folder)}
-                      >
-                        <div className='flex w-full items-center gap-2 overflow-hidden'>
-                          {getFolderIcon('sm')}
-                          <span className='truncate font-normal'>{folder.name}</span>
-                          {folder.id === selectedFolderId && <Check className='ml-auto h-4 w-4' />}
-                        </div>
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-
-                {/* Connect account option - only show if no credentials */}
-                {credentials.length === 0 && (
-                  <CommandGroup>
-                    <CommandItem onSelect={handleAddCredential}>
-                      <div className='flex items-center gap-2 text-primary'>
-                        <span>Connect {getProviderName()} account</span>
+              <Command>
+                <CommandInput
+                  placeholder={`Search ${getFolderLabel()}...`}
+                  onValueChange={handleSearch}
+                />
+                <CommandList>
+                  <CommandEmpty>
+                    {isLoading ? (
+                      <div className='flex items-center justify-center p-4'>
+                        <RefreshCw className='h-4 w-4 animate-spin' />
+                        <span className='ml-2'>Loading {getFolderLabel()}...</span>
                       </div>
-                    </CommandItem>
-                  </CommandGroup>
-                )}
-              </CommandList>
-            </Command>
-          </PopoverContent>
+                    ) : credentials.length === 0 ? (
+                      <div className='p-4 text-center'>
+                        <p className='font-medium text-sm'>No accounts connected.</p>
+                        <p className='text-muted-foreground text-xs'>
+                          Connect a {getProviderName()} account to continue.
+                        </p>
+                      </div>
+                    ) : (
+                      <div className='p-4 text-center'>
+                        <p className='font-medium text-sm'>No {getFolderLabel()} found.</p>
+                        <p className='text-muted-foreground text-xs'>
+                          Try a different search or account.
+                        </p>
+                      </div>
+                    )}
+                  </CommandEmpty>
+
+                  {/* Account selection - only show if we have multiple accounts */}
+                  {credentials.length > 1 && (
+                    <CommandGroup>
+                      <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
+                        Switch Account
+                      </div>
+                      {credentials.map((cred) => (
+                        <CommandItem
+                          key={cred.id}
+                          value={`account-${cred.id}`}
+                          onSelect={() => setSelectedCredentialId(cred.id)}
+                        >
+                          <div className='flex items-center gap-2'>
+                            <span className='font-normal'>{cred.name}</span>
+                          </div>
+                          {cred.id === selectedCredentialId && (
+                            <Check className='ml-auto h-4 w-4' />
+                          )}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+
+                  {/* Folders list */}
+                  {folders.length > 0 && (
+                    <CommandGroup>
+                      <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
+                        {getFolderLabel().charAt(0).toUpperCase() + getFolderLabel().slice(1)}
+                      </div>
+                      {folders.map((folder) => (
+                        <CommandItem
+                          key={folder.id}
+                          value={`folder-${folder.id}-${folder.name}`}
+                          onSelect={() => handleSelectFolder(folder)}
+                        >
+                          <div className='flex w-full items-center gap-2 overflow-hidden'>
+                            {getFolderIcon('sm')}
+                            <span className='truncate font-normal'>{folder.name}</span>
+                            {folder.id === selectedFolderId && (
+                              <Check className='ml-auto h-4 w-4' />
+                            )}
+                          </div>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+
+                  {/* Connect account option - only show if no credentials */}
+                  {credentials.length === 0 && (
+                    <CommandGroup>
+                      <CommandItem onSelect={handleAddCredential}>
+                        <div className='flex items-center gap-2 text-primary'>
+                          <span>Connect {getProviderName()} account</span>
+                        </div>
+                      </CommandItem>
+                    </CommandGroup>
+                  )}
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          )}
         </Popover>
       </div>
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/folder-selector/folder-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/folder-selector/folder-selector.tsx
@@ -300,21 +300,17 @@ export function FolderSelector({
     }
   }, [value, isPreview, previewValue])
 
-  // Fetch the selected folder metadata once credentials are ready (Gmail only)
+  // Fetch the selected folder metadata once credentials are ready or value changes
   useEffect(() => {
-    const currentValue = isPreview ? previewValue : value
-    if (currentValue && selectedCredentialId && !selectedFolder && provider !== 'outlook') {
+    const currentValue = isPreview ? (previewValue as string) : (value as string)
+    if (
+      currentValue &&
+      selectedCredentialId &&
+      (!selectedFolder || selectedFolder.id !== currentValue)
+    ) {
       fetchFolderById(currentValue)
     }
-  }, [
-    value,
-    selectedCredentialId,
-    selectedFolder,
-    fetchFolderById,
-    provider,
-    isPreview,
-    previewValue,
-  ])
+  }, [value, selectedCredentialId, selectedFolder, fetchFolderById, isPreview, previewValue])
 
   // Handle folder selection
   const handleSelectFolder = (folder: FolderInfo) => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
@@ -64,6 +64,7 @@ export function JiraProjectSelector({
   showPreview = true,
   onProjectInfoChange,
   credentialId,
+  isForeignCredential = false,
 }: JiraProjectSelectorProps) {
   const [open, setOpen] = useState(false)
   const [credentials, setCredentials] = useState<Credential[]>([])
@@ -334,16 +335,13 @@ export function JiraProjectSelector({
 
   // Fetch the selected project metadata once credentials are ready or changed
   useEffect(() => {
-    if (
-      value &&
-      selectedCredentialId &&
-      domain &&
-      domain.includes('.') &&
-      (!selectedProject || selectedProject.id !== value)
-    ) {
-      fetchProjectInfo(value)
+    if (value && selectedCredentialId && domain && domain.includes('.')) {
+      // Always try to resolve the name on value change, even if dropdown never opens
+      if (!selectedProject || selectedProject.id !== value) {
+        fetchProjectInfo(value)
+      }
     }
-  }, [value, selectedCredentialId, selectedProject, domain, fetchProjectInfo])
+  }, [value, selectedCredentialId, domain, fetchProjectInfo, selectedProject])
 
   // Keep internal selectedProjectId in sync with the value prop
   useEffect(() => {
@@ -396,7 +394,7 @@ export function JiraProjectSelector({
               role='combobox'
               aria-expanded={open}
               className='w-full justify-between'
-              disabled={disabled || !domain || !selectedCredentialId}
+              disabled={disabled || !domain || !selectedCredentialId || isForeignCredential}
             >
               {selectedProject ? (
                 <div className='flex items-center gap-2 overflow-hidden'>
@@ -417,126 +415,131 @@ export function JiraProjectSelector({
               <ChevronDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
             </Button>
           </PopoverTrigger>
-          <PopoverContent className='w-[300px] p-0' align='start'>
-            {/* Current account indicator */}
-            {selectedCredentialId && credentials.length > 0 && (
-              <div className='flex items-center justify-between border-b px-3 py-2'>
-                <div className='flex items-center gap-2'>
-                  <JiraIcon className='h-4 w-4' />
-                  <span className='text-muted-foreground text-xs'>
-                    {credentials.find((cred) => cred.id === selectedCredentialId)?.name ||
-                      'Unknown'}
-                  </span>
-                </div>
-                {credentials.length > 1 && (
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    className='h-6 px-2 text-xs'
-                    onClick={() => setOpen(true)}
-                  >
-                    Switch
-                  </Button>
-                )}
-              </div>
-            )}
-
-            <Command>
-              <CommandInput placeholder='Search projects...' onValueChange={handleSearch} />
-              <CommandList>
-                <CommandEmpty>
-                  {isLoading ? (
-                    <div className='flex items-center justify-center p-4'>
-                      <RefreshCw className='h-4 w-4 animate-spin' />
-                      <span className='ml-2'>Loading projects...</span>
-                    </div>
-                  ) : error ? (
-                    <div className='p-4 text-center'>
-                      <p className='text-destructive text-sm'>{error}</p>
-                    </div>
-                  ) : credentials.length === 0 ? (
-                    <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>No accounts connected.</p>
-                      <p className='text-muted-foreground text-xs'>
-                        Connect a Jira account to continue.
-                      </p>
-                    </div>
-                  ) : (
-                    <div className='p-4 text-center'>
-                      <p className='font-medium text-sm'>No projects found.</p>
-                      <p className='text-muted-foreground text-xs'>
-                        Try a different search or account.
-                      </p>
-                    </div>
+          {!isForeignCredential && (
+            <PopoverContent className='w-[300px] p-0' align='start'>
+              {selectedCredentialId && credentials.length > 0 && (
+                <div className='flex items-center justify-between border-b px-3 py-2'>
+                  <div className='flex items-center gap-2'>
+                    <JiraIcon className='h-4 w-4' />
+                    <span className='text-muted-foreground text-xs'>
+                      {credentials.find((cred) => cred.id === selectedCredentialId)?.name ||
+                        'Unknown'}
+                    </span>
+                  </div>
+                  {credentials.length > 1 && (
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-6 px-2 text-xs'
+                      onClick={() => setOpen(true)}
+                    >
+                      Switch
+                    </Button>
                   )}
-                </CommandEmpty>
+                </div>
+              )}
 
-                {/* Account selection - only show if we have multiple accounts */}
-                {credentials.length > 1 && (
-                  <CommandGroup>
-                    <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
-                      Switch Account
-                    </div>
-                    {credentials.map((cred) => (
-                      <CommandItem
-                        key={cred.id}
-                        value={`account-${cred.id}`}
-                        onSelect={() => setSelectedCredentialId(cred.id)}
-                      >
-                        <div className='flex items-center gap-2'>
-                          <JiraIcon className='h-4 w-4' />
-                          <span className='font-normal'>{cred.name}</span>
-                        </div>
-                        {cred.id === selectedCredentialId && <Check className='ml-auto h-4 w-4' />}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-
-                {/* Projects list */}
-                {projects.length > 0 && (
-                  <CommandGroup>
-                    <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
-                      Projects
-                    </div>
-                    {projects.map((project) => (
-                      <CommandItem
-                        key={project.id}
-                        value={`project-${project.id}-${project.name}`}
-                        onSelect={() => handleSelectProject(project)}
-                      >
-                        <div className='flex items-center gap-2 overflow-hidden'>
-                          {project.avatarUrl ? (
-                            <img
-                              src={project.avatarUrl}
-                              alt={project.name}
-                              className='h-4 w-4 rounded'
-                            />
-                          ) : (
-                            <JiraIcon className='h-4 w-4' />
-                          )}
-                          <span className='truncate font-normal'>{project.name}</span>
-                        </div>
-                        {project.id === selectedProjectId && <Check className='ml-auto h-4 w-4' />}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-
-                {/* Connect account option - only show if no credentials */}
-                {credentials.length === 0 && (
-                  <CommandGroup>
-                    <CommandItem onSelect={handleAddCredential}>
-                      <div className='flex items-center gap-2 text-primary'>
-                        <JiraIcon className='h-4 w-4' />
-                        <span>Connect Jira account</span>
+              <Command>
+                <CommandInput placeholder='Search projects...' onValueChange={handleSearch} />
+                <CommandList>
+                  <CommandEmpty>
+                    {isLoading ? (
+                      <div className='flex items-center justify-center p-4'>
+                        <RefreshCw className='h-4 w-4 animate-spin' />
+                        <span className='ml-2'>Loading projects...</span>
                       </div>
-                    </CommandItem>
-                  </CommandGroup>
-                )}
-              </CommandList>
-            </Command>
-          </PopoverContent>
+                    ) : error ? (
+                      <div className='p-4 text-center'>
+                        <p className='text-destructive text-sm'>{error}</p>
+                      </div>
+                    ) : credentials.length === 0 ? (
+                      <div className='p-4 text-center'>
+                        <p className='font-medium text-sm'>No accounts connected.</p>
+                        <p className='text-muted-foreground text-xs'>
+                          Connect a Jira account to continue.
+                        </p>
+                      </div>
+                    ) : (
+                      <div className='p-4 text-center'>
+                        <p className='font-medium text-sm'>No projects found.</p>
+                        <p className='text-muted-foreground text-xs'>
+                          Try a different search or account.
+                        </p>
+                      </div>
+                    )}
+                  </CommandEmpty>
+
+                  {/* Account selection - only show if we have multiple accounts */}
+                  {credentials.length > 1 && (
+                    <CommandGroup>
+                      <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
+                        Switch Account
+                      </div>
+                      {credentials.map((cred) => (
+                        <CommandItem
+                          key={cred.id}
+                          value={`account-${cred.id}`}
+                          onSelect={() => setSelectedCredentialId(cred.id)}
+                        >
+                          <div className='flex items-center gap-2'>
+                            <JiraIcon className='h-4 w-4' />
+                            <span className='font-normal'>{cred.name}</span>
+                          </div>
+                          {cred.id === selectedCredentialId && (
+                            <Check className='ml-auto h-4 w-4' />
+                          )}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+
+                  {/* Projects list */}
+                  {projects.length > 0 && (
+                    <CommandGroup>
+                      <div className='px-2 py-1.5 font-medium text-muted-foreground text-xs'>
+                        Projects
+                      </div>
+                      {projects.map((project) => (
+                        <CommandItem
+                          key={project.id}
+                          value={`project-${project.id}-${project.name}`}
+                          onSelect={() => handleSelectProject(project)}
+                        >
+                          <div className='flex items-center gap-2 overflow-hidden'>
+                            {project.avatarUrl ? (
+                              <img
+                                src={project.avatarUrl}
+                                alt={project.name}
+                                className='h-4 w-4 rounded'
+                              />
+                            ) : (
+                              <JiraIcon className='h-4 w-4' />
+                            )}
+                            <span className='truncate font-normal'>{project.name}</span>
+                          </div>
+                          {project.id === selectedProjectId && (
+                            <Check className='ml-auto h-4 w-4' />
+                          )}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+
+                  {/* Connect account option - only show if no credentials */}
+                  {credentials.length === 0 && (
+                    <CommandGroup>
+                      <CommandItem onSelect={handleAddCredential}>
+                        <div className='flex items-center gap-2 text-primary'>
+                          <JiraIcon className='h-4 w-4' />
+                          <span>Connect Jira account</span>
+                        </div>
+                      </CommandItem>
+                    </CommandGroup>
+                  )}
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          )}
         </Popover>
 
         {/* Project preview */}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
@@ -149,15 +149,14 @@ export function JiraProjectSelector({
 
       try {
         // Get the access token from the selected credential
-        const tokenUrl = new URL('/api/auth/oauth/token', window.location.origin)
-        if (workflowId) tokenUrl.searchParams.set('workflowId', workflowId)
-        const tokenResponse = await fetch(tokenUrl.toString(), {
+        const tokenResponse = await fetch('/api/auth/oauth/token', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
             credentialId: selectedCredentialId,
+            workflowId,
           }),
         })
 
@@ -236,15 +235,14 @@ export function JiraProjectSelector({
 
       try {
         // Get the access token from the selected credential
-        const tokenUrl = new URL('/api/auth/oauth/token', window.location.origin)
-        if (workflowId) tokenUrl.searchParams.set('workflowId', workflowId)
-        const tokenResponse = await fetch(tokenUrl.toString(), {
+        const tokenResponse = await fetch('/api/auth/oauth/token', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
             credentialId: selectedCredentialId,
+            workflowId,
           }),
         })
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
@@ -50,6 +50,7 @@ interface JiraProjectSelectorProps {
   onProjectInfoChange?: (projectInfo: JiraProjectInfo | null) => void
   credentialId?: string
   isForeignCredential?: boolean
+  workflowId?: string
 }
 
 export function JiraProjectSelector({
@@ -65,6 +66,7 @@ export function JiraProjectSelector({
   onProjectInfoChange,
   credentialId,
   isForeignCredential = false,
+  workflowId,
 }: JiraProjectSelectorProps) {
   const [open, setOpen] = useState(false)
   const [credentials, setCredentials] = useState<Credential[]>([])
@@ -147,7 +149,9 @@ export function JiraProjectSelector({
 
       try {
         // Get the access token from the selected credential
-        const tokenResponse = await fetch('/api/auth/oauth/token', {
+        const tokenUrl = new URL('/api/auth/oauth/token', window.location.origin)
+        if (workflowId) tokenUrl.searchParams.set('workflowId', workflowId)
+        const tokenResponse = await fetch(tokenUrl.toString(), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -232,7 +236,9 @@ export function JiraProjectSelector({
 
       try {
         // Get the access token from the selected credential
-        const tokenResponse = await fetch('/api/auth/oauth/token', {
+        const tokenUrl = new URL('/api/auth/oauth/token', window.location.origin)
+        if (workflowId) tokenUrl.searchParams.set('workflowId', workflowId)
+        const tokenResponse = await fetch(tokenUrl.toString(), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/jira-project-selector.tsx
@@ -340,7 +340,6 @@ export function JiraProjectSelector({
   // Fetch the selected project metadata once credentials are ready or changed
   useEffect(() => {
     if (value && selectedCredentialId && domain && domain.includes('.')) {
-      // Always try to resolve the name on value change, even if dropdown never opens
       if (!selectedProject || selectedProject.id !== value) {
         fetchProjectInfo(value)
       }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
@@ -240,6 +240,7 @@ export function ProjectSelectorInput({
               onProjectInfoChange={setProjectInfo}
               credentialId={(jiraCredential as string) || ''}
               isForeignCredential={isForeignCredential}
+              workflowId={activeWorkflowId || ''}
             />
           </div>
         </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
@@ -18,6 +18,7 @@ import {
   type LinearTeamInfo,
   LinearTeamSelector,
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/components/linear-team-selector'
+import { useForeignCredential } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-foreign-credential'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
 import type { SubBlockConfig } from '@/blocks/types'
 import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
@@ -43,11 +44,13 @@ export function ProjectSelectorInput({
   const { collaborativeSetSubblockValue } = useCollaborativeWorkflow()
   const [selectedProjectId, setSelectedProjectId] = useState<string>('')
   const [_projectInfo, setProjectInfo] = useState<JiraProjectInfo | DiscordServerInfo | null>(null)
-  const [isForeignCredential, setIsForeignCredential] = useState<boolean>(false)
-
   // Use the proper hook to get the current value and setter
   const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlock.id)
   const [connectedCredential] = useSubBlockValue(blockId, 'credential')
+  const { isForeignCredential } = useForeignCredential(
+    subBlock.provider || subBlock.serviceId || 'jira',
+    (connectedCredential as string) || ''
+  )
   // Local setters for related Jira fields to ensure immediate UI clearing
   const [_issueKeyValue, setIssueKeyValue] = useSubBlockValue<string>(blockId, 'issueKey')
   const [_manualIssueKeyValue, setManualIssueKeyValue] = useSubBlockValue<string>(
@@ -71,31 +74,6 @@ export function ProjectSelectorInput({
   const botToken = ''
 
   // Verify Jira credential belongs to current user; if not, treat as absent
-  useEffect(() => {
-    const cred = (connectedCredential as string) || ''
-    if (!cred) {
-      setIsForeignCredential(false)
-      return
-    }
-    let aborted = false
-    ;(async () => {
-      try {
-        const resp = await fetch(`/api/auth/oauth/credentials?credentialId=${cred}`)
-        if (aborted) return
-        if (!resp.ok) {
-          setIsForeignCredential(true)
-          return
-        }
-        const data = await resp.json()
-        setIsForeignCredential(!(data.credentials && data.credentials.length === 1))
-      } catch {
-        setIsForeignCredential(true)
-      }
-    })()
-    return () => {
-      aborted = true
-    }
-  }, [blockId, connectedCredential])
 
   // Get the current value from the store or prop value if in preview mode
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/project-selector/project-selector-input.tsx
@@ -47,6 +47,7 @@ export function ProjectSelectorInput({
 
   // Use the proper hook to get the current value and setter
   const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlock.id)
+  const [connectedCredential] = useSubBlockValue(blockId, 'credential')
   // Local setters for related Jira fields to ensure immediate UI clearing
   const [_issueKeyValue, setIssueKeyValue] = useSubBlockValue<string>(blockId, 'issueKey')
   const [_manualIssueKeyValue, setManualIssueKeyValue] = useSubBlockValue<string>(
@@ -71,7 +72,7 @@ export function ProjectSelectorInput({
 
   // Verify Jira credential belongs to current user; if not, treat as absent
   useEffect(() => {
-    const cred = (jiraCredential as string) || ''
+    const cred = (connectedCredential as string) || ''
     if (!cred) {
       setIsForeignCredential(false)
       return
@@ -94,8 +95,7 @@ export function ProjectSelectorInput({
     return () => {
       aborted = true
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockId, jiraCredential])
+  }, [blockId, connectedCredential])
 
   // Get the current value from the store or prop value if in preview mode
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-foreign-credential.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-foreign-credential.ts
@@ -1,0 +1,50 @@
+import { useEffect, useMemo, useState } from 'react'
+
+export function useForeignCredential(
+  provider: string | undefined,
+  credentialId: string | undefined
+) {
+  const [isForeign, setIsForeign] = useState<boolean>(false)
+  const [loading, setLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const normalizedProvider = useMemo(() => (provider || '').toString(), [provider])
+  const normalizedCredentialId = useMemo(() => credentialId || '', [credentialId])
+
+  useEffect(() => {
+    let cancelled = false
+    async function check() {
+      setLoading(true)
+      setError(null)
+      try {
+        if (!normalizedCredentialId) {
+          if (!cancelled) setIsForeign(false)
+          return
+        }
+        const res = await fetch(
+          `/api/auth/oauth/credentials?provider=${encodeURIComponent(normalizedProvider)}`
+        )
+        if (!res.ok) {
+          if (!cancelled) setIsForeign(true)
+          return
+        }
+        const data = await res.json()
+        const isOwn = (data.credentials || []).some((c: any) => c.id === normalizedCredentialId)
+        if (!cancelled) setIsForeign(!isOwn)
+      } catch (e) {
+        if (!cancelled) {
+          setIsForeign(true)
+          setError((e as Error).message)
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void check()
+    return () => {
+      cancelled = true
+    }
+  }, [normalizedProvider, normalizedCredentialId])
+
+  return { isForeignCredential: isForeign, loading, error }
+}

--- a/apps/sim/tools/google_sheets/read.ts
+++ b/apps/sim/tools/google_sheets/read.ts
@@ -42,9 +42,12 @@ export const readTool: ToolConfig<GoogleSheetsToolParams, GoogleSheetsReadRespon
         throw new Error('Spreadsheet ID is required')
       }
 
-      // If no range is provided, get all values from the first sheet
+      // If no range is provided, default to the first sheet without hardcoding the title
+      // Using A1 notation without a sheet name targets the first sheet (per Sheets API)
+      // Keep a generous column/row bound to avoid huge payloads
       if (!params.range) {
-        return `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/Sheet1!A1:Z1000`
+        const defaultRange = 'A1:Z1000'
+        return `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${defaultRange}`
       }
 
       // Otherwise, get values from the specified range


### PR DESCRIPTION
## Summary

Google blocks with folder / sheet pickers have confusing UI in the sense that you need to open this box which says Documents not available to open up the google driven picker. This PR changes that to directly open Google picker. 

Also greys out subblocks that are dependent on the credential until credential is selected.

## Type of Change
- [x] Other: UX Improvement

## Testing
Manually with Google Sheets and Drive Block.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)


https://github.com/user-attachments/assets/db05fc05-ebcd-40ee-b428-890576791563

