### PR TITLE
improvement(copilot): scrolling stickiness

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/copilot.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/copilot.tsx
@@ -131,10 +131,8 @@ export const Copilot = forwardRef<CopilotRef, CopilotProps>(({ panelWidth }, ref
     resumeActiveStream,
   })
 
-  // Handle scroll management (80px stickiness for copilot)
-  const { scrollAreaRef, scrollToBottom } = useScrollManagement(messages, isSendingMessage, {
-    stickinessThreshold: 40,
-  })
+  // Handle scroll management
+  const { scrollAreaRef, scrollToBottom } = useScrollManagement(messages, isSendingMessage)
 
   // Handle chat history grouping
   const { groupedChats, handleHistoryDropdownOpen: handleHistoryDropdownOpenHook } = useChatHistory(

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-scroll-management.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-scroll-management.ts
@@ -16,7 +16,7 @@ interface UseScrollManagementOptions {
   /**
    * Distance from bottom (in pixels) within which auto-scroll stays active
    * @remarks Lower values = less sticky (user can scroll away easier)
-   * @defaultValue 100
+   * @defaultValue 30
    */
   stickinessThreshold?: number
 }
@@ -41,7 +41,7 @@ export function useScrollManagement(
   const lastScrollTopRef = useRef(0)
 
   const scrollBehavior = options?.behavior ?? 'smooth'
-  const stickinessThreshold = options?.stickinessThreshold ?? 100
+  const stickinessThreshold = options?.stickinessThreshold ?? 30
 
   /** Scrolls the container to the bottom */
   const scrollToBottom = useCallback(() => {


### PR DESCRIPTION
## Summary
Reduced scroll stickiness for Copilot and Chat messages to improve user control and ensure consistent behavior across all message scrolling interactions. The default `stickinessThreshold` was updated from 100 to 30, and Copilot now uses this unified default.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [x] Other: Improvement

## Testing
Manually verified by observing scroll behavior in both Copilot and Chat panels. Reviewers should focus on confirming the new scroll stickiness feels appropriate and consistent when new messages arrive while the user is scrolling.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
