### PR TITLE
fix(api): add configurable request retries

### DIFF
--- a/apps/docs/content/docs/en/blocks/api.mdx
+++ b/apps/docs/content/docs/en/blocks/api.mdx
@@ -95,11 +95,17 @@ const apiUrl = `https://api.example.com/users/${userId}/profile`;
 
 ### Request Retries
 
-The API block automatically handles:
-- Network timeouts with exponential backoff
-- Rate limit responses (429 status codes)
-- Server errors (5xx status codes) with retry logic
-- Connection failures with reconnection attempts
+The API block supports **configurable retries** (see the block’s **Advanced** settings):
+
+- **Retries**: Number of retry attempts (additional tries after the first request)
+- **Retry delay (ms)**: Initial delay before retrying (uses exponential backoff)
+- **Max retry delay (ms)**: Maximum delay between retries
+- **Retry non-idempotent methods**: Allow retries for **POST/PATCH** (may create duplicate requests)
+
+Retries are attempted for:
+
+- Network/connection failures and timeouts (with exponential backoff)
+- Rate limits (**429**) and server errors (**5xx**)
 
 ### Response Validation
 

--- a/apps/sim/blocks/blocks/api.ts
+++ b/apps/sim/blocks/blocks/api.ts
@@ -89,6 +89,38 @@ Example:
         'Request timeout in milliseconds (default: 300000 = 5 minutes, max: 600000 = 10 minutes)',
       mode: 'advanced',
     },
+    {
+      id: 'retries',
+      title: 'Retries',
+      type: 'short-input',
+      placeholder: '2',
+      description:
+        'Number of retry attempts for timeouts, 429 responses, and 5xx errors (default: 2 for GET/PUT/DELETE/HEAD)',
+      mode: 'advanced',
+    },
+    {
+      id: 'retryDelayMs',
+      title: 'Retry delay (ms)',
+      type: 'short-input',
+      placeholder: '500',
+      description: 'Initial retry delay in milliseconds (exponential backoff)',
+      mode: 'advanced',
+    },
+    {
+      id: 'retryMaxDelayMs',
+      title: 'Max retry delay (ms)',
+      type: 'short-input',
+      placeholder: '30000',
+      description: 'Maximum delay between retries in milliseconds',
+      mode: 'advanced',
+    },
+    {
+      id: 'retryNonIdempotent',
+      title: 'Retry non-idempotent methods',
+      type: 'switch',
+      description: 'Allow retries for POST/PATCH requests (may create duplicate requests)',
+      mode: 'advanced',
+    },
   ],
   tools: {
     access: ['http_request'],
@@ -100,6 +132,16 @@ Example:
     body: { type: 'json', description: 'Request body data' },
     params: { type: 'json', description: 'URL query parameters' },
     timeout: { type: 'number', description: 'Request timeout in milliseconds' },
+    retries: { type: 'number', description: 'Number of retry attempts for retryable failures' },
+    retryDelayMs: { type: 'number', description: 'Initial retry delay in milliseconds' },
+    retryMaxDelayMs: {
+      type: 'number',
+      description: 'Maximum delay between retries in milliseconds',
+    },
+    retryNonIdempotent: {
+      type: 'boolean',
+      description: 'Allow retries for non-idempotent methods like POST/PATCH',
+    },
   },
   outputs: {
     data: { type: 'json', description: 'API response data (JSON, text, or other formats)' },

--- a/apps/sim/tools/http/request.ts
+++ b/apps/sim/tools/http/request.ts
@@ -53,6 +53,28 @@ export const requestTool: ToolConfig<RequestParams, RequestResponse> = {
       visibility: 'user-only',
       description: 'Request timeout in milliseconds (default: 300000 = 5 minutes)',
     },
+    retries: {
+      type: 'number',
+      visibility: 'user-only',
+      description:
+        'Number of retry attempts for retryable failures (timeouts, 429, 5xx). Defaults to 2 for idempotent methods (GET/PUT/DELETE/HEAD) and 0 otherwise.',
+    },
+    retryDelayMs: {
+      type: 'number',
+      visibility: 'user-only',
+      description: 'Initial retry delay in milliseconds (default: 500)',
+    },
+    retryMaxDelayMs: {
+      type: 'number',
+      visibility: 'user-only',
+      description: 'Maximum delay between retries in milliseconds (default: 30000)',
+    },
+    retryNonIdempotent: {
+      type: 'boolean',
+      visibility: 'user-only',
+      description:
+        'Allow retries for non-idempotent methods like POST/PATCH (may create duplicate requests).',
+    },
   },
 
   request: {
@@ -119,6 +141,26 @@ export const requestTool: ToolConfig<RequestParams, RequestResponse> = {
 
       return undefined
     }) as (params: RequestParams) => Record<string, any> | string | FormData | undefined,
+
+    retry: {
+      enabled: true,
+      maxRetries: 2,
+      maxRetriesLimit: 10,
+      initialDelayMs: 500,
+      maxDelayMs: 30000,
+      retryOnStatusCodes: [429],
+      retryOnStatusRanges: [{ min: 500, max: 599 }],
+      retryOnTimeout: true,
+      retryOnNetworkError: true,
+      respectRetryAfter: true,
+      retryableMethods: ['GET', 'HEAD', 'PUT', 'DELETE'],
+      paramOverrides: {
+        retries: 'retries',
+        initialDelayMs: 'retryDelayMs',
+        maxDelayMs: 'retryMaxDelayMs',
+        nonIdempotent: 'retryNonIdempotent',
+      },
+    },
   },
 
   transformResponse: async (response: Response) => {

--- a/apps/sim/tools/http/types.ts
+++ b/apps/sim/tools/http/types.ts
@@ -9,6 +9,10 @@ export interface RequestParams {
   pathParams?: Record<string, string>
   formData?: Record<string, string | Blob>
   timeout?: number
+  retries?: number
+  retryDelayMs?: number
+  retryMaxDelayMs?: number
+  retryNonIdempotent?: boolean
 }
 
 export interface RequestResponse extends ToolResponse {

--- a/apps/sim/tools/types.ts
+++ b/apps/sim/tools/types.ts
@@ -58,6 +58,59 @@ export interface OAuthConfig {
   requiredScopes?: string[] // Specific scopes this tool needs (for granular scope validation)
 }
 
+export interface RetryStatusRange {
+  min: number
+  max: number
+}
+
+export interface ToolRequestRetryConfig {
+  /**
+   * Enables retry logic for this tool's HTTP request execution.
+   * If disabled, tool requests are executed exactly once.
+   */
+  enabled: boolean
+
+  /** Default number of retries (additional attempts after the first). */
+  maxRetries?: number
+  /** Hard cap for maxRetries after parsing user inputs. */
+  maxRetriesLimit?: number
+
+  /** Initial delay before the first retry (ms). */
+  initialDelayMs?: number
+  /** Maximum delay between retries (ms). */
+  maxDelayMs?: number
+
+  /** Specific HTTP status codes that should be retried. */
+  retryOnStatusCodes?: number[]
+  /** Inclusive status code ranges that should be retried. */
+  retryOnStatusRanges?: RetryStatusRange[]
+
+  /** Retry when a request times out (e.g., AbortController timeout). */
+  retryOnTimeout?: boolean
+  /** Retry on network/connection failures (DNS/connection reset/etc.). */
+  retryOnNetworkError?: boolean
+
+  /** Respect `Retry-After` header when retrying HTTP responses (429/503/etc.). */
+  respectRetryAfter?: boolean
+
+  /**
+   * Methods that are considered safe to retry by default.
+   * If the request method is not listed, retries are disabled unless `nonIdempotent` override is enabled.
+   */
+  retryableMethods?: HttpMethod[]
+
+  /**
+   * Parameter names used to override defaults at runtime.
+   * Useful for blocks that expose retry settings via UI inputs.
+   */
+  paramOverrides?: {
+    retries?: string
+    initialDelayMs?: string
+    maxDelayMs?: string
+    nonIdempotent?: string
+  }
+}
+
 export interface ToolConfig<P = any, R = any> {
   // Basic tool identification
   id: string
@@ -115,6 +168,7 @@ export interface ToolConfig<P = any, R = any> {
     method: HttpMethod | ((params: P) => HttpMethod)
     headers: (params: P) => Record<string, string>
     body?: (params: P) => Record<string, any> | string | FormData | undefined
+    retry?: ToolRequestRetryConfig
   }
 
   // Post-processing (optional) - allows additional processing after the initial request


### PR DESCRIPTION
## Summary
- Add tool-level HTTP retry support with exponential backoff (including `Retry-After`) for timeouts/network failures, 429s, and 5xx responses.
- Expose retry controls in the API block (Advanced) and the `http_request` tool.
- Update API block docs so the retries section matches behavior and configuration.

## Test plan
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres bun run test tools/index.test.ts`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres bun run test tools/http/request.test.ts`

Fixes #3225