### PR TITLE
fix(http): serialize nested objects in form-urlencoded body

### DIFF
--- a/apps/sim/tools/http/request.test.ts
+++ b/apps/sim/tools/http/request.test.ts
@@ -286,6 +286,30 @@ describe('HTTP Request Tool', () => {
       )
     })
 
+    it('should handle nested objects and arrays in URL-encoded form data', async () => {
+      tester.setup({ result: 'success' })
+
+      const body = {
+        name: 'test',
+        data: { nested: 'value' },
+        items: [1, 2, 3],
+      }
+
+      await tester.execute({
+        url: 'https://api.example.com/submit',
+        method: 'POST',
+        body,
+        headers: [{ cells: { Key: 'Content-Type', Value: 'application/x-www-form-urlencoded' } }],
+      })
+
+      const fetchCall = (global.fetch as any).mock.calls[0]
+      const bodyStr = fetchCall[1].body
+
+      expect(bodyStr).toContain('name=test')
+      expect(bodyStr).toContain('data=%7B%22nested%22%3A%22value%22%7D')
+      expect(bodyStr).toContain('items=%5B1%2C2%2C3%5D')
+    })
+
     it('should handle OAuth client credentials requests', async () => {
       tester.setup({ access_token: 'token123', token_type: 'Bearer' })
 

--- a/apps/sim/tools/http/request.ts
+++ b/apps/sim/tools/http/request.ts
@@ -105,7 +105,10 @@ export const requestTool: ToolConfig<RequestParams, RequestResponse> = {
           const urlencoded = new URLSearchParams()
           Object.entries(params.body as Record<string, unknown>).forEach(([key, value]) => {
             if (value !== undefined && value !== null) {
-              urlencoded.append(key, String(value))
+              urlencoded.append(
+                key,
+                typeof value === 'object' ? JSON.stringify(value) : String(value)
+              )
             }
           })
           return urlencoded.toString()


### PR DESCRIPTION
## Summary
- Fix URLSearchParams corrupting nested objects/arrays to `[object Object]`
- JSON.stringify object values in form-urlencoded body serialization

Fixes https://github.com/simstudioai/sim/issues/3109

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)