### PR TITLE
fix(cron): reject CRON requests when CRON secret is not set

### DIFF
--- a/apps/sim/app/api/workflows/middleware.ts
+++ b/apps/sim/app/api/workflows/middleware.ts
@@ -42,7 +42,7 @@ export async function validateWorkflowAccess(
       }
 
       const internalSecret = request.headers.get('X-Internal-Secret')
-      if (internalSecret === env.INTERNAL_API_SECRET) {
+      if (env.INTERNAL_API_SECRET && internalSecret === env.INTERNAL_API_SECRET) {
         return { workflow }
       }
 

--- a/apps/sim/lib/auth/internal.ts
+++ b/apps/sim/lib/auth/internal.ts
@@ -69,6 +69,16 @@ export async function verifyInternalToken(
  * Returns null if authorized, or a NextResponse with error if unauthorized
  */
 export function verifyCronAuth(request: NextRequest, context?: string): NextResponse | null {
+  if (!env.CRON_SECRET) {
+    const contextInfo = context ? ` for ${context}` : ''
+    logger.warn(`CRON endpoint accessed but CRON_SECRET is not configured${contextInfo}`, {
+      ip: request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip') ?? 'unknown',
+      userAgent: request.headers.get('user-agent') ?? 'unknown',
+      context,
+    })
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const authHeader = request.headers.get('authorization')
   const expectedAuth = `Bearer ${env.CRON_SECRET}`
   if (authHeader !== expectedAuth) {


### PR DESCRIPTION
## Summary
- reject CRON requests when CRON secret is not set
  - the reason CRON_SECRET is not required and is optional is because not everyone OSS user has the cron jobs setup to run, but when we validateCronAuth we ensure that the user has it set 

thanks to https://github.com/H2u8s for pointing this out

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)