### PR TITLE
fix: V1 log API endpoints silently drop logs for deleted workflows

### DIFF
--- a/apps/sim/app/api/v1/logs/[id]/route.ts
+++ b/apps/sim/app/api/v1/logs/[id]/route.ts
@@ -47,12 +47,12 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         workflowUpdatedAt: workflow.updatedAt,
       })
       .from(workflowExecutionLogs)
-      .innerJoin(workflow, eq(workflowExecutionLogs.workflowId, workflow.id))
+      .leftJoin(workflow, eq(workflowExecutionLogs.workflowId, workflow.id))
       .innerJoin(
         permissions,
         and(
           eq(permissions.entityType, 'workspace'),
-          eq(permissions.entityId, workflow.workspaceId),
+          eq(permissions.entityId, workflowExecutionLogs.workspaceId),
           eq(permissions.userId, userId)
         )
       )
@@ -64,17 +64,29 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: 'Log not found' }, { status: 404 })
     }
 
-    const workflowSummary = {
-      id: log.workflowId,
-      name: log.workflowName,
-      description: log.workflowDescription,
-      color: log.workflowColor,
-      folderId: log.workflowFolderId,
-      userId: log.workflowUserId,
-      workspaceId: log.workflowWorkspaceId,
-      createdAt: log.workflowCreatedAt,
-      updatedAt: log.workflowUpdatedAt,
-    }
+    const workflowSummary = log.workflowName
+      ? {
+          id: log.workflowId,
+          name: log.workflowName,
+          description: log.workflowDescription,
+          color: log.workflowColor,
+          folderId: log.workflowFolderId,
+          userId: log.workflowUserId,
+          workspaceId: log.workflowWorkspaceId,
+          createdAt: log.workflowCreatedAt,
+          updatedAt: log.workflowUpdatedAt,
+        }
+      : {
+          id: log.workflowId,
+          name: 'Deleted Workflow',
+          description: null,
+          color: null,
+          folderId: null,
+          userId: null,
+          workspaceId: null,
+          createdAt: null,
+          updatedAt: null,
+        }
 
     const response = {
       id: log.id,

--- a/apps/sim/app/api/v1/logs/executions/[executionId]/route.ts
+++ b/apps/sim/app/api/v1/logs/executions/[executionId]/route.ts
@@ -34,12 +34,12 @@ export async function GET(
         workflow: workflow,
       })
       .from(workflowExecutionLogs)
-      .innerJoin(workflow, eq(workflowExecutionLogs.workflowId, workflow.id))
+      .leftJoin(workflow, eq(workflowExecutionLogs.workflowId, workflow.id))
       .innerJoin(
         permissions,
         and(
           eq(permissions.entityType, 'workspace'),
-          eq(permissions.entityId, workflow.workspaceId),
+          eq(permissions.entityId, workflowExecutionLogs.workspaceId),
           eq(permissions.userId, userId)
         )
       )

--- a/apps/sim/app/api/v1/logs/route.ts
+++ b/apps/sim/app/api/v1/logs/route.ts
@@ -123,7 +123,7 @@ export async function GET(request: NextRequest) {
         workflowDescription: workflow.description,
       })
       .from(workflowExecutionLogs)
-      .innerJoin(workflow, eq(workflowExecutionLogs.workflowId, workflow.id))
+      .leftJoin(workflow, eq(workflowExecutionLogs.workflowId, workflow.id))
       .innerJoin(
         permissions,
         and(
@@ -168,8 +168,8 @@ export async function GET(request: NextRequest) {
       if (params.details === 'full') {
         result.workflow = {
           id: log.workflowId,
-          name: log.workflowName,
-          description: log.workflowDescription,
+          name: log.workflowName ?? 'Deleted Workflow',
+          description: log.workflowDescription ?? null,
         }
 
         if (log.cost) {


### PR DESCRIPTION
## Summary

The V1 public API log endpoints (`/api/v1/logs`, `/api/v1/logs/[id]`, `/api/v1/logs/executions/[executionId]`) use `innerJoin` with the `workflow` table, which silently drops all logs for workflows that have been deleted. This is inconsistent with the internal API endpoints (`/api/logs`, `/api/logs/[id]`) which correctly use `leftJoin`.

**Impact:**
- `GET /api/v1/logs` — omits logs for deleted workflows from the list (data silently disappears)
- `GET /api/v1/logs/[id]` — returns 404 for logs whose workflow was deleted
- `GET /api/v1/logs/executions/[executionId]` — returns 404 for executions whose workflow was deleted

Additionally, the `[id]` and `executions/[executionId]` endpoints join permissions via `workflow.workspaceId`, which would be `null` when the workflow is deleted — breaking the authorization check entirely. The internal API correctly uses `workflowExecutionLogs.workspaceId` for this.

## Changes

- **`v1/logs/route.ts`**: `innerJoin` → `leftJoin` for workflow table; handle null `workflowName`/`workflowDescription` with fallback to `'Deleted Workflow'`
- **`v1/logs/[id]/route.ts`**: `innerJoin` → `leftJoin` for workflow table; fix permissions join to use `workflowExecutionLogs.workspaceId` instead of `workflow.workspaceId`; handle null workflow fields in response
- **`v1/logs/executions/[executionId]/route.ts`**: same `innerJoin` → `leftJoin` and permissions join fix

All changes align the V1 public API with the patterns already used by the internal API (`/api/logs/*`).

## Test plan

- [ ] Verify `GET /api/v1/logs?workspaceId=...` includes logs for deleted workflows
- [ ] Verify `GET /api/v1/logs/[id]` returns log data (not 404) when the workflow has been deleted
- [ ] Verify `GET /api/v1/logs/executions/[executionId]` returns execution data (not 404) when the workflow has been deleted
- [ ] Verify deleted workflow logs show `"Deleted Workflow"` as the workflow name

> This PR was authored by Claude Opus 4.6 (AI), operated by @MaxwellCalkin

🤖 Generated with [Claude Code](https://claude.com/claude-code)