### PR TITLE
fix(knowledge): compute KB tokenCount from documents instead of stale column

### DIFF
--- a/apps/sim/lib/knowledge/service.ts
+++ b/apps/sim/lib/knowledge/service.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto'
 import { db } from '@sim/db'
 import { document, knowledgeBase, knowledgeConnector, permissions } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
-import { and, count, eq, inArray, isNotNull, isNull, or } from 'drizzle-orm'
+import { and, count, eq, inArray, isNotNull, isNull, or, sql } from 'drizzle-orm'
 import type {
   ChunkingConfig,
   CreateKnowledgeBaseData,
@@ -24,7 +24,7 @@ export async function getKnowledgeBases(
       id: knowledgeBase.id,
       name: knowledgeBase.name,
       description: knowledgeBase.description,
-      tokenCount: knowledgeBase.tokenCount,
+      tokenCount: sql<number>`COALESCE(SUM(${document.tokenCount}), 0)`.mapWith(Number),
       embeddingModel: knowledgeBase.embeddingModel,
       embeddingDimension: knowledgeBase.embeddingDimension,
       chunkingConfig: knowledgeBase.chunkingConfig,
@@ -204,7 +204,7 @@ export async function updateKnowledgeBase(
       id: knowledgeBase.id,
       name: knowledgeBase.name,
       description: knowledgeBase.description,
-      tokenCount: knowledgeBase.tokenCount,
+      tokenCount: sql<number>`COALESCE(SUM(${document.tokenCount}), 0)`.mapWith(Number),
       embeddingModel: knowledgeBase.embeddingModel,
       embeddingDimension: knowledgeBase.embeddingDimension,
       chunkingConfig: knowledgeBase.chunkingConfig,
@@ -247,7 +247,7 @@ export async function getKnowledgeBaseById(
       id: knowledgeBase.id,
       name: knowledgeBase.name,
       description: knowledgeBase.description,
-      tokenCount: knowledgeBase.tokenCount,
+      tokenCount: sql<number>`COALESCE(SUM(${document.tokenCount}), 0)`.mapWith(Number),
       embeddingModel: knowledgeBase.embeddingModel,
       embeddingDimension: knowledgeBase.embeddingDimension,
       chunkingConfig: knowledgeBase.chunkingConfig,


### PR DESCRIPTION
## Summary
- `knowledge_base.token_count` was always 0 — initialized on creation but never updated
- Replaced with `COALESCE(SUM(document.token_count), 0)` in all read queries
- All 3 queries already LEFT JOIN on documents with GROUP BY, so no additional joins needed
- Document-level token counts are actively maintained across all chunk CRUD operations

## Type of Change
- [x] Bug fix

## Testing
Verified document-level tokenCount is maintained across all chunk create/update/delete paths

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)