### PR TITLE
feat(starter): in start block input format, don't prevent deletion if only one field remaining, just clear form

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/starter/input-format.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/starter/input-format.tsx
@@ -125,10 +125,16 @@ export function FieldFormat({
   }
 
   /**
-   * Removes a field by ID, preventing removal of the last field
+   * Removes a field by ID, or clears it if it's the last field
    */
   const removeField = (id: string) => {
-    if (isReadOnly || fields.length === 1) return
+    if (isReadOnly) return
+
+    if (fields.length === 1) {
+      setStoreValue([createDefaultField()])
+      return
+    }
+
     setStoreValue(fields.filter((field) => field.id !== id))
   }
 
@@ -273,7 +279,7 @@ export function FieldFormat({
         <Button
           variant='ghost'
           onClick={() => removeField(field.id)}
-          disabled={isReadOnly || fields.length === 1}
+          disabled={isReadOnly}
           className='h-auto p-0 text-[var(--text-error)] hover:text-[var(--text-error)]'
         >
           <Trash className='h-[14px] w-[14px]' />


### PR DESCRIPTION
## Summary
- in start block input format, don't prevent deletion if only one field remaining, just clear form

## Type of Change
- [x] New feature  

## Testing
tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)