### PR TITLE
fix(deploy): reuse subblock merge helper in use change detection hook 

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/hooks/use-change-detection.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/hooks/use-change-detection.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { hasWorkflowChanged } from '@/lib/workflows/comparison'
+import { mergeSubblockStateWithValues } from '@/lib/workflows/subblocks'
 import { useVariablesStore } from '@/stores/panel/variables/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
@@ -42,39 +43,10 @@ export function useChangeDetection({
   const currentState = useMemo((): WorkflowState | null => {
     if (!workflowId) return null
 
-    const blocksWithSubBlocks: WorkflowState['blocks'] = {}
-    for (const [blockId, block] of Object.entries(blocks)) {
-      const blockSubValues = subBlockValues?.[blockId] || {}
-      const subBlocks: Record<string, any> = {}
-
-      if (block.subBlocks) {
-        for (const [subId, subBlock] of Object.entries(block.subBlocks)) {
-          const storedValue = blockSubValues[subId]
-          subBlocks[subId] = {
-            ...subBlock,
-            value: storedValue !== undefined ? storedValue : subBlock.value,
-          }
-        }
-      }
-
-      for (const [subId, value] of Object.entries(blockSubValues)) {
-        if (!subBlocks[subId] && value !== null && value !== undefined) {
-          subBlocks[subId] = {
-            id: subId,
-            type: 'short-input',
-            value,
-          }
-        }
-      }
-
-      blocksWithSubBlocks[blockId] = {
-        ...block,
-        subBlocks,
-      }
-    }
+    const mergedBlocks = mergeSubblockStateWithValues(blocks, subBlockValues ?? {})
 
     return {
-      blocks: blocksWithSubBlocks,
+      blocks: mergedBlocks,
       edges,
       loops,
       parallels,


### PR DESCRIPTION
## Summary

Use mergeSubblockStateWithValues in change detection hook to prevent unrolling differences. 


## Type of Change
- [x] Bug fix


## Testing
Tested manually with Slack trigger

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)