### PR TITLE
improvement(resend): add error handling, authMode, and naming consistency

### DIFF
--- a/apps/sim/blocks/blocks/resend.ts
+++ b/apps/sim/blocks/blocks/resend.ts
@@ -1,5 +1,6 @@
 import { ResendIcon } from '@/components/icons'
 import type { BlockConfig } from '@/blocks/types'
+import { AuthMode } from '@/blocks/types'
 
 export const ResendBlock: BlockConfig = {
   type: 'resend',
@@ -11,6 +12,7 @@ export const ResendBlock: BlockConfig = {
   category: 'tools',
   bgColor: '#181C1E',
   icon: ResendIcon,
+  authMode: AuthMode.ApiKey,
 
   subBlocks: [
     {
@@ -18,16 +20,13 @@ export const ResendBlock: BlockConfig = {
       title: 'Operation',
       type: 'dropdown',
       options: [
-        // Email Operations
         { label: 'Send Email', id: 'send_email' },
         { label: 'Get Email', id: 'get_email' },
-        // Contact Operations
         { label: 'Create Contact', id: 'create_contact' },
         { label: 'List Contacts', id: 'list_contacts' },
         { label: 'Get Contact', id: 'get_contact' },
         { label: 'Update Contact', id: 'update_contact' },
         { label: 'Delete Contact', id: 'delete_contact' },
-        // Domain Operations
         { label: 'List Domains', id: 'list_domains' },
       ],
       value: () => 'send_email',
@@ -41,7 +40,6 @@ export const ResendBlock: BlockConfig = {
       password: true,
     },
 
-    // Send Email fields
     {
       id: 'fromAddress',
       title: 'From Address',
@@ -80,7 +78,7 @@ export const ResendBlock: BlockConfig = {
 "Order confirmation" -> "Your Order #12345 is Confirmed"
 "Newsletter about new features" -> "New Features You'll Love"
 
-Return ONLY the subject line - no explanations.`,
+Return ONLY the subject line - no explanations, no extra text.`,
         placeholder: 'Describe the email topic...',
       },
     },
@@ -100,7 +98,7 @@ Return ONLY the subject line - no explanations.`,
 - Keep paragraphs short
 - Include appropriate greeting and sign-off
 
-Return ONLY the email body - no explanations.`,
+Return ONLY the email body - no explanations, no extra text.`,
         placeholder: 'Describe the email content...',
       },
     },
@@ -114,6 +112,7 @@ Return ONLY the email body - no explanations.`,
       ],
       value: () => 'text',
       condition: { field: 'operation', value: 'send_email' },
+      mode: 'advanced',
     },
     {
       id: 'cc',
@@ -121,6 +120,7 @@ Return ONLY the email body - no explanations.`,
       type: 'short-input',
       placeholder: 'cc@example.com',
       condition: { field: 'operation', value: 'send_email' },
+      mode: 'advanced',
     },
     {
       id: 'bcc',
@@ -128,6 +128,7 @@ Return ONLY the email body - no explanations.`,
       type: 'short-input',
       placeholder: 'bcc@example.com',
       condition: { field: 'operation', value: 'send_email' },
+      mode: 'advanced',
     },
     {
       id: 'replyTo',
@@ -135,6 +136,7 @@ Return ONLY the email body - no explanations.`,
       type: 'short-input',
       placeholder: 'reply@example.com',
       condition: { field: 'operation', value: 'send_email' },
+      mode: 'advanced',
     },
     {
       id: 'scheduledAt',
@@ -142,6 +144,14 @@ Return ONLY the email body - no explanations.`,
       type: 'short-input',
       placeholder: '2024-08-05T11:52:01.858Z',
       condition: { field: 'operation', value: 'send_email' },
+      mode: 'advanced',
+      wandConfig: {
+        enabled: true,
+        generationType: 'timestamp',
+        prompt:
+          'Generate an ISO 8601 timestamp for scheduling email delivery. Return ONLY the timestamp - no explanations, no extra text.',
+        placeholder: 'Describe when to send (e.g., "tomorrow at 9am")...',
+      },
     },
     {
       id: 'tags',
@@ -149,9 +159,15 @@ Return ONLY the email body - no explanations.`,
       type: 'short-input',
       placeholder: 'category:welcome,type:onboarding',
       condition: { field: 'operation', value: 'send_email' },
+      mode: 'advanced',
+      wandConfig: {
+        enabled: true,
+        prompt:
+          'Generate comma-separated key:value pairs for email tags based on the description. Example format: "category:welcome,type:onboarding". Return ONLY the tag pairs - no explanations, no extra text.',
+        placeholder: 'Describe the email tags...',
+      },
     },
 
-    // Get Email fields
     {
       id: 'emailId',
       title: 'Email ID',
@@ -161,7 +177,6 @@ Return ONLY the email body - no explanations.`,
       required: true,
     },
 
-    // Create Contact fields
     {
       id: 'email',
       title: 'Email',
@@ -196,7 +211,6 @@ Return ONLY the email body - no explanations.`,
       condition: { field: 'operation', value: ['create_contact', 'update_contact'] },
     },
 
-    // Get/Update/Delete Contact fields
     {
       id: 'contactId',
       title: 'Contact ID or Email',
@@ -239,7 +253,6 @@ Return ONLY the email body - no explanations.`,
   inputs: {
     operation: { type: 'string', description: 'Operation to perform' },
     resendApiKey: { type: 'string', description: 'Resend API key' },
-    // Send email inputs
     fromAddress: { type: 'string', description: 'Email address to send from' },
     to: { type: 'string', description: 'Recipient email address' },
     subject: { type: 'string', description: 'Email subject' },
@@ -250,9 +263,7 @@ Return ONLY the email body - no explanations.`,
     replyTo: { type: 'string', description: 'Reply-to email address' },
     scheduledAt: { type: 'string', description: 'Scheduled send time in ISO 8601 format' },
     tags: { type: 'string', description: 'Email tags as key:value pairs' },
-    // Get email inputs
     emailId: { type: 'string', description: 'Email ID to retrieve' },
-    // Contact inputs
     email: { type: 'string', description: 'Contact email address' },
     firstName: { type: 'string', description: 'Contact first name' },
     lastName: { type: 'string', description: 'Contact last name' },
@@ -262,24 +273,22 @@ Return ONLY the email body - no explanations.`,
 
   outputs: {
     success: { type: 'boolean', description: 'Operation success status' },
-    // Send email outputs
+    id: { type: 'string', description: 'Email or contact ID' },
     to: { type: 'string', description: 'Recipient email address' },
     subject: { type: 'string', description: 'Email subject' },
     body: { type: 'string', description: 'Email body content' },
-    // Get email outputs
-    id: { type: 'string', description: 'Email or contact ID' },
     from: { type: 'string', description: 'Sender email address' },
     html: { type: 'string', description: 'HTML email content' },
     text: { type: 'string', description: 'Plain text email content' },
     lastEvent: { type: 'string', description: 'Last event status' },
     createdAt: { type: 'string', description: 'Creation timestamp' },
+    scheduledAt: { type: 'string', description: 'Scheduled send timestamp' },
     tags: { type: 'json', description: 'Email tags as name-value pairs' },
-    // Contact outputs
     email: { type: 'string', description: 'Contact email address' },
     firstName: { type: 'string', description: 'Contact first name' },
     lastName: { type: 'string', description: 'Contact last name' },
+    unsubscribed: { type: 'boolean', description: 'Whether the contact is unsubscribed' },
     contacts: { type: 'json', description: 'Array of contacts' },
-    // Domain outputs
     domains: { type: 'json', description: 'Array of domains' },
     hasMore: { type: 'boolean', description: 'Whether more results are available' },
     deleted: { type: 'boolean', description: 'Whether the resource was deleted' },

--- a/apps/sim/tools/registry.ts
+++ b/apps/sim/tools/registry.ts
@@ -1599,13 +1599,13 @@ import {
 } from '@/tools/redis'
 import { reductoParserTool, reductoParserV2Tool } from '@/tools/reducto'
 import {
-  mailSendTool,
   resendCreateContactTool,
   resendDeleteContactTool,
   resendGetContactTool,
   resendGetEmailTool,
   resendListContactsTool,
   resendListDomainsTool,
+  resendSendTool,
   resendUpdateContactTool,
 } from '@/tools/resend'
 import {
@@ -2390,7 +2390,7 @@ export const tools: Record<string, ToolConfig> = {
   luma_update_event: lumaUpdateEventTool,
   linkedin_share_post: linkedInSharePostTool,
   linkedin_get_profile: linkedInGetProfileTool,
-  resend_send: mailSendTool,
+  resend_send: resendSendTool,
   resend_get_email: resendGetEmailTool,
   resend_create_contact: resendCreateContactTool,
   resend_list_contacts: resendListContactsTool,

--- a/apps/sim/tools/resend/create_contact.ts
+++ b/apps/sim/tools/resend/create_contact.ts
@@ -1,5 +1,8 @@
+import { createLogger } from '@sim/logger'
 import type { CreateContactParams, CreateContactResult } from '@/tools/resend/types'
 import type { ToolConfig } from '@/tools/types'
+
+const logger = createLogger('ResendCreateContactTool')
 
 export const resendCreateContactTool: ToolConfig<CreateContactParams, CreateContactResult> = {
   id: 'resend_create_contact',
@@ -57,6 +60,17 @@ export const resendCreateContactTool: ToolConfig<CreateContactParams, CreateCont
 
   transformResponse: async (response: Response): Promise<CreateContactResult> => {
     const data = await response.json()
+
+    if (!data.id) {
+      logger.error('Resend Create Contact API error:', JSON.stringify(data, null, 2))
+      return {
+        success: false,
+        error: data.message || 'Failed to create contact',
+        output: {
+          id: '',
+        },
+      }
+    }
 
     return {
       success: true,

--- a/apps/sim/tools/resend/index.ts
+++ b/apps/sim/tools/resend/index.ts
@@ -4,7 +4,7 @@ export { resendGetContactTool } from '@/tools/resend/get_contact'
 export { resendGetEmailTool } from '@/tools/resend/get_email'
 export { resendListContactsTool } from '@/tools/resend/list_contacts'
 export { resendListDomainsTool } from '@/tools/resend/list_domains'
-export { mailSendTool } from '@/tools/resend/send'
+export { resendSendTool } from '@/tools/resend/send'
 export type {
   CreateContactParams,
   CreateContactResult,

--- a/apps/sim/tools/resend/list_contacts.ts
+++ b/apps/sim/tools/resend/list_contacts.ts
@@ -1,5 +1,8 @@
+import { createLogger } from '@sim/logger'
 import type { ListContactsParams, ListContactsResult } from '@/tools/resend/types'
 import type { ToolConfig } from '@/tools/types'
+
+const logger = createLogger('ResendListContactsTool')
 
 export const resendListContactsTool: ToolConfig<ListContactsParams, ListContactsResult> = {
   id: 'resend_list_contacts',
@@ -28,11 +31,23 @@ export const resendListContactsTool: ToolConfig<ListContactsParams, ListContacts
   transformResponse: async (response: Response): Promise<ListContactsResult> => {
     const data = await response.json()
 
+    if (data.message) {
+      logger.error('Resend List Contacts API error:', JSON.stringify(data, null, 2))
+      return {
+        success: false,
+        error: data.message || 'Failed to list contacts',
+        output: {
+          contacts: [],
+          hasMore: false,
+        },
+      }
+    }
+
     return {
       success: true,
       output: {
-        contacts: data.data || [],
-        hasMore: data.has_more || false,
+        contacts: data.data ?? [],
+        hasMore: data.has_more ?? false,
       },
     }
   },

--- a/apps/sim/tools/resend/send.ts
+++ b/apps/sim/tools/resend/send.ts
@@ -1,7 +1,7 @@
 import type { MailSendParams, MailSendResult } from '@/tools/resend/types'
 import type { ToolConfig } from '@/tools/types'
 
-export const mailSendTool: ToolConfig<MailSendParams, MailSendResult> = {
+export const resendSendTool: ToolConfig<MailSendParams, MailSendResult> = {
   id: 'resend_send',
   name: 'Send Email',
   description: 'Send an email using your own Resend API key and from address',


### PR DESCRIPTION
## Summary
- Add createLogger and error handling to all 7 direct-API tool files
- Add authMode: AuthMode.ApiKey to block config
- Add .trim() on ID fields in URL paths
- Move optional send-email fields (cc, bcc, replyTo, scheduledAt, tags) to advanced mode
- Add wandConfig for scheduledAt (timestamp) and tags fields
- Add missing block outputs (scheduledAt, unsubscribed)
- Add optional: true on nullable tool outputs
- Rename mailSendTool to resendSendTool for naming consistency
- Use ?? instead of || for null-coalescing in response transforms

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)