### PR TITLE
fix(webhooks): test url must be based on next public app url

### DIFF
--- a/apps/sim/app/api/webhooks/[id]/test-url/route.ts
+++ b/apps/sim/app/api/webhooks/[id]/test-url/route.ts
@@ -64,13 +64,13 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
 
-    const origin = new URL(request.url).origin
-    const effectiveOrigin = origin.includes('localhost')
-      ? env.NEXT_PUBLIC_APP_URL || origin
-      : origin
+    if (!env.NEXT_PUBLIC_APP_URL) {
+      logger.error(`[${requestId}] NEXT_PUBLIC_APP_URL not configured`)
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+    }
 
     const token = await signTestWebhookToken(id, ttlSeconds)
-    const url = `${effectiveOrigin}/api/webhooks/test/${id}?token=${encodeURIComponent(token)}`
+    const url = `${env.NEXT_PUBLIC_APP_URL}/api/webhooks/test/${id}?token=${encodeURIComponent(token)}`
 
     logger.info(`[${requestId}] Minted test URL for webhook ${id}`)
     return NextResponse.json({


### PR DESCRIPTION
## Summary
Was incorrectly falling back to origin rather than next public app url. 

## Type of Change
- [x] Bug fix

## Testing
Manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)