### PR TITLE
fix(dropbox): access type param pass through to get refresh token

### DIFF
--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -1437,6 +1437,9 @@ export const auth = betterAuth({
           pkce: true,
           accessType: 'offline',
           prompt: 'consent',
+          authorizationUrlParams: {
+            token_access_type: 'offline',
+          },
           getUserInfo: async (tokens) => {
             try {
               const response = await fetch(


### PR DESCRIPTION
## Summary

Dropbox refresh token not being fetched correctly.

## Type of Change
- [x] Bug fix


## Testing
Tested manually with @aadamgough 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
