### PR TITLE
fix(kb): force kb uploads to use serve route

### DIFF
--- a/apps/sim/app/api/files/presigned/route.ts
+++ b/apps/sim/app/api/files/presigned/route.ts
@@ -265,9 +265,8 @@ async function handleS3PresignedUrl(
       )
     }
 
-    // For chat images, knowledge base files, and profile pictures, use direct URLs since they need to be accessible by external services
     const finalPath =
-      uploadType === 'chat' || uploadType === 'knowledge-base' || uploadType === 'profile-pictures'
+      uploadType === 'chat' || uploadType === 'profile-pictures'
         ? `https://${config.bucket}.s3.${config.region}.amazonaws.com/${uniqueKey}`
         : `/api/files/serve/s3/${encodeURIComponent(uniqueKey)}`
 


### PR DESCRIPTION
## Summary
force kb uploads to use serve route instead of direct uploads/GETs since those caused sporadic failures with forbidden errors

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)