### PR TITLE
fix: enable word-break for long unbroken strings

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/user-input.tsx
@@ -2117,7 +2117,7 @@ const UserInput = forwardRef<UserInputRef, UserInputProps>(
           <div className='relative'>
             {/* Highlight overlay */}
             <div className='pointer-events-none absolute inset-0 z-[1] px-[2px] py-1'>
-              <pre className='whitespace-pre-wrap font-sans text-foreground text-sm leading-[1.25rem]'>
+              <pre className='whitespace-pre-wrap break-all font-sans text-foreground text-sm leading-[1.25rem]'>
                 {(() => {
                   const elements: React.ReactNode[] = []
                   const remaining = message


### PR DESCRIPTION
## Summary
Fixes text wrapping issue in **Copilot Chat field** where long unbroken strings is not breaking to next line correctly.  
Now long words wrap correctly, improving readability and layout stability.  

Fixes #1210

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
- Typed long unbroken text (e.g., `anilanilanilanil...`) → wrapped correctly  
- Normal sentences with spaces remain unaffected  
- Verified on Chrome, Firefox, and Safari  

## Checklist
- [x] Code follows project style guidelines  
- [x] Self-reviewed my changes  
- [x] Tests added/updated and passing  
- [x] No new warnings introduced  
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)  

## Screenshots/Videos
**Before:**  
<img width="1261" height="572" alt="image" src="https://github.com/user-attachments/assets/dba6c83a-22ec-448e-86fa-bc38109871b8" />

**After:**  
<img width="1287" height="621" alt="image" src="https://github.com/user-attachments/assets/d5922e4b-cd49-49ea-92f3-fde56934cae7" />

