### PR TITLE
fix(code-subblock): added validation to not parse non-variables as variables in the code subblock

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/wand-prompt-bar/wand-prompt-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/wand-prompt-bar/wand-prompt-bar.tsx
@@ -81,8 +81,8 @@ export function WandPromptBar({
     <div
       ref={promptBarRef}
       className={cn(
-        '-top-20 absolute right-0 left-0',
-        'rounded-xl border bg-background shadow-lg',
+        '-translate-y-3 absolute right-0 bottom-full left-0 gap-2',
+        'rounded-lg border bg-background shadow-lg',
         'z-9999999 transition-all duration-150',
         isExiting ? 'opacity-0' : 'opacity-100',
         className

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/wand-prompt-bar/wand-prompt-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/wand-prompt-bar/wand-prompt-bar.tsx
@@ -89,7 +89,7 @@ export function WandPromptBar({
       )}
     >
       <div className='flex items-center gap-2 p-2'>
-        <div className={cn('status-indicator ml-1', isStreaming && 'streaming')} />
+        <div className={cn('status-indicator ml-2 self-center', isStreaming && 'streaming')} />
 
         <div className='relative flex-1'>
           <Input
@@ -98,7 +98,7 @@ export function WandPromptBar({
             placeholder={placeholder}
             className={cn(
               'rounded-xl border-0 text-foreground text-sm placeholder:text-muted-foreground/50 focus-visible:ring-0 focus-visible:ring-offset-0',
-              isStreaming && 'text-primary',
+              isStreaming && 'text-foreground/70',
               (isLoading || isStreaming) && 'loading-placeholder'
             )}
             onKeyDown={(e) => {
@@ -111,11 +111,6 @@ export function WandPromptBar({
             disabled={isLoading || isStreaming}
             autoFocus={!isStreaming}
           />
-          {isStreaming && (
-            <div className='pointer-events-none absolute inset-0 h-full w-full overflow-hidden'>
-              <div className='shimmer-effect' />
-            </div>
-          )}
         </div>
 
         <Button
@@ -141,14 +136,6 @@ export function WandPromptBar({
       </div>
 
       <style jsx global>{`
-        @keyframes shimmer {
-          0% {
-            transform: translateX(-100%);
-          }
-          100% {
-            transform: translateX(100%);
-          }
-        }
 
         @keyframes smoke-pulse {
           0%,
@@ -164,8 +151,8 @@ export function WandPromptBar({
 
         .status-indicator {
           position: relative;
-          width: 16px;
-          height: 16px;
+          width: 12px;
+          height: 12px;
           border-radius: 50%;
           overflow: hidden;
           background-color: hsl(var(--muted-foreground) / 0.5);
@@ -183,36 +170,20 @@ export function WandPromptBar({
           border-radius: 50%;
           background: radial-gradient(
             circle,
-            hsl(var(--primary) / 0.7) 0%,
-            hsl(var(--primary) / 0.2) 60%,
+            hsl(var(--primary) / 0.9) 0%,
+            hsl(var(--primary) / 0.4) 60%,
             transparent 80%
           );
           animation: smoke-pulse 1.8s ease-in-out infinite;
+          opacity: 0.9;
         }
 
-        .shimmer-effect {
-          position: absolute;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
-          background: linear-gradient(
-            90deg,
-            rgba(255, 255, 255, 0) 0%,
-            rgba(255, 255, 255, 0.4) 50%,
-            rgba(255, 255, 255, 0) 100%
-          );
-          animation: shimmer 2s infinite;
+        .dark .status-indicator.streaming::before {
+          background: #6b7280;
+          opacity: 0.9;
+          animation: smoke-pulse 1.8s ease-in-out infinite;
         }
 
-        .dark .shimmer-effect {
-          background: linear-gradient(
-            90deg,
-            rgba(50, 50, 50, 0) 0%,
-            rgba(80, 80, 80, 0.4) 50%,
-            rgba(50, 50, 50, 0) 100%
-          );
-        }
       `}</style>
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
@@ -404,8 +404,7 @@ IMPORTANT FORMATTING RULES:
       <div
         className={cn(
           'group relative min-h-[100px] rounded-md border border-input bg-background font-mono text-sm transition-colors',
-          isConnecting && 'ring-2 ring-blue-500 ring-offset-2',
-          !isValidJson && 'border-destructive bg-destructive/10'
+          isConnecting && 'ring-2 ring-blue-500 ring-offset-2'
         )}
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}
@@ -418,7 +417,7 @@ IMPORTANT FORMATTING RULES:
               onClick={isPromptVisible ? hidePromptInline : showPromptInline}
               disabled={isAiLoading || isAiStreaming}
               aria-label='Generate code with AI'
-              className='h-8 w-8 rounded-full border border-transparent bg-muted/80 text-muted-foreground shadow-sm transition-all duration-200 hover:border-primary/20 hover:bg-muted hover:text-primary hover:shadow'
+              className='h-8 w-8 rounded-full border border-transparent bg-muted/80 text-muted-foreground shadow-sm transition-all duration-200 hover:border-primary/20 hover:bg-muted hover:text-foreground hover:shadow'
             >
               <Wand2 className='h-4 w-4' />
             </Button>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/code.tsx
@@ -407,7 +407,6 @@ IMPORTANT FORMATTING RULES:
           isConnecting && 'ring-2 ring-blue-500 ring-offset-2',
           !isValidJson && 'border-destructive bg-destructive/10'
         )}
-        title={!isValidJson ? 'Invalid JSON' : undefined}
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}
       >

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/long-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/long-input.tsx
@@ -426,7 +426,7 @@ export function LongInput({
               }
               disabled={wandHook.isLoading || wandHook.isStreaming || disabled}
               aria-label='Generate content with AI'
-              className='h-8 w-8 rounded-full border border-transparent bg-muted/80 text-muted-foreground shadow-sm transition-all duration-200 hover:border-primary/20 hover:bg-muted hover:text-primary hover:shadow'
+              className='h-8 w-8 rounded-full border border-transparent bg-muted/80 text-muted-foreground shadow-sm transition-all duration-200 hover:border-primary/20 hover:bg-muted hover:text-foreground hover:shadow'
             >
               <Wand2 className='h-4 w-4' />
             </Button>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/short-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/short-input.tsx
@@ -436,7 +436,7 @@ export function ShortInput({
               }
               disabled={wandHook.isLoading || wandHook.isStreaming || disabled}
               aria-label='Generate content with AI'
-              className='h-8 w-8 rounded-full border border-transparent bg-muted/80 text-muted-foreground shadow-sm transition-all duration-200 hover:border-primary/20 hover:bg-muted hover:text-primary hover:shadow'
+              className='h-8 w-8 rounded-full border border-transparent bg-muted/80 text-muted-foreground shadow-sm transition-all duration-200 hover:border-primary/20 hover:bg-muted hover:text-foreground hover:shadow'
             >
               <Wand2 className='h-4 w-4' />
             </Button>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/tool-input/components/code-editor/code-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/tool-input/components/code-editor/code-editor.tsx
@@ -6,6 +6,7 @@ import 'prismjs/components/prism-json'
 import 'prismjs/themes/prism.css'
 import { Wand2 } from 'lucide-react'
 import Editor from 'react-simple-code-editor'
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
 interface CodeEditorProps {
@@ -213,19 +214,16 @@ export function CodeEditor({
       )}
     >
       {showWandButton && onWandClick && (
-        <button
+        <Button
+          variant='ghost'
+          size='icon'
           onClick={onWandClick}
           disabled={wandButtonDisabled}
-          className={cn(
-            'absolute top-2 right-2 z-10 flex h-8 w-8 items-center justify-center rounded-full border border-transparent bg-muted/80 p-0 text-foreground shadow-sm transition-all duration-200',
-            'hover:border-primary/20 hover:bg-muted hover:text-foreground hover:shadow',
-            'opacity-0 transition-opacity group-hover:opacity-100',
-            wandButtonDisabled && 'cursor-not-allowed opacity-50'
-          )}
           aria-label='Generate with AI'
+          className='absolute top-2 right-3 z-10 h-8 w-8 rounded-full border border-transparent bg-muted/80 text-muted-foreground opacity-0 shadow-sm transition-all duration-200 hover:border-primary/20 hover:bg-muted hover:text-foreground hover:shadow group-hover:opacity-100'
         >
           <Wand2 className='h-4 w-4' />
-        </button>
+        </Button>
       )}
 
       {!showWandButton && code.split('\n').length > 5 && (

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/tool-input/components/custom-tool-modal/custom-tool-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/tool-input/components/custom-tool-modal/custom-tool-modal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Code, FileJson, Trash2, X } from 'lucide-react'
+import { AlertTriangle, Code, FileJson, Trash2, X } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import {
   AlertDialog,
@@ -934,11 +934,18 @@ try {
                     <Label htmlFor='json-schema' className='font-medium'>
                       JSON Schema
                     </Label>
+                    {schemaError &&
+                      !schemaGeneration.isStreaming && ( // Hide schema error while streaming
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <AlertTriangle className='h-4 w-4 cursor-pointer text-destructive' />
+                          </TooltipTrigger>
+                          <TooltipContent side='top'>
+                            <p>Invalid JSON</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
                   </div>
-                  {schemaError &&
-                    !schemaGeneration.isStreaming && ( // Hide schema error while streaming
-                      <div className='ml-4 break-words text-red-600 text-sm'>{schemaError}</div>
-                    )}
                 </div>
                 <CodeEditor
                   value={jsonSchema}
@@ -975,7 +982,6 @@ try {
 }`}
                   minHeight='360px'
                   className={cn(
-                    schemaError && !schemaGeneration.isStreaming ? 'border-red-500' : '',
                     (schemaGeneration.isLoading || schemaGeneration.isStreaming) &&
                       'cursor-not-allowed opacity-50'
                   )}

--- a/apps/sim/executor/resolver/resolver.test.ts
+++ b/apps/sim/executor/resolver/resolver.test.ts
@@ -1610,7 +1610,7 @@ describe('InputResolver', () => {
       }
 
       expect(() => connectionResolver.resolveInputs(testBlock, contextWithConnections)).toThrow(
-        /Available connected blocks:.*Agent Block.*agent-1.*start/
+        /Available connected blocks:.*Agent Block.*Start/
       )
     })
 

--- a/apps/sim/executor/resolver/resolver.ts
+++ b/apps/sim/executor/resolver/resolver.ts
@@ -1211,6 +1211,24 @@ export class InputResolver {
   }
 
   /**
+   * Gets user-friendly block names for error messages.
+   * Only returns the actual block names that users see in the UI.
+   */
+  private getAccessibleBlockNamesForError(currentBlockId: string): string[] {
+    const accessibleBlockIds = this.getAccessibleBlocks(currentBlockId)
+    const names: string[] = []
+
+    for (const blockId of accessibleBlockIds) {
+      const block = this.blockById.get(blockId)
+      if (block?.metadata?.name) {
+        names.push(block.metadata.name)
+      }
+    }
+
+    return [...new Set(names)] // Remove duplicates
+  }
+
+  /**
    * Checks if a block reference could potentially be valid without throwing errors.
    * Used to filter out non-block patterns like <test> from block reference resolution.
    *
@@ -1262,7 +1280,7 @@ export class InputResolver {
     }
 
     if (!sourceBlock) {
-      const accessibleNames = this.getAccessibleBlockNames(currentBlockId)
+      const accessibleNames = this.getAccessibleBlockNamesForError(currentBlockId)
       return {
         isValid: false,
         errorMessage: `Block "${blockRef}" was not found. Available connected blocks: ${accessibleNames.join(', ')}`,
@@ -1272,7 +1290,7 @@ export class InputResolver {
     // Check if block is accessible (connected)
     const accessibleBlocks = this.getAccessibleBlocks(currentBlockId)
     if (!accessibleBlocks.has(sourceBlock.id)) {
-      const accessibleNames = this.getAccessibleBlockNames(currentBlockId)
+      const accessibleNames = this.getAccessibleBlockNamesForError(currentBlockId)
       return {
         isValid: false,
         errorMessage: `Block "${blockRef}" is not connected to this block. Available connected blocks: ${accessibleNames.join(', ')}`,


### PR DESCRIPTION
## Summary
added validation to not parse non-variables as variables in the code subblock, fixed styling of wand prompt bar and icons not visible in dark mode

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Before:
<img width="1573" height="1025" alt="Screenshot 2025-09-03 at 1 03 04 PM" src="https://github.com/user-attachments/assets/abf3550c-1cfe-43ac-b3f6-b46545974461" />

After:
<img width="1526" height="982" alt="Screenshot 2025-09-03 at 1 03 16 PM" src="https://github.com/user-attachments/assets/ebbe0994-576e-408a-98ec-0bbee323e4ba" />