### PR TITLE
fix(executor): guard against missing content in provider responses

### DIFF
--- a/apps/sim/executor/handlers/evaluator/evaluator-handler.test.ts
+++ b/apps/sim/executor/handlers/evaluator/evaluator-handler.test.ts
@@ -287,6 +287,29 @@ describe('EvaluatorBlockHandler', () => {
     expect((result as any).fluency).toBe(0)
   })
 
+  it('should throw a clear error when provider returns no content', async () => {
+    const inputs = {
+      content: 'Test content to evaluate',
+      metrics: [{ name: 'quality', description: 'Quality', range: { min: 0, max: 10 } }],
+      apiKey: 'test-api-key',
+    }
+
+    mockFetch.mockImplementationOnce(() => {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            model: 'gpt-4o',
+            tokens: { input: 50, output: 0, total: 50 },
+          }),
+      })
+    })
+
+    await expect(handler.execute(mockContext, mockBlock, inputs)).rejects.toThrow(
+      'Provider returned an empty response'
+    )
+  })
+
   it('should extract metric scores ignoring case', async () => {
     const inputs = {
       content: 'Test',

--- a/apps/sim/executor/handlers/evaluator/evaluator-handler.ts
+++ b/apps/sim/executor/handlers/evaluator/evaluator-handler.ts
@@ -145,6 +145,12 @@ export class EvaluatorBlockHandler implements BlockHandler {
 
       const result = await response.json()
 
+      if (!result.content) {
+        throw new Error(
+          'Provider returned an empty response. The model may be unavailable or the request was malformed.'
+        )
+      }
+
       const parsedContent = this.extractJSONFromResponse(result.content)
 
       const metricScores = this.extractMetricScores(parsedContent, inputs.metrics)

--- a/apps/sim/executor/handlers/router/router-handler.test.ts
+++ b/apps/sim/executor/handlers/router/router-handler.test.ts
@@ -244,6 +244,45 @@ describe('RouterBlockHandler', () => {
     await expect(handler.execute(mockContext, mockBlock, inputs)).rejects.toThrow('Server error')
   })
 
+  it('should throw a clear error when provider returns no content', async () => {
+    const inputs = { prompt: 'Choose the best option.', apiKey: 'test-api-key' }
+
+    mockFetch.mockImplementationOnce(() => {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            model: 'gpt-4o',
+            tokens: { input: 100, output: 0, total: 100 },
+          }),
+      })
+    })
+
+    await expect(handler.execute(mockContext, mockBlock, inputs)).rejects.toThrow(
+      'Provider returned an empty response'
+    )
+  })
+
+  it('should throw a clear error when provider content is empty string', async () => {
+    const inputs = { prompt: 'Choose the best option.', apiKey: 'test-api-key' }
+
+    mockFetch.mockImplementationOnce(() => {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            content: '',
+            model: 'gpt-4o',
+            tokens: { input: 100, output: 0, total: 100 },
+          }),
+      })
+    })
+
+    await expect(handler.execute(mockContext, mockBlock, inputs)).rejects.toThrow(
+      'Provider returned an empty response'
+    )
+  })
+
   it('should handle Azure OpenAI models with endpoint and API version', async () => {
     const inputs = {
       prompt: 'Choose the best option.',
@@ -586,5 +625,31 @@ describe('RouterBlockHandler V2', () => {
 
     expect(result.selectedRoute).toBe('route-1')
     expect(result.reasoning).toBe('')
+  })
+
+  it('should throw a clear error when provider returns no content (V2)', async () => {
+    const inputs = {
+      context: 'I need help with billing',
+      model: 'gpt-4o',
+      apiKey: 'test-api-key',
+      routes: JSON.stringify([
+        { id: 'route-support', title: 'Support', value: 'Customer support inquiries' },
+      ]),
+    }
+
+    mockFetch.mockImplementationOnce(() => {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            model: 'gpt-4o',
+            tokens: { input: 150, output: 0, total: 150 },
+          }),
+      })
+    })
+
+    await expect(handler.execute(mockContext, mockRouterV2Block, inputs)).rejects.toThrow(
+      'Provider returned an empty response'
+    )
   })
 })

--- a/apps/sim/executor/handlers/router/router-handler.ts
+++ b/apps/sim/executor/handlers/router/router-handler.ts
@@ -124,6 +124,12 @@ export class RouterBlockHandler implements BlockHandler {
 
       const result = await response.json()
 
+      if (!result.content) {
+        throw new Error(
+          'Provider returned an empty response. The model may be unavailable or the request was malformed.'
+        )
+      }
+
       const chosenBlockId = result.content.trim().toLowerCase()
       const chosenBlock = targetBlocks?.find((b) => b.id === chosenBlockId)
 
@@ -272,6 +278,12 @@ export class RouterBlockHandler implements BlockHandler {
       }
 
       const result = await response.json()
+
+      if (!result.content) {
+        throw new Error(
+          'Provider returned an empty response. The model may be unavailable or the request was malformed.'
+        )
+      }
 
       let chosenRouteId: string
       let reasoning = ''


### PR DESCRIPTION
## Problem

While reading through the executor handlers, I noticed that the router and evaluator handlers access `result.content` directly after `response.json()` without checking whether the field is present. If an LLM provider returns a 200 response but without a `content` field — for example when a model is temporarily unavailable, rate-limited mid-stream, or the provider returns an unexpected response structure — the handlers crash with:

```
TypeError: Cannot read properties of undefined (reading 'trim')
```

This surfaces as an opaque internal error to the user, with no indication of what went wrong.

### Affected paths

- **RouterBlockHandler (legacy)**: `result.content.trim().toLowerCase()` at the routing decision step
- **RouterBlockHandler V2**: `result.content.trim()` in the JSON parse fallback path — the `try` block catches the parse error, but the `catch` fallback also crashes if content is missing
- **EvaluatorBlockHandler**: `this.extractJSONFromResponse(result.content)` passes undefined into `extractJSONFromResponse`, which then calls `.trim()` on it

### Existing correct pattern

`shared/response-format.ts` (line 91) already handles this case:
```typescript
const content = result.content ?? ''
```

The mothership handler also uses `result.content || ''`. The router and evaluator handlers were the only ones missing this guard.

## Fix

Add an explicit `!result.content` check before accessing the field. When the content is missing or empty, the handler now throws a descriptive error message instead of an opaque TypeError.

## Before → After

**Before:** Provider returns `{ model: "gpt-4o", tokens: {...} }` (no content field) → `TypeError: Cannot read properties of undefined (reading 'trim')` → workflow fails with cryptic error

**After:** Same response → `Error: Provider returned an empty response. The model may be unavailable or the request was malformed.` → workflow fails with actionable error message

## Tests added

- `router-handler.test.ts`: 3 new tests covering legacy (missing content, empty string content) and V2 (missing content)
- `evaluator-handler.test.ts`: 1 new test for missing content

All 33 handler tests pass.