### PR TITLE
fix(output-selector): z-index in chat deploy modal

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/output-select/output-select.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/output-select/output-select.tsx
@@ -288,7 +288,7 @@ export function OutputSelect({
       <PopoverContent
         ref={popoverRef}
         side='bottom'
-        align='end'
+        align='start'
         sideOffset={4}
         maxHeight={140}
         maxWidth={140}


### PR DESCRIPTION
## Summary
Output Selector in chat deploy modal was rendering to the right. 

## Type of Change
- [x] Bug fix


## Testing
Tested manually. 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
