### PR TITLE
fix(modal): center 'no result found' message with proper padding

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/search-modal/search-modal.tsx
@@ -910,7 +910,7 @@ export function SearchModal({
                 filteredBlocks.length === 0 &&
                 filteredTools.length === 0 &&
                 filteredTemplates.length === 0 && (
-                  <div className='ml-6 py-12 text-center'>
+                  <div className='px-6 py-12 text-center'>
                     <p className='text-muted-foreground'>No results found for "{searchQuery}"</p>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
This PR fixes the alignment issue in the modal when a search returns no results.  
The `"No result found"` message is now perfectly centered with equal horizontal padding for better UI consistency.

## Type of Change
- [x] Bug fix

## Testing
- Manually tested by opening the modal and entering a non-existent search term.  
- Verified that the `"No result found"` message appears centered with consistent horizontal spacing across different screen sizes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
**Before:**  
<img width="551" height="372" alt="image" src="https://github.com/user-attachments/assets/36686d2d-1cbb-48de-ab70-44ffa11ba265" />

**After:**  
<img width="482" height="357" alt="image" src="https://github.com/user-attachments/assets/aa93049a-dbe2-4688-b67c-0097ccad66b2" />

