### PR TITLE
fix(resolver): add both new and old workflow blocks for backwards compatibility

### DIFF
--- a/apps/sim/executor/variables/resolvers/block.ts
+++ b/apps/sim/executor/variables/resolvers/block.ts
@@ -90,11 +90,13 @@ export class BlockResolver implements Resolver {
     // Workflow block backwards compatibility:
     // Old: <workflowBlock.result.response.data> -> New: <workflowBlock.result.data>
     // Only apply fallback if:
-    // 1. Block type is 'workflow'
+    // 1. Block type is 'workflow' or 'workflow_input'
     // 2. Path starts with 'result.response.'
     // 3. output.result.response doesn't exist (confirming child used new format)
+    const isWorkflowBlock =
+      block?.metadata?.id === 'workflow' || block?.metadata?.id === 'workflow_input'
     if (
-      block?.metadata?.id === 'workflow' &&
+      isWorkflowBlock &&
       pathParts[0] === 'result' &&
       pathParts[1] === 'response' &&
       output?.result?.response === undefined


### PR DESCRIPTION
## Summary
- add both new and old workflow blocks for backwards compatibility for response block 

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)