### PR TITLE
fix(sidebar): re-ordering based on last edit is confusing

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/control-bar.tsx
@@ -1101,21 +1101,11 @@ export function ControlBar({ hasValidationErrors = false }: ControlBarProps) {
    * Get workflows in the exact order they appear in the sidebar
    */
   const getSidebarOrderedWorkflows = () => {
-    // Get and sort regular workflows by last modified (newest first)
+    // Get and sort regular workflows by name alphabetically for stable ordering
     const regularWorkflows = Object.values(workflows)
       .filter((workflow) => workflow.workspaceId === workspaceId)
       .filter((workflow) => workflow.marketplaceData?.status !== 'temp')
-      .sort((a, b) => {
-        const dateA =
-          a.lastModified instanceof Date
-            ? a.lastModified.getTime()
-            : new Date(a.lastModified).getTime()
-        const dateB =
-          b.lastModified instanceof Date
-            ? b.lastModified.getTime()
-            : new Date(b.lastModified).getTime()
-        return dateB - dateA
-      })
+      .sort((a, b) => a.name.localeCompare(b.name))
 
     // Group workflows by folder
     const workflowsByFolder = regularWorkflows.reduce(

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/user-input.tsx
@@ -393,11 +393,9 @@ const UserInput = forwardRef<UserInputRef, UserInputProps>(
         const workspaceFiltered = items.filter(
           (w: any) => w.workspaceId === workspaceId || !w.workspaceId
         )
-        // Sort by last modified/updated (newest first), matching sidebar behavior
+        // Sort by name alphabetically for stable ordering, matching sidebar behavior
         const sorted = [...workspaceFiltered].sort((a: any, b: any) => {
-          const ta = new Date(a.lastModified || a.updatedAt || a.createdAt || 0).getTime()
-          const tb = new Date(b.lastModified || b.updatedAt || b.createdAt || 0).getTime()
-          return tb - ta
+          return (a.name || 'Untitled Workflow').localeCompare(b.name || 'Untitled Workflow')
         })
         setWorkflows(
           sorted.map((w: any) => ({

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -691,21 +691,13 @@ export function Sidebar() {
         }
       })
 
-      // Sort by last modified date (newest first)
-      const sortByLastModified = (a: WorkflowMetadata, b: WorkflowMetadata) => {
-        const dateA =
-          a.lastModified instanceof Date
-            ? a.lastModified.getTime()
-            : new Date(a.lastModified).getTime()
-        const dateB =
-          b.lastModified instanceof Date
-            ? b.lastModified.getTime()
-            : new Date(b.lastModified).getTime()
-        return dateB - dateA
+      // Sort by name alphabetically for stable ordering
+      const sortByName = (a: WorkflowMetadata, b: WorkflowMetadata) => {
+        return a.name.localeCompare(b.name)
       }
 
-      regular.sort(sortByLastModified)
-      temp.sort(sortByLastModified)
+      regular.sort(sortByName)
+      temp.sort(sortByName)
     }
 
     return { regularWorkflows: regular, tempWorkflows: temp }


### PR DESCRIPTION
## Summary
Keeps reordering the sidebar. Keep it stable with alphabetical sort. 

## Type of Change
- [x] Bug fix

## Testing
Manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
