### PR TITLE
fix(security): allow HTTP for localhost and loopback addresses

### DIFF
--- a/apps/sim/lib/core/security/input-validation.test.ts
+++ b/apps/sim/lib/core/security/input-validation.test.ts
@@ -569,10 +569,28 @@ describe('validateUrlWithDNS', () => {
       expect(result.error).toContain('https://')
     })
 
-    it('should reject localhost URLs', async () => {
+    it('should accept https localhost URLs', async () => {
       const result = await validateUrlWithDNS('https://localhost/api')
-      expect(result.isValid).toBe(false)
-      expect(result.error).toContain('localhost')
+      expect(result.isValid).toBe(true)
+      expect(result.resolvedIP).toBeDefined()
+    })
+
+    it('should accept http localhost URLs', async () => {
+      const result = await validateUrlWithDNS('http://localhost/api')
+      expect(result.isValid).toBe(true)
+      expect(result.resolvedIP).toBeDefined()
+    })
+
+    it('should accept IPv4 loopback URLs', async () => {
+      const result = await validateUrlWithDNS('http://127.0.0.1/api')
+      expect(result.isValid).toBe(true)
+      expect(result.resolvedIP).toBeDefined()
+    })
+
+    it('should accept IPv6 loopback URLs', async () => {
+      const result = await validateUrlWithDNS('http://[::1]/api')
+      expect(result.isValid).toBe(true)
+      expect(result.resolvedIP).toBeDefined()
     })
 
     it('should reject private IP URLs', async () => {
@@ -899,16 +917,37 @@ describe('validateExternalUrl', () => {
       expect(result.error).toContain('valid URL')
     })
 
-    it.concurrent('should reject localhost', () => {
+  })
+
+  describe('localhost and loopback addresses', () => {
+    it.concurrent('should accept https localhost', () => {
       const result = validateExternalUrl('https://localhost/api')
-      expect(result.isValid).toBe(false)
-      expect(result.error).toContain('localhost')
+      expect(result.isValid).toBe(true)
     })
 
-    it.concurrent('should reject 127.0.0.1', () => {
+    it.concurrent('should accept http localhost', () => {
+      const result = validateExternalUrl('http://localhost/api')
+      expect(result.isValid).toBe(true)
+    })
+
+    it.concurrent('should accept https 127.0.0.1', () => {
       const result = validateExternalUrl('https://127.0.0.1/api')
-      expect(result.isValid).toBe(false)
-      expect(result.error).toContain('private IP')
+      expect(result.isValid).toBe(true)
+    })
+
+    it.concurrent('should accept http 127.0.0.1', () => {
+      const result = validateExternalUrl('http://127.0.0.1/api')
+      expect(result.isValid).toBe(true)
+    })
+
+    it.concurrent('should accept https IPv6 loopback', () => {
+      const result = validateExternalUrl('https://[::1]/api')
+      expect(result.isValid).toBe(true)
+    })
+
+    it.concurrent('should accept http IPv6 loopback', () => {
+      const result = validateExternalUrl('http://[::1]/api')
+      expect(result.isValid).toBe(true)
     })
 
     it.concurrent('should reject 0.0.0.0', () => {
@@ -989,9 +1028,9 @@ describe('validateImageUrl', () => {
     expect(result.isValid).toBe(true)
   })
 
-  it.concurrent('should reject localhost URLs', () => {
+  it.concurrent('should accept localhost URLs', () => {
     const result = validateImageUrl('https://localhost/image.png')
-    expect(result.isValid).toBe(false)
+    expect(result.isValid).toBe(true)
   })
 
   it.concurrent('should use imageUrl as default param name', () => {


### PR DESCRIPTION
## Summary

This PR restores support for HTTP on localhost for local development while preserving existing SSRF protections and HTTPS requirements for external URLs.
Previously, HTTP requests to localhost were rejected due to strict HTTPS enforcement and private IP blocking. This prevented local development and testing without configuring HTTPS.
This change allows HTTP requests for loopback addresses while maintaining security constraints for all other hosts.

Allowed loopback addresses:
localhost
127.0.0.1
::1

Security protections remain unchanged for non-loopback addresses.

Fixes #3112


## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Tested locally using the development server.

Verified Working

Allowed:
```
http://localhost:3000
https://localhost:3000
http://127.0.0.1:3000
https://127.0.0.1:3000
http://[::1]:3000
https://[::1]:3000
```

Blocked:
```
http://192.168.1.1
http://10.0.0.1
http://172.16.0.1
http://169.254.169.254
```

Automated Tests

Added unit tests covering:
localhost URLs
IPv4 loopback addresses
IPv6 loopback addresses
HTTPS enforcement for external URLs
Private IP blocking

All tests pass successfully.

Reviewers should focus on:
validateExternalUrl()
validateUrlWithDNS()
Loopback detection logic
SSRF protection behavior

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
Not applicable