### PR TITLE
fix(chat): allow file-only messages with no text to be sent in chat panel and deployed chat

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/chat/chat.tsx
@@ -476,6 +476,8 @@ export function Chat({ chatMessage, setChatMessage }: ChatProps) {
     focusInput(100)
   }, [
     chatMessage,
+    chatFiles,
+    isUploadingFiles,
     activeWorkflowId,
     isExecuting,
     promptHistory,
@@ -487,6 +489,9 @@ export function Chat({ chatMessage, setChatMessage }: ChatProps) {
     appendMessageContent,
     finalizeMessageStream,
     focusInput,
+    setChatMessage,
+    setChatFiles,
+    setUploadErrors,
   ])
 
   // Handle key press


### PR DESCRIPTION
## Summary
allow file-only messages with no text to be sent in chat panel and deployed chat

## Type of Change
- [x] Bug fix

## Testing
Tested manually by sending messages with no text and only images.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)