### PR TITLE
fix(workflow-auth): adding workflowId param to only internal urls

### DIFF
--- a/apps/sim/tools/index.ts
+++ b/apps/sim/tools/index.ts
@@ -429,7 +429,10 @@ async function handleInternalRequest(
       typeof tool.request.url === 'function' ? tool.request.url(params) : tool.request.url
 
     const fullUrlObj = new URL(endpointUrl, baseUrl)
-    if (executionContext?.workflowId && typeof window === 'undefined') {
+    const isInternalRoute = endpointUrl.startsWith('/api/')
+
+    // Only add workflowId to internal routes, not external APIs
+    if (executionContext?.workflowId && typeof window === 'undefined' && isInternalRoute) {
       fullUrlObj.searchParams.set('workflowId', executionContext.workflowId)
     }
     const fullUrl = fullUrlObj.toString()
@@ -451,7 +454,6 @@ async function handleInternalRequest(
     }
 
     const headers = new Headers(requestParams.headers)
-    const isInternalRoute = endpointUrl.startsWith('/api/')
     if (typeof window === 'undefined') {
       if (isInternalRoute) {
         try {


### PR DESCRIPTION
## Summary
Did not have internal URL check. So was adding workflowId to external calls too. Not ignored by some providers.

## Type of Change
- [x] Bug fix

## Testing
Manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
