### PR TITLE
fix(pagination): add missing next_page to response interfaces and operator comments

### DIFF
--- a/apps/sim/tools/supabase/text_search.ts
+++ b/apps/sim/tools/supabase/text_search.ts
@@ -80,6 +80,7 @@ export const textSearchTool: ToolConfig<SupabaseTextSearchParams, SupabaseTextSe
       let url = `https://${params.projectId}.supabase.co/rest/v1/${params.table}?select=*`
 
       // Map search types to PostgREST operators
+      // plfts = plainto_tsquery (natural language), phfts = phraseto_tsquery, wfts = websearch_to_tsquery
       const operatorMap: Record<string, string> = {
         plain: 'plfts',
         phrase: 'phfts',

--- a/apps/sim/tools/zendesk/autocomplete_organizations.ts
+++ b/apps/sim/tools/zendesk/autocomplete_organizations.ts
@@ -23,6 +23,7 @@ export interface ZendeskAutocompleteOrganizationsResponse {
     paging?: {
       after_cursor: string | null
       has_more: boolean
+      next_page?: string | null
     }
     metadata: {
       total_returned: number

--- a/apps/sim/tools/zendesk/search_users.ts
+++ b/apps/sim/tools/zendesk/search_users.ts
@@ -24,6 +24,7 @@ export interface ZendeskSearchUsersResponse {
     paging?: {
       after_cursor: string | null
       has_more: boolean
+      next_page?: string | null
     }
     metadata: {
       total_returned: number


### PR DESCRIPTION
## Summary
- Add `next_page` to `ZendeskAutocompleteOrganizationsResponse` and `ZendeskSearchUsersResponse` paging interfaces to match runtime output
- Add PostgREST operator mapping comment in Supabase `text_search.ts` for clarity

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)