### PR TITLE
feat(sub): hide enterprise member usage limits for non admin

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/settings-modal/components/subscription/subscription-permissions.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/settings-modal/components/subscription/subscription-permissions.ts
@@ -7,6 +7,8 @@ export interface SubscriptionPermissions {
   canCancelSubscription: boolean
   showTeamMemberView: boolean
   showUpgradePlans: boolean
+  isEnterpriseMember: boolean
+  canViewUsageInfo: boolean
 }
 
 export interface SubscriptionState {
@@ -31,6 +33,9 @@ export function getSubscriptionPermissions(
   const { isFree, isPro, isTeam, isEnterprise, isPaid } = subscription
   const { isTeamAdmin } = userRole
 
+  const isEnterpriseMember = isEnterprise && !isTeamAdmin
+  const canViewUsageInfo = !isEnterpriseMember
+
   return {
     canUpgradeToPro: isFree,
     canUpgradeToTeam: isFree || (isPro && !isTeam),
@@ -40,6 +45,8 @@ export function getSubscriptionPermissions(
     canCancelSubscription: isPaid && !isEnterprise && !(isTeam && !isTeamAdmin), // Team members can't cancel
     showTeamMemberView: isTeam && !isTeamAdmin,
     showUpgradePlans: isFree || (isPro && !isTeam) || (isTeam && isTeamAdmin), // Free users, Pro users, Team owners see plans
+    isEnterpriseMember,
+    canViewUsageInfo,
   }
 }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/usage-indicator/usage-indicator.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/usage-indicator/usage-indicator.tsx
@@ -285,6 +285,7 @@ export function UsageIndicator({ onClick }: UsageIndicatorProps) {
   const isPro = planType === 'pro'
   const isTeam = planType === 'team'
   const isEnterprise = planType === 'enterprise'
+  const isEnterpriseMember = isEnterprise && !userCanManageBilling
 
   const handleUpgradeToPro = useCallback(async () => {
     try {
@@ -461,6 +462,18 @@ export function UsageIndicator({ onClick }: UsageIndicatorProps) {
     } catch (error) {
       logger.error('Failed to handle usage indicator click', { error })
     }
+  }
+
+  if (isEnterpriseMember) {
+    return (
+      <div className='flex flex-shrink-0 flex-col border-t px-[13.5px] pt-[8px] pb-[10px]'>
+        <div className='flex h-[18px] items-center'>
+          <span className='font-medium text-[12px] text-[var(--text-primary)]'>
+            {PLAN_NAMES[planType]}
+          </span>
+        </div>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary
This PR implements changes to hide usage limits, seat information, and other billing-related details from non-admin enterprise members in the settings tabs. Only enterprise administrators will now be able to view this sensitive information.

Fixes #(issue) - *Please link the relevant issue if one exists.*

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
The changes have been verified with TypeScript type checking and linting.
Reviewers should manually test by logging in as:
1.  An enterprise administrator to ensure all usage and billing information is visible.
2.  A non-admin enterprise member to confirm that usage limits, credit balance, next billing date, usage notifications, and seat badges are hidden in the Subscription tab, and only the "Enterprise" plan name is shown in the Usage Indicator.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->

---
[Slack Thread](https://sim-ai.slack.com/archives/C093DF8MA21/p1771392866690719?thread_ts=1771392866.690719&cid=C093DF8MA21)

<p><a href="https://cursor.com/background-agent?bcId=bc-0af56858-caa8-5c1b-ab7a-898690aa382b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0af56858-caa8-5c1b-ab7a-898690aa382b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

