### PR TITLE
fix(tools): allow transformResponse to handle non-JSON API responses

### DIFF
--- a/apps/sim/tools/index.ts
+++ b/apps/sim/tools/index.ts
@@ -516,13 +516,19 @@ async function handleInternalRequest(
       // Many APIs (e.g., Microsoft Graph) return 202 with empty body
       responseData = { status }
     } else {
-      try {
-        responseData = await response.json()
-      } catch (jsonError) {
-        logger.error(`[${requestId}] JSON parse error for ${toolId}:`, {
-          error: jsonError instanceof Error ? jsonError.message : String(jsonError),
-        })
-        throw new Error(`Failed to parse response from ${toolId}: ${jsonError}`)
+      // If the tool has a transformResponse function, don't parse JSON here
+      // as the transformResponse function will handle the response parsing
+      if (tool.transformResponse) {
+        responseData = null // Will be handled by transformResponse
+      } else {
+        try {
+          responseData = await response.json()
+        } catch (jsonError) {
+          logger.error(`[${requestId}] JSON parse error for ${toolId}:`, {
+            error: jsonError instanceof Error ? jsonError.message : String(jsonError),
+          })
+          throw new Error(`Failed to parse response from ${toolId}: ${jsonError}`)
+        }
       }
     }
 

--- a/apps/sim/tools/utils.test.ts
+++ b/apps/sim/tools/utils.test.ts
@@ -527,6 +527,43 @@ describe('executeRequest', () => {
       error: 'Server Error', // Should use statusText in the error message
     })
   })
+
+  it('should handle transformResponse with non-JSON response', async () => {
+    const toolWithTransform = {
+      ...mockTool,
+      transformResponse: async (response: Response) => {
+        const xmlText = await response.text()
+        return {
+          success: true,
+          output: {
+            parsedData: 'mocked xml parsing result',
+            originalXml: xmlText,
+          },
+        }
+      },
+    }
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '<xml><test>Mock XML response</test></xml>',
+    })
+
+    const result = await executeRequest('test-tool', toolWithTransform, {
+      url: 'https://api.example.com',
+      method: 'GET',
+      headers: {},
+    })
+
+    expect(result).toEqual({
+      success: true,
+      output: {
+        parsedData: 'mocked xml parsing result',
+        originalXml: '<xml><test>Mock XML response</test></xml>',
+      },
+    })
+  })
 })
 
 describe('createParamSchema', () => {


### PR DESCRIPTION
## Summary
Fix tool execution JSON parsing error for non-JSON API responses.

Fixes issue where tools with transformResponse functions (like ArXiv tools) failed with JSON parsing errors when APIs return XML instead of JSON.

The root cause was the tool execution system was trying to parse ALL responses as JSON before calling transformResponse, causing failures for non-JSON APIs (ArXiv).

To fix it, I skipped automatic JSON parsing when transformResponse is present, allowing transformResponse to handle response parsing.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Added test case verifying transformResponse works with non-JSON responses. The test mocks a tool with transformResponse that uses response.text() to handle XML data, confirming the fix allows proper response handling while maintaining existing JSON API functionality (tested with basic JSON tools like Mistral Parser for example).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<img width="1150" height="699" alt="image" src="https://github.com/user-attachments/assets/41c814b1-00d8-4e32-a3fa-7d3c0ecaf552" />