### PR TITLE
fix(selectors): use shared hook to ensure the assets in selectors are only fetched once

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/hooks/use-fetch-attempt-guard.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/hooks/use-fetch-attempt-guard.ts
@@ -1,0 +1,21 @@
+'use client'
+
+import { useRef } from 'react'
+
+export function useFetchAttemptGuard() {
+  const lastAttemptKeyRef = useRef<string>('')
+
+  const shouldAttempt = (key: string): boolean => {
+    return lastAttemptKeyRef.current !== key
+  }
+
+  const markAttempt = (key: string) => {
+    lastAttemptKeyRef.current = key
+  }
+
+  const reset = () => {
+    lastAttemptKeyRef.current = ''
+  }
+
+  return { shouldAttempt, markAttempt, reset }
+}


### PR DESCRIPTION
## Summary
use shared hook to ensure the assets in selectors are only fetched once, in slack + google drive thye were being fetched quite a few times, indefinitely even if the credential failed

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
