### PR TITLE
fix(confluence): add input validation for SSRF-flagged parameters

### DIFF
--- a/apps/sim/app/api/tools/confluence/page-descendants/route.ts
+++ b/apps/sim/app/api/tools/confluence/page-descendants/route.ts
@@ -1,7 +1,11 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
-import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
+import {
+  validateAlphanumericId,
+  validateJiraCloudId,
+  validatePaginationCursor,
+} from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
 
 const logger = createLogger('ConfluencePageDescendantsAPI')
@@ -50,6 +54,10 @@ export async function POST(request: NextRequest) {
     queryParams.append('limit', String(Math.min(limit, 250)))
 
     if (cursor) {
+      const cursorValidation = validatePaginationCursor(cursor, 'cursor')
+      if (!cursorValidation.isValid) {
+        return NextResponse.json({ error: cursorValidation.error }, { status: 400 })
+      }
       queryParams.append('cursor', cursor)
     }
 

--- a/apps/sim/app/api/tools/confluence/space-permissions/route.ts
+++ b/apps/sim/app/api/tools/confluence/space-permissions/route.ts
@@ -1,7 +1,11 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
-import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
+import {
+  validateAlphanumericId,
+  validateJiraCloudId,
+  validatePaginationCursor,
+} from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
 
 const logger = createLogger('ConfluenceSpacePermissionsAPI')
@@ -50,6 +54,10 @@ export async function POST(request: NextRequest) {
     queryParams.append('limit', String(Math.min(limit, 250)))
 
     if (cursor) {
+      const cursorValidation = validatePaginationCursor(cursor, 'cursor')
+      if (!cursorValidation.isValid) {
+        return NextResponse.json({ error: cursorValidation.error }, { status: 400 })
+      }
       queryParams.append('cursor', cursor)
     }
 

--- a/apps/sim/app/api/tools/confluence/user/route.ts
+++ b/apps/sim/app/api/tools/confluence/user/route.ts
@@ -34,11 +34,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Account ID is required' }, { status: 400 })
     }
 
-    // Atlassian account IDs use format like 557058:6b9c9931-4693-49c1-8b3a-931f1af98134
+    // Atlassian account IDs: 5d5bd05c3aee0123abc or 557058:6b9c9931-4693-49c1-8b3a-931f1af98134
     const accountIdValidation = validatePathSegment(accountId, {
       paramName: 'accountId',
-      maxLength: 255,
-      customPattern: /^[a-zA-Z0-9:-]+$/,
+      maxLength: 128,
+      customPattern: /^[a-zA-Z0-9_|:-]+$/,
     })
     if (!accountIdValidation.isValid) {
       return NextResponse.json({ error: accountIdValidation.error }, { status: 400 })


### PR DESCRIPTION
## Summary
- Add `validatePaginationCursor` utility to input-validation for opaque cursor tokens
- Validate `cursor` param in page-descendants, page-versions, space-permissions, space-properties, and tasks routes
- Validate `versionNumber` with `validateNumericId` in page-versions route
- Validate `pageId`, `spaceId`, `assignedTo` query params in tasks list endpoint
- Use `encodeURIComponent` for `propertyId` in space-properties delete path
- Fix accountId pattern to match official Atlassian format (`^[a-zA-Z0-9_|:-]{1,128}$`) in user and tasks routes

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)