### PR TITLE
fix(logs): use formatDuration utility and align file cards styling

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/file-download/file-download.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/file-download/file-download.tsx
@@ -104,14 +104,12 @@ function FileCard({ file, isExecutionFile = false, workspaceId }: FileCardProps)
   }
 
   return (
-    <div className='flex flex-col gap-[8px] rounded-[6px] bg-[var(--surface-1)] px-[10px] py-[8px]'>
-      <div className='flex items-center justify-between'>
-        <div className='flex items-center gap-[8px]'>
-          <span className='truncate font-medium text-[12px] text-[var(--text-secondary)]'>
-            {file.name}
-          </span>
-        </div>
-        <span className='font-medium text-[12px] text-[var(--text-tertiary)]'>
+    <div className='flex flex-col gap-[4px] rounded-[6px] bg-[var(--surface-1)] px-[8px] py-[6px]'>
+      <div className='flex min-w-0 items-center justify-between gap-[8px]'>
+        <span className='min-w-0 flex-1 truncate font-medium text-[12px] text-[var(--text-secondary)]'>
+          {file.name}
+        </span>
+        <span className='flex-shrink-0 font-medium text-[12px] text-[var(--text-tertiary)]'>
           {formatFileSize(file.size)}
         </span>
       </div>
@@ -142,20 +140,18 @@ export function FileCards({ files, isExecutionFile = false, workspaceId }: FileC
   }
 
   return (
-    <div className='flex w-full flex-col gap-[6px] rounded-[6px] bg-[var(--surface-2)] px-[10px] py-[8px]'>
+    <div className='mt-[4px] flex flex-col gap-[6px] rounded-[6px] border border-[var(--border)] bg-[var(--surface-2)] px-[10px] py-[8px] dark:bg-transparent'>
       <span className='font-medium text-[12px] text-[var(--text-tertiary)]'>
         Files ({files.length})
       </span>
-      <div className='flex flex-col gap-[8px]'>
-        {files.map((file, index) => (
-          <FileCard
-            key={file.id || `file-${index}`}
-            file={file}
-            isExecutionFile={isExecutionFile}
-            workspaceId={workspaceId}
-          />
-        ))}
-      </div>
+      {files.map((file, index) => (
+        <FileCard
+          key={file.id || `file-${index}`}
+          file={file}
+          isExecutionFile={isExecutionFile}
+          workspaceId={workspaceId}
+        />
+      ))}
     </div>
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/log-details.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/log-details.tsx
@@ -18,6 +18,7 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { BASE_EXECUTION_CHARGE } from '@/lib/billing/constants'
 import { cn } from '@/lib/core/utils/cn'
+import { formatDuration } from '@/lib/core/utils/formatting'
 import { filterHiddenOutputKeys } from '@/lib/logs/execution/trace-spans/trace-spans'
 import {
   ExecutionSnapshot,
@@ -453,7 +454,7 @@ export const LogDetails = memo(function LogDetails({
                       Duration
                     </span>
                     <span className='font-medium text-[13px] text-[var(--text-secondary)]'>
-                      {log.duration || '—'}
+                      {formatDuration(log.duration, { precision: 2 }) || '—'}
                     </span>
                   </div>
 


### PR DESCRIPTION
## Summary
- Use `formatDuration` utility for duration display in log details (e.g., 18706ms → 18.71s)
- Fix FileCards container styling to match other log detail sections (border, padding, dark mode)
- Remove unnecessary wrapper div and fix file name truncation

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)