### PR TITLE
fix(kb): removed filename constraint from knowledgebase doc names

### DIFF
--- a/apps/sim/tools/knowledge/create_document.ts
+++ b/apps/sim/tools/knowledge/create_document.ts
@@ -82,9 +82,6 @@ export const knowledgeCreateDocumentTool: ToolConfig<any, KnowledgeCreateDocumen
       if (documentName.length > 255) {
         throw new Error('Document name must be 255 characters or less')
       }
-      if (/[<>:"/\\|?*]/.test(documentName)) {
-        throw new Error('Document name contains invalid characters. Avoid: < > : " / \\ | ? *')
-      }
       if (!textContent || textContent.length < 1) {
         throw new Error('Document content cannot be empty')
       }


### PR DESCRIPTION
## Summary
 removed filename constraint from knowledgebase doc names, previously we had some constraints to the filename that are not hard restraints, since we store the file name as-is in the db

## Type of Change
- [x] Bug fix

## Testing
Manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)