### PR TITLE
fix(redirects): update middleware to allow access to /chat regardless of auth status

### DIFF
--- a/apps/sim/middleware.ts
+++ b/apps/sim/middleware.ts
@@ -147,6 +147,10 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next()
   }
 
+  if (url.pathname.startsWith('/chat/')) {
+    return NextResponse.next()
+  }
+
   if (url.pathname.startsWith('/workspace')) {
     if (!hasActiveSession) {
       return NextResponse.redirect(new URL('/login', request.url))


### PR DESCRIPTION
## Summary
- update middleware to allow access to /chat regardless of auth status
  - previously, authorized users were auto-redirected to the workspace & unauthorized users were redirected to the homepage

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)