### PR TITLE
improvement(var-resolution): resolve variables with block name check and consolidate code

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/combobox.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/combobox.tsx
@@ -10,6 +10,7 @@ import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
 import { createLogger } from '@/lib/logs/console/logger'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
+import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import type { SubBlockConfig } from '@/blocks/types'
 import { useTagSelection } from '@/hooks/use-tag-selection'
 
@@ -60,6 +61,7 @@ export function ComboBox({
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
 
   const emitTagSelection = useTagSelection(blockId, subBlockId)
+  const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
 
   const inputRef = useRef<HTMLInputElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
@@ -432,7 +434,10 @@ export function ComboBox({
           style={{ right: '42px' }}
         >
           <div className='w-full truncate text-foreground' style={{ scrollbarWidth: 'none' }}>
-            {formatDisplayText(displayValue)}
+            {formatDisplayText(displayValue, {
+              accessiblePrefixes,
+              highlightAll: !accessiblePrefixes,
+            })}
           </div>
         </div>
         {/* Chevron button */}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/input-mapping/input-mapping.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/input-mapping/input-mapping.tsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label'
 import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
+import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 
 interface InputFormatField {
@@ -151,6 +152,8 @@ export function InputMapping({
     const updated = { ...valueObj, [field]: value }
     setMapping(updated)
   }
+
+  const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
 
   if (!selectedWorkflowId) {
     return (
@@ -318,7 +321,10 @@ function InputMappingField({
             className='w-full whitespace-pre'
             style={{ scrollbarWidth: 'none', minWidth: 'fit-content' }}
           >
-            {formatDisplayText(value)}
+            {formatDisplayText(value, {
+              accessiblePrefixes,
+              highlightAll: !accessiblePrefixes,
+            })}
           </div>
         </div>
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/input-mapping/input-mapping.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/input-mapping/input-mapping.tsx
@@ -216,6 +216,7 @@ export function InputMapping({
             blockId={blockId}
             subBlockId={subBlockId}
             disabled={isPreview || disabled}
+            accessiblePrefixes={accessiblePrefixes}
           />
         )
       })}
@@ -232,6 +233,7 @@ function InputMappingField({
   blockId,
   subBlockId,
   disabled,
+  accessiblePrefixes,
 }: {
   fieldName: string
   fieldType?: string
@@ -240,6 +242,7 @@ function InputMappingField({
   blockId: string
   subBlockId: string
   disabled: boolean
+  accessiblePrefixes: Set<string> | undefined
 }) {
   const [showTags, setShowTags] = useState(false)
   const [cursorPosition, setCursorPosition] = useState(0)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/knowledge-tag-filters/knowledge-tag-filters.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/knowledge-tag-filters/knowledge-tag-filters.tsx
@@ -7,6 +7,7 @@ import { formatDisplayText } from '@/components/ui/formatted-text'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
+import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import type { SubBlockConfig } from '@/blocks/types'
 import { useKnowledgeBaseTagDefinitions } from '@/hooks/use-knowledge-base-tag-definitions'
 import { useTagSelection } from '@/hooks/use-tag-selection'
@@ -54,6 +55,9 @@ export function KnowledgeTagFilters({
 
   // Use KB tag definitions hook to get available tags
   const { tagDefinitions, isLoading } = useKnowledgeBaseTagDefinitions(knowledgeBaseId)
+
+  // Get accessible prefixes for variable highlighting
+  const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
 
   // State for managing tag dropdown
   const [activeTagDropdown, setActiveTagDropdown] = useState<{
@@ -314,7 +318,12 @@ export function KnowledgeTagFilters({
             className='w-full border-0 text-transparent caret-foreground placeholder:text-muted-foreground/50 focus-visible:ring-0 focus-visible:ring-offset-0'
           />
           <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'>
-            <div className='whitespace-pre'>{formatDisplayText(cellValue)}</div>
+            <div className='whitespace-pre'>
+              {formatDisplayText(cellValue, {
+                accessiblePrefixes,
+                highlightAll: !accessiblePrefixes,
+              })}
+            </div>
           </div>
         </div>
       </td>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/long-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/long-input.tsx
@@ -11,6 +11,7 @@ import { createLogger } from '@/lib/logs/console/logger'
 import { cn } from '@/lib/utils'
 import { WandPromptBar } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/wand-prompt-bar/wand-prompt-bar'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
+import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import { useWand } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-wand'
 import type { SubBlockConfig } from '@/blocks/types'
 import { useTagSelection } from '@/hooks/use-tag-selection'
@@ -92,6 +93,7 @@ export function LongInput({
   const overlayRef = useRef<HTMLDivElement>(null)
   const [activeSourceBlockId, setActiveSourceBlockId] = useState<string | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
 
   // Use preview value when in preview mode, otherwise use store value or prop value
   const baseValue = isPreview ? previewValue : propValue !== undefined ? propValue : storeValue
@@ -405,7 +407,10 @@ export function LongInput({
             height: `${height}px`,
           }}
         >
-          {formatDisplayText(value?.toString() ?? '')}
+          {formatDisplayText(value?.toString() ?? '', {
+            accessiblePrefixes,
+            highlightAll: !accessiblePrefixes,
+          })}
         </div>
 
         {/* Wand Button */}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/short-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/short-input.tsx
@@ -11,6 +11,7 @@ import { createLogger } from '@/lib/logs/console/logger'
 import { cn } from '@/lib/utils'
 import { WandPromptBar } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/wand-prompt-bar/wand-prompt-bar'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
+import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import { useWand } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-wand'
 import type { SubBlockConfig } from '@/blocks/types'
 import { useTagSelection } from '@/hooks/use-tag-selection'
@@ -345,6 +346,8 @@ export function ShortInput({
     }
   }
 
+  const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
+
   return (
     <>
       <WandPromptBar
@@ -417,7 +420,10 @@ export function ShortInput({
           >
             {password && !isFocused
               ? '•'.repeat(value?.toString().length ?? 0)
-              : formatDisplayText(value?.toString() ?? '')}
+              : formatDisplayText(value?.toString() ?? '', {
+                  accessiblePrefixes,
+                  highlightAll: !accessiblePrefixes,
+                })}
           </div>
         </div>
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/starter/input-format.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/starter/input-format.tsx
@@ -22,6 +22,7 @@ import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
 import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
+import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 
 interface Field {
   id: string
@@ -80,6 +81,7 @@ export function FieldFormat({
   const [cursorPosition, setCursorPosition] = useState(0)
   const [activeFieldId, setActiveFieldId] = useState<string | null>(null)
   const [activeSourceBlockId, setActiveSourceBlockId] = useState<string | null>(null)
+  const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
 
   // Use preview value when in preview mode, otherwise use store value
   const value = isPreview ? previewValue : storeValue
@@ -471,7 +473,10 @@ export function FieldFormat({
                                 style={{ scrollbarWidth: 'none', minWidth: 'fit-content' }}
                               >
                                 {formatDisplayText(
-                                  (localValues[field.id] ?? field.value ?? '')?.toString()
+                                  (localValues[field.id] ?? field.value ?? '')?.toString(),
+                                  accessiblePrefixes
+                                    ? { accessiblePrefixes }
+                                    : { highlightAll: true }
                                 )}
                               </div>
                             </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/tool-input/components/mcp-server-modal/mcp-server-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/tool-input/components/mcp-server-modal/mcp-server-modal.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/select'
 import { createLogger } from '@/lib/logs/console/logger'
 import type { McpTransport } from '@/lib/mcp/types'
+import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import { useMcpServerTest } from '@/hooks/use-mcp-server-test'
 import { useMcpServersStore } from '@/stores/mcp-servers/store'
 
@@ -33,6 +34,7 @@ interface McpServerModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onServerCreated?: () => void
+  blockId: string
 }
 
 interface McpServerFormData {
@@ -42,7 +44,12 @@ interface McpServerFormData {
   headers?: Record<string, string>
 }
 
-export function McpServerModal({ open, onOpenChange, onServerCreated }: McpServerModalProps) {
+export function McpServerModal({
+  open,
+  onOpenChange,
+  onServerCreated,
+  blockId,
+}: McpServerModalProps) {
   const params = useParams()
   const workspaceId = params.workspaceId as string
   const [formData, setFormData] = useState<McpServerFormData>({
@@ -262,6 +269,8 @@ export function McpServerModal({ open, onOpenChange, onServerCreated }: McpServe
     workspaceId,
   ])
 
+  const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className='sm:max-w-[600px]'>
@@ -337,7 +346,10 @@ export function McpServerModal({ open, onOpenChange, onServerCreated }: McpServe
                   className='whitespace-nowrap'
                   style={{ transform: `translateX(-${urlScrollLeft}px)` }}
                 >
-                  {formatDisplayText(formData.url || '')}
+                  {formatDisplayText(formData.url || '', {
+                    accessiblePrefixes,
+                    highlightAll: !accessiblePrefixes,
+                  })}
                 </div>
               </div>
             </div>
@@ -389,7 +401,10 @@ export function McpServerModal({ open, onOpenChange, onServerCreated }: McpServe
                           transform: `translateX(-${headerScrollLeft[`key-${index}`] || 0}px)`,
                         }}
                       >
-                        {formatDisplayText(key || '')}
+                        {formatDisplayText(key || '', {
+                          accessiblePrefixes,
+                          highlightAll: !accessiblePrefixes,
+                        })}
                       </div>
                     </div>
                   </div>
@@ -417,7 +432,10 @@ export function McpServerModal({ open, onOpenChange, onServerCreated }: McpServe
                           transform: `translateX(-${headerScrollLeft[`value-${index}`] || 0}px)`,
                         }}
                       >
-                        {formatDisplayText(value || '')}
+                        {formatDisplayText(value || '', {
+                          accessiblePrefixes,
+                          highlightAll: !accessiblePrefixes,
+                        })}
                       </div>
                     </div>
                   </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
@@ -1977,6 +1977,7 @@ export function ToolInput({
           // Refresh MCP tools when a new server is created
           refreshTools(true)
         }}
+        blockId={blockId}
       />
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes.ts
@@ -1,0 +1,64 @@
+import { useMemo } from 'react'
+import { shallow } from 'zustand/shallow'
+import { BlockPathCalculator } from '@/lib/block-path-calculator'
+import { SYSTEM_REFERENCE_PREFIXES } from '@/lib/workflows/references'
+import { normalizeBlockName } from '@/stores/workflows/utils'
+import { useWorkflowStore } from '@/stores/workflows/workflow/store'
+import type { Loop, Parallel } from '@/stores/workflows/workflow/types'
+
+export function useAccessibleReferencePrefixes(blockId?: string | null): Set<string> | undefined {
+  const { blocks, edges, loops, parallels } = useWorkflowStore(
+    (state) => ({
+      blocks: state.blocks,
+      edges: state.edges,
+      loops: state.loops || {},
+      parallels: state.parallels || {},
+    }),
+    shallow
+  )
+
+  return useMemo(() => {
+    if (!blockId) {
+      return undefined
+    }
+
+    const graphEdges = edges.map((edge) => ({ source: edge.source, target: edge.target }))
+    const ancestorIds = BlockPathCalculator.findAllPathNodes(graphEdges, blockId)
+    const accessibleIds = new Set<string>(ancestorIds)
+    accessibleIds.add(blockId)
+
+    const starterBlock = Object.values(blocks).find((block) => block.type === 'starter')
+    if (starterBlock) {
+      accessibleIds.add(starterBlock.id)
+    }
+
+    const loopValues = Object.values(loops as Record<string, Loop>)
+    loopValues.forEach((loop) => {
+      if (!loop?.nodes) return
+      if (loop.nodes.includes(blockId)) {
+        loop.nodes.forEach((nodeId) => accessibleIds.add(nodeId))
+      }
+    })
+
+    const parallelValues = Object.values(parallels as Record<string, Parallel>)
+    parallelValues.forEach((parallel) => {
+      if (!parallel?.nodes) return
+      if (parallel.nodes.includes(blockId)) {
+        parallel.nodes.forEach((nodeId) => accessibleIds.add(nodeId))
+      }
+    })
+
+    const prefixes = new Set<string>()
+    accessibleIds.forEach((id) => {
+      prefixes.add(normalizeBlockName(id))
+      const block = blocks[id]
+      if (block?.name) {
+        prefixes.add(normalizeBlockName(block.name))
+      }
+    })
+
+    SYSTEM_REFERENCE_PREFIXES.forEach((prefix) => prefixes.add(prefix))
+
+    return prefixes
+  }, [blockId, blocks, edges, loops, parallels])
+}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/knowledge-tags/knowledge-tags.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/knowledge-tags/knowledge-tags.tsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui'
+import { formatDisplayText } from '@/components/ui/formatted-text'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { MAX_TAG_SLOTS, TAG_SLOTS, type TagSlot } from '@/lib/knowledge/consts'
 import { createLogger } from '@/lib/logs/console/logger'
@@ -582,24 +583,31 @@ export function KnowledgeTags({ knowledgeBaseId, documentId }: KnowledgeTagsProp
 
                             <div className='space-y-1.5'>
                               <Label className='font-medium text-xs'>Value</Label>
-                              <Input
-                                value={editForm.value}
-                                onChange={(e) =>
-                                  setEditForm({ ...editForm, value: e.target.value })
-                                }
-                                placeholder='Enter tag value'
-                                className='h-8 w-full rounded-md text-sm'
-                                onKeyDown={(e) => {
-                                  if (e.key === 'Enter' && canSave) {
-                                    e.preventDefault()
-                                    saveTag()
+                              <div className='relative'>
+                                <Input
+                                  value={editForm.value}
+                                  onChange={(e) =>
+                                    setEditForm({ ...editForm, value: e.target.value })
                                   }
-                                  if (e.key === 'Escape') {
-                                    e.preventDefault()
-                                    cancelEditing()
-                                  }
-                                }}
-                              />
+                                  placeholder='Enter tag value'
+                                  className='h-8 w-full rounded-md text-sm text-transparent caret-foreground'
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter' && canSave) {
+                                      e.preventDefault()
+                                      saveTag()
+                                    }
+                                    if (e.key === 'Escape') {
+                                      e.preventDefault()
+                                      cancelEditing()
+                                    }
+                                  }}
+                                />
+                                <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'>
+                                  <div className='w-full truncate'>
+                                    {formatDisplayText(editForm.value, { highlightAll: true })}
+                                  </div>
+                                </div>
+                              </div>
                             </div>
 
                             <div className='pt-1'>
@@ -734,22 +742,29 @@ export function KnowledgeTags({ knowledgeBaseId, documentId }: KnowledgeTagsProp
 
                   <div className='space-y-1.5'>
                     <Label className='font-medium text-xs'>Value</Label>
-                    <Input
-                      value={editForm.value}
-                      onChange={(e) => setEditForm({ ...editForm, value: e.target.value })}
-                      placeholder='Enter tag value'
-                      className='h-8 w-full rounded-md text-sm'
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && canSave) {
-                          e.preventDefault()
-                          saveTag()
-                        }
-                        if (e.key === 'Escape') {
-                          e.preventDefault()
-                          cancelEditing()
-                        }
-                      }}
-                    />
+                    <div className='relative'>
+                      <Input
+                        value={editForm.value}
+                        onChange={(e) => setEditForm({ ...editForm, value: e.target.value })}
+                        placeholder='Enter tag value'
+                        className='h-8 w-full rounded-md text-sm text-transparent caret-foreground'
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && canSave) {
+                            e.preventDefault()
+                            saveTag()
+                          }
+                          if (e.key === 'Escape') {
+                            e.preventDefault()
+                            cancelEditing()
+                          }
+                        }}
+                      />
+                      <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'>
+                        <div className='w-full truncate'>
+                          {formatDisplayText(editForm.value, { highlightAll: true })}
+                        </div>
+                      </div>
+                    </div>
                   </div>
 
                   {/* Warning when at max slots */}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/knowledge-tags/knowledge-tags.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/knowledge-tags/knowledge-tags.tsx
@@ -16,7 +16,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui'
-import { formatDisplayText } from '@/components/ui/formatted-text'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { MAX_TAG_SLOTS, TAG_SLOTS, type TagSlot } from '@/lib/knowledge/consts'
 import { createLogger } from '@/lib/logs/console/logger'
@@ -583,31 +582,24 @@ export function KnowledgeTags({ knowledgeBaseId, documentId }: KnowledgeTagsProp
 
                             <div className='space-y-1.5'>
                               <Label className='font-medium text-xs'>Value</Label>
-                              <div className='relative'>
-                                <Input
-                                  value={editForm.value}
-                                  onChange={(e) =>
-                                    setEditForm({ ...editForm, value: e.target.value })
+                              <Input
+                                value={editForm.value}
+                                onChange={(e) =>
+                                  setEditForm({ ...editForm, value: e.target.value })
+                                }
+                                placeholder='Enter tag value'
+                                className='h-8 w-full rounded-md text-sm'
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter' && canSave) {
+                                    e.preventDefault()
+                                    saveTag()
                                   }
-                                  placeholder='Enter tag value'
-                                  className='h-8 w-full rounded-md text-sm text-transparent caret-foreground'
-                                  onKeyDown={(e) => {
-                                    if (e.key === 'Enter' && canSave) {
-                                      e.preventDefault()
-                                      saveTag()
-                                    }
-                                    if (e.key === 'Escape') {
-                                      e.preventDefault()
-                                      cancelEditing()
-                                    }
-                                  }}
-                                />
-                                <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'>
-                                  <div className='w-full truncate'>
-                                    {formatDisplayText(editForm.value, { highlightAll: true })}
-                                  </div>
-                                </div>
-                              </div>
+                                  if (e.key === 'Escape') {
+                                    e.preventDefault()
+                                    cancelEditing()
+                                  }
+                                }}
+                              />
                             </div>
 
                             <div className='pt-1'>
@@ -742,29 +734,22 @@ export function KnowledgeTags({ knowledgeBaseId, documentId }: KnowledgeTagsProp
 
                   <div className='space-y-1.5'>
                     <Label className='font-medium text-xs'>Value</Label>
-                    <div className='relative'>
-                      <Input
-                        value={editForm.value}
-                        onChange={(e) => setEditForm({ ...editForm, value: e.target.value })}
-                        placeholder='Enter tag value'
-                        className='h-8 w-full rounded-md text-sm text-transparent caret-foreground'
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' && canSave) {
-                            e.preventDefault()
-                            saveTag()
-                          }
-                          if (e.key === 'Escape') {
-                            e.preventDefault()
-                            cancelEditing()
-                          }
-                        }}
-                      />
-                      <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'>
-                        <div className='w-full truncate'>
-                          {formatDisplayText(editForm.value, { highlightAll: true })}
-                        </div>
-                      </div>
-                    </div>
+                    <Input
+                      value={editForm.value}
+                      onChange={(e) => setEditForm({ ...editForm, value: e.target.value })}
+                      placeholder='Enter tag value'
+                      className='h-8 w-full rounded-md text-sm'
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && canSave) {
+                          e.preventDefault()
+                          saveTag()
+                        }
+                        if (e.key === 'Escape') {
+                          e.preventDefault()
+                          cancelEditing()
+                        }
+                      }}
+                    />
                   </div>
 
                   {/* Warning when at max slots */}

--- a/apps/sim/components/ui/formatted-text.tsx
+++ b/apps/sim/components/ui/formatted-text.tsx
@@ -1,28 +1,50 @@
 'use client'
 
 import type { ReactNode } from 'react'
+import { normalizeBlockName } from '@/stores/workflows/utils'
+
+export interface HighlightContext {
+  accessiblePrefixes?: Set<string>
+  highlightAll?: boolean
+}
+
+const SYSTEM_PREFIXES = new Set(['start', 'loop', 'parallel', 'variable'])
 
 /**
  * Formats text by highlighting block references (<...>) and environment variables ({{...}})
  * Used in code editor, long inputs, and short inputs for consistent syntax highlighting
- *
- * @param text The text to format
  */
-export function formatDisplayText(text: string): ReactNode[] {
+export function formatDisplayText(text: string, context?: HighlightContext): ReactNode[] {
   if (!text) return []
+
+  const shouldHighlightPart = (part: string): boolean => {
+    if (!part.startsWith('<') || !part.endsWith('>')) {
+      return false
+    }
+
+    if (context?.highlightAll) {
+      return true
+    }
+
+    const inner = part.slice(1, -1)
+    const [prefix] = inner.split('.')
+    const normalizedPrefix = normalizeBlockName(prefix)
+
+    if (SYSTEM_PREFIXES.has(normalizedPrefix)) {
+      return true
+    }
+
+    if (context?.accessiblePrefixes?.has(normalizedPrefix)) {
+      return true
+    }
+
+    return false
+  }
 
   const parts = text.split(/(<[^>]+>|\{\{[^}]+\}\})/g)
 
   return parts.map((part, index) => {
-    if (part.startsWith('<') && part.endsWith('>')) {
-      return (
-        <span key={index} className='text-blue-500'>
-          {part}
-        </span>
-      )
-    }
-
-    if (part.match(/^\{\{[^}]+\}\}$/)) {
+    if (shouldHighlightPart(part) || part.match(/^\{\{[^}]+\}\}$/)) {
       return (
         <span key={index} className='text-blue-500'>
           {part}

--- a/apps/sim/lib/workflows/references.ts
+++ b/apps/sim/lib/workflows/references.ts
@@ -1,0 +1,73 @@
+import { normalizeBlockName } from '@/stores/workflows/utils'
+
+export const SYSTEM_REFERENCE_PREFIXES = new Set(['start', 'loop', 'parallel', 'variable'])
+
+const INVALID_REFERENCE_CHARS = /[+*/=<>!]/
+
+export function isLikelyReferenceSegment(segment: string): boolean {
+  if (!segment.startsWith('<') || !segment.endsWith('>')) {
+    return false
+  }
+
+  const inner = segment.slice(1, -1)
+
+  if (inner.startsWith(' ')) {
+    return false
+  }
+
+  if (inner.match(/^\s*[<>=!]+\s*$/) || inner.match(/\s[<>=!]+\s/)) {
+    return false
+  }
+
+  if (inner.match(/^[<>=!]+\s/)) {
+    return false
+  }
+
+  if (inner.includes('.')) {
+    const dotIndex = inner.indexOf('.')
+    const beforeDot = inner.substring(0, dotIndex)
+    const afterDot = inner.substring(dotIndex + 1)
+
+    if (afterDot.includes(' ')) {
+      return false
+    }
+
+    if (INVALID_REFERENCE_CHARS.test(beforeDot) || INVALID_REFERENCE_CHARS.test(afterDot)) {
+      return false
+    }
+  } else if (INVALID_REFERENCE_CHARS.test(inner) || inner.match(/^\d/) || inner.match(/\s\d/)) {
+    return false
+  }
+
+  return true
+}
+
+export function extractReferencePrefixes(value: string): Array<{ raw: string; prefix: string }> {
+  if (!value || typeof value !== 'string') {
+    return []
+  }
+
+  const matches = value.match(/<[^>]+>/g)
+  if (!matches) {
+    return []
+  }
+
+  const references: Array<{ raw: string; prefix: string }> = []
+
+  for (const match of matches) {
+    if (!isLikelyReferenceSegment(match)) {
+      continue
+    }
+
+    const inner = match.slice(1, -1)
+    const [rawPrefix] = inner.split('.')
+    if (!rawPrefix) {
+      continue
+    }
+
+    const normalized = normalizeBlockName(rawPrefix)
+    references.push({ raw: match, prefix: normalized })
+  }
+
+  return references
+}


### PR DESCRIPTION
## Summary
- Block references (e.g., <function1.result>) are now validated against accessible blocks before resolution - only references to connected/accessible blocks are highlighted in blue and resolved
- Inaccessible references remain as literal strings instead of throwing validation errors, following the principle that only highlighted references get resolved
- Removed validation errors from serializer and updated tests to match the new behavior where unconnected block references are left as-is rather than causing failures


## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Manually + Test suite

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)