### PR TITLE
fix(blocks): render tooltip field in sub-block label

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
@@ -7,6 +7,7 @@ import {
   Check,
   Clipboard,
   ExternalLink,
+  Info,
 } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { Button, Input, Label, Tooltip } from '@/components/emcn/components'
@@ -249,6 +250,18 @@ const renderLabel = (
       <Label className='flex items-baseline gap-1.5 whitespace-nowrap'>
         {config.title}
         {required && <span className='ml-0.5'>*</span>}
+        {config.tooltip && (
+          <Tooltip.Root>
+            <Tooltip.Trigger asChild>
+              <span className='inline-flex'>
+                <Info className='h-3 w-3 flex-shrink-0 cursor-pointer text-muted-foreground' />
+              </span>
+            </Tooltip.Trigger>
+            <Tooltip.Content side='top'>
+              <p>{config.tooltip}</p>
+            </Tooltip.Content>
+          </Tooltip.Root>
+        )}
         {labelSuffix}
         {config.type === 'code' &&
           config.language === 'json' &&

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
@@ -253,7 +253,7 @@ const renderLabel = (
         {config.tooltip && (
           <Tooltip.Root>
             <Tooltip.Trigger asChild>
-              <span className='inline-flex'>
+              <span className='inline-flex' tabIndex={0} role='button'>
                 <Info className='h-3 w-3 flex-shrink-0 cursor-pointer text-muted-foreground' />
               </span>
             </Tooltip.Trigger>
@@ -269,7 +269,7 @@ const renderLabel = (
           !wandState?.isStreaming && (
             <Tooltip.Root>
               <Tooltip.Trigger asChild>
-                <span className='inline-flex'>
+                <span className='inline-flex' tabIndex={0} role='button'>
                   <AlertTriangle className='h-3 w-3 flex-shrink-0 cursor-pointer text-destructive' />
                 </span>
               </Tooltip.Trigger>


### PR DESCRIPTION
## Summary

- `SubBlockConfig.tooltip` was typed in `blocks/types.ts` (added in commit 8215a819) but never rendered in `sub-block.tsx`
- Adds an `Info` icon next to the field label that shows the tooltip text on hover
- Reuses the existing `Tooltip.Root/Trigger/Content` pattern already present in the same file

## Changes

**`apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx`**
- Add `Info` to lucide-react imports
- Render tooltip icon after the required asterisk in `renderLabel`

## Test plan

- [ ] Add `tooltip: 'some help text'` to a subBlock in any block config
- [ ] Open the workflow editor and find that block
- [ ] Verify an Info icon appears next to the field label
- [ ] Hover over the icon and verify the tooltip text appears

Fixes #4071
