### PR TITLE
fix(selector): remove subblock state prop for subblock component

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
@@ -346,10 +346,11 @@ function SubBlockComponent({
     | undefined
 
   // Use dependsOn gating to compute final disabled state
+  // Only pass previewContextValues when in preview mode to avoid format mismatches
   const { finalDisabled: gatedDisabled } = useDependsOnGate(blockId, config, {
     disabled,
     isPreview,
-    previewContextValues: subBlockValues,
+    previewContextValues: isPreview ? subBlockValues : undefined,
   })
 
   const isDisabled = gatedDisabled
@@ -611,7 +612,7 @@ function SubBlockComponent({
             disabled={isDisabled}
             isPreview={isPreview}
             previewValue={previewValue}
-            previewContextValues={subBlockValues}
+            previewContextValues={isPreview ? subBlockValues : undefined}
           />
         )
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/editor.tsx
@@ -353,7 +353,6 @@ export function Editor() {
                           blockId={currentBlockId}
                           config={subBlock}
                           isPreview={false}
-                          subBlockValues={subBlockState}
                           disabled={!userPermissions.canEdit}
                           fieldDiffStatus={undefined}
                           allowExpandInPreview={false}


### PR DESCRIPTION
## Summary

Subblock State prop is removed since fallback was always used. 

## Type of Change
- [x] Bug fix

## Testing
Tested manually with @aadamgough 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
