### PR TITLE
fix(hotkeys): remove C, T, E tab-switching hotkeys

### DIFF
--- a/apps/docs/content/docs/de/keyboard-shortcuts/index.mdx
+++ b/apps/docs/content/docs/de/keyboard-shortcuts/index.mdx
@@ -41,9 +41,6 @@ Diese Tastenkombinationen wechseln zwischen den Panel-Tabs auf der rechten Seite
 
 | Tastenkombination | Aktion |
 |----------|--------|
-| `C` | Copilot-Tab fokussieren |
-| `T` | Toolbar-Tab fokussieren |
-| `E` | Editor-Tab fokussieren |
 | `Mod` + `F` | Toolbar-Suche fokussieren |
 
 ## Globale Navigation

--- a/apps/docs/content/docs/en/keyboard-shortcuts/index.mdx
+++ b/apps/docs/content/docs/en/keyboard-shortcuts/index.mdx
@@ -43,9 +43,6 @@ These shortcuts switch between panel tabs on the right side of the canvas.
 
 | Shortcut | Action |
 |----------|--------|
-| `C` | Focus Copilot tab |
-| `T` | Focus Toolbar tab |
-| `E` | Focus Editor tab |
 | `Mod` + `F` | Focus Toolbar search |
 
 ## Global Navigation

--- a/apps/docs/content/docs/es/keyboard-shortcuts/index.mdx
+++ b/apps/docs/content/docs/es/keyboard-shortcuts/index.mdx
@@ -42,9 +42,6 @@ Estos atajos cambian entre las pestañas del panel en el lado derecho del lienzo
 
 | Atajo | Acción |
 |----------|--------|
-| `C` | Enfocar pestaña Copilot |
-| `T` | Enfocar pestaña Barra de herramientas |
-| `E` | Enfocar pestaña Editor |
 | `Mod` + `F` | Enfocar búsqueda de Barra de herramientas |
 
 ## Navegación global

--- a/apps/docs/content/docs/fr/keyboard-shortcuts/index.mdx
+++ b/apps/docs/content/docs/fr/keyboard-shortcuts/index.mdx
@@ -42,9 +42,6 @@ Ces raccourcis permettent de basculer entre les onglets du panneau sur le côté
 
 | Raccourci | Action |
 |----------|--------|
-| `C` | Activer l'onglet Copilot |
-| `T` | Activer l'onglet Barre d'outils |
-| `E` | Activer l'onglet Éditeur |
 | `Mod` + `F` | Activer la recherche dans la barre d'outils |
 
 ## Navigation globale

--- a/apps/docs/content/docs/ja/keyboard-shortcuts/index.mdx
+++ b/apps/docs/content/docs/ja/keyboard-shortcuts/index.mdx
@@ -41,9 +41,6 @@ import { Callout } from 'fumadocs-ui/components/callout'
 
 | ショートカット | 操作 |
 |----------|--------|
-| `C` | Copilotタブにフォーカス |
-| `T` | Toolbarタブにフォーカス |
-| `E` | Editorタブにフォーカス |
 | `Mod` + `F` | Toolbar検索にフォーカス |
 
 ## グローバルナビゲーション

--- a/apps/docs/content/docs/zh/keyboard-shortcuts/index.mdx
+++ b/apps/docs/content/docs/zh/keyboard-shortcuts/index.mdx
@@ -41,9 +41,6 @@ import { Callout } from 'fumadocs-ui/components/callout'
 
 | 快捷键 | 操作 |
 |----------|--------|
-| `C` | 聚焦 Copilot 标签页 |
-| `T` | 聚焦 Toolbar 标签页 |
-| `E` | 聚焦 Editor 标签页 |
 | `Mod` + `F` | 聚焦 Toolbar 搜索 |
 
 ## 全局导航

--- a/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
@@ -13,9 +13,6 @@ export type CommandId =
   | 'goto-logs'
   | 'open-search'
   | 'run-workflow'
-  | 'focus-copilot-tab'
-  | 'focus-toolbar-tab'
-  | 'focus-editor-tab'
   | 'clear-terminal-console'
   | 'focus-toolbar-search'
   | 'clear-notifications'
@@ -73,21 +70,6 @@ export const COMMAND_DEFINITIONS: Record<CommandId, CommandDefinition> = {
   'run-workflow': {
     id: 'run-workflow',
     shortcut: 'Mod+Enter',
-    allowInEditable: false,
-  },
-  'focus-copilot-tab': {
-    id: 'focus-copilot-tab',
-    shortcut: 'C',
-    allowInEditable: false,
-  },
-  'focus-toolbar-tab': {
-    id: 'focus-toolbar-tab',
-    shortcut: 'T',
-    allowInEditable: false,
-  },
-  'focus-editor-tab': {
-    id: 'focus-editor-tab',
-    shortcut: 'E',
     allowInEditable: false,
   },
   'clear-terminal-console': {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -340,13 +340,7 @@ export const Panel = memo(function Panel() {
    * Register global keyboard shortcuts using the central commands registry.
    *
    * - Mod+Enter: Run / cancel workflow (matches the Run button behavior)
-   * - C: Focus Copilot tab
-   * - T: Focus Toolbar tab
-   * - E: Focus Editor tab
    * - Mod+F: Focus Toolbar tab and search input
-   *
-   * The tab-switching commands are disabled inside editable elements so typing
-   * in inputs or textareas is not interrupted.
    */
   useRegisterGlobalCommands(() =>
     createCommands([
@@ -358,33 +352,6 @@ export const Panel = memo(function Panel() {
           } else {
             void runWorkflow()
           }
-        },
-        overrides: {
-          allowInEditable: false,
-        },
-      },
-      {
-        id: 'focus-copilot-tab',
-        handler: () => {
-          setActiveTab('copilot')
-        },
-        overrides: {
-          allowInEditable: false,
-        },
-      },
-      {
-        id: 'focus-toolbar-tab',
-        handler: () => {
-          setActiveTab('toolbar')
-        },
-        overrides: {
-          allowInEditable: false,
-        },
-      },
-      {
-        id: 'focus-editor-tab',
-        handler: () => {
-          setActiveTab('editor')
         },
         overrides: {
           allowInEditable: false,


### PR DESCRIPTION
## Summary
- Remove C, T, E single-key hotkeys for switching panel tabs (Copilot, Toolbar, Editor)
- Remove command definitions and registrations from global keyboard config
- Remove from docs across all 6 locales (en, es, fr, de, ja, zh)

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)