### PR TITLE
feat(billing): integrate Loops checkout for subscription upgrades

### DIFF
--- a/apps/sim/app/api/billing/checkout/route.ts
+++ b/apps/sim/app/api/billing/checkout/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getSession } from '@/lib/auth'
+import { createLoopsCheckoutSession } from '@/lib/billing/loops-checkout'
+import { isLoopsEnabled } from '@/lib/billing/loops-client'
+import { createLogger } from '@/lib/logs/console/logger'
+import { getBaseUrl } from '@/lib/urls/utils'
+
+const logger = createLogger('BillingCheckout')
+
+/**
+ * POST /api/billing/checkout
+ * Creates a Loops v3 checkout session for subscription upgrade
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getSession()
+
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    if (!isLoopsEnabled()) {
+      return NextResponse.json(
+        { error: 'Loops checkout is not enabled' },
+        { status: 400 }
+      )
+    }
+
+    const body = await request.json()
+    const { plan, successUrl, cancelUrl, metadata } = body
+
+    if (!plan) {
+      return NextResponse.json({ error: 'Plan is required' }, { status: 400 })
+    }
+
+    // Use provided URLs or default to current page
+    const finalSuccessUrl = successUrl || `${getBaseUrl()}/workspace`
+    const finalCancelUrl = cancelUrl || `${getBaseUrl()}/workspace`
+
+    logger.info('Creating Loops checkout session', {
+      userId: session.user.id,
+      plan,
+      successUrl: finalSuccessUrl,
+      cancelUrl: finalCancelUrl,
+    })
+
+    const checkoutSession = await createLoopsCheckoutSession({
+      plan,
+      externalCustomerId: session.user.id,
+      successUrl: finalSuccessUrl,
+      cancelUrl: finalCancelUrl,
+      metadata: {
+        userId: session.user.id,
+        userEmail: session.user.email,
+        ...metadata,
+      },
+    })
+
+    return NextResponse.json({
+      url: checkoutSession.url,
+      sessionId: checkoutSession.sessionId,
+    })
+  } catch (error) {
+    logger.error('Failed to create checkout session', { error })
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Failed to create checkout session',
+      },
+      { status: 500 }
+    )
+  }
+}
+

--- a/apps/sim/lib/billing/loops-checkout.ts
+++ b/apps/sim/lib/billing/loops-checkout.ts
@@ -1,0 +1,87 @@
+import { getLoopsClient, isLoopsEnabled } from './loops-client'
+import { getPlans, getPlanByName } from './plans'
+import { createLogger } from '@/lib/logs/console/logger'
+
+const logger = createLogger('LoopsCheckout')
+
+// Note: We use lineItems with Stripe price IDs directly instead of payment links
+// Payment links are not directly supported in checkout session creation
+
+/**
+ * Creates a Loops v3 checkout session for a subscription
+ */
+export async function createLoopsCheckoutSession(params: {
+  plan: string
+  externalCustomerId: string
+  successUrl: string
+  cancelUrl: string
+  metadata?: Record<string, any>
+}): Promise<{ url: string; sessionId: string }> {
+  if (!isLoopsEnabled()) {
+    throw new Error('Loops is not enabled. Please provide LOOPS_API_KEY in environment variables.')
+  }
+
+  const loops = getLoopsClient()
+  const plan = getPlanByName(params.plan)
+
+  if (!plan) {
+    throw new Error(`Invalid plan: ${params.plan}`)
+  }
+
+  if (!plan.priceId) {
+    throw new Error(`Price ID not configured for plan: ${plan.name}`)
+  }
+
+  logger.info('Creating Loops checkout session', {
+    plan: plan.name,
+    priceId: plan.priceId,
+    externalCustomerId: params.externalCustomerId,
+  })
+
+  try {
+    // Create checkout session using Loops API (v3)
+    // Use lineItems with Stripe price ID since paymentLinkId is not directly supported
+    const result = await loops.checkoutSessions.create({
+      lineItems: [
+        {
+          price: plan.priceId,
+          quantity: params.metadata?.seats || 1,
+          ...(plan.name === 'team' && {
+            adjustableQuantity: {
+              enabled: true,
+              minimum: 1,
+              maximum: 50,
+            },
+          }),
+        },
+      ],
+      mode: 'subscription',
+      successUrl: params.successUrl,
+      cancelUrl: params.cancelUrl,
+      externalCustomerId: params.externalCustomerId,
+      metadata: {
+        plan: plan.name,
+        planPriceId: plan.priceId,
+        ...params.metadata,
+      },
+    })
+
+    logger.info('Loops checkout session created successfully', {
+      sessionId: result.id,
+      url: result.url,
+    })
+
+    return {
+      url: result.url || '',
+      sessionId: result.id || '',
+    }
+  } catch (error) {
+    logger.error('Failed to create Loops checkout session', {
+      error,
+      plan: plan.name,
+      priceId: plan.priceId,
+    })
+    throw error
+  }
+}
+

--- a/apps/sim/lib/billing/loops-client.ts
+++ b/apps/sim/lib/billing/loops-client.ts
@@ -1,0 +1,29 @@
+import { Loops } from '@loops-fi/sdk'
+import { env } from '@/lib/env'
+import { createLogger } from '@/lib/logs/console/logger'
+
+const logger = createLogger('Loops')
+
+// Initialize Loops client only if API key is provided
+let loopsClient: Loops | null = null
+
+if (env.LOOPS_API_KEY) {
+  loopsClient = new Loops({
+    apiKey: env.LOOPS_API_KEY,
+  })
+  logger.info('Loops client initialized')
+} else {
+  logger.warn('Loops API key not provided, Loops client not initialized')
+}
+
+export function getLoopsClient(): Loops {
+  if (!loopsClient) {
+    throw new Error('Loops client not initialized. Please provide LOOPS_API_KEY in environment variables.')
+  }
+  return loopsClient
+}
+
+export function isLoopsEnabled(): boolean {
+  return !!env.LOOPS_API_KEY && !!loopsClient
+}
+

--- a/apps/sim/lib/env.ts
+++ b/apps/sim/lib/env.ts
@@ -40,6 +40,7 @@ export const env = createEnv({
     // Payment & Billing
     STRIPE_SECRET_KEY:                     z.string().min(1).optional(),           // Stripe secret key for payment processing
     STRIPE_WEBHOOK_SECRET:                 z.string().min(1).optional(),           // General Stripe webhook secret
+    LOOPS_API_KEY:                         z.string().min(1).optional(),           // Loops API key for checkout links
     STRIPE_FREE_PRICE_ID:                  z.string().min(1).optional(),           // Stripe price ID for free tier
     FREE_TIER_COST_LIMIT:                  z.number().optional(),                  // Cost limit for free tier users
     FREE_STORAGE_LIMIT_GB:                 z.number().optional().default(5),       // Storage limit in GB for free tier users

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -34,6 +34,7 @@
     "@cerebras/cerebras_cloud_sdk": "^1.23.0",
     "@e2b/code-interpreter": "^2.0.0",
     "@hookform/resolvers": "^4.1.3",
+    "@loops-fi/sdk": "0.5.6",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-jaeger": "2.1.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",

--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,7 @@
         "@cerebras/cerebras_cloud_sdk": "^1.23.0",
         "@e2b/code-interpreter": "^2.0.0",
         "@hookform/resolvers": "^4.1.3",
+        "@loops-fi/sdk": "0.5.6",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-jaeger": "2.1.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
@@ -651,6 +652,8 @@
     "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
     "@linear/sdk": ["@linear/sdk@40.0.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.0", "graphql": "^15.4.0", "isomorphic-unfetch": "^3.1.0" } }, "sha512-R4lyDIivdi00fO+DYPs7gWNX221dkPJhgDowFrsfos/rNG6o5HixsCPgwXWtKN0GA0nlqLvFTmzvzLXpud1xKw=="],
+
+    "@loops-fi/sdk": ["@loops-fi/sdk@0.5.6", "", { "dependencies": { "zod": "^3.20.0" } }, "sha512-HlTBu6Dny5Ysi4ih7nRcAH72RAM8vBXtTqWrbWq7hzfbCNG3zAXwS3twugnZDOhZn7NCc5Fuq9hlLYZigLoMeg=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 


### PR DESCRIPTION
## Summary

- Add Loops SDK (@loops-fi/sdk) for checkout session management
- Create Loops client utility with environment variable support
- Implement Loops checkout helper using checkoutSessions API
- Add custom checkout API endpoint (/api/billing/checkout)
- Update subscription upgrade flow to use Loops checkout when enabled
- Fallback to Stripe checkout if Loops is not configured
- Use existing Stripe price IDs directly in Loops checkout sessions
- Add LOOPS_API_KEY environment variable

This integration allows using Loops checkout links while keeping all other billing functionality (webhooks, subscriptions) on Stripe.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How has this been tested? What should reviewers focus on?

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
