### PR TITLE
fix(custom-tools): remove unsafe title fallback in getCustomTool

### DIFF
--- a/apps/sim/hooks/queries/custom-tools.ts
+++ b/apps/sim/hooks/queries/custom-tools.ts
@@ -110,15 +110,16 @@ export function getCustomTools(workspaceId?: string): CustomToolDefinition[] {
 }
 
 /**
- * Get a specific custom tool from the query cache by ID (for non-React code)
+ * Get a specific custom tool from the query cache by ID or title (for non-React code)
+ * Custom tools are referenced by title in the system (custom_${title}), so title lookup is required.
  * If workspaceId is not provided, extracts it from the current URL
  */
 export function getCustomTool(
-  toolId: string,
+  identifier: string,
   workspaceId?: string
 ): CustomToolDefinition | undefined {
   const tools = getCustomTools(workspaceId)
-  return tools.find((tool) => tool.id === toolId)
+  return tools.find((tool) => tool.id === identifier || tool.title === identifier)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove title fallback in `getCustomTool` that could return wrong tool if titles collide
- Tools should always be looked up by ID, not title

## Type of Change
- [x] Bug fix

## Testing
- All 3,392 tests pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)