### PR TITLE
fix(cmd-k): z-index + reoder tools, triggers

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components-new/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components-new/search-modal/search-modal.tsx
@@ -488,8 +488,8 @@ export function SearchModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogPortal>
         <DialogOverlay
-          className='bg-white/80 dark:bg-[#1b1b1b]/90'
-          style={{ backdropFilter: 'blur(4px)', zIndex: 40 }}
+          className='z-40 bg-white/80 dark:bg-[#1b1b1b]/90'
+          style={{ backdropFilter: 'blur(4px)' }}
         />
         <DialogPrimitive.Content className='fixed top-[15%] left-[50%] z-50 flex w-[500px] translate-x-[-50%] flex-col gap-[12px] p-0 focus:outline-none focus-visible:outline-none'>
           <VisuallyHidden.Root>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components-new/settings-modal/components/subscription/subscription.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components-new/settings-modal/components/subscription/subscription.tsx
@@ -670,7 +670,7 @@ export function Subscription({ onOpenChange }: SubscriptionProps) {
                 <SelectTrigger className='h-8 w-[200px] justify-between text-left text-xs'>
                   <SelectValue placeholder='Select admin' />
                 </SelectTrigger>
-                <SelectContent align='start'>
+                <SelectContent align='start' className='z-50'>
                   <SelectGroup>
                     <SelectLabel className='px-3 py-1 text-[11px] text-muted-foreground uppercase'>
                       Workspace admins


### PR DESCRIPTION
## Summary

- Incorrect z-index for cmd k modal 
- Ordering to have tools above triggers


## Type of Change
- [x] Bug fix

## Testing
Tested manually 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)