### PR TITLE
improvement(luma): expand host response fields and harden event ID inputs

### DIFF
--- a/apps/docs/content/docs/en/tools/luma.mdx
+++ b/apps/docs/content/docs/en/tools/luma.mdx
@@ -70,8 +70,12 @@ Retrieve details of a Luma event including name, time, location, hosts, and visi
 |   ↳ `geoLongitude` | string | Venue longitude coordinate |
 |   ↳ `calendarId` | string | Associated calendar ID |
 | `hosts` | array | Event hosts |
-|   ↳ `name` | string | Host name |
+|   ↳ `id` | string | Host ID |
+|   ↳ `name` | string | Host display name |
+|   ↳ `firstName` | string | Host first name |
+|   ↳ `lastName` | string | Host last name |
 |   ↳ `email` | string | Host email address |
+|   ↳ `avatarUrl` | string | Host avatar image URL |
 
 ### `luma_create_event`
 
@@ -115,8 +119,12 @@ Create a new event on Luma with a name, start time, timezone, and optional detai
 |   ↳ `geoLongitude` | string | Venue longitude coordinate |
 |   ↳ `calendarId` | string | Associated calendar ID |
 | `hosts` | array | Event hosts |
-|   ↳ `name` | string | Host name |
+|   ↳ `id` | string | Host ID |
+|   ↳ `name` | string | Host display name |
+|   ↳ `firstName` | string | Host first name |
+|   ↳ `lastName` | string | Host last name |
 |   ↳ `email` | string | Host email address |
+|   ↳ `avatarUrl` | string | Host avatar image URL |
 
 ### `luma_update_event`
 
@@ -161,8 +169,12 @@ Update an existing Luma event. Only the fields you provide will be changed; all 
 |   ↳ `geoLongitude` | string | Venue longitude coordinate |
 |   ↳ `calendarId` | string | Associated calendar ID |
 | `hosts` | array | Event hosts |
-|   ↳ `name` | string | Host name |
+|   ↳ `id` | string | Host ID |
+|   ↳ `name` | string | Host display name |
+|   ↳ `firstName` | string | Host first name |
+|   ↳ `lastName` | string | Host last name |
 |   ↳ `email` | string | Host email address |
+|   ↳ `avatarUrl` | string | Host avatar image URL |
 
 ### `luma_list_events`
 
@@ -177,7 +189,7 @@ List events from your Luma calendar with optional date range filtering, sorting,
 | `before` | string | No | Return events before this ISO 8601 datetime \(e.g., 2025-12-31T23:59:59Z\) |
 | `paginationLimit` | number | No | Maximum number of events to return per page |
 | `paginationCursor` | string | No | Pagination cursor from a previous response \(next_cursor\) to fetch the next page of results |
-| `sortColumn` | string | No | Column to sort by \(e.g., start_at\) |
+| `sortColumn` | string | No | Column to sort by \(only start_at is supported\) |
 | `sortDirection` | string | No | Sort direction: asc, desc, asc nulls last, or desc nulls last |
 
 #### Output

--- a/apps/sim/blocks/blocks/luma.ts
+++ b/apps/sim/blocks/blocks/luma.ts
@@ -370,10 +370,25 @@ Return ONLY the ISO 8601 timestamp - no explanations, no quotes, no extra text.`
   },
 
   outputs: {
-    event: { type: 'json', description: 'Event details' },
-    hosts: { type: 'json', description: 'Event hosts' },
-    events: { type: 'json', description: 'List of events' },
-    guests: { type: 'json', description: 'List of guests' },
+    event: {
+      type: 'json',
+      description:
+        'Event details (id, name, startAt, endAt, timezone, durationInterval, createdAt, description, descriptionMd, coverUrl, url, visibility, meetingUrl, geoAddressJson, geoLatitude, geoLongitude, calendarId)',
+    },
+    hosts: {
+      type: 'json',
+      description: 'Event hosts (id, name, firstName, lastName, email, avatarUrl)',
+    },
+    events: {
+      type: 'json',
+      description:
+        'List of events, each with id, name, startAt, endAt, timezone, durationInterval, createdAt, description, descriptionMd, coverUrl, url, visibility, meetingUrl, geoAddressJson, geoLatitude, geoLongitude, calendarId',
+    },
+    guests: {
+      type: 'json',
+      description:
+        'List of guests (id, email, name, firstName, lastName, approvalStatus, registeredAt, invitedAt, joinedAt, checkedInAt, phoneNumber)',
+    },
     hasMore: { type: 'boolean', description: 'Whether more results are available' },
     nextCursor: { type: 'string', description: 'Pagination cursor for next page' },
   },

--- a/apps/sim/tools/luma/add_guests.ts
+++ b/apps/sim/tools/luma/add_guests.ts
@@ -47,7 +47,7 @@ export const addGuestsTool: ToolConfig<LumaAddGuestsParams, LumaAddGuestsRespons
         guestsArray = [{ email: params.guests }]
       }
       return {
-        event_id: params.eventId,
+        event_id: params.eventId.trim(),
         guests: guestsArray,
       }
     },

--- a/apps/sim/tools/luma/create_event.ts
+++ b/apps/sim/tools/luma/create_event.ts
@@ -106,8 +106,12 @@ export const createEventTool: ToolConfig<LumaCreateEventParams, LumaCreateEventR
 
     const event = data.event
     const hosts = (data.hosts ?? []).map((h: Record<string, unknown>) => ({
+      id: (h.id as string) ?? null,
       name: (h.name as string) ?? null,
+      firstName: (h.first_name as string) ?? null,
+      lastName: (h.last_name as string) ?? null,
       email: (h.email as string) ?? null,
+      avatarUrl: (h.avatar_url as string) ?? null,
     }))
 
     return {

--- a/apps/sim/tools/luma/get_event.ts
+++ b/apps/sim/tools/luma/get_event.ts
@@ -27,7 +27,7 @@ export const getEventTool: ToolConfig<LumaGetEventParams, LumaGetEventResponse> 
   request: {
     url: (params) => {
       const url = new URL('https://public-api.luma.com/v1/event/get')
-      url.searchParams.set('id', params.eventId)
+      url.searchParams.set('id', params.eventId.trim())
       return url.toString()
     },
     method: 'GET',
@@ -46,8 +46,12 @@ export const getEventTool: ToolConfig<LumaGetEventParams, LumaGetEventResponse> 
 
     const event = data.event
     const hosts = (data.hosts ?? []).map((h: Record<string, unknown>) => ({
+      id: (h.id as string) ?? null,
       name: (h.name as string) ?? null,
+      firstName: (h.first_name as string) ?? null,
+      lastName: (h.last_name as string) ?? null,
       email: (h.email as string) ?? null,
+      avatarUrl: (h.avatar_url as string) ?? null,
     }))
 
     return {

--- a/apps/sim/tools/luma/get_guests.ts
+++ b/apps/sim/tools/luma/get_guests.ts
@@ -59,7 +59,7 @@ export const getGuestsTool: ToolConfig<LumaGetGuestsParams, LumaGetGuestsRespons
   request: {
     url: (params) => {
       const url = new URL('https://public-api.luma.com/v1/event/get-guests')
-      url.searchParams.set('event_id', params.eventId)
+      url.searchParams.set('event_id', params.eventId.trim())
       if (params.approvalStatus) url.searchParams.set('approval_status', params.approvalStatus)
       if (params.paginationLimit)
         url.searchParams.set('pagination_limit', String(params.paginationLimit))

--- a/apps/sim/tools/luma/index.ts
+++ b/apps/sim/tools/luma/index.ts
@@ -5,6 +5,8 @@ import { getGuestsTool } from '@/tools/luma/get_guests'
 import { listEventsTool } from '@/tools/luma/list_events'
 import { updateEventTool } from '@/tools/luma/update_event'
 
+export * from './types'
+
 export const lumaAddGuestsTool = addGuestsTool
 export const lumaCreateEventTool = createEventTool
 export const lumaGetEventTool = getEventTool

--- a/apps/sim/tools/luma/list_events.ts
+++ b/apps/sim/tools/luma/list_events.ts
@@ -45,7 +45,7 @@ export const listEventsTool: ToolConfig<LumaListEventsParams, LumaListEventsResp
       type: 'string',
       required: false,
       visibility: 'user-or-llm',
-      description: 'Column to sort by (e.g., start_at)',
+      description: 'Column to sort by (only start_at is supported)',
     },
     sortDirection: {
       type: 'string',

--- a/apps/sim/tools/luma/types.ts
+++ b/apps/sim/tools/luma/types.ts
@@ -59,8 +59,12 @@ export interface LumaAddGuestsParams {
 }
 
 export interface LumaHostEntry {
+  id: string | null
   name: string | null
+  firstName: string | null
+  lastName: string | null
   email: string | null
+  avatarUrl: string | null
 }
 
 export interface LumaEventEntry {
@@ -141,8 +145,12 @@ export interface LumaAddGuestsResponse extends ToolResponse {
 }
 
 export const LUMA_HOST_OUTPUT_PROPERTIES = {
-  name: { type: 'string' as const, description: 'Host name' },
+  id: { type: 'string' as const, description: 'Host ID' },
+  name: { type: 'string' as const, description: 'Host display name' },
+  firstName: { type: 'string' as const, description: 'Host first name' },
+  lastName: { type: 'string' as const, description: 'Host last name' },
   email: { type: 'string' as const, description: 'Host email address' },
+  avatarUrl: { type: 'string' as const, description: 'Host avatar image URL' },
 }
 
 export const LUMA_EVENT_OUTPUT_PROPERTIES = {

--- a/apps/sim/tools/luma/update_event.ts
+++ b/apps/sim/tools/luma/update_event.ts
@@ -89,7 +89,7 @@ export const updateEventTool: ToolConfig<LumaUpdateEventParams, LumaUpdateEventR
     }),
     body: (params) => {
       const body: Record<string, unknown> = {
-        id: params.eventId,
+        id: params.eventId.trim(),
       }
       if (params.name) body.name = params.name
       if (params.startAt) body.start_at = params.startAt
@@ -113,8 +113,12 @@ export const updateEventTool: ToolConfig<LumaUpdateEventParams, LumaUpdateEventR
 
     const event = data.event
     const hosts = (data.hosts ?? []).map((h: Record<string, unknown>) => ({
+      id: (h.id as string) ?? null,
       name: (h.name as string) ?? null,
+      firstName: (h.first_name as string) ?? null,
+      lastName: (h.last_name as string) ?? null,
       email: (h.email as string) ?? null,
+      avatarUrl: (h.avatar_url as string) ?? null,
     }))
 
     return {


### PR DESCRIPTION
## Summary
- Expanded host response mapping to include id, firstName, lastName, avatarUrl from Luma API
- Added .trim() on eventId params to prevent whitespace copy-paste errors
- Added types barrel export and improved block output descriptions
- Updated docs to reflect new host fields

## Type of Change
- [x] Enhancement to existing integration

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)