### PR TITLE
fix(otp): send welcome email even when user signs up via email/pass along with oauth providers

### DIFF
--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -592,6 +592,7 @@ export const auth = betterAuth({
       sendVerificationOnSignUp: false,
       otpLength: 6, // Explicitly set the OTP length
       expiresIn: 15 * 60, // 15 minutes in seconds
+      overrideDefaultEmailVerification: true,
     }),
     genericOAuth({
       config: [


### PR DESCRIPTION
## Summary
- added `overrideDefaultEmailVerification: true` to fix welcome email not sent for email/OTP signups
  - https://www.better-auth.com/docs/plugins/email-otp 

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)