### PR TITLE
feat(shortlink): add Beluga short link rewrite for hosted campaigns

### DIFF
--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -326,6 +326,18 @@ const nextConfig: NextConfig = {
 
     return redirects
   },
+  async rewrites() {
+    return [
+      ...(isHosted
+        ? [
+            {
+              source: '/r/:shortCode',
+              destination: 'https://go.trybeluga.ai/:shortCode',
+            },
+          ]
+        : []),
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- Add `/r/:shortCode` rewrite to proxy short links to Beluga's tracking system (`go.trybeluga.ai`)
- Only active when `isHosted` is true so it doesn't affect self-hosted/OSS deployments

## Type of Change
- [x] New feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)