### PR TITLE
fix(copy): preserve block names when pasting into workflows without conflicts

### DIFF
--- a/apps/sim/stores/workflows/utils.ts
+++ b/apps/sim/stores/workflows/utils.ts
@@ -445,7 +445,10 @@ export function regenerateBlockIds(
     blockIdMap.set(oldId, newId)
 
     const oldNormalizedName = normalizeName(block.name)
-    const newName = uniqueNameFn(block.name, allBlocksForNaming)
+    const nameConflicts = Object.values(allBlocksForNaming).some(
+      (existing) => normalizeName(existing.name) === oldNormalizedName
+    )
+    const newName = nameConflicts ? uniqueNameFn(block.name, allBlocksForNaming) : block.name
     const newNormalizedName = normalizeName(newName)
     nameMap.set(oldNormalizedName, newNormalizedName)
 


### PR DESCRIPTION
## Summary
- Preserve original block names when pasting into a workflow with no naming conflicts
- Previously blocks always got " 1" appended (e.g., "Pages" → "Pages 1") even when no conflict existed
- Added comprehensive tests for name preservation and conflict detection

## Type of Change
- [x] Bug fix

## Testing
- Added 9 new test cases covering happy path and edge cases
- All 43 tests passing

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)