### PR TITLE
fix(chat): fix stale closure in workflow runner for chat

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -655,6 +655,7 @@ export function useWorkflowExecution() {
       setExecutor,
       setPendingBlocks,
       setActiveBlocks,
+      workflows,
     ]
   )
 


### PR DESCRIPTION
## Summary
-  fix stale closure in workflow runner for chat
  - workspaceId is not present for chat execution run and causes react stale closure that sends infinite messages without triggering the workflow -> forces user to clear cache to get it to work 

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)