### PR TITLE
fix(tool-input): restore workflow input mapper visibility

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -1969,9 +1969,8 @@ export const ToolInput = memo(function ToolInput({
                     }
 
                     if (useSubBlocks && displaySubBlocks.length > 0) {
-                      const allBlockSubBlocks = toolBlock?.subBlocks || []
                       const coveredParamIds = new Set(
-                        allBlockSubBlocks.flatMap((sb) => {
+                        displaySubBlocks.flatMap((sb) => {
                           const ids = [sb.id]
                           if (sb.canonicalParamId) ids.push(sb.canonicalParamId)
                           const cId = toolCanonicalIndex?.canonicalIdBySubBlockId[sb.id]


### PR DESCRIPTION
## Summary
- Fix workflow start inputs not showing when a workflow is used as a tool in Agent
- `coveredParamIds` was changed from `displaySubBlocks` to `allBlockSubBlocks` in #3211, which caused excluded subBlock types (like `input-mapping`) to still count as "covered", preventing `inputMapping` from rendering as an uncovered param

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)