### PR TITLE
fix(permissions): add client-side hints to prevent read-only users from creating workflows or folders

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -9,6 +9,7 @@ import { useSession } from '@/lib/auth/auth-client'
 import { getEnv, isTruthy } from '@/lib/core/config/env'
 import { createLogger } from '@/lib/logs/console/logger'
 import { useRegisterGlobalCommands } from '@/app/workspace/[workspaceId]/providers/global-commands-provider'
+import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
 import { createCommands } from '@/app/workspace/[workspaceId]/utils/commands-utils'
 import {
   HelpModal,
@@ -65,6 +66,7 @@ export function Sidebar() {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   const { data: sessionData, isPending: sessionLoading } = useSession()
+  const { canEdit } = useUserPermissionsContext()
 
   /**
    * Sidebar state from store with hydration tracking to prevent SSR mismatch.
@@ -516,7 +518,7 @@ export function Sidebar() {
                             variant='ghost'
                             className='translate-y-[-0.25px] p-[1px]'
                             onClick={handleImportWorkflow}
-                            disabled={isImporting}
+                            disabled={isImporting || !canEdit}
                           >
                             <ArrowDown className='h-[14px] w-[14px]' />
                           </Button>
@@ -531,7 +533,7 @@ export function Sidebar() {
                             variant='ghost'
                             className='mr-[1px] translate-y-[-0.25px] p-[1px]'
                             onClick={handleCreateFolder}
-                            disabled={isCreatingFolder}
+                            disabled={isCreatingFolder || !canEdit}
                           >
                             <FolderPlus className='h-[14px] w-[14px]' />
                           </Button>
@@ -546,7 +548,7 @@ export function Sidebar() {
                             variant='outline'
                             className='translate-y-[-0.25px] p-[1px]'
                             onClick={handleCreateWorkflow}
-                            disabled={isCreatingWorkflow}
+                            disabled={isCreatingWorkflow || !canEdit}
                           >
                             <Plus className='h-[14px] w-[14px]' />
                           </Button>


### PR DESCRIPTION
## Summary
- add client-side hints to prevent read-only users from creating workflows or folders
  - we already rejected this on the server-side, but the buttons themselves were not disabled 

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)