### PR TITLE
improvement(providers): replace @ts-ignore with typed ProviderError class

### DIFF
--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -14,6 +14,7 @@ import {
   supportsNativeStructuredOutputs,
 } from '@/providers/models'
 import type { ProviderRequest, ProviderResponse, TimeSegment } from '@/providers/types'
+import { ProviderError } from '@/providers/types'
 import {
   calculateCost,
   prepareToolExecution,
@@ -842,15 +843,11 @@ export async function executeAnthropicProviderRequest(
         duration: totalDuration,
       })
 
-      const enhancedError = new Error(error instanceof Error ? error.message : String(error))
-      // @ts-ignore
-      enhancedError.timing = {
+      throw new ProviderError(error instanceof Error ? error.message : String(error), {
         startTime: providerStartTimeISO,
         endTime: providerEndTimeISO,
         duration: totalDuration,
-      }
-
-      throw enhancedError
+      })
     }
   }
 
@@ -1299,14 +1296,10 @@ export async function executeAnthropicProviderRequest(
       duration: totalDuration,
     })
 
-    const enhancedError = new Error(error instanceof Error ? error.message : String(error))
-    // @ts-ignore
-    enhancedError.timing = {
+    throw new ProviderError(error instanceof Error ? error.message : String(error), {
       startTime: providerStartTimeISO,
       endTime: providerEndTimeISO,
       duration: totalDuration,
-    }
-
-    throw enhancedError
+    })
   }
 }

--- a/apps/sim/providers/azure-openai/index.ts
+++ b/apps/sim/providers/azure-openai/index.ts
@@ -30,6 +30,7 @@ import type {
   ProviderResponse,
   TimeSegment,
 } from '@/providers/types'
+import { ProviderError } from '@/providers/types'
 import {
   calculateCost,
   prepareToolExecution,
@@ -251,7 +252,7 @@ async function executeChatCompletionsRequest(
       output: currentResponse.usage?.completion_tokens || 0,
       total: currentResponse.usage?.total_tokens || 0,
     }
-    const toolCalls: (FunctionCallResponse & { success: boolean })[] = []
+    const toolCalls: FunctionCallResponse[] = []
     const toolResults: Record<string, unknown>[] = []
     const currentMessages = [...allMessages]
     let iterationCount = 0
@@ -577,15 +578,11 @@ async function executeChatCompletionsRequest(
       duration: totalDuration,
     })
 
-    const enhancedError = new Error(error instanceof Error ? error.message : String(error))
-    // @ts-ignore - Adding timing property to the error
-    enhancedError.timing = {
+    throw new ProviderError(error instanceof Error ? error.message : String(error), {
       startTime: providerStartTimeISO,
       endTime: providerEndTimeISO,
       duration: totalDuration,
-    }
-
-    throw enhancedError
+    })
   }
 }
 

--- a/apps/sim/providers/cerebras/index.ts
+++ b/apps/sim/providers/cerebras/index.ts
@@ -11,6 +11,7 @@ import type {
   ProviderResponse,
   TimeSegment,
 } from '@/providers/types'
+import { ProviderError } from '@/providers/types'
 import {
   calculateCost,
   prepareToolExecution,
@@ -539,15 +540,11 @@ export const cerebrasProvider: ProviderConfig = {
         duration: totalDuration,
       })
 
-      const enhancedError = new Error(error instanceof Error ? error.message : String(error))
-      // @ts-ignore - Adding timing property to error for debugging
-      enhancedError.timing = {
+      throw new ProviderError(error instanceof Error ? error.message : String(error), {
         startTime: providerStartTimeISO,
         endTime: providerEndTimeISO,
         duration: totalDuration,
-      }
-
-      throw enhancedError
+      })
     }
   },
 }

--- a/apps/sim/providers/deepseek/index.ts
+++ b/apps/sim/providers/deepseek/index.ts
@@ -10,6 +10,7 @@ import type {
   ProviderResponse,
   TimeSegment,
 } from '@/providers/types'
+import { ProviderError } from '@/providers/types'
 import {
   calculateCost,
   prepareToolExecution,
@@ -538,15 +539,11 @@ export const deepseekProvider: ProviderConfig = {
         duration: totalDuration,
       })
 
-      const enhancedError = new Error(error instanceof Error ? error.message : String(error))
-      // @ts-ignore
-      enhancedError.timing = {
+      throw new ProviderError(error instanceof Error ? error.message : String(error), {
         startTime: providerStartTimeISO,
         endTime: providerEndTimeISO,
         duration: totalDuration,
-      }
-
-      throw enhancedError
+      })
     }
   },
 }

--- a/apps/sim/providers/groq/index.ts
+++ b/apps/sim/providers/groq/index.ts
@@ -10,6 +10,7 @@ import type {
   ProviderResponse,
   TimeSegment,
 } from '@/providers/types'
+import { ProviderError } from '@/providers/types'
 import {
   calculateCost,
   prepareToolExecution,
@@ -496,15 +497,11 @@ export const groqProvider: ProviderConfig = {
         duration: totalDuration,
       })
 
-      const enhancedError = new Error(error instanceof Error ? error.message : String(error))
-      // @ts-ignore
-      enhancedError.timing = {
+      throw new ProviderError(error instanceof Error ? error.message : String(error), {
         startTime: providerStartTimeISO,
         endTime: providerEndTimeISO,
         duration: totalDuration,
-      }
-
-      throw enhancedError
+      })
     }
   },
 }

--- a/apps/sim/providers/mistral/index.ts
+++ b/apps/sim/providers/mistral/index.ts
@@ -11,6 +11,7 @@ import type {
   ProviderResponse,
   TimeSegment,
 } from '@/providers/types'
+import { ProviderError } from '@/providers/types'
 import {
   calculateCost,
   prepareToolExecution,
@@ -551,15 +552,11 @@ export const mistralProvider: ProviderConfig = {
         duration: totalDuration,
       })
 
-      const enhancedError = new Error(error instanceof Error ? error.message : String(error))
-      // @ts-ignore - Adding timing property to error for debugging
-      enhancedError.timing = {
+      throw new ProviderError(error instanceof Error ? error.message : String(error), {
         startTime: providerStartTimeISO,
         endTime: providerEndTimeISO,
         duration: totalDuration,
-      }
-
-      throw enhancedError
+      })
     }
   },
 }

--- a/apps/sim/providers/ollama/index.ts
+++ b/apps/sim/providers/ollama/index.ts
@@ -12,6 +12,7 @@ import type {
   ProviderResponse,
   TimeSegment,
 } from '@/providers/types'
+import { ProviderError } from '@/providers/types'
 import { calculateCost, prepareToolExecution } from '@/providers/utils'
 import { useProvidersStore } from '@/stores/providers'
 import { executeTool } from '@/tools'
@@ -554,15 +555,11 @@ export const ollamaProvider: ProviderConfig = {
         duration: totalDuration,
       })
 
-      const enhancedError = new Error(error instanceof Error ? error.message : String(error))
-      // @ts-ignore
-      enhancedError.timing = {
+      throw new ProviderError(error instanceof Error ? error.message : String(error), {
         startTime: providerStartTimeISO,
         endTime: providerEndTimeISO,
         duration: totalDuration,
-      }
-
-      throw enhancedError
+      })
     }
   },
 }

--- a/apps/sim/providers/openai/core.ts
+++ b/apps/sim/providers/openai/core.ts
@@ -3,6 +3,7 @@ import type OpenAI from 'openai'
 import type { StreamingExecution } from '@/executor/types'
 import { MAX_TOOL_ITERATIONS } from '@/providers'
 import type { Message, ProviderRequest, ProviderResponse, TimeSegment } from '@/providers/types'
+import { ProviderError } from '@/providers/types'
 import {
   calculateCost,
   prepareToolExecution,
@@ -806,14 +807,10 @@ export async function executeResponsesProviderRequest(
       duration: totalDuration,
     })
 
-    const enhancedError = new Error(error instanceof Error ? error.message : String(error))
-    // @ts-ignore - Adding timing property to the error
-    enhancedError.timing = {
+    throw new ProviderError(error instanceof Error ? error.message : String(error), {
       startTime: providerStartTimeISO,
       endTime: providerEndTimeISO,
       duration: totalDuration,
-    }
-
-    throw enhancedError
+    })
   }
 }

--- a/apps/sim/providers/types.ts
+++ b/apps/sim/providers/types.ts
@@ -59,6 +59,7 @@ export interface FunctionCallResponse {
   result?: Record<string, any>
   output?: Record<string, any>
   input?: Record<string, any>
+  success?: boolean
 }
 
 export interface TimeSegment {
@@ -175,6 +176,23 @@ export interface ProviderRequest {
   isDeployedContext?: boolean
   /** Previous interaction ID for multi-turn Interactions API requests (deep research follow-ups) */
   previousInteractionId?: string
+}
+
+/**
+ * Typed error class for provider failures that includes timing information.
+ */
+export class ProviderError extends Error {
+  timing: {
+    startTime: string
+    endTime: string
+    duration: number
+  }
+
+  constructor(message: string, timing: { startTime: string; endTime: string; duration: number }) {
+    super(message)
+    this.name = 'ProviderError'
+    this.timing = timing
+  }
 }
 
 export const providers: Record<string, ProviderConfig> = {}

--- a/apps/sim/providers/vllm/index.ts
+++ b/apps/sim/providers/vllm/index.ts
@@ -6,11 +6,13 @@ import type { StreamingExecution } from '@/executor/types'
 import { MAX_TOOL_ITERATIONS } from '@/providers'
 import { getProviderDefaultModel, getProviderModels } from '@/providers/models'
 import type {
+  Message,
   ProviderConfig,
   ProviderRequest,
   ProviderResponse,
   TimeSegment,
 } from '@/providers/types'
+import { ProviderError } from '@/providers/types'
 import {
   calculateCost,
   prepareToolExecution,
@@ -98,7 +100,7 @@ export const vllmProvider: ProviderConfig = {
       baseURL: `${baseUrl}/v1`,
     })
 
-    const allMessages = [] as any[]
+    const allMessages: Message[] = []
 
     if (request.systemPrompt) {
       allMessages.push({
@@ -635,23 +637,11 @@ export const vllmProvider: ProviderConfig = {
         duration: totalDuration,
       })
 
-      const enhancedError = new Error(errorMessage)
-      // @ts-ignore
-      enhancedError.timing = {
+      throw new ProviderError(errorMessage, {
         startTime: providerStartTimeISO,
         endTime: providerEndTimeISO,
         duration: totalDuration,
-      }
-      if (errorType) {
-        // @ts-ignore
-        enhancedError.vllmErrorType = errorType
-      }
-      if (errorCode) {
-        // @ts-ignore
-        enhancedError.vllmErrorCode = errorCode
-      }
-
-      throw enhancedError
+      })
     }
   },
 }

--- a/apps/sim/providers/xai/index.ts
+++ b/apps/sim/providers/xai/index.ts
@@ -5,11 +5,13 @@ import type { StreamingExecution } from '@/executor/types'
 import { MAX_TOOL_ITERATIONS } from '@/providers'
 import { getProviderDefaultModel, getProviderModels } from '@/providers/models'
 import type {
+  Message,
   ProviderConfig,
   ProviderRequest,
   ProviderResponse,
   TimeSegment,
 } from '@/providers/types'
+import { ProviderError } from '@/providers/types'
 import {
   calculateCost,
   prepareToolExecution,
@@ -52,7 +54,7 @@ export const xAIProvider: ProviderConfig = {
       streaming: !!request.stream,
     })
 
-    const allMessages: any[] = []
+    const allMessages: Message[] = []
 
     if (request.systemPrompt) {
       allMessages.push({
@@ -587,15 +589,11 @@ export const xAIProvider: ProviderConfig = {
         hasResponseFormat: !!request.responseFormat,
       })
 
-      const enhancedError = new Error(error instanceof Error ? error.message : String(error))
-      // @ts-ignore - Adding timing property to error for debugging
-      enhancedError.timing = {
+      throw new ProviderError(error instanceof Error ? error.message : String(error), {
         startTime: providerStartTimeISO,
         endTime: providerEndTimeISO,
         duration: totalDuration,
-      }
-
-      throw enhancedError
+      })
     }
   },
 }


### PR DESCRIPTION
## Summary
- Add `ProviderError` class to `providers/types.ts` with typed `timing` property
- Replace 14 `@ts-ignore` + dynamic property assignments across 12 provider files
- Add `success` field to `FunctionCallResponse` (already pushed by every provider)
- Replace `any[]` casts with proper types (`Message[]`, `FunctionCallResponse[]`) in xai, openrouter, vllm, bedrock
- Remove unused `vllmErrorType`/`vllmErrorCode` dead code
- Remove `& { success: boolean }` workaround in azure-openai

fixes #3180 

## Type of Change
- [x] Refactor (type safety improvement, no runtime behavior change)

## Testing
TypeScript compiles cleanly with `tsc --noEmit`. No runtime changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)