### PR TITLE
fix(schedules): restore enabling/disabling of schedules, fix premature cron validation

### DIFF
--- a/apps/sim/lib/schedules/utils.ts
+++ b/apps/sim/lib/schedules/utils.ts
@@ -142,14 +142,6 @@ export function getScheduleTimeValues(starterBlock: BlockState): {
 
   const cronExpression = getSubBlockValue(starterBlock, 'cronExpression') || null
 
-  // Validate cron expression if provided
-  if (cronExpression) {
-    const validation = validateCronExpression(cronExpression)
-    if (!validation.isValid) {
-      throw new Error(`Invalid cron expression: ${validation.error}`)
-    }
-  }
-
   return {
     scheduleTime,
     scheduleStartAt,


### PR DESCRIPTION
## Summary
- restore enabling/disabling of schedules
- fix premature cron validation that was validating all fields irregardless of dropdown options selected, now it only validates fields for that one frequency option specifically

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)