### PR TITLE
improvement(action-bar): run button label and hover

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/action-bar/action-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/action-bar/action-bar.tsx
@@ -192,10 +192,10 @@ export const ActionBar = memo(
             </Tooltip.Trigger>
             <Tooltip.Content side='top'>
               {(() => {
-                if (disabled) return getTooltipMessage('Run from block')
+                if (disabled) return getTooltipMessage('Run')
                 if (isExecuting) return 'Execution in progress'
-                if (!dependenciesSatisfied) return 'Run previous blocks first'
-                return 'Run from block'
+                if (!dependenciesSatisfied) return 'Disabled: Run Blocks Before'
+                return 'Run'
               })()}
             </Tooltip.Content>
           </Tooltip.Root>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/block-menu/block-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/block-menu/block-menu.tsx
@@ -273,7 +273,7 @@ export function BlockMenu({
                 }
               }}
             >
-              Run from block
+              Run
             </PopoverItem>
             {/* Hide "Run until" for triggers - they're always at the start */}
             {!hasTriggerBlock && (

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -1173,7 +1173,7 @@ const WorkflowContent = React.memo(() => {
       block.parentId && (block.parentType === 'loop' || block.parentType === 'parallel')
 
     if (isInsideSubflow) return { canRun: false, reason: 'Cannot run from inside subflow' }
-    if (!dependenciesSatisfied) return { canRun: false, reason: 'Run previous blocks first' }
+    if (!dependenciesSatisfied) return { canRun: false, reason: 'Disabled: Run Blocks Before' }
     if (isNoteBlock) return { canRun: false, reason: undefined }
     if (isExecuting) return { canRun: false, reason: undefined }
 


### PR DESCRIPTION
## Summary
Updates the "Run from block" button in the action bar to simply "Run". When the button is disabled due to unsatisfied dependencies, the hover tooltip now displays "Disabled: Run Blocks Before" for improved clarity.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: UI Text/Tooltip Change

## Testing
The changes were verified by running lint and type checks. Visual inspection of the action bar button and its hover states (enabled and disabled) is recommended.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->

---
<a href="https://cursor.com/background-agent?bcId=bc-94e27d41-8ed8-4758-801a-3c080f95a9f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94e27d41-8ed8-4758-801a-3c080f95a9f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

