### PR TITLE
fix(folders): folder creation scroll behavior

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -75,6 +75,16 @@ export function FolderItem({ folder, level, hoverHandlers }: FolderItemProps) {
     getFolderIds: () => folder.id,
   })
 
+  // Folder expand hook - must be declared before callbacks that use expandFolder
+  const {
+    isExpanded,
+    handleToggleExpanded,
+    expandFolder,
+    handleKeyDown: handleExpandKeyDown,
+  } = useFolderExpand({
+    folderId: folder.id,
+  })
+
   /**
    * Handle create workflow in folder using React Query mutation.
    * Generates name and color upfront for optimistic UI updates.
@@ -95,6 +105,8 @@ export function FolderItem({ folder, level, hoverHandlers }: FolderItemProps) {
 
       if (result.id) {
         router.push(`/workspace/${workspaceId}/w/${result.id}`)
+        // Expand the parent folder so the new workflow is visible
+        expandFolder()
         // Scroll to the newly created workflow
         window.dispatchEvent(
           new CustomEvent(SIDEBAR_SCROLL_EVENT, { detail: { itemId: result.id } })
@@ -104,7 +116,7 @@ export function FolderItem({ folder, level, hoverHandlers }: FolderItemProps) {
       // Error already handled by mutation's onError callback
       logger.error('Failed to create workflow in folder:', error)
     }
-  }, [createWorkflowMutation, workspaceId, folder.id, router])
+  }, [createWorkflowMutation, workspaceId, folder.id, router, expandFolder])
 
   /**
    * Handle create sub-folder using React Query mutation.
@@ -118,6 +130,8 @@ export function FolderItem({ folder, level, hoverHandlers }: FolderItemProps) {
         parentId: folder.id,
       })
       if (result.id) {
+        // Expand the parent folder so the new folder is visible
+        expandFolder()
         // Scroll to the newly created folder
         window.dispatchEvent(
           new CustomEvent(SIDEBAR_SCROLL_EVENT, { detail: { itemId: result.id } })
@@ -126,16 +140,7 @@ export function FolderItem({ folder, level, hoverHandlers }: FolderItemProps) {
     } catch (error) {
       logger.error('Failed to create folder:', error)
     }
-  }, [createFolderMutation, workspaceId, folder.id])
-
-  // Folder expand hook
-  const {
-    isExpanded,
-    handleToggleExpanded,
-    handleKeyDown: handleExpandKeyDown,
-  } = useFolderExpand({
-    folderId: folder.id,
-  })
+  }, [createFolderMutation, workspaceId, folder.id, expandFolder])
 
   /**
    * Drag start handler - sets folder data for drag operation

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/hooks/use-folder-expand.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/hooks/use-folder-expand.ts
@@ -13,7 +13,7 @@ interface UseFolderExpandProps {
  * @returns Expansion state and event handlers
  */
 export function useFolderExpand({ folderId }: UseFolderExpandProps) {
-  const { expandedFolders, toggleExpanded } = useFolderStore()
+  const { expandedFolders, toggleExpanded, setExpanded } = useFolderStore()
   const isExpanded = expandedFolders.has(folderId)
 
   /**
@@ -22,6 +22,13 @@ export function useFolderExpand({ folderId }: UseFolderExpandProps) {
   const handleToggleExpanded = useCallback(() => {
     toggleExpanded(folderId)
   }, [folderId, toggleExpanded])
+
+  /**
+   * Expand the folder (useful when creating items inside)
+   */
+  const expandFolder = useCallback(() => {
+    setExpanded(folderId, true)
+  }, [folderId, setExpanded])
 
   /**
    * Handle keyboard navigation (Enter/Space)
@@ -39,6 +46,7 @@ export function useFolderExpand({ folderId }: UseFolderExpandProps) {
   return {
     isExpanded,
     handleToggleExpanded,
+    expandFolder,
     handleKeyDown,
   }
 }


### PR DESCRIPTION
## Summary
Fixes a bug where creating a new folder or workflow inside a collapsed parent folder would not automatically expand the parent, making the newly created item invisible and preventing the scroll-to-item functionality from working. This ensures a clear user experience by automatically revealing new items.

Fixes #(issue) - *[Bug]* When I create a folder inside of another folder, it doesn't open that folder and scroll.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
The fix was verified by running lint and type checks, which passed. The behavior was manually tested by creating new folders and workflows within collapsed parent folders to confirm they now expand and scroll correctly.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

---
<a href="https://cursor.com/background-agent?bcId=bc-79fbb5fb-3533-4110-8750-9b6988eb9049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79fbb5fb-3533-4110-8750-9b6988eb9049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

