### PR TITLE
fix(layout): polyfill crypto.randomUUID for non-secure HTTP contexts

### DIFF
--- a/apps/sim/app/layout.tsx
+++ b/apps/sim/app/layout.tsx
@@ -38,6 +38,24 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang='en' suppressHydrationWarning>
       <head>
+        {/* Polyfill crypto.randomUUID for non-secure contexts (HTTP on non-localhost) */}
+        <script
+          id='crypto-randomuuid-polyfill'
+          dangerouslySetInnerHTML={{
+            __html: `
+              if (typeof crypto !== 'undefined' && typeof crypto.randomUUID !== 'function' && typeof crypto.getRandomValues === 'function') {
+                crypto.randomUUID = function() {
+                  var a = new Uint8Array(16);
+                  crypto.getRandomValues(a);
+                  a[6] = (a[6] & 0x0f) | 0x40;
+                  a[8] = (a[8] & 0x3f) | 0x80;
+                  var h = Array.prototype.map.call(a, function(b) { return ('0' + b.toString(16)).slice(-2); }).join('');
+                  return h.slice(0,8) + '-' + h.slice(8,12) + '-' + h.slice(12,16) + '-' + h.slice(16,20) + '-' + h.slice(20);
+                };
+              }
+            `,
+          }}
+        />
         {isReactScanEnabled && (
           <Script
             src='https://unpkg.com/react-scan/dist/auto.global.js'


### PR DESCRIPTION
## Summary
- Add `crypto.randomUUID` polyfill in root layout for self-hosted instances accessed over plain HTTP
- Uses `crypto.getRandomValues` (available in insecure contexts) to generate RFC 4122 v4 UUIDs
- Fixes white screen crash: `TypeError: crypto.randomUUID is not a function`

Closes #3393

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)