### PR TITLE
feat(models): add gemini-3.1-pro-preview and update gemini-3-pro thinking levels

### DIFF
--- a/apps/sim/app/api/tools/stt/route.ts
+++ b/apps/sim/app/api/tools/stt/route.ts
@@ -766,7 +766,7 @@ async function transcribeWithGemini(
     const error = await response.json()
     if (response.status === 404) {
       throw new Error(
-        `Model not found: ${modelName}. Use gemini-3-pro-preview, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite, or gemini-2.0-flash-exp`
+        `Model not found: ${modelName}. Use gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite, or gemini-2.0-flash-exp`
       )
     }
     const errorMessage = error.error?.message || JSON.stringify(error)

--- a/apps/sim/blocks/blocks/stt.ts
+++ b/apps/sim/blocks/blocks/stt.ts
@@ -94,6 +94,7 @@ export const SttBlock: BlockConfig<SttBlockResponse> = {
       type: 'dropdown',
       condition: { field: 'provider', value: 'gemini' },
       options: [
+        { label: 'Gemini 3.1 Pro', id: 'gemini-3.1-pro-preview' },
         { label: 'Gemini 3 Pro', id: 'gemini-3-pro-preview' },
         { label: 'Gemini 2.5 Pro', id: 'gemini-2.5-pro' },
         { label: 'Gemini 2.5 Flash', id: 'gemini-2.5-flash' },

--- a/apps/sim/blocks/blocks/vision.ts
+++ b/apps/sim/blocks/blocks/vision.ts
@@ -13,6 +13,7 @@ const VISION_MODEL_OPTIONS = [
   { label: 'Claude Opus 4.5', id: 'claude-opus-4-5' },
   { label: 'Claude Sonnet 4.5', id: 'claude-sonnet-4-5' },
   { label: 'Claude Haiku 4.5', id: 'claude-haiku-4-5' },
+  { label: 'Gemini 3.1 Pro Preview', id: 'gemini-3.1-pro-preview' },
   { label: 'Gemini 3 Pro Preview', id: 'gemini-3-pro-preview' },
   { label: 'Gemini 3 Flash Preview', id: 'gemini-3-flash-preview' },
   { label: 'Gemini 2.5 Pro', id: 'gemini-2.5-pro' },

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -835,6 +835,23 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     icon: GeminiIcon,
     models: [
       {
+        id: 'gemini-3.1-pro-preview',
+        pricing: {
+          input: 2.0,
+          cachedInput: 0.2,
+          output: 12.0,
+          updatedAt: '2026-02-19',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['low', 'medium', 'high'],
+            default: 'high',
+          },
+        },
+        contextWindow: 1048576,
+      },
+      {
         id: 'gemini-3-pro-preview',
         pricing: {
           input: 2.0,
@@ -845,7 +862,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         capabilities: {
           temperature: { min: 0, max: 2 },
           thinking: {
-            levels: ['low', 'high'],
+            levels: ['low', 'medium', 'high'],
             default: 'high',
           },
         },
@@ -958,6 +975,23 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     },
     models: [
       {
+        id: 'vertex/gemini-3.1-pro-preview',
+        pricing: {
+          input: 2.0,
+          cachedInput: 0.2,
+          output: 12.0,
+          updatedAt: '2026-02-19',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['low', 'medium', 'high'],
+            default: 'high',
+          },
+        },
+        contextWindow: 1048576,
+      },
+      {
         id: 'vertex/gemini-3-pro-preview',
         pricing: {
           input: 2.0,
@@ -968,7 +1002,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         capabilities: {
           temperature: { min: 0, max: 2 },
           thinking: {
-            levels: ['low', 'high'],
+            levels: ['low', 'medium', 'high'],
             default: 'high',
           },
         },


### PR DESCRIPTION
## Summary
- Added `gemini-3.1-pro-preview` to Google and Vertex AI providers
- Added `medium` thinking level to `gemini-3-pro-preview` per updated docs
- Added model to vision and STT block dropdowns

## Type of Change
- [x] New feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)