### PR TITLE
fix(subflows): prevent cross-boundary connections on autoconnect drop between subflow blocks and regular blocks

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -579,8 +579,10 @@ const WorkflowContent = React.memo(() => {
           const node = nodeIndex.get(id)
           if (!node) return false
 
-          // If dropping outside containers, ignore blocks that are inside a container
-          if (!containerAtPoint && blocks[id]?.data?.parentId) return false
+          const blockParentId = blocks[id]?.data?.parentId
+          const dropParentId = containerAtPoint?.loopId
+          if (dropParentId !== blockParentId) return false
+
           return true
         })
         .map(([id, block]) => {


### PR DESCRIPTION
## Summary
- prevent cross-boundary connections on autoconnect drop between subflow blocks and regular blocks

## Type of Change
- [x] Bug fix

## Testing
Tested manually


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)