### PR TITLE
fix(devcontainer): use bunx for concurrently command

### DIFF
--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -11,7 +11,7 @@
     "dev": "next dev --port 3000",
     "dev:webpack": "next dev --webpack",
     "dev:sockets": "bun run socket/index.ts",
-    "dev:full": "concurrently -n \"App,Realtime\" -c \"cyan,magenta\" \"bun run dev\" \"bun run dev:sockets\"",
+    "dev:full": "bunx concurrently -n \"App,Realtime\" -c \"cyan,magenta\" \"bun run dev\" \"bun run dev:sockets\"",
     "build": "next build",
     "start": "next start",
     "prepare": "cd ../.. && bun husky",


### PR DESCRIPTION
## Description
Fixes #2661 

Changed `concurrently` to `bunx concurrently` in the `dev:full` script to resolve the "command not found" error when running the dev environment.

## Problem
When running `bun run dev:full` in a devcontainer, the script fails with:
```
/bin/bash: line 1: concurrently: command not found
error: script "dev:full" exited with code 127
```

## Solution
The issue occurs because `concurrently` is not in the system PATH. Using `bunx concurrently` ensures that Bun properly resolves and executes the binary from `node_modules/.bin/`.

## Changes
- Updated `apps/sim/package.json`: Changed `concurrently` to `bunx concurrently` in the `dev:full` script

## Testing
- ✅ Verified `concurrently` is installed as a devDependency
- ✅ Confirmed the binary exists in `node_modules/.bin/concurrently`
- ✅ Change follows Bun best practices for running binaries

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update