### PR TITLE
feat[ui]: enable light/dark mode toggle and fix light theme colors

### DIFF
--- a/apps/sim/app/_shell/providers/theme-provider.tsx
+++ b/apps/sim/app/_shell/providers/theme-provider.tsx
@@ -29,7 +29,7 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
       enableSystem={false}
       disableTransitionOnChange
       storageKey='sim-theme'
-      forcedTheme={isLightModePage ? 'light' : 'dark'}
+      forcedTheme={isLightModePage ? 'light' : undefined}
       {...props}
     >
       {children}

--- a/apps/sim/app/_styles/globals.css
+++ b/apps/sim/app/_styles/globals.css
@@ -717,7 +717,7 @@ input[type="search"]::-ms-clear {
     --brand-accent-hex: #6f3dfa;
     --brand-accent-hover-hex: #6f3dfa;
     --brand-background-hex: #ffffff;
-    --surface-elevated: #202020;
+    --surface-elevated: #ffffff; 
   }
 
   .dark {

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/settings-modal/components/general/general.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/settings-modal/components/general/general.tsx
@@ -224,8 +224,9 @@ export function General({ onOpenChange }: GeneralProps) {
     }
   }
 
-  const handleThemeChange = async (value: string) => {
-    await updateSetting.mutateAsync({ key: 'theme', value: value as 'system' | 'light' | 'dark' })
+  const handleThemeChange = async (checked: boolean) => {
+    const newTheme = checked ? 'dark' : 'light'
+    await updateSetting.mutateAsync({ key: 'theme', value: newTheme })
   }
 
   const handleAutoConnectChange = async (checked: boolean) => {
@@ -384,27 +385,18 @@ export function General({ onOpenChange }: GeneralProps) {
       </div>
       {uploadError && <p className='text-[13px] text-[var(--text-error)]'>{uploadError}</p>}
 
-      {/* <div className='flex items-center justify-between border-b pb-[12px]'>
-        <Label htmlFor='theme-select'>Theme</Label>
-        <div className='w-[100px]'>
-          <Combobox
-            size='sm'
-            align='end'
-            dropdownWidth={140}
-            value={settings?.theme}
-            onChange={handleThemeChange}
-            disabled={updateSetting.isPending}
-            placeholder='Select theme'
-            options={[
-              { label: 'System', value: 'system' },
-              { label: 'Light', value: 'light' },
-              { label: 'Dark', value: 'dark' },
-            ]}
-          />
-        </div>
-      </div> */}
+      <div className='flex items-center justify-between'>
+        <Label htmlFor='dark-mode'>Dark Mode</Label>
+        <Switch
+          id='dark-mode'
+          // Check if theme is specifically set to dark
+          checked={settings?.theme === 'dark'}
+          onCheckedChange={handleThemeChange}
+          disabled={updateSetting.isPending}
+        />
+      </div>
 
-      <div className='flex items-center justify-between pt-[12px]'>
+      <div className='flex items-center justify-between'>
         <Label htmlFor='auto-connect'>Auto-connect on drop</Label>
         <Switch
           id='auto-connect'

--- a/apps/sim/components/emcn/components/switch/switch.tsx
+++ b/apps/sim/components/emcn/components/switch/switch.tsx
@@ -24,9 +24,8 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        'pointer-events-none block h-[14px] w-[14px] rounded-full shadow-sm ring-0 transition-transform',
-        'bg-[var(--text-primary)] data-[state=checked]:bg-[var(--white)]',
-        'data-[state=checked]:translate-x-[14px] data-[state=unchecked]:translate-x-[2px]'
+        'pointer-events-none block h-[14px] w-[14px] rounded-full shadow-sm ring-0 transition-transform bg-white',
+        'data-[state=checked]:translate-x-[14px] data-[state=unchecked]:translate-x-[2px]',
       )}
     />
   </SwitchPrimitives.Root>

--- a/apps/sim/hooks/queries/general-settings.ts
+++ b/apps/sim/hooks/queries/general-settings.ts
@@ -43,9 +43,7 @@ async function fetchGeneralSettings(): Promise<GeneralSettings> {
     autoConnect: data.autoConnect ?? true,
     showTrainingControls: data.showTrainingControls ?? false,
     superUserModeEnabled: data.superUserModeEnabled ?? true,
-    // theme: data.theme || 'system',
-    // Force dark mode - light mode is temporarily disabled (TODO: Remove this)
-    theme: 'dark' as const,
+    theme: data.theme || 'system',
     telemetryEnabled: data.telemetryEnabled ?? true,
     billingUsageNotificationsEnabled: data.billingUsageNotificationsEnabled ?? true,
     errorNotificationsEnabled: data.errorNotificationsEnabled ?? true,

--- a/apps/sim/lib/core/utils/theme.ts
+++ b/apps/sim/lib/core/utils/theme.ts
@@ -5,30 +5,32 @@
 /**
  * Updates the theme in next-themes by dispatching a storage event.
  * This works by updating localStorage and notifying next-themes of the change.
- * NOTE: Light mode is temporarily disabled - this function always forces dark mode.
- * @param _theme - The theme parameter (currently ignored, dark mode is forced)
+ * @param _theme - The theme parameter
  */
 export function syncThemeToNextThemes(_theme: 'system' | 'light' | 'dark') {
   if (typeof window === 'undefined') return
 
-  // Force dark mode - light mode is temporarily disabled
-  const forcedTheme = 'dark'
-
-  localStorage.setItem('sim-theme', forcedTheme)
+  localStorage.setItem('sim-theme', _theme)
 
   window.dispatchEvent(
     new StorageEvent('storage', {
       key: 'sim-theme',
-      newValue: forcedTheme,
+      newValue: _theme,
       oldValue: localStorage.getItem('sim-theme'),
       storageArea: localStorage,
       url: window.location.href,
-    })
+    }),
   )
 
   const root = document.documentElement
   root.classList.remove('light', 'dark')
-  root.classList.add('dark')
+  
+  if (_theme === 'system') {
+    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    root.classList.add(systemTheme)
+  } else {
+    root.classList.add(_theme)
+  }
 }
 
 /**
@@ -36,5 +38,8 @@ export function syncThemeToNextThemes(_theme: 'system' | 'light' | 'dark') {
  */
 export function getThemeFromNextThemes(): 'system' | 'light' | 'dark' {
   if (typeof window === 'undefined') return 'system'
-  return (localStorage.getItem('sim-theme') as 'system' | 'light' | 'dark') || 'system'
+  return (
+    (localStorage.getItem('sim-theme') as 'system' | 'light' | 'dark') ||
+    'system'
+  )
 }


### PR DESCRIPTION
Enabled the ability to toggle between Light and Dark modes in the General settings. Previously, the app was forced into Dark mode. This change also includes minor color refinements to the Switch Thumb to ensure proper contrast in light mode.

## Summary
Brief description of what this PR does and why.

Fixes #(issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How has this been tested? What should reviewers focus on?

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
https://github.com/user-attachments/assets/1941b504-af39-483c-beb2-59314d5ce960



