### PR TITLE
fix(models): update Cerebras and Groq model definitions

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -1130,7 +1130,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     id: 'cerebras',
     name: 'Cerebras',
     description: 'Cerebras Cloud LLMs',
-    defaultModel: 'cerebras/llama-3.3-70b',
+    defaultModel: 'cerebras/gpt-oss-120b',
     modelPatterns: [/^cerebras/],
     icon: CerebrasIcon,
     capabilities: {
@@ -1138,44 +1138,64 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     },
     models: [
       {
-        id: 'cerebras/llama-3.1-8b',
+        id: 'cerebras/gpt-oss-120b',
+        pricing: {
+          input: 0.35,
+          output: 0.75,
+          updatedAt: '2026-01-27',
+        },
+        capabilities: {},
+        contextWindow: 131000,
+      },
+      {
+        id: 'cerebras/llama3.1-8b',
         pricing: {
           input: 0.1,
           output: 0.1,
-          updatedAt: '2025-10-11',
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 32000,
       },
       {
-        id: 'cerebras/llama-3.1-70b',
-        pricing: {
-          input: 0.6,
-          output: 0.6,
-          updatedAt: '2025-10-11',
-        },
-        capabilities: {},
-        contextWindow: 128000,
-      },
-      {
         id: 'cerebras/llama-3.3-70b',
         pricing: {
-          input: 0.6,
-          output: 0.6,
-          updatedAt: '2025-10-11',
+          input: 0.85,
+          output: 1.2,
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 128000,
       },
       {
-        id: 'cerebras/llama-4-scout-17b-16e-instruct',
+        id: 'cerebras/qwen-3-32b',
         pricing: {
-          input: 0.11,
-          output: 0.34,
-          updatedAt: '2025-10-11',
+          input: 0.4,
+          output: 0.8,
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
-        contextWindow: 10000000,
+        contextWindow: 131000,
+      },
+      {
+        id: 'cerebras/qwen-3-235b-a22b-instruct-2507',
+        pricing: {
+          input: 0.6,
+          output: 1.2,
+          updatedAt: '2026-01-27',
+        },
+        capabilities: {},
+        contextWindow: 131000,
+      },
+      {
+        id: 'cerebras/zai-glm-4.7',
+        pricing: {
+          input: 2.25,
+          output: 2.75,
+          updatedAt: '2026-01-27',
+        },
+        capabilities: {},
+        contextWindow: 131000,
       },
     ],
   },
@@ -1194,8 +1214,8 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         id: 'groq/openai/gpt-oss-120b',
         pricing: {
           input: 0.15,
-          output: 0.75,
-          updatedAt: '2025-10-11',
+          output: 0.6,
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 131072,
@@ -1203,9 +1223,29 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
       {
         id: 'groq/openai/gpt-oss-20b',
         pricing: {
-          input: 0.01,
-          output: 0.25,
-          updatedAt: '2025-10-11',
+          input: 0.075,
+          output: 0.3,
+          updatedAt: '2026-01-27',
+        },
+        capabilities: {},
+        contextWindow: 131072,
+      },
+      {
+        id: 'groq/openai/gpt-oss-safeguard-20b',
+        pricing: {
+          input: 0.075,
+          output: 0.3,
+          updatedAt: '2026-01-27',
+        },
+        capabilities: {},
+        contextWindow: 131072,
+      },
+      {
+        id: 'groq/qwen/qwen3-32b',
+        pricing: {
+          input: 0.29,
+          output: 0.59,
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 131072,
@@ -1215,7 +1255,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         pricing: {
           input: 0.05,
           output: 0.08,
-          updatedAt: '2025-10-11',
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 131072,
@@ -1225,27 +1265,17 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         pricing: {
           input: 0.59,
           output: 0.79,
-          updatedAt: '2025-10-11',
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 131072,
       },
       {
-        id: 'groq/llama-4-scout-17b-instruct',
+        id: 'groq/meta-llama/llama-4-scout-17b-16e-instruct',
         pricing: {
           input: 0.11,
           output: 0.34,
-          updatedAt: '2025-10-11',
-        },
-        capabilities: {},
-        contextWindow: 131072,
-      },
-      {
-        id: 'groq/llama-4-maverick-17b-instruct',
-        pricing: {
-          input: 0.5,
-          output: 0.77,
-          updatedAt: '2025-10-11',
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 131072,
@@ -1253,9 +1283,9 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
       {
         id: 'groq/meta-llama/llama-4-maverick-17b-128e-instruct',
         pricing: {
-          input: 0.5,
-          output: 0.77,
-          updatedAt: '2025-10-11',
+          input: 0.2,
+          output: 0.6,
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 131072,
@@ -1265,7 +1295,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         pricing: {
           input: 0.04,
           output: 0.04,
-          updatedAt: '2025-10-11',
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 8192,
@@ -1275,27 +1305,37 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         pricing: {
           input: 0.59,
           output: 0.79,
-          updatedAt: '2025-10-11',
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 128000,
       },
       {
-        id: 'groq/moonshotai/kimi-k2-instruct',
+        id: 'groq/deepseek-r1-distill-qwen-32b',
+        pricing: {
+          input: 0.69,
+          output: 0.69,
+          updatedAt: '2026-01-27',
+        },
+        capabilities: {},
+        contextWindow: 128000,
+      },
+      {
+        id: 'groq/moonshotai/kimi-k2-instruct-0905',
         pricing: {
           input: 1.0,
           output: 3.0,
-          updatedAt: '2025-10-11',
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
-        contextWindow: 131072,
+        contextWindow: 262144,
       },
       {
         id: 'groq/meta-llama/llama-guard-4-12b',
         pricing: {
           input: 0.2,
           output: 0.2,
-          updatedAt: '2025-10-11',
+          updatedAt: '2026-01-27',
         },
         capabilities: {},
         contextWindow: 131072,


### PR DESCRIPTION
## Summary
- Updated Cerebras models based on current API docs (removed deprecated models, added gpt-oss-120b, qwen-3-32b, qwen-3-235b, zai-glm-4.7)
- Updated Groq models with correct pricing and added missing models (qwen3-32b, gpt-oss-safeguard-20b, deepseek-r1-distill-qwen-32b)
- Fixed model IDs and context windows based on official documentation

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)