### PR TITLE
fix(editor): block rename applies to correct block when selection changes

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -1185,6 +1185,12 @@ export function useWorkflowExecution() {
                 })
               }
             },
+
+            onExecutionCancelled: () => {
+              if (activeWorkflowId) {
+                cancelRunningEntries(activeWorkflowId)
+              }
+            },
           },
         })
 
@@ -1738,6 +1744,10 @@ export function useWorkflowExecution() {
                 })
               }
             },
+
+            onExecutionCancelled: () => {
+              cancelRunningEntries(workflowId)
+            },
           },
         })
       } catch (error) {
@@ -1759,6 +1769,7 @@ export function useWorkflowExecution() {
       setEdgeRunStatus,
       addNotification,
       addConsole,
+      cancelRunningEntries,
       executionStream,
     ]
   )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -1132,7 +1132,7 @@ const WorkflowContent = React.memo(() => {
   const handleContextRename = useCallback(() => {
     if (contextMenuBlocks.length === 1) {
       usePanelEditorStore.getState().setCurrentBlockId(contextMenuBlocks[0].id)
-      usePanelEditorStore.getState().setShouldFocusRename(true)
+      usePanelEditorStore.getState().triggerRename()
     }
   }, [contextMenuBlocks])
 

--- a/apps/sim/executor/execution/engine.ts
+++ b/apps/sim/executor/execution/engine.ts
@@ -130,6 +130,7 @@ export class ExecutionEngine {
       this.context.metadata.duration = endTime - startTime
 
       if (this.cancelledFlag) {
+        this.finalizeIncompleteLogs()
         return {
           success: false,
           output: this.finalOutput,
@@ -151,6 +152,7 @@ export class ExecutionEngine {
       this.context.metadata.duration = endTime - startTime
 
       if (this.cancelledFlag) {
+        this.finalizeIncompleteLogs()
         return {
           success: false,
           output: this.finalOutput,
@@ -472,6 +474,22 @@ export class ExecutionEngine {
     return {
       pausedBlocks: responses,
       pauseCount: responses.length,
+    }
+  }
+
+  /**
+   * Finalizes any block logs that were still running when execution was cancelled.
+   * Sets their endedAt to now and calculates the actual elapsed duration.
+   */
+  private finalizeIncompleteLogs(): void {
+    const now = new Date()
+    const nowIso = now.toISOString()
+
+    for (const log of this.context.blockLogs) {
+      if (!log.endedAt) {
+        log.endedAt = nowIso
+        log.durationMs = now.getTime() - new Date(log.startedAt).getTime()
+      }
     }
   }
 }

--- a/apps/sim/lib/core/utils/formatting.ts
+++ b/apps/sim/lib/core/utils/formatting.ts
@@ -176,6 +176,10 @@ export function formatDuration(
     }
   } else {
     ms = duration
+    // Handle NaN/Infinity (e.g., cancelled blocks with no end time)
+    if (!Number.isFinite(ms)) {
+      return '—'
+    }
   }
 
   const precision = options?.precision ?? 0

--- a/apps/sim/stores/terminal/console/store.ts
+++ b/apps/sim/stores/terminal/console/store.ts
@@ -380,13 +380,18 @@ export const useTerminalConsoleStore = create<ConsoleStore>()(
 
         cancelRunningEntries: (workflowId: string) => {
           set((state) => {
+            const now = new Date()
             const updatedEntries = state.entries.map((entry) => {
               if (entry.workflowId === workflowId && entry.isRunning) {
+                const durationMs = entry.startedAt
+                  ? now.getTime() - new Date(entry.startedAt).getTime()
+                  : entry.durationMs
                 return {
                   ...entry,
                   isRunning: false,
                   isCanceled: true,
-                  endedAt: new Date().toISOString(),
+                  endedAt: now.toISOString(),
+                  durationMs,
                 }
               }
               return entry


### PR DESCRIPTION
## Summary
- Fixed block rename applying to wrong block when user clicks another block mid-rename
- Fixed cancelled executions showing as "running" in terminal logs
- Refactored flag+effect anti-pattern to callback registration pattern
- Added duration calculation for cancelled entries

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)