### PR TITLE
improvement(tools): add eleven_v3 to elevenlabs block

### DIFF
--- a/apps/sim/blocks/blocks/elevenlabs.ts
+++ b/apps/sim/blocks/blocks/elevenlabs.ts
@@ -38,6 +38,7 @@ export const ElevenLabsBlock: BlockConfig<ElevenLabsBlockResponse> = {
         { label: 'eleven_turbo_v2', id: 'eleven_turbo_v2' },
         { label: 'eleven_turbo_v2_5', id: 'eleven_turbo_v2_5' },
         { label: 'eleven_flash_v2_5', id: 'eleven_flash_v2_5' },
+        { label: 'eleven_v3', id: 'eleven_v3' },
       ],
     },
     {


### PR DESCRIPTION
## Summary
Adds `eleven_v3` support to the elevenlabs block.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
I copied the model ID from here: https://elevenlabs.io/docs/models#models-overview

I verified this model_id works for me in the API tester: https://elevenlabs.io/docs/api-reference/text-to-speech/convert

The `eleven_ttv_v3` model ID did not work for me, so I didn't add it here.

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
