### PR TITLE
Log details refresh

### DIFF
--- a/apps/sim/hooks/queries/logs.ts
+++ b/apps/sim/hooks/queries/logs.ts
@@ -165,7 +165,8 @@ export function useLogDetail(logId: string | undefined, options?: UseLogDetailOp
     queryFn: () => fetchLogDetail(logId as string),
     enabled: Boolean(logId) && (options?.enabled ?? true),
     refetchInterval: options?.refetchInterval ?? false,
-    staleTime: 30 * 1000,
+    staleTime: 0,
+    refetchOnMount: 'always',
     initialData: () => {
       if (!logId) return undefined
       const listQueries = queryClient.getQueriesData<{
@@ -190,7 +191,7 @@ export function prefetchLogDetail(queryClient: QueryClient, logId: string) {
   queryClient.prefetchQuery({
     queryKey: logKeys.detail(logId),
     queryFn: () => fetchLogDetail(logId),
-    staleTime: 30 * 1000,
+    staleTime: 5 * 1000,
   })
 }
 


### PR DESCRIPTION
## Summary
Fixes an issue where log details, particularly `executionData` (e.g., trace spans), did not display correctly when selecting a log entry without a hard refresh. The `useLogDetail` hook now ensures detailed log data is always refetched upon selection, overriding stale cached data.

Fixes #

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Verify that selecting any log entry on the logs page immediately displays its complete details, including `executionData` like trace spans, without requiring a hard refresh.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->

---
[Slack Thread](https://sim-ai.slack.com/archives/C093DF8MA21/p1771625921127049?thread_ts=1771625921.127049&cid=C093DF8MA21)

<p><a href="https://cursor.com/agents?id=bc-8f76b6e5-0998-53b6-b0fa-b88a37886ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f76b6e5-0998-53b6-b0fa-b88a37886ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

