### PR TITLE
feat(router): expose reasoning output in router v2 block

### DIFF
--- a/apps/sim/blocks/blocks/router.ts
+++ b/apps/sim/blocks/blocks/router.ts
@@ -129,12 +129,9 @@ ROUTING RULES:
 3. If the context is even partially related to a route's description, select that route
 4. ONLY output NO_MATCH if the context is completely unrelated to ALL route descriptions
 
-OUTPUT FORMAT:
-- Output EXACTLY one route ID (copied exactly as shown above) OR "NO_MATCH"
-- No explanation, no punctuation, no additional text
-- Just the route ID or NO_MATCH
-
-Your response:`
+Respond with a JSON object containing:
+- route: EXACTLY one route ID (copied exactly as shown above) OR "NO_MATCH"
+- reasoning: A brief explanation (1-2 sentences) of why you chose this route`
 }
 
 /**
@@ -272,6 +269,7 @@ interface RouterV2Response extends ToolResponse {
       total: number
     }
     selectedRoute: string
+    reasoning: string
     selectedPath: {
       blockId: string
       blockType: string
@@ -355,6 +353,7 @@ export const RouterV2Block: BlockConfig<RouterV2Response> = {
     tokens: { type: 'json', description: 'Token usage' },
     cost: { type: 'json', description: 'Cost information' },
     selectedRoute: { type: 'string', description: 'Selected route ID' },
+    reasoning: { type: 'string', description: 'Explanation of why this route was chosen' },
     selectedPath: { type: 'json', description: 'Selected routing path' },
   },
 }


### PR DESCRIPTION
## Summary
- Added `reasoning` output to Router V2 block that explains why a route was chosen
- Uses native `responseFormat` to enforce structured JSON responses from LLM
- Added fallback handling for providers that return plain text
- Added comprehensive tests for V2 router with reasoning

## Type of Change
- [x] New feature

## Testing
- Added 8 new tests for Router V2
- All 16 router tests passing
- Tested fallback behavior for non-JSON responses

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)