### PR TITLE
fix(copilot): reliable zoom to changed blocks after diff applied

### DIFF
--- a/apps/sim/hooks/use-canvas-viewport.ts
+++ b/apps/sim/hooks/use-canvas-viewport.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import type { Node, ReactFlowInstance } from 'reactflow'
+import { BLOCK_DIMENSIONS } from '@/lib/workflows/blocks/block-dimensions'
 
 interface VisibleBounds {
   width: number
@@ -139,8 +140,8 @@ export function useCanvasViewport(reactFlowInstance: ReactFlowInstance | null) {
       let maxY = Number.NEGATIVE_INFINITY
 
       nodes.forEach((node) => {
-        const nodeWidth = node.width ?? 200
-        const nodeHeight = node.height ?? 100
+        const nodeWidth = node.width ?? BLOCK_DIMENSIONS.FIXED_WIDTH
+        const nodeHeight = node.height ?? BLOCK_DIMENSIONS.MIN_HEIGHT
 
         minX = Math.min(minX, node.position.x)
         minY = Math.min(minY, node.position.y)


### PR DESCRIPTION
## Summary
- Fixed zoom timing issue after copilot applies workflow edits
- Changed from polling/retry approach to event-driven two-phase zoom
- Phase 1: Records block IDs to zoom to when diff becomes ready
- Phase 2: Performs zoom when displayNodes contains all expected blocks with valid dimensions
- Fixed fallback dimensions in fitViewToBounds to match actual block sizes (250px instead of 200px)

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)