### PR TITLE
fix(logs): make child workflow span errors the same as root level workflow errors

### DIFF
--- a/apps/sim/executor/index.ts
+++ b/apps/sim/executor/index.ts
@@ -455,6 +455,14 @@ export class Executor {
           success: false,
           output: finalOutput,
           error: 'Workflow execution was cancelled',
+          metadata: {
+            duration: Date.now() - startTime.getTime(),
+            startTime: context.metadata.startTime!,
+            workflowConnections: this.actualWorkflow.connections.map((conn: any) => ({
+              source: conn.source,
+              target: conn.target,
+            })),
+          },
           logs: context.blockLogs,
         }
       }
@@ -503,6 +511,14 @@ export class Executor {
         success: false,
         output: finalOutput,
         error: this.extractErrorMessage(error),
+        metadata: {
+          duration: Date.now() - startTime.getTime(),
+          startTime: context.metadata.startTime!,
+          workflowConnections: this.actualWorkflow.connections.map((conn: any) => ({
+            source: conn.source,
+            target: conn.target,
+          })),
+        },
         logs: context.blockLogs,
       }
     } finally {
@@ -530,6 +546,14 @@ export class Executor {
         success: false,
         output: finalOutput,
         error: 'Workflow execution was cancelled',
+        metadata: {
+          duration: Date.now() - new Date(context.metadata.startTime!).getTime(),
+          startTime: context.metadata.startTime!,
+          workflowConnections: this.actualWorkflow.connections.map((conn: any) => ({
+            source: conn.source,
+            target: conn.target,
+          })),
+        },
         logs: context.blockLogs,
       }
     }
@@ -596,6 +620,14 @@ export class Executor {
         success: false,
         output: finalOutput,
         error: this.extractErrorMessage(error),
+        metadata: {
+          duration: Date.now() - new Date(context.metadata.startTime!).getTime(),
+          startTime: context.metadata.startTime!,
+          workflowConnections: this.actualWorkflow.connections.map((conn: any) => ({
+            source: conn.source,
+            target: conn.target,
+          })),
+        },
         logs: context.blockLogs,
       }
     }

--- a/apps/sim/lib/logs/execution/trace-spans/trace-spans.ts
+++ b/apps/sim/lib/logs/execution/trace-spans/trace-spans.ts
@@ -119,7 +119,10 @@ export function buildTraceSpans(result: ExecutionResult): {
       const flatChildSpans: TraceSpan[] = []
       childTraceSpans.forEach((childSpan) => {
         // Skip the synthetic workflow span wrapper - we only want the actual block executions
-        if (childSpan.type === 'workflow' && childSpan.name === 'Workflow Execution') {
+        if (
+          childSpan.type === 'workflow' &&
+          (childSpan.name === 'Workflow Execution' || childSpan.name.endsWith(' workflow'))
+        ) {
           // Add its children directly, skipping the synthetic wrapper
           if (childSpan.children && Array.isArray(childSpan.children)) {
             flatChildSpans.push(...childSpan.children)
@@ -401,7 +404,10 @@ function ensureNestedWorkflowsProcessed(span: TraceSpan): TraceSpan {
 
     childTraceSpans.forEach((childSpan) => {
       // Skip synthetic workflow wrappers and get the actual blocks
-      if (childSpan.type === 'workflow' && childSpan.name === 'Workflow Execution') {
+      if (
+        childSpan.type === 'workflow' &&
+        (childSpan.name === 'Workflow Execution' || childSpan.name.endsWith(' workflow'))
+      ) {
         if (childSpan.children && Array.isArray(childSpan.children)) {
           // Recursively process each child to handle deeper nesting
           childSpan.children.forEach((grandchildSpan) => {


### PR DESCRIPTION
## Summary
make child workflow span errors the same as root level workflow errors

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)