### PR TITLE
improvement(autolayout): use live block heights / widths for autolayout to prevent overlaps

### DIFF
--- a/apps/sim/app/api/workflows/[id]/autolayout/route.ts
+++ b/apps/sim/app/api/workflows/[id]/autolayout/route.ts
@@ -8,7 +8,10 @@ import { createLogger } from '@/lib/logs/console/logger'
 import { getUserEntityPermissions } from '@/lib/permissions/utils'
 import { generateRequestId } from '@/lib/utils'
 import { applyAutoLayout } from '@/lib/workflows/autolayout'
-import { loadWorkflowFromNormalizedTables } from '@/lib/workflows/db-helpers'
+import {
+  loadWorkflowFromNormalizedTables,
+  type NormalizedWorkflowData,
+} from '@/lib/workflows/db-helpers'
 
 export const dynamic = 'force-dynamic'
 
@@ -114,7 +117,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
     // Use provided blocks/edges if available (with live measurements from UI),
     // otherwise load from database
-    let currentWorkflowData
+    let currentWorkflowData: NormalizedWorkflowData | null
 
     if (layoutOptions.blocks && layoutOptions.edges) {
       logger.info(`[${requestId}] Using provided blocks with live measurements`)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils.ts
@@ -98,18 +98,12 @@ const getBlockDimensions = (
     }
   }
 
-  if (block.type === 'workflowBlock') {
-    const nodeWidth = block.data?.width || block.width
-    const nodeHeight = block.data?.height || block.height
-
-    if (nodeWidth && nodeHeight) {
-      return { width: nodeWidth, height: nodeHeight }
-    }
-  }
-
   return {
-    width: block.isWide ? 450 : block.data?.width || block.width || 350,
-    height: Math.max(block.height || block.data?.height || 150, 100),
+    width: block.layout?.measuredWidth || (block.isWide ? 450 : block.data?.width || 350),
+    height: Math.max(
+      block.layout?.measuredHeight || block.height || block.data?.height || 150,
+      100
+    ),
   }
 }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/auto-layout.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/auto-layout.ts
@@ -78,13 +78,19 @@ export async function applyAutoLayoutToWorkflow(
       },
     }
 
-    // Call the autolayout API route which has access to the server-side API key
+    // Call the autolayout API route, sending blocks with live measurements
     const response = await fetch(`/api/workflows/${workflowId}/autolayout`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(layoutOptions),
+      body: JSON.stringify({
+        ...layoutOptions,
+        blocks,
+        edges,
+        loops,
+        parallels,
+      }),
     })
 
     if (!response.ok) {

--- a/apps/sim/lib/workflows/autolayout/containers.ts
+++ b/apps/sim/lib/workflows/autolayout/containers.ts
@@ -3,7 +3,12 @@ import type { BlockState } from '@/stores/workflows/workflow/types'
 import { assignLayers, groupByLayer } from './layering'
 import { calculatePositions } from './positioning'
 import type { Edge, LayoutOptions } from './types'
-import { DEFAULT_CONTAINER_HEIGHT, DEFAULT_CONTAINER_WIDTH, getBlocksByParent } from './utils'
+import {
+  DEFAULT_CONTAINER_HEIGHT,
+  DEFAULT_CONTAINER_WIDTH,
+  getBlocksByParent,
+  prepareBlockMetrics,
+} from './utils'
 
 const logger = createLogger('AutoLayout:Containers')
 
@@ -45,6 +50,7 @@ export function layoutContainers(
     }
 
     const childNodes = assignLayers(childBlocks, childEdges)
+    prepareBlockMetrics(childNodes)
     const childLayers = groupByLayer(childNodes)
     calculatePositions(childLayers, containerOptions)
 
@@ -57,8 +63,8 @@ export function layoutContainers(
     for (const node of childNodes.values()) {
       minX = Math.min(minX, node.position.x)
       minY = Math.min(minY, node.position.y)
-      maxX = Math.max(maxX, node.position.x + node.dimensions.width)
-      maxY = Math.max(maxY, node.position.y + node.dimensions.height)
+      maxX = Math.max(maxX, node.position.x + node.metrics.width)
+      maxY = Math.max(maxY, node.position.y + node.metrics.height)
     }
 
     // Adjust all child positions to start at proper padding from container edges

--- a/apps/sim/lib/workflows/autolayout/incremental.ts
+++ b/apps/sim/lib/workflows/autolayout/incremental.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@/lib/logs/console/logger'
 import type { BlockState } from '@/stores/workflows/workflow/types'
 import type { AdjustmentOptions, Edge } from './types'
-import { boxesOverlap, createBoundingBox, getBlockDimensions } from './utils'
+import { boxesOverlap, createBoundingBox, getBlockMetrics } from './utils'
 
 const logger = createLogger('AutoLayout:Incremental')
 
@@ -70,8 +70,8 @@ export function adjustForNewBlock(
     })
   }
 
-  const newBlockDims = getBlockDimensions(newBlock)
-  const newBlockBox = createBoundingBox(newBlock.position, newBlockDims)
+  const newBlockMetrics = getBlockMetrics(newBlock)
+  const newBlockBox = createBoundingBox(newBlock.position, newBlockMetrics)
 
   const blocksToShift: Array<{ block: BlockState; shiftAmount: number }> = []
 
@@ -80,11 +80,11 @@ export function adjustForNewBlock(
     if (block.data?.parentId) continue
 
     if (block.position.x >= newBlock.position.x) {
-      const blockDims = getBlockDimensions(block)
-      const blockBox = createBoundingBox(block.position, blockDims)
+      const blockMetrics = getBlockMetrics(block)
+      const blockBox = createBoundingBox(block.position, blockMetrics)
 
       if (boxesOverlap(newBlockBox, blockBox, 50)) {
-        const requiredShift = newBlock.position.x + newBlockDims.width + 50 - block.position.x
+        const requiredShift = newBlock.position.x + newBlockMetrics.width + 50 - block.position.x
         if (requiredShift > 0) {
           blocksToShift.push({ block, shiftAmount: requiredShift })
         }
@@ -115,8 +115,8 @@ export function compactHorizontally(blocks: Record<string, BlockState>, edges: E
     const prevBlock = blockArray[i - 1]
     const currentBlock = blockArray[i]
 
-    const prevDims = getBlockDimensions(prevBlock)
-    const expectedX = prevBlock.position.x + prevDims.width + MIN_SPACING
+    const prevMetrics = getBlockMetrics(prevBlock)
+    const expectedX = prevBlock.position.x + prevMetrics.width + MIN_SPACING
 
     if (currentBlock.position.x > expectedX + 150) {
       const shift = currentBlock.position.x - expectedX

--- a/apps/sim/lib/workflows/autolayout/index.ts
+++ b/apps/sim/lib/workflows/autolayout/index.ts
@@ -17,34 +17,12 @@ export function applyAutoLayout(
   options: LayoutOptions = {}
 ): LayoutResult {
   try {
-    // Debug: Check if blocks have layout data before processing
-    const blocksWithLayout = Object.entries(blocks).filter(
-      ([_, block]) => block.layout?.measuredHeight || block.layout?.measuredWidth
-    )
-
     logger.info('Starting auto layout', {
       blockCount: Object.keys(blocks).length,
       edgeCount: edges.length,
       loopCount: Object.keys(loops).length,
       parallelCount: Object.keys(parallels).length,
-      blocksWithMeasurements: blocksWithLayout.length,
     })
-
-    if (blocksWithLayout.length > 0) {
-      console.log(
-        '[AutoLayout] Blocks with measurements:',
-        blocksWithLayout.map(([id, block]) => ({
-          id,
-          type: block.type,
-          layout: block.layout,
-          height: block.height,
-        }))
-      )
-    } else {
-      console.warn(
-        '[AutoLayout] No blocks have measured dimensions - ResizeObserver may not be working'
-      )
-    }
 
     const blocksCopy: Record<string, BlockState> = JSON.parse(JSON.stringify(blocks))
 

--- a/apps/sim/lib/workflows/autolayout/layering.ts
+++ b/apps/sim/lib/workflows/autolayout/layering.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@/lib/logs/console/logger'
 import type { BlockState } from '@/stores/workflows/workflow/types'
 import type { Edge, GraphNode } from './types'
-import { getBlockDimensions, isStarterBlock } from './utils'
+import { getBlockMetrics } from './utils'
 
 const logger = createLogger('AutoLayout:Layering')
 
@@ -15,7 +15,7 @@ export function assignLayers(
     nodes.set(id, {
       id,
       block,
-      dimensions: getBlockDimensions(block),
+      metrics: getBlockMetrics(block),
       incoming: new Set(),
       outgoing: new Set(),
       layer: 0,
@@ -33,9 +33,9 @@ export function assignLayers(
     }
   }
 
-  const starterNodes = Array.from(nodes.values()).filter(
-    (node) => node.incoming.size === 0 || isStarterBlock(node.block)
-  )
+  // Only treat blocks as starters if they have no incoming edges
+  // This prevents triggers that are mid-flow from being forced to layer 0
+  const starterNodes = Array.from(nodes.values()).filter((node) => node.incoming.size === 0)
 
   if (starterNodes.length === 0 && nodes.size > 0) {
     const firstNode = Array.from(nodes.values())[0]

--- a/apps/sim/lib/workflows/autolayout/positioning.ts
+++ b/apps/sim/lib/workflows/autolayout/positioning.ts
@@ -26,7 +26,7 @@ export function calculatePositions(
 
     // Calculate total height needed for this layer
     const totalHeight = nodesInLayer.reduce(
-      (sum, node, idx) => sum + node.dimensions.height + (idx > 0 ? verticalSpacing : 0),
+      (sum, node, idx) => sum + node.metrics.height + (idx > 0 ? verticalSpacing : 0),
       0
     )
 
@@ -55,7 +55,7 @@ export function calculatePositions(
         y: yOffset,
       }
 
-      yOffset += node.dimensions.height + verticalSpacing
+      yOffset += node.metrics.height + verticalSpacing
     }
   }
 
@@ -83,8 +83,8 @@ function resolveOverlaps(nodes: GraphNode[], verticalSpacing: number): void {
         const node1 = sortedNodes[i]
         const node2 = sortedNodes[j]
 
-        const box1 = createBoundingBox(node1.position, node1.dimensions)
-        const box2 = createBoundingBox(node2.position, node2.dimensions)
+        const box1 = createBoundingBox(node1.position, node1.metrics)
+        const box2 = createBoundingBox(node2.position, node2.metrics)
 
         // Check for overlap with margin
         if (boxesOverlap(box1, box2, 30)) {
@@ -92,11 +92,11 @@ function resolveOverlaps(nodes: GraphNode[], verticalSpacing: number): void {
 
           // If in same layer, shift vertically
           if (node1.layer === node2.layer) {
-            const totalHeight = node1.dimensions.height + node2.dimensions.height + verticalSpacing
+            const totalHeight = node1.metrics.height + node2.metrics.height + verticalSpacing
             const midpoint = (node1.position.y + node2.position.y) / 2
 
-            node1.position.y = midpoint - node1.dimensions.height / 2 - verticalSpacing / 2
-            node2.position.y = midpoint + node2.dimensions.height / 2 + verticalSpacing / 2
+            node1.position.y = midpoint - node1.metrics.height / 2 - verticalSpacing / 2
+            node2.position.y = midpoint + node2.metrics.height / 2 + verticalSpacing / 2
           } else {
             // Different layers - shift the later one down
             const requiredSpace = box1.y + box1.height + verticalSpacing

--- a/apps/sim/lib/workflows/autolayout/types.ts
+++ b/apps/sim/lib/workflows/autolayout/types.ts
@@ -35,9 +35,15 @@ export interface Parallel {
   parallelType?: 'count' | 'collection'
 }
 
-export interface BlockDimensions {
+export interface BlockMetrics {
   width: number
   height: number
+  minWidth: number
+  minHeight: number
+  paddingTop: number
+  paddingBottom: number
+  paddingLeft: number
+  paddingRight: number
 }
 
 export interface BoundingBox {
@@ -55,7 +61,7 @@ export interface LayerInfo {
 export interface GraphNode {
   id: string
   block: BlockState
-  dimensions: BlockDimensions
+  metrics: BlockMetrics
   incoming: Set<string>
   outgoing: Set<string>
   layer: number

--- a/apps/sim/lib/workflows/autolayout/utils.ts
+++ b/apps/sim/lib/workflows/autolayout/utils.ts
@@ -51,17 +51,6 @@ function getRegularBlockMetrics(block: BlockState): BlockMetrics {
   const width = Math.max(measuredW ?? minWidth, minWidth)
   const height = Math.max(measuredH ?? minHeight, minHeight)
 
-  if (block.layout?.measuredHeight || block.layout?.measuredWidth) {
-    console.log(`[AutoLayout] Block ${block.id} (${block.type}):`, {
-      measuredW: block.layout?.measuredWidth,
-      measuredH: block.layout?.measuredHeight,
-      fallbackH: block.height,
-      finalWidth: width,
-      finalHeight: height,
-      isWide: block.isWide,
-    })
-  }
-
   return {
     width,
     height,

--- a/apps/sim/stores/workflows/workflow/store.ts
+++ b/apps/sim/stores/workflows/workflow/store.ts
@@ -185,6 +185,7 @@ export const useWorkflowStore = create<WorkflowStoreWithHistory>()(
               advancedMode: blockProperties?.advancedMode ?? false,
               triggerMode: blockProperties?.triggerMode ?? false,
               height: blockProperties?.height ?? 0,
+              layout: {},
               data: nodeData,
             },
           },
@@ -232,6 +233,11 @@ export const useWorkflowStore = create<WorkflowStoreWithHistory>()(
                   ...block.data,
                   width: dimensions.width,
                   height: dimensions.height,
+                },
+                layout: {
+                  ...block.layout,
+                  measuredWidth: dimensions.width,
+                  measuredHeight: dimensions.height,
                 },
               },
             },
@@ -786,20 +792,33 @@ export const useWorkflowStore = create<WorkflowStoreWithHistory>()(
         // Note: Socket.IO handles real-time sync automatically
       },
 
-      updateBlockHeight: (id: string, height: number) => {
-        set((state) => ({
-          blocks: {
-            ...state.blocks,
-            [id]: {
-              ...state.blocks[id],
-              height,
+      updateBlockLayoutMetrics: (id: string, dimensions: { width: number; height: number }) => {
+        set((state) => {
+          const block = state.blocks[id]
+          if (!block) {
+            logger.warn(`Cannot update layout metrics: Block ${id} not found in workflow store`)
+            return state
+          }
+
+          return {
+            blocks: {
+              ...state.blocks,
+              [id]: {
+                ...block,
+                height: dimensions.height,
+                layout: {
+                  ...block.layout,
+                  measuredWidth: dimensions.width,
+                  measuredHeight: dimensions.height,
+                },
+              },
             },
-          },
-          edges: [...state.edges],
-          loops: { ...state.loops },
-        }))
+            edges: [...state.edges],
+            loops: { ...state.loops },
+          }
+        })
         get().updateLastSaved()
-        // No sync needed for height changes, just visual
+        // No sync needed for layout changes, just visual
       },
 
       updateLoopCount: (loopId: string, count: number) =>

--- a/apps/sim/stores/workflows/workflow/types.ts
+++ b/apps/sim/stores/workflows/workflow/types.ts
@@ -62,6 +62,11 @@ export interface BlockData {
   type?: string
 }
 
+export interface BlockLayoutState {
+  measuredWidth?: number
+  measuredHeight?: number
+}
+
 export interface BlockState {
   id: string
   type: string
@@ -76,6 +81,7 @@ export interface BlockState {
   advancedMode?: boolean
   triggerMode?: boolean
   data?: BlockData
+  layout?: BlockLayoutState
 }
 
 export interface SubBlockState {
@@ -197,7 +203,7 @@ export interface WorkflowActions {
   setBlockWide: (id: string, isWide: boolean) => void
   setBlockAdvancedMode: (id: string, advancedMode: boolean) => void
   setBlockTriggerMode: (id: string, triggerMode: boolean) => void
-  updateBlockHeight: (id: string, height: number) => void
+  updateBlockLayoutMetrics: (id: string, dimensions: { width: number; height: number }) => void
   triggerUpdate: () => void
   updateLoopCount: (loopId: string, count: number) => void
   updateLoopType: (loopId: string, loopType: 'for' | 'forEach') => void


### PR DESCRIPTION
## Summary
- Don't align start triggers 
- Use live block heights / widths in autolayout algo 

## Type of Change
- [x] Bug fix


## Testing
<img width="680" height="603" alt="Screenshot 2025-09-30 at 1 03 40 PM" src="https://github.com/user-attachments/assets/e1a5169f-a393-4c11-99e8-38bb2e84faf6" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)