### PR TITLE
fix: retry resume during pause persistence

### DIFF
--- a/apps/sim/lib/core/utils/retry.ts
+++ b/apps/sim/lib/core/utils/retry.ts
@@ -1,0 +1,64 @@
+export interface RetryOptions {
+  maxAttempts?: number
+  initialDelayMs?: number
+  maxDelayMs?: number
+  backoffMultiplier?: number
+  jitterRatio?: number
+  isRetryable?: (error: unknown) => boolean
+  onRetry?: (args: { attempt: number; error: unknown; delayMs: number }) => void
+  sleepFn?: (ms: number) => Promise<void>
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const {
+    maxAttempts = 5,
+    initialDelayMs = 100,
+    maxDelayMs = 10_000,
+    backoffMultiplier = 2,
+    jitterRatio = 0.1,
+    isRetryable = () => true,
+    onRetry,
+    sleepFn = sleep,
+  } = options
+
+  if (maxAttempts < 1) {
+    throw new Error('maxAttempts must be >= 1')
+  }
+
+  let delayMs = Math.max(0, initialDelayMs)
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await operation()
+    } catch (error) {
+      const isLastAttempt = attempt >= maxAttempts
+      if (isLastAttempt) {
+        throw error
+      }
+      if (!isRetryable(error)) {
+        throw error
+      }
+
+      const jitter = jitterRatio > 0 ? (Math.random() * 2 - 1) * jitterRatio * delayMs : 0
+      const nextDelayMs = Math.max(0, delayMs + jitter)
+      const cappedDelayMs = Math.min(nextDelayMs, maxDelayMs)
+
+      onRetry?.({ attempt, error, delayMs: cappedDelayMs })
+
+      if (cappedDelayMs > 0) {
+        await sleepFn(cappedDelayMs)
+      }
+
+      delayMs = Math.min(delayMs * Math.max(1, backoffMultiplier), maxDelayMs)
+    }
+  }
+
+  throw new Error('Retry operation failed unexpectedly')
+}

--- a/apps/sim/lib/workflows/executor/pause-resume-errors.ts
+++ b/apps/sim/lib/workflows/executor/pause-resume-errors.ts
@@ -1,0 +1,27 @@
+export class PausedExecutionNotFoundError extends Error {
+  constructor(message = 'Paused execution not found or already resumed') {
+    super(message)
+    this.name = 'PausedExecutionNotFoundError'
+  }
+}
+
+export class PauseSnapshotNotReadyError extends Error {
+  constructor(message = 'Snapshot not ready; execution still finalizing pause') {
+    super(message)
+    this.name = 'PauseSnapshotNotReadyError'
+  }
+}
+
+export class PausePointNotFoundError extends Error {
+  constructor(message = 'Pause point not found for execution') {
+    super(message)
+    this.name = 'PausePointNotFoundError'
+  }
+}
+
+export class PausePointNotPausedError extends Error {
+  constructor(message = 'Pause point already resumed or in progress') {
+    super(message)
+    this.name = 'PausePointNotPausedError'
+  }
+}


### PR DESCRIPTION
## Summary
- Add a bounded retry around `enqueueOrStartResume` to handle the short window where the pause record is not yet visible/ready.
- Retry only for transient conditions (missing paused execution, snapshot-not-ready) and fail fast for all other errors.

## Test plan
- [x] `cd apps/sim && bun run test -- lib/workflows/executor/human-in-the-loop-manager.test.ts`

Fixes #3081