### PR TITLE
fix(tool-input): code subblock should be emptyable

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -210,7 +210,7 @@ function GenericSyncWrapper<T = unknown>({
   const [storeValue] = useSubBlockValue(blockId, paramId)
 
   useEffect(() => {
-    if (storeValue) {
+    if (storeValue != null) {
       const transformedValue = transformer ? transformer(storeValue) : String(storeValue)
       if (transformedValue !== value) {
         onChange(transformedValue)


### PR DESCRIPTION
## Summary

Subblock being empty string should fail useEffect check in tool-input.tsx

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)