### PR TITLE
docs: clarify working directory for drizzle migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ DATABASE_URL="postgresql://postgres:your_password@localhost:5432/simstudio"
 
 Then run the migrations:
 ```bash
+cd apps/sim # Required so drizzle picks correct .env file
 bunx drizzle-kit migrate --config=./drizzle.config.ts
 ```
 


### PR DESCRIPTION
Added a note to Self-hosted: Manual Setup that you should `cd apps/sim` before running `bunx drizzle-kit migrate` so that drizzle picks up the correct .env file.

## Summary
Clarifies that the user must change into `apps/sim` before running the database migration to ensure the correct `.env` file is used.

Fixes #N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [x] Documentation
- [ ] Other: ___________

## Testing
Reviewed locally by following the setup steps in the documentation to ensure the added note makes the migration command clear.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
