### PR TITLE
improvement(performance): remove writes to workflow updated_at on position updates for blocks, edges, & subflows

### DIFF
--- a/apps/sim/app/api/v1/logs/route.ts
+++ b/apps/sim/app/api/v1/logs/route.ts
@@ -106,7 +106,7 @@ export async function GET(request: NextRequest) {
     const conditions = buildLogFilters(filters)
     const orderBy = getOrderBy(params.order)
 
-    // Build and execute query
+    // Build and execute query - optimized to filter workspace during join
     const baseQuery = db
       .select({
         id: workflowExecutionLogs.id,
@@ -124,7 +124,13 @@ export async function GET(request: NextRequest) {
         workflowDescription: workflow.description,
       })
       .from(workflowExecutionLogs)
-      .innerJoin(workflow, eq(workflowExecutionLogs.workflowId, workflow.id))
+      .innerJoin(
+        workflow,
+        and(
+          eq(workflowExecutionLogs.workflowId, workflow.id),
+          eq(workflow.workspaceId, params.workspaceId) // Filter workspace during join!
+        )
+      )
       .innerJoin(
         permissions,
         and(


### PR DESCRIPTION
## Summary
- remove writes to workflow updated_at on position updates for blocks, edges, & subflows 
- previosuly, every position update or any operation for that matter updated the workflow record int he wrofklow table
  - this caused many different operations to contend for the same lock since they were all trying to update the updated_at timestamp of the same record. to resolve this, we removed the writes to updated_at on position changes and made it only for non position-update ops. this will significantly reduce the 200ms avg update time 

- for the logs, this was the pattern before
```
  1. Scan ALL workflow_execution_logs (millions of rows)
  2. Join to workflow table
  3. Join to permissions WHERE user_id = X
  4. Filter WHERE workspace_id = Y
  5. Return 100 rows
```

  - pattern now
```
  1. Start with workflow WHERE workspace_id = Y (filters to ~50-100 rows)
  2. Join to workflow_execution_logs for only those workflows
  3. Verify permissions for user
  4. Return 100 rows 
```


## Type of Change
- [x] Other: Performance

## Testing
Manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)