### PR TITLE
fix(env-vars): remove regex parsing from table subblock, add formatDisplayText to various subblocks that didn't have it

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/document-tag-entry/document-tag-entry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/document-tag-entry/document-tag-entry.tsx
@@ -9,6 +9,7 @@ import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
 import { MAX_TAG_SLOTS } from '@/lib/knowledge/consts'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
+import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import type { SubBlockConfig } from '@/blocks/types'
 import { useKnowledgeBaseTagDefinitions } from '@/hooks/use-knowledge-base-tag-definitions'
 import { useTagSelection } from '@/hooks/use-tag-selection'
@@ -40,6 +41,7 @@ export function DocumentTagEntry({
   isConnecting = false,
 }: DocumentTagEntryProps) {
   const [storeValue, setStoreValue] = useSubBlockValue<string>(blockId, subBlock.id)
+  const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
 
   // Get the knowledge base ID from other sub-blocks
   const [knowledgeBaseIdValue] = useSubBlockValue(blockId, 'knowledgeBaseId')
@@ -301,7 +303,12 @@ export function DocumentTagEntry({
             )}
           />
           <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'>
-            <div className='whitespace-pre'>{formatDisplayText(cellValue)}</div>
+            <div className='whitespace-pre'>
+              {formatDisplayText(cellValue, {
+                accessiblePrefixes,
+                highlightAll: !accessiblePrefixes,
+              })}
+            </div>
           </div>
           {showDropdown && availableTagDefinitions.length > 0 && (
             <div className='absolute top-full left-0 z-[100] mt-1 w-full'>
@@ -389,7 +396,10 @@ export function DocumentTagEntry({
           />
           <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'>
             <div className='whitespace-pre text-muted-foreground'>
-              {formatDisplayText(cellValue)}
+              {formatDisplayText(cellValue, {
+                accessiblePrefixes,
+                highlightAll: !accessiblePrefixes,
+              })}
             </div>
           </div>
           {showTypeDropdown && !isReadOnly && (
@@ -469,7 +479,12 @@ export function DocumentTagEntry({
             className='w-full border-0 text-transparent caret-foreground placeholder:text-muted-foreground/50 focus-visible:ring-0 focus-visible:ring-offset-0'
           />
           <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'>
-            <div className='whitespace-pre'>{formatDisplayText(cellValue)}</div>
+            <div className='whitespace-pre'>
+              {formatDisplayText(cellValue, {
+                accessiblePrefixes,
+                highlightAll: !accessiblePrefixes,
+              })}
+            </div>
           </div>
         </div>
       </td>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/knowledge-tag-filters/knowledge-tag-filters.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/knowledge-tag-filters/knowledge-tag-filters.tsx
@@ -239,7 +239,12 @@ export function KnowledgeTagFilters({
             onBlur={handleBlur}
           />
           <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'>
-            <div className='whitespace-pre'>{formatDisplayText(cellValue || 'Select tag')}</div>
+            <div className='whitespace-pre'>
+              {formatDisplayText(cellValue || 'Select tag', {
+                accessiblePrefixes,
+                highlightAll: !accessiblePrefixes,
+              })}
+            </div>
           </div>
           {showDropdown && tagDefinitions.length > 0 && (
             <div className='absolute top-full left-0 z-[100] mt-1 w-full'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/table.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input'
 import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
 import { cn } from '@/lib/utils'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/hooks/use-sub-block-value'
+import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 
 interface TableProps {
   blockId: string
@@ -34,6 +35,7 @@ export function Table({
   const params = useParams()
   const workspaceId = params.workspaceId as string
   const [storeValue, setStoreValue] = useSubBlockValue<TableRow[]>(blockId, subBlockId)
+  const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
 
   // Use preview value when in preview mode, otherwise use store value
   const value = isPreview ? previewValue : storeValue
@@ -240,7 +242,12 @@ export function Table({
             data-overlay={cellKey}
             className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'
           >
-            <div className='whitespace-pre'>{formatDisplayText(cellValue)}</div>
+            <div className='whitespace-pre'>
+              {formatDisplayText(cellValue, {
+                accessiblePrefixes,
+                highlightAll: !accessiblePrefixes,
+              })}
+            </div>
           </div>
         </div>
       </td>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/trigger-config/components/trigger-config-section.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/trigger-config/components/trigger-config-section.tsx
@@ -10,6 +10,7 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command'
+import { formatDisplayText } from '@/components/ui/formatted-text'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -23,9 +24,11 @@ import {
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import type { TriggerConfig } from '@/triggers/types'
 
 interface TriggerConfigSectionProps {
+  blockId: string
   triggerDef: TriggerConfig
   config: Record<string, any>
   onChange: (fieldId: string, value: any) => void
@@ -34,6 +37,7 @@ interface TriggerConfigSectionProps {
 }
 
 export function TriggerConfigSection({
+  blockId,
   triggerDef,
   config,
   onChange,
@@ -42,6 +46,7 @@ export function TriggerConfigSection({
 }: TriggerConfigSectionProps) {
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({})
   const [copied, setCopied] = useState<string | null>(null)
+  const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
 
   const copyToClipboard = (text: string, type: string) => {
     navigator.clipboard.writeText(text)
@@ -258,9 +263,20 @@ export function TriggerConfigSection({
                 className={cn(
                   'h-9 rounded-[8px]',
                   isSecret ? 'pr-32' : '',
-                  'focus-visible:ring-2 focus-visible:ring-primary/20'
+                  'focus-visible:ring-2 focus-visible:ring-primary/20',
+                  !isSecret && 'text-transparent caret-foreground'
                 )}
               />
+              {!isSecret && (
+                <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden bg-transparent px-3 text-sm'>
+                  <div className='whitespace-pre'>
+                    {formatDisplayText(value?.toString() || '', {
+                      accessiblePrefixes,
+                      highlightAll: !accessiblePrefixes,
+                    })}
+                  </div>
+                </div>
+              )}
               {isSecret && (
                 <div className='absolute top-0.5 right-0.5 flex h-8 items-center gap-1 pr-1'>
                   <Button

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/trigger-config/components/trigger-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/trigger-config/components/trigger-modal.tsx
@@ -467,6 +467,7 @@ export function TriggerModal({
             )}
 
             <TriggerConfigSection
+              blockId={blockId}
               triggerDef={triggerDef}
               config={config}
               onChange={handleConfigChange}

--- a/apps/sim/executor/handlers/condition/condition-handler.test.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.test.ts
@@ -165,7 +165,7 @@ describe('ConditionBlockHandler', () => {
       mockContext,
       mockBlock
     )
-    expect(mockResolver.resolveEnvVariables).toHaveBeenCalledWith('context.value > 5', true)
+    expect(mockResolver.resolveEnvVariables).toHaveBeenCalledWith('context.value > 5')
     expect(result).toEqual(expectedOutput)
     expect(mockContext.decisions.condition.get(mockBlock.id)).toBe('cond1')
   })
@@ -205,7 +205,7 @@ describe('ConditionBlockHandler', () => {
       mockContext,
       mockBlock
     )
-    expect(mockResolver.resolveEnvVariables).toHaveBeenCalledWith('context.value < 0', true)
+    expect(mockResolver.resolveEnvVariables).toHaveBeenCalledWith('context.value < 0')
     expect(result).toEqual(expectedOutput)
     expect(mockContext.decisions.condition.get(mockBlock.id)).toBe('else1')
   })
@@ -241,7 +241,7 @@ describe('ConditionBlockHandler', () => {
       mockContext,
       mockBlock
     )
-    expect(mockResolver.resolveEnvVariables).toHaveBeenCalledWith('10 > 5', true)
+    expect(mockResolver.resolveEnvVariables).toHaveBeenCalledWith('10 > 5')
     expect(mockContext.decisions.condition.get(mockBlock.id)).toBe('cond1')
   })
 
@@ -268,7 +268,7 @@ describe('ConditionBlockHandler', () => {
       mockContext,
       mockBlock
     )
-    expect(mockResolver.resolveEnvVariables).toHaveBeenCalledWith('"john" !== null', true)
+    expect(mockResolver.resolveEnvVariables).toHaveBeenCalledWith('"john" !== null')
     expect(mockContext.decisions.condition.get(mockBlock.id)).toBe('cond1')
   })
 
@@ -295,7 +295,7 @@ describe('ConditionBlockHandler', () => {
       mockContext,
       mockBlock
     )
-    expect(mockResolver.resolveEnvVariables).toHaveBeenCalledWith('{{POOP}} === "hi"', true)
+    expect(mockResolver.resolveEnvVariables).toHaveBeenCalledWith('{{POOP}} === "hi"')
     expect(mockContext.decisions.condition.get(mockBlock.id)).toBe('cond1')
   })
 

--- a/apps/sim/executor/handlers/condition/condition-handler.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.ts
@@ -109,7 +109,7 @@ export class ConditionBlockHandler implements BlockHandler {
         // Use full resolution pipeline: variables -> block references -> env vars
         const resolvedVars = this.resolver.resolveVariableReferences(conditionValueString, block)
         const resolvedRefs = this.resolver.resolveBlockReferences(resolvedVars, context, block)
-        resolvedConditionValue = this.resolver.resolveEnvVariables(resolvedRefs, true)
+        resolvedConditionValue = this.resolver.resolveEnvVariables(resolvedRefs)
         logger.info(
           `Resolved condition "${condition.title}" (${condition.id}): from "${conditionValueString}" to "${resolvedConditionValue}"`
         )

--- a/apps/sim/executor/resolver/resolver.test.ts
+++ b/apps/sim/executor/resolver/resolver.test.ts
@@ -432,7 +432,7 @@ describe('InputResolver', () => {
 
       expect(result.apiKey).toBe('test-api-key')
       expect(result.url).toBe('https://example.com?key=test-api-key')
-      expect(result.regularParam).toBe('Base URL is: {{BASE_URL}}')
+      expect(result.regularParam).toBe('Base URL is: https://api.example.com')
     })
 
     it('should resolve explicit environment variables', () => {
@@ -458,7 +458,7 @@ describe('InputResolver', () => {
       expect(result.explicitEnv).toBe('https://api.example.com')
     })
 
-    it('should not resolve environment variables in regular contexts', () => {
+    it('should resolve environment variables in all contexts', () => {
       const block: SerializedBlock = {
         id: 'test-block',
         metadata: { id: 'generic', name: 'Test Block' },
@@ -478,7 +478,7 @@ describe('InputResolver', () => {
 
       const result = resolver.resolveInputs(block, mockContext)
 
-      expect(result.regularParam).toBe('Value with {{API_KEY}} embedded')
+      expect(result.regularParam).toBe('Value with test-api-key embedded')
     })
   })
 


### PR DESCRIPTION
## Summary
- remove regex parsing from table subblock, add formatDisplayText to various subblocks that didn't have it
  - we had this complex logic that checked if it was an API key field and did regex to parse the value based on whether we thought it was an auth key. We simplified this to now just parse the keys that are in the `{{}}` format

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)