### PR TITLE
fix(tests): use UTC methods for timezone-independent schedule assertions

### DIFF
--- a/apps/sim/app/api/schedules/[id]/route.test.ts
+++ b/apps/sim/app/api/schedules/[id]/route.test.ts
@@ -344,7 +344,7 @@ describe('Schedule PUT API (Reactivate)', () => {
       expect(nextRunAt).toBeGreaterThan(beforeCall)
       expect(nextRunAt).toBeLessThanOrEqual(afterCall + 5 * 60 * 1000 + 1000)
       // Should align with 5-minute intervals (minute divisible by 5)
-      expect(new Date(nextRunAt).getMinutes() % 5).toBe(0)
+      expect(new Date(nextRunAt).getUTCMinutes() % 5).toBe(0)
     })
 
     it('calculates nextRunAt from daily cron expression', async () => {
@@ -572,7 +572,7 @@ describe('Schedule PUT API (Reactivate)', () => {
       expect(nextRunAt.getTime()).toBeGreaterThan(beforeCall)
       expect(nextRunAt.getTime()).toBeLessThanOrEqual(beforeCall + 10 * 60 * 1000 + 1000)
       // Should align with 10-minute intervals
-      expect(nextRunAt.getMinutes() % 10).toBe(0)
+      expect(nextRunAt.getUTCMinutes() % 10).toBe(0)
     })
 
     it('handles hourly schedules with timezone correctly', async () => {
@@ -598,8 +598,8 @@ describe('Schedule PUT API (Reactivate)', () => {
 
       // Should be a future date at minute 15
       expect(nextRunAt.getTime()).toBeGreaterThan(beforeCall)
-      expect(nextRunAt.getMinutes()).toBe(15)
-      expect(nextRunAt.getSeconds()).toBe(0)
+      expect(nextRunAt.getUTCMinutes()).toBe(15)
+      expect(nextRunAt.getUTCSeconds()).toBe(0)
     })
 
     it('handles custom cron expressions with complex patterns and timezone', async () => {

--- a/apps/sim/lib/workflows/schedules/utils.test.ts
+++ b/apps/sim/lib/workflows/schedules/utils.test.ts
@@ -266,9 +266,9 @@ describe('Schedule Utilities', () => {
       const nextRun = calculateNextRunTime('minutes', scheduleValues)
 
       // Should return the future start date with time
-      expect(nextRun.getFullYear()).toBe(2025)
-      expect(nextRun.getMonth()).toBe(3) // April
-      expect(nextRun.getDate()).toBe(15)
+      expect(nextRun.getUTCFullYear()).toBe(2025)
+      expect(nextRun.getUTCMonth()).toBe(3) // April
+      expect(nextRun.getUTCDate()).toBe(15)
     })
 
     it.concurrent('should calculate next run for hourly schedule using Croner', () => {
@@ -292,7 +292,7 @@ describe('Schedule Utilities', () => {
       expect(nextRun instanceof Date).toBe(true)
       expect(nextRun > new Date()).toBe(true)
       // Croner calculates based on cron "30 * * * *"
-      expect(nextRun.getMinutes()).toBe(30)
+      expect(nextRun.getUTCMinutes()).toBe(30)
     })
 
     it.concurrent('should calculate next run for daily schedule using Croner with timezone', () => {
@@ -439,7 +439,7 @@ describe('Schedule Utilities', () => {
 
       // Should not use the past date but calculate normally
       expect(nextRun > new Date()).toBe(true)
-      expect(nextRun.getMinutes() % 10).toBe(0) // Should align with the interval
+      expect(nextRun.getUTCMinutes() % 10).toBe(0) // Should align with the interval
     })
   })
 


### PR DESCRIPTION
## Summary
- Replace `getMinutes()`, `getSeconds()`, `getDate()`, etc. with UTC equivalents in schedule tests
- Fixes test failures in timezones with non-integer hour offsets (e.g., UTC+05:30, UTC+09:30)

Fixes https://github.com/simstudioai/sim/issues/3045

## Type of Change
- [x] Bug fix

## Testing
Tested with multiple timezones: UTC, Asia/Kolkata (UTC+05:30), Australia/Adelaide (UTC+09:30), Asia/Kathmandu (UTC+05:45)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)