### PR TITLE
improvement(helm): add per-deployment extraVolumes support

### DIFF
--- a/helm/sim/templates/deployment-app.yaml
+++ b/helm/sim/templates/deployment-app.yaml
@@ -110,12 +110,22 @@ spec:
           {{- end }}
           {{- include "sim.resources" .Values.app | nindent 10 }}
           {{- include "sim.securityContext" .Values.app | nindent 10 }}
-          {{- with .Values.extraVolumeMounts }}
+          {{- if or .Values.extraVolumeMounts .Values.app.extraVolumeMounts }}
           volumeMounts:
+            {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.app.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- with .Values.extraVolumes }}
+      {{- if or .Values.extraVolumes .Values.app.extraVolumes }}
       volumes:
+        {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.app.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/helm/sim/templates/deployment-ollama.yaml
+++ b/helm/sim/templates/deployment-ollama.yaml
@@ -92,6 +92,7 @@ spec:
             {{- toYaml .Values.ollama.readinessProbe | nindent 12 }}
           {{- end }}
           {{- include "sim.resources" .Values.ollama | nindent 10 }}
+          {{- if or .Values.ollama.persistence.enabled .Values.extraVolumeMounts .Values.ollama.extraVolumeMounts }}
           volumeMounts:
             {{- if .Values.ollama.persistence.enabled }}
             - name: ollama-data
@@ -100,12 +101,21 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-      {{- if .Values.ollama.persistence.enabled }}
+            {{- with .Values.ollama.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.ollama.persistence.enabled .Values.extraVolumes .Values.ollama.extraVolumes }}
       volumes:
+        {{- if .Values.ollama.persistence.enabled }}
         - name: ollama-data
           persistentVolumeClaim:
             claimName: {{ include "sim.fullname" . }}-ollama-data
+        {{- end }}
         {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.ollama.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}

--- a/helm/sim/templates/deployment-realtime.yaml
+++ b/helm/sim/templates/deployment-realtime.yaml
@@ -84,12 +84,22 @@ spec:
           {{- end }}
           {{- include "sim.resources" .Values.realtime | nindent 10 }}
           {{- include "sim.securityContext" .Values.realtime | nindent 10 }}
-          {{- with .Values.extraVolumeMounts }}
+          {{- if or .Values.extraVolumeMounts .Values.realtime.extraVolumeMounts }}
           volumeMounts:
+            {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.realtime.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- with .Values.extraVolumes }}
+      {{- if or .Values.extraVolumes .Values.realtime.extraVolumes }}
       volumes:
+        {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.realtime.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/helm/sim/values.yaml
+++ b/helm/sim/values.yaml
@@ -224,6 +224,10 @@ app:
     timeoutSeconds: 5
     failureThreshold: 3
 
+  # Additional volumes for app deployment (e.g., branding assets, custom configs)
+  extraVolumes: []
+  extraVolumeMounts: []
+
 # Realtime socket server configuration
 realtime:
   # Enable/disable the realtime service
@@ -300,6 +304,10 @@ realtime:
     periodSeconds: 90
     timeoutSeconds: 5
     failureThreshold: 3
+
+  # Additional volumes for realtime deployment
+  extraVolumes: []
+  extraVolumeMounts: []
 
 # Database migrations job configuration
 migrations:
@@ -538,6 +546,10 @@ ollama:
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
+
+  # Additional volumes for ollama deployment
+  extraVolumes: []
+  extraVolumeMounts: []
 
 # Ingress configuration
 ingress:


### PR DESCRIPTION
## Summary
- Add per-deployment `extraVolumes` and `extraVolumeMounts` for app, realtime, and ollama
- Allows users to mount volumes to specific deployments instead of all deployments
- Maintains backward compatibility with global extraVolumes

## Type of Change
- [x] New feature / enhancement

## Testing
Tested with `helm lint --strict` and `helm template` with various volume configurations

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)