### PR TITLE
fix(trigger): add isolated-vm support to trigger.dev container builds

### DIFF
--- a/apps/sim/lib/execution/isolated-vm.ts
+++ b/apps/sim/lib/execution/isolated-vm.ts
@@ -679,11 +679,15 @@ function spawnWorker(): Promise<WorkerInfo> {
     }
 
     const currentDir = path.dirname(fileURLToPath(import.meta.url))
-    const workerPath = path.join(currentDir, 'isolated-vm-worker.cjs')
+    const candidatePaths = [
+      path.join(currentDir, 'isolated-vm-worker.cjs'),
+      path.join(process.cwd(), 'lib', 'execution', 'isolated-vm-worker.cjs'),
+    ]
+    const workerPath = candidatePaths.find((p) => fs.existsSync(p))
 
-    if (!fs.existsSync(workerPath)) {
+    if (!workerPath) {
       settleSpawnInProgress()
-      reject(new Error(`Worker file not found at ${workerPath}`))
+      reject(new Error(`Worker file not found at any of: ${candidatePaths.join(', ')}`))
       return
     }
 

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -1,4 +1,4 @@
-import { additionalPackages } from '@trigger.dev/build/extensions/core'
+import { additionalFiles, additionalPackages } from '@trigger.dev/build/extensions/core'
 import { defineConfig } from '@trigger.dev/sdk'
 import { env } from './lib/core/config/env'
 
@@ -15,9 +15,11 @@ export default defineConfig({
   },
   dirs: ['./background'],
   build: {
+    external: ['isolated-vm'],
     extensions: [
+      additionalFiles({ files: ['./lib/execution/isolated-vm-worker.cjs'] }),
       additionalPackages({
-        packages: ['unpdf', 'pdf-lib'],
+        packages: ['unpdf', 'pdf-lib', 'isolated-vm'],
       }),
     ],
   },


### PR DESCRIPTION
## Summary
- Scheduled workflow executions in trigger.dev containers were failing to spawn isolated-vm workers because the native module wasn't installed in the container
- Loop condition evaluation silently returned `false` on VM error, causing loops to exit after 1 iteration
- Manual runs worked fine because `next.config.ts` correctly externalizes `isolated-vm` for the Next.js server

## Changes
- Add `isolated-vm` to `build.external` and `additionalPackages` in `trigger.config.ts`
- Include `isolated-vm-worker.cjs` via `additionalFiles` for child process spawning
- Add fallback path resolution in `isolated-vm.ts` for trigger.dev environment

## Test plan
- [x] Dry-run deploy confirms `isolated-vm@6.0.2` in container `package.json`
- [x] Dry-run deploy confirms `lib/execution/isolated-vm-worker.cjs` in build output
- [ ] Deploy to staging and verify scheduled workflows with loops iterate correctly