### PR TITLE
improvement(api): add native support for form-urlencoded inputs into API block

### DIFF
--- a/apps/sim/tools/__test-utils__/test-tools.ts
+++ b/apps/sim/tools/__test-utils__/test-tools.ts
@@ -192,7 +192,18 @@ export class ToolTester<P = any, R = any> {
       const response = await this.mockFetch(url, {
         method: method,
         headers: this.tool.request.headers(params),
-        body: this.tool.request.body ? JSON.stringify(this.tool.request.body(params)) : undefined,
+        body: this.tool.request.body
+          ? (() => {
+              const bodyResult = this.tool.request.body(params)
+              const headers = this.tool.request.headers(params)
+              const isPreformattedContent =
+                headers['Content-Type'] === 'application/x-ndjson' ||
+                headers['Content-Type'] === 'application/x-www-form-urlencoded'
+              return isPreformattedContent && typeof bodyResult === 'string'
+                ? bodyResult
+                : JSON.stringify(bodyResult)
+            })()
+          : undefined,
       })
 
       if (!response.ok) {

--- a/apps/sim/tools/utils.test.ts
+++ b/apps/sim/tools/utils.test.ts
@@ -164,7 +164,7 @@ describe('formatRequestParams', () => {
     })
 
     // Return a preformatted body
-    mockTool.request.body = vi.fn().mockReturnValue({ body: 'key1=value1&key2=value2' })
+    mockTool.request.body = vi.fn().mockReturnValue('key1=value1&key2=value2')
 
     const params = { method: 'POST' }
     const result = formatRequestParams(mockTool, params)
@@ -179,9 +179,7 @@ describe('formatRequestParams', () => {
     })
 
     // Return a preformatted body for NDJSON
-    mockTool.request.body = vi.fn().mockReturnValue({
-      body: '{"prompt": "Hello"}\n{"prompt": "World"}',
-    })
+    mockTool.request.body = vi.fn().mockReturnValue('{"prompt": "Hello"}\n{"prompt": "World"}')
 
     const params = { method: 'POST' }
     const result = formatRequestParams(mockTool, params)

--- a/apps/sim/tools/utils.ts
+++ b/apps/sim/tools/utils.ts
@@ -63,8 +63,8 @@ export function formatRequestParams(tool: ToolConfig, params: Record<string, any
     headers['Content-Type'] === 'application/x-ndjson' ||
     headers['Content-Type'] === 'application/x-www-form-urlencoded'
   const body = hasBody
-    ? isPreformattedContent && bodyResult
-      ? bodyResult.body
+    ? isPreformattedContent && typeof bodyResult === 'string'
+      ? bodyResult
       : JSON.stringify(bodyResult)
     : undefined
 


### PR DESCRIPTION
## Summary
add native support for form-urlencoded inputs into API block

## Type of Change
- [x] New feature  

## Testing
Tested the same request here & in postman, ensured that the responses were identical

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots:
Before (even adding content-type to application/x-www-form-urlencoded it still used application/json):
<img width="1184" height="1235" alt="Screenshot 2025-08-19 at 12 28 18 PM" src="https://github.com/user-attachments/assets/643812a1-5fde-4900-b873-426ec0c962a8" />

After (respects the users content-type, converts json body into url encoded entry):
<img width="1048" height="1185" alt="Screenshot 2025-08-19 at 12 28 01 PM" src="https://github.com/user-attachments/assets/e6ee92ba-1238-4b5b-a583-2f4f2d62c905" />

