### PR TITLE
improvement(trigger): increase maxDuration for background tasks to 10 min to match sync API executions

### DIFF
--- a/apps/sim/lib/env.ts
+++ b/apps/sim/lib/env.ts
@@ -103,6 +103,7 @@ export const env = createEnv({
     DOCKER_BUILD:                          z.boolean().optional(),                 // Flag indicating Docker build environment
 
     // Background Jobs & Scheduling
+    TRIGGER_PROJECT_ID:                    z.string().optional(),                  // Trigger.dev project ID
     TRIGGER_SECRET_KEY:                    z.string().min(1).optional(),           // Trigger.dev secret key for background jobs
     TRIGGER_DEV_ENABLED:                   z.boolean().optional(),                 // Toggle to enable/disable Trigger.dev for async jobs
     CRON_SECRET:                           z.string().optional(),                  // Secret for authenticating cron job requests

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   project: 'proj_kufttkwzywcydwtccqhx',
   runtime: 'node',
   logLevel: 'log',
-  maxDuration: 180,
+  maxDuration: 600,
   retries: {
     enabledInDev: false,
     default: {

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from '@trigger.dev/sdk'
+import { env } from './lib/env'
 
 export default defineConfig({
-  project: 'proj_kufttkwzywcydwtccqhx',
+  project: env.TRIGGER_PROJECT_ID ?? '',
   runtime: 'node',
   logLevel: 'log',
   maxDuration: 600,


### PR DESCRIPTION
## Summary
increase maxDuration for background tasks to 10 min to match sync API executions. previously, the async executions had a timeout of 180s but we increase that to 10m to match the synchronous executions timeout

## Type of Change
- [x] New feature  

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)