### PR TITLE
fix(editor): advanced toggle respects user edit permissions

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/editor.tsx
@@ -150,7 +150,9 @@ export function Editor() {
     blockSubBlockValues,
     canonicalIndex
   )
-  const displayAdvancedOptions = advancedMode || advancedValuesPresent
+  const displayAdvancedOptions = userPermissions.canEdit
+    ? advancedMode
+    : advancedMode || advancedValuesPresent
 
   const hasAdvancedOnlyFields = useMemo(() => {
     for (const subBlock of subBlocksForCanonical) {


### PR DESCRIPTION
## Summary
- Fixed advanced fields toggle not working when blocks have default values
- Toggle now works directly for editable users, matching canvas block behavior
- Read-only users still auto-expand to see all values

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)