### PR TITLE
feat(docs): added 404 page for the docs

### DIFF
--- a/apps/docs/app/[lang]/not-found.tsx
+++ b/apps/docs/app/[lang]/not-found.tsx
@@ -1,5 +1,9 @@
 import { DocsBody, DocsPage } from 'fumadocs-ui/page'
 
+export const metadata = {
+  title: 'Page Not Found',
+}
+
 export default function NotFound() {
   return (
     <DocsPage>


### PR DESCRIPTION
## Summary
- added 404 page for the docs instead of generic nextjs 404, maintains the same docs layout

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)