### PR TITLE
fix(dropdown): add dependsOn to dropdown component to dynamically fetch options predicated on another subblock

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel-new/components/editor/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel-new/components/editor/components/sub-block/sub-block.tsx
@@ -210,6 +210,7 @@ function SubBlockComponent({
               disabled={isDisabled}
               multiSelect={config.multiSelect}
               fetchOptions={config.fetchOptions}
+              dependsOn={config.dependsOn}
             />
           </div>
         )

--- a/apps/sim/triggers/gmail/poller.ts
+++ b/apps/sim/triggers/gmail/poller.ts
@@ -58,6 +58,7 @@ export const gmailPollingTrigger: TriggerConfig = {
           return []
         }
       },
+      dependsOn: ['triggerCredentials'],
       mode: 'trigger',
     },
     {

--- a/apps/sim/triggers/outlook/poller.ts
+++ b/apps/sim/triggers/outlook/poller.ts
@@ -58,6 +58,7 @@ export const outlookPollingTrigger: TriggerConfig = {
           return []
         }
       },
+      dependsOn: ['triggerCredentials'],
       mode: 'trigger',
     },
     {


### PR DESCRIPTION
## Summary
- add dependsOn to dropdown component to dynamically fetch options predicated on another subblock

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)