### PR TITLE
improvement(helm): support copilot-only deployments

### DIFF
--- a/helm/sim/examples/values-copilot.yaml
+++ b/helm/sim/examples/values-copilot.yaml
@@ -63,7 +63,7 @@ copilot:
     
     image:
       repository: postgres
-      tag: 16-alpine
+      tag: 17-alpine
       pullPolicy: IfNotPresent
     
     auth:

--- a/helm/sim/templates/ingress-internal.yaml
+++ b/helm/sim/templates/ingress-internal.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.ingressInternal.enabled }}
+{{- $appActive := .Values.app.enabled -}}
+{{- $realtimeActive := .Values.realtime.enabled -}}
+{{- $hasCopilotIngress := and .Values.copilot.enabled .Values.ingressInternal.copilot -}}
+{{- $realtimeHasOwnRule := and $realtimeActive (or (not $appActive) (ne .Values.ingressInternal.realtime.host .Values.ingressInternal.app.host)) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -17,22 +21,32 @@ spec:
   {{- if .Values.ingressInternal.tls.enabled }}
   tls:
     - hosts:
+        {{- if $appActive }}
         - {{ .Values.ingressInternal.app.host | quote }}
-        {{- if and .Values.realtime.enabled (ne .Values.ingressInternal.realtime.host .Values.ingressInternal.app.host) }}
+        {{- end }}
+        {{- if $realtimeHasOwnRule }}
         - {{ .Values.ingressInternal.realtime.host | quote }}
         {{- end }}
-        {{- if and .Values.copilot.enabled .Values.ingressInternal.copilot }}
-          {{- if and (ne .Values.ingressInternal.copilot.host .Values.ingressInternal.app.host) (ne .Values.ingressInternal.copilot.host .Values.ingressInternal.realtime.host) }}
+        {{- if $hasCopilotIngress }}
+          {{- $copilotHostCovered := false }}
+          {{- if and $appActive (eq .Values.ingressInternal.copilot.host .Values.ingressInternal.app.host) }}
+            {{- $copilotHostCovered = true }}
+          {{- end }}
+          {{- if and $realtimeHasOwnRule (eq .Values.ingressInternal.copilot.host .Values.ingressInternal.realtime.host) }}
+            {{- $copilotHostCovered = true }}
+          {{- end }}
+          {{- if not $copilotHostCovered }}
         - {{ .Values.ingressInternal.copilot.host | quote }}
           {{- end }}
         {{- end }}
       secretName: {{ .Values.ingressInternal.tls.secretName }}
   {{- end }}
   rules:
+    {{- if $appActive }}
     - host: {{ .Values.ingressInternal.app.host | quote }}
       http:
         paths:
-          {{- if and .Values.realtime.enabled (eq .Values.ingressInternal.realtime.host .Values.ingressInternal.app.host) }}
+          {{- if and $realtimeActive (eq .Values.ingressInternal.realtime.host .Values.ingressInternal.app.host) }}
           {{- range .Values.ingressInternal.realtime.paths }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
@@ -43,7 +57,7 @@ spec:
                   number: {{ $.Values.realtime.service.port }}
           {{- end }}
           {{- end }}
-          {{- if and .Values.copilot.enabled .Values.ingressInternal.copilot (eq .Values.ingressInternal.copilot.host .Values.ingressInternal.app.host) }}
+          {{- if and $hasCopilotIngress (eq .Values.ingressInternal.copilot.host .Values.ingressInternal.app.host) }}
           {{- range .Values.ingressInternal.copilot.paths }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
@@ -63,7 +77,8 @@ spec:
                 port:
                   number: {{ $.Values.app.service.port }}
           {{- end }}
-    {{- if and .Values.realtime.enabled (ne .Values.ingressInternal.realtime.host .Values.ingressInternal.app.host) }}
+    {{- end }}
+    {{- if $realtimeHasOwnRule }}
     - host: {{ .Values.ingressInternal.realtime.host | quote }}
       http:
         paths:
@@ -76,7 +91,7 @@ spec:
                 port:
                   number: {{ $.Values.realtime.service.port }}
           {{- end }}
-          {{- if and .Values.copilot.enabled .Values.ingressInternal.copilot (eq .Values.ingressInternal.copilot.host .Values.ingressInternal.realtime.host) }}
+          {{- if and $hasCopilotIngress (eq .Values.ingressInternal.copilot.host .Values.ingressInternal.realtime.host) }}
           {{- range .Values.ingressInternal.copilot.paths }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
@@ -88,7 +103,15 @@ spec:
           {{- end }}
           {{- end }}
     {{- end }}
-    {{- if and .Values.copilot.enabled .Values.ingressInternal.copilot (and (ne .Values.ingressInternal.copilot.host .Values.ingressInternal.app.host) (ne .Values.ingressInternal.copilot.host .Values.ingressInternal.realtime.host)) }}
+    {{- if $hasCopilotIngress }}
+      {{- $copilotServed := false }}
+      {{- if and $appActive (eq .Values.ingressInternal.copilot.host .Values.ingressInternal.app.host) }}
+        {{- $copilotServed = true }}
+      {{- end }}
+      {{- if and $realtimeHasOwnRule (eq .Values.ingressInternal.copilot.host .Values.ingressInternal.realtime.host) }}
+        {{- $copilotServed = true }}
+      {{- end }}
+      {{- if not $copilotServed }}
     - host: {{ .Values.ingressInternal.copilot.host | quote }}
       http:
         paths:
@@ -101,5 +124,6 @@ spec:
                 port:
                   number: {{ $.Values.copilot.server.service.port }}
           {{- end }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/helm/sim/templates/ingress.yaml
+++ b/helm/sim/templates/ingress.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.ingress.enabled }}
+{{- $appActive := .Values.app.enabled -}}
+{{- $realtimeActive := .Values.realtime.enabled -}}
+{{- $hasCopilotIngress := and .Values.copilot.enabled .Values.ingress.copilot -}}
+{{- $realtimeHasOwnRule := and $realtimeActive (or (not $appActive) (ne .Values.ingress.realtime.host .Values.ingress.app.host)) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -17,22 +21,32 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
+        {{- if $appActive }}
         - {{ .Values.ingress.app.host | quote }}
-        {{- if and .Values.realtime.enabled (ne .Values.ingress.realtime.host .Values.ingress.app.host) }}
+        {{- end }}
+        {{- if $realtimeHasOwnRule }}
         - {{ .Values.ingress.realtime.host | quote }}
         {{- end }}
-        {{- if and .Values.copilot.enabled .Values.ingress.copilot }}
-          {{- if and (ne .Values.ingress.copilot.host .Values.ingress.app.host) (ne .Values.ingress.copilot.host .Values.ingress.realtime.host) }}
+        {{- if $hasCopilotIngress }}
+          {{- $copilotHostCovered := false }}
+          {{- if and $appActive (eq .Values.ingress.copilot.host .Values.ingress.app.host) }}
+            {{- $copilotHostCovered = true }}
+          {{- end }}
+          {{- if and $realtimeHasOwnRule (eq .Values.ingress.copilot.host .Values.ingress.realtime.host) }}
+            {{- $copilotHostCovered = true }}
+          {{- end }}
+          {{- if not $copilotHostCovered }}
         - {{ .Values.ingress.copilot.host | quote }}
           {{- end }}
         {{- end }}
       secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
+    {{- if $appActive }}
     - host: {{ .Values.ingress.app.host | quote }}
       http:
         paths:
-          {{- if and .Values.realtime.enabled (eq .Values.ingress.realtime.host .Values.ingress.app.host) }}
+          {{- if and $realtimeActive (eq .Values.ingress.realtime.host .Values.ingress.app.host) }}
           {{- range .Values.ingress.realtime.paths }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
@@ -43,7 +57,7 @@ spec:
                   number: {{ $.Values.realtime.service.port }}
           {{- end }}
           {{- end }}
-          {{- if and .Values.copilot.enabled .Values.ingress.copilot (eq .Values.ingress.copilot.host .Values.ingress.app.host) }}
+          {{- if and $hasCopilotIngress (eq .Values.ingress.copilot.host .Values.ingress.app.host) }}
           {{- range .Values.ingress.copilot.paths }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
@@ -63,7 +77,8 @@ spec:
                 port:
                   number: {{ $.Values.app.service.port }}
           {{- end }}
-    {{- if and .Values.realtime.enabled (ne .Values.ingress.realtime.host .Values.ingress.app.host) }}
+    {{- end }}
+    {{- if $realtimeHasOwnRule }}
     - host: {{ .Values.ingress.realtime.host | quote }}
       http:
         paths:
@@ -76,7 +91,7 @@ spec:
                 port:
                   number: {{ $.Values.realtime.service.port }}
           {{- end }}
-          {{- if and .Values.copilot.enabled .Values.ingress.copilot (eq .Values.ingress.copilot.host .Values.ingress.realtime.host) }}
+          {{- if and $hasCopilotIngress (eq .Values.ingress.copilot.host .Values.ingress.realtime.host) }}
           {{- range .Values.ingress.copilot.paths }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
@@ -88,7 +103,15 @@ spec:
           {{- end }}
           {{- end }}
     {{- end }}
-    {{- if and .Values.copilot.enabled .Values.ingress.copilot (and (ne .Values.ingress.copilot.host .Values.ingress.app.host) (ne .Values.ingress.copilot.host .Values.ingress.realtime.host)) }}
+    {{- if $hasCopilotIngress }}
+      {{- $copilotServed := false }}
+      {{- if and $appActive (eq .Values.ingress.copilot.host .Values.ingress.app.host) }}
+        {{- $copilotServed = true }}
+      {{- end }}
+      {{- if and $realtimeHasOwnRule (eq .Values.ingress.copilot.host .Values.ingress.realtime.host) }}
+        {{- $copilotServed = true }}
+      {{- end }}
+      {{- if not $copilotServed }}
     - host: {{ .Values.ingress.copilot.host | quote }}
       http:
         paths:
@@ -101,5 +124,6 @@ spec:
                 port:
                   number: {{ $.Values.copilot.server.service.port }}
           {{- end }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/helm/sim/templates/job-copilot-migrations.yaml
+++ b/helm/sim/templates/job-copilot-migrations.yaml
@@ -36,7 +36,7 @@ spec:
       {{- if .Values.copilot.postgresql.enabled }}
       initContainers:
         - name: wait-for-postgres
-          image: postgres:16-alpine
+          image: {{ include "sim.image" (dict "context" . "image" .Values.copilot.postgresql.image) }}
           command:
             - /bin/sh
             - -c

--- a/helm/sim/templates/statefulset-copilot-postgres.yaml
+++ b/helm/sim/templates/statefulset-copilot-postgres.yaml
@@ -80,6 +80,9 @@ spec:
             - name: postgresql
               containerPort: {{ .Values.copilot.postgresql.service.targetPort }}
               protocol: TCP
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           envFrom:
             - secretRef:
                 name: {{ include "sim.fullname" . }}-copilot-postgresql-secret

--- a/helm/sim/values.schema.json
+++ b/helm/sim/values.schema.json
@@ -1008,7 +1008,31 @@
               }
             }
           }
-        }
+        },
+        "anyOf": [
+          {
+            "properties": {
+              "app": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "realtime": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        ]
       },
       "then": {
         "properties": {

--- a/helm/sim/values.yaml
+++ b/helm/sim/values.yaml
@@ -1073,11 +1073,11 @@ copilot:
   postgresql:
     # Enable/disable internal PostgreSQL for copilot
     enabled: true
-    
+
     # Image configuration
     image:
       repository: postgres
-      tag: 16-alpine
+      tag: 17-alpine
       pullPolicy: IfNotPresent
     
     # Authentication configuration


### PR DESCRIPTION
## Summary
- Fix JSON schema validation to allow copilot-only deploys without requiring externalDatabase
- Add missing PGDATA env var to copilot PostgreSQL (fixes CrashLoopBackOff with subPath mount)
- Bump copilot postgres default from 16-alpine to 17-alpine
- Use configured image for migration init container instead of hardcoded postgres:16-alpine
- Guard ingress app/realtime rules behind their enabled flags so copilot-only ingress works

## Type of Change
- [x] Bug fix
- [x] Improvement

## Testing
Validated via helm template for standard, copilot-only, and full+copilot scenarios

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)