### PR TITLE
fix(sidebar): prevent missed clicks during rapid workflow switching (keep row drag)

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/folder-tree/components/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/folder-tree/components/workflow-item.tsx
@@ -128,7 +128,7 @@ export function WorkflowItem({
   }
 
   const handleClick = (e: React.MouseEvent) => {
-    if (dragStartedRef.current || isEditing) {
+    if (isDragging || isEditing) {
       e.preventDefault()
       return
     }


### PR DESCRIPTION
## Summary
Prevent missed clicks when rapidly switching workflows by gating navigation on active drag state rather than a transient drag-start flag. Keeps full-row drag-and-drop intact.

Fixes: N/A (surgical UX bugfix)

## Type of Change
- [x] Bug fix

## Testing
- Rapidly clicked multiple workflows (not intending to drag): each click navigates immediately.
- Intentionally dragged rows between folders and to root: DnD still works; payload (`workflow-ids`) unchanged.
- Shift+click multi-select, rename input, and hover edit button behaviors unchanged.
- Marketplace/editing states still disable drag as before.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] No new warnings introduced

## Screenshots/Videos
N/A