### PR TITLE
improvement(subblock-defaults): custom defaults for subblocks if needed

### DIFF
--- a/apps/sim/blocks/blocks/agent.ts
+++ b/apps/sim/blocks/blocks/agent.ts
@@ -175,6 +175,7 @@ Create a system prompt appropriately detailed for the request, using clear langu
       layout: 'half',
       min: 0,
       max: 1,
+      defaultValue: 0.5,
       condition: () => ({
         field: 'model',
         value: (() => {
@@ -192,6 +193,7 @@ Create a system prompt appropriately detailed for the request, using clear langu
       layout: 'half',
       min: 0,
       max: 2,
+      defaultValue: 1,
       condition: () => ({
         field: 'model',
         value: (() => {
@@ -289,6 +291,7 @@ Create a system prompt appropriately detailed for the request, using clear langu
       title: 'Tools',
       type: 'tool-input',
       layout: 'full',
+      defaultValue: [],
     },
     {
       id: 'responseFormat',

--- a/apps/sim/blocks/types.ts
+++ b/apps/sim/blocks/types.ts
@@ -103,6 +103,7 @@ export interface SubBlockConfig {
   mode?: 'basic' | 'advanced' | 'both' // Default is 'both' if not specified
   canonicalParamId?: string
   required?: boolean
+  defaultValue?: string | number | boolean | Record<string, unknown> | Array<unknown>
   options?:
     | { label: string; id: string; icon?: React.ComponentType<{ className?: string }> }[]
     | (() => { label: string; id: string; icon?: React.ComponentType<{ className?: string }> }[])

--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -634,7 +634,7 @@ export function useCollaborativeWorkflow() {
           subBlocks[subBlock.id] = {
             id: subBlock.id,
             type: subBlock.type,
-            value: null,
+            value: subBlock.defaultValue ?? null,
           }
         })
       }


### PR DESCRIPTION
## Summary
Right now, we always set subblock values to null which isn't always appropriate. We need to be able to custom defaults for subblocks. Added this as a field into subblock configs. 

## Type of Change
- [x] Bug fix

## Testing
Manually. Used for temperature and tools in the Agent block right now.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
