### PR TITLE
fix(slack-channel): fixes infinite api call to slack channel

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/channel-selector/channel-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/channel-selector/channel-selector-input.tsx
@@ -110,7 +110,7 @@ export function ChannelSelectorInput({
                 credential={effectiveCredential}
                 workflowId={workflowIdParam}
                 label={subBlock.placeholder || 'Select Slack channel'}
-                disabled={finalDisabled || !hasValidCredential}
+                disabled={finalDisabled}
               />
             </div>
           </TooltipTrigger>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/channel-selector/channel-selector-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/channel-selector/channel-selector-input.tsx
@@ -61,7 +61,9 @@ export function ChannelSelectorInput({
   }
 
   // Check if the selected OAuth credential belongs to current user (avoid foreign creds)
-  const { isForeignCredential } = useForeignCredential('slack', connectedCredential as string)
+  const credentialIdForCheck =
+    (authMethod as string) === 'bot_token' ? undefined : credential || undefined
+  const { isForeignCredential } = useForeignCredential(provider, credentialIdForCheck)
 
   // Determine if a valid credential is present to enable the selector
   const hasValidCredential = (() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/channel-selector/components/slack-channel-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/channel-selector/components/slack-channel-selector.tsx
@@ -22,6 +22,7 @@ interface SlackChannelSelectorProps {
   value: string
   onChange: (channelId: string, channelInfo?: SlackChannelInfo) => void
   credential: string
+  workflowId?: string
   label?: string
   disabled?: boolean
 }
@@ -30,6 +31,7 @@ export function SlackChannelSelector({
   value,
   onChange,
   credential,
+  workflowId,
   label = 'Select Slack channel',
   disabled = false,
 }: SlackChannelSelectorProps) {
@@ -51,7 +53,7 @@ export function SlackChannelSelector({
       const res = await fetch('/api/tools/slack/channels', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ credential }),
+        body: JSON.stringify({ credential, workflowId }),
       })
 
       if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`)
@@ -62,7 +64,6 @@ export function SlackChannelSelector({
         setChannels([])
       } else {
         setChannels(data.channels)
-        setInitialFetchDone(true)
       }
     } catch (err) {
       if ((err as Error).name === 'AbortError') return
@@ -70,8 +71,10 @@ export function SlackChannelSelector({
       setChannels([])
     } finally {
       setLoading(false)
+      // Mark that we attempted an initial fetch to avoid repeated automatic retries on failure
+      setInitialFetchDone(true)
     }
-  }, [credential])
+  }, [credential, workflowId])
 
   // Handle dropdown open/close - fetch channels when opening
   const handleOpenChange = (isOpen: boolean) => {


### PR DESCRIPTION
## Summary
When you remove a slack credential, there is a infinite post request to slack/channels. Added selector disabled when there is not credential present to prevent the request from occurring. This follows same patterns as other selectors.

## Type of Change
- [x] Bug fix

## Testing
Add a credential, then remove the credential and replicate the 403. The changes disabled the selector and cleared the 403.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

