### PR TITLE
fix(workflow-vars): duplicate, export/import copies

### DIFF
--- a/apps/sim/lib/workflows/operations/import-export.ts
+++ b/apps/sim/lib/workflows/operations/import-export.ts
@@ -583,7 +583,10 @@ export function parseWorkflowJson(
       loops: workflowData.loops || {},
       parallels: workflowData.parallels || {},
       metadata: workflowData.metadata,
-      variables: Array.isArray(workflowData.variables) ? workflowData.variables : undefined,
+      variables:
+        workflowData.variables && typeof workflowData.variables === 'object'
+          ? workflowData.variables
+          : undefined,
     }
 
     if (regenerateIdsFlag) {

--- a/apps/sim/lib/workflows/sanitization/json-sanitizer.ts
+++ b/apps/sim/lib/workflows/sanitization/json-sanitizer.ts
@@ -57,12 +57,15 @@ export interface ExportWorkflowState {
       sortOrder?: number
       exportedAt?: string
     }
-    variables?: Array<{
-      id: string
-      name: string
-      type: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'plain'
-      value: unknown
-    }>
+    variables?: Record<
+      string,
+      {
+        id: string
+        name: string
+        type: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'plain'
+        value: unknown
+      }
+    >
   }
 }
 


### PR DESCRIPTION
## Summary
- Duplicate is not regenerating and mapping workflow variable ids accurately affecting variables block 
- Import/Export -- doesn't keep workflow variables. 

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)