### PR TITLE
fix(mcp): increase timeout from 1m to 10m

### DIFF
--- a/apps/sim/app/api/mcp/serve/[serverId]/route.ts
+++ b/apps/sim/app/api/mcp/serve/[serverId]/route.ts
@@ -264,7 +264,7 @@ async function handleToolsCall(
       method: 'POST',
       headers,
       body: JSON.stringify({ input: params.arguments || {}, triggerType: 'mcp' }),
-      signal: AbortSignal.timeout(300000), // 5 minute timeout
+      signal: AbortSignal.timeout(600000), // 10 minute timeout
     })
 
     const executeResult = await response.json()

--- a/apps/sim/lib/mcp/shared.ts
+++ b/apps/sim/lib/mcp/shared.ts
@@ -34,7 +34,7 @@ export function sanitizeHeaders(
  * Client-safe MCP constants
  */
 export const MCP_CLIENT_CONSTANTS = {
-  CLIENT_TIMEOUT: 60000,
+  CLIENT_TIMEOUT: 600000,
   MAX_RETRIES: 3,
   RECONNECT_DELAY: 1000,
 } as const

--- a/apps/sim/lib/mcp/utils.test.ts
+++ b/apps/sim/lib/mcp/utils.test.ts
@@ -81,8 +81,8 @@ describe('generateMcpServerId', () => {
 })
 
 describe('MCP_CONSTANTS', () => {
-  it.concurrent('has correct execution timeout', () => {
-    expect(MCP_CONSTANTS.EXECUTION_TIMEOUT).toBe(60000)
+  it.concurrent('has correct execution timeout (10 minutes)', () => {
+    expect(MCP_CONSTANTS.EXECUTION_TIMEOUT).toBe(600000)
   })
 
   it.concurrent('has correct cache timeout (5 minutes)', () => {
@@ -107,8 +107,8 @@ describe('MCP_CONSTANTS', () => {
 })
 
 describe('MCP_CLIENT_CONSTANTS', () => {
-  it.concurrent('has correct client timeout', () => {
-    expect(MCP_CLIENT_CONSTANTS.CLIENT_TIMEOUT).toBe(60000)
+  it.concurrent('has correct client timeout (10 minutes)', () => {
+    expect(MCP_CLIENT_CONSTANTS.CLIENT_TIMEOUT).toBe(600000)
   })
 
   it.concurrent('has correct auto refresh interval (5 minutes)', () => {

--- a/apps/sim/lib/mcp/utils.ts
+++ b/apps/sim/lib/mcp/utils.ts
@@ -6,7 +6,7 @@ import { isMcpTool, MCP } from '@/executor/constants'
  * MCP-specific constants
  */
 export const MCP_CONSTANTS = {
-  EXECUTION_TIMEOUT: 60000,
+  EXECUTION_TIMEOUT: 600000,
   CACHE_TIMEOUT: 5 * 60 * 1000,
   DEFAULT_RETRIES: 3,
   DEFAULT_CONNECTION_TIMEOUT: 30000,
@@ -49,7 +49,7 @@ export function sanitizeHeaders(
  * Client-safe MCP constants
  */
 export const MCP_CLIENT_CONSTANTS = {
-  CLIENT_TIMEOUT: 60000,
+  CLIENT_TIMEOUT: 600000,
   AUTO_REFRESH_INTERVAL: 5 * 60 * 1000,
 } as const
 


### PR DESCRIPTION
## Summary
- Increased MCP tool execution timeout from 1 minute to 10 minutes
- Increased workflow MCP server timeout from 5 minutes to 10 minutes
- Aligns MCP timeouts with workflow execution timeout

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)