### PR TITLE
fix(docs): update docs to background instead of backgroundColor

### DIFF
--- a/apps/docs/components/ui/block-info-card.tsx
+++ b/apps/docs/components/ui/block-info-card.tsx
@@ -24,7 +24,7 @@ export function BlockInfoCard({
       <div className='flex items-center justify-center p-6'>
         <div
           className='flex h-20 w-20 items-center justify-center rounded-lg'
-          style={{ backgroundColor: color }}
+          style={{ background: color }}
         >
           {ResolvedIcon ? (
             <ResolvedIcon className='h-10 w-10 text-white' />


### PR DESCRIPTION
## Summary
- update docs to `background` instead of `backgroundColor`, the main app was just recently updated to use `background` instead of `backgroundColor` as well, to accommodate gradients 

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)