### PR TITLE
fix(gmail): expose messageId field in read email block

### DIFF
--- a/apps/sim/blocks/blocks/gmail.ts
+++ b/apps/sim/blocks/blocks/gmail.ts
@@ -242,15 +242,9 @@ Return ONLY the email body - no explanations, no extra text.`,
       id: 'messageId',
       title: 'Message ID',
       type: 'short-input',
-      placeholder: 'Enter message ID to read (optional)',
-      condition: {
-        field: 'operation',
-        value: 'read_gmail',
-        and: {
-          field: 'folder',
-          value: '',
-        },
-      },
+      placeholder: 'Read specific email by ID (overrides label/folder)',
+      condition: { field: 'operation', value: 'read_gmail' },
+      mode: 'advanced',
     },
     // Search Fields
     {


### PR DESCRIPTION
## Summary
- Fixed messageId field not showing in Gmail read email operation
- Field was hidden by broken condition that required folder to be empty
- Now shows in advanced mode, allowing users to read specific emails by ID with attachments

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)