### PR TITLE
feat(ci): auto-create github releases and add workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   test-build:
     name: Test and Build
@@ -278,3 +281,30 @@ jobs:
     if: needs.check-docs-changes.outputs.docs_changed == 'true'
     uses: ./.github/workflows/docs-embeddings.yml
     secrets: inherit
+
+  # Create GitHub Release (only for version commits on main, after all builds complete)
+  create-release:
+    name: Create GitHub Release
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [create-ghcr-manifests, detect-version]
+    if: needs.detect-version.outputs.is_release == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Create release
+        env:
+          GH_PAT: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run scripts/create-single-release.ts ${{ needs.detect-version.outputs.version }}

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   process-docs-embeddings:
     name: Process Documentation Embeddings

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   migrate:
     name: Apply Database Migrations

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'packages/cli/**'
 
+permissions:
+  contents: read
+
 jobs:
   publish-npm:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'packages/python-sdk/**'
 
+permissions:
+  contents: write
+
 jobs:
   publish-pypi:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'packages/ts-sdk/**'
 
+permissions:
+  contents: write
+
 jobs:
   publish-npm:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-build:
     name: Test and Build


### PR DESCRIPTION
## Summary
- Automate GitHub Release creation when merging version commits to main
- Runs existing release script after Docker builds complete
- No more manual `bun release` step needed
- Add explicit permissions blocks to all workflows (security best practice)

## Type of Change
- [x] New feature
- [x] Security improvement

## Testing
Tested by reviewing workflow logic

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)