### PR TITLE
fix(billing-ui): open settings when enterprise sub folks press usage indicator

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -1007,8 +1007,11 @@ export function Sidebar() {
         >
           <UsageIndicator
             onClick={() => {
-              const isBlocked = useSubscriptionStore.getState().getBillingStatus() === 'blocked'
-              if (isBlocked) {
+              const subscriptionStore = useSubscriptionStore.getState()
+              const isBlocked = subscriptionStore.getBillingStatus() === 'blocked'
+              const canUpgrade = subscriptionStore.canUpgrade()
+
+              if (isBlocked || !canUpgrade) {
                 if (typeof window !== 'undefined') {
                   window.dispatchEvent(
                     new CustomEvent('open-settings', { detail: { tab: 'subscription' } })


### PR DESCRIPTION
## Summary
- open settings when enterprise sub folks press usage indicator
  -  previously, we open the settings indicator for users that are on the team plan and users that are blocked 
  - now, we show the settings for enterprise users all around as well

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)