### PR TITLE
fix: prevent block card name text from overlapping icons

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -672,7 +672,7 @@ export function WorkflowBlock({ id, data }: NodeProps<WorkflowBlockProps>) {
             >
               <config.icon className='h-5 w-5 text-white' />
             </div>
-            <div className='min-w-0'>
+            <div className='w-full overflow-hidden'>
               {isEditing ? (
                 <input
                   ref={nameInputRef}
@@ -681,7 +681,7 @@ export function WorkflowBlock({ id, data }: NodeProps<WorkflowBlockProps>) {
                   onChange={(e) => handleNodeNameChange(e.target.value)}
                   onBlur={handleNameSubmit}
                   onKeyDown={handleNameKeyDown}
-                  className='border-none bg-transparent p-0 font-medium text-md outline-none'
+                  className='w-full border-none bg-transparent p-0 font-medium text-md outline-none'
                   maxLength={18}
                 />
               ) : (


### PR DESCRIPTION
## Summary
This PR fixes a UI issue in **block cards** where long block names overlapped with other icons.
The text now hide properly and maintains spacing without colliding with icons.

## Type of Change
- [x] Bug fix

## Testing
- Tested with long block names to confirm text no longer overlaps icons.  
- Verified alignment works for both short and long names.  

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
**Before:** Long block names overlapped with icons, breaking layout.  
<img width="711" height="516" alt="image" src="https://github.com/user-attachments/assets/08a270c5-211d-4132-abba-7a14e8d99ba8" />

**After:** Text hide properly; icons remain aligned.
<img width="650" height="486" alt="image" src="https://github.com/user-attachments/assets/2b2c78a9-066c-46b2-aac4-105f0dc00518" />