### PR TITLE
fix(canvas): add handler for focus loss for hotkey operations

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -1947,11 +1947,26 @@ const WorkflowContent = React.memo(() => {
     const handleKeyUp = (e: KeyboardEvent) => {
       if (e.key === 'Shift') setIsShiftPressed(false)
     }
+    const handleFocusLoss = () => {
+      setIsShiftPressed(false)
+      setIsSelectionDragActive(false)
+    }
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        handleFocusLoss()
+      }
+    }
+
     window.addEventListener('keydown', handleKeyDown)
     window.addEventListener('keyup', handleKeyUp)
+    window.addEventListener('blur', handleFocusLoss)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', handleFocusLoss)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- add handler for focus loss for hotkey operations
- this would cause shift click down to be perma set to true because focus was lost while it was pressed

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)