### PR TITLE
0.3.49: readme updates, router block and variables improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ bun run dev:sockets
 Copilot is a Sim-managed service. To use Copilot on a self-hosted instance:
 
 - Go to https://sim.ai → Settings → Copilot and generate a Copilot API key
-- Set `COPILOT_API_KEY` in your self-hosted environment to that value
+- Set `COPILOT_API_KEY` environment variable in your self-hosted apps/sim/.env file to that value
 
 ## Tech Stack
 

--- a/apps/docs/content/docs/blocks/router.mdx
+++ b/apps/docs/content/docs/blocks/router.mdx
@@ -117,7 +117,7 @@ Your API key for the selected LLM provider. This is securely stored and used for
 
 After a router makes a decision, you can access its outputs:
 
-- **`<router.content>`**: Summary of the routing decision made
+- **`<router.prompt>`**: Summary of the routing prompt used
 - **`<router.selected_path>`**: Details of the chosen destination block
 - **`<router.tokens>`**: Token usage statistics from the LLM
 - **`<router.model>`**: The model used for decision-making
@@ -182,7 +182,7 @@ Confidence Threshold: 0.7 // Minimum confidence for routing
   <Tab>
     <ul className="list-disc space-y-2 pl-6">
       <li>
-        <strong>router.content</strong>: Summary of routing decision
+        <strong>router.prompt</strong>: Summary of routing prompt used
       </li>
       <li>
         <strong>router.selected_path</strong>: Details of chosen destination

--- a/apps/sim/blocks/blocks/router.ts
+++ b/apps/sim/blocks/blocks/router.ts
@@ -18,7 +18,7 @@ const getCurrentOllamaModels = () => {
 
 interface RouterResponse extends ToolResponse {
   output: {
-    content: string
+    prompt: string
     model: string
     tokens?: {
       prompt?: number
@@ -198,7 +198,6 @@ export const RouterBlock: BlockConfig<RouterResponse> = {
       hidden: true,
       min: 0,
       max: 2,
-      value: () => '0.1',
     },
     {
       id: 'systemPrompt',
@@ -246,7 +245,7 @@ export const RouterBlock: BlockConfig<RouterResponse> = {
     },
   },
   outputs: {
-    content: { type: 'string', description: 'Routing response content' },
+    prompt: { type: 'string', description: 'Routing prompt used' },
     model: { type: 'string', description: 'Model used' },
     tokens: { type: 'json', description: 'Token usage' },
     cost: { type: 'json', description: 'Cost information' },

--- a/apps/sim/db/migrations/0009_far_sharon_ventura.sql
+++ b/apps/sim/db/migrations/0009_far_sharon_ventura.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "workflow_schedule" DROP COLUMN "timezone";

--- a/apps/sim/executor/handlers/router/router-handler.test.ts
+++ b/apps/sim/executor/handlers/router/router-handler.test.ts
@@ -119,7 +119,7 @@ describe('RouterBlockHandler', () => {
     const inputs = {
       prompt: 'Choose the best option.',
       model: 'gpt-4o',
-      temperature: 0.5,
+      temperature: 0.1,
     }
 
     const expectedTargetBlocks = [
@@ -168,11 +168,11 @@ describe('RouterBlockHandler', () => {
       model: 'gpt-4o',
       systemPrompt: 'Generated System Prompt',
       context: JSON.stringify([{ role: 'user', content: 'Choose the best option.' }]),
-      temperature: 0.5,
+      temperature: 0.1,
     })
 
     expect(result).toEqual({
-      content: 'Choose the best option.',
+      prompt: 'Choose the best option.',
       model: 'mock-model',
       tokens: { prompt: 100, completion: 5, total: 105 },
       cost: {
@@ -233,7 +233,7 @@ describe('RouterBlockHandler', () => {
     const requestBody = JSON.parse(fetchCallArgs[1].body)
     expect(requestBody).toMatchObject({
       model: 'gpt-4o',
-      temperature: 0,
+      temperature: 0.1,
     })
   })
 

--- a/apps/sim/executor/handlers/router/router-handler.ts
+++ b/apps/sim/executor/handlers/router/router-handler.ts
@@ -51,7 +51,7 @@ export class RouterBlockHandler implements BlockHandler {
         model: routerConfig.model,
         systemPrompt: systemPrompt,
         context: JSON.stringify(messages),
-        temperature: routerConfig.temperature,
+        temperature: 0.1,
         apiKey: routerConfig.apiKey,
         workflowId: context.workflowId,
       }
@@ -102,7 +102,7 @@ export class RouterBlockHandler implements BlockHandler {
       )
 
       return {
-        content: inputs.prompt,
+        prompt: inputs.prompt,
         model: result.model,
         tokens: {
           prompt: tokens.prompt || 0,

--- a/apps/sim/executor/resolver/resolver.ts
+++ b/apps/sim/executor/resolver/resolver.ts
@@ -836,31 +836,11 @@ export class InputResolver {
   private isValidVariableReference(match: string): boolean {
     const innerContent = match.slice(1, -1)
 
-    if (!innerContent.includes('.')) {
-      return false
-    }
-
-    const dotIndex = innerContent.indexOf('.')
-    const beforeDot = innerContent.substring(0, dotIndex)
-    const afterDot = innerContent.substring(dotIndex + 1)
-
-    if (afterDot.includes(' ')) {
-      return false
-    }
-
-    if (
-      beforeDot.match(/^\s*[<>=!]+\s*$/) ||
-      beforeDot.match(/\s[<>=!]+\s/) ||
-      beforeDot.match(/^[<>=!]+\s/)
-    ) {
-      return false
-    }
-
     if (innerContent.startsWith(' ')) {
       return false
     }
 
-    if (innerContent.match(/^[a-zA-Z][a-zA-Z0-9]*$/) && !innerContent.includes('.')) {
+    if (innerContent.match(/^\s*[<>=!]+\s*$/) || innerContent.match(/\s[<>=!]+\s/)) {
       return false
     }
 
@@ -868,12 +848,26 @@ export class InputResolver {
       return false
     }
 
-    if (beforeDot.match(/[+*/=<>!]/)) {
-      return false
-    }
+    if (innerContent.includes('.')) {
+      const dotIndex = innerContent.indexOf('.')
+      const beforeDot = innerContent.substring(0, dotIndex)
+      const afterDot = innerContent.substring(dotIndex + 1)
 
-    if (afterDot.match(/[+\-*/=<>!]/)) {
-      return false
+      if (afterDot.includes(' ')) {
+        return false
+      }
+
+      if (beforeDot.match(/[+*/=<>!]/) || afterDot.match(/[+\-*/=<>!]/)) {
+        return false
+      }
+    } else {
+      if (
+        innerContent.match(/[+\-*/=<>!]/) ||
+        innerContent.match(/^\d/) ||
+        innerContent.match(/\s\d/)
+      ) {
+        return false
+      }
     }
 
     return true


### PR DESCRIPTION
- **improvement(docs): readme.md to mention .env setup for copilot setup**
- **fix(schedule-self-host): remove incorrect migration (#1260)**
- **fix(router): change router block `content` to `prompt` (#1261)**
- **fix(variables): add back ability to reference root block like <start> (#1262)**