### PR TITLE
fix(tags): only show start block upstream if is ancestor

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes.ts
@@ -30,7 +30,7 @@ export function useAccessibleReferencePrefixes(blockId?: string | null): Set<str
     const starterBlock = Object.values(blocks).find(
       (block) => block.type === 'starter' || block.type === 'start_trigger'
     )
-    if (starterBlock) {
+    if (starterBlock && ancestorIds.includes(starterBlock.id)) {
       accessibleIds.add(starterBlock.id)
     }
 

--- a/apps/sim/lib/block-path-calculator.ts
+++ b/apps/sim/lib/block-path-calculator.ts
@@ -85,9 +85,10 @@ export class BlockPathCalculator {
       const pathNodes = BlockPathCalculator.findAllPathNodes(workflow.connections, block.id)
       pathNodes.forEach((nodeId) => accessibleBlocks.add(nodeId))
 
-      // Always allow referencing the starter block (special case)
+      // Only add starter block if it's actually upstream (already in pathNodes)
+      // Don't add it just because it exists on the canvas
       const starterBlock = workflow.blocks.find((b) => b.metadata?.id === 'starter')
-      if (starterBlock && starterBlock.id !== block.id) {
+      if (starterBlock && starterBlock.id !== block.id && pathNodes.includes(starterBlock.id)) {
         accessibleBlocks.add(starterBlock.id)
       }
 

--- a/apps/sim/serializer/index.ts
+++ b/apps/sim/serializer/index.ts
@@ -592,7 +592,9 @@ export class Serializer {
       const accessibleIds = new Set<string>(ancestorIds)
       accessibleIds.add(blockId)
 
-      if (starterBlock) {
+      // Only add starter block if it's actually upstream (already in ancestorIds)
+      // Don't add it just because it exists on the canvas
+      if (starterBlock && ancestorIds.includes(starterBlock.id)) {
         accessibleIds.add(starterBlock.id)
       }
 


### PR DESCRIPTION
## Summary
Only shows start block in the tag dropdown if it is an ancestor of the block

## Type of Change
- [x] Bug fix

## Testing
Manual

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)