### PR TITLE
fix(kb): align bulk chunk operation with API response

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
@@ -538,14 +538,11 @@ export function Document({
       },
       {
         onSuccess: (result) => {
-          if (operation === 'delete') {
+          if (operation === 'delete' || result.errorCount > 0) {
             refreshChunks()
           } else {
-            const failedChunkIds = new Set(result.errors.map((e) => e.chunkId))
             chunks.forEach((chunk) => {
-              if (!failedChunkIds.has(chunk.id)) {
-                updateChunk(chunk.id, { enabled: operation === 'enable' })
-              }
+              updateChunk(chunk.id, { enabled: operation === 'enable' })
             })
           }
           logger.info(`Successfully ${operation}d ${result.successCount} chunks`)

--- a/apps/sim/hooks/queries/knowledge.ts
+++ b/apps/sim/hooks/queries/knowledge.ts
@@ -759,7 +759,7 @@ export interface BulkChunkOperationResult {
   successCount: number
   errorCount: number
   processed: number
-  errors: Array<{ chunkId: string; error: string }>
+  errors: string[]
 }
 
 export async function bulkChunkOperation({


### PR DESCRIPTION
## Summary
- Fixed BulkChunkOperationResult interface to match actual API response
- Fixed TypeError when bulk enabling/disabling chunks (was accessing non-existent `results` property)

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)