### PR TITLE
fix(organizations): remove org calls when billing is disabled

### DIFF
--- a/apps/sim/stores/organization/store.ts
+++ b/apps/sim/stores/organization/store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import { client } from '@/lib/auth-client'
 import { checkEnterprisePlan } from '@/lib/billing/subscriptions/utils'
+import { getEnv, isTruthy } from '@/lib/env'
 import { createLogger } from '@/lib/logs/console/logger'
 import type {
   OrganizationStore,
@@ -16,6 +17,8 @@ import {
 } from '@/stores/organization/utils'
 
 const logger = createLogger('OrganizationStore')
+
+const isBillingEnabled = isTruthy(getEnv('NEXT_PUBLIC_BILLING_ENABLED'))
 
 const CACHE_DURATION = 30 * 1000
 
@@ -49,6 +52,20 @@ export const useOrganizationStore = create<OrganizationStore>()(
       hasEnterprisePlan: false,
 
       loadData: async () => {
+        if (!isBillingEnabled) {
+          logger.debug('Billing disabled, skipping organization data loading')
+          set({
+            organizations: [],
+            activeOrganization: null,
+            hasTeamPlan: false,
+            hasEnterprisePlan: false,
+            isLoading: false,
+            error: null,
+            lastFetched: Date.now(),
+          })
+          return
+        }
+
         const state = get()
 
         if (state.lastFetched && Date.now() - state.lastFetched < CACHE_DURATION) {
@@ -287,6 +304,11 @@ export const useOrganizationStore = create<OrganizationStore>()(
       },
 
       refreshOrganization: async () => {
+        if (!isBillingEnabled) {
+          logger.debug('Billing disabled, skipping organization refresh')
+          return
+        }
+
         const { activeOrganization } = get()
         if (!activeOrganization?.id) return
 
@@ -318,6 +340,15 @@ export const useOrganizationStore = create<OrganizationStore>()(
 
       // Organization management
       createOrganization: async (name: string, slug: string) => {
+        if (!isBillingEnabled) {
+          logger.debug('Billing disabled, skipping organization creation')
+          set({
+            error: 'Organizations are only available when billing is enabled',
+            isCreatingOrg: false,
+          })
+          return
+        }
+
         set({ isCreatingOrg: true, error: null })
 
         try {


### PR DESCRIPTION
## Summary
remove org calls when billing is disabled to prevent the users that have billing disabled (OSS) from getting 404's. removed it from the places that programatically get called when the user loads into the platform,

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)