### PR TITLE
fix(ci): modify docs embeddings ci to only run on english documentation

### DIFF
--- a/apps/sim/scripts/process-docs-embeddings.ts
+++ b/apps/sim/scripts/process-docs-embeddings.ts
@@ -37,7 +37,7 @@ async function processDocsEmbeddings(options: ProcessingOptions = {}) {
     // Configuration
     const config = {
       clearExisting: options.clearExisting ?? false,
-      docsPath: options.docsPath ?? path.join(process.cwd(), '../../apps/docs/content/docs'),
+      docsPath: options.docsPath ?? path.join(process.cwd(), '../../apps/docs/content/docs/en'),
       baseUrl: options.baseUrl ?? (isDev ? 'http://localhost:3001' : 'https://docs.sim.ai'),
       chunkSize: options.chunkSize ?? 300, // Max 300 tokens per chunk
       minChunkSize: options.minChunkSize ?? 100,


### PR DESCRIPTION
## Summary
modify docs embeddings ci to only run on english documentation. docs embeddings were running in every language and updates were taking a while

## Type of Change
- [x] Other: performance

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)