### PR TITLE
fix(mcp): exclude serverUrl from mcp tool call params

### DIFF
--- a/apps/sim/tools/index.ts
+++ b/apps/sim/tools/index.ts
@@ -121,6 +121,7 @@ function handleBodySizeLimitError(error: unknown, requestId: string, context: st
  */
 const MCP_SYSTEM_PARAMETERS = new Set([
   'serverId',
+  'serverUrl',
   'toolName',
   'serverName',
   '_context',


### PR DESCRIPTION
## Summary

Need to exclude serverUrl from mcp tool call params. 

## Type of Change
- [x] Bug fix


## Testing
Tested manually with @aadamgough 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)