### PR TITLE
feat(generic): enable results tab wiring

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
@@ -1213,31 +1213,30 @@ export function useChat(
                 }
                 flush()
 
-                // TODO: Uncomment when rich UI for Results tab is ready
-                // if (shouldOpenGenericResource(name)) {
-                //   if (!genericEntryMap.has(id)) {
-                //     const entryIdx = appendGenericEntry({
-                //       toolCallId: id,
-                //       toolName: name,
-                //       displayTitle: displayTitle ?? name,
-                //       status: 'executing',
-                //       params: args,
-                //     })
-                //     genericEntryMap.set(id, entryIdx)
-                //     const opened = addResource({ type: 'generic', id: 'results', title: 'Results' })
-                //     if (opened) onResourceEventRef.current?.()
-                //     else setActiveResourceId('results')
-                //   } else {
-                //     const entryIdx = genericEntryMap.get(id)
-                //     if (entryIdx !== undefined) {
-                //       updateGenericEntry(entryIdx, {
-                //         toolName: name,
-                //         ...(displayTitle && { displayTitle }),
-                //         ...(args && { params: args }),
-                //       })
-                //     }
-                //   }
-                // }
+                if (shouldOpenGenericResource(name)) {
+                  if (!genericEntryMap.has(id)) {
+                    const entryIdx = appendGenericEntry({
+                      toolCallId: id,
+                      toolName: name,
+                      displayTitle: displayTitle ?? name,
+                      status: 'executing',
+                      params: args,
+                    })
+                    genericEntryMap.set(id, entryIdx)
+                    const opened = addResource({ type: 'generic', id: 'results', title: 'Results' })
+                    if (opened) onResourceEventRef.current?.()
+                    else setActiveResourceId('results')
+                  } else {
+                    const entryIdx = genericEntryMap.get(id)
+                    if (entryIdx !== undefined) {
+                      updateGenericEntry(entryIdx, {
+                        toolName: name,
+                        ...(displayTitle && { displayTitle }),
+                        ...(args && { params: args }),
+                      })
+                    }
+                  }
+                }
 
                 if (
                   parsed.type === 'tool_call' &&
@@ -1334,18 +1333,17 @@ export function useChat(
                   flush()
                 }
 
-                // TODO: Uncomment when rich UI for Results tab is ready
-                // if (toolName && shouldOpenGenericResource(toolName)) {
-                //   const entryIdx = genericEntryMap.get(id)
-                //   if (entryIdx !== undefined) {
-                //     const entry = genericResourceDataRef.current.entries[entryIdx]
-                //     if (entry) {
-                //       updateGenericEntry(entryIdx, {
-                //         streamingArgs: (entry.streamingArgs ?? '') + delta,
-                //       })
-                //     }
-                //   }
-                // }
+                if (toolName && shouldOpenGenericResource(toolName)) {
+                  const entryIdx = genericEntryMap.get(id)
+                  if (entryIdx !== undefined) {
+                    const entry = genericResourceDataRef.current.entries[entryIdx]
+                    if (entry) {
+                      updateGenericEntry(entryIdx, {
+                        streamingArgs: (entry.streamingArgs ?? '') + delta,
+                      })
+                    }
+                  }
+                }
 
                 break
               }
@@ -1454,33 +1452,32 @@ export function useChat(
                     }
                   }
 
-                  // TODO: Uncomment when rich UI for Results tab is ready
-                  // if (
-                  //   shouldOpenGenericResource(tc.name) ||
-                  //   (isDeferredResourceTool(tc.name) && extractedResources.length === 0)
-                  // ) {
-                  //   const entryIdx = genericEntryMap.get(id)
-                  //   if (entryIdx !== undefined) {
-                  //     updateGenericEntry(entryIdx, {
-                  //       status: tc.status,
-                  //       result: tc.result ?? undefined,
-                  //       streamingArgs: undefined,
-                  //     })
-                  //   } else {
-                  //     const newIdx = appendGenericEntry({
-                  //       toolCallId: id,
-                  //       toolName: tc.name,
-                  //       displayTitle: tc.displayTitle ?? tc.name,
-                  //       status: tc.status,
-                  //       params: toolArgsMap.get(id) as Record<string, unknown> | undefined,
-                  //       result: tc.result ?? undefined,
-                  //     })
-                  //     genericEntryMap.set(id, newIdx)
-                  //     if (addResource({ type: 'generic', id: 'results', title: 'Results' })) {
-                  //       onResourceEventRef.current?.()
-                  //     }
-                  //   }
-                  // }
+                  if (
+                    shouldOpenGenericResource(tc.name) ||
+                    (isDeferredResourceTool(tc.name) && extractedResources.length === 0)
+                  ) {
+                    const entryIdx = genericEntryMap.get(id)
+                    if (entryIdx !== undefined) {
+                      updateGenericEntry(entryIdx, {
+                        status: tc.status,
+                        result: tc.result ?? undefined,
+                        streamingArgs: undefined,
+                      })
+                    } else {
+                      const newIdx = appendGenericEntry({
+                        toolCallId: id,
+                        toolName: tc.name,
+                        displayTitle: tc.displayTitle ?? tc.name,
+                        status: tc.status,
+                        params: toolArgsMap.get(id) as Record<string, unknown> | undefined,
+                        result: tc.result ?? undefined,
+                      })
+                      genericEntryMap.set(id, newIdx)
+                      if (addResource({ type: 'generic', id: 'results', title: 'Results' })) {
+                        onResourceEventRef.current?.()
+                      }
+                    }
+                  }
                 }
 
                 break
@@ -1577,13 +1574,12 @@ export function useChat(
                   }
                   flush()
 
-                  // TODO: Uncomment when rich UI for Results tab is ready
-                  // if (toolCallName && shouldOpenGenericResource(toolCallName)) {
-                  //   const entryIdx = genericEntryMap.get(id)
-                  //   if (entryIdx !== undefined) {
-                  //     updateGenericEntry(entryIdx, { status: 'error', streamingArgs: undefined })
-                  //   }
-                  // }
+                  if (toolCallName && shouldOpenGenericResource(toolCallName)) {
+                    const entryIdx = genericEntryMap.get(id)
+                    if (entryIdx !== undefined) {
+                      updateGenericEntry(entryIdx, { status: 'error', streamingArgs: undefined })
+                    }
+                  }
                 }
                 break
               }


### PR DESCRIPTION
## Summary
- Enables the Results tab wiring in the mothership chat — tool call results now stream into the resource panel in real time
- Uncommented all four SSE event handlers (tool_call, tool_call_delta, tool_result, tool_error) to populate the generic resource feed
- Placeholder UI in place with TODO comment for Emir to replace with rich result cards

## Type of Change
- [x] New feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)