### PR TITLE
improvement(console): increase console max entries for larger workflows

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -807,7 +807,7 @@ export function useWorkflowExecution() {
 
       // Continue execution until there are no more pending blocks
       let iterationCount = 0
-      const maxIterations = 100 // Safety to prevent infinite loops
+      const maxIterations = 500 // Safety to prevent infinite loops
 
       while (currentPendingBlocks.length > 0 && iterationCount < maxIterations) {
         logger.info(

--- a/apps/sim/executor/index.ts
+++ b/apps/sim/executor/index.ts
@@ -225,7 +225,7 @@ export class Executor {
 
       let hasMoreLayers = true
       let iteration = 0
-      const maxIterations = 100 // Safety limit for infinite loops
+      const maxIterations = 500 // Safety limit for infinite loops
 
       while (hasMoreLayers && iteration < maxIterations && !this.isCancelled) {
         const nextLayer = this.getNextExecutionLayer(context)

--- a/apps/sim/stores/panel/console/store.ts
+++ b/apps/sim/stores/panel/console/store.ts
@@ -4,7 +4,7 @@ import { redactApiKeys } from '@/lib/utils'
 import type { NormalizedBlockOutput } from '@/executor/types'
 import type { ConsoleEntry, ConsoleStore } from '@/stores/panel/console/types'
 
-const MAX_ENTRIES = 50 // MAX across all workflows
+const MAX_ENTRIES = 500 // MAX across all workflows - allows for 100 loop iterations + other workflow logs
 const MAX_IMAGE_DATA_SIZE = 1000 // Maximum size of image data to store (in characters)
 const MAX_ANY_DATA_SIZE = 5000 // Maximum size of any data to store (in characters)
 const MAX_TOTAL_ENTRY_SIZE = 50000 // Maximum size of entire entry to prevent localStorage overflow

--- a/apps/sim/stores/workflows/workflow/store.test.ts
+++ b/apps/sim/stores/workflows/workflow/store.test.ts
@@ -109,7 +109,7 @@ describe('workflow store', () => {
       expect(state.loops.loop1.forEachItems).toEqual(['item1', 'item2', 'item3'])
     })
 
-    it('should clamp loop count between 1 and 50', () => {
+    it('should clamp loop count between 1 and 100', () => {
       const { addBlock, updateLoopCount } = useWorkflowStore.getState()
 
       // Add a loop block
@@ -199,7 +199,7 @@ describe('workflow store', () => {
       expect(parsedDistribution).toHaveLength(3)
     })
 
-    it('should clamp parallel count between 1 and 50', () => {
+    it('should clamp parallel count between 1 and 20', () => {
       const { addBlock, updateParallelCount } = useWorkflowStore.getState()
 
       // Add a parallel block


### PR DESCRIPTION
## Summary
increase console max entries for larger workflows, this was causing a loop with 100 iterations to prematurely stop at 50 since that was the max entries for the console, bad UX

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<img width="1946" height="1291" alt="Screenshot 2025-08-19 at 11 20 38 AM" src="https://github.com/user-attachments/assets/8547a82a-8704-4a0f-b497-792ba6ad93af" />
