### PR TITLE
improvement(context-menu): disable undo and redo if the stack is empty

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/context-menu/pane-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/context-menu/pane-context-menu.tsx
@@ -24,6 +24,8 @@ export function PaneContextMenu({
   hasClipboard = false,
   disableEdit = false,
   disableAdmin = false,
+  canUndo = false,
+  canRedo = false,
 }: PaneContextMenuProps) {
   return (
     <Popover open={isOpen} onOpenChange={onClose} variant='secondary' size='sm'>
@@ -40,7 +42,7 @@ export function PaneContextMenu({
         {/* Undo */}
         <PopoverItem
           className='group'
-          disabled={disableEdit}
+          disabled={disableEdit || !canUndo}
           onClick={() => {
             onUndo()
             onClose()
@@ -53,7 +55,7 @@ export function PaneContextMenu({
         {/* Redo */}
         <PopoverItem
           className='group'
-          disabled={disableEdit}
+          disabled={disableEdit || !canRedo}
           onClick={() => {
             onRedo()
             onClose()

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/context-menu/types.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/context-menu/types.ts
@@ -86,4 +86,8 @@ export interface PaneContextMenuProps {
   disableEdit?: boolean
   /** Whether admin actions are disabled (no admin permission) */
   disableAdmin?: boolean
+  /** Whether undo is available */
+  canUndo?: boolean
+  /** Whether redo is available */
+  canRedo?: boolean
 }


### PR DESCRIPTION
## Summary
- disable the undo redo options from the context menu if the stack is empty

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)