### PR TITLE
fix(confluence): prevent content erasure on page/blogpost update and fix space update

### DIFF
--- a/apps/sim/app/api/tools/confluence/blogposts/route.ts
+++ b/apps/sim/app/api/tools/confluence/blogposts/route.ts
@@ -317,7 +317,7 @@ export async function PUT(request: NextRequest) {
     }
 
     // Fetch current blog post to get version number
-    const currentUrl = `https://api.atlassian.com/ex/confluence/${cloudId}/wiki/api/v2/blogposts/${blogPostId}`
+    const currentUrl = `https://api.atlassian.com/ex/confluence/${cloudId}/wiki/api/v2/blogposts/${blogPostId}?body-format=storage`
     const currentResponse = await fetch(currentUrl, {
       headers: {
         Accept: 'application/json',

--- a/apps/sim/app/api/tools/confluence/page/route.ts
+++ b/apps/sim/app/api/tools/confluence/page/route.ts
@@ -185,7 +185,7 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: cloudIdValidation.error }, { status: 400 })
     }
 
-    const currentPageUrl = `https://api.atlassian.com/ex/confluence/${cloudId}/wiki/api/v2/pages/${pageId}`
+    const currentPageUrl = `https://api.atlassian.com/ex/confluence/${cloudId}/wiki/api/v2/pages/${pageId}?body-format=storage`
     const currentPageResponse = await fetch(currentPageUrl, {
       headers: {
         Accept: 'application/json',

--- a/apps/sim/app/api/tools/confluence/space/route.ts
+++ b/apps/sim/app/api/tools/confluence/space/route.ts
@@ -205,7 +205,26 @@ export async function PUT(request: NextRequest) {
     }
 
     const updateBody: Record<string, unknown> = {}
-    if (name) updateBody.name = name
+
+    if (name) {
+      updateBody.name = name
+    } else {
+      const currentResponse = await fetch(url, {
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      if (!currentResponse.ok) {
+        return NextResponse.json(
+          { error: `Failed to fetch current space: ${currentResponse.status}` },
+          { status: currentResponse.status }
+        )
+      }
+      const currentSpace = await currentResponse.json()
+      updateBody.name = currentSpace.name
+    }
+
     if (description !== undefined) {
       updateBody.description = { value: description, representation: 'plain' }
     }


### PR DESCRIPTION
## Summary
- Add `body-format=storage` to GET-before-PUT for page and blogpost updates (without this, Confluence v2 API does not return body content, causing the fallback to erase content when only updating the title)
- Fetch current space name when updating only description (Confluence API requires `name` on PUT, so we preserve the existing name automatically)

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)