### PR TITLE
fix(router): change router block `content` to `prompt`

### DIFF
--- a/apps/docs/content/docs/blocks/router.mdx
+++ b/apps/docs/content/docs/blocks/router.mdx
@@ -117,7 +117,7 @@ Your API key for the selected LLM provider. This is securely stored and used for
 
 After a router makes a decision, you can access its outputs:
 
-- **`<router.content>`**: Summary of the routing decision made
+- **`<router.prompt>`**: Summary of the routing prompt used
 - **`<router.selected_path>`**: Details of the chosen destination block
 - **`<router.tokens>`**: Token usage statistics from the LLM
 - **`<router.model>`**: The model used for decision-making
@@ -182,7 +182,7 @@ Confidence Threshold: 0.7 // Minimum confidence for routing
   <Tab>
     <ul className="list-disc space-y-2 pl-6">
       <li>
-        <strong>router.content</strong>: Summary of routing decision
+        <strong>router.prompt</strong>: Summary of routing prompt used
       </li>
       <li>
         <strong>router.selected_path</strong>: Details of chosen destination

--- a/apps/sim/blocks/blocks/router.ts
+++ b/apps/sim/blocks/blocks/router.ts
@@ -18,7 +18,7 @@ const getCurrentOllamaModels = () => {
 
 interface RouterResponse extends ToolResponse {
   output: {
-    content: string
+    prompt: string
     model: string
     tokens?: {
       prompt?: number
@@ -198,7 +198,6 @@ export const RouterBlock: BlockConfig<RouterResponse> = {
       hidden: true,
       min: 0,
       max: 2,
-      value: () => '0.1',
     },
     {
       id: 'systemPrompt',
@@ -246,7 +245,7 @@ export const RouterBlock: BlockConfig<RouterResponse> = {
     },
   },
   outputs: {
-    content: { type: 'string', description: 'Routing response content' },
+    prompt: { type: 'string', description: 'Routing prompt used' },
     model: { type: 'string', description: 'Model used' },
     tokens: { type: 'json', description: 'Token usage' },
     cost: { type: 'json', description: 'Cost information' },

--- a/apps/sim/executor/handlers/router/router-handler.test.ts
+++ b/apps/sim/executor/handlers/router/router-handler.test.ts
@@ -119,7 +119,7 @@ describe('RouterBlockHandler', () => {
     const inputs = {
       prompt: 'Choose the best option.',
       model: 'gpt-4o',
-      temperature: 0.5,
+      temperature: 0.1,
     }
 
     const expectedTargetBlocks = [
@@ -168,11 +168,11 @@ describe('RouterBlockHandler', () => {
       model: 'gpt-4o',
       systemPrompt: 'Generated System Prompt',
       context: JSON.stringify([{ role: 'user', content: 'Choose the best option.' }]),
-      temperature: 0.5,
+      temperature: 0.1,
     })
 
     expect(result).toEqual({
-      content: {},
+      prompt: 'Choose the best option.',
       model: 'mock-model',
       tokens: { prompt: 100, completion: 5, total: 105 },
       cost: {
@@ -233,7 +233,7 @@ describe('RouterBlockHandler', () => {
     const requestBody = JSON.parse(fetchCallArgs[1].body)
     expect(requestBody).toMatchObject({
       model: 'gpt-4o',
-      temperature: 0,
+      temperature: 0.1,
     })
   })
 

--- a/apps/sim/executor/handlers/router/router-handler.test.ts
+++ b/apps/sim/executor/handlers/router/router-handler.test.ts
@@ -172,7 +172,7 @@ describe('RouterBlockHandler', () => {
     })
 
     expect(result).toEqual({
-      content: 'Choose the best option.',
+      content: {},
       model: 'mock-model',
       tokens: { prompt: 100, completion: 5, total: 105 },
       cost: {

--- a/apps/sim/executor/handlers/router/router-handler.ts
+++ b/apps/sim/executor/handlers/router/router-handler.ts
@@ -51,7 +51,7 @@ export class RouterBlockHandler implements BlockHandler {
         model: routerConfig.model,
         systemPrompt: systemPrompt,
         context: JSON.stringify(messages),
-        temperature: routerConfig.temperature,
+        temperature: 0.1,
         apiKey: routerConfig.apiKey,
         workflowId: context.workflowId,
       }
@@ -102,7 +102,7 @@ export class RouterBlockHandler implements BlockHandler {
       )
 
       return {
-        content: {},
+        prompt: inputs.prompt,
         model: result.model,
         tokens: {
           prompt: tokens.prompt || 0,

--- a/apps/sim/executor/handlers/router/router-handler.ts
+++ b/apps/sim/executor/handlers/router/router-handler.ts
@@ -102,7 +102,7 @@ export class RouterBlockHandler implements BlockHandler {
       )
 
       return {
-        content: inputs.prompt,
+        content: {},
         model: result.model,
         tokens: {
           prompt: tokens.prompt || 0,


### PR DESCRIPTION
## Summary
modify the content in the router response to be `prompt` instead, since it is not referenced in any workflows and did not accurately reflect what was in that field anyways

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)