### PR TITLE
improvement(logging): capture pre-execution validation errors in logging session

### DIFF
--- a/apps/sim/lib/logs/execution/logging-session.ts
+++ b/apps/sim/lib/logs/execution/logging-session.ts
@@ -7,7 +7,12 @@ import {
   createTriggerObject,
   loadWorkflowStateForExecution,
 } from '@/lib/logs/execution/logging-factory'
-import type { ExecutionEnvironment, ExecutionTrigger, WorkflowState } from '@/lib/logs/types'
+import type {
+  ExecutionEnvironment,
+  ExecutionTrigger,
+  TraceSpan,
+  WorkflowState,
+} from '@/lib/logs/types'
 
 const logger = createLogger('LoggingSession')
 
@@ -23,6 +28,15 @@ export interface SessionCompleteParams {
   totalDurationMs?: number
   finalOutput?: any
   traceSpans?: any[]
+}
+
+export interface SessionErrorCompleteParams {
+  endedAt?: string
+  totalDurationMs?: number
+  error?: {
+    message?: string
+    stackTrace?: string
+  }
 }
 
 export class LoggingSession {
@@ -115,8 +129,14 @@ export class LoggingSession {
     }
   }
 
-  async completeWithError(error?: any): Promise<void> {
+  async completeWithError(params: SessionErrorCompleteParams = {}): Promise<void> {
     try {
+      const { endedAt, totalDurationMs, error } = params
+
+      const endTime = endedAt ? new Date(endedAt) : new Date()
+      const durationMs = typeof totalDurationMs === 'number' ? totalDurationMs : 0
+      const startTime = new Date(endTime.getTime() - Math.max(1, durationMs))
+
       const costSummary = {
         totalCost: BASE_EXECUTION_CHARGE,
         totalInputCost: 0,
@@ -129,13 +149,30 @@ export class LoggingSession {
         models: {},
       }
 
+      const message = error?.message || 'Execution failed before starting blocks'
+      const stackTrace = error?.stackTrace
+
+      const syntheticErrorSpan: TraceSpan[] = [
+        {
+          id: 'pre-execution-validation',
+          name: 'Pre-execution validation',
+          type: 'validation',
+          duration: Math.max(1, durationMs),
+          startTime: startTime.toISOString(),
+          endTime: endTime.toISOString(),
+          status: 'error',
+          children: [],
+          output: stackTrace ? { error: message, stackTrace } : { error: message },
+        },
+      ]
+
       await executionLogger.completeWorkflowExecution({
         executionId: this.executionId,
-        endedAt: new Date().toISOString(),
-        totalDurationMs: 0,
+        endedAt: endTime.toISOString(),
+        totalDurationMs: Math.max(1, durationMs),
         costSummary,
-        finalOutput: null,
-        traceSpans: [],
+        finalOutput: { error: message },
+        traceSpans: syntheticErrorSpan,
       })
 
       if (this.requestId) {
@@ -170,7 +207,7 @@ export class LoggingSession {
     }
   }
 
-  async safeCompleteWithError(error?: any): Promise<void> {
+  async safeCompleteWithError(error?: SessionErrorCompleteParams): Promise<void> {
     try {
       await this.completeWithError(error)
     } catch (enhancedError) {


### PR DESCRIPTION
## Summary

Need to capture tracespans for pre-execution / serialization errors in logs. E.g. Api key missing.

## Type of Change
- [x] Bug fix

## Testing
IN PROGRESS

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
