### PR TITLE
fix(parsers): fix md, pptx, html kb uploads

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/upload-modal/upload-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/upload-modal/upload-modal.tsx
@@ -22,10 +22,30 @@ const ACCEPTED_FILE_TYPES = [
   'application/vnd.ms-excel',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   'text/markdown',
+  'text/x-markdown',
   'application/vnd.ms-powerpoint',
   'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   'text/html',
 ]
+
+// File extensions to include in accept attribute for better browser compatibility
+const ACCEPTED_FILE_EXTENSIONS = [
+  '.pdf',
+  '.doc',
+  '.docx',
+  '.txt',
+  '.csv',
+  '.xls',
+  '.xlsx',
+  '.md',
+  '.ppt',
+  '.pptx',
+  '.html',
+  '.htm',
+]
+
+// Combined accept string with both MIME types and extensions
+const ACCEPT_ATTRIBUTE = [...ACCEPTED_FILE_TYPES, ...ACCEPTED_FILE_EXTENSIONS].join(',')
 
 interface FileWithPreview extends File {
   preview: string
@@ -197,7 +217,7 @@ export function UploadModal({
                 <input
                   ref={fileInputRef}
                   type='file'
-                  accept={ACCEPTED_FILE_TYPES.join(',')}
+                  accept={ACCEPT_ATTRIBUTE}
                   onChange={handleFileChange}
                   className='hidden'
                   multiple
@@ -228,7 +248,7 @@ export function UploadModal({
                   <input
                     ref={fileInputRef}
                     type='file'
-                    accept={ACCEPTED_FILE_TYPES.join(',')}
+                    accept={ACCEPT_ATTRIBUTE}
                     onChange={handleFileChange}
                     className='hidden'
                     multiple

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/upload-modal/upload-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/upload-modal/upload-modal.tsx
@@ -7,45 +7,11 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Label } from '@/components/ui/label'
 import { Progress } from '@/components/ui/progress'
 import { createLogger } from '@/lib/logs/console/logger'
+import { ACCEPT_ATTRIBUTE, ACCEPTED_FILE_TYPES, MAX_FILE_SIZE } from '@/lib/uploads/validation'
 import { getDocumentIcon } from '@/app/workspace/[workspaceId]/knowledge/components'
 import { useKnowledgeUpload } from '@/app/workspace/[workspaceId]/knowledge/hooks/use-knowledge-upload'
 
 const logger = createLogger('UploadModal')
-
-const MAX_FILE_SIZE = 100 * 1024 * 1024 // 100MB
-const ACCEPTED_FILE_TYPES = [
-  'application/pdf',
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'text/plain',
-  'text/csv',
-  'application/vnd.ms-excel',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  'text/markdown',
-  'text/x-markdown',
-  'application/vnd.ms-powerpoint',
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-  'text/html',
-]
-
-// File extensions to include in accept attribute for better browser compatibility
-const ACCEPTED_FILE_EXTENSIONS = [
-  '.pdf',
-  '.doc',
-  '.docx',
-  '.txt',
-  '.csv',
-  '.xls',
-  '.xlsx',
-  '.md',
-  '.ppt',
-  '.pptx',
-  '.html',
-  '.htm',
-]
-
-// Combined accept string with both MIME types and extensions
-const ACCEPT_ATTRIBUTE = [...ACCEPTED_FILE_TYPES, ...ACCEPTED_FILE_EXTENSIONS].join(',')
 
 interface FileWithPreview extends File {
   preview: string
@@ -192,7 +158,7 @@ export function UploadModal({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className='flex max-h-[95vh] max-w-2xl flex-col overflow-hidden'>
+      <DialogContent className='flex max-h-[95vh] flex-col overflow-hidden sm:max-w-[600px]'>
         <DialogHeader>
           <DialogTitle>Upload Documents</DialogTitle>
         </DialogHeader>
@@ -258,7 +224,7 @@ export function UploadModal({
                   </p>
                 </div>
 
-                <div className='max-h-60 space-y-2 overflow-auto'>
+                <div className='max-h-80 space-y-2 overflow-auto'>
                   {files.map((file, index) => {
                     const fileStatus = uploadProgress.fileStatuses?.[index]
                     const isCurrentlyUploading = fileStatus?.status === 'uploading'

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/create-modal/create-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/create-modal/create-modal.tsx
@@ -30,10 +30,30 @@ const ACCEPTED_FILE_TYPES = [
   'application/vnd.ms-excel',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   'text/markdown',
+  'text/x-markdown',
   'application/vnd.ms-powerpoint',
   'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   'text/html',
 ]
+
+// File extensions to include in accept attribute for better browser compatibility
+const ACCEPTED_FILE_EXTENSIONS = [
+  '.pdf',
+  '.doc',
+  '.docx',
+  '.txt',
+  '.csv',
+  '.xls',
+  '.xlsx',
+  '.md',
+  '.ppt',
+  '.pptx',
+  '.html',
+  '.htm',
+]
+
+// Combined accept string with both MIME types and extensions
+const ACCEPT_ATTRIBUTE = [...ACCEPTED_FILE_TYPES, ...ACCEPTED_FILE_EXTENSIONS].join(',')
 
 interface FileWithPreview extends File {
   preview: string
@@ -498,7 +518,7 @@ export function CreateModal({ open, onOpenChange, onKnowledgeBaseCreated }: Crea
                         <input
                           ref={fileInputRef}
                           type='file'
-                          accept={ACCEPTED_FILE_TYPES.join(',')}
+                          accept={ACCEPT_ATTRIBUTE}
                           onChange={handleFileChange}
                           className='hidden'
                           multiple
@@ -540,7 +560,7 @@ export function CreateModal({ open, onOpenChange, onKnowledgeBaseCreated }: Crea
                           <input
                             ref={fileInputRef}
                             type='file'
-                            accept={ACCEPTED_FILE_TYPES.join(',')}
+                            accept={ACCEPT_ATTRIBUTE}
                             onChange={handleFileChange}
                             className='hidden'
                             multiple

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/create-modal/create-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/create-modal/create-modal.tsx
@@ -14,46 +14,12 @@ import { Label } from '@/components/ui/label'
 import { Progress } from '@/components/ui/progress'
 import { Textarea } from '@/components/ui/textarea'
 import { createLogger } from '@/lib/logs/console/logger'
+import { ACCEPT_ATTRIBUTE, ACCEPTED_FILE_TYPES, MAX_FILE_SIZE } from '@/lib/uploads/validation'
 import { getDocumentIcon } from '@/app/workspace/[workspaceId]/knowledge/components'
 import { useKnowledgeUpload } from '@/app/workspace/[workspaceId]/knowledge/hooks/use-knowledge-upload'
 import type { KnowledgeBaseData } from '@/stores/knowledge/store'
 
 const logger = createLogger('CreateModal')
-
-const MAX_FILE_SIZE = 100 * 1024 * 1024 // 100MB
-const ACCEPTED_FILE_TYPES = [
-  'application/pdf',
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'text/plain',
-  'text/csv',
-  'application/vnd.ms-excel',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  'text/markdown',
-  'text/x-markdown',
-  'application/vnd.ms-powerpoint',
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-  'text/html',
-]
-
-// File extensions to include in accept attribute for better browser compatibility
-const ACCEPTED_FILE_EXTENSIONS = [
-  '.pdf',
-  '.doc',
-  '.docx',
-  '.txt',
-  '.csv',
-  '.xls',
-  '.xlsx',
-  '.md',
-  '.ppt',
-  '.pptx',
-  '.html',
-  '.htm',
-]
-
-// Combined accept string with both MIME types and extensions
-const ACCEPT_ATTRIBUTE = [...ACCEPTED_FILE_TYPES, ...ACCEPTED_FILE_EXTENSIONS].join(',')
 
 interface FileWithPreview extends File {
   preview: string

--- a/apps/sim/lib/uploads/validation.ts
+++ b/apps/sim/lib/uploads/validation.ts
@@ -9,6 +9,10 @@ export const SUPPORTED_DOCUMENT_EXTENSIONS = [
   'md',
   'xlsx',
   'xls',
+  'ppt',
+  'pptx',
+  'html',
+  'htm',
 ] as const
 
 export type SupportedDocumentExtension = (typeof SUPPORTED_DOCUMENT_EXTENSIONS)[number]
@@ -19,9 +23,13 @@ export const SUPPORTED_MIME_TYPES: Record<SupportedDocumentExtension, string[]> 
   doc: ['application/msword'],
   docx: ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
   txt: ['text/plain'],
-  md: ['text/markdown', 'text/x-markdown'],
+  md: ['text/markdown', 'text/x-markdown', 'text/plain'],
   xlsx: ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
   xls: ['application/vnd.ms-excel'],
+  ppt: ['application/vnd.ms-powerpoint'],
+  pptx: ['application/vnd.openxmlformats-officedocument.presentationml.presentation'],
+  html: ['text/html'],
+  htm: ['text/html'],
 }
 
 export interface FileValidationError {

--- a/apps/sim/lib/uploads/validation.ts
+++ b/apps/sim/lib/uploads/validation.ts
@@ -1,5 +1,7 @@
 import path from 'path'
 
+export const MAX_FILE_SIZE = 100 * 1024 * 1024 // 100MB
+
 export const SUPPORTED_DOCUMENT_EXTENSIONS = [
   'pdf',
   'csv',
@@ -18,19 +20,39 @@ export const SUPPORTED_DOCUMENT_EXTENSIONS = [
 export type SupportedDocumentExtension = (typeof SUPPORTED_DOCUMENT_EXTENSIONS)[number]
 
 export const SUPPORTED_MIME_TYPES: Record<SupportedDocumentExtension, string[]> = {
-  pdf: ['application/pdf'],
-  csv: ['text/csv', 'application/csv'],
-  doc: ['application/msword'],
-  docx: ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
-  txt: ['text/plain'],
-  md: ['text/markdown', 'text/x-markdown', 'text/plain'],
-  xlsx: ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
-  xls: ['application/vnd.ms-excel'],
-  ppt: ['application/vnd.ms-powerpoint'],
-  pptx: ['application/vnd.openxmlformats-officedocument.presentationml.presentation'],
-  html: ['text/html'],
-  htm: ['text/html'],
+  pdf: ['application/pdf', 'application/x-pdf'],
+  csv: ['text/csv', 'application/csv', 'text/comma-separated-values'],
+  doc: ['application/msword', 'application/doc', 'application/vnd.ms-word'],
+  docx: [
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/octet-stream',
+  ],
+  txt: ['text/plain', 'text/x-plain', 'application/txt'],
+  md: ['text/markdown', 'text/x-markdown', 'text/plain', 'application/markdown'],
+  xlsx: [
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/octet-stream',
+  ],
+  xls: [
+    'application/vnd.ms-excel',
+    'application/excel',
+    'application/x-excel',
+    'application/x-msexcel',
+  ],
+  ppt: ['application/vnd.ms-powerpoint', 'application/powerpoint', 'application/x-mspowerpoint'],
+  pptx: [
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'application/octet-stream',
+  ],
+  html: ['text/html', 'application/xhtml+xml'],
+  htm: ['text/html', 'application/xhtml+xml'],
 }
+
+export const ACCEPTED_FILE_TYPES = Object.values(SUPPORTED_MIME_TYPES).flat()
+
+export const ACCEPTED_FILE_EXTENSIONS = SUPPORTED_DOCUMENT_EXTENSIONS.map((ext) => `.${ext}`)
+
+export const ACCEPT_ATTRIBUTE = [...ACCEPTED_FILE_TYPES, ...ACCEPTED_FILE_EXTENSIONS].join(',')
 
 export interface FileValidationError {
   code: 'UNSUPPORTED_FILE_TYPE' | 'MIME_TYPE_MISMATCH'


### PR DESCRIPTION
## Summary
fix md, pptx, html kb uploads. we added the parsers for them, but needed to add some additional logic to ensure we accept any of their formats in the UI uploads

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

https://github.com/user-attachments/assets/883eeb32-e4fd-46a0-af33-a5b19bc22c15

