### PR TITLE
improvement(avatar): use selection-update as the source of truth for presence, ignore other socket ops

### DIFF
--- a/apps/sim/app/workspace/providers/socket-provider.tsx
+++ b/apps/sim/app/workspace/providers/socket-provider.tsx
@@ -407,6 +407,7 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
           setPresenceUsers((prev) => {
             const existingIndex = prev.findIndex((user) => user.socketId === data.socketId)
             if (existingIndex === -1) {
+              logger.debug('Received cursor-update for unknown user', { socketId: data.socketId })
               return prev
             }
             return prev.map((user) =>
@@ -420,6 +421,9 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
           setPresenceUsers((prev) => {
             const existingIndex = prev.findIndex((user) => user.socketId === data.socketId)
             if (existingIndex === -1) {
+              logger.debug('Received selection-update for unknown user', {
+                socketId: data.socketId,
+              })
               return prev
             }
             return prev.map((user) =>


### PR DESCRIPTION
## Summary
- use selection-update as the source of truth for presence, ignore other socket ops

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)