### PR TITLE
fix(copilot): handle negated operation conditions in block config extraction

### DIFF
--- a/apps/sim/lib/copilot/tools/server/blocks/get-block-config.ts
+++ b/apps/sim/lib/copilot/tools/server/blocks/get-block-config.ts
@@ -175,20 +175,9 @@ function extractInputsFromSubBlocks(
     // 2. Have a condition matching the operation
     if (operation) {
       const condition =
-        typeof sb.condition === 'function'
-          ? sb.condition(operation ? { operation } : undefined)
-          : sb.condition
-      if (condition) {
-        if (condition.field === 'operation' && !condition.not) {
-          // This is an operation-specific field
-          const values = Array.isArray(condition.value) ? condition.value : [condition.value]
-          if (!values.includes(operation)) {
-            continue // Skip if doesn't match our operation
-          }
-        } else if (!matchesOperation(condition, operation)) {
-          // Other condition that doesn't match
-          continue
-        }
+        typeof sb.condition === 'function' ? sb.condition({ operation }) : sb.condition
+      if (condition && !matchesOperation(condition, operation)) {
+        continue
       }
     }
 


### PR DESCRIPTION
## Summary
- Fix copilot's `extractInputsFromSubBlocks` to pass operation context to function-based conditions
- Fix `matchesOperation` to properly handle `not: true` operation conditions
- Without this, the copilot excluded required fields (e.g. channel for Slack ephemeral, spreadsheetId for Google Sheets read) from its input schema

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)