### PR TITLE
fix(notion): remove hyphenation of incoming page ID's

### DIFF
--- a/apps/sim/blocks/blocks/notion.ts
+++ b/apps/sim/blocks/blocks/notion.ts
@@ -35,7 +35,6 @@ export const NotionBlock: BlockConfig<NotionResponse> = {
       title: 'Notion Account',
       type: 'oauth-input',
       serviceId: 'notion',
-      requiredScopes: ['workspace.content', 'workspace.name', 'page.read', 'page.write'],
       placeholder: 'Select Notion account',
       required: true,
     },

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -212,7 +212,6 @@ export const auth = betterAuth({
         'github',
         'email-password',
         'confluence',
-        // 'supabase',
         'x',
         'notion',
         'microsoft',
@@ -950,56 +949,6 @@ export const auth = betterAuth({
           },
         },
 
-        // Supabase provider (unused)
-        // {
-        //   providerId: 'supabase',
-        //   clientId: env.SUPABASE_CLIENT_ID as string,
-        //   clientSecret: env.SUPABASE_CLIENT_SECRET as string,
-        //   authorizationUrl: 'https://api.supabase.com/v1/oauth/authorize',
-        //   tokenUrl: 'https://api.supabase.com/v1/oauth/token',
-        //   userInfoUrl: 'https://dummy-not-used.supabase.co',
-        //   scopes: ['database.read', 'database.write', 'projects.read'],
-        //   responseType: 'code',
-        //   pkce: true,
-        //   redirectURI: `${getBaseUrl()}/api/auth/oauth2/callback/supabase`,
-        //   getUserInfo: async (tokens) => {
-        //     try {
-        //       logger.info('Creating Supabase user profile from token data')
-
-        //       let userId = 'supabase-user'
-        //       if (tokens.idToken) {
-        //         try {
-        //           const decodedToken = JSON.parse(
-        //             Buffer.from(tokens.idToken.split('.')[1], 'base64').toString()
-        //           )
-        //           if (decodedToken.sub) {
-        //             userId = decodedToken.sub
-        //           }
-        //         } catch (e) {
-        //           logger.warn('Failed to decode Supabase ID token', {
-        //             error: e,
-        //           })
-        //         }
-        //       }
-
-        //       const uniqueId = `${userId}-${Date.now()}`
-        //       const now = new Date()
-
-        //       return {
-        //         id: uniqueId,
-        //         name: 'Supabase User',
-        //         email: `${uniqueId.replace(/[^a-zA-Z0-9]/g, '')}@supabase.user`,
-        //         emailVerified: false,
-        //         createdAt: now,
-        //         updatedAt: now,
-        //       }
-        //     } catch (error) {
-        //       logger.error('Error creating Supabase user profile:', { error })
-        //       return null
-        //     }
-        //   },
-        // },
-
         // X provider
         {
           providerId: 'x',
@@ -1132,57 +1081,6 @@ export const auth = betterAuth({
             }
           },
         },
-
-        // Discord provider (unused)
-        // {
-        //   providerId: 'discord',
-        //   clientId: env.DISCORD_CLIENT_ID as string,
-        //   clientSecret: env.DISCORD_CLIENT_SECRET as string,
-        //   authorizationUrl: 'https://discord.com/api/oauth2/authorize',
-        //   tokenUrl: 'https://discord.com/api/oauth2/token',
-        //   userInfoUrl: 'https://discord.com/api/users/@me',
-        //   scopes: ['identify', 'bot', 'messages.read', 'guilds', 'guilds.members.read'],
-        //   responseType: 'code',
-        //   accessType: 'offline',
-        //   authentication: 'basic',
-        //   prompt: 'consent',
-        //   redirectURI: `${getBaseUrl()}/api/auth/oauth2/callback/discord`,
-        //   getUserInfo: async (tokens) => {
-        //     try {
-        //       const response = await fetch('https://discord.com/api/users/@me', {
-        //         headers: {
-        //           Authorization: `Bearer ${tokens.accessToken}`,
-        //         },
-        //       })
-
-        //       if (!response.ok) {
-        //         logger.error('Error fetching Discord user info:', {
-        //           status: response.status,
-        //           statusText: response.statusText,
-        //         })
-        //         return null
-        //       }
-
-        //       const profile = await response.json()
-        //       const now = new Date()
-
-        //       return {
-        //         id: profile.id,
-        //         name: profile.username || 'Discord User',
-        //         email: profile.email || `${profile.id}@discord.user`,
-        //         image: profile.avatar
-        //           ? `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`
-        //           : undefined,
-        //         emailVerified: profile.verified || false,
-        //         createdAt: now,
-        //         updatedAt: now,
-        //       }
-        //     } catch (error) {
-        //       logger.error('Error in Discord getUserInfo:', { error })
-        //       return null
-        //     }
-        //   },
-        // },
 
         // Jira provider
         {
@@ -1323,7 +1221,6 @@ export const auth = betterAuth({
           authorizationUrl: 'https://api.notion.com/v1/oauth/authorize',
           tokenUrl: 'https://api.notion.com/v1/oauth/token',
           userInfoUrl: 'https://api.notion.com/v1/users/me',
-          scopes: ['workspace.content', 'workspace.name', 'page.read', 'page.write'],
           responseType: 'code',
           pkce: false,
           accessType: 'offline',

--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -3,7 +3,6 @@ import {
   AirtableIcon,
   AsanaIcon,
   ConfluenceIcon,
-  // DiscordIcon,
   DropboxIcon,
   GithubIcon,
   GmailIcon,
@@ -32,7 +31,6 @@ import {
   ShopifyIcon,
   SlackIcon,
   SpotifyIcon,
-  // SupabaseIcon,
   TrelloIcon,
   WealthboxIcon,
   WebflowIcon,
@@ -49,12 +47,10 @@ export type OAuthProvider =
   | 'google'
   | 'github'
   | 'x'
-  // | 'supabase'
   | 'confluence'
   | 'airtable'
   | 'notion'
   | 'jira'
-  // | 'discord'
   | 'dropbox'
   | 'microsoft'
   | 'linear'
@@ -86,12 +82,10 @@ export type OAuthService =
   | 'google-groups'
   | 'github'
   | 'x'
-  // | 'supabase'
   | 'confluence'
   | 'airtable'
   | 'notion'
   | 'jira'
-  // | 'discord'
   | 'dropbox'
   | 'microsoft-excel'
   | 'microsoft-teams'
@@ -388,23 +382,6 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     },
     defaultService: 'x',
   },
-  // supabase: {
-  //   id: 'supabase',
-  //   name: 'Supabase',
-  //   icon: (props) => SupabaseIcon(props),
-  //   services: {
-  //     supabase: {
-  //       id: 'supabase',
-  //       name: 'Supabase',
-  //       description: 'Connect to your Supabase projects and manage data.',
-  //       providerId: 'supabase',
-  //       icon: (props) => SupabaseIcon(props),
-  //       baseProviderIcon: (props) => SupabaseIcon(props),
-  //       scopes: ['database.read', 'database.write', 'projects.read'],
-  //     },
-  //   },
-  //   defaultService: 'supabase',
-  // },
   confluence: {
     id: 'confluence',
     name: 'Confluence',
@@ -518,23 +495,6 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     },
     defaultService: 'airtable',
   },
-  // discord: {
-  //   id: 'discord',
-  //   name: 'Discord',
-  //   icon: (props) => DiscordIcon(props),
-  //   services: {
-  //     discord: {
-  //       id: 'discord',
-  //       name: 'Discord',
-  //       description: 'Read and send messages to Discord channels and interact with servers.',
-  //       providerId: 'discord',
-  //       icon: (props) => DiscordIcon(props),
-  //       baseProviderIcon: (props) => DiscordIcon(props),
-  //       scopes: ['identify', 'bot', 'messages.read', 'guilds', 'guilds.members.read'],
-  //     },
-  //   },
-  //   defaultService: 'discord',
-  // },
   notion: {
     id: 'notion',
     name: 'Notion',
@@ -547,7 +507,7 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
         providerId: 'notion',
         icon: (props) => NotionIcon(props),
         baseProviderIcon: (props) => NotionIcon(props),
-        scopes: ['workspace.content', 'workspace.name', 'page.read', 'page.write'],
+        scopes: [],
       },
     },
     defaultService: 'notion',
@@ -1272,18 +1232,6 @@ function getProviderAuthConfig(provider: string): ProviderAuthConfig {
         useBasicAuth: false,
       }
     }
-    // case 'discord': {
-    //   const { clientId, clientSecret } = getCredentials(
-    //     env.DISCORD_CLIENT_ID,
-    //     env.DISCORD_CLIENT_SECRET
-    //   )
-    //   return {
-    //     tokenEndpoint: 'https://discord.com/api/v10/oauth2/token',
-    //     clientId,
-    //     clientSecret,
-    //     useBasicAuth: true,
-    //   }
-    // }
     case 'microsoft': {
       const { clientId, clientSecret } = getCredentials(
         env.MICROSOFT_CLIENT_ID,

--- a/apps/sim/tools/notion/create_database.ts
+++ b/apps/sim/tools/notion/create_database.ts
@@ -75,16 +75,10 @@ export const notionCreateDatabaseTool: ToolConfig<NotionCreateDatabaseParams, No
         }
       }
 
-      // Format parent ID
-      const formattedParentId = params.parentId.replace(
-        /(.{8})(.{4})(.{4})(.{4})(.{12})/,
-        '$1-$2-$3-$4-$5'
-      )
-
       const body = {
         parent: {
           type: 'page_id',
-          page_id: formattedParentId,
+          page_id: params.parentId,
         },
         title: [
           {

--- a/apps/sim/tools/notion/create_page.ts
+++ b/apps/sim/tools/notion/create_page.ts
@@ -54,21 +54,13 @@ export const notionCreatePageTool: ToolConfig<NotionCreatePageParams, NotionResp
       }
     },
     body: (params: NotionCreatePageParams) => {
-      // Format parent ID with hyphens if needed
-      const formattedParentId = params.parentId.replace(
-        /(.{8})(.{4})(.{4})(.{4})(.{12})/,
-        '$1-$2-$3-$4-$5'
-      )
-
-      // Prepare the body for page parent
       const body: any = {
         parent: {
           type: 'page_id',
-          page_id: formattedParentId,
+          page_id: params.parentId,
         },
       }
 
-      // Add title if provided
       if (params.title) {
         body.properties = {
           title: {
@@ -87,7 +79,6 @@ export const notionCreatePageTool: ToolConfig<NotionCreatePageParams, NotionResp
         body.properties = {}
       }
 
-      // Add content if provided
       if (params.content) {
         body.children = [
           {
@@ -115,7 +106,6 @@ export const notionCreatePageTool: ToolConfig<NotionCreatePageParams, NotionResp
     const data = await response.json()
     let pageTitle = 'Untitled'
 
-    // Try to extract the title from properties
     if (data.properties?.title) {
       const titleProperty = data.properties.title
       if (

--- a/apps/sim/tools/notion/query_database.ts
+++ b/apps/sim/tools/notion/query_database.ts
@@ -48,11 +48,7 @@ export const notionQueryDatabaseTool: ToolConfig<NotionQueryDatabaseParams, Noti
 
   request: {
     url: (params: NotionQueryDatabaseParams) => {
-      const formattedId = params.databaseId.replace(
-        /(.{8})(.{4})(.{4})(.{4})(.{12})/,
-        '$1-$2-$3-$4-$5'
-      )
-      return `https://api.notion.com/v1/databases/${formattedId}/query`
+      return `https://api.notion.com/v1/databases/${params.databaseId}/query`
     },
     method: 'POST',
     headers: (params: NotionQueryDatabaseParams) => {

--- a/apps/sim/tools/notion/read.ts
+++ b/apps/sim/tools/notion/read.ts
@@ -29,11 +29,7 @@ export const notionReadTool: ToolConfig<NotionReadParams, NotionResponse> = {
 
   request: {
     url: (params: NotionReadParams) => {
-      // Format page ID with hyphens if needed
-      const formattedId = params.pageId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5')
-
-      // Use the page endpoint to get page properties
-      return `https://api.notion.com/v1/pages/${formattedId}`
+      return `https://api.notion.com/v1/pages/${params.pageId}`
     },
     method: 'GET',
     headers: (params: NotionReadParams) => {
@@ -85,12 +81,9 @@ export const notionReadTool: ToolConfig<NotionReadParams, NotionResponse> = {
       }
     }
 
-    // Format page ID for blocks endpoint
-    const formattedId = pageId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5')
-
     // Fetch page content using blocks endpoint
     const blocksResponse = await fetch(
-      `https://api.notion.com/v1/blocks/${formattedId}/children?page_size=100`,
+      `https://api.notion.com/v1/blocks/${pageId}/children?page_size=100`,
       {
         method: 'GET',
         headers: {

--- a/apps/sim/tools/notion/read_database.ts
+++ b/apps/sim/tools/notion/read_database.ts
@@ -34,13 +34,7 @@ export const notionReadDatabaseTool: ToolConfig<NotionReadDatabaseParams, Notion
 
   request: {
     url: (params: NotionReadDatabaseParams) => {
-      // Format database ID with hyphens if needed
-      const formattedId = params.databaseId.replace(
-        /(.{8})(.{4})(.{4})(.{4})(.{12})/,
-        '$1-$2-$3-$4-$5'
-      )
-
-      return `https://api.notion.com/v1/databases/${formattedId}`
+      return `https://api.notion.com/v1/databases/${params.databaseId}`
     },
     method: 'GET',
     headers: (params: NotionReadDatabaseParams) => {

--- a/apps/sim/tools/notion/update_page.ts
+++ b/apps/sim/tools/notion/update_page.ts
@@ -35,9 +35,7 @@ export const notionUpdatePageTool: ToolConfig<NotionUpdatePageParams, NotionResp
 
   request: {
     url: (params: NotionUpdatePageParams) => {
-      // Format page ID with hyphens if needed
-      const formattedId = params.pageId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5')
-      return `https://api.notion.com/v1/pages/${formattedId}`
+      return `https://api.notion.com/v1/pages/${params.pageId}`
     },
     method: 'PATCH',
     headers: (params: NotionUpdatePageParams) => {

--- a/apps/sim/tools/notion/write.ts
+++ b/apps/sim/tools/notion/write.ts
@@ -35,9 +35,7 @@ export const notionWriteTool: ToolConfig<NotionWriteParams, NotionResponse> = {
 
   request: {
     url: (params: NotionWriteParams) => {
-      // Format page ID with hyphens if needed
-      const formattedId = params.pageId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5')
-      return `https://api.notion.com/v1/blocks/${formattedId}/children`
+      return `https://api.notion.com/v1/blocks/${params.pageId}/children`
     },
     method: 'PATCH',
     headers: (params: NotionWriteParams) => {


### PR DESCRIPTION
## Summary
- remove hyphenation of incoming page ID's
- remove extraneous scopes for notion, since notion doesn't use scopes for oauth, they use configuration on the applicatio side

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)