### PR TITLE
fix(monitoring): set MemoryTelemetry logger to INFO for production

### DIFF
--- a/apps/sim/lib/monitoring/memory-telemetry.ts
+++ b/apps/sim/lib/monitoring/memory-telemetry.ts
@@ -12,7 +12,7 @@ import {
   getActiveSSEConnectionsByRoute,
 } from '@/lib/monitoring/sse-connections'
 
-const logger = createLogger('MemoryTelemetry')
+const logger = createLogger('MemoryTelemetry', { logLevel: 'INFO' })
 
 const MB = 1024 * 1024
 


### PR DESCRIPTION
## Summary
- Production logger defaults to ERROR-only, which silently suppressed our `logger.info('Memory snapshot', ...)` calls
- Adds `{ logLevel: 'INFO' }` override specifically for the MemoryTelemetry logger so snapshots appear in CloudWatch

## Test plan
- [x] Deploy to staging and verify `Memory snapshot` entries appear in `/ecs/sim-staging/us-east-1/app` CloudWatch logs every 60s