### PR TITLE
fix(credentials): add cross-cache invalidation for oauth credential queries

### DIFF
--- a/apps/sim/hooks/queries/credential-sets.ts
+++ b/apps/sim/hooks/queries/credential-sets.ts
@@ -157,7 +157,7 @@ export function useAcceptCredentialSetInvitation() {
       }
       return response.json()
     },
-    onSuccess: () => {
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: credentialSetKeys.memberships() })
       queryClient.invalidateQueries({ queryKey: credentialSetKeys.invitations() })
     },
@@ -187,7 +187,7 @@ export function useCreateCredentialSet() {
       }
       return response.json()
     },
-    onSuccess: (_data, variables) => {
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({ queryKey: credentialSetKeys.list(variables.organizationId) })
     },
   })
@@ -209,7 +209,7 @@ export function useCreateCredentialSetInvitation() {
       }
       return response.json()
     },
-    onSuccess: (_data, variables) => {
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: credentialSetKeys.detailInvitations(variables.credentialSetId),
       })
@@ -264,7 +264,7 @@ export function useRemoveCredentialSetMember() {
       }
       return response.json()
     },
-    onSuccess: (_data, variables) => {
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: credentialSetKeys.detailMembers(variables.credentialSetId),
       })
@@ -288,7 +288,7 @@ export function useLeaveCredentialSet() {
       }
       return response.json()
     },
-    onSuccess: () => {
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: credentialSetKeys.memberships() })
     },
   })
@@ -313,7 +313,7 @@ export function useDeleteCredentialSet() {
       }
       return response.json()
     },
-    onSuccess: (_data, variables) => {
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: credentialSetKeys.list(variables.organizationId),
       })
@@ -370,7 +370,7 @@ export function useCancelCredentialSetInvitation() {
       }
       return response.json()
     },
-    onSuccess: (_data, variables) => {
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: credentialSetKeys.detailInvitations(variables.credentialSetId),
       })
@@ -393,7 +393,7 @@ export function useResendCredentialSetInvitation() {
       }
       return response.json()
     },
-    onSuccess: (_data, variables) => {
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: credentialSetKeys.detailInvitations(variables.credentialSetId),
       })

--- a/apps/sim/hooks/queries/credentials.ts
+++ b/apps/sim/hooks/queries/credentials.ts
@@ -5,6 +5,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { environmentKeys } from '@/hooks/queries/environment'
 import { fetchJson } from '@/hooks/selectors/helpers'
 
+/**
+ * Key prefix for OAuth credential queries.
+ * Duplicated here to avoid circular imports with oauth-credentials.ts.
+ */
+const OAUTH_CREDENTIALS_KEY = ['oauthCredentials'] as const
+
 export type WorkspaceCredentialType = 'oauth' | 'env_workspace' | 'env_personal' | 'service_account'
 export type WorkspaceCredentialRole = 'admin' | 'member'
 export type WorkspaceCredentialMemberStatus = 'active' | 'pending' | 'revoked'
@@ -192,6 +198,9 @@ export function useCreateWorkspaceCredential() {
       queryClient.invalidateQueries({
         queryKey: workspaceCredentialKeys.lists(),
       })
+      queryClient.invalidateQueries({
+        queryKey: OAUTH_CREDENTIALS_KEY,
+      })
     },
   })
 }
@@ -269,6 +278,9 @@ export function useUpdateWorkspaceCredential() {
       queryClient.invalidateQueries({
         queryKey: workspaceCredentialKeys.lists(),
       })
+      queryClient.invalidateQueries({
+        queryKey: OAUTH_CREDENTIALS_KEY,
+      })
     },
   })
 }
@@ -290,6 +302,7 @@ export function useDeleteWorkspaceCredential() {
     onSettled: (_data, _error, credentialId) => {
       queryClient.invalidateQueries({ queryKey: workspaceCredentialKeys.detail(credentialId) })
       queryClient.invalidateQueries({ queryKey: workspaceCredentialKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: OAUTH_CREDENTIALS_KEY })
       queryClient.invalidateQueries({ queryKey: environmentKeys.all })
     },
   })


### PR DESCRIPTION
## Summary
- When creating/updating/deleting workspace credentials (e.g. Google service accounts), also invalidate `oauthCredentialKeys` so credential-selector dropdowns update immediately
- Switch all credential-set mutations from `onSuccess` to `onSettled` for reliable cache reconciliation

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)