### PR TITLE
Workflow block spacing adjustment

### DIFF
--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import type { Edge } from 'reactflow'
 import { useSession } from '@/lib/auth/auth-client'
 import { createLogger } from '@/lib/logs/console/logger'
+import { NEW_BLOCK_OFFSET } from '@/lib/workflows/autolayout/constants'
 import { getBlockOutputs } from '@/lib/workflows/blocks/block-outputs'
 import { TriggerUtils } from '@/lib/workflows/triggers/triggers'
 import { useSocket } from '@/app/workspace/providers/socket-provider'
@@ -1326,8 +1327,8 @@ export function useCollaborativeWorkflow() {
       // Generate new ID and calculate position
       const newId = crypto.randomUUID()
       const offsetPosition = {
-        x: sourceBlock.position.x + 250,
-        y: sourceBlock.position.y + 20,
+        x: sourceBlock.position.x + NEW_BLOCK_OFFSET.X,
+        y: sourceBlock.position.y + NEW_BLOCK_OFFSET.Y,
       }
 
       const newName = getUniqueBlockName(sourceBlock.name, workflowStore.blocks)

--- a/apps/sim/lib/workflows/autolayout/constants.ts
+++ b/apps/sim/lib/workflows/autolayout/constants.ts
@@ -11,7 +11,17 @@ export { BLOCK_DIMENSIONS, CONTAINER_DIMENSIONS } from '@/lib/workflows/blocks/b
 /**
  * Horizontal spacing between layers (columns)
  */
-export const DEFAULT_HORIZONTAL_SPACING = 250
+export const DEFAULT_HORIZONTAL_SPACING = 200
+
+/**
+ * Offset for newly added/duplicated blocks
+ */
+export const NEW_BLOCK_OFFSET = {
+  /** Horizontal offset from source block */
+  X: 200,
+  /** Vertical offset from source block */
+  Y: 20,
+} as const
 
 /**
  * Vertical spacing between blocks in the same layer

--- a/apps/sim/stores/workflows/workflow/store.ts
+++ b/apps/sim/stores/workflows/workflow/store.ts
@@ -2,6 +2,7 @@ import type { Edge } from 'reactflow'
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import { createLogger } from '@/lib/logs/console/logger'
+import { NEW_BLOCK_OFFSET } from '@/lib/workflows/autolayout/constants'
 import { getBlockOutputs } from '@/lib/workflows/blocks/block-outputs'
 import { TriggerUtils } from '@/lib/workflows/triggers/triggers'
 import { getBlock } from '@/blocks'
@@ -591,8 +592,8 @@ export const useWorkflowStore = create<WorkflowStore>()(
 
         const newId = crypto.randomUUID()
         const offsetPosition = {
-          x: block.position.x + 250,
-          y: block.position.y + 20,
+          x: block.position.x + NEW_BLOCK_OFFSET.X,
+          y: block.position.y + NEW_BLOCK_OFFSET.Y,
         }
 
         const newName = getUniqueBlockName(block.name, get().blocks)


### PR DESCRIPTION
## Summary
Adjusts the default spacing for newly added and duplicated workflow blocks, as well as auto-layout, to place them closer together. This change reduces the horizontal offset from 250px to 200px and centralizes these values in a new `NEW_BLOCK_OFFSET` constant for consistency and easier future adjustments.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
The changes were verified by running lint and type checks. Reviewers can observe the new block placement when duplicating blocks or adding new blocks to the canvas.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

---
<a href="https://cursor.com/background-agent?bcId=bc-92db43a2-4873-4168-ac65-5719e8b8fa14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92db43a2-4873-4168-ac65-5719e8b8fa14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

