### PR TITLE
fix(helm): add custom egress rules to realtime network policy

### DIFF
--- a/helm/sim/templates/networkpolicy.yaml
+++ b/helm/sim/templates/networkpolicy.yaml
@@ -141,6 +141,10 @@ spec:
     ports:
     - protocol: TCP
       port: 443
+  # Allow custom egress rules
+  {{- with .Values.networkPolicy.egress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.postgresql.enabled }}


### PR DESCRIPTION


## Summary
The realtime service network policy was missing the custom egress rules section that allows configuration of additional egress rules via values.yaml. This caused the realtime pods to be unable to connect to external databases (e.g., PostgreSQL on port 5432) when using external database configurations.

The app network policy already had this section, but the realtime network policy was missing it, creating an inconsistency and preventing the realtime service from accessing external databases configured via networkPolicy.egress values.

This fix adds the same custom egress rules template section to the realtime network policy, matching the app network policy behavior and allowing users to configure database connectivity via values.yaml.

Fixes https://discord.com/channels/1344142560293290024/1441430398155493396/1441430398155493396

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
- Tested without this change - my connection from realtime svc to pg db inside a kubernetes cluster, behind a VPN was failing (cluster DNS)
- With the change, the egress rule unblocks the WS conection
- Before the change `could not receive data from client: Connection reset by peer` was thrown by PSQL

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

