### PR TITLE
fix(cost): restored cost reporting for agent block in console entry

### DIFF
--- a/apps/sim/providers/index.ts
+++ b/apps/sim/providers/index.ts
@@ -86,7 +86,7 @@ export async function executeProviderRequest(
     const { prompt: promptTokens = 0, completion: completionTokens = 0 } = response.tokens
     const useCachedInput = !!request.context && request.context.length > 0
 
-    if (shouldBillModelUsage(response.model, request.apiKey)) {
+    if (shouldBillModelUsage(response.model)) {
       response.cost = calculateCost(response.model, promptTokens, completionTokens, useCachedInput)
     } else {
       response.cost = {

--- a/apps/sim/providers/utils.ts
+++ b/apps/sim/providers/utils.ts
@@ -548,20 +548,11 @@ export function getHostedModels(): string[] {
  * Determine if model usage should be billed to the user
  *
  * @param model The model name
- * @param userProvidedApiKey Whether the user provided their own API key
  * @returns true if the usage should be billed to the user
  */
-export function shouldBillModelUsage(model: string, userProvidedApiKey?: string): boolean {
+export function shouldBillModelUsage(model: string): boolean {
   const hostedModels = getHostedModels()
-  if (!hostedModels.includes(model)) {
-    return false
-  }
-
-  if (userProvidedApiKey && userProvidedApiKey.trim() !== '') {
-    return false
-  }
-
-  return true
+  return hostedModels.includes(model)
 }
 
 /**


### PR DESCRIPTION
## Summary
restored cost reporting for agent block in console entry, for hosted models we inject api key and in the check where we see if there is a `user-provided` api key, we incorrectly parsed our own keys as that

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)