### PR TITLE
fix: prevent URL encoding for spaces

### DIFF
--- a/apps/sim/app/(landing)/components/footer/footer.tsx
+++ b/apps/sim/app/(landing)/components/footer/footer.tsx
@@ -109,7 +109,7 @@ export default function Footer({ fullWidth = false }: FooterProps) {
               {FOOTER_BLOCKS.map((block) => (
                 <Link
                   key={block}
-                  href={`https://docs.sim.ai/blocks/${block.toLowerCase().replace(' ', '-')}`}
+                  href={`https://docs.sim.ai/blocks/${block.toLowerCase().replaceAll(' ', '-')}`}
                   target='_blank'
                   rel='noopener noreferrer'
                   className='text-[14px] text-muted-foreground transition-colors hover:text-foreground'


### PR DESCRIPTION
## Summary
Brief description of what this PR does and why.
fix: use replaceAll for footer block URLs to handle multi-word names which fixes issue where "Human In The Loop" was generating 
/blocks/human-in%20the%20loop instead of /blocks/human-in-the-loop
by replacing only the first space. Changed to replaceAll(' ', '-') 
to handle all spaces correctly.

Fixes #(issue)

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How has this been tested? What should reviewers focus on?
Click on Human In The Loop from site's footer block it will redirect to 404 - https://docs.sim.ai/blocks/human-in%20the%20loop

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
