### PR TITLE
fix(jsm): jsm requestTypeId requirement

### DIFF
--- a/apps/sim/blocks/blocks/jira_service_management.ts
+++ b/apps/sim/blocks/blocks/jira_service_management.ts
@@ -99,6 +99,7 @@ export const JiraServiceManagementBlock: BlockConfig<JsmResponse> = {
       id: 'serviceDeskId',
       title: 'Service Desk ID',
       type: 'short-input',
+      required: true,
       placeholder: 'Enter service desk ID',
       condition: {
         field: 'operation',


### PR DESCRIPTION
## Summary
Makes the `serviceDeskId` parameter required in the JSM block configuration (`jira_service_management.ts`). Previously, `serviceDeskId` was optional in the UI, but it is a mandatory parameter for the JSM API's `create_request` operation and other JSM operations. This change prevents runtime API failures when users leave this field blank.

Fixes #(issue) - *No specific issue number provided, so leaving as a placeholder.*

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
The change was verified by re-reading the file to confirm `required: true` was added to the `serviceDeskId` subBlock. TypeScript type checking (`tsc`) and linting commands were run and passed successfully. No specific JSM block tests were found or added.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
N/A

---
[Slack Thread](https://sim-ai.slack.com/archives/C093DF8MA21/p1771613633594909?thread_ts=1771613633.594909&cid=C093DF8MA21)

<p><a href="https://cursor.com/agents?id=bc-9f4f4ec7-68ef-5de4-af31-72cba806abfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f4f4ec7-68ef-5de4-af31-72cba806abfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

