### PR TITLE
improvement(docs): multiplier dropped to 1.4

### DIFF
--- a/apps/docs/content/docs/en/execution/costs.mdx
+++ b/apps/docs/content/docs/en/execution/costs.mdx
@@ -48,40 +48,40 @@ The model breakdown shows:
 
 <Tabs items={['Hosted Models', 'Bring Your Own API Key']}>
   <Tab>
-    **Hosted Models** - Sim provides API keys with a 2x pricing multiplier:
+    **Hosted Models** - Sim provides API keys with a 1.4x pricing multiplier for Agent blocks:
 
     **OpenAI**
     | Model | Base Price (Input/Output) | Hosted Price (Input/Output) |
     |-------|---------------------------|----------------------------|
-    | GPT-5.1 | $1.25 / $10.00 | $2.50 / $20.00 |
-    | GPT-5 | $1.25 / $10.00 | $2.50 / $20.00 |
-    | GPT-5 Mini | $0.25 / $2.00 | $0.50 / $4.00 |
-    | GPT-5 Nano | $0.05 / $0.40 | $0.10 / $0.80 |
-    | GPT-4o | $2.50 / $10.00 | $5.00 / $20.00 |
-    | GPT-4.1 | $2.00 / $8.00 | $4.00 / $16.00 |
-    | GPT-4.1 Mini | $0.40 / $1.60 | $0.80 / $3.20 |
-    | GPT-4.1 Nano | $0.10 / $0.40 | $0.20 / $0.80 |
-    | o1 | $15.00 / $60.00 | $30.00 / $120.00 |
-    | o3 | $2.00 / $8.00 | $4.00 / $16.00 |
-    | o4 Mini | $1.10 / $4.40 | $2.20 / $8.80 |
+    | GPT-5.1 | $1.25 / $10.00 | $1.75 / $14.00 |
+    | GPT-5 | $1.25 / $10.00 | $1.75 / $14.00 |
+    | GPT-5 Mini | $0.25 / $2.00 | $0.35 / $2.80 |
+    | GPT-5 Nano | $0.05 / $0.40 | $0.07 / $0.56 |
+    | GPT-4o | $2.50 / $10.00 | $3.50 / $14.00 |
+    | GPT-4.1 | $2.00 / $8.00 | $2.80 / $11.20 |
+    | GPT-4.1 Mini | $0.40 / $1.60 | $0.56 / $2.24 |
+    | GPT-4.1 Nano | $0.10 / $0.40 | $0.14 / $0.56 |
+    | o1 | $15.00 / $60.00 | $21.00 / $84.00 |
+    | o3 | $2.00 / $8.00 | $2.80 / $11.20 |
+    | o4 Mini | $1.10 / $4.40 | $1.54 / $6.16 |
 
     **Anthropic**
     | Model | Base Price (Input/Output) | Hosted Price (Input/Output) |
     |-------|---------------------------|----------------------------|
-    | Claude Opus 4.5 | $5.00 / $25.00 | $10.00 / $50.00 |
-    | Claude Opus 4.1 | $15.00 / $75.00 | $30.00 / $150.00 |
-    | Claude Sonnet 4.5 | $3.00 / $15.00 | $6.00 / $30.00 |
-    | Claude Sonnet 4.0 | $3.00 / $15.00 | $6.00 / $30.00 |
-    | Claude Haiku 4.5 | $1.00 / $5.00 | $2.00 / $10.00 |
+    | Claude Opus 4.5 | $5.00 / $25.00 | $7.00 / $35.00 |
+    | Claude Opus 4.1 | $15.00 / $75.00 | $21.00 / $105.00 |
+    | Claude Sonnet 4.5 | $3.00 / $15.00 | $4.20 / $21.00 |
+    | Claude Sonnet 4.0 | $3.00 / $15.00 | $4.20 / $21.00 |
+    | Claude Haiku 4.5 | $1.00 / $5.00 | $1.40 / $7.00 |
 
     **Google**
     | Model | Base Price (Input/Output) | Hosted Price (Input/Output) |
     |-------|---------------------------|----------------------------|
-    | Gemini 3 Pro Preview | $2.00 / $12.00 | $4.00 / $24.00 |
-    | Gemini 2.5 Pro | $1.25 / $10.00 | $2.50 / $20.00 |
-    | Gemini 2.5 Flash | $0.30 / $2.50 | $0.60 / $5.00 |
+    | Gemini 3 Pro Preview | $2.00 / $12.00 | $2.80 / $16.80 |
+    | Gemini 2.5 Pro | $1.25 / $10.00 | $1.75 / $14.00 |
+    | Gemini 2.5 Flash | $0.30 / $2.50 | $0.42 / $3.50 |
 
-    *The 2x multiplier covers infrastructure and API management costs.*
+    *The 1.4x multiplier covers infrastructure and API management costs.*
   </Tab>
 
   <Tab>


### PR DESCRIPTION
## Summary
BYOK made enterprise only so we're dropping multiplier to 1.4.


## Type of Change
- [x] Documentation

## Testing
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
