### PR TITLE
fix(mcp): pass timeout to SDK callTool to override 60s default

### DIFF
--- a/apps/sim/lib/mcp/client.ts
+++ b/apps/sim/lib/mcp/client.ts
@@ -199,10 +199,11 @@ export class McpClient {
         protocolVersion: this.getNegotiatedVersion(),
       })
 
-      const sdkResult = await this.client.callTool({
-        name: toolCall.name,
-        arguments: toolCall.arguments,
-      })
+      const sdkResult = await this.client.callTool(
+        { name: toolCall.name, arguments: toolCall.arguments },
+        undefined,
+        { timeout: 600000 } // 10 minutes - override SDK's 60s default
+      )
 
       return sdkResult as McpToolResult
     } catch (error) {


### PR DESCRIPTION
## Summary
- The MCP SDK has a hardcoded 60-second default timeout (DEFAULT_REQUEST_TIMEOUT_MSEC)
- Pass our configured timeout (600000ms = 10 min) to callTool to override it

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)