### PR TITLE
fix(onedrive): incorrect canonical param

### DIFF
--- a/apps/sim/blocks/blocks/onedrive.ts
+++ b/apps/sim/blocks/blocks/onedrive.ts
@@ -351,19 +351,11 @@ export const OneDriveBlock: BlockConfig<OneDriveResponse> = {
       params: (params) => {
         const { credential, folderId, fileId, mimeType, values, downloadFileName, ...rest } = params
 
-        // Handle values - could be string (from UI) or already parsed (from variable reference)
         let parsedValues
-        if (values) {
-          if (typeof values === 'string') {
-            try {
-              parsedValues = JSON.parse(values)
-            } catch (error) {
-              throw new Error('Invalid JSON format for values')
-            }
-          } else {
-            // Already an object/array from variable reference
-            parsedValues = values
-          }
+        try {
+          parsedValues = values ? JSON.parse(values as string) : undefined
+        } catch (error) {
+          throw new Error('Invalid JSON format for values')
         }
 
         return {


### PR DESCRIPTION
## Summary
Similar to slack, download file defined incorrect canonical param that hit create file. 


## Type of Change
- [x] Bug fix


## Testing
Tested manually 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
