### PR TITLE
fix(api): add limit/offset pagination to GET workflows

### DIFF
--- a/apps/sim/app/api/workflows/route.ts
+++ b/apps/sim/app/api/workflows/route.ts
@@ -62,12 +62,18 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    let workflows
+    const pageParam = url.searchParams.get('page')
+    const limitParam = url.searchParams.get('limit')
+    const page = pageParam ? parseInt(pageParam, 10) : undefined
+    const limit = limitParam ? parseInt(limitParam, 10) : undefined
 
+    let workflows
     const orderByClause = [asc(workflow.sortOrder), asc(workflow.createdAt), asc(workflow.id)]
 
+    let baseQuery: any
+
     if (workspaceId) {
-      workflows = await db
+      baseQuery = db
         .select()
         .from(workflow)
         .where(eq(workflow.workspaceId, workspaceId))
@@ -77,16 +83,28 @@ export async function GET(request: NextRequest) {
         .select({ workspaceId: permissions.entityId })
         .from(permissions)
         .where(and(eq(permissions.userId, userId), eq(permissions.entityType, 'workspace')))
+
       const workspaceIds = workspacePermissionRows.map((row) => row.workspaceId)
+
       if (workspaceIds.length === 0) {
         return NextResponse.json({ data: [] }, { status: 200 })
       }
-      workflows = await db
+
+      baseQuery = db
         .select()
         .from(workflow)
         .where(inArray(workflow.workspaceId, workspaceIds))
         .orderBy(...orderByClause)
     }
+
+    if (limit && !isNaN(limit) && limit > 0) {
+      baseQuery = baseQuery.limit(limit)
+      if (page && !isNaN(page) && page > 1) {
+        baseQuery = baseQuery.offset((page - 1) * limit)
+      }
+    }
+
+    workflows = await baseQuery
 
     return NextResponse.json({ data: workflows }, { status: 200 })
   } catch (error: any) {


### PR DESCRIPTION
## Summary
Fixes a bug where fetching workspaces drops the server due to excessive memory exhaustion.
The `GET /api/workflows` endpoint was basically fetching every single workflow without any bounds or limits. On larger workspaces, this risks causing OOM crashes or freezing the frontend. 
I just added standard offset/limit pagination pulling directly from the URL parameters so that the UI can paginate gracefully.

Fixes #3435

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: _________

## Testing

Tested pulling workflows with and without the URL limit/offset parameters locally. The query gracefully degrades to the default fetch if no params are provided, so it doesn't break any existing UI logic anywhere else.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)