### PR TITLE
fix(profile-pics): remove sharp depenencey for serving profile pics in settings

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components-new/settings-modal/components/general/general.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components-new/settings-modal/components/general/general.tsx
@@ -291,6 +291,7 @@ export function General({ onOpenChange }: GeneralProps) {
                     alt={profile?.name || 'User'}
                     width={36}
                     height={36}
+                    unoptimized
                     className={`h-full w-full object-cover transition-opacity duration-300 ${
                       isUploadingProfilePicture ? 'opacity-50' : 'opacity-100'
                     }`}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components-new/settings-modal/components/template-profile/template-profile.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components-new/settings-modal/components/template-profile/template-profile.tsx
@@ -348,6 +348,7 @@ export function TemplateProfile() {
                           alt={formData.name || 'Profile picture'}
                           width={36}
                           height={36}
+                          unoptimized
                           className={`h-full w-full object-cover transition-opacity duration-300 ${
                             isUploadingProfilePicture ? 'opacity-50' : 'opacity-100'
                           }`}


### PR DESCRIPTION
## Summary
- remove sharp-based optimization for serving profile pics in settings, was causing issues

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)