### PR TITLE
fix(agent-logs): don't filter out any agent outputs from trace span

### DIFF
--- a/apps/sim/blocks/blocks/agent.ts
+++ b/apps/sim/blocks/blocks/agent.ts
@@ -774,8 +774,7 @@ Example 3 (Array Input):
     providerTiming: {
       type: 'json',
       description: 'Provider timing information',
-      hiddenFromDisplay: true,
     },
-    cost: { type: 'number', description: 'Cost of the API call', hiddenFromDisplay: true },
+    cost: { type: 'json', description: 'Cost of the API call' },
   },
 }


### PR DESCRIPTION
## Summary
Do not filter out any agent outputs from trace spans.

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
