### PR TITLE
feat: enable light mode and add theme toggle in sidebar

### DIFF
--- a/apps/sim/app/_shell/providers/theme-provider.tsx
+++ b/apps/sim/app/_shell/providers/theme-provider.tsx
@@ -29,7 +29,7 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
       enableSystem={false}
       disableTransitionOnChange
       storageKey='sim-theme'
-      forcedTheme={isLightModePage ? 'light' : 'dark'}
+      forcedTheme={isLightModePage ? 'light' : undefined}
       {...props}
     >
       {children}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowDown, Database, HelpCircle, Layout, Plus, Search, Settings } from 'lucide-react'
+import { ArrowDown, Database, HelpCircle, Layout, Plus, Search, Settings, Sun, Moon } from 'lucide-react'
+import { useTheme } from 'next-themes'
 import Link from 'next/link'
 import { useParams, usePathname, useRouter } from 'next/navigation'
 import { Button, FolderPlus, Library, Tooltip } from '@/components/emcn'
@@ -59,6 +60,7 @@ export function Sidebar() {
   const workflowId = params.workflowId as string | undefined
   const router = useRouter()
   const pathname = usePathname()
+  const { theme, setTheme } = useTheme()
 
   const sidebarRef = useRef<HTMLElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -219,8 +221,14 @@ export function Sidebar() {
         icon: Settings,
         onClick: () => setIsSettingsModalOpen(true),
       },
+      {
+        id: 'theme',
+        label: theme === 'light' ? 'Dark Mode' : 'Light Mode',
+        icon: theme === 'light' ? Moon : Sun,
+        onClick: () => setTheme(theme === 'light' ? 'dark' : 'light'),
+      },
     ],
-    [workspaceId]
+    [workspaceId, theme]
   )
 
   const isLoading = workflowsLoading || sessionLoading


### PR DESCRIPTION
Fixes

Fixes #2372

Type of Change
	•	Bug fix
	•	New feature
	•	Breaking change
	•	Documentation
	•	Other: UI/UX enhancement

Description

This PR adds Light Mode support along with a theme toggle in the sidebar.
Users can now switch between light and dark themes easily, improving accessibility and overall user experience. The selected theme persists across sessions.

Testing
	•	Manually tested theme switching between Light and Dark modes
	•	Verified styles across main pages and components
	•	Checked persistence on page reload
	•	Ensured no visual regressions in existing dark mode

Reviewers can focus on:
	•	UI consistency in light mode
	•	Sidebar toggle behavior
	•	Theme persistence logic

Checklist
	•	Code follows project style guidelines
	•	Self-reviewed my changes
	•	Tests added/updated (not applicable for UI-only change)
	•	No new warnings introduced
	•	I confirm that I have read and agree to the terms outlined in the CLA
