### PR TITLE
fix(posthog): move session recording proxy to middleware for large payload support

### DIFF
--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -325,18 +325,6 @@ const nextConfig: NextConfig = {
 
     return redirects
   },
-  async rewrites() {
-    return [
-      {
-        source: '/ingest/static/:path*',
-        destination: 'https://us-assets.i.posthog.com/static/:path*',
-      },
-      {
-        source: '/ingest/:path*',
-        destination: 'https://us.i.posthog.com/:path*',
-      },
-    ]
-  },
 }
 
 export default nextConfig

--- a/apps/sim/proxy.ts
+++ b/apps/sim/proxy.ts
@@ -134,6 +134,24 @@ function handleSecurityFiltering(request: NextRequest): NextResponse | null {
 export async function proxy(request: NextRequest) {
   const url = request.nextUrl
 
+  if (url.pathname.startsWith('/ingest/')) {
+    const hostname = url.pathname.startsWith('/ingest/static/')
+      ? 'us-assets.i.posthog.com'
+      : 'us.i.posthog.com'
+
+    const targetPath = url.pathname.replace(/^\/ingest/, '')
+    const targetUrl = `https://${hostname}${targetPath}${url.search}`
+
+    return NextResponse.rewrite(new URL(targetUrl), {
+      request: {
+        headers: new Headers({
+          ...Object.fromEntries(request.headers),
+          host: hostname,
+        }),
+      },
+    })
+  }
+
   const sessionCookie = getSessionCookie(request)
   const hasActiveSession = isAuthDisabled || !!sessionCookie
 
@@ -195,6 +213,7 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
+    '/ingest/:path*', // PostHog proxy for session recording
     '/', // Root path for self-hosted redirect logic
     '/terms', // Whitelabel terms redirect
     '/privacy', // Whitelabel privacy redirect


### PR DESCRIPTION
## Summary
- Move PostHog proxy from Next.js rewrites to middleware
- Fixes 400 errors on `/ingest/s` for large session recording payloads (1MB+)

## Type of Change
- [x] Bug fix

## Testing
Tested manually - deploy to preview and verify `/ingest/s` requests return 200

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)