### PR TITLE
fix(mcp): child workflow with response block returns error

### DIFF
--- a/apps/sim/app/api/mcp/serve/[serverId]/route.ts
+++ b/apps/sim/app/api/mcp/serve/[serverId]/route.ts
@@ -284,7 +284,7 @@ async function handleToolsCall(
       content: [
         { type: 'text', text: JSON.stringify(executeResult.output || executeResult, null, 2) },
       ],
-      isError: !executeResult.success,
+      isError: executeResult.success === false,
     }
 
     return NextResponse.json(createResponse(id, result))


### PR DESCRIPTION
## Summary

Undefined in response block payload is being interpreted as false returning an error flag even when executed correctly.

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)