### PR TITLE
fix(tools): added transform response to handle non-json responses for internal tools

### DIFF
--- a/apps/sim/tools/index.ts
+++ b/apps/sim/tools/index.ts
@@ -516,13 +516,17 @@ async function handleInternalRequest(
       // Many APIs (e.g., Microsoft Graph) return 202 with empty body
       responseData = { status }
     } else {
-      try {
-        responseData = await response.json()
-      } catch (jsonError) {
-        logger.error(`[${requestId}] JSON parse error for ${toolId}:`, {
-          error: jsonError instanceof Error ? jsonError.message : String(jsonError),
-        })
-        throw new Error(`Failed to parse response from ${toolId}: ${jsonError}`)
+      if (tool.transformResponse) {
+        responseData = null
+      } else {
+        try {
+          responseData = await response.json()
+        } catch (jsonError) {
+          logger.error(`[${requestId}] JSON parse error for ${toolId}:`, {
+            error: jsonError instanceof Error ? jsonError.message : String(jsonError),
+          })
+          throw new Error(`Failed to parse response from ${toolId}: ${jsonError}`)
+        }
       }
     }
 

--- a/apps/sim/tools/utils.test.ts
+++ b/apps/sim/tools/utils.test.ts
@@ -527,6 +527,43 @@ describe('executeRequest', () => {
       error: 'Server Error', // Should use statusText in the error message
     })
   })
+
+  it('should handle transformResponse with non-JSON response', async () => {
+    const toolWithTransform = {
+      ...mockTool,
+      transformResponse: async (response: Response) => {
+        const xmlText = await response.text()
+        return {
+          success: true,
+          output: {
+            parsedData: 'mocked xml parsing result',
+            originalXml: xmlText,
+          },
+        }
+      },
+    }
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '<xml><test>Mock XML response</test></xml>',
+    })
+
+    const result = await executeRequest('test-tool', toolWithTransform, {
+      url: 'https://api.example.com',
+      method: 'GET',
+      headers: {},
+    })
+
+    expect(result).toEqual({
+      success: true,
+      output: {
+        parsedData: 'mocked xml parsing result',
+        originalXml: '<xml><test>Mock XML response</test></xml>',
+      },
+    })
+  })
 })
 
 describe('createParamSchema', () => {


### PR DESCRIPTION
## Summary
added transform response to handle non-json responses for internal tools

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)