### PR TITLE
fix(terminal): persist collapsed state across page refresh

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/terminal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/terminal.tsx
@@ -1048,7 +1048,14 @@ export const Terminal = memo(function Terminal() {
     }
 
     prevWorkflowEntriesLengthRef.current = currentLength
-  }, [allWorkflowEntries.length, expandToLastHeight, openOnRun, isExpanded, hasConsoleHydrated])
+  }, [
+    allWorkflowEntries.length,
+    expandToLastHeight,
+    openOnRun,
+    isExpanded,
+    hasConsoleHydrated,
+    activeWorkflowId,
+  ])
 
   /**
    * Handle row click - toggle if clicking same entry


### PR DESCRIPTION
## Summary
- Fix terminal collapsed state not persisting across page refresh
- Skip auto-open trigger for hydrated console entries on initial load
- Reset entry tracking when switching workflows

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)