### PR TITLE
fix(executor): prevent raw workflowInput from overwriting coerced start block values

### DIFF
--- a/apps/sim/executor/utils/start-block.ts
+++ b/apps/sim/executor/utils/start-block.ts
@@ -262,6 +262,7 @@ function buildUnifiedStartOutput(
   hasStructured: boolean
 ): NormalizedBlockOutput {
   const output: NormalizedBlockOutput = {}
+  const structuredKeys = hasStructured ? new Set(Object.keys(structuredInput)) : null
 
   if (hasStructured) {
     for (const [key, value] of Object.entries(structuredInput)) {
@@ -272,6 +273,9 @@ function buildUnifiedStartOutput(
   if (isPlainObject(workflowInput)) {
     for (const [key, value] of Object.entries(workflowInput)) {
       if (key === 'onUploadError') continue
+      // Skip keys already set by schema-coerced structuredInput to
+      // prevent raw workflowInput strings from overwriting typed values.
+      if (structuredKeys?.has(key)) continue
       // Runtime values override defaults (except undefined/null which mean "not provided")
       if (value !== undefined && value !== null) {
         output[key] = value
@@ -384,6 +388,7 @@ function buildIntegrationTriggerOutput(
   hasStructured: boolean
 ): NormalizedBlockOutput {
   const output: NormalizedBlockOutput = {}
+  const structuredKeys = hasStructured ? new Set(Object.keys(structuredInput)) : null
 
   if (hasStructured) {
     for (const [key, value] of Object.entries(structuredInput)) {
@@ -393,6 +398,7 @@ function buildIntegrationTriggerOutput(
 
   if (isPlainObject(workflowInput)) {
     for (const [key, value] of Object.entries(workflowInput)) {
+      if (structuredKeys?.has(key)) continue
       if (value !== undefined && value !== null) {
         output[key] = value
       } else if (!Object.hasOwn(output, key)) {


### PR DESCRIPTION
## Summary
- Prevent `buildUnifiedStartOutput` and `buildIntegrationTriggerOutput` from overwriting schema-coerced `structuredInput` values with raw `workflowInput` strings
- Add `structuredKeys` guard so the `workflowInput` loop skips keys already set by `coerceValue`, preserving typed values (arrays, objects, numbers, booleans) passed to child workflows

## Type of Change
- [x] Bug fix

## Testing
- `bun run --filter sim test -- executor/utils/start-block.test.ts` (11 tests pass)
- New tests: coerced type preservation (number, object, boolean), structured key priority over duplicated workflowInput keys, EXTERNAL_TRIGGER path

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

Fixes #3105