### PR TITLE
improvement(block-metadata): remove references to yaml syntax in best practices

### DIFF
--- a/apps/sim/blocks/blocks/agent.ts
+++ b/apps/sim/blocks/blocks/agent.ts
@@ -71,8 +71,7 @@ export const AgentBlock: BlockConfig<AgentResponse> = {
   longDescription:
     'The Agent block is a core workflow block that is a wrapper around an LLM. It takes in system/user prompts and calls an LLM provider. It can also make tool calls by directly containing tools inside of its tool input. It can additionally return structured output.',
   bestPractices: `
-  - Cannot use core blocks like API, Webhook, Function, Workflow, Memory as tools. Only integrations or custom tools. 
-  - Check custom tools examples for YAML syntax. Only construct these if there isn't an existing integration for that purpose.
+  - Prefer using integrations as tools within the agent block over separate integration blocks unless complete determinism needed. 
   - Response Format should be a valid JSON Schema. This determines the output of the agent only if present. Fields can be accessed at root level by the following blocks: e.g. <agent1.field>. If response format is not present, the agent will return the standard outputs: content, model, tokens, toolCalls.
   `,
   docsLink: 'https://docs.sim.ai/blocks/agent',

--- a/apps/sim/blocks/blocks/knowledge.ts
+++ b/apps/sim/blocks/blocks/knowledge.ts
@@ -8,7 +8,6 @@ export const KnowledgeBlock: BlockConfig = {
   longDescription:
     'Integrate Knowledge into the workflow. Can search, upload chunks, and create documents.',
   bestPractices: `
-  - Search up examples with knowledge base blocks to understand YAML syntax.
   - Clarify which tags are available for the knowledge base to understand whether to use tag filters on a search.
   `,
   bgColor: '#00B0B0',

--- a/apps/sim/blocks/blocks/memory.ts
+++ b/apps/sim/blocks/blocks/memory.ts
@@ -10,8 +10,7 @@ export const MemoryBlock: BlockConfig = {
   bgColor: '#F64F9E',
   bestPractices: `
   - Do not use this block unless the user explicitly asks for it.
-  - Search up examples with memory blocks to understand YAML syntax. 
-  - Used in conjunction with agent blocks to persist messages between runs. User messages should be added with role 'user' and assistant messages should be added with role 'assistant' with the agent sandwiched between.
+  - Used in conjunction with agent blocks to inject artificial memory into the conversation. For natural conversations, use the agent block memories modes directly instead.
   `,
   icon: BrainIcon,
   category: 'blocks',

--- a/apps/sim/blocks/blocks/schedule.ts
+++ b/apps/sim/blocks/blocks/schedule.ts
@@ -14,7 +14,6 @@ export const ScheduleBlock: BlockConfig = {
   longDescription:
     'Integrate Schedule into the workflow. Can trigger a workflow on a schedule configuration.',
   bestPractices: `
-  - Search up examples with schedule blocks to understand YAML syntax. 
   - Prefer the custom cron expression input method over the other schedule configuration methods. 
   - Clarify the timezone if the user doesn't specify it.
   `,


### PR DESCRIPTION
## Summary
Some blocks had references to yaml syntax in best practices field.

## Type of Change
- [x] Bug fix


## Testing
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
