### PR TITLE
fix(landing): replace per-icon hover with smooth sliding pill highlight

### DIFF
--- a/apps/sim/app/(landing)/components/hero/components/icon-button.tsx
+++ b/apps/sim/app/(landing)/components/hero/components/icon-button.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { forwardRef } from 'react'
 import type React from 'react'
 
 interface IconButtonProps {
@@ -8,31 +9,23 @@ interface IconButtonProps {
   onMouseEnter?: () => void
   style?: React.CSSProperties
   'aria-label': string
-  isAutoHovered?: boolean
 }
 
-export function IconButton({
-  children,
-  onClick,
-  onMouseEnter,
-  style,
-  'aria-label': ariaLabel,
-  isAutoHovered = false,
-}: IconButtonProps) {
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton(
+  { children, onClick, onMouseEnter, style, 'aria-label': ariaLabel },
+  ref
+) {
   return (
     <button
+      ref={ref}
       type='button'
       aria-label={ariaLabel}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
-      className={`flex items-center justify-center rounded-xl border p-2 outline-none transition-all duration-300 ${
-        isAutoHovered
-          ? 'border-[#E5E5E5] shadow-[0_2px_4px_0_rgba(0,0,0,0.08)]'
-          : 'border-transparent hover:border-[#E5E5E5] hover:shadow-[0_2px_4px_0_rgba(0,0,0,0.08)]'
-      }`}
+      className='flex items-center justify-center rounded-xl border border-transparent p-2 outline-none'
       style={style}
     >
       {children}
     </button>
   )
-}
+})

--- a/apps/sim/app/(landing)/components/hero/hero.tsx
+++ b/apps/sim/app/(landing)/components/hero/hero.tsx
@@ -153,6 +153,18 @@ export default function Hero() {
   const intervalRef = React.useRef<NodeJS.Timeout | null>(null)
 
   /**
+   * Refs for smooth sliding pill highlight
+   */
+  const iconContainerRef = React.useRef<HTMLDivElement>(null)
+  const iconRefs = React.useRef<(HTMLButtonElement | null)[]>([])
+  const [pillStyle, setPillStyle] = React.useState<React.CSSProperties>({
+    opacity: 0,
+    width: 0,
+    height: 0,
+    transform: 'translateX(0px)',
+  })
+
+  /**
    * Handle service icon click to populate textarea with template
    */
   const handleServiceClick = (service: keyof typeof SERVICE_TEMPLATES) => {
@@ -224,6 +236,40 @@ export default function Hero() {
       }
     }
   }, [isUserHovering, visibleIconCount])
+
+  /**
+   * Compute the active icon index and update the pill position
+   */
+  const activeIndex = isUserHovering ? lastHoveredIndex : autoHoverIndex
+
+  const updatePillPosition = React.useCallback(() => {
+    if (activeIndex == null) {
+      setPillStyle((prev) => ({ ...prev, opacity: 0 }))
+      return
+    }
+
+    const button = iconRefs.current[activeIndex]
+    const container = iconContainerRef.current
+    if (!button || !container) return
+
+    const containerRect = container.getBoundingClientRect()
+    const buttonRect = button.getBoundingClientRect()
+    const offsetX = buttonRect.left - containerRect.left
+
+    setPillStyle({
+      width: buttonRect.width,
+      height: buttonRect.height,
+      transform: `translateX(${offsetX}px)`,
+      opacity: 1,
+    })
+  }, [activeIndex])
+
+  React.useEffect(() => {
+    updatePillPosition()
+
+    window.addEventListener('resize', updatePillPosition)
+    return () => window.removeEventListener('resize', updatePillPosition)
+  }, [updatePillPosition])
 
   /**
    * Handle mouse enter on icon container
@@ -377,21 +423,30 @@ export default function Hero() {
         Build and deploy AI agent workflows
       </p>
       <div
-        className='flex items-center justify-center gap-[2px] pt-[18px] sm:pt-[32px]'
+        ref={iconContainerRef}
+        className='relative flex items-center justify-center gap-[2px] pt-[18px] sm:pt-[32px]'
         onMouseEnter={handleIconContainerMouseEnter}
         onMouseLeave={handleIconContainerMouseLeave}
       >
+        {/* Sliding highlight pill */}
+        <div
+          className='pointer-events-none absolute top-[18px] left-0 rounded-xl border border-[#E5E5E5] shadow-[0_2px_4px_0_rgba(0,0,0,0.08)] transition-all duration-300 ease-in-out sm:top-[32px]'
+          style={pillStyle}
+          aria-hidden='true'
+        />
         {/* Service integration buttons */}
         {serviceIcons.slice(0, visibleIconCount).map((service, index) => {
           const Icon = service.icon
           return (
             <IconButton
               key={service.key}
+              ref={(el) => {
+                iconRefs.current[index] = el
+              }}
               aria-label={service.label}
               onClick={() => handleServiceClick(service.key as keyof typeof SERVICE_TEMPLATES)}
               onMouseEnter={() => setLastHoveredIndex(index)}
               style={service.style}
-              isAutoHovered={!isUserHovering && index === autoHoverIndex}
             >
               <Icon className='h-5 w-5 sm:h-6 sm:w-6' />
             </IconButton>


### PR DESCRIPTION
## Summary

Replaces the abrupt per-icon border/shadow hover effect on the landing hero icon row with a single highlight pill that smoothly translates between icons. The pill follows both the auto-hover cycle and manual cursor hover using CSS `transition-all duration-300`, creating a fluid, continuous highlight rather than a jarring jump.

Fixes #3468

## Changes

- **`icon-button.tsx`**: Convert to `forwardRef` to expose button DOM refs for position measurement. Remove the per-icon `isAutoHovered` prop and `hover:border`/`hover:shadow` classes — highlighting is now handled by the parent pill element.
- **`hero.tsx`**: Add `iconRefs` and `iconContainerRef` for measuring each button's position via `getBoundingClientRect`. Compute the active index (user hover takes priority over auto-hover), then position an absolute pill element with `translateX`. Recalculates on window resize for responsive correctness.

## How it works

1. A single `<div>` pill sits at `position: absolute` inside the icon container
2. On each active-index change, the pill's `width`, `height`, and `transform: translateX(...)` are updated
3. `transition-all duration-300 ease-in-out` on the pill creates the smooth sliding motion
4. When the user hovers over the icon row, the auto-cycle pauses and the pill tracks the cursor
5. When the cursor leaves, the auto-cycle resumes from the next icon

---

> [!NOTE]
> This PR was authored by an AI (Claude Opus 4.6, Anthropic). See https://github.com/anthropics/claude-code for details on the tool used.