### PR TITLE
improvement(sockets): position persistence on drag end, perms call only on joining room

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -1422,7 +1422,7 @@ const WorkflowContent = React.memo(() => {
       setDraggedNodeId(node.id)
 
       // Emit collaborative position update during drag for smooth real-time movement
-      collaborativeUpdateBlockPosition(node.id, node.position)
+      collaborativeUpdateBlockPosition(node.id, node.position, false)
 
       // Get the current parent ID of the node being dragged
       const currentParentId = blocks[node.id]?.data?.parentId || null
@@ -1608,7 +1608,7 @@ const WorkflowContent = React.memo(() => {
 
       // Emit collaborative position update for the final position
       // This ensures other users see the smooth final position
-      collaborativeUpdateBlockPosition(node.id, node.position)
+      collaborativeUpdateBlockPosition(node.id, node.position, true)
 
       // Record single move entry on drag end to avoid micro-moves
       try {

--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -868,13 +868,19 @@ export function useCollaborativeWorkflow() {
   )
 
   const collaborativeUpdateBlockPosition = useCallback(
-    (id: string, position: Position) => {
-      // Only apply position updates here (no undo recording to avoid micro-moves)
-      executeQueuedDebouncedOperation('update-position', 'block', { id, position }, () =>
+    (id: string, position: Position, commit = true) => {
+      if (commit) {
+        executeQueuedOperation('update-position', 'block', { id, position, commit }, () => {
+          workflowStore.updateBlockPosition(id, position)
+        })
+        return
+      }
+
+      executeQueuedDebouncedOperation('update-position', 'block', { id, position }, () => {
         workflowStore.updateBlockPosition(id, position)
-      )
+      })
     },
-    [executeQueuedDebouncedOperation, workflowStore]
+    [executeQueuedDebouncedOperation, executeQueuedOperation, workflowStore]
   )
 
   const collaborativeUpdateBlockName = useCallback(

--- a/apps/sim/hooks/use-undo-redo.ts
+++ b/apps/sim/hooks/use-undo-redo.ts
@@ -603,6 +603,7 @@ export function useUndoRedo() {
                 id: moveOp.data.blockId,
                 position: { x: moveOp.data.after.x, y: moveOp.data.after.y },
                 parentId: moveOp.data.after.parentId,
+                commit: true,
                 isUndo: true,
                 originalOpId: entry.id,
               },
@@ -706,6 +707,7 @@ export function useUndoRedo() {
               payload: {
                 id: blockId,
                 position: newPosition,
+                commit: true,
                 isUndo: true,
                 originalOpId: entry.id,
               },

--- a/apps/sim/socket-server/database/operations.ts
+++ b/apps/sim/socket-server/database/operations.ts
@@ -340,6 +340,10 @@ async function handleBlockOperationTx(
         throw new Error('Missing required fields for update position operation')
       }
 
+      if (payload.commit !== true) {
+        return
+      }
+
       const updateResult = await tx
         .update(workflowBlocks)
         .set({

--- a/apps/sim/socket-server/handlers/workflow.ts
+++ b/apps/sim/socket-server/handlers/workflow.ts
@@ -46,6 +46,7 @@ export function setupWorkflowHandlers(
 
       logger.info(`Join workflow request from ${userId} (${userName}) for workflow ${workflowId}`)
 
+      let userRole: string
       try {
         const accessInfo = await verifyWorkflowAccess(userId, workflowId)
         if (!accessInfo.hasAccess) {
@@ -53,6 +54,7 @@ export function setupWorkflowHandlers(
           socket.emit('join-workflow-error', { error: 'Access denied to workflow' })
           return
         }
+        userRole = accessInfo.role || 'read'
       } catch (error) {
         logger.warn(`Error verifying workflow access for ${userId}:`, error)
         socket.emit('join-workflow-error', { error: 'Failed to verify workflow access' })
@@ -85,6 +87,7 @@ export function setupWorkflowHandlers(
         socketId: socket.id,
         joinedAt: Date.now(),
         lastActivity: Date.now(),
+        role: userRole,
       }
 
       room.users.set(socket.id, userPresence)

--- a/apps/sim/socket-server/index.test.ts
+++ b/apps/sim/socket-server/index.test.ts
@@ -40,9 +40,9 @@ vi.mock('@/socket-server/middleware/auth', () => ({
 vi.mock('@/socket-server/middleware/permissions', () => ({
   verifyWorkflowAccess: vi.fn().mockResolvedValue({
     hasAccess: true,
-    role: 'owner',
+    role: 'admin',
   }),
-  verifyOperationPermission: vi.fn().mockResolvedValue({
+  checkRolePermission: vi.fn().mockReturnValue({
     allowed: true,
   }),
 }))
@@ -212,6 +212,7 @@ describe('Socket Server Index Integration', () => {
         socketId,
         joinedAt: Date.now(),
         lastActivity: Date.now(),
+        role: 'admin',
       })
       room.activeConnections = 1
 

--- a/apps/sim/socket-server/rooms/manager.ts
+++ b/apps/sim/socket-server/rooms/manager.ts
@@ -28,6 +28,7 @@ export interface UserPresence {
   socketId: string
   joinedAt: number
   lastActivity: number
+  role: string
   cursor?: { x: number; y: number }
   selection?: { type: 'block' | 'edge' | 'none'; id?: string }
 }

--- a/apps/sim/socket-server/validation/schemas.ts
+++ b/apps/sim/socket-server/validation/schemas.ts
@@ -36,6 +36,7 @@ export const BlockOperationSchema = z.object({
     type: z.string().optional(),
     name: z.string().optional(),
     position: PositionSchema.optional(),
+    commit: z.boolean().optional(),
     data: z.record(z.any()).optional(),
     subBlocks: z.record(z.any()).optional(),
     outputs: z.record(z.any()).optional(),


### PR DESCRIPTION
## Summary

- Persist position update only on drag end 
- Make permissions check only on room join to reduce number of db calls

## Type of Change
- [x] Other: Performance Improvement 

## Testing
Tested by observing sockets server logs 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)