### PR TITLE
fix(lock): prevent socket crash when locking agent blocks

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/editor.tsx
@@ -618,6 +618,15 @@ export function Editor() {
                       <div className='h-[1.25px] flex-1' style={DASHED_DIVIDER_STYLE} />
                     </div>
                   )}
+                  {hasAdvancedOnlyFields && !canEditBlock && displayAdvancedOptions && (
+                    <div className='flex items-center gap-[10px] px-[2px] pt-[14px] pb-[12px]'>
+                      <div className='h-[1.25px] flex-1' style={DASHED_DIVIDER_STYLE} />
+                      <span className='whitespace-nowrap font-medium text-[13px] text-[var(--text-secondary)]'>
+                        Additional fields
+                      </span>
+                      <div className='h-[1.25px] flex-1' style={DASHED_DIVIDER_STYLE} />
+                    </div>
+                  )}
 
                   {advancedOnlySubBlocks.map((subBlock, index) => {
                     const stableKey = getSubBlockStableKey(


### PR DESCRIPTION
## Summary
- Confirm subblock updates on locked blocks instead of failing them — prevents socket offline mode
- Show "Additional fields" divider on locked blocks so spacing matches unlocked view

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)