### PR TITLE
fix(logs): replace initialData with placeholderData to fix stale log details

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
@@ -208,9 +208,10 @@ export default function Logs() {
 
   const selectedLog = useMemo(() => {
     if (!selectedLogFromList) return null
-    if (!activeLogQuery.data || isPreviewOpen) return selectedLogFromList
+    if (!activeLogQuery.data || isPreviewOpen || activeLogQuery.isPlaceholderData)
+      return selectedLogFromList
     return { ...selectedLogFromList, ...activeLogQuery.data }
-  }, [selectedLogFromList, activeLogQuery.data, isPreviewOpen])
+  }, [selectedLogFromList, activeLogQuery.data, activeLogQuery.isPlaceholderData, isPreviewOpen])
 
   const handleLogHover = useCallback(
     (log: WorkflowLog) => {
@@ -650,7 +651,7 @@ export default function Logs() {
         hasActiveFilters={filtersActive}
       />
 
-      {isPreviewOpen && activeLogQuery.data?.executionId && (
+      {isPreviewOpen && !activeLogQuery.isPlaceholderData && activeLogQuery.data?.executionId && (
         <ExecutionSnapshot
           executionId={activeLogQuery.data.executionId}
           traceSpans={activeLogQuery.data.executionData?.traceSpans}

--- a/apps/sim/hooks/queries/logs.ts
+++ b/apps/sim/hooks/queries/logs.ts
@@ -3,7 +3,6 @@ import {
   type QueryClient,
   useInfiniteQuery,
   useQuery,
-  useQueryClient,
 } from '@tanstack/react-query'
 import { getEndDateFromTimeRange, getStartDateFromTimeRange } from '@/lib/logs/filters'
 import { parseQuery, queryToApiParams } from '@/lib/logs/query-parser'
@@ -159,27 +158,13 @@ interface UseLogDetailOptions {
 }
 
 export function useLogDetail(logId: string | undefined, options?: UseLogDetailOptions) {
-  const queryClient = useQueryClient()
   return useQuery({
     queryKey: logKeys.detail(logId),
     queryFn: () => fetchLogDetail(logId as string),
     enabled: Boolean(logId) && (options?.enabled ?? true),
     refetchInterval: options?.refetchInterval ?? false,
     staleTime: 30 * 1000,
-    initialData: () => {
-      if (!logId) return undefined
-      const listQueries = queryClient.getQueriesData<{
-        pages: { logs: WorkflowLog[] }[]
-      }>({
-        queryKey: logKeys.lists(),
-      })
-      for (const [, data] of listQueries) {
-        const match = data?.pages?.flatMap((p) => p.logs).find((l) => l.id === logId)
-        if (match) return match
-      }
-      return undefined
-    },
-    initialDataUpdatedAt: 0,
+    placeholderData: keepPreviousData,
   })
 }
 


### PR DESCRIPTION
## Summary
- Replaced `initialData` from list cache with `placeholderData: keepPreviousData` in `useLogDetail`
- `initialData` with `initialDataUpdatedAt: 0` was seeding the detail cache with incomplete list data, requiring a hard refresh to see full log details
- Hover prefetch still works for instant detail rendering

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)