### PR TITLE
fix(chat): use explicit trigger type check instead of heuristic for chat guard

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -1496,7 +1496,7 @@ export function useWorkflowExecution() {
                 // For chat executions, don't set isExecuting=false here — the chat's
                 // client-side stream wrapper still has buffered data to deliver.
                 // The chat's finally block handles cleanup after the stream is fully consumed.
-                if (overrideTriggerType !== 'chat') {
+                if (!isExecutingFromChat) {
                   setIsExecuting(activeWorkflowId, false)
                   setActiveBlocks(activeWorkflowId, new Set())
                 }
@@ -1539,7 +1539,7 @@ export function useWorkflowExecution() {
                 isPreExecutionError,
               })
 
-              if (activeWorkflowId && overrideTriggerType !== 'chat') {
+              if (activeWorkflowId && !isExecutingFromChat) {
                 setIsExecuting(activeWorkflowId, false)
                 setIsDebugging(activeWorkflowId, false)
                 setActiveBlocks(activeWorkflowId, new Set())
@@ -1565,7 +1565,7 @@ export function useWorkflowExecution() {
                 durationMs: data?.duration,
               })
 
-              if (activeWorkflowId && overrideTriggerType !== 'chat') {
+              if (activeWorkflowId && !isExecutingFromChat) {
                 setIsExecuting(activeWorkflowId, false)
                 setIsDebugging(activeWorkflowId, false)
                 setActiveBlocks(activeWorkflowId, new Set())


### PR DESCRIPTION
## Summary
- Replace `!isExecutingFromChat` heuristic with explicit `overrideTriggerType !== 'chat'` check in execution completion callbacks
- The `isExecutingFromChat` heuristic (`'input' in workflowInput`) could false-positive for manual executions with a user-defined "input" test field, leaving `isExecuting` stuck true forever
- All 3 call sites of `executeWorkflow` always pass an explicit trigger type (`'chat'`, `'manual'`), so this check is deterministic

## Type of Change
- [x] Bug fix

## Testing
Verified all 3 `executeWorkflow` call sites always pass explicit `overrideTriggerType`. Type check passes clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)