### PR TITLE
fix(context-menu): make divider on context menu aware of available options

### DIFF
--- a/apps/sim/app/playground/page.tsx
+++ b/apps/sim/app/playground/page.tsx
@@ -462,9 +462,6 @@ export default function PlaygroundPage() {
               <Avatar size='lg'>
                 <AvatarFallback>LG</AvatarFallback>
               </Avatar>
-              <Avatar size='xl'>
-                <AvatarFallback>XL</AvatarFallback>
-              </Avatar>
             </VariantRow>
             <VariantRow label='with image'>
               <Avatar size='md'>
@@ -504,9 +501,6 @@ export default function PlaygroundPage() {
               </Avatar>
               <Avatar size='lg' status='online'>
                 <AvatarFallback>LG</AvatarFallback>
-              </Avatar>
-              <Avatar size='xl' status='online'>
-                <AvatarFallback>XL</AvatarFallback>
               </Avatar>
             </VariantRow>
           </Section>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
@@ -147,6 +147,12 @@ export function ContextMenu({
   disableCreate = false,
   disableCreateFolder = false,
 }: ContextMenuProps) {
+  // Section visibility for divider logic
+  const hasNavigationSection = showOpenInNewTab && onOpenInNewTab
+  const hasEditSection =
+    (showRename && onRename) || (showCreate && onCreate) || (showCreateFolder && onCreateFolder)
+  const hasCopySection = (showDuplicate && onDuplicate) || (showExport && onExport)
+
   return (
     <Popover
       open={isOpen}
@@ -176,7 +182,7 @@ export function ContextMenu({
             Open in new tab
           </PopoverItem>
         )}
-        {showOpenInNewTab && onOpenInNewTab && <PopoverDivider />}
+        {hasNavigationSection && (hasEditSection || hasCopySection) && <PopoverDivider />}
 
         {/* Edit and create actions */}
         {showRename && onRename && (
@@ -214,7 +220,7 @@ export function ContextMenu({
         )}
 
         {/* Copy and export actions */}
-        {(showDuplicate || showExport) && <PopoverDivider />}
+        {hasEditSection && hasCopySection && <PopoverDivider />}
         {showDuplicate && onDuplicate && (
           <PopoverItem
             disabled={disableDuplicate}
@@ -239,7 +245,7 @@ export function ContextMenu({
         )}
 
         {/* Destructive action */}
-        <PopoverDivider />
+        {(hasNavigationSection || hasEditSection || hasCopySection) && <PopoverDivider />}
         <PopoverItem
           disabled={disableDelete}
           onClick={() => {

--- a/apps/sim/components/emcn/components/avatar/avatar.tsx
+++ b/apps/sim/components/emcn/components/avatar/avatar.tsx
@@ -16,7 +16,6 @@ const avatarVariants = cva('relative flex shrink-0 overflow-hidden rounded-full'
       sm: 'h-8 w-8',
       md: 'h-10 w-10',
       lg: 'h-12 w-12',
-      xl: 'h-16 w-16',
     },
   },
   defaultVariants: {
@@ -42,7 +41,6 @@ const avatarStatusVariants = cva(
         sm: 'h-2.5 w-2.5',
         md: 'h-3 w-3',
         lg: 'h-3.5 w-3.5',
-        xl: 'h-4 w-4',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- make divider on context menu aware of available options
- remove xl avatar

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)