### PR TITLE
improvement(hitl): show resume url in tag dropdown within hitl block

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/tag-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/tag-dropdown.tsx
@@ -964,10 +964,7 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
             const outputPaths = getBlockOutputPaths(accessibleBlock.type, mergedSubBlocks, true)
             blockTags = outputPaths.map((path) => `${normalizedBlockName}.${path}`)
           }
-        } else if (
-          accessibleBlock.type === 'approval' ||
-          accessibleBlock.type === 'human_in_the_loop'
-        ) {
+        } else if (accessibleBlock.type === 'approval') {
           const dynamicOutputs = getBlockOutputPaths(accessibleBlock.type, mergedSubBlocks)
 
           const isSelfReference = accessibleBlockId === blockId
@@ -980,6 +977,8 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
             const allTags = outputPaths.map((path) => `${normalizedBlockName}.${path}`)
             blockTags = isSelfReference ? allTags.filter((tag) => tag.endsWith('.url')) : allTags
           }
+        } else if (accessibleBlock.type === 'human_in_the_loop') {
+          blockTags = [`${normalizedBlockName}.url`]
         } else {
           const operationValue =
             mergedSubBlocks?.operation?.value ?? getSubBlockValue(accessibleBlockId, 'operation')

--- a/apps/sim/lib/workflows/blocks/block-outputs.ts
+++ b/apps/sim/lib/workflows/blocks/block-outputs.ts
@@ -225,7 +225,14 @@ export function getBlockOutputs(
     return getUnifiedStartOutputs(subBlocks)
   }
 
-  if (blockType === 'approval' || blockType === 'human_in_the_loop') {
+  if (blockType === 'human_in_the_loop') {
+    // For human_in_the_loop, only expose url (inputFormat fields are only available after resume)
+    return {
+      url: { type: 'string', description: 'Resume UI URL' },
+    }
+  }
+
+  if (blockType === 'approval') {
     // Start with only url (apiUrl commented out - not accessible as output)
     const pauseResumeOutputs: Record<string, any> = {
       url: { type: 'string', description: 'Resume UI URL' },


### PR DESCRIPTION
## Summary
Add a check for human in the loop , to directly resolve the url

## Type of Change
- [x] Bug fix

## Testing
Manually tested
## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

