### PR TITLE
fix(change-detection): resolve false positive trigger block change detection

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/hooks/use-change-detection.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/hooks/use-change-detection.ts
@@ -57,6 +57,21 @@ export function useChangeDetection({
         }
       }
 
+      if (block.triggerMode) {
+        const triggerConfigValue = blockSubValues?.triggerConfig
+        if (
+          triggerConfigValue &&
+          typeof triggerConfigValue === 'object' &&
+          !subBlocks.triggerConfig
+        ) {
+          subBlocks.triggerConfig = {
+            id: 'triggerConfig',
+            type: 'short-input',
+            value: triggerConfigValue,
+          }
+        }
+      }
+
       blocksWithSubBlocks[blockId] = {
         ...block,
         subBlocks,

--- a/apps/sim/lib/workflows/comparison/compare.ts
+++ b/apps/sim/lib/workflows/comparison/compare.ts
@@ -9,6 +9,7 @@ import {
   normalizeLoop,
   normalizeParallel,
   normalizeSubBlockValue,
+  normalizeTriggerConfigValues,
   normalizeValue,
   normalizeVariables,
   sanitizeVariable,
@@ -172,14 +173,18 @@ export function generateWorkflowDiffSummary(
       }
     }
 
+    // Normalize trigger config values for both states before comparison
+    const normalizedCurrentSubs = normalizeTriggerConfigValues(currentSubBlocks)
+    const normalizedPreviousSubs = normalizeTriggerConfigValues(previousSubBlocks)
+
     // Compare subBlocks using shared helper for filtering (single source of truth)
     const allSubBlockIds = filterSubBlockIds([
-      ...new Set([...Object.keys(currentSubBlocks), ...Object.keys(previousSubBlocks)]),
+      ...new Set([...Object.keys(normalizedCurrentSubs), ...Object.keys(normalizedPreviousSubs)]),
     ])
 
     for (const subId of allSubBlockIds) {
-      const currentSub = currentSubBlocks[subId] as Record<string, unknown> | undefined
-      const previousSub = previousSubBlocks[subId] as Record<string, unknown> | undefined
+      const currentSub = normalizedCurrentSubs[subId] as Record<string, unknown> | undefined
+      const previousSub = normalizedPreviousSubs[subId] as Record<string, unknown> | undefined
 
       if (!currentSub || !previousSub) {
         changes.push({

--- a/apps/sim/lib/workflows/comparison/normalize.ts
+++ b/apps/sim/lib/workflows/comparison/normalize.ts
@@ -418,8 +418,46 @@ export function extractBlockFieldsForComparison(block: BlockState): ExtractedBlo
  */
 export function filterSubBlockIds(subBlockIds: string[]): string[] {
   return subBlockIds
-    .filter((id) => !SYSTEM_SUBBLOCK_IDS.includes(id) && !TRIGGER_RUNTIME_SUBBLOCK_IDS.includes(id))
+    .filter((id) => {
+      if (TRIGGER_RUNTIME_SUBBLOCK_IDS.includes(id)) return false
+      if (SYSTEM_SUBBLOCK_IDS.some((sysId) => id === sysId || id.startsWith(`${sysId}_`)))
+        return false
+      return true
+    })
     .sort()
+}
+
+/**
+ * Normalizes trigger block subBlocks by populating null/empty individual fields
+ * from the triggerConfig aggregate subBlock. This compensates for the runtime
+ * population done by populateTriggerFieldsFromConfig, ensuring consistent
+ * comparison between client state (with populated values) and deployed state
+ * (with null values from DB).
+ */
+export function normalizeTriggerConfigValues(
+  subBlocks: Record<string, unknown>
+): Record<string, unknown> {
+  const triggerConfigSub = subBlocks.triggerConfig as Record<string, unknown> | undefined
+  const triggerConfigValue = triggerConfigSub?.value
+  if (!triggerConfigValue || typeof triggerConfigValue !== 'object') {
+    return subBlocks
+  }
+
+  const result = { ...subBlocks }
+  for (const [fieldId, configValue] of Object.entries(
+    triggerConfigValue as Record<string, unknown>
+  )) {
+    if (configValue === null || configValue === undefined) continue
+    const existingSub = result[fieldId] as Record<string, unknown> | undefined
+    if (
+      existingSub &&
+      (existingSub.value === null || existingSub.value === undefined || existingSub.value === '')
+    ) {
+      result[fieldId] = { ...existingSub, value: configValue }
+    }
+  }
+
+  return result
 }
 
 /**

--- a/apps/sim/triggers/constants.ts
+++ b/apps/sim/triggers/constants.ts
@@ -23,7 +23,12 @@ export const SYSTEM_SUBBLOCK_IDS: string[] = [
  * with default values from the trigger definition on load, which aren't present in
  * the deployed state, causing false positive change detection.
  */
-export const TRIGGER_RUNTIME_SUBBLOCK_IDS: string[] = ['webhookId', 'triggerPath', 'triggerConfig']
+export const TRIGGER_RUNTIME_SUBBLOCK_IDS: string[] = [
+  'webhookId',
+  'triggerPath',
+  'triggerConfig',
+  'triggerId',
+]
 
 /**
  * Maximum number of consecutive failures before a trigger (schedule/webhook) is auto-disabled.


### PR DESCRIPTION
## Summary
- Fix false positive "changes detected" for deployed trigger blocks (e.g., Slack webhook)
- Add `triggerId` to runtime subblock exclusion list
- Fix prefix matching for namespaced system subblock IDs (e.g., `samplePayload_slack_webhook`)
- Add `normalizeTriggerConfigValues` to populate null fields from triggerConfig before comparison
- Inject triggerConfig into current state for trigger-mode blocks
- Add 27 new tests covering all edge cases

## Type of Change
- [x] Bug fix

## Testing
- 206 tests passing (27 new)
- TypeScript compiles clean
- Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)