### PR TITLE
fix(custom-tools): added missing _toolSchema to internal param set for agents calling custom tools

### DIFF
--- a/apps/sim/tools/index.ts
+++ b/apps/sim/tools/index.ts
@@ -766,6 +766,7 @@ function validateClientSideParams(
   // Internal parameters that should be excluded from validation
   const internalParamSet = new Set([
     '_context',
+    '_toolSchema',
     'workflowId',
     'envVars',
     'workflowVariables',


### PR DESCRIPTION
## Summary
- added missing _toolSchema to internal param set for agents calling custom tools

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)