### PR TITLE
fix(dashboard): flash based on loading check

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/dashboard.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/dashboard.tsx
@@ -537,7 +537,7 @@ export default function Dashboard({ logs, isLoading, error }: DashboardProps) {
     }
   }, [])
 
-  if (isLoading && Object.keys(allWorkflows).length === 0) {
+  if (isLoading) {
     return <DashboardSkeleton />
   }
 


### PR DESCRIPTION
## Summary

The skeleton loading state check was too restrictive before loading dashboard skeleton. 

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)