### PR TITLE
improvement(ci): add sticky disk caches and bump runner for faster builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   test-build:
     name: Test and Build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
 
     steps:
       - name: Checkout code
@@ -37,6 +37,20 @@ jobs:
         with:
           key: ${{ github.repository }}-node-modules
           path: ./node_modules
+
+      - name: Mount Turbo cache (Sticky Disk)
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-turbo-cache
+          path: ./.turbo
+
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: ./apps/sim/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -85,6 +99,7 @@ jobs:
           NEXT_PUBLIC_APP_URL: 'https://www.sim.ai'
           DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/simstudio'
           ENCRYPTION_KEY: '7cf672e460e430c1fba707575c2b0e2ad5a99dddf9b7b7e3b5646e630861db1c' # dummy key for CI only
+          TURBO_CACHE_DIR: .turbo
         run: bun run test
 
       - name: Check schema and migrations are in sync
@@ -110,6 +125,7 @@ jobs:
           RESEND_API_KEY: 'dummy_key_for_ci_only'
           AWS_REGION: 'us-west-2'
           ENCRYPTION_KEY: '7cf672e460e430c1fba707575c2b0e2ad5a99dddf9b7b7e3b5646e630861db1c' # dummy key for CI only
+          TURBO_CACHE_DIR: .turbo
         run: bunx turbo run build --filter=sim
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
## Summary
- Add Next.js build cache sticky disk to persist incremental compilation across runs
- Add Turbo cache sticky disk so turbo can skip unchanged tasks
- Bump test-build runner from 4vcpu to 8vcpu for faster CPU-bound steps
- Enable cancel-in-progress for PR runs to avoid wasting runner minutes on stale pushes

## Type of Change
- [x] Enhancement / improvement

## Testing
Will verify on first CI run after merge

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)