### PR TITLE
fix(executor): workflow abort has to send abort signal to route for correct state update

### DIFF
--- a/apps/sim/executor/execution/engine.ts
+++ b/apps/sim/executor/execution/engine.ts
@@ -39,7 +39,7 @@ export class ExecutionEngine {
       this.initializeQueue(triggerBlockId)
 
       while (this.hasWork()) {
-        if (this.context.isCancelled && this.executing.size === 0) {
+        if (this.context.abortSignal?.aborted && this.executing.size === 0) {
           break
         }
         await this.processQueue()
@@ -54,7 +54,7 @@ export class ExecutionEngine {
       this.context.metadata.endTime = new Date(endTime).toISOString()
       this.context.metadata.duration = endTime - startTime
 
-      if (this.context.isCancelled) {
+      if (this.context.abortSignal?.aborted) {
         return {
           success: false,
           output: this.finalOutput,
@@ -75,7 +75,7 @@ export class ExecutionEngine {
       this.context.metadata.endTime = new Date(endTime).toISOString()
       this.context.metadata.duration = endTime - startTime
 
-      if (this.context.isCancelled) {
+      if (this.context.abortSignal?.aborted) {
         return {
           success: false,
           output: this.finalOutput,
@@ -234,7 +234,7 @@ export class ExecutionEngine {
 
   private async processQueue(): Promise<void> {
     while (this.readyQueue.length > 0) {
-      if (this.context.isCancelled) {
+      if (this.context.abortSignal?.aborted) {
         break
       }
       const nodeId = this.dequeue()

--- a/apps/sim/executor/execution/snapshot.ts
+++ b/apps/sim/executor/execution/snapshot.ts
@@ -34,7 +34,6 @@ export interface ExecutionCallbacks {
     blockType: string,
     output: any
   ) => Promise<void>
-  onExecutorCreated?: (executor: any) => void
 }
 
 export interface SerializableExecutionState {

--- a/apps/sim/executor/execution/types.ts
+++ b/apps/sim/executor/execution/types.ts
@@ -22,6 +22,11 @@ export interface ContextExtensions {
   dagIncomingEdges?: Record<string, string[]>
   snapshotState?: SerializableExecutionState
   metadata?: ExecutionMetadata
+  /**
+   * AbortSignal for cancellation support.
+   * When aborted, the execution should stop gracefully.
+   */
+  abortSignal?: AbortSignal
   onStream?: (streamingExecution: unknown) => Promise<void>
   onBlockStart?: (
     blockId: string,

--- a/apps/sim/executor/orchestrators/loop.ts
+++ b/apps/sim/executor/orchestrators/loop.ts
@@ -229,7 +229,7 @@ export class LoopOrchestrator {
       }
     }
 
-    if (ctx.isCancelled) {
+    if (ctx.abortSignal?.aborted) {
       logger.info('Loop execution cancelled', { loopId, iteration: scope.iteration })
       return this.createExitResult(ctx, loopId, scope)
     }

--- a/apps/sim/executor/types.ts
+++ b/apps/sim/executor/types.ts
@@ -222,8 +222,12 @@ export interface ExecutionContext {
     output: any
   ) => Promise<void>
 
-  // Cancellation support
-  isCancelled?: boolean
+  /**
+   * AbortSignal for cancellation support.
+   * When the signal is aborted, execution should stop gracefully.
+   * This is triggered when the SSE client disconnects.
+   */
+  abortSignal?: AbortSignal
 
   // Dynamically added nodes that need to be scheduled (e.g., from parallel expansion)
   pendingDynamicNodes?: string[]


### PR DESCRIPTION
## Summary
To work with app running on multiple tasks + executor implementation the abort signal to execute route is the correct pattern to properly pause execution after current block finishes running. 

## Type of Change
- [x] Bug fix


## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
