### PR TITLE
fix(import): preserve workflow colors during import

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/hooks/use-import-workflow.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/hooks/use-import-workflow.ts
@@ -52,9 +52,8 @@ export function useImportWorkflow({ workspaceId }: UseImportWorkflowProps) {
       const workflowName = extractWorkflowName(content, filename)
       clearDiff()
 
-      const parsedContent = JSON.parse(content)
       const workflowColor =
-        parsedContent.state?.metadata?.color || parsedContent.metadata?.color || '#3972F6'
+        (workflowData.metadata as { color?: string } | undefined)?.color || '#3972F6'
 
       const result = await createWorkflowMutation.mutateAsync({
         name: workflowName,
@@ -66,11 +65,15 @@ export function useImportWorkflow({ workspaceId }: UseImportWorkflowProps) {
       })
       const newWorkflowId = result.id
 
-      await fetch(`/api/workflows/${newWorkflowId}/state`, {
+      const stateResponse = await fetch(`/api/workflows/${newWorkflowId}/state`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(workflowData),
       })
+
+      if (!stateResponse.ok) {
+        logger.error(`Failed to save workflow state for ${newWorkflowId}`)
+      }
 
       if (workflowData.variables) {
         const variablesArray = Array.isArray(workflowData.variables)
@@ -94,11 +97,15 @@ export function useImportWorkflow({ workspaceId }: UseImportWorkflowProps) {
             }
           }
 
-          await fetch(`/api/workflows/${newWorkflowId}/variables`, {
+          const variablesResponse = await fetch(`/api/workflows/${newWorkflowId}/variables`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ variables: variablesRecord }),
           })
+
+          if (!variablesResponse.ok) {
+            logger.error(`Failed to save variables for ${newWorkflowId}`)
+          }
         }
       }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/hooks/use-import-workspace.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/hooks/use-import-workspace.ts
@@ -160,9 +160,8 @@ export function useImportWorkspace({ onSuccess }: UseImportWorkspaceProps = {}) 
             const workflowName = extractWorkflowName(workflow.content, workflow.name)
             clearDiff()
 
-            const parsedContent = JSON.parse(workflow.content)
             const workflowColor =
-              parsedContent.state?.metadata?.color || parsedContent.metadata?.color || '#3972F6'
+              (workflowData.metadata as { color?: string } | undefined)?.color || '#3972F6'
 
             const createWorkflowResponse = await fetch('/api/workflows', {
               method: 'POST',
@@ -216,11 +215,18 @@ export function useImportWorkspace({ onSuccess }: UseImportWorkspaceProps = {}) 
                   }
                 }
 
-                await fetch(`/api/workflows/${newWorkflow.id}/variables`, {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ variables: variablesRecord }),
-                })
+                const variablesResponse = await fetch(
+                  `/api/workflows/${newWorkflow.id}/variables`,
+                  {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ variables: variablesRecord }),
+                  }
+                )
+
+                if (!variablesResponse.ok) {
+                  logger.error(`Failed to save variables for ${newWorkflow.id}`)
+                }
               }
             }
 


### PR DESCRIPTION
## Summary
- Pass workflow color directly during creation instead of patching after
- Removes unreliable PATCH call that was skipped for default blue color

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)