### PR TITLE
fix(hex): scope param renames to their respective operations

### DIFF
--- a/apps/sim/blocks/blocks/hex.ts
+++ b/apps/sim/blocks/blocks/hex.ts
@@ -322,13 +322,19 @@ Example:
       },
       params: (params) => {
         const result: Record<string, unknown> = {}
+        const op = params.operation
+
         if (params.limit) result.limit = Number(params.limit)
-        if (params.offset) result.offset = Number(params.offset)
-        if (params.projectStatus) result.status = params.projectStatus
-        if (params.runStatusFilter) result.statusFilter = params.runStatusFilter
-        if (params.groupIdInput) result.groupId = params.groupIdInput
-        if (params.collectionName) result.name = params.collectionName
-        if (params.collectionDescription) result.description = params.collectionDescription
+        if (op === 'get_project_runs' && params.offset) result.offset = Number(params.offset)
+        if (op === 'update_project' && params.projectStatus) result.status = params.projectStatus
+        if (op === 'get_project_runs' && params.runStatusFilter)
+          result.statusFilter = params.runStatusFilter
+        if (op === 'get_group' && params.groupIdInput) result.groupId = params.groupIdInput
+        if (op === 'list_users' && params.groupId) result.groupId = params.groupId
+        if (op === 'create_collection' && params.collectionName) result.name = params.collectionName
+        if (op === 'create_collection' && params.collectionDescription)
+          result.description = params.collectionDescription
+
         return result
       },
     },


### PR DESCRIPTION
## Summary
- Scoped param field renames in the Hex block's `tools.config.params` to their respective operations
- Prevents stale values from hidden conditional subblocks leaking across operations (e.g., `runStatusFilter` from `get_project_runs` overriding `statusFilter` on `list_projects`)

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)