### PR TITLE
fix(client-exec): send correct client workflow state override

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -1288,6 +1288,13 @@ export function useWorkflowExecution() {
           onBlockCompleteCallback: onBlockComplete,
         })
 
+        const clientWorkflowState = executionWorkflowState || {
+          blocks: filteredStates,
+          edges: workflowEdges,
+          loops: latestWorkflowState.loops,
+          parallels: latestWorkflowState.parallels,
+        }
+
         await executionStream.execute({
           workflowId: activeWorkflowId,
           input: finalWorkflowInput,
@@ -1297,14 +1304,12 @@ export function useWorkflowExecution() {
           useDraftState: true,
           isClientSession: true,
           stopAfterBlockId,
-          workflowStateOverride: executionWorkflowState
-            ? {
-                blocks: executionWorkflowState.blocks,
-                edges: executionWorkflowState.edges,
-                loops: executionWorkflowState.loops,
-                parallels: executionWorkflowState.parallels,
-              }
-            : undefined,
+          workflowStateOverride: {
+            blocks: clientWorkflowState.blocks,
+            edges: clientWorkflowState.edges,
+            loops: clientWorkflowState.loops,
+            parallels: clientWorkflowState.parallels,
+          },
           callbacks: {
             onExecutionStarted: (data) => {
               logger.info('Server execution started:', data)


### PR DESCRIPTION
## Summary

Need to send client side state as workflow state override correctly since db is out of sync for 1-2 seconds so validations must run on the former.

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)