### PR TITLE
feat(search): added operations to search modal in main app, updated retrieval in docs to use RRF

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -692,7 +692,8 @@ const WorkflowContent = React.memo(() => {
       parentId?: string,
       extent?: 'parent',
       autoConnectEdge?: Edge,
-      triggerMode?: boolean
+      triggerMode?: boolean,
+      presetSubBlockValues?: Record<string, unknown>
     ) => {
       setPendingSelection([id])
       setSelectedEdges(new Map())
@@ -720,6 +721,14 @@ const WorkflowContent = React.memo(() => {
             subBlockValues[id][subBlockId] = subBlock.value
           }
         }
+      }
+
+      // Apply preset subblock values (e.g., from tool-operation search)
+      if (presetSubBlockValues) {
+        if (!subBlockValues[id]) {
+          subBlockValues[id] = {}
+        }
+        Object.assign(subBlockValues[id], presetSubBlockValues)
       }
 
       collaborativeBatchAddBlocks(
@@ -1489,7 +1498,7 @@ const WorkflowContent = React.memo(() => {
         return
       }
 
-      const { type, enableTriggerMode } = event.detail
+      const { type, enableTriggerMode, presetOperation } = event.detail
 
       if (!type) return
       if (type === 'connectionBlock') return
@@ -1552,7 +1561,8 @@ const WorkflowContent = React.memo(() => {
         undefined,
         undefined,
         autoConnectEdge,
-        enableTriggerMode
+        enableTriggerMode,
+        presetOperation ? { operation: presetOperation } : undefined
       )
     }
 

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -326,32 +326,32 @@ export const env = createEnv({
 
     NEXT_PUBLIC_E2B_ENABLED:               z.string().optional(),
     NEXT_PUBLIC_COPILOT_TRAINING_ENABLED:  z.string().optional(),
-    NEXT_PUBLIC_ENABLE_PLAYGROUND:         z.string().optional(),                  // Enable component playground at /playground                  
+    NEXT_PUBLIC_ENABLE_PLAYGROUND:         z.string().optional(),                  // Enable component playground at /playground
     NEXT_PUBLIC_DOCUMENTATION_URL:         z.string().url().optional(),            // Custom documentation URL
     NEXT_PUBLIC_TERMS_URL:                 z.string().url().optional(),            // Custom terms of service URL
     NEXT_PUBLIC_PRIVACY_URL:               z.string().url().optional(),            // Custom privacy policy URL
 
     // Theme Customization
     NEXT_PUBLIC_BRAND_PRIMARY_COLOR:       z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),     // Primary brand color (hex format, e.g., "#701ffc")
-    NEXT_PUBLIC_BRAND_PRIMARY_HOVER_COLOR: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),    // Primary brand hover state (hex format)
+    NEXT_PUBLIC_BRAND_PRIMARY_HOVER_COLOR: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),     // Primary brand hover state (hex format)
     NEXT_PUBLIC_BRAND_ACCENT_COLOR:        z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),     // Accent brand color (hex format)
     NEXT_PUBLIC_BRAND_ACCENT_HOVER_COLOR:  z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),     // Accent brand hover state (hex format)
     NEXT_PUBLIC_BRAND_BACKGROUND_COLOR:    z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),     // Brand background color (hex format)
 
     // Feature Flags
-    NEXT_PUBLIC_TRIGGER_DEV_ENABLED:       z.boolean().optional(),                 // Client-side gate for async executions UI
-    NEXT_PUBLIC_SSO_ENABLED:               z.boolean().optional(),                 // Enable SSO login UI components
-    NEXT_PUBLIC_CREDENTIAL_SETS_ENABLED:   z.boolean().optional(),                 // Enable credential sets (email polling) on self-hosted
-    NEXT_PUBLIC_ACCESS_CONTROL_ENABLED:    z.boolean().optional(),                 // Enable access control (permission groups) on self-hosted
-    NEXT_PUBLIC_ORGANIZATIONS_ENABLED:     z.boolean().optional(),                 // Enable organizations on self-hosted (bypasses plan requirements)
-    NEXT_PUBLIC_DISABLE_INVITATIONS:       z.boolean().optional(),                 // Disable workspace invitations globally (for self-hosted deployments)
+    NEXT_PUBLIC_TRIGGER_DEV_ENABLED:       z.boolean().optional(),                   // Client-side gate for async executions UI
+    NEXT_PUBLIC_SSO_ENABLED:               z.boolean().optional(),                   // Enable SSO login UI components
+    NEXT_PUBLIC_CREDENTIAL_SETS_ENABLED:   z.boolean().optional(),                   // Enable credential sets (email polling) on self-hosted
+    NEXT_PUBLIC_ACCESS_CONTROL_ENABLED:    z.boolean().optional(),                   // Enable access control (permission groups) on self-hosted
+    NEXT_PUBLIC_ORGANIZATIONS_ENABLED:     z.boolean().optional(),                   // Enable organizations on self-hosted (bypasses plan requirements)
+    NEXT_PUBLIC_DISABLE_INVITATIONS:       z.boolean().optional(),                   // Disable workspace invitations globally (for self-hosted deployments)
     NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED: z.boolean().optional().default(true), // Control visibility of email/password login forms
   },
 
   // Variables available on both server and client
   shared: {
     NODE_ENV:                              z.enum(['development', 'test', 'production']).optional(), // Runtime environment
-    NEXT_TELEMETRY_DISABLED:               z.string().optional(),                // Disable Next.js telemetry collection
+    NEXT_TELEMETRY_DISABLED:               z.string().optional(),                                    // Disable Next.js telemetry collection
   },
 
   experimental__runtimeEnv: {

--- a/apps/sim/lib/search/tool-operations.ts
+++ b/apps/sim/lib/search/tool-operations.ts
@@ -1,0 +1,193 @@
+import type { ComponentType } from 'react'
+import { getAllBlocks } from '@/blocks'
+import type { BlockConfig, SubBlockConfig } from '@/blocks/types'
+
+/**
+ * Represents a searchable tool operation extracted from block configurations.
+ * Each operation maps to a specific tool that can be invoked when the block
+ * is configured with that operation selected.
+ */
+export interface ToolOperationItem {
+  /** Unique identifier combining block type and operation ID (e.g., "slack_send") */
+  id: string
+  /** The block type this operation belongs to (e.g., "slack") */
+  blockType: string
+  /** The operation dropdown value (e.g., "send") */
+  operationId: string
+  /** Human-readable service name from the block (e.g., "Slack") */
+  serviceName: string
+  /** Human-readable operation name from the dropdown label (e.g., "Send Message") */
+  operationName: string
+  /** The block's icon component */
+  icon: ComponentType<{ className?: string }>
+  /** The block's background color */
+  bgColor: string
+  /** Search aliases for common synonyms */
+  aliases: string[]
+}
+
+/**
+ * Maps common action verbs to their synonyms for better search matching.
+ * When a user searches for "post message", it should match "send message".
+ * Based on analysis of 1000+ tool operations in the codebase.
+ */
+const ACTION_VERB_ALIASES: Record<string, string[]> = {
+  get: ['read', 'fetch', 'retrieve', 'load', 'obtain'],
+  read: ['get', 'fetch', 'retrieve', 'load'],
+  create: ['make', 'new', 'add', 'generate', 'insert'],
+  add: ['create', 'insert', 'append', 'include'],
+  update: ['edit', 'modify', 'change', 'patch', 'set'],
+  set: ['update', 'configure', 'assign'],
+  delete: ['remove', 'trash', 'destroy', 'erase'],
+  remove: ['delete', 'clear', 'drop', 'unset'],
+  list: ['show', 'display', 'view', 'browse', 'enumerate'],
+  search: ['find', 'query', 'lookup', 'locate'],
+  query: ['search', 'find', 'lookup'],
+  send: ['post', 'write', 'deliver', 'transmit', 'publish'],
+  write: ['send', 'post', 'compose'],
+  download: ['export', 'save', 'pull', 'fetch'],
+  upload: ['import', 'push', 'transfer', 'attach'],
+  execute: ['run', 'invoke', 'trigger', 'perform', 'start'],
+  check: ['verify', 'validate', 'test', 'inspect'],
+  cancel: ['abort', 'stop', 'terminate', 'revoke'],
+  archive: ['store', 'backup', 'preserve'],
+  copy: ['duplicate', 'clone', 'replicate'],
+  move: ['transfer', 'relocate', 'migrate'],
+  share: ['publish', 'distribute', 'broadcast'],
+}
+
+/**
+ * Generates search aliases for an operation name by finding synonyms
+ * for action verbs in the operation name.
+ */
+function generateAliases(operationName: string): string[] {
+  const aliases: string[] = []
+  const lowerName = operationName.toLowerCase()
+
+  for (const [verb, synonyms] of Object.entries(ACTION_VERB_ALIASES)) {
+    if (lowerName.includes(verb)) {
+      for (const synonym of synonyms) {
+        aliases.push(lowerName.replace(verb, synonym))
+      }
+    }
+  }
+
+  return aliases
+}
+
+/**
+ * Extracts the operation dropdown subblock from a block's configuration.
+ * Returns null if no operation dropdown exists.
+ */
+function findOperationDropdown(block: BlockConfig): SubBlockConfig | null {
+  return (
+    block.subBlocks.find(
+      (sb) => sb.id === 'operation' && sb.type === 'dropdown' && Array.isArray(sb.options)
+    ) ?? null
+  )
+}
+
+/**
+ * Resolves the tool ID for a given operation using the block's tool config.
+ * Falls back to checking tools.access if no config.tool function exists.
+ */
+function resolveToolId(block: BlockConfig, operationId: string): string | null {
+  if (!block.tools) return null
+
+  if (block.tools.config?.tool) {
+    try {
+      return block.tools.config.tool({ operation: operationId })
+    } catch {
+      return null
+    }
+  }
+
+  if (block.tools.access?.length === 1) {
+    return block.tools.access[0]
+  }
+
+  return null
+}
+
+/**
+ * Builds an index of all tool operations from the block registry.
+ * This index is used by the search modal to enable operation-level discovery.
+ *
+ * The function iterates through all blocks that have:
+ * 1. A tools.access array (indicating they use tools)
+ * 2. An "operation" dropdown subblock with options
+ *
+ * For each operation option, it creates a ToolOperationItem that maps
+ * the operation to its corresponding tool.
+ */
+export function buildToolOperationsIndex(): ToolOperationItem[] {
+  const operations: ToolOperationItem[] = []
+  const allBlocks = getAllBlocks()
+
+  for (const block of allBlocks) {
+    if (!block.tools?.access?.length || block.hideFromToolbar) {
+      continue
+    }
+
+    if (block.category !== 'tools') {
+      continue
+    }
+
+    const operationDropdown = findOperationDropdown(block)
+    if (!operationDropdown) {
+      continue
+    }
+
+    const options =
+      typeof operationDropdown.options === 'function'
+        ? operationDropdown.options()
+        : operationDropdown.options
+
+    if (!options) continue
+
+    for (const option of options) {
+      if (!resolveToolId(block, option.id)) continue
+
+      const operationName = option.label
+      const aliases = generateAliases(operationName)
+
+      operations.push({
+        id: `${block.type}_${option.id}`,
+        blockType: block.type,
+        operationId: option.id,
+        serviceName: block.name,
+        operationName,
+        icon: block.icon,
+        bgColor: block.bgColor,
+        aliases,
+      })
+    }
+  }
+
+  return operations
+}
+
+/**
+ * Cached operations index to avoid rebuilding on every search.
+ * The index is built lazily on first access.
+ */
+let cachedOperations: ToolOperationItem[] | null = null
+
+/**
+ * Returns the tool operations index, building it if necessary.
+ * The index is cached after first build since block registry is static.
+ */
+export function getToolOperationsIndex(): ToolOperationItem[] {
+  if (!cachedOperations) {
+    cachedOperations = buildToolOperationsIndex()
+  }
+  return cachedOperations
+}
+
+/**
+ * Clears the cached operations index.
+ * Useful for testing or if blocks are dynamically modified.
+ */
+export function clearToolOperationsCache(): void {
+  cachedOperations = null
+}


### PR DESCRIPTION
## Summary
- added operations to search modal in main app
  - when the selected option maps to an operation for a tool, then it adds that block to the canvas with that operation pre-selected 
- updated retrieval in docs to use RRF, fixed some broken links because of it appending index.ts after the base URL

## Type of Change
- [x] New Feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)