### PR TITLE
fix(terminal): fix text wrap for errors and messages with long strings

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/terminal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/terminal.tsx
@@ -1741,7 +1741,7 @@ export function Terminal() {
               )}
 
               {/* Content */}
-              <div className='flex-1 overflow-x-auto overflow-y-auto'>
+              <div className={clsx('flex-1 overflow-y-auto', !wrapText && 'overflow-x-auto')}>
                 {shouldShowCodeDisplay ? (
                   <OutputCodeContent
                     code={selectedEntry.input.code}

--- a/apps/sim/components/emcn/components/code/code.tsx
+++ b/apps/sim/components/emcn/components/code/code.tsx
@@ -291,7 +291,7 @@ function CodeRow({ index, style, ...props }: RowComponentProps<CodeRowProps>) {
   const line = lines[index]
 
   return (
-    <div style={style} className='flex' data-row-index={index}>
+    <div style={style} className={cn('flex', wrapText && 'overflow-hidden')} data-row-index={index}>
       {showGutter && (
         <div
           className='flex-shrink-0 select-none pr-0.5 text-right text-[var(--text-muted)] text-xs tabular-nums leading-[21px] dark:text-[#a8a8a8]'
@@ -303,7 +303,7 @@ function CodeRow({ index, style, ...props }: RowComponentProps<CodeRowProps>) {
       <pre
         className={cn(
           'm-0 flex-1 pr-2 pl-2 font-mono text-[13px] text-[var(--text-primary)] leading-[21px] dark:text-[#eeeeee]',
-          wrapText ? 'whitespace-pre-wrap break-words' : 'whitespace-pre'
+          wrapText ? 'min-w-0 whitespace-pre-wrap break-words' : 'whitespace-pre'
         )}
         dangerouslySetInnerHTML={{ __html: line.html || '&nbsp;' }}
       />
@@ -625,7 +625,7 @@ const VirtualizedViewerInner = memo(function VirtualizedViewerInner({
         rowComponent={CodeRow}
         rowProps={rowProps}
         overscanCount={5}
-        className='overflow-x-auto'
+        className={wrapText ? 'overflow-x-hidden' : 'overflow-x-auto'}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- fix text wrap for errors and messages with long strings

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Before (Wrap enabled):
<img width="1814" height="1226" alt="Screenshot 2025-12-17 at 1 36 29 PM" src="https://github.com/user-attachments/assets/54e01340-7ad2-4c5f-8800-47b7f3aed81a" />

After (Wrap enabled):
<img width="1662" height="1293" alt="Screenshot 2025-12-17 at 1 36 44 PM" src="https://github.com/user-attachments/assets/1b36d91f-2b08-4e41-8500-b5f5436d9e52" />