### PR TITLE
fix(ui): adjust text to prevent clipping

### DIFF
--- a/apps/sim/app/(landing)/components/sections/hero.tsx
+++ b/apps/sim/app/(landing)/components/sections/hero.tsx
@@ -130,7 +130,7 @@ function Hero() {
       </div>
 
       <div className='animation-container relative z-20 space-y-4 px-4 text-center'>
-        <h1 className='animation-container animate-fade-up font-semibold text-[42px] leading-[1.10] opacity-0 will-change-[opacity,transform] [animation-delay:200ms] md:text-[68px]'>
+        <h1 className='animation-container animate-fade-up font-semibold text-[42px] leading-[1.10] pb-2 opacity-0 will-change-[opacity,transform] [animation-delay:200ms] md:text-[68px]'>
           Build / Deploy
           <br />
           Agent Workflows


### PR DESCRIPTION
## Summary
This PR fixes a minor UI issue on the homepage where the letter g was being clipped.

I resolved this by adding pb-2. The issue was caused by the line height (leading) being too small. Increasing the leading directly caused some text to overlap with the HeroWorkflowProvider in responsive views, so adding padding-bottom was the safer fix. If needed to change line height, then I can try to adjust the HeroWorkflowProvider to make it better.

Fixes #1049 

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Visual check – confirmed fix locally.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

**Before**
<img width="1912" height="926" alt="before" src="https://github.com/user-attachments/assets/0e833af2-41fd-4900-9314-e4bf0078e861" />

**After**
<img width="1912" height="926" alt="after" src="https://github.com/user-attachments/assets/9ed42235-c92a-42c8-a483-b1098ffcf2ae" />


