### PR TITLE
fix(credential-selector): remove reserved icon space when no credential selected

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/credential-selector/credential-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/credential-selector/credential-selector.tsx
@@ -379,7 +379,7 @@ export function CredentialSelector({
         filterOptions={true}
         isLoading={credentialsLoading}
         overlayContent={overlayContent}
-        className={selectedId || isCredentialSetSelected ? 'pl-[28px]' : ''}
+        className={overlayContent ? 'pl-[28px]' : ''}
       />
 
       {needsUpdate && (


### PR DESCRIPTION
## Summary
- Only reserve left padding for the credential icon when the overlay content (icon + label) is actually rendered
- Previously, padding was reserved based on selectedId which could be truthy without a visible icon

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)