### PR TITLE
fix(nextjs-size-limit): surface 413s accurately

### DIFF
--- a/apps/sim/tools/index.ts
+++ b/apps/sim/tools/index.ts
@@ -42,7 +42,7 @@ function validateRequestBodySize(
 ): void {
   if (!body) return
 
-  const bodySize = new Blob([body]).size
+  const bodySize = Buffer.byteLength(body, 'utf8')
   if (bodySize > MAX_REQUEST_BODY_SIZE_BYTES) {
     const bodySizeMB = (bodySize / (1024 * 1024)).toFixed(2)
     const maxSizeMB = (MAX_REQUEST_BODY_SIZE_BYTES / (1024 * 1024)).toFixed(0)


### PR DESCRIPTION
## Summary
Hitting a size limit error randomly truncates payload making error reporting ad hoc. 

## Type of Change
- [x] Bug fix

## Testing
Tested with @aadamgough 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
