### PR TITLE
fix(socket): persist outbound edges from locked blocks

### DIFF
--- a/apps/sim/socket/database/operations.ts
+++ b/apps/sim/socket/database/operations.ts
@@ -1269,7 +1269,7 @@ async function handleEdgeOperationTx(tx: any, workflowId: string, operation: str
         throw new Error('Missing edge ID for remove operation')
       }
 
-      // Get the edge to check if connected blocks are protected
+      // Get the edge to check if target block is protected
       const [edgeToRemove] = await tx
         .select({
           sourceBlockId: workflowEdges.sourceBlockId,
@@ -1283,7 +1283,7 @@ async function handleEdgeOperationTx(tx: any, workflowId: string, operation: str
         throw new Error(`Edge ${payload.id} not found in workflow ${workflowId}`)
       }
 
-      // Check if source or target blocks are protected
+      // Check if target block is protected
       const connectedBlocks = await tx
         .select({
           id: workflowBlocks.id,


### PR DESCRIPTION
## Summary
- Server-side edge add operation was checking if source block is protected, preventing outbound connections from locked blocks from being persisted
- Client-side already correctly only checks target block protection
- Removed source block protection check to align server with client behavior

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)