### PR TITLE
improvement(logs): skill icon for tool call

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/trace-spans/trace-spans.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/trace-spans/trace-spans.tsx
@@ -16,7 +16,7 @@ import {
   PopoverItem,
   Tooltip,
 } from '@/components/emcn'
-import { WorkflowIcon } from '@/components/icons'
+import { AgentSkillsIcon, WorkflowIcon } from '@/components/icons'
 import { cn } from '@/lib/core/utils/cn'
 import { formatDuration } from '@/lib/core/utils/formatting'
 import { LoopTool } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/subflows/loop/loop-config'
@@ -118,6 +118,10 @@ function getBlockIconAndColor(
 
   // Check for tool by name first (most specific)
   if (lowerType === 'tool' && toolName) {
+    // Handle load_skill tool with the AgentSkillsIcon
+    if (toolName === 'load_skill') {
+      return { icon: AgentSkillsIcon, bgColor: '#8B5CF6' }
+    }
     const toolBlock = getBlockByToolName(toolName)
     if (toolBlock) {
       return { icon: toolBlock.icon, bgColor: toolBlock.bgColor }


### PR DESCRIPTION
## Summary
Adds the `AgentSkillsIcon` and a consistent purple background color to skill entries in the logs' trace spans. Previously, skill entries appeared with a generic gray icon due to missing specific handling for the `load_skill` tool.

Fixes # (issue) - *No specific issue number provided, remove if not applicable*

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
The change was verified by running lint and type checks, which passed successfully. Visual inspection confirms the icon and color are now displayed correctly for skill blocks in the logs.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->

---
<p><a href="https://cursor.com/background-agent?bcId=bc-65ead900-8208-41c2-9f38-59f5aacb7422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-65ead900-8208-41c2-9f38-59f5aacb7422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

