### PR TITLE
fix(subblock-race-condition): check loading state correctly

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -39,7 +39,7 @@ import { useExecutionStore } from '@/stores/execution/store'
 import { useVariablesStore } from '@/stores/panel/variables/store'
 import { useGeneralStore } from '@/stores/settings/general/store'
 import { useWorkflowDiffStore } from '@/stores/workflow-diff/store'
-import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
+import { hasWorkflowsInitiallyLoaded, useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 const logger = createLogger('Workflow')
@@ -908,14 +908,21 @@ const WorkflowContent = React.memo(() => {
       const workflowIds = Object.keys(workflows)
       const currentId = params.workflowId as string
 
+      // Check if workflows have been initially loaded at least once
+      // This prevents premature navigation decisions on page refresh
+      if (!hasWorkflowsInitiallyLoaded()) {
+        logger.info('Waiting for initial workflow load...')
+        return
+      }
+
       // Wait for both initialization and workflow loading to complete
       if (isLoading) {
         logger.info('Workflows still loading, waiting...')
         return
       }
 
-      // If no workflows exist, redirect to workspace root to let server handle workflow creation
-      if (workflowIds.length === 0 && !isLoading) {
+      // If no workflows exist after loading, redirect to workspace root
+      if (workflowIds.length === 0) {
         logger.info('No workflows found, redirecting to workspace root')
         router.replace(`/workspace/${workspaceId}/w`)
         return

--- a/apps/sim/stores/workflows/registry/store.ts
+++ b/apps/sim/stores/workflows/registry/store.ts
@@ -20,7 +20,6 @@ let isFetching = false
 let lastFetchTimestamp = 0
 
 async function fetchWorkflowsFromDB(workspaceId?: string): Promise<void> {
-  // Skip fetch on server-side to prevent hydration issues
   if (typeof window === 'undefined') return
 
   // Prevent concurrent fetch operations
@@ -109,7 +108,7 @@ async function fetchWorkflowsFromDB(workspaceId?: string): Promise<void> {
         name,
         description: description || '',
         color: color || '#3972F6',
-        lastModified: new Date(createdAt || 0), // Use epoch time if no createdAt to avoid SSR issues
+        lastModified: new Date(createdAt || 0),
         marketplaceData: marketplaceData || null,
         workspaceId,
         folderId: folderId || null,

--- a/apps/sim/stores/workflows/workflow/store.ts
+++ b/apps/sim/stores/workflows/workflow/store.ts
@@ -46,7 +46,7 @@ const initialState = {
         isDeployed: false,
         isPublished: false,
       },
-      timestamp: Date.now(),
+      timestamp: 0, // Use 0 for initial state to avoid SSR hydration issues
       action: 'Initial state',
       subblockValues: {},
     },

--- a/apps/sim/stores/workflows/workflow/store.ts
+++ b/apps/sim/stores/workflows/workflow/store.ts
@@ -46,7 +46,7 @@ const initialState = {
         isDeployed: false,
         isPublished: false,
       },
-      timestamp: 0, // Use 0 for initial state to avoid SSR hydration issues
+      timestamp: 0,
       action: 'Initial state',
       subblockValues: {},
     },


### PR DESCRIPTION
## Summary
- Populate SubBlockStore with subblock values BEFORE changing activeWorkflowId in setActiveWorkflow(), ensuring data is available when components re-render after the workflow switch.
- Fix hydration error

## Type of Change
- [x] Bug fix


## Testing
Manually switch workflows, workspaces, refresh.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)