### PR TITLE
fix(wand): should not be able to use wand ui without write/admin perms

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
@@ -157,6 +157,7 @@ const renderLabel = (
     isWandEnabled: boolean
     isPreview: boolean
     isStreaming: boolean
+    disabled: boolean
     onSearchClick: () => void
     onSearchBlur: () => void
     onSearchChange: (value: string) => void
@@ -175,6 +176,7 @@ const renderLabel = (
     isWandEnabled,
     isPreview,
     isStreaming,
+    disabled,
     onSearchClick,
     onSearchBlur,
     onSearchChange,
@@ -208,7 +210,7 @@ const renderLabel = (
       </div>
 
       {/* Wand inline prompt */}
-      {isWandEnabled && !isPreview && (
+      {isWandEnabled && !isPreview && !disabled && (
         <div className='flex min-w-0 flex-1 items-center justify-end pr-[4px]'>
           {!isSearchActive ? (
             <Button
@@ -824,6 +826,7 @@ function SubBlockComponent({
           isWandEnabled,
           isPreview,
           isStreaming: wandControlRef.current?.isWandStreaming ?? false,
+          disabled: isDisabled,
           onSearchClick: handleSearchClick,
           onSearchBlur: handleSearchBlur,
           onSearchChange: handleSearchChange,


### PR DESCRIPTION
## Summary

Should not be able to use wand ui without write/admin perms.

## Type of Change
- [x] Bug fix


## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)