### PR TITLE
fix(oauth): add User-Agent header to Reddit token refresh

### DIFF
--- a/apps/sim/lib/oauth/oauth.test.ts
+++ b/apps/sim/lib/oauth/oauth.test.ts
@@ -214,6 +214,17 @@ describe('OAuth Token Refresh', () => {
       const [, requestOptions] = (mockFetch as Mock).mock.calls[0]
       expect(requestOptions.headers.Accept).toBe('application/json')
     })
+
+    it('should include User-Agent header for Reddit requests', async () => {
+      const refreshToken = 'test_refresh_token'
+
+      await refreshOAuthToken('reddit', refreshToken)
+
+      const [, requestOptions] = (mockFetch as Mock).mock.calls[0]
+      expect(requestOptions.headers['User-Agent']).toBe(
+        'sim-studio/1.0 (https://github.com/simstudioai/sim)'
+      )
+    })
   })
 
   describe('Error Handling', () => {

--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -1327,6 +1327,9 @@ function getProviderAuthConfig(provider: string): ProviderAuthConfig {
         clientId,
         clientSecret,
         useBasicAuth: true,
+        additionalHeaders: {
+          'User-Agent': 'sim-studio/1.0 (https://github.com/simstudioai/sim)',
+        },
       }
     }
     case 'wealthbox': {


### PR DESCRIPTION
## Summary
- Add User-Agent header to Reddit OAuth token refresh requests
- Reddit API requires User-Agent header for all requests, including token refresh
- Without this header, requests fail with 403 error after initial token expires

## Test plan
- [x] Added test to verify User-Agent header is included in Reddit OAuth requests
- [x] All existing OAuth tests pass (23 tests)

Fixes #1822