### PR TITLE
fix(ui): dark mode styling for switch, trigger modal UI, signup/login improvements with auto-submit for OTP

### DIFF
--- a/apps/sim/app/(auth)/signup/signup-form.test.tsx
+++ b/apps/sim/app/(auth)/signup/signup-form.test.tsx
@@ -166,8 +166,9 @@ describe('SignupPage', () => {
       })
     })
 
-    it('should prevent submission with invalid name validation', async () => {
+    it('should automatically trim spaces from name input', async () => {
       const mockSignUp = vi.mocked(client.signUp.email)
+      mockSignUp.mockResolvedValue({ data: null, error: null })
 
       render(<SignupPage {...defaultProps} />)
 
@@ -176,22 +177,20 @@ describe('SignupPage', () => {
       const passwordInput = screen.getByPlaceholderText(/enter your password/i)
       const submitButton = screen.getByRole('button', { name: /create account/i })
 
-      // Use name with leading/trailing spaces which should fail validation
       fireEvent.change(nameInput, { target: { value: '  John Doe  ' } })
       fireEvent.change(emailInput, { target: { value: 'user@company.com' } })
       fireEvent.change(passwordInput, { target: { value: 'Password123!' } })
       fireEvent.click(submitButton)
 
-      // Should not call signUp because validation failed
-      expect(mockSignUp).not.toHaveBeenCalled()
-
-      // Should show validation error
       await waitFor(() => {
-        expect(
-          screen.getByText(
-            /Name cannot contain consecutive spaces|Name cannot start or end with spaces/
-          )
-        ).toBeInTheDocument()
+        expect(mockSignUp).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'John Doe',
+            email: 'user@company.com',
+            password: 'Password123!',
+          }),
+          expect.any(Object)
+        )
       })
     })
 

--- a/apps/sim/app/(auth)/signup/signup-form.tsx
+++ b/apps/sim/app/(auth)/signup/signup-form.tsx
@@ -49,10 +49,6 @@ const NAME_VALIDATIONS = {
     regex: /^(?!.*\s\s).*$/,
     message: 'Name cannot contain consecutive spaces.',
   },
-  noLeadingTrailingSpaces: {
-    test: (value: string) => value === value.trim(),
-    message: 'Name cannot start or end with spaces.',
-  },
 }
 
 const validateEmailField = (emailValue: string): string[] => {
@@ -175,10 +171,6 @@ function SignupFormContent({
       errors.push(NAME_VALIDATIONS.noConsecutiveSpaces.message)
     }
 
-    if (!NAME_VALIDATIONS.noLeadingTrailingSpaces.test(nameValue)) {
-      errors.push(NAME_VALIDATIONS.noLeadingTrailingSpaces.message)
-    }
-
     return errors
   }
 
@@ -193,11 +185,10 @@ function SignupFormContent({
   }
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newName = e.target.value
-    setName(newName)
+    const rawValue = e.target.value
+    setName(rawValue)
 
-    // Silently validate but don't show errors until submit
-    const errors = validateName(newName)
+    const errors = validateName(rawValue)
     setNameErrors(errors)
     setShowNameValidationError(false)
   }
@@ -224,23 +215,21 @@ function SignupFormContent({
     const formData = new FormData(e.currentTarget)
     const emailValue = formData.get('email') as string
     const passwordValue = formData.get('password') as string
-    const name = formData.get('name') as string
+    const nameValue = formData.get('name') as string
 
-    // Validate name on submit
-    const nameValidationErrors = validateName(name)
+    const trimmedName = nameValue.trim()
+
+    const nameValidationErrors = validateName(trimmedName)
     setNameErrors(nameValidationErrors)
     setShowNameValidationError(nameValidationErrors.length > 0)
 
-    // Validate email on submit
     const emailValidationErrors = validateEmailField(emailValue)
     setEmailErrors(emailValidationErrors)
     setShowEmailValidationError(emailValidationErrors.length > 0)
 
-    // Validate password on submit
     const errors = validatePassword(passwordValue)
     setPasswordErrors(errors)
 
-    // Only show validation errors if there are any
     setShowValidationError(errors.length > 0)
 
     try {
@@ -249,7 +238,6 @@ function SignupFormContent({
         emailValidationErrors.length > 0 ||
         errors.length > 0
       ) {
-        // Prioritize name errors first, then email errors, then password errors
         if (nameValidationErrors.length > 0) {
           setNameErrors([nameValidationErrors[0]])
           setShowNameValidationError(true)
@@ -266,8 +254,6 @@ function SignupFormContent({
         return
       }
 
-      // Check if name will be truncated and warn user
-      const trimmedName = name.trim()
       if (trimmedName.length > 100) {
         setNameErrors(['Name will be truncated to 100 characters. Please shorten your name.'])
         setShowNameValidationError(true)
@@ -337,7 +323,6 @@ function SignupFormContent({
         logger.info('Session refreshed after successful signup')
       } catch (sessionError) {
         logger.error('Failed to refresh session after signup:', sessionError)
-        // Continue anyway - the verification flow will handle this
       }
 
       // For new signups, always require verification

--- a/apps/sim/app/(auth)/verify/use-verification.ts
+++ b/apps/sim/app/(auth)/verify/use-verification.ts
@@ -213,29 +213,30 @@ export function useVerification({
       setErrorMessage('')
     }
     setOtp(value)
-
-    // Auto-submit when OTP is complete (6 digits)
-    if (value.length === 6 && email) {
-      setTimeout(() => {
-        verifyCode()
-      }, 100) // Small delay to ensure state is updated
-    }
   }
+
+  // Auto-submit when OTP is complete
+  useEffect(() => {
+    if (otp.length === 6 && email && !isLoading && !isVerified) {
+      const timeoutId = setTimeout(() => {
+        verifyCode()
+      }, 300) // Small delay to ensure UI is ready
+
+      return () => clearTimeout(timeoutId)
+    }
+  }, [otp, email, isLoading, isVerified])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       if (!isProduction || !hasResendKey) {
         const storedEmail = sessionStorage.getItem('verificationEmail')
-        logger.info('Auto-verifying user', { email: storedEmail })
       }
 
       const isDevOrDocker = !isProduction || isTruthy(env.DOCKER_BUILD)
 
-      // Auto-verify and redirect in development/docker environments
       if (isDevOrDocker || !hasResendKey) {
         setIsVerified(true)
 
-        // Clear verification requirement cookie (same as manual verification)
         document.cookie =
           'requiresEmailVerification=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
 

--- a/apps/sim/app/(auth)/verify/use-verification.ts
+++ b/apps/sim/app/(auth)/verify/use-verification.ts
@@ -213,6 +213,13 @@ export function useVerification({
       setErrorMessage('')
     }
     setOtp(value)
+
+    // Auto-submit when OTP is complete (6 digits)
+    if (value.length === 6 && email) {
+      setTimeout(() => {
+        verifyCode()
+      }, 100) // Small delay to ensure state is updated
+    }
   }
 
   useEffect(() => {

--- a/apps/sim/app/(auth)/verify/verify-content.tsx
+++ b/apps/sim/app/(auth)/verify/verify-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { Suspense, useEffect, useState } from 'react'
-import { Button } from '@/components/ui/button'
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp'
 import { cn } from '@/lib/utils'
 import { useVerification } from '@/app/(auth)/verify/use-verification'
@@ -122,13 +121,15 @@ function VerificationForm({
               </div>
             )}
 
-            <Button
-              onClick={verifyCode}
-              className='h-11 w-full bg-[var(--brand-primary-hex)] font-medium text-base text-white shadow-[var(--brand-primary-hex)]/20 shadow-lg transition-colors duration-200 hover:bg-[var(--brand-primary-hover-hex)]'
-              disabled={!isOtpComplete || isLoading}
-            >
-              {isLoading ? 'Verifying...' : 'Verify Email'}
-            </Button>
+            {/* Auto-verification status */}
+            {isLoading && (
+              <div className='flex items-center justify-center py-4'>
+                <div className='flex items-center space-x-2 text-neutral-400'>
+                  <div className='h-4 w-4 animate-spin rounded-full border-[var(--brand-primary-hex)] border-b-2' />
+                  <span className='text-sm'>Verifying...</span>
+                </div>
+              </div>
+            )}
 
             {hasResendKey && (
               <div className='mt-4 text-center'>

--- a/apps/sim/app/(auth)/verify/verify-content.tsx
+++ b/apps/sim/app/(auth)/verify/verify-content.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Suspense, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp'
 import { cn } from '@/lib/utils'
 import { useVerification } from '@/app/(auth)/verify/use-verification'
@@ -121,15 +122,13 @@ function VerificationForm({
               </div>
             )}
 
-            {/* Auto-verification status */}
-            {isLoading && (
-              <div className='flex items-center justify-center py-4'>
-                <div className='flex items-center space-x-2 text-neutral-400'>
-                  <div className='h-4 w-4 animate-spin rounded-full border-[var(--brand-primary-hex)] border-b-2' />
-                  <span className='text-sm'>Verifying...</span>
-                </div>
-              </div>
-            )}
+            <Button
+              onClick={verifyCode}
+              className='h-11 w-full bg-[var(--brand-primary-hex)] font-medium text-base text-white shadow-[var(--brand-primary-hex)]/20 shadow-lg transition-colors duration-200 hover:bg-[var(--brand-primary-hover-hex)]'
+              disabled={!isOtpComplete || isLoading}
+            >
+              {isLoading ? 'Verifying...' : 'Verify Email'}
+            </Button>
 
             {hasResendKey && (
               <div className='mt-4 text-center'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/credential-selector/credential-selector.tsx
@@ -279,7 +279,10 @@ export function CredentialSelector({
         </PopoverTrigger>
         <PopoverContent className='w-[250px] p-0' align='start'>
           <Command>
-            <CommandInput placeholder='Search credentials...' />
+            <CommandInput
+              placeholder='Search credentials...'
+              className='text-foreground placeholder:text-muted-foreground'
+            />
             <CommandList>
               <CommandEmpty>
                 {isLoading ? (

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/trigger-config/components/trigger-config-section.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/trigger-config/components/trigger-config-section.tsx
@@ -149,9 +149,15 @@ export function TriggerConfigSection({
                 </Button>
               </PopoverTrigger>
               <PopoverContent className='w-[400px] p-0' align='start'>
-                <Command>
-                  <CommandInput placeholder={`Search ${fieldDef.label.toLowerCase()}...`} />
-                  <CommandList className='max-h-[200px] overflow-y-auto'>
+                <Command className='outline-none focus:outline-none'>
+                  <CommandInput
+                    placeholder={`Search ${fieldDef.label.toLowerCase()}...`}
+                    className='text-foreground placeholder:text-muted-foreground'
+                  />
+                  <CommandList
+                    className='max-h-[200px] overflow-y-auto outline-none focus:outline-none'
+                    onWheel={(e) => e.stopPropagation()}
+                  >
                     <CommandEmpty>
                       {availableOptions.length === 0
                         ? 'No options available. Please select credentials first.'

--- a/apps/sim/components/ui/switch.tsx
+++ b/apps/sim/components/ui/switch.tsx
@@ -10,7 +10,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-foreground data-[state=unchecked]:bg-input',
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
Recently, we changed the way that we detect dark mode on our platform and we didn't have proper handling in certain areas to display the text correctly so it was unreadable. We've since changed this to have a specific dark mode style that will make it readable

Also, updated the login/signup
- Reset pass UI and error handling matches that of signup and login
- Auto-submit OTP when the digits are entered instead of making the user press enter
- Trim leading and trailing whitespace in name to avoid whitespace errors.

## Type of Change
- [x] Other: UI/UX improvements

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)