### PR TITLE
chore(executor): extract shared utils and remove dead code from handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ start-collector.sh
 ## Helm Chart Tests
 helm/sim/test
 i18n.cache
+
+## Claude Code
+.claude/launch.json
+.claude/worktrees/

--- a/apps/sim/executor/handlers/workflow/workflow-handler.ts
+++ b/apps/sim/executor/handlers/workflow/workflow-handler.ts
@@ -579,45 +579,6 @@ export class WorkflowBlockHandler implements BlockHandler {
     return processed
   }
 
-  private flattenChildWorkflowSpans(spans: TraceSpan[]): WorkflowTraceSpan[] {
-    const flattened: WorkflowTraceSpan[] = []
-
-    spans.forEach((span) => {
-      if (this.isSyntheticWorkflowWrapper(span)) {
-        if (span.children && Array.isArray(span.children)) {
-          flattened.push(...this.flattenChildWorkflowSpans(span.children))
-        }
-        return
-      }
-
-      const workflowSpan: WorkflowTraceSpan = {
-        ...span,
-      }
-
-      if (Array.isArray(workflowSpan.children)) {
-        const childSpans = workflowSpan.children as TraceSpan[]
-        workflowSpan.children = this.flattenChildWorkflowSpans(childSpans)
-      }
-
-      if (workflowSpan.output && typeof workflowSpan.output === 'object') {
-        const { childTraceSpans: nestedChildSpans, ...outputRest } = workflowSpan.output as {
-          childTraceSpans?: TraceSpan[]
-        } & Record<string, unknown>
-
-        if (Array.isArray(nestedChildSpans) && nestedChildSpans.length > 0) {
-          const flattenedNestedChildren = this.flattenChildWorkflowSpans(nestedChildSpans)
-          workflowSpan.children = [...(workflowSpan.children || []), ...flattenedNestedChildren]
-        }
-
-        workflowSpan.output = outputRest
-      }
-
-      flattened.push(workflowSpan)
-    })
-
-    return flattened
-  }
-
   private toExecutionResult(result: ExecutionResult | StreamingExecution): ExecutionResult {
     return 'execution' in result ? result.execution : result
   }

--- a/apps/sim/executor/utils/builder-data.ts
+++ b/apps/sim/executor/utils/builder-data.ts
@@ -1,0 +1,149 @@
+import { REFERENCE } from '@/executor/constants'
+
+export interface JSONProperty {
+  id: string
+  name: string
+  type: string
+  value: any
+  collapsed?: boolean
+}
+
+/**
+ * Converts builder data (structured JSON properties) into a plain JSON object.
+ */
+export function convertBuilderDataToJson(builderData: JSONProperty[]): any {
+  if (!Array.isArray(builderData)) {
+    return {}
+  }
+
+  const result: any = {}
+
+  for (const prop of builderData) {
+    if (!prop.name || !prop.name.trim()) {
+      continue
+    }
+
+    const value = convertPropertyValue(prop)
+    result[prop.name] = value
+  }
+
+  return result
+}
+
+/**
+ * Converts builder data into a JSON string with variable references unquoted.
+ */
+export function convertBuilderDataToJsonString(builderData: JSONProperty[]): string {
+  if (!Array.isArray(builderData) || builderData.length === 0) {
+    return '{\n  \n}'
+  }
+
+  const result: any = {}
+
+  for (const prop of builderData) {
+    if (!prop.name || !prop.name.trim()) {
+      continue
+    }
+
+    result[prop.name] = prop.value
+  }
+
+  let jsonString = JSON.stringify(result, null, 2)
+
+  jsonString = jsonString.replace(/"(<[^>]+>)"/g, '$1')
+
+  return jsonString
+}
+
+export function convertPropertyValue(prop: JSONProperty): any {
+  switch (prop.type) {
+    case 'object':
+      return convertObjectValue(prop.value)
+    case 'array':
+      return convertArrayValue(prop.value)
+    case 'number':
+      return convertNumberValue(prop.value)
+    case 'boolean':
+      return convertBooleanValue(prop.value)
+    case 'files':
+      return prop.value
+    default:
+      return prop.value
+  }
+}
+
+function convertObjectValue(value: any): any {
+  if (Array.isArray(value)) {
+    return convertBuilderDataToJson(value)
+  }
+
+  if (typeof value === 'string' && !isVariableReference(value)) {
+    return tryParseJson(value, value)
+  }
+
+  return value
+}
+
+function convertArrayValue(value: any): any {
+  if (Array.isArray(value)) {
+    return value.map((item: any) => convertArrayItem(item))
+  }
+
+  if (typeof value === 'string' && !isVariableReference(value)) {
+    const parsed = tryParseJson(value, value)
+    return Array.isArray(parsed) ? parsed : value
+  }
+
+  return value
+}
+
+function convertArrayItem(item: any): any {
+  if (typeof item !== 'object' || !item.type) {
+    return item
+  }
+
+  if (item.type === 'object' && Array.isArray(item.value)) {
+    return convertBuilderDataToJson(item.value)
+  }
+
+  if (item.type === 'array' && Array.isArray(item.value)) {
+    return item.value.map((subItem: any) =>
+      typeof subItem === 'object' && subItem.type ? subItem.value : subItem
+    )
+  }
+
+  return item.value
+}
+
+function convertNumberValue(value: any): any {
+  if (isVariableReference(value)) {
+    return value
+  }
+
+  const numValue = Number(value)
+  return Number.isNaN(numValue) ? value : numValue
+}
+
+function convertBooleanValue(value: any): any {
+  if (isVariableReference(value)) {
+    return value
+  }
+
+  return value === 'true' || value === true
+}
+
+function tryParseJson(jsonString: string, fallback: any): any {
+  try {
+    return JSON.parse(jsonString)
+  } catch {
+    return fallback
+  }
+}
+
+function isVariableReference(value: any): boolean {
+  return (
+    typeof value === 'string' &&
+    value.trim().startsWith(REFERENCE.START) &&
+    value.trim().includes(REFERENCE.END)
+  )
+}

--- a/apps/sim/executor/utils/vertex-credential.ts
+++ b/apps/sim/executor/utils/vertex-credential.ts
@@ -1,0 +1,42 @@
+import { db } from '@sim/db'
+import { account } from '@sim/db/schema'
+import { createLogger } from '@sim/logger'
+import { eq } from 'drizzle-orm'
+import { refreshTokenIfNeeded, resolveOAuthAccountId } from '@/app/api/auth/oauth/utils'
+
+const logger = createLogger('VertexCredential')
+
+/**
+ * Resolves a Vertex AI OAuth credential to an access token.
+ * Shared across agent, evaluator, and router handlers.
+ */
+export async function resolveVertexCredential(
+  credentialId: string,
+  callerLabel = 'vertex'
+): Promise<string> {
+  const requestId = `${callerLabel}-${Date.now()}`
+
+  logger.info(`[${requestId}] Resolving Vertex AI credential: ${credentialId}`)
+
+  const resolved = await resolveOAuthAccountId(credentialId)
+  if (!resolved) {
+    throw new Error(`Vertex AI credential is not a valid OAuth credential: ${credentialId}`)
+  }
+
+  const credential = await db.query.account.findFirst({
+    where: eq(account.id, resolved.accountId),
+  })
+
+  if (!credential) {
+    throw new Error(`Vertex AI credential not found: ${credentialId}`)
+  }
+
+  const { accessToken } = await refreshTokenIfNeeded(requestId, credential, resolved.accountId)
+
+  if (!accessToken) {
+    throw new Error('Failed to get Vertex AI access token')
+  }
+
+  logger.info(`[${requestId}] Successfully resolved Vertex AI credential`)
+  return accessToken
+}


### PR DESCRIPTION
## Summary
- Extract duplicated builder data conversion logic into `executor/utils/builder-data.ts` (used by response and HITL handlers)
- Extract vertex credential resolution into `executor/utils/vertex-credential.ts` (used by agent handler)
- Deduplicate MCP tool building in agent handler via shared `buildMcpTool` method
- Remove dead code and unused imports across executor handlers
- Add `.claude/launch.json` and `.claude/worktrees/` to gitignore

## Type of Change
- [x] Refactoring / cleanup (no behavior change)

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)