### PR TITLE
feat(blocks): add Webhook tool for sending HTTP requests

### DIFF
--- a/apps/sim/blocks/blocks/webhook_notification.ts
+++ b/apps/sim/blocks/blocks/webhook_notification.ts
@@ -1,0 +1,96 @@
+import { createElement, type SVGProps } from 'react'
+import { Webhook } from 'lucide-react'
+import type { BlockConfig } from '@/blocks/types'
+import type { RequestResponse } from '@/tools/http/types'
+
+const WebhookIcon = (props: SVGProps<SVGSVGElement>) => createElement(Webhook, props)
+
+/**
+ * Webhook block for sending HTTP requests to external endpoints.
+ * Can be used standalone, as an agent tool, or for notifications.
+ */
+export const WebhookNotificationBlock: BlockConfig<RequestResponse> = {
+  type: 'webhook_notification',
+  name: 'Webhook',
+  description: 'Send HTTP requests to webhook endpoints',
+  longDescription:
+    'Send HTTP POST/PUT/PATCH requests to external webhook URLs. Integrate with services like Slack, Discord, Jira, ServiceNow, or any custom endpoint that accepts webhooks.',
+  category: 'tools',
+  bgColor: '#10B981',
+  icon: WebhookIcon,
+  subBlocks: [
+    {
+      id: 'url',
+      title: 'URL',
+      type: 'short-input',
+      placeholder: 'https://hooks.example.com/webhook',
+      required: true,
+    },
+    {
+      id: 'method',
+      title: 'Method',
+      type: 'dropdown',
+      options: [
+        { label: 'POST', id: 'POST' },
+        { label: 'PUT', id: 'PUT' },
+        { label: 'PATCH', id: 'PATCH' },
+      ],
+      value: () => 'POST',
+    },
+    {
+      id: 'headers',
+      title: 'Headers',
+      type: 'table',
+      columns: ['Key', 'Value'],
+      description: 'Custom headers (e.g., Authorization, Content-Type)',
+    },
+    {
+      id: 'body',
+      title: 'Body',
+      type: 'code',
+      placeholder: `{
+  "event": "workflow_completed",
+  "data": "<agent1.content>",
+  "timestamp": "<function1.output>"
+}`,
+      wandConfig: {
+        enabled: true,
+        maintainHistory: true,
+        prompt: `You are an expert JSON programmer.
+Generate ONLY the raw JSON object based on the user's request.
+The output MUST be a single, valid JSON object, starting with { and ending with }.
+
+Current body: {context}
+
+Do not include any explanations, markdown formatting, or other text outside the JSON object.
+
+You have access to workflow variables using angle bracket syntax, e.g., <blockName.output>.
+
+Example:
+{
+  "event": "data_processed",
+  "payload": "<agent1.content>",
+  "metadata": {
+    "workflowId": "<start.workflowId>"
+  }
+}`,
+        placeholder: 'Describe the webhook payload...',
+        generationType: 'json-object',
+      },
+    },
+  ],
+  tools: {
+    access: ['http_request'],
+  },
+  inputs: {
+    url: { type: 'string', description: 'Webhook URL to send the request to' },
+    method: { type: 'string', description: 'HTTP method (POST, PUT, PATCH)' },
+    headers: { type: 'json', description: 'Request headers as key-value pairs' },
+    body: { type: 'json', description: 'Request body (JSON)' },
+  },
+  outputs: {
+    data: { type: 'json', description: 'Response data from the webhook endpoint' },
+    status: { type: 'number', description: 'HTTP status code' },
+    headers: { type: 'json', description: 'Response headers' },
+  },
+}

--- a/apps/sim/blocks/registry.ts
+++ b/apps/sim/blocks/registry.ts
@@ -125,6 +125,7 @@ import { WaitBlock } from '@/blocks/blocks/wait'
 import { WealthboxBlock } from '@/blocks/blocks/wealthbox'
 import { WebflowBlock } from '@/blocks/blocks/webflow'
 import { WebhookBlock } from '@/blocks/blocks/webhook'
+import { WebhookNotificationBlock } from '@/blocks/blocks/webhook_notification'
 import { WhatsAppBlock } from '@/blocks/blocks/whatsapp'
 import { WikipediaBlock } from '@/blocks/blocks/wikipedia'
 import { WordPressBlock } from '@/blocks/blocks/wordpress'
@@ -268,6 +269,7 @@ export const registry: Record<string, BlockConfig> = {
   wealthbox: WealthboxBlock,
   webflow: WebflowBlock,
   webhook: WebhookBlock,
+  webhook_notification: WebhookNotificationBlock,
   whatsapp: WhatsAppBlock,
   wikipedia: WikipediaBlock,
   wordpress: WordPressBlock,


### PR DESCRIPTION
Adds a new **Webhook** tool block that allows sending HTTP requests to external webhook endpoints. This fixes the bug where users couldn't find a Webhook option in the Human in the Loop notification section as documented.

The block has `category: 'tools'` so it appears in:
- Human in the Loop notification dropdown (fixes the reported bug)
- Agent block's tool selector (enables agents to call webhooks)

Fixes #2379

## Type of Change
- [x] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
1. Open a workflow with a Human in the Loop block
2. Click the Notification field
3. Verify "Webhook" now appears in the tool dropdown
4. Configure URL, method, headers, and body
5. Test the webhook sends correctly when HITL pauses

Also verify the Webhook tool appears in Agent block's tool selector.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

<img width="395" height="173" alt="Screenshot 2025-12-16 at 14 45 12" src="https://github.com/user-attachments/assets/061800f4-64b7-4388-98b5-d45225755521" />

