### PR TITLE
fix(whitelabel): move redirects (build-time) for whitelabeling to middlware (runtime)

### DIFF
--- a/apps/sim/middleware.ts
+++ b/apps/sim/middleware.ts
@@ -83,6 +83,21 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL('/login', request.url))
   }
 
+  // Handle whitelabel redirects for terms and privacy pages
+  if (url.pathname === '/terms') {
+    const termsUrl = process.env.NEXT_PUBLIC_TERMS_URL
+    if (termsUrl?.startsWith('http')) {
+      return NextResponse.redirect(termsUrl)
+    }
+  }
+
+  if (url.pathname === '/privacy') {
+    const privacyUrl = process.env.NEXT_PUBLIC_PRIVACY_URL
+    if (privacyUrl?.startsWith('http')) {
+      return NextResponse.redirect(privacyUrl)
+    }
+  }
+
   // Legacy redirect: /w -> /workspace (will be handled by workspace layout)
   if (url.pathname === '/w' || url.pathname.startsWith('/w/')) {
     // Extract workflow ID if present
@@ -195,6 +210,8 @@ export async function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     '/', // Root path for self-hosted redirect logic
+    '/terms', // Whitelabel terms redirect
+    '/privacy', // Whitelabel privacy redirect
     '/w', // Legacy /w redirect
     '/w/:path*', // Legacy /w/* redirects
     '/workspace/:path*', // New workspace routes

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -1,6 +1,6 @@
 import { withSentryConfig } from '@sentry/nextjs'
 import type { NextConfig } from 'next'
-import { env, getEnv, isTruthy } from './lib/env'
+import { env, isTruthy } from './lib/env'
 import { isDev, isHosted, isProd } from './lib/environment'
 import { getMainCSPPolicy, getWorkflowExecutionCSPPolicy } from './lib/security/csp'
 
@@ -186,24 +186,6 @@ const nextConfig: NextConfig = {
   },
   async redirects() {
     const redirects = []
-    // Add whitelabel redirects for terms and privacy pages if external URLs are configured
-    const termsUrl = getEnv('NEXT_PUBLIC_TERMS_URL')
-    if (termsUrl?.startsWith('http')) {
-      redirects.push({
-        source: '/terms',
-        destination: termsUrl,
-        permanent: false,
-      })
-    }
-
-    const privacyUrl = getEnv('NEXT_PUBLIC_PRIVACY_URL')
-    if (privacyUrl?.startsWith('http')) {
-      redirects.push({
-        source: '/privacy',
-        destination: privacyUrl,
-        permanent: false,
-      })
-    }
 
     // Only enable domain redirects for the hosted version
     if (isHosted) {


### PR DESCRIPTION
## Summary
move redirects (build-time) for whitelabeling to middlware (runtime), this allows for people to bring their own privacy policy & terms URLs because otherwise, the next config is bundled in at build time, which doesn't actually bundle their redirects in if its in next config

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)