### PR TITLE
Slack reaction webhook fields

### DIFF
--- a/apps/sim/triggers/slack/webhook.ts
+++ b/apps/sim/triggers/slack/webhook.ts
@@ -67,7 +67,7 @@ export const slackWebhookTrigger: TriggerConfig = {
         'Go to <a href="https://api.slack.com/apps" target="_blank" rel="noopener noreferrer" class="text-muted-foreground underline transition-colors hover:text-muted-foreground/80">Slack Apps page</a>',
         'If you don\'t have an app:<br><ul class="mt-1 ml-5 list-disc"><li>Create an app from scratch</li><li>Give it a name and select your workspace</li></ul>',
         'Go to "Basic Information", find the "Signing Secret", and paste it in the field above.',
-        'Go to "OAuth & Permissions" and add bot token scopes:<br><ul class="mt-1 ml-5 list-disc"><li><code>app_mentions:read</code> - For viewing messages that tag your bot with an @</li><li><code>chat:write</code> - To send messages to channels your bot is a part of</li><li><code>files:read</code> - To access files and images shared in messages</li></ul>',
+        'Go to "OAuth & Permissions" and add bot token scopes:<br><ul class="mt-1 ml-5 list-disc"><li><code>app_mentions:read</code> - For viewing messages that tag your bot with an @</li><li><code>chat:write</code> - To send messages to channels your bot is a part of</li><li><code>files:read</code> - To access files and images shared in messages</li><li><code>channels:history</code> - To fetch message text for reaction events</li><li><code>reactions:read</code> - To receive reaction events</li></ul>',
         'Go to "Event Subscriptions":<br><ul class="mt-1 ml-5 list-disc"><li>Enable events</li><li>Under "Subscribe to Bot Events", add <code>app_mention</code> to listen to messages that mention your bot</li><li>Paste the Webhook URL above into the "Request URL" field</li></ul>',
         'Go to "Install App" in the left sidebar and install the app into your desired Slack workspace and channel.',
         'Copy the "Bot User OAuth Token" (starts with <code>xoxb-</code>) and paste it in the Bot Token field above to enable file downloads.',
@@ -90,7 +90,8 @@ export const slackWebhookTrigger: TriggerConfig = {
       properties: {
         event_type: {
           type: 'string',
-          description: 'Type of Slack event (e.g., app_mention, message)',
+          description:
+            'Type of Slack event (e.g., app_mention, message, reaction_added, reaction_removed)',
         },
         channel: {
           type: 'string',
@@ -102,7 +103,8 @@ export const slackWebhookTrigger: TriggerConfig = {
         },
         user: {
           type: 'string',
-          description: 'User ID who triggered the event',
+          description:
+            'User ID who triggered the event (for reactions, the user who added/removed the reaction)',
         },
         user_name: {
           type: 'string',
@@ -110,11 +112,26 @@ export const slackWebhookTrigger: TriggerConfig = {
         },
         text: {
           type: 'string',
-          description: 'Message text content',
+          description:
+            'Message text content. For reaction events, fetched via API if bot token has channels:history scope.',
+        },
+        reaction: {
+          type: 'string',
+          description: 'Emoji name for reaction events (e.g., "thumbsup", "heart")',
+        },
+        item_user: {
+          type: 'string',
+          description: 'User ID of the message author (for reaction events)',
         },
         timestamp: {
           type: 'string',
-          description: 'Message timestamp from the triggering event',
+          description:
+            'Message timestamp. For reactions, this is the timestamp of the reacted-to message (item.ts).',
+        },
+        event_ts: {
+          type: 'string',
+          description:
+            'Event timestamp. For reactions, this is when the reaction was added/removed.',
         },
         thread_ts: {
           type: 'string',


### PR DESCRIPTION
## Summary
This PR fixes the Slack webhook handler for `reaction_added` and `reaction_removed` events, which previously failed to extract event-specific fields correctly.

It introduces special handling for these reaction events to:
*   Correctly extract `channel` from `event.item.channel`.
*   Use `item.ts` for the `timestamp` field, referencing the reacted message.
*   Extract the `reaction` emoji name from `event.reaction`.
*   Add `item_user` (the original message author) and `event_ts` (when the reaction occurred).
*   Fetch the original message `text` using `conversations.history` API if the bot has `channels:history` scope, gracefully returning an empty string if permissions are insufficient.

Additionally, the Slack webhook trigger output fields and setup instructions have been updated to reflect these changes, including the necessary `channels:history` and `reactions:read` scopes.

Fixes #(issue) - *Assuming there's an issue tracking this, otherwise remove.*

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Type checks and lint checks were run and passed on the modified files. The logic for fetching message text and handling permissions was verified.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->

---
[Slack Thread](https://sim-ai.slack.com/archives/C093DF8MA21/p1771625838223019?thread_ts=1771625838.223019&cid=C093DF8MA21)

<p><a href="https://cursor.com/agents?id=bc-041a5d90-6876-5376-9be1-a5ee56779214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-041a5d90-6876-5376-9be1-a5ee56779214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

