### PR TITLE
fix(organizations): move organization better-auth client to conditionally be included based on FF

### DIFF
--- a/apps/sim/lib/auth/auth-client.ts
+++ b/apps/sim/lib/auth/auth-client.ts
@@ -42,7 +42,9 @@ export function useSession(): SessionHookResult {
   return ctx
 }
 
-export const { useActiveOrganization } = client
+export const useActiveOrganization = isBillingEnabled
+  ? client.useActiveOrganization
+  : () => ({ data: undefined, isPending: false, error: null })
 
 export const useSubscription = () => {
   return {


### PR DESCRIPTION
## Summary
- move organization better-auth client to conditionally be included based on FF
- since we have it conditionally included on the server `auth.ts` and enabled all the time on the client, it always checked for an org and got a 404 back every time, but now they are aligned

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)