### PR TITLE
Homepage button styling

### DIFF
--- a/apps/sim/app/(landing)/components/hero/hero.tsx
+++ b/apps/sim/app/(landing)/components/hero/hero.tsx
@@ -425,26 +425,13 @@ export default function Hero() {
             key={isEmpty ? 'empty' : 'filled'}
             type='button'
             aria-label='Submit description'
-            className='absolute right-2.5 bottom-4 flex h-[30px] w-[30px] items-center justify-center transition-all duration-200 sm:right-[11px] sm:bottom-[16px] sm:h-[34px] sm:w-[34px]'
+            className={`absolute right-2.5 bottom-4 flex h-[30px] w-[30px] items-center justify-center rounded-full p-1 transition-all duration-200 sm:right-[11px] sm:bottom-[16px] sm:h-[34px] sm:w-[34px] ${
+              isEmpty
+                ? 'cursor-not-allowed border border-[#E0E0E0] bg-[#E5E5E5]'
+                : 'cursor-pointer border border-[#343434] bg-gradient-to-b from-[#060606] to-[#323232] shadow-[inset_0_1.25px_2.5px_0_#9B77FF] hover:opacity-90'
+            }`}
             disabled={isEmpty}
             onClick={handleSubmit}
-            style={{
-              padding: '3.75px 3.438px 3.75px 4.063px',
-              borderRadius: 55,
-              ...(isEmpty
-                ? {
-                    border: '0.625px solid #E0E0E0',
-                    background: '#E5E5E5',
-                    boxShadow: 'none',
-                    cursor: 'not-allowed',
-                  }
-                : {
-                    border: '0.625px solid #343434',
-                    background: 'linear-gradient(180deg, #060606 0%, #323232 100%)',
-                    boxShadow: '0 1.25px 2.5px 0 #9B77FF inset',
-                    cursor: 'pointer',
-                  }),
-            }}
           >
             <ArrowUp size={18} className='sm:h-5 sm:w-5' color={isEmpty ? '#999999' : '#FFFFFF'} />
           </button>

--- a/apps/sim/app/(landing)/components/landing-pricing/landing-pricing.tsx
+++ b/apps/sim/app/(landing)/components/landing-pricing/landing-pricing.tsx
@@ -186,7 +186,7 @@ function PricingCard({
               onClick={handleCtaClick}
               onMouseEnter={() => setIsHovered(true)}
               onMouseLeave={() => setIsHovered(false)}
-              className='group inline-flex w-full items-center justify-center gap-2 rounded-[10px] border border-[#E8E8E8] bg-gradient-to-b from-[#F8F8F8] to-white px-3 py-[6px] font-medium text-[#6F3DFA] text-[14px] shadow-[inset_0_2px_4px_0_rgba(255,255,255,0.9)] transition-all'
+              className='group inline-flex w-full items-center justify-center gap-2 rounded-[10px] border border-[#E8E8E8] bg-gradient-to-b from-[#F8F8F8] to-white px-3 py-[6px] font-medium text-[#6F3DFA] text-[14px] shadow-[inset_0_2px_4px_0_rgba(255,255,255,0.9)] transition-all hover:opacity-90'
             >
               <span className='flex items-center gap-1'>
                 {tier.ctaText}
@@ -204,7 +204,7 @@ function PricingCard({
               onClick={handleCtaClick}
               onMouseEnter={() => setIsHovered(true)}
               onMouseLeave={() => setIsHovered(false)}
-              className='group inline-flex w-full items-center justify-center gap-2 rounded-[10px] border border-[#343434] bg-gradient-to-b from-[#060606] to-[#323232] px-3 py-[6px] font-medium text-[14px] text-white shadow-[inset_0_1.25px_2.5px_0_#9B77FF] transition-all'
+              className='group inline-flex w-full items-center justify-center gap-2 rounded-[10px] border border-[#343434] bg-gradient-to-b from-[#060606] to-[#323232] px-3 py-[6px] font-medium text-[14px] text-white shadow-[inset_0_1.25px_2.5px_0_#9B77FF] transition-all hover:opacity-90'
             >
               <span className='flex items-center gap-1'>
                 {tier.ctaText}


### PR DESCRIPTION
## Summary
Fixes inconsistent button styling on the homepage to provide clear and consistent visual feedback.

Specifically:
- The Hero section's submit button has been refactored from inline styles to Tailwind classes, adding a `hover:opacity-90` effect and ensuring proper `rounded-full` styling.
- Pricing card buttons now also include a `hover:opacity-90` effect for consistent user experience.

This improves maintainability and ensures all primary call-to-action buttons on the homepage have a visible hover state.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Changes were visually verified on the homepage to confirm consistent hover states and correct styling for all affected buttons.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->

---
<a href="https://cursor.com/background-agent?bcId=bc-13176908-ab2e-4051-8ed3-c4d593a6759c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-13176908-ab2e-4051-8ed3-c4d593a6759c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

