### PR TITLE
fix(shortlink): use redirect instead of rewrite for Beluga tracking

### DIFF
--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -324,19 +324,16 @@ const nextConfig: NextConfig = {
       )
     }
 
+    // Beluga campaign short link tracking
+    if (isHosted) {
+      redirects.push({
+        source: '/r/:shortCode',
+        destination: 'https://go.trybeluga.ai/:shortCode',
+        permanent: false,
+      })
+    }
+
     return redirects
-  },
-  async rewrites() {
-    return [
-      ...(isHosted
-        ? [
-            {
-              source: '/r/:shortCode',
-              destination: 'https://go.trybeluga.ai/:shortCode',
-            },
-          ]
-        : []),
-    ]
   },
 }
 


### PR DESCRIPTION
## Summary
- Switch Beluga short link from rewrite to redirect so their tracking system actually sees the client
- Rewrites proxy server-side which prevents Beluga from logging clicks

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)