### PR TITLE
fix(trigger-dup): on duplicate trigger should not point at old webhook row

### DIFF
--- a/apps/sim/stores/workflows/server-utils.ts
+++ b/apps/sim/stores/workflows/server-utils.ts
@@ -10,6 +10,8 @@
 
 import type { BlockState, SubBlockState } from '@/stores/workflows/workflow/types'
 
+const WEBHOOK_SUBBLOCK_FIELDS = ['webhookId', 'triggerPath']
+
 /**
  * Server-safe version of mergeSubblockState for API routes
  *
@@ -42,10 +44,11 @@ export function mergeSubblockState(
       const blockValues = subBlockValues[id] || {}
 
       // Create a deep copy of the block's subBlocks to maintain structure
+      // Exclude webhook-specific fields that should not be persisted
       const mergedSubBlocks = Object.entries(blockSubBlocks).reduce(
         (subAcc, [subBlockId, subBlock]) => {
-          // Skip if subBlock is undefined
-          if (!subBlock) {
+          // Skip if subBlock is undefined or is a webhook-specific field
+          if (!subBlock || WEBHOOK_SUBBLOCK_FIELDS.includes(subBlockId)) {
             return subAcc
           }
 
@@ -72,7 +75,12 @@ export function mergeSubblockState(
       // Add any values that exist in the provided values but aren't in the block structure
       // This handles cases where block config has been updated but values still exist
       Object.entries(blockValues).forEach(([subBlockId, value]) => {
-        if (!mergedSubBlocks[subBlockId] && value !== null && value !== undefined) {
+        if (
+          !mergedSubBlocks[subBlockId] &&
+          value !== null &&
+          value !== undefined &&
+          !WEBHOOK_SUBBLOCK_FIELDS.includes(subBlockId)
+        ) {
           // Create a minimal subblock structure
           mergedSubBlocks[subBlockId] = {
             id: subBlockId,

--- a/apps/sim/stores/workflows/utils.ts
+++ b/apps/sim/stores/workflows/utils.ts
@@ -1,6 +1,8 @@
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import type { BlockState, SubBlockState } from '@/stores/workflows/workflow/types'
 
+const WEBHOOK_SUBBLOCK_FIELDS = ['webhookId', 'triggerPath']
+
 /**
  * Normalizes a block name for comparison by converting to lowercase and removing spaces
  * @param name - The block name to normalize
@@ -75,10 +77,11 @@ export function mergeSubblockState(
       const blockValues = workflowSubblockValues[id] || {}
 
       // Create a deep copy of the block's subBlocks to maintain structure
+      // Exclude webhook-specific fields that should not be persisted
       const mergedSubBlocks = Object.entries(blockSubBlocks).reduce(
         (subAcc, [subBlockId, subBlock]) => {
-          // Skip if subBlock is undefined
-          if (!subBlock) {
+          // Skip if subBlock is undefined or is a webhook-specific field
+          if (!subBlock || WEBHOOK_SUBBLOCK_FIELDS.includes(subBlockId)) {
             return subAcc
           }
 
@@ -116,7 +119,12 @@ export function mergeSubblockState(
       // Add any values that exist in the store but aren't in the block structure
       // This handles cases where block config has been updated but values still exist
       Object.entries(blockValues).forEach(([subBlockId, value]) => {
-        if (!mergedSubBlocks[subBlockId] && value !== null && value !== undefined) {
+        if (
+          !mergedSubBlocks[subBlockId] &&
+          value !== null &&
+          value !== undefined &&
+          !WEBHOOK_SUBBLOCK_FIELDS.includes(subBlockId)
+        ) {
           // Create a minimal subblock structure
           mergedSubBlocks[subBlockId] = {
             id: subBlockId,
@@ -166,27 +174,22 @@ export async function mergeSubblockStateAsync(
       // Process all subblocks in parallel
       const subBlockEntries = await Promise.all(
         Object.entries(block.subBlocks).map(async ([subBlockId, subBlock]) => {
-          // Skip if subBlock is undefined
-          if (!subBlock) {
-            return [subBlockId, subBlock] as const
+          // Skip if subBlock is undefined or webhook-specific
+          if (!subBlock || WEBHOOK_SUBBLOCK_FIELDS.includes(subBlockId)) {
+            return null
           }
 
-          // Get the stored value for this subblock
           let storedValue = null
 
-          // If workflowId is provided, use it to get the value
           if (workflowId) {
-            // Try to get the value from the subblock store for this specific workflow
             const workflowValues = subBlockStore.workflowValues[workflowId]
             if (workflowValues?.[id]) {
               storedValue = workflowValues[id][subBlockId]
             }
           } else {
-            // Fall back to the active workflow if no workflowId is provided
             storedValue = subBlockStore.getValue(id, subBlockId)
           }
 
-          // Create a new subblock object with the same structure but updated value
           return [
             subBlockId,
             {
@@ -199,7 +202,9 @@ export async function mergeSubblockStateAsync(
       )
 
       // Convert entries back to an object
-      const mergedSubBlocks = Object.fromEntries(subBlockEntries) as Record<string, SubBlockState>
+      const mergedSubBlocks = Object.fromEntries(
+        subBlockEntries.filter((entry): entry is readonly [string, SubBlockState] => entry !== null)
+      ) as Record<string, SubBlockState>
 
       // Return the full block state with updated subBlocks
       return [


### PR DESCRIPTION
## Summary

On duplicating trigger block should not point at old webhook row. 

## Type of Change
- [x] Bug fix

## Testing
Tested manually with @waleedlatif1 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
