### PR TITLE
fix(shortlink): remove isHosted guard from redirects, not available at build time on ECS

### DIFF
--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -306,14 +306,15 @@ const nextConfig: NextConfig = {
       }
     )
 
-    // Beluga campaign short link tracking (always registered — harmless for self-hosted)
-    redirects.push({
-      source: '/r/:shortCode',
-      destination: 'https://go.trybeluga.ai/:shortCode',
-      permanent: false,
-    })
-
     return redirects
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/r/:shortCode',
+        destination: 'https://go.trybeluga.ai/:shortCode',
+      },
+    ]
   },
 }
 


### PR DESCRIPTION
## Summary
- Remove `isHosted` guard from Beluga short link redirect — `isHosted` evaluates at build time but `NEXT_PUBLIC_APP_URL` is a runtime env var on ECS, so the redirect was never registered
- Remove dead `simstudio.ai` domain redirects (same issue, and simstudio.ai doesn't have HTTPS configured)
- Clean up unused `isHosted` import from next.config.ts

## Type of Change
- [x] Bug fix

## Testing
- Verified `/discord` redirect works (not gated by `isHosted`)
- Verified `/r/9Px2V` returns 404 on production (confirms redirect was never registered)
- Tested locally with `isHosted` set to true — redirect works

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)