### PR TITLE
feat(helm): add branding configmap for custom assets

### DIFF
--- a/helm/sim/templates/configmap-branding.yaml
+++ b/helm/sim/templates/configmap-branding.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.branding.enabled }}
+---
+# Branding ConfigMap
+# Mounts custom branding assets (logos, CSS, etc.) into the application
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sim.fullname" . }}-branding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: branding
+{{- if .Values.branding.files }}
+data:
+  {{- range $key, $value := .Values.branding.files }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- if .Values.branding.binaryFiles }}
+binaryData:
+  {{- range $key, $value := .Values.branding.binaryFiles }}
+  {{ $key }}: {{ $value }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/sim/templates/deployment-app.yaml
+++ b/helm/sim/templates/deployment-app.yaml
@@ -110,8 +110,13 @@ spec:
           {{- end }}
           {{- include "sim.resources" .Values.app | nindent 10 }}
           {{- include "sim.securityContext" .Values.app | nindent 10 }}
-          {{- if or .Values.extraVolumeMounts .Values.app.extraVolumeMounts }}
+          {{- if or .Values.branding.enabled .Values.extraVolumeMounts .Values.app.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.branding.enabled }}
+            - name: branding
+              mountPath: {{ .Values.branding.mountPath | default "/app/public/branding" }}
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -119,8 +124,13 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or .Values.extraVolumes .Values.app.extraVolumes }}
+      {{- if or .Values.branding.enabled .Values.extraVolumes .Values.app.extraVolumes }}
       volumes:
+        {{- if .Values.branding.enabled }}
+        - name: branding
+          configMap:
+            name: {{ include "sim.fullname" . }}-branding
+        {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/sim/values.yaml
+++ b/helm/sim/values.yaml
@@ -738,6 +738,32 @@ sharedStorage:
 extraVolumes: []
 extraVolumeMounts: []
 
+# Branding configuration
+# Use this to inject custom branding assets (logos, CSS, etc.) into the application
+branding:
+  # Enable/disable branding ConfigMap
+  enabled: false
+
+  # Mount path in the container where branding files will be available
+  mountPath: "/app/public/branding"
+
+  # Text files (CSS, JSON, HTML, etc.) - values are plain text
+  # Example:
+  #   files:
+  #     custom.css: |
+  #       .logo { background-color: #ff0000; }
+  #     config.json: |
+  #       {"theme": "dark"}
+  files: {}
+
+  # Binary files (PNG, JPG, ICO, etc.) - values must be base64 encoded
+  # Generate base64 with: base64 -i logo.png | tr -d '\n'
+  # Example:
+  #   binaryFiles:
+  #     logo.png: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk..."
+  #     favicon.ico: "AAABAAEAEBAAAAEAIABoBAAAFgAAAA..."
+  binaryFiles: {}
+
 # Additional environment variables for custom integrations
 extraEnvVars: []
 


### PR DESCRIPTION
## Summary
- Add branding ConfigMap to inject custom logos, CSS, and binary assets into the app
- Auto-mounts to `/app/public/branding` when enabled
- Supports both text files (`files`) and binary files (`binaryFiles`) via base64

## Type of Change
- [x] New feature

## Testing
Tested with `helm template` and `helm lint` - both pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)