### PR TITLE
feat(image): add Fal.ai image generation provider support

### DIFF
--- a/apps/sim/app/api/proxy/image/falai/route.ts
+++ b/apps/sim/app/api/proxy/image/falai/route.ts
@@ -1,0 +1,300 @@
+import { Buffer } from 'node:buffer'
+import { type NextRequest, NextResponse } from 'next/server'
+import { checkHybridAuth } from '@/lib/auth/hybrid'
+import { createLogger } from '@/lib/logs/console/logger'
+import type { FalAIImageResponse } from '@/tools/image/types'
+
+const logger = createLogger('FalAIImageProxyAPI')
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 120 // 2 minutes for image generation
+
+interface FalAIImageRequestBody {
+  provider: string
+  apiKey: string
+  model: string
+  prompt: string
+  size?: string
+  numInferenceSteps?: number
+  enableSafetyChecker?: boolean
+  outputFormat?: string
+  workspaceId?: string
+  workflowId?: string
+  executionId?: string
+}
+
+export async function POST(request: NextRequest) {
+  const requestId = crypto.randomUUID()
+  logger.info(`[${requestId}] Fal.ai image generation request started`)
+
+  try {
+    const authResult = await checkHybridAuth(request, { requireWorkflowId: false })
+    if (!authResult.success) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body: FalAIImageRequestBody = await request.json()
+
+    const {
+      apiKey,
+      model: rawModel,
+      prompt,
+      size,
+      numInferenceSteps,
+      enableSafetyChecker,
+      outputFormat,
+    } = body
+
+    if (!apiKey || !prompt) {
+      return NextResponse.json(
+        { error: 'Missing required fields: apiKey and prompt' },
+        { status: 400 }
+      )
+    }
+
+    if (prompt.length < 1 || prompt.length > 2000) {
+      return NextResponse.json(
+        { error: 'Prompt must be between 1 and 2000 characters' },
+        { status: 400 }
+      )
+    }
+
+    const model = rawModel || 'fal-ai/flux/schnell'
+    const { queueModelId, statusModelId } = normalizeModelId(model)
+
+    logger.info(`[${requestId}] Generating image with Fal.ai model: ${queueModelId}`)
+
+    // Build request body
+    const requestBody: Record<string, unknown> = {
+      prompt,
+      num_images: 1,
+    }
+
+    // Map size to Fal.ai format
+    if (size) {
+      requestBody.image_size = size
+    }
+
+    if (numInferenceSteps !== undefined) {
+      requestBody.num_inference_steps = numInferenceSteps
+    }
+
+    if (enableSafetyChecker !== undefined) {
+      requestBody.enable_safety_checker = enableSafetyChecker
+    }
+
+    if (outputFormat) {
+      requestBody.output_format = outputFormat
+    }
+
+    // Submit to queue
+    const createResponse = await fetch(`https://queue.fal.run/${queueModelId}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Key ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    })
+
+    if (!createResponse.ok) {
+      const error = await createResponse.text()
+      logger.error(`[${requestId}] Fal.ai API error:`, error)
+      return NextResponse.json(
+        { error: `Fal.ai API error: ${createResponse.status} - ${error}` },
+        { status: createResponse.status }
+      )
+    }
+
+    const createData = await createResponse.json()
+    const requestIdFal = createData.request_id
+
+    logger.info(`[${requestId}] Fal.ai request created: ${requestIdFal}`)
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), maxDuration * 1000)
+    const statusUrl = `https://queue.fal.run/${statusModelId}/requests/${requestIdFal}/status/stream?logs=1`
+
+    const statusResponse = await fetch(statusUrl, {
+      headers: {
+        Authorization: `Key ${apiKey}`,
+      },
+      signal: controller.signal,
+    })
+
+    if (!statusResponse.ok || !statusResponse.body) {
+      clearTimeout(timeout)
+      const error = await statusResponse.text().catch(() => 'Failed to read status stream')
+      logger.error(`[${requestId}] Fal.ai status stream error:`, error)
+      return NextResponse.json(
+        { error: `Fal.ai status stream error: ${statusResponse.status} - ${error}` },
+        { status: statusResponse.status || 500 }
+      )
+    }
+
+    const reader = statusResponse.body.getReader()
+    const decoder = new TextDecoder()
+    let streamBuffer = ''
+    let completed = false
+    let failed: string | null = null
+
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      streamBuffer += decoder.decode(value, { stream: true })
+
+      const lines = streamBuffer.split('\n')
+      streamBuffer = lines.pop() || ''
+
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed || trimmed.startsWith(':')) continue
+        if (!trimmed.startsWith('data:')) continue
+
+        const jsonStr = trimmed.slice('data:'.length).trim()
+        if (!jsonStr) continue
+
+        try {
+          const statusData = JSON.parse(jsonStr)
+          const status = statusData.status as string | undefined
+
+          if (status === 'COMPLETED') {
+            completed = true
+            break
+          }
+          if (status === 'FAILED') {
+            failed = statusData.error || 'Fal.ai generation failed'
+            break
+          }
+        } catch (error) {
+          logger.error(`[${requestId}] Failed to parse status event:`, error)
+        }
+      }
+
+      if (completed || failed) {
+        break
+      }
+    }
+
+    clearTimeout(timeout)
+
+    if (failed) {
+      logger.error(`[${requestId}] Fal.ai generation failed:`, failed)
+      return NextResponse.json({ error: failed }, { status: 500 })
+    }
+
+    if (!completed) {
+      return NextResponse.json(
+        { error: 'Fal.ai generation did not complete before stream ended' },
+        { status: 504 }
+      )
+    }
+
+    // Fetch the result
+    const resultResponse = await fetch(
+      `https://queue.fal.run/${statusModelId}/requests/${requestIdFal}`,
+      {
+        headers: {
+          Authorization: `Key ${apiKey}`,
+        },
+      }
+    )
+
+    if (!resultResponse.ok) {
+      const error = await resultResponse.text()
+      logger.error(`[${requestId}] Failed to fetch result:`, error)
+      return NextResponse.json(
+        { error: `Failed to fetch result: ${resultResponse.status} - ${error}` },
+        { status: resultResponse.status }
+      )
+    }
+
+    const resultData: FalAIImageResponse = await resultResponse.json()
+
+    const imageData = resultData.images?.[0]
+    if (!imageData?.url) {
+      return NextResponse.json({ error: 'No image URL in response' }, { status: 500 })
+    }
+
+    // Fetch the image and convert to base64
+    const imageResponse = await fetch(imageData.url)
+    if (!imageResponse.ok) {
+      return NextResponse.json(
+        { error: `Failed to download image: ${imageResponse.status}` },
+        { status: imageResponse.status }
+      )
+    }
+
+    const imageBlob = await imageResponse.blob()
+    const arrayBuffer = await imageBlob.arrayBuffer()
+    const imgBuffer = Buffer.from(arrayBuffer)
+    const base64Image = imgBuffer.toString('base64')
+
+    // Store the image if we have execution context
+    const hasExecutionContext = body.workspaceId && body.workflowId && body.executionId
+
+    if (hasExecutionContext) {
+      const { uploadExecutionFile } = await import('@/lib/uploads/contexts/execution')
+      const timestamp = Date.now()
+      const extension = outputFormat === 'jpeg' ? 'jpg' : 'png'
+      const fileName = `image-falai-${model}-${timestamp}.${extension}`
+      const contentType = outputFormat === 'jpeg' ? 'image/jpeg' : 'image/png'
+
+      try {
+        const imageFile = await uploadExecutionFile(
+          {
+            workspaceId: body.workspaceId!,
+            workflowId: body.workflowId!,
+            executionId: body.executionId!,
+          },
+          imgBuffer,
+          fileName,
+          contentType,
+          authResult.userId
+        )
+
+        logger.info(`[${requestId}] Image stored successfully:`, {
+          fileName,
+          size: imageFile.size,
+          executionId: body.executionId,
+        })
+
+        return NextResponse.json({
+          imageUrl: imageFile.url,
+          image: base64Image,
+          model: model || 'flux-schnell',
+          width: imageData.width,
+          height: imageData.height,
+          contentType: imageData.content_type,
+        })
+      } catch (error) {
+        logger.error(`[${requestId}] Failed to upload image file:`, error)
+        // Continue without storage, return base64
+      }
+    }
+
+    return NextResponse.json({
+      imageUrl: imageData.url,
+      image: base64Image,
+      model: model || 'flux-schnell',
+      width: imageData.width,
+      height: imageData.height,
+      contentType: imageData.content_type,
+    })
+  } catch (error) {
+    logger.error(`[${requestId}] Fal.ai image proxy error:`, error)
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: errorMessage }, { status: 500 })
+  }
+}
+
+function normalizeModelId(model: string): { queueModelId: string; statusModelId: string } {
+  // For status/result requests, subpath should be stripped (per Fal queue docs)
+  const parts = model.split('/').filter(Boolean)
+  if (parts.length <= 2) {
+    return { queueModelId: model, statusModelId: model }
+  }
+  const statusModelId = `${parts[0]}/${parts[1]}`
+  return { queueModelId: model, statusModelId }
+}
+

--- a/apps/sim/tools/image/falai.ts
+++ b/apps/sim/tools/image/falai.ts
@@ -1,0 +1,137 @@
+import type { ToolConfig } from '@/tools/types'
+import type { ImageParams, ImageResponse } from '@/tools/image/types'
+
+export const falaiImageTool: ToolConfig<ImageParams, ImageResponse> = {
+  id: 'falai_image',
+  name: 'Fal.ai Image Generation',
+  description:
+    'Generate images using Fal.ai platform with access to FLUX models including Schnell, Dev, Pro, and more',
+  version: '1.0.0',
+
+  params: {
+    provider: {
+      type: 'string',
+      required: true,
+      visibility: 'user-only',
+      description: 'Image provider (falai)',
+    },
+    apiKey: {
+      type: 'string',
+      required: true,
+      visibility: 'user-only',
+      description: 'Fal.ai API key',
+    },
+    model: {
+      type: 'string',
+      required: true,
+      visibility: 'user-or-llm',
+      description:
+        'Fal.ai model path (e.g., fal-ai/flux/schnell, fal-ai/flux/dev, fal-ai/flux-pro/v1.1)',
+    },
+    prompt: {
+      type: 'string',
+      required: true,
+      visibility: 'user-or-llm',
+      description: 'Text prompt describing the image to generate',
+    },
+    size: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description:
+        'Image size: square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9',
+    },
+    numInferenceSteps: {
+      type: 'number',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Number of inference steps (1-50, default varies by model)',
+    },
+    enableSafetyChecker: {
+      type: 'boolean',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Enable safety checker (default: true)',
+    },
+    outputFormat: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Output format: png or jpeg (default: png)',
+    },
+  },
+
+  request: {
+    url: '/api/proxy/image/falai',
+    method: 'POST',
+    headers: () => ({
+      'Content-Type': 'application/json',
+    }),
+    body: (
+      params: ImageParams & {
+        _context?: { workspaceId?: string; workflowId?: string; executionId?: string }
+      }
+    ) => ({
+      provider: 'falai',
+      apiKey: params.apiKey,
+      model: params.model,
+      prompt: params.prompt,
+      size: params.size,
+      numInferenceSteps: params.numInferenceSteps,
+      enableSafetyChecker: params.enableSafetyChecker,
+      outputFormat: params.outputFormat,
+      workspaceId: params._context?.workspaceId,
+      workflowId: params._context?.workflowId,
+      executionId: params._context?.executionId,
+    }),
+  },
+
+  transformResponse: async (response: Response) => {
+    const data = await response.json()
+
+    if (!response.ok || data.error) {
+      return {
+        success: false,
+        error: data.error || 'Image generation failed',
+        output: {
+          content: '',
+          image: '',
+          metadata: {
+            model: '',
+          },
+        },
+      }
+    }
+
+    return {
+      success: true,
+      output: {
+        content: data.imageUrl || '',
+        image: data.image || '',
+        metadata: {
+          model: data.model || '',
+          provider: 'falai',
+          width: data.width,
+          height: data.height,
+          contentType: data.contentType,
+        },
+      },
+    }
+  },
+
+  outputs: {
+    content: { type: 'string', description: 'Image URL' },
+    image: { type: 'string', description: 'Base64 encoded image data' },
+    metadata: {
+      type: 'object',
+      description: 'Image generation metadata',
+      properties: {
+        model: { type: 'string', description: 'Model used for image generation' },
+        provider: { type: 'string', description: 'Provider used (falai)' },
+        width: { type: 'number', description: 'Image width in pixels' },
+        height: { type: 'number', description: 'Image height in pixels' },
+        contentType: { type: 'string', description: 'Image content type' },
+      },
+    },
+  },
+}

--- a/apps/sim/tools/image/index.ts
+++ b/apps/sim/tools/image/index.ts
@@ -1,0 +1,3 @@
+import { falaiImageTool } from '@/tools/image/falai'
+
+export { falaiImageTool }

--- a/apps/sim/tools/image/types.ts
+++ b/apps/sim/tools/image/types.ts
@@ -1,0 +1,55 @@
+import type { ToolResponse } from '@/tools/types'
+
+export interface ImageParams {
+  provider: 'openai' | 'falai'
+  apiKey: string
+  model?: string
+  prompt: string
+  size?: string
+  aspectRatio?: string
+  quality?: string
+  style?: string
+  background?: string
+  numInferenceSteps?: number
+  enableSafetyChecker?: boolean
+  outputFormat?: string
+}
+
+export interface ImageResponse extends ToolResponse {
+  output: {
+    content: string // Image URL or identifier
+    image: string // Base64 encoded image data
+    metadata: {
+      model: string
+      provider?: string
+      width?: number
+      height?: number
+      contentType?: string
+    }
+  }
+}
+
+export interface FalAIImageRequestBody {
+  prompt: string
+  image_size?: string | { width: number; height: number }
+  num_inference_steps?: number
+  num_images?: number
+  seed?: number
+  enable_safety_checker?: boolean
+  output_format?: string
+}
+
+export interface FalAIImageResponse {
+  images: Array<{
+    url: string
+    width: number
+    height: number
+    content_type: string
+  }>
+  timings?: {
+    inference: number
+  }
+  seed?: number
+  has_nsfw_concepts?: boolean[]
+  prompt?: string
+}

--- a/apps/sim/tools/registry.ts
+++ b/apps/sim/tools/registry.ts
@@ -742,6 +742,7 @@ import {
   onedriveListTool,
   onedriveUploadTool,
 } from '@/tools/onedrive'
+import { falaiImageTool } from '@/tools/image'
 import { openAIEmbeddingsTool, openAIImageTool } from '@/tools/openai'
 import {
   outlookCopyTool,
@@ -1969,6 +1970,7 @@ export const tools: Record<string, ToolConfig> = {
   datadog_list_downtimes: datadogListDowntimesTool,
   datadog_cancel_downtime: datadogCancelDowntimeTool,
   openai_image: openAIImageTool,
+  falai_image: falaiImageTool,
   microsoft_teams_read_chat: microsoftTeamsReadChatTool,
   microsoft_teams_write_chat: microsoftTeamsWriteChatTool,
   microsoft_teams_read_channel: microsoftTeamsReadChannelTool,


### PR DESCRIPTION
## Summary
Added Fal.ai as an image generation provider alongside OpenAI. Implemented proxy API endpoint for Fal.ai with streaming status support, queue-based generation, and execution file storage. Updated image generator block to support provider selection with conditional model and parameter fields for both OpenAI (DALL-E 3, GPT Image) and Fal.ai models.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How has this been tested? What should reviewers focus on?

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<img width="939" height="690" alt="image" src="https://github.com/user-attachments/assets/1379ee98-fe40-4594-80e1-64db18822c7a" />




I haven't tested it yet throughly. Also I believe openai image can be moved from openai folder to image folder and all image generation providers can implemented there. 