### PR TITLE
Slack webhook URL fix

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -363,11 +363,10 @@ const SubBlockRow = ({
       return null
     }
     const baseUrl = getBaseUrl()
-    const triggerPath = allSubBlockValues?.triggerPath?.value as string | undefined
-    return triggerPath
-      ? `${baseUrl}/api/webhooks/trigger/${triggerPath}`
-      : `${baseUrl}/api/webhooks/trigger/${blockId}`
-  }, [subBlock?.id, blockId, allSubBlockValues])
+    // Always use blockId for consistency - the webhook path should always match blockId
+    // This prevents the URL from changing after loading webhook data
+    return `${baseUrl}/api/webhooks/trigger/${blockId}`
+  }, [subBlock?.id, blockId])
 
   const allVariables = useVariablesStore((state) => state.variables)
 

--- a/apps/sim/hooks/use-webhook-management.ts
+++ b/apps/sim/hooks/use-webhook-management.ts
@@ -108,13 +108,11 @@ export function useWebhookManagement({
   const isChecked = useSubBlockStore((state) => state.checkedWebhooks.has(blockId))
 
   const webhookUrl = useMemo(() => {
-    if (!webhookPath) {
-      const baseUrl = getBaseUrl()
-      return `${baseUrl}/api/webhooks/trigger/${blockId}`
-    }
     const baseUrl = getBaseUrl()
-    return `${baseUrl}/api/webhooks/trigger/${webhookPath}`
-  }, [webhookPath, blockId])
+    // Always use blockId for consistency - the webhook path should always match blockId
+    // This prevents the URL from changing after loading webhook data from the API
+    return `${baseUrl}/api/webhooks/trigger/${blockId}`
+  }, [blockId])
 
   const [isSaving, setIsSaving] = useState(false)
 


### PR DESCRIPTION
## Summary
This PR fixes a bug where the displayed webhook URL would change after a webhook trigger was created and its data loaded from the API. Previously, the URL was initially computed using `blockId` as a fallback, but would reactively update if the `triggerPath` (from the loaded webhook data) differed. This caused instability and broke external integrations.

The fix ensures the webhook URL is always consistently computed using the `blockId`, making it stable from creation and preventing unexpected changes.

Fixes # (issue) - *[Bug]* I added a slack trigger from scratch. At some point, the webhook URL changed.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
The changes involve simplifying the webhook URL computation to always use `blockId`. Reviewers should focus on ensuring that this consistent use of `blockId` for the webhook URL display aligns with how webhooks are created and handled in the backend, and that no other components rely on the `triggerPath` for URL display.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->

---
<a href="https://cursor.com/background-agent?bcId=bc-9c0ed1c5-7c19-4416-a219-1767df46aff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c0ed1c5-7c19-4416-a219-1767df46aff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

