### PR TITLE
fix(templates): show description tagline on template cards

### DIFF
--- a/apps/sim/app/templates/components/template-card.tsx
+++ b/apps/sim/app/templates/components/template-card.tsx
@@ -21,6 +21,7 @@ interface TemplateCardProps {
   blocks?: string[]
   className?: string
   state?: WorkflowState
+  description?: string | null
   isStarred?: boolean
   isVerified?: boolean
 }
@@ -124,6 +125,7 @@ function TemplateCardInner({
   blocks = [],
   className,
   state,
+  description,
   isStarred = false,
   isVerified = false,
 }: TemplateCardProps) {
@@ -269,6 +271,12 @@ function TemplateCardInner({
           )}
         </div>
       </div>
+
+      {description && (
+        <p className='mt-[4px] truncate pl-[2px] text-[12px] text-[var(--text-tertiary)]'>
+          {description}
+        </p>
+      )}
 
       <div className='mt-[10px] flex items-center justify-between'>
         <div className='flex min-w-0 items-center gap-[8px]'>

--- a/apps/sim/app/templates/templates.tsx
+++ b/apps/sim/app/templates/templates.tsx
@@ -196,6 +196,7 @@ export default function Templates({
                   key={template.id}
                   id={template.id}
                   title={template.name}
+                  description={template.details?.tagline}
                   author={template.creator?.name || 'Unknown'}
                   authorImageUrl={template.creator?.profileImageUrl || null}
                   usageCount={template.views.toString()}

--- a/apps/sim/app/workspace/[workspaceId]/templates/components/template-card.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/templates/components/template-card.tsx
@@ -18,6 +18,7 @@ interface TemplateCardProps {
   blocks?: string[]
   className?: string
   state?: WorkflowState
+  description?: string | null
   isStarred?: boolean
   isVerified?: boolean
 }
@@ -127,6 +128,7 @@ function TemplateCardInner({
   blocks = [],
   className,
   state,
+  description,
   isStarred = false,
   isVerified = false,
 }: TemplateCardProps) {
@@ -276,6 +278,12 @@ function TemplateCardInner({
           )}
         </div>
       </div>
+
+      {description && (
+        <p className='mt-[4px] truncate pl-[2px] text-[12px] text-[var(--text-tertiary)]'>
+          {description}
+        </p>
+      )}
 
       <div className='mt-[10px] flex items-center justify-between'>
         <div className='flex min-w-0 flex-1 items-center gap-[6px]'>

--- a/apps/sim/app/workspace/[workspaceId]/templates/templates.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/templates/templates.tsx
@@ -222,6 +222,7 @@ export default function Templates({
                   key={template.id}
                   id={template.id}
                   title={template.name}
+                  description={template.details?.tagline}
                   author={template.creator?.name || 'Unknown'}
                   authorImageUrl={template.creator?.profileImageUrl || null}
                   usageCount={template.views.toString()}


### PR DESCRIPTION
## Summary
- Show template description (tagline) on template cards between the title and author/stats row
- Applied to both public and workspace template cards

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)