### PR TITLE
fix(telegram): accept URL/file_id media inputs

### DIFF
--- a/apps/sim/blocks/blocks/telegram.test.ts
+++ b/apps/sim/blocks/blocks/telegram.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { TelegramBlock } from '@/blocks/blocks/telegram'
+
+describe('TelegramBlock', () => {
+  const paramsFn = TelegramBlock.tools.config?.params
+
+  if (!paramsFn) {
+    throw new Error('TelegramBlock.tools.config.params function is missing')
+  }
+
+  it.concurrent('accepts a public URL string for telegram_send_photo', () => {
+    const result = paramsFn({
+      operation: 'telegram_send_photo',
+      botToken: 'token',
+      chatId: ' 123 ',
+      photo: ' https://example.com/a.jpg ',
+      caption: 'hello',
+    })
+
+    expect(result).toEqual({
+      botToken: 'token',
+      chatId: '123',
+      photo: 'https://example.com/a.jpg',
+      caption: 'hello',
+    })
+  })
+
+  it.concurrent('accepts a file-like object for telegram_send_photo (uses url)', () => {
+    const result = paramsFn({
+      operation: 'telegram_send_photo',
+      botToken: 'token',
+      chatId: '123',
+      photo: { id: 'f1', url: 'https://example.com/file.png' },
+    })
+
+    expect(result).toMatchObject({
+      photo: 'https://example.com/file.png',
+    })
+  })
+
+  it.concurrent('accepts JSON-stringified file objects in advanced mode', () => {
+    const result = paramsFn({
+      operation: 'telegram_send_photo',
+      botToken: 'token',
+      chatId: '123',
+      photo: JSON.stringify({ id: 'f1', url: 'https://example.com/file.png' }),
+    })
+
+    expect(result).toMatchObject({
+      photo: 'https://example.com/file.png',
+    })
+  })
+
+  it.concurrent('throws a user-facing error when photo is missing/blank', () => {
+    expect(() =>
+      paramsFn({
+        operation: 'telegram_send_photo',
+        botToken: 'token',
+        chatId: '123',
+        photo: '   ',
+      })
+    ).toThrow('Photo is required.')
+  })
+
+  it.concurrent('accepts a public URL string for telegram_send_video', () => {
+    const result = paramsFn({
+      operation: 'telegram_send_video',
+      botToken: 'token',
+      chatId: '123',
+      video: 'https://example.com/v.mp4',
+    })
+
+    expect(result).toMatchObject({
+      video: 'https://example.com/v.mp4',
+    })
+  })
+})

--- a/apps/sim/blocks/blocks/telegram.ts
+++ b/apps/sim/blocks/blocks/telegram.ts
@@ -1,7 +1,7 @@
 import { TelegramIcon } from '@/components/icons'
 import type { BlockConfig } from '@/blocks/types'
 import { AuthMode } from '@/blocks/types'
-import { normalizeFileInput } from '@/blocks/utils'
+import { normalizeFileInput, normalizeFileOrUrlInput } from '@/blocks/utils'
 import type { TelegramResponse } from '@/tools/telegram/types'
 import { getTrigger } from '@/triggers'
 
@@ -270,7 +270,7 @@ export const TelegramBlock: BlockConfig<TelegramResponse> = {
             }
           case 'telegram_send_photo': {
             // photo is the canonical param for both basic (photoFile) and advanced modes
-            const photoSource = normalizeFileInput(params.photo, {
+            const photoSource = normalizeFileOrUrlInput(params.photo, {
               single: true,
             })
             if (!photoSource) {
@@ -284,7 +284,7 @@ export const TelegramBlock: BlockConfig<TelegramResponse> = {
           }
           case 'telegram_send_video': {
             // video is the canonical param for both basic (videoFile) and advanced modes
-            const videoSource = normalizeFileInput(params.video, {
+            const videoSource = normalizeFileOrUrlInput(params.video, {
               single: true,
             })
             if (!videoSource) {
@@ -298,7 +298,7 @@ export const TelegramBlock: BlockConfig<TelegramResponse> = {
           }
           case 'telegram_send_audio': {
             // audio is the canonical param for both basic (audioFile) and advanced modes
-            const audioSource = normalizeFileInput(params.audio, {
+            const audioSource = normalizeFileOrUrlInput(params.audio, {
               single: true,
             })
             if (!audioSource) {
@@ -312,7 +312,7 @@ export const TelegramBlock: BlockConfig<TelegramResponse> = {
           }
           case 'telegram_send_animation': {
             // animation is the canonical param for both basic (animationFile) and advanced modes
-            const animationSource = normalizeFileInput(params.animation, {
+            const animationSource = normalizeFileOrUrlInput(params.animation, {
               single: true,
             })
             if (!animationSource) {

--- a/apps/sim/blocks/utils.test.ts
+++ b/apps/sim/blocks/utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeFileOrUrlInput } from '@/blocks/utils'
+
+describe('normalizeFileOrUrlInput', () => {
+  it.concurrent('returns undefined for nullish and empty values', () => {
+    expect(normalizeFileOrUrlInput(undefined, { single: true })).toBeUndefined()
+    expect(normalizeFileOrUrlInput(null, { single: true })).toBeUndefined()
+    expect(normalizeFileOrUrlInput('', { single: true })).toBeUndefined()
+    expect(normalizeFileOrUrlInput('   ', { single: true })).toBeUndefined()
+  })
+
+  it.concurrent('passes through trimmed URL/file_id strings', () => {
+    expect(normalizeFileOrUrlInput(' https://example.com/a.jpg ', { single: true })).toBe(
+      'https://example.com/a.jpg'
+    )
+    expect(normalizeFileOrUrlInput('AgACAgUAAxkBAAIB...', { single: true })).toBe(
+      'AgACAgUAAxkBAAIB...'
+    )
+    expect(normalizeFileOrUrlInput('1234567890', { single: true })).toBe('1234567890')
+  })
+
+  it.concurrent('extracts url from a file-like object', () => {
+    expect(normalizeFileOrUrlInput({ url: 'https://example.com/file.png' }, { single: true })).toBe(
+      'https://example.com/file.png'
+    )
+  })
+
+  it.concurrent('extracts url from JSON-stringified file objects/arrays', () => {
+    expect(
+      normalizeFileOrUrlInput(JSON.stringify({ url: 'https://example.com/a.png' }), {
+        single: true,
+      })
+    ).toBe('https://example.com/a.png')
+
+    expect(
+      normalizeFileOrUrlInput(JSON.stringify([{ url: 'https://example.com/a.png' }]), {
+        single: true,
+      })
+    ).toBe('https://example.com/a.png')
+  })
+
+  it.concurrent('throws when single=true and multiple values resolve', () => {
+    expect(() =>
+      normalizeFileOrUrlInput(
+        JSON.stringify([{ url: 'https://a.com' }, { url: 'https://b.com' }]),
+        {
+          single: true,
+        }
+      )
+    ).toThrow('File reference must be a single file')
+  })
+
+  it.concurrent('treats invalid JSON strings as raw identifiers', () => {
+    expect(normalizeFileOrUrlInput('{not json', { single: true })).toBe('{not json')
+  })
+})

--- a/apps/sim/tools/telegram/send_animation.ts
+++ b/apps/sim/tools/telegram/send_animation.ts
@@ -4,7 +4,7 @@ import type {
   TelegramSendAnimationParams,
   TelegramSendMediaResponse,
 } from '@/tools/telegram/types'
-import { convertMarkdownToHTML } from '@/tools/telegram/utils'
+import { convertMarkdownToHTML, normalizeTelegramMediaParam } from '@/tools/telegram/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const telegramSendAnimationTool: ToolConfig<
@@ -52,9 +52,14 @@ export const telegramSendAnimationTool: ToolConfig<
       'Content-Type': 'application/json',
     }),
     body: (params: TelegramSendAnimationParams) => {
+      const animation = normalizeTelegramMediaParam(params.animation, { single: true })
+      if (typeof animation !== 'string' || !animation) {
+        throw new Error('Animation is required.')
+      }
+
       const body: Record<string, any> = {
         chat_id: params.chatId,
-        animation: params.animation,
+        animation,
       }
 
       if (params.caption) {

--- a/apps/sim/tools/telegram/send_audio.ts
+++ b/apps/sim/tools/telegram/send_audio.ts
@@ -4,7 +4,7 @@ import type {
   TelegramSendAudioParams,
   TelegramSendAudioResponse,
 } from '@/tools/telegram/types'
-import { convertMarkdownToHTML } from '@/tools/telegram/utils'
+import { convertMarkdownToHTML, normalizeTelegramMediaParam } from '@/tools/telegram/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const telegramSendAudioTool: ToolConfig<TelegramSendAudioParams, TelegramSendAudioResponse> =
@@ -50,9 +50,14 @@ export const telegramSendAudioTool: ToolConfig<TelegramSendAudioParams, Telegram
         'Content-Type': 'application/json',
       }),
       body: (params: TelegramSendAudioParams) => {
+        const audio = normalizeTelegramMediaParam(params.audio, { single: true })
+        if (typeof audio !== 'string' || !audio) {
+          throw new Error('Audio is required.')
+        }
+
         const body: Record<string, any> = {
           chat_id: params.chatId,
-          audio: params.audio,
+          audio,
         }
 
         if (params.caption) {

--- a/apps/sim/tools/telegram/send_photo.ts
+++ b/apps/sim/tools/telegram/send_photo.ts
@@ -4,7 +4,7 @@ import type {
   TelegramSendPhotoParams,
   TelegramSendPhotoResponse,
 } from '@/tools/telegram/types'
-import { convertMarkdownToHTML } from '@/tools/telegram/utils'
+import { convertMarkdownToHTML, normalizeTelegramMediaParam } from '@/tools/telegram/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const telegramSendPhotoTool: ToolConfig<TelegramSendPhotoParams, TelegramSendPhotoResponse> =
@@ -50,9 +50,14 @@ export const telegramSendPhotoTool: ToolConfig<TelegramSendPhotoParams, Telegram
         'Content-Type': 'application/json',
       }),
       body: (params: TelegramSendPhotoParams) => {
+        const photo = normalizeTelegramMediaParam(params.photo, { single: true })
+        if (typeof photo !== 'string' || !photo) {
+          throw new Error('Photo is required.')
+        }
+
         const body: Record<string, any> = {
           chat_id: params.chatId,
-          photo: params.photo,
+          photo,
         }
 
         if (params.caption) {

--- a/apps/sim/tools/telegram/send_video.ts
+++ b/apps/sim/tools/telegram/send_video.ts
@@ -4,7 +4,7 @@ import type {
   TelegramSendMediaResponse,
   TelegramSendVideoParams,
 } from '@/tools/telegram/types'
-import { convertMarkdownToHTML } from '@/tools/telegram/utils'
+import { convertMarkdownToHTML, normalizeTelegramMediaParam } from '@/tools/telegram/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const telegramSendVideoTool: ToolConfig<TelegramSendVideoParams, TelegramSendMediaResponse> =
@@ -50,9 +50,14 @@ export const telegramSendVideoTool: ToolConfig<TelegramSendVideoParams, Telegram
         'Content-Type': 'application/json',
       }),
       body: (params: TelegramSendVideoParams) => {
+        const video = normalizeTelegramMediaParam(params.video, { single: true })
+        if (typeof video !== 'string' || !video) {
+          throw new Error('Video is required.')
+        }
+
         const body: Record<string, any> = {
           chat_id: params.chatId,
-          video: params.video,
+          video,
         }
 
         if (params.caption) {

--- a/apps/sim/tools/telegram/utils.ts
+++ b/apps/sim/tools/telegram/utils.ts
@@ -13,3 +13,65 @@ export function convertMarkdownToHTML(text: string): string {
       .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
   )
 }
+
+const DEFAULT_MULTIPLE_MEDIA_ERROR =
+  'Media reference must be a single value, not an array. Use <block.files[0]> to select one file.'
+
+function extractUrlFromFileLike(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const url = (value as { url?: unknown }).url
+  if (typeof url !== 'string') return undefined
+  const trimmed = url.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * Normalizes a "Telegram media" parameter that can be:
+ * - a plain string (file_id, URL)
+ * - a UserFile-like object with a `url`
+ * - a JSON-stringified file object/array (advanced mode)
+ */
+export function normalizeTelegramMediaParam(
+  value: unknown,
+  options?: { single?: boolean; errorMessage?: string }
+): string | string[] | undefined {
+  if (value === null || value === undefined) return undefined
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return undefined
+
+    // Only attempt JSON parsing for object/array payloads.
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        value = JSON.parse(trimmed)
+      } catch {
+        return options?.single ? trimmed : [trimmed]
+      }
+    } else {
+      return options?.single ? trimmed : [trimmed]
+    }
+  }
+
+  const values: unknown[] = Array.isArray(value) ? value : [value]
+  const normalized = values
+    .map((v) => {
+      if (typeof v === 'string') {
+        const trimmed = v.trim()
+        return trimmed.length > 0 ? trimmed : undefined
+      }
+      return extractUrlFromFileLike(v)
+    })
+    .filter((v): v is string => typeof v === 'string' && v.length > 0)
+
+  if (normalized.length === 0) return undefined
+
+  if (options?.single) {
+    if (normalized.length > 1) {
+      throw new Error(options.errorMessage ?? DEFAULT_MULTIPLE_MEDIA_ERROR)
+    }
+    return normalized[0]
+  }
+
+  return normalized
+}


### PR DESCRIPTION
## Summary
- Accept plain URL/file_id strings for Telegram send photo/video/audio/animation block inputs.
- Normalize UserFile-like inputs by extracting their `url` when present (defense-in-depth at both block config + tool request layers).
- Add unit tests for normalization and Telegram block param building.

## Test plan
- `cd apps/sim && bun run test -- blocks/utils.test.ts blocks/blocks/telegram.test.ts`

Fixes #3220 