### PR TITLE
fix(models): remove retired claude-3-7-sonnet and update default models

### DIFF
--- a/apps/sim/app/api/tools/stagehand/agent/route.ts
+++ b/apps/sim/app/api/tools/stagehand/agent/route.ts
@@ -165,7 +165,7 @@ export async function POST(request: NextRequest) {
     }
 
     const modelName =
-      provider === 'anthropic' ? 'anthropic/claude-3-7-sonnet-latest' : 'openai/gpt-4.1'
+      provider === 'anthropic' ? 'anthropic/claude-sonnet-4-5-20250929' : 'openai/gpt-5'
 
     try {
       logger.info('Initializing Stagehand with Browserbase (v3)', { provider, modelName })

--- a/apps/sim/app/api/tools/stagehand/extract/route.ts
+++ b/apps/sim/app/api/tools/stagehand/extract/route.ts
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest) {
 
     try {
       const modelName =
-        provider === 'anthropic' ? 'anthropic/claude-3-7-sonnet-latest' : 'openai/gpt-4.1'
+        provider === 'anthropic' ? 'anthropic/claude-sonnet-4-5-20250929' : 'openai/gpt-5'
 
       logger.info('Initializing Stagehand with Browserbase (v3)', { provider, modelName })
 

--- a/apps/sim/blocks/blocks/browser_use.ts
+++ b/apps/sim/blocks/blocks/browser_use.ts
@@ -33,6 +33,7 @@ export const BrowserUseBlock: BlockConfig<BrowserUseResponse> = {
       type: 'dropdown',
       options: [
         { label: 'Browser Use LLM', id: 'browser-use-llm' },
+        { label: 'Browser Use 2.0', id: 'browser-use-2.0' },
         { label: 'GPT-4o', id: 'gpt-4o' },
         { label: 'GPT-4o Mini', id: 'gpt-4o-mini' },
         { label: 'GPT-4.1', id: 'gpt-4.1' },
@@ -42,6 +43,7 @@ export const BrowserUseBlock: BlockConfig<BrowserUseResponse> = {
         { label: 'Gemini 2.5 Flash', id: 'gemini-2.5-flash' },
         { label: 'Gemini 2.5 Pro', id: 'gemini-2.5-pro' },
         { label: 'Gemini 3 Pro Preview', id: 'gemini-3-pro-preview' },
+        { label: 'Gemini 3 Flash Preview', id: 'gemini-3-flash-preview' },
         { label: 'Gemini Flash Latest', id: 'gemini-flash-latest' },
         { label: 'Gemini Flash Lite Latest', id: 'gemini-flash-lite-latest' },
         { label: 'Claude 3.7 Sonnet', id: 'claude-3-7-sonnet-20250219' },

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -467,25 +467,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 200000,
       },
-      {
-        id: 'claude-3-7-sonnet-latest',
-        pricing: {
-          input: 3.0,
-          cachedInput: 0.3,
-          output: 15.0,
-          updatedAt: '2026-02-05',
-        },
-        capabilities: {
-          temperature: { min: 0, max: 1 },
-          computerUse: true,
-          maxOutputTokens: 64000,
-          thinking: {
-            levels: ['low', 'medium', 'high'],
-            default: 'high',
-          },
-        },
-        contextWindow: 200000,
-      },
     ],
   },
   'azure-openai': {

--- a/apps/sim/providers/utils.test.ts
+++ b/apps/sim/providers/utils.test.ts
@@ -183,7 +183,6 @@ describe('Model Capabilities', () => {
         'gemini-2.5-flash',
         'claude-sonnet-4-0',
         'claude-opus-4-0',
-        'claude-3-7-sonnet-latest',
         'grok-3-latest',
         'grok-3-fast-latest',
         'deepseek-v3',
@@ -260,7 +259,6 @@ describe('Model Capabilities', () => {
       const modelsRange01 = [
         'claude-sonnet-4-0',
         'claude-opus-4-0',
-        'claude-3-7-sonnet-latest',
         'grok-3-latest',
         'grok-3-fast-latest',
       ]


### PR DESCRIPTION
## Summary
- Remove `claude-3-7-sonnet-latest` from Anthropic provider (retired by Anthropic)
- Update stagehand default models to Claude Sonnet 4.5 and GPT-5
- Sync browser_use block model list with official SupportedLLMs enum (add `browser-use-2.0`, `gemini-3-flash-preview`)
- Update related tests

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)