### PR TITLE
fix(editor): pass workspaceId to useCredentialName in block preview

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -527,7 +527,8 @@ const SubBlockRow = memo(function SubBlockRow({
   const { displayName: credentialName } = useCredentialName(
     credentialSourceId,
     credentialProviderId,
-    workflowId
+    workflowId,
+    workspaceId
   )
 
   const credentialId = dependencyValues.credential


### PR DESCRIPTION
## Summary
- Fix credential names not showing in block preview on canvas
- Pass workspaceId to useCredentialName so it shares the same React Query cache key as the editor panel

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)