### PR TITLE
fix(execution): ensure background tasks await post-execution DB status updates

### DIFF
--- a/apps/sim/background/schedule-execution.ts
+++ b/apps/sim/background/schedule-execution.ts
@@ -238,6 +238,8 @@ async function runWorkflowExecution({
       await PauseResumeManager.processQueuedResumes(executionId)
     }
 
+    await loggingSession.waitForPostExecution()
+
     logger.info(`[${requestId}] Workflow execution completed: ${payload.workflowId}`, {
       success: executionResult.success,
       executionTime: executionResult.metadata?.duration,

--- a/apps/sim/background/webhook-execution.ts
+++ b/apps/sim/background/webhook-execution.ts
@@ -312,6 +312,8 @@ async function executeWebhookJobInternal(
           await PauseResumeManager.processQueuedResumes(executionId)
         }
 
+        await loggingSession.waitForPostExecution()
+
         logger.info(`[${requestId}] Airtable webhook execution completed`, {
           success: executionResult.success,
           workflowId: payload.workflowId,
@@ -584,6 +586,8 @@ async function executeWebhookJobInternal(
     } else {
       await PauseResumeManager.processQueuedResumes(executionId)
     }
+
+    await loggingSession.waitForPostExecution()
 
     logger.info(`[${requestId}] Webhook execution completed`, {
       success: executionResult.success,

--- a/apps/sim/background/workflow-execution.ts
+++ b/apps/sim/background/workflow-execution.ts
@@ -158,6 +158,8 @@ export async function executeWorkflowJob(payload: WorkflowExecutionPayload) {
       await PauseResumeManager.processQueuedResumes(executionId)
     }
 
+    await loggingSession.waitForPostExecution()
+
     logger.info(`[${requestId}] Workflow execution completed: ${workflowId}`, {
       success: result.success,
       executionTime: result.metadata?.duration,

--- a/apps/sim/lib/logs/execution/logging-session.ts
+++ b/apps/sim/lib/logs/execution/logging-session.ts
@@ -101,6 +101,7 @@ export class LoggingSession {
     models: {},
   }
   private costFlushed = false
+  private postExecutionPromise: Promise<void> | null = null
 
   constructor(
     workflowId: string,
@@ -684,6 +685,20 @@ export class LoggingSession {
         await this.completionPromise
       } catch {
         /* already handled by safe* wrapper */
+      }
+    }
+  }
+
+  setPostExecutionPromise(promise: Promise<void>): void {
+    this.postExecutionPromise = promise
+  }
+
+  async waitForPostExecution(): Promise<void> {
+    if (this.postExecutionPromise) {
+      try {
+        await this.postExecutionPromise
+      } catch {
+        /* already handled inside the IIFE */
       }
     }
   }

--- a/apps/sim/lib/workflows/executor/execution-core.ts
+++ b/apps/sim/lib/workflows/executor/execution-core.ts
@@ -360,48 +360,49 @@ export async function executeWorkflowCore(
         )) as ExecutionResult)
       : ((await executorInstance.execute(workflowId, resolvedTriggerBlockId)) as ExecutionResult)
 
-    // Fire-and-forget: post-execution logging, billing, and cleanup
-    void (async () => {
-      try {
-        const { traceSpans, totalDuration } = buildTraceSpans(result)
+    loggingSession.setPostExecutionPromise(
+      (async () => {
+        try {
+          const { traceSpans, totalDuration } = buildTraceSpans(result)
 
-        if (result.success && result.status !== 'paused') {
-          try {
-            await updateWorkflowRunCounts(workflowId)
-          } catch (runCountError) {
-            logger.error(`[${requestId}] Failed to update run counts`, { error: runCountError })
+          if (result.success && result.status !== 'paused') {
+            try {
+              await updateWorkflowRunCounts(workflowId)
+            } catch (runCountError) {
+              logger.error(`[${requestId}] Failed to update run counts`, { error: runCountError })
+            }
           }
-        }
 
-        if (result.status === 'cancelled') {
-          await loggingSession.safeCompleteWithCancellation({
-            endedAt: new Date().toISOString(),
-            totalDurationMs: totalDuration || 0,
-            traceSpans: traceSpans || [],
-          })
-        } else if (result.status === 'paused') {
-          await loggingSession.safeCompleteWithPause({
-            endedAt: new Date().toISOString(),
-            totalDurationMs: totalDuration || 0,
-            traceSpans: traceSpans || [],
-            workflowInput: processedInput,
-          })
-        } else {
-          await loggingSession.safeComplete({
-            endedAt: new Date().toISOString(),
-            totalDurationMs: totalDuration || 0,
-            finalOutput: result.output || {},
-            traceSpans: traceSpans || [],
-            workflowInput: processedInput,
-            executionState: result.executionState,
-          })
-        }
+          if (result.status === 'cancelled') {
+            await loggingSession.safeCompleteWithCancellation({
+              endedAt: new Date().toISOString(),
+              totalDurationMs: totalDuration || 0,
+              traceSpans: traceSpans || [],
+            })
+          } else if (result.status === 'paused') {
+            await loggingSession.safeCompleteWithPause({
+              endedAt: new Date().toISOString(),
+              totalDurationMs: totalDuration || 0,
+              traceSpans: traceSpans || [],
+              workflowInput: processedInput,
+            })
+          } else {
+            await loggingSession.safeComplete({
+              endedAt: new Date().toISOString(),
+              totalDurationMs: totalDuration || 0,
+              finalOutput: result.output || {},
+              traceSpans: traceSpans || [],
+              workflowInput: processedInput,
+              executionState: result.executionState,
+            })
+          }
 
-        await clearExecutionCancellation(executionId)
-      } catch (postExecError) {
-        logger.error(`[${requestId}] Post-execution logging failed`, { error: postExecError })
-      }
-    })()
+          await clearExecutionCancellation(executionId)
+        } catch (postExecError) {
+          logger.error(`[${requestId}] Post-execution logging failed`, { error: postExecError })
+        }
+      })()
+    )
 
     logger.info(`[${requestId}] Workflow execution completed`, {
       success: result.success,
@@ -413,31 +414,32 @@ export async function executeWorkflowCore(
   } catch (error: unknown) {
     logger.error(`[${requestId}] Execution failed:`, error)
 
-    // Fire-and-forget: error logging and cleanup
-    void (async () => {
-      try {
-        const executionResult = hasExecutionResult(error) ? error.executionResult : undefined
-        const { traceSpans } = executionResult
-          ? buildTraceSpans(executionResult)
-          : { traceSpans: [] }
+    loggingSession.setPostExecutionPromise(
+      (async () => {
+        try {
+          const executionResult = hasExecutionResult(error) ? error.executionResult : undefined
+          const { traceSpans } = executionResult
+            ? buildTraceSpans(executionResult)
+            : { traceSpans: [] }
 
-        await loggingSession.safeCompleteWithError({
-          endedAt: new Date().toISOString(),
-          totalDurationMs: executionResult?.metadata?.duration || 0,
-          error: {
-            message: error instanceof Error ? error.message : 'Execution failed',
-            stackTrace: error instanceof Error ? error.stack : undefined,
-          },
-          traceSpans,
-        })
+          await loggingSession.safeCompleteWithError({
+            endedAt: new Date().toISOString(),
+            totalDurationMs: executionResult?.metadata?.duration || 0,
+            error: {
+              message: error instanceof Error ? error.message : 'Execution failed',
+              stackTrace: error instanceof Error ? error.stack : undefined,
+            },
+            traceSpans,
+          })
 
-        await clearExecutionCancellation(executionId)
-      } catch (postExecError) {
-        logger.error(`[${requestId}] Post-execution error logging failed`, {
-          error: postExecError,
-        })
-      }
-    })()
+          await clearExecutionCancellation(executionId)
+        } catch (postExecError) {
+          logger.error(`[${requestId}] Post-execution error logging failed`, {
+            error: postExecError,
+          })
+        }
+      })()
+    )
 
     throw error
   }


### PR DESCRIPTION
## Summary
- Workflow executions triggered via trigger.dev (webhook, schedule, workflow tasks) could get permanently stuck in "running" status because the post-execution DB update was fire-and-forget and the process could exit before it completed
- Store the fire-and-forget promise on `LoggingSession` via `setPostExecutionPromise()` so background callers can optionally await it with `waitForPostExecution()`
- Background tasks now await the post-execution promise before returning — client-facing paths (SSE/API) are completely unaffected and retain the latency optimization

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)