### PR TITLE
fix(ci): update trigger.dev ci to only push to staging on merge to staging & for prod as well

### DIFF
--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -32,11 +32,11 @@ jobs:
         run: bun install
 
       - name: Deploy to Trigger.dev (Staging)
-        if: github.ref == 'refs/heads/staging'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
         working-directory: ./apps/sim
         run: npx --yes trigger.dev@4.0.4 deploy -e staging
 
       - name: Deploy to Trigger.dev (Production)
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: ./apps/sim
         run: npx --yes trigger.dev@4.0.4 deploy


### PR DESCRIPTION
## Summary
update trigger.dev ci to only push to staging on merge to staging & for prod as well

## Type of Change
- [x] Bug fix

## Testing
Added provision to make deployment to trigger only happen on merges to the branches, not when PRs were made against branches

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)