### PR TITLE
fix(security): use CSPRNG for password and OTP generation

### DIFF
--- a/apps/sim/app/api/chat/[identifier]/otp/route.ts
+++ b/apps/sim/app/api/chat/[identifier]/otp/route.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto'
+import { randomInt, randomUUID } from 'crypto'
 import { db } from '@sim/db'
 import { chat, verification } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
@@ -17,7 +17,7 @@ import { createErrorResponse, createSuccessResponse } from '@/app/api/workflows/
 const logger = createLogger('ChatOtpAPI')
 
 function generateOTP() {
-  return Math.floor(100000 + Math.random() * 900000).toString()
+  return randomInt(100000, 1000000).toString()
 }
 
 const OTP_EXPIRY = 15 * 60 // 15 minutes

--- a/apps/sim/lib/core/security/encryption.ts
+++ b/apps/sim/lib/core/security/encryption.ts
@@ -76,8 +76,9 @@ export function generatePassword(length = 24): string {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_-+='
   let result = ''
 
+  const bytes = randomBytes(length)
   for (let i = 0; i < length; i++) {
-    result += chars.charAt(Math.floor(Math.random() * chars.length))
+    result += chars.charAt(bytes[i] % chars.length)
   }
 
   return result


### PR DESCRIPTION
## Summary

`generatePassword()` and `generateOTP()` use `Math.random()` to produce security-critical authentication material. `Math.random()` is not a cryptographically secure PRNG — its internal state can be reconstructed from a handful of observed outputs, making the generated values predictable.

### Changes

- **`lib/core/security/encryption.ts` — `generatePassword()`**: Replace `Math.random()` with `randomBytes()` from Node.js `crypto` (already imported in this file). Used to generate deployment passwords that protect published chat widgets.
- **`app/api/chat/[identifier]/otp/route.ts` — `generateOTP()`**: Replace `Math.floor(100000 + Math.random() * 900000)` with `crypto.randomInt(100000, 1000000)`. Used to generate 6-digit email verification codes for chat authentication.

Both are minimal, drop-in replacements that preserve the same output format and character set. No behavioral changes other than the entropy source.

### Why this matters

An attacker who can observe a few outputs from `Math.random()` (e.g., by triggering OTP requests) can predict future outputs, enabling:
- Guessing upcoming OTP codes to bypass email authentication on deployed chats
- Predicting generated passwords for password-protected deployments

## Test plan

- [ ] Existing `generatePassword` tests in `encryption.test.ts` continue to pass (length, character set, uniqueness)
- [ ] OTP email flow still generates valid 6-digit codes and verifies correctly
- [ ] No changes to public API surface

---

> This PR was authored by Claude Opus 4.6 (AI), operated by @MaxwellCalkin