### PR TITLE
fix(file-upload): workspace/chat context not being passed in some forms

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/components/deploy-modal/components/chat-deploy/hooks/use-image-upload.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/components/deploy-modal/components/chat-deploy/hooks/use-image-upload.ts
@@ -94,6 +94,7 @@ export function useImageUpload({
       // Fallback to traditional upload through API route
       const formData = new FormData()
       formData.append('file', file)
+      formData.append('context', 'chat')
 
       const response = await fetch('/api/files/upload', {
         method: 'POST',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/components/deploy-modal/components/image-selector/image-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/control-bar/components/deploy-modal/components/image-selector/image-selector.tsx
@@ -111,6 +111,7 @@ export function ImageSelector({
         // Fallback to traditional upload through API route
         const formData = new FormData()
         formData.append('file', file)
+        formData.append('context', 'chat')
 
         const response = await fetch('/api/files/upload', {
           method: 'POST',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-upload.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/components/sub-block/components/file-upload.tsx
@@ -219,6 +219,7 @@ export function FileUpload({
           // Create FormData for upload
           const formData = new FormData()
           formData.append('file', file)
+          formData.append('context', 'workspace')
 
           // Add workspace ID for workspace-scoped storage
           if (workspaceId) {


### PR DESCRIPTION
## Summary

Pass storage context in form based callsites correctly.

## Type of Change
- [x] Bug fix

## Testing
Tested with @aadamgough 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
