### PR TITLE
fix(executor): guard loop and agent logs against memory growth

### DIFF
--- a/apps/sim/executor/execution/state.ts
+++ b/apps/sim/executor/execution/state.ts
@@ -8,6 +8,15 @@ export interface LoopScope {
   iteration: number
   currentIterationOutputs: Map<string, NormalizedBlockOutput>
   allIterationOutputs: NormalizedBlockOutput[][]
+  /**
+   * Number of iteration result entries dropped from the head of `allIterationOutputs`
+   * due to retention limits.
+   */
+  allIterationOutputsDroppedCount?: number
+  /**
+   * Max number of iterations retained in `allIterationOutputs` (tail retention).
+   */
+  allIterationOutputsLimit?: number
   maxIterations?: number
   item?: any
   items?: any[]

--- a/apps/sim/executor/orchestrators/loop.orchestrator.test.ts
+++ b/apps/sim/executor/orchestrators/loop.orchestrator.test.ts
@@ -1,0 +1,76 @@
+import { loggerMock } from '@sim/testing'
+import { describe, expect, it, vi } from 'vitest'
+import { LoopOrchestrator } from '@/executor/orchestrators/loop'
+
+vi.mock('@sim/logger', () => loggerMock)
+
+describe('LoopOrchestrator retention', () => {
+  it('retains only the tail of allIterationOutputs and tracks dropped count', async () => {
+    const state = { setBlockOutput: vi.fn() } as any
+    const orchestrator = new LoopOrchestrator({} as any, state, {} as any)
+
+    vi.spyOn(orchestrator as any, 'evaluateCondition').mockResolvedValue(true)
+
+    const scope: any = {
+      iteration: 0,
+      currentIterationOutputs: new Map(),
+      allIterationOutputs: [],
+      allIterationOutputsDroppedCount: 0,
+      allIterationOutputsLimit: 3,
+    }
+
+    const ctx: any = {
+      loopExecutions: new Map([['loop-1', scope]]),
+      metadata: { duration: 0 },
+    }
+
+    for (let i = 0; i < 5; i++) {
+      scope.currentIterationOutputs.set('block', { i })
+      const result = await orchestrator.evaluateLoopContinuation(ctx, 'loop-1')
+      expect(result.shouldContinue).toBe(true)
+    }
+
+    expect(scope.allIterationOutputs).toHaveLength(3)
+    expect(scope.allIterationOutputsDroppedCount).toBe(2)
+    expect(scope.allIterationOutputs[0][0]).toEqual({ i: 2 })
+    expect(scope.allIterationOutputs[2][0]).toEqual({ i: 4 })
+  })
+
+  it('includes truncation metadata in exit output', () => {
+    const state = { setBlockOutput: vi.fn() } as any
+    const orchestrator = new LoopOrchestrator({} as any, state, {} as any)
+
+    const scope: any = {
+      iteration: 0,
+      currentIterationOutputs: new Map(),
+      allIterationOutputs: [[{ a: 1 }]],
+      allIterationOutputsDroppedCount: 5,
+      allIterationOutputsLimit: 1,
+    }
+
+    const ctx: any = {
+      metadata: { duration: 0 },
+    }
+
+    const result = (orchestrator as any).createExitResult(ctx, 'loop-1', scope)
+
+    expect(result.resultsTruncated).toBe(true)
+    expect(result.totalIterations).toBe(6)
+    expect(result.droppedIterations).toBe(5)
+    expect(result.retainedIterations).toBe(1)
+    expect(result.retentionLimit).toBe(1)
+
+    expect(state.setBlockOutput).toHaveBeenCalledWith(
+      'loop-1',
+      expect.objectContaining({
+        results: scope.allIterationOutputs,
+        resultsTruncated: true,
+        totalIterations: 6,
+        droppedIterations: 5,
+        retainedIterations: 1,
+        retentionLimit: 1,
+      }),
+      expect.any(Number)
+    )
+  })
+})

--- a/apps/sim/executor/types.ts
+++ b/apps/sim/executor/types.ts
@@ -80,6 +80,9 @@ export interface NormalizedBlockOutput {
   toolCalls?: {
     list: any[]
     count: number
+    omitted?: number
+    truncated?: boolean
+    limit?: number
   }
   files?: UserFile[]
   selectedPath?: {
@@ -144,6 +147,10 @@ export interface ExecutionMetadata {
   credentialAccountUserId?: string
   status?: 'running' | 'paused' | 'completed'
   pausePoints?: string[]
+  logTruncation?: {
+    dropped: number
+    limit: number
+  }
   resumeChain?: {
     parentExecutionId?: string
     depth: number
@@ -193,12 +200,15 @@ export interface ExecutionContext {
       iteration: number
       currentIterationOutputs: Map<string, any>
       allIterationOutputs: any[][]
+      allIterationOutputsDroppedCount?: number
+      allIterationOutputsLimit?: number
       maxIterations?: number
       item?: any
       items?: any[]
       condition?: string
       skipFirstConditionCheck?: boolean
       loopType?: 'for' | 'forEach' | 'while' | 'doWhile'
+      validationError?: string
     }
   >
 

--- a/apps/sim/executor/utils/memory.ts
+++ b/apps/sim/executor/utils/memory.ts
@@ -1,0 +1,104 @@
+export type CompactOptions = {
+  maxDepth: number
+  maxStringLength: number
+  maxArrayLength: number
+  maxObjectKeys: number
+}
+
+const DEFAULT_COMPACT_OPTIONS: CompactOptions = {
+  maxDepth: 6,
+  maxStringLength: 4000,
+  maxArrayLength: 50,
+  maxObjectKeys: 100,
+}
+
+export function retainTailInPlace<T>(items: T[], maxItems: number): { dropped: number } {
+  const max = Number.isFinite(maxItems) ? Math.max(0, Math.floor(maxItems)) : 0
+  const dropped = items.length > max ? items.length - max : 0
+  if (dropped > 0) {
+    items.splice(0, dropped)
+  }
+  return { dropped }
+}
+
+export function compactValue(value: unknown, options?: Partial<CompactOptions>): unknown {
+  const opts: CompactOptions = { ...DEFAULT_COMPACT_OPTIONS, ...(options ?? {}) }
+  const seen = new WeakSet<object>()
+  return compactValueInner(value, opts, 0, seen)
+}
+
+function compactValueInner(
+  value: unknown,
+  options: CompactOptions,
+  depth: number,
+  seen: WeakSet<object>
+): unknown {
+  if (value === null || value === undefined) return value
+
+  const t = typeof value
+  if (t === 'string') {
+    if (value.length <= options.maxStringLength) return value
+    const kept = value.slice(0, options.maxStringLength)
+    return `${kept}... [truncated ${value.length - options.maxStringLength} chars]`
+  }
+  if (t === 'number' || t === 'boolean') return value
+  if (t === 'bigint') return value.toString()
+  if (t === 'symbol') return value.toString()
+  if (t === 'function') return '[Function]'
+
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack:
+        typeof value.stack === 'string'
+          ? (compactValueInner(value.stack, options, depth + 1, seen) as string)
+          : undefined,
+    }
+  }
+
+  if (depth >= options.maxDepth) {
+    return '[MaxDepth]'
+  }
+
+  if (Array.isArray(value)) {
+    const out: unknown[] = []
+    const limit = Math.max(0, options.maxArrayLength)
+    const slice = value.slice(0, limit)
+    for (const item of slice) {
+      out.push(compactValueInner(item, options, depth + 1, seen))
+    }
+    if (value.length > limit) {
+      out.push(`[... omitted ${value.length - limit} items]`)
+    }
+    return out
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return '[Circular]'
+    }
+    seen.add(value)
+
+    const entries = Object.entries(value as Record<string, unknown>)
+    const limit = Math.max(0, options.maxObjectKeys)
+    const out: Record<string, unknown> = {}
+    for (const [key, val] of entries.slice(0, limit)) {
+      out[key] = compactValueInner(val, options, depth + 1, seen)
+    }
+    if (entries.length > limit) {
+      out.__omittedKeys = entries.length - limit
+    }
+    return out
+  }
+
+  try {
+    return String(value)
+  } catch {
+    return '[Unserializable]'
+  }
+}


### PR DESCRIPTION
## Summary
- Compact and cap agent `toolCalls` metadata to prevent large tool payloads from ballooning execution output/log memory.
- Retain only a bounded tail of loop iteration aggregates and expose truncation metadata (`totalIterations`, `droppedIterations`, `retentionLimit`).
- Add a hard cap on in-memory block log retention and record how many logs were dropped.

## Test plan
- `cd apps/sim && bun run test -- executor/handlers/agent/agent-handler.test.ts executor/orchestrators/loop.orchestrator.test.ts`

Fixes #2525