### PR TITLE
fix(kb): show 'pending' instead of past date for overdue next sync

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connectors-section/connectors-section.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connectors-section/connectors-section.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createLogger } from '@sim/logger'
-import { format, formatDistanceToNow } from 'date-fns'
+import { format, formatDistanceToNow, isPast } from 'date-fns'
 import {
   AlertCircle,
   CheckCircle2,
@@ -380,7 +380,9 @@ function ConnectorCard({
                   <span>·</span>
                   <span>
                     Next sync:{' '}
-                    {formatDistanceToNow(new Date(connector.nextSyncAt), { addSuffix: true })}
+                    {isPast(new Date(connector.nextSyncAt))
+                      ? 'pending'
+                      : formatDistanceToNow(new Date(connector.nextSyncAt), { addSuffix: true })}
                   </span>
                 </>
               )}


### PR DESCRIPTION
## Summary
- When a connector's `nextSyncAt` is in the past (sync overdue / cron delayed), the UI was showing "Next sync: 2 days ago" via `formatDistanceToNow`. Now shows "Next sync: pending" instead.

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)