### PR TITLE
docs(openapi): add Human in the Loop API endpoints

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -65,9 +65,7 @@
         "operationId": "executeWorkflow",
         "summary": "Execute Workflow",
         "description": "Execute a deployed workflow. Supports synchronous, asynchronous, and streaming modes. For async execution, the response includes a statusUrl you can poll for results.",
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -176,9 +174,7 @@
         "operationId": "cancelExecution",
         "summary": "Cancel Execution",
         "description": "Cancel a running workflow execution. Only effective for executions that are still in progress.",
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -248,9 +244,7 @@
         "operationId": "listPausedExecutions",
         "summary": "List Paused Executions",
         "description": "List all paused executions for a workflow. Workflows pause at Human in the Loop blocks and wait for input before continuing. Use this endpoint to discover which executions need attention.",
-        "tags": [
-          "Human in the Loop"
-        ],
+        "tags": ["Human in the Loop"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -360,9 +354,7 @@
         "operationId": "getPausedExecution",
         "summary": "Get Paused Execution",
         "description": "Get detailed information about a specific paused execution, including its pause points, execution snapshot, and resume queue. Use this to inspect the state before resuming.",
-        "tags": [
-          "Human in the Loop"
-        ],
+        "tags": ["Human in the Loop"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -421,9 +413,7 @@
         "operationId": "getPausedExecutionByResumePath",
         "summary": "Get Paused Execution (Resume Path)",
         "description": "Get detailed information about a specific paused execution using the resume URL path. Returns the same data as the workflow paused execution detail endpoint.",
-        "tags": [
-          "Human in the Loop"
-        ],
+        "tags": ["Human in the Loop"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -498,9 +488,7 @@
         "operationId": "getPauseContext",
         "summary": "Get Pause Context",
         "description": "Get detailed information about a specific pause context within a paused execution. Returns the pause point details, resume queue state, and any active resume entry.",
-        "tags": [
-          "Human in the Loop"
-        ],
+        "tags": ["Human in the Loop"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -567,9 +555,7 @@
         "operationId": "resumeExecution",
         "summary": "Resume Execution",
         "description": "Resume a paused workflow execution by providing input for a specific pause context. The execution continues from where it paused, using the provided input. Supports synchronous, asynchronous, and streaming modes (determined by the original execution's configuration).",
-        "tags": [
-          "Human in the Loop"
-        ],
+        "tags": ["Human in the Loop"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -649,9 +635,7 @@
                       "properties": {
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "queued"
-                          ],
+                          "enum": ["queued"],
                           "description": "Indicates the resume is queued."
                         },
                         "executionId": {
@@ -674,9 +658,7 @@
                       "properties": {
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "started"
-                          ],
+                          "enum": ["started"],
                           "description": "Indicates the resume execution has started."
                         },
                         "executionId": {
@@ -800,9 +782,7 @@
         "operationId": "listWorkflows",
         "summary": "List Workflows",
         "description": "Retrieve all workflows in a workspace with cursor-based pagination.",
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -908,9 +888,7 @@
         "operationId": "getWorkflow",
         "summary": "Get Workflow",
         "description": "Retrieve details for a single workflow, including its input fields and deployment status.",
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -979,9 +957,7 @@
         "operationId": "getJobStatus",
         "summary": "Get Job Status",
         "description": "Poll the status of an asynchronous workflow execution. Use the jobId returned from the Execute Workflow endpoint when the execution is queued asynchronously.",
-        "tags": [
-          "Workflows"
-        ],
+        "tags": ["Workflows"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1041,9 +1017,7 @@
         "operationId": "queryLogs",
         "summary": "Query Logs",
         "description": "List workflow execution logs with advanced filtering and cursor-based pagination. Supports filtering by workflow, trigger type, date range, duration, cost, and more.",
-        "tags": [
-          "Logs"
-        ],
+        "tags": ["Logs"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1260,9 +1234,7 @@
         "operationId": "getLogDetails",
         "summary": "Get Log Details",
         "description": "Retrieve detailed information about a specific log entry, including workflow metadata, execution data, and cost breakdown.",
-        "tags": [
-          "Logs"
-        ],
+        "tags": ["Logs"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1333,9 +1305,7 @@
         "operationId": "getExecutionDetails",
         "summary": "Get Execution Details",
         "description": "Retrieve the full execution state snapshot, including the workflow state at time of execution and detailed metadata.",
-        "tags": [
-          "Logs"
-        ],
+        "tags": ["Logs"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1456,9 +1426,7 @@
         "operationId": "listAuditLogs",
         "summary": "List Audit Logs",
         "description": "Retrieve audit logs for your organization with cursor-based pagination. Requires an Enterprise subscription and organization admin or owner role.",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1610,9 +1578,7 @@
         "operationId": "getAuditLogDetails",
         "summary": "Get Audit Log Details",
         "description": "Retrieve a single audit log entry by ID. Requires an Enterprise subscription and organization admin or owner role.",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1686,9 +1652,7 @@
         "operationId": "getUsageLimits",
         "summary": "Get Usage Limits",
         "description": "Retrieve your current rate limits, usage spending, and storage consumption for the billing period.",
-        "tags": [
-          "Usage"
-        ],
+        "tags": ["Usage"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1745,9 +1709,7 @@
         "operationId": "listTables",
         "summary": "List Tables",
         "description": "List all tables in a workspace. Returns table metadata including name, schema, and row counts.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1840,9 +1802,7 @@
         "operationId": "createTable",
         "summary": "Create Table",
         "description": "Create a new table in a workspace. Define the table schema with typed columns, optional constraints (required, unique), and a name.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1857,11 +1817,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId",
-                  "name",
-                  "schema"
-                ],
+                "required": ["workspaceId", "name", "schema"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -1878,9 +1834,7 @@
                   },
                   "schema": {
                     "type": "object",
-                    "required": [
-                      "columns"
-                    ],
+                    "required": ["columns"],
                     "properties": {
                       "columns": {
                         "type": "array",
@@ -1999,9 +1953,7 @@
         "operationId": "getTable",
         "summary": "Get Table",
         "description": "Retrieve a table's metadata, schema, and row count.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2090,9 +2042,7 @@
         "operationId": "deleteTable",
         "summary": "Delete Table",
         "description": "Delete a table and all its rows. This action is irreversible.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2165,9 +2115,7 @@
         "operationId": "addColumn",
         "summary": "Add Column",
         "description": "Add a new column to the table schema. Optionally specify a position to insert the column at a specific index.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "lang": "curl",
@@ -2185,10 +2133,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId",
-                  "column"
-                ],
+                "required": ["workspaceId", "column"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -2196,10 +2141,7 @@
                   },
                   "column": {
                     "type": "object",
-                    "required": [
-                      "name",
-                      "type"
-                    ],
+                    "required": ["name", "type"],
                     "properties": {
                       "name": {
                         "type": "string",
@@ -2207,13 +2149,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "string",
-                          "number",
-                          "boolean",
-                          "date",
-                          "json"
-                        ],
+                        "enum": ["string", "number", "boolean", "date", "json"],
                         "description": "Column data type"
                       },
                       "required": {
@@ -2309,9 +2245,7 @@
         "operationId": "updateColumn",
         "summary": "Update Column",
         "description": "Update a column's name, type, or constraints. Multiple updates can be applied in a single request. When renaming, subsequent updates (type, constraints) use the new name.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "lang": "curl",
@@ -2329,11 +2263,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId",
-                  "columnName",
-                  "updates"
-                ],
+                "required": ["workspaceId", "columnName", "updates"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -2352,13 +2282,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "string",
-                          "number",
-                          "boolean",
-                          "date",
-                          "json"
-                        ],
+                        "enum": ["string", "number", "boolean", "date", "json"],
                         "description": "New column data type"
                       },
                       "required": {
@@ -2449,9 +2373,7 @@
         "operationId": "deleteColumn",
         "summary": "Delete Column",
         "description": "Delete a column from the table schema. This removes the column definition and strips the corresponding key from all existing row data. Cannot delete the last remaining column.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "lang": "curl",
@@ -2469,10 +2391,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId",
-                  "columnName"
-                ],
+                "required": ["workspaceId", "columnName"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -2551,9 +2470,7 @@
         "operationId": "listRows",
         "summary": "List Rows",
         "description": "Query rows from a table with optional filtering, sorting, and pagination. Filters and sorts are passed as JSON-encoded query parameters.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2699,9 +2616,7 @@
         "operationId": "insertRows",
         "summary": "Insert Rows",
         "description": "Insert one or more rows into a table. For a single row, pass a `data` object. For batch insert, pass a `rows` array (up to 1000 rows).",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2723,10 +2638,7 @@
                 "oneOf": [
                   {
                     "type": "object",
-                    "required": [
-                      "workspaceId",
-                      "data"
-                    ],
+                    "required": ["workspaceId", "data"],
                     "description": "Single row insert.",
                     "properties": {
                       "workspaceId": {
@@ -2747,10 +2659,7 @@
                   },
                   {
                     "type": "object",
-                    "required": [
-                      "workspaceId",
-                      "rows"
-                    ],
+                    "required": ["workspaceId", "rows"],
                     "description": "Batch insert (up to 1000 rows).",
                     "properties": {
                       "workspaceId": {
@@ -2872,9 +2781,7 @@
         "operationId": "updateRows",
         "summary": "Update Rows",
         "description": "Bulk update rows matching a filter. All matching rows will have the specified fields updated. Validates against schema and unique constraints.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2894,11 +2801,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId",
-                  "filter",
-                  "data"
-                ],
+                "required": ["workspaceId", "filter", "data"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -2959,9 +2862,7 @@
         "operationId": "deleteRows",
         "summary": "Delete Rows",
         "description": "Delete rows by filter criteria or by an explicit list of row IDs. Pass either a `filter` object or a `rowIds` array.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2983,10 +2884,7 @@
                 "oneOf": [
                   {
                     "type": "object",
-                    "required": [
-                      "workspaceId",
-                      "filter"
-                    ],
+                    "required": ["workspaceId", "filter"],
                     "description": "Delete by filter.",
                     "properties": {
                       "workspaceId": {
@@ -3008,10 +2906,7 @@
                   },
                   {
                     "type": "object",
-                    "required": [
-                      "workspaceId",
-                      "rowIds"
-                    ],
+                    "required": ["workspaceId", "rowIds"],
                     "description": "Delete by IDs.",
                     "properties": {
                       "workspaceId": {
@@ -3032,10 +2927,7 @@
               },
               "example": {
                 "workspaceId": "wsp_abc123",
-                "rowIds": [
-                  "row_abc123",
-                  "row_def456"
-                ]
+                "rowIds": ["row_abc123", "row_def456"]
               }
             }
           }
@@ -3091,10 +2983,7 @@
                   "data": {
                     "message": "Rows deleted successfully",
                     "deletedCount": 2,
-                    "deletedRowIds": [
-                      "row_abc123",
-                      "row_def456"
-                    ]
+                    "deletedRowIds": ["row_abc123", "row_def456"]
                   }
                 }
               }
@@ -3121,9 +3010,7 @@
         "operationId": "batchUpdateRows",
         "summary": "Batch Update Rows",
         "description": "Update multiple specific rows by their IDs in a single request. Each entry in the `updates` array specifies a row ID and the fields to update. Validates against the table schema and unique constraints. Up to 1000 rows can be updated per request.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3143,10 +3030,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId",
-                  "updates"
-                ],
+                "required": ["workspaceId", "updates"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -3156,10 +3040,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "rowId",
-                        "data"
-                      ],
+                      "required": ["rowId", "data"],
                       "properties": {
                         "rowId": {
                           "type": "string",
@@ -3225,9 +3106,7 @@
         "operationId": "getRow",
         "summary": "Get Row",
         "description": "Retrieve a single row by its ID.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3310,9 +3189,7 @@
         "operationId": "updateRow",
         "summary": "Update Row",
         "description": "Partially update a single row. Only the provided fields are updated; existing fields are preserved. Data is validated against the table schema.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3335,10 +3212,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId",
-                  "data"
-                ],
+                "required": ["workspaceId", "data"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -3428,9 +3302,7 @@
         "operationId": "deleteRow",
         "summary": "Delete Row",
         "description": "Delete a single row by its ID.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3507,9 +3379,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId"
-                ],
+                "required": ["workspaceId"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -3530,9 +3400,7 @@
         "operationId": "upsertRow",
         "summary": "Upsert Row",
         "description": "Insert a new row or update an existing one based on a unique column value. The table must have at least one column with a unique constraint. If a row with a matching unique value exists, it is updated; otherwise, a new row is inserted. When multiple unique columns exist, specify `conflictTarget` to indicate which column to match on.",
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3552,10 +3420,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId",
-                  "data"
-                ],
+                "required": ["workspaceId", "data"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -3603,10 +3468,7 @@
                         },
                         "operation": {
                           "type": "string",
-                          "enum": [
-                            "insert",
-                            "update"
-                          ],
+                          "enum": ["insert", "update"],
                           "description": "Whether the row was inserted or updated."
                         },
                         "message": {
@@ -3660,9 +3522,7 @@
         "operationId": "listFiles",
         "summary": "List Files",
         "description": "List all files in a workspace.",
-        "tags": [
-          "Files"
-        ],
+        "tags": ["Files"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3745,9 +3605,7 @@
         "operationId": "uploadFile",
         "summary": "Upload File",
         "description": "Upload a file to a workspace. Send the file as multipart/form-data with a `file` field and a `workspaceId` field. Maximum file size is 100MB. Duplicate filenames within a workspace are not allowed.",
-        "tags": [
-          "Files"
-        ],
+        "tags": ["Files"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3762,10 +3620,7 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "file",
-                  "workspaceId"
-                ],
+                "required": ["file", "workspaceId"],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -3864,9 +3719,7 @@
         "operationId": "downloadFile",
         "summary": "Download File",
         "description": "Download a file's content. Returns the raw file bytes with appropriate Content-Type, Content-Disposition, and Content-Length headers. File metadata is included in custom response headers: X-File-Id, X-File-Name, X-Uploaded-At.",
-        "tags": [
-          "Files"
-        ],
+        "tags": ["Files"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3965,9 +3818,7 @@
         "operationId": "deleteFile",
         "summary": "Delete File",
         "description": "Delete a file from a workspace. This removes both the file content and its metadata. This action is irreversible.",
-        "tags": [
-          "Files"
-        ],
+        "tags": ["Files"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4047,9 +3898,7 @@
         "operationId": "listKnowledgeBases",
         "summary": "List Knowledge Bases",
         "description": "List all knowledge bases in a workspace.",
-        "tags": [
-          "Knowledge Bases"
-        ],
+        "tags": ["Knowledge Bases"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4133,9 +3982,7 @@
         "operationId": "createKnowledgeBase",
         "summary": "Create Knowledge Base",
         "description": "Create a new knowledge base in a workspace. Optionally configure chunking parameters for document processing.",
-        "tags": [
-          "Knowledge Bases"
-        ],
+        "tags": ["Knowledge Bases"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4150,10 +3997,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId",
-                  "name"
-                ],
+                "required": ["workspaceId", "name"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -4251,9 +4095,7 @@
         "operationId": "getKnowledgeBase",
         "summary": "Get Knowledge Base",
         "description": "Get details of a specific knowledge base.",
-        "tags": [
-          "Knowledge Bases"
-        ],
+        "tags": ["Knowledge Bases"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4339,9 +4181,7 @@
         "operationId": "updateKnowledgeBase",
         "summary": "Update Knowledge Base",
         "description": "Update a knowledge base's name, description, or chunking configuration. At least one field must be provided.",
-        "tags": [
-          "Knowledge Bases"
-        ],
+        "tags": ["Knowledge Bases"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4367,9 +4207,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId"
-                ],
+                "required": ["workspaceId"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -4467,9 +4305,7 @@
         "operationId": "deleteKnowledgeBase",
         "summary": "Delete Knowledge Base",
         "description": "Soft-delete a knowledge base and all its documents.",
-        "tags": [
-          "Knowledge Bases"
-        ],
+        "tags": ["Knowledge Bases"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4545,9 +4381,7 @@
         "operationId": "listDocuments",
         "summary": "List Documents",
         "description": "List documents in a knowledge base with pagination, filtering, and sorting.",
-        "tags": [
-          "Knowledge Bases"
-        ],
+        "tags": ["Knowledge Bases"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4604,11 +4438,7 @@
             "description": "Filter by enabled status.",
             "schema": {
               "type": "string",
-              "enum": [
-                "all",
-                "enabled",
-                "disabled"
-              ],
+              "enum": ["all", "enabled", "disabled"],
               "default": "all"
             }
           },
@@ -4636,10 +4466,7 @@
             "description": "Sort direction.",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "default": "desc"
             }
           }
@@ -4742,9 +4569,7 @@
         "operationId": "uploadDocument",
         "summary": "Upload Document",
         "description": "Upload a document to a knowledge base. The document will be processed asynchronously (chunked and embedded). Maximum file size is 100MB.",
-        "tags": [
-          "Knowledge Bases"
-        ],
+        "tags": ["Knowledge Bases"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4770,10 +4595,7 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "file",
-                  "workspaceId"
-                ],
+                "required": ["file", "workspaceId"],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -4909,9 +4731,7 @@
         "operationId": "getDocument",
         "summary": "Get Document",
         "description": "Get details of a specific document in a knowledge base.",
-        "tags": [
-          "Knowledge Bases"
-        ],
+        "tags": ["Knowledge Bases"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -5006,9 +4826,7 @@
         "operationId": "deleteDocument",
         "summary": "Delete Document",
         "description": "Soft-delete a document from a knowledge base. For connector-sourced documents, this also prevents re-import on future syncs.",
-        "tags": [
-          "Knowledge Bases"
-        ],
+        "tags": ["Knowledge Bases"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -5093,9 +4911,7 @@
         "operationId": "searchKnowledgeBase",
         "summary": "Search Knowledge Base",
         "description": "Perform vector similarity search across one or more knowledge bases. Supports semantic search via query text, tag-based filtering, or a combination of both.",
-        "tags": [
-          "Knowledge Bases"
-        ],
+        "tags": ["Knowledge Bases"],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -5110,10 +4926,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "workspaceId",
-                  "knowledgeBaseIds"
-                ],
+                "required": ["workspaceId", "knowledgeBaseIds"],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -5157,9 +4970,7 @@
               },
               "example": {
                 "workspaceId": "wsp_abc123",
-                "knowledgeBaseIds": [
-                  "kb_abc123"
-                ],
+                "knowledgeBaseIds": ["kb_abc123"],
                 "query": "How do I reset my password?",
                 "topK": 5
               }
@@ -5226,9 +5037,7 @@
                       }
                     ],
                     "query": "How do I reset my password?",
-                    "knowledgeBaseIds": [
-                      "kb_abc123"
-                    ],
+                    "knowledgeBaseIds": ["kb_abc123"],
                     "topK": 5,
                     "totalResults": 1
                   }
@@ -5300,10 +5109,7 @@
       "ColumnDefinition": {
         "type": "object",
         "description": "Definition of a table column including its type and constraints.",
-        "required": [
-          "name",
-          "type"
-        ],
+        "required": ["name", "type"],
         "properties": {
           "name": {
             "type": "string",
@@ -5313,13 +5119,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "string",
-              "number",
-              "boolean",
-              "date",
-              "json"
-            ],
+            "enum": ["string", "number", "boolean", "date", "json"],
             "description": "Data type of the column."
           },
           "required": {
@@ -5984,12 +5784,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "queued",
-              "processing",
-              "completed",
-              "failed"
-            ],
+            "enum": ["queued", "processing", "completed", "failed"],
             "description": "Current status of the job.",
             "example": "completed"
           },
@@ -6347,12 +6142,7 @@
           },
           "processingStatus": {
             "type": "string",
-            "enum": [
-              "pending",
-              "processing",
-              "completed",
-              "failed"
-            ],
+            "enum": ["pending", "processing", "completed", "failed"],
             "description": "Current processing status."
           },
           "chunkCount": {
@@ -6404,12 +6194,7 @@
           },
           "processingStatus": {
             "type": "string",
-            "enum": [
-              "pending",
-              "processing",
-              "completed",
-              "failed"
-            ],
+            "enum": ["pending", "processing", "completed", "failed"],
             "description": "Current processing status."
           },
           "processingError": {
@@ -6502,10 +6287,7 @@
       "TagFilter": {
         "type": "object",
         "description": "A tag-based filter for knowledge base search.",
-        "required": [
-          "tagName",
-          "value"
-        ],
+        "required": ["tagName", "value"],
         "properties": {
           "tagName": {
             "type": "string",
@@ -6513,12 +6295,7 @@
           },
           "fieldType": {
             "type": "string",
-            "enum": [
-              "text",
-              "number",
-              "date",
-              "boolean"
-            ],
+            "enum": ["text", "number", "date", "boolean"],
             "default": "text",
             "description": "Data type of the tag field."
           },
@@ -6645,13 +6422,7 @@
           },
           "resumeStatus": {
             "type": "string",
-            "enum": [
-              "paused",
-              "resumed",
-              "failed",
-              "queued",
-              "resuming"
-            ],
+            "enum": ["paused", "resumed", "failed", "queued", "resuming"],
             "description": "Current status of this pause point."
           },
           "snapshotReady": {
@@ -6861,12 +6632,7 @@
           "status": {
             "type": "string",
             "description": "Execution status.",
-            "enum": [
-              "completed",
-              "failed",
-              "paused",
-              "cancelled"
-            ],
+            "enum": ["completed", "failed", "paused", "cancelled"],
             "example": "completed"
           },
           "executionId": {
@@ -7041,10 +6807,7 @@
               "data": {
                 "message": "Rows updated successfully",
                 "updatedCount": 2,
-                "updatedRowIds": [
-                  "row_abc123",
-                  "row_def456"
-                ]
+                "updatedRowIds": ["row_abc123", "row_def456"]
               }
             }
           }

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -65,7 +65,9 @@
         "operationId": "executeWorkflow",
         "summary": "Execute Workflow",
         "description": "Execute a deployed workflow. Supports synchronous, asynchronous, and streaming modes. For async execution, the response includes a statusUrl you can poll for results.",
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -174,7 +176,9 @@
         "operationId": "cancelExecution",
         "summary": "Cancel Execution",
         "description": "Cancel a running workflow execution. Only effective for executions that are still in progress.",
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -244,7 +248,9 @@
         "operationId": "listPausedExecutions",
         "summary": "List Paused Executions",
         "description": "List all paused executions for a workflow. Workflows pause at Human in the Loop blocks and wait for input before continuing. Use this endpoint to discover which executions need attention.",
-        "tags": ["Human in the Loop"],
+        "tags": [
+          "Human in the Loop"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -340,6 +346,9 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
           }
@@ -351,7 +360,9 @@
         "operationId": "getPausedExecution",
         "summary": "Get Paused Execution",
         "description": "Get detailed information about a specific paused execution, including its pause points, execution snapshot, and resume queue. Use this to inspect the state before resuming.",
-        "tags": ["Human in the Loop"],
+        "tags": [
+          "Human in the Loop"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -396,6 +407,9 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
           }
@@ -407,7 +421,9 @@
         "operationId": "getPausedExecutionByResumePath",
         "summary": "Get Paused Execution (Resume Path)",
         "description": "Get detailed information about a specific paused execution using the resume URL path. Returns the same data as the workflow paused execution detail endpoint.",
-        "tags": ["Human in the Loop"],
+        "tags": [
+          "Human in the Loop"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -452,8 +468,27 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "Human-readable error message."
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -463,7 +498,9 @@
         "operationId": "getPauseContext",
         "summary": "Get Pause Context",
         "description": "Get detailed information about a specific pause context within a paused execution. Returns the pause point details, resume queue state, and any active resume entry.",
-        "tags": ["Human in the Loop"],
+        "tags": [
+          "Human in the Loop"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -518,6 +555,9 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
           }
@@ -527,7 +567,9 @@
         "operationId": "resumeExecution",
         "summary": "Resume Execution",
         "description": "Resume a paused workflow execution by providing input for a specific pause context. The execution continues from where it paused, using the provided input. Supports synchronous, asynchronous, and streaming modes (determined by the original execution's configuration).",
-        "tags": ["Human in the Loop"],
+        "tags": [
+          "Human in the Loop"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -607,7 +649,9 @@
                       "properties": {
                         "status": {
                           "type": "string",
-                          "enum": ["queued"],
+                          "enum": [
+                            "queued"
+                          ],
                           "description": "Indicates the resume is queued."
                         },
                         "executionId": {
@@ -630,7 +674,9 @@
                       "properties": {
                         "status": {
                           "type": "string",
-                          "enum": ["started"],
+                          "enum": [
+                            "started"
+                          ],
                           "description": "Indicates the resume execution has started."
                         },
                         "executionId": {
@@ -708,6 +754,9 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
@@ -726,6 +775,22 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "Human-readable error message."
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -735,7 +800,9 @@
         "operationId": "listWorkflows",
         "summary": "List Workflows",
         "description": "Retrieve all workflows in a workspace with cursor-based pagination.",
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -841,7 +908,9 @@
         "operationId": "getWorkflow",
         "summary": "Get Workflow",
         "description": "Retrieve details for a single workflow, including its input fields and deployment status.",
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -910,7 +979,9 @@
         "operationId": "getJobStatus",
         "summary": "Get Job Status",
         "description": "Poll the status of an asynchronous workflow execution. Use the jobId returned from the Execute Workflow endpoint when the execution is queued asynchronously.",
-        "tags": ["Workflows"],
+        "tags": [
+          "Workflows"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -970,7 +1041,9 @@
         "operationId": "queryLogs",
         "summary": "Query Logs",
         "description": "List workflow execution logs with advanced filtering and cursor-based pagination. Supports filtering by workflow, trigger type, date range, duration, cost, and more.",
-        "tags": ["Logs"],
+        "tags": [
+          "Logs"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1187,7 +1260,9 @@
         "operationId": "getLogDetails",
         "summary": "Get Log Details",
         "description": "Retrieve detailed information about a specific log entry, including workflow metadata, execution data, and cost breakdown.",
-        "tags": ["Logs"],
+        "tags": [
+          "Logs"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1258,7 +1333,9 @@
         "operationId": "getExecutionDetails",
         "summary": "Get Execution Details",
         "description": "Retrieve the full execution state snapshot, including the workflow state at time of execution and detailed metadata.",
-        "tags": ["Logs"],
+        "tags": [
+          "Logs"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1379,7 +1456,9 @@
         "operationId": "listAuditLogs",
         "summary": "List Audit Logs",
         "description": "Retrieve audit logs for your organization with cursor-based pagination. Requires an Enterprise subscription and organization admin or owner role.",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1531,7 +1610,9 @@
         "operationId": "getAuditLogDetails",
         "summary": "Get Audit Log Details",
         "description": "Retrieve a single audit log entry by ID. Requires an Enterprise subscription and organization admin or owner role.",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1605,7 +1686,9 @@
         "operationId": "getUsageLimits",
         "summary": "Get Usage Limits",
         "description": "Retrieve your current rate limits, usage spending, and storage consumption for the billing period.",
-        "tags": ["Usage"],
+        "tags": [
+          "Usage"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1662,7 +1745,9 @@
         "operationId": "listTables",
         "summary": "List Tables",
         "description": "List all tables in a workspace. Returns table metadata including name, schema, and row counts.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1755,7 +1840,9 @@
         "operationId": "createTable",
         "summary": "Create Table",
         "description": "Create a new table in a workspace. Define the table schema with typed columns, optional constraints (required, unique), and a name.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1770,7 +1857,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId", "name", "schema"],
+                "required": [
+                  "workspaceId",
+                  "name",
+                  "schema"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -1787,7 +1878,9 @@
                   },
                   "schema": {
                     "type": "object",
-                    "required": ["columns"],
+                    "required": [
+                      "columns"
+                    ],
                     "properties": {
                       "columns": {
                         "type": "array",
@@ -1906,7 +1999,9 @@
         "operationId": "getTable",
         "summary": "Get Table",
         "description": "Retrieve a table's metadata, schema, and row count.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -1995,7 +2090,9 @@
         "operationId": "deleteTable",
         "summary": "Delete Table",
         "description": "Delete a table and all its rows. This action is irreversible.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2068,7 +2165,9 @@
         "operationId": "addColumn",
         "summary": "Add Column",
         "description": "Add a new column to the table schema. Optionally specify a position to insert the column at a specific index.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "lang": "curl",
@@ -2086,7 +2185,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId", "column"],
+                "required": [
+                  "workspaceId",
+                  "column"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -2094,7 +2196,10 @@
                   },
                   "column": {
                     "type": "object",
-                    "required": ["name", "type"],
+                    "required": [
+                      "name",
+                      "type"
+                    ],
                     "properties": {
                       "name": {
                         "type": "string",
@@ -2102,7 +2207,13 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["string", "number", "boolean", "date", "json"],
+                        "enum": [
+                          "string",
+                          "number",
+                          "boolean",
+                          "date",
+                          "json"
+                        ],
                         "description": "Column data type"
                       },
                       "required": {
@@ -2198,7 +2309,9 @@
         "operationId": "updateColumn",
         "summary": "Update Column",
         "description": "Update a column's name, type, or constraints. Multiple updates can be applied in a single request. When renaming, subsequent updates (type, constraints) use the new name.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "lang": "curl",
@@ -2216,7 +2329,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId", "columnName", "updates"],
+                "required": [
+                  "workspaceId",
+                  "columnName",
+                  "updates"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -2235,7 +2352,13 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["string", "number", "boolean", "date", "json"],
+                        "enum": [
+                          "string",
+                          "number",
+                          "boolean",
+                          "date",
+                          "json"
+                        ],
                         "description": "New column data type"
                       },
                       "required": {
@@ -2326,7 +2449,9 @@
         "operationId": "deleteColumn",
         "summary": "Delete Column",
         "description": "Delete a column from the table schema. This removes the column definition and strips the corresponding key from all existing row data. Cannot delete the last remaining column.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "lang": "curl",
@@ -2344,7 +2469,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId", "columnName"],
+                "required": [
+                  "workspaceId",
+                  "columnName"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -2423,7 +2551,9 @@
         "operationId": "listRows",
         "summary": "List Rows",
         "description": "Query rows from a table with optional filtering, sorting, and pagination. Filters and sorts are passed as JSON-encoded query parameters.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2569,7 +2699,9 @@
         "operationId": "insertRows",
         "summary": "Insert Rows",
         "description": "Insert one or more rows into a table. For a single row, pass a `data` object. For batch insert, pass a `rows` array (up to 1000 rows).",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2591,7 +2723,10 @@
                 "oneOf": [
                   {
                     "type": "object",
-                    "required": ["workspaceId", "data"],
+                    "required": [
+                      "workspaceId",
+                      "data"
+                    ],
                     "description": "Single row insert.",
                     "properties": {
                       "workspaceId": {
@@ -2612,7 +2747,10 @@
                   },
                   {
                     "type": "object",
-                    "required": ["workspaceId", "rows"],
+                    "required": [
+                      "workspaceId",
+                      "rows"
+                    ],
                     "description": "Batch insert (up to 1000 rows).",
                     "properties": {
                       "workspaceId": {
@@ -2734,7 +2872,9 @@
         "operationId": "updateRows",
         "summary": "Update Rows",
         "description": "Bulk update rows matching a filter. All matching rows will have the specified fields updated. Validates against schema and unique constraints.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2754,7 +2894,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId", "filter", "data"],
+                "required": [
+                  "workspaceId",
+                  "filter",
+                  "data"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -2815,7 +2959,9 @@
         "operationId": "deleteRows",
         "summary": "Delete Rows",
         "description": "Delete rows by filter criteria or by an explicit list of row IDs. Pass either a `filter` object or a `rowIds` array.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2837,7 +2983,10 @@
                 "oneOf": [
                   {
                     "type": "object",
-                    "required": ["workspaceId", "filter"],
+                    "required": [
+                      "workspaceId",
+                      "filter"
+                    ],
                     "description": "Delete by filter.",
                     "properties": {
                       "workspaceId": {
@@ -2859,7 +3008,10 @@
                   },
                   {
                     "type": "object",
-                    "required": ["workspaceId", "rowIds"],
+                    "required": [
+                      "workspaceId",
+                      "rowIds"
+                    ],
                     "description": "Delete by IDs.",
                     "properties": {
                       "workspaceId": {
@@ -2880,7 +3032,10 @@
               },
               "example": {
                 "workspaceId": "wsp_abc123",
-                "rowIds": ["row_abc123", "row_def456"]
+                "rowIds": [
+                  "row_abc123",
+                  "row_def456"
+                ]
               }
             }
           }
@@ -2936,7 +3091,10 @@
                   "data": {
                     "message": "Rows deleted successfully",
                     "deletedCount": 2,
-                    "deletedRowIds": ["row_abc123", "row_def456"]
+                    "deletedRowIds": [
+                      "row_abc123",
+                      "row_def456"
+                    ]
                   }
                 }
               }
@@ -2963,7 +3121,9 @@
         "operationId": "batchUpdateRows",
         "summary": "Batch Update Rows",
         "description": "Update multiple specific rows by their IDs in a single request. Each entry in the `updates` array specifies a row ID and the fields to update. Validates against the table schema and unique constraints. Up to 1000 rows can be updated per request.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -2983,7 +3143,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId", "updates"],
+                "required": [
+                  "workspaceId",
+                  "updates"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -2993,7 +3156,10 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["rowId", "data"],
+                      "required": [
+                        "rowId",
+                        "data"
+                      ],
                       "properties": {
                         "rowId": {
                           "type": "string",
@@ -3059,7 +3225,9 @@
         "operationId": "getRow",
         "summary": "Get Row",
         "description": "Retrieve a single row by its ID.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3142,7 +3310,9 @@
         "operationId": "updateRow",
         "summary": "Update Row",
         "description": "Partially update a single row. Only the provided fields are updated; existing fields are preserved. Data is validated against the table schema.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3165,7 +3335,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId", "data"],
+                "required": [
+                  "workspaceId",
+                  "data"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -3255,7 +3428,9 @@
         "operationId": "deleteRow",
         "summary": "Delete Row",
         "description": "Delete a single row by its ID.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3332,7 +3507,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId"],
+                "required": [
+                  "workspaceId"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -3353,7 +3530,9 @@
         "operationId": "upsertRow",
         "summary": "Upsert Row",
         "description": "Insert a new row or update an existing one based on a unique column value. The table must have at least one column with a unique constraint. If a row with a matching unique value exists, it is updated; otherwise, a new row is inserted. When multiple unique columns exist, specify `conflictTarget` to indicate which column to match on.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3373,7 +3552,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId", "data"],
+                "required": [
+                  "workspaceId",
+                  "data"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -3421,7 +3603,10 @@
                         },
                         "operation": {
                           "type": "string",
-                          "enum": ["insert", "update"],
+                          "enum": [
+                            "insert",
+                            "update"
+                          ],
                           "description": "Whether the row was inserted or updated."
                         },
                         "message": {
@@ -3475,7 +3660,9 @@
         "operationId": "listFiles",
         "summary": "List Files",
         "description": "List all files in a workspace.",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3558,7 +3745,9 @@
         "operationId": "uploadFile",
         "summary": "Upload File",
         "description": "Upload a file to a workspace. Send the file as multipart/form-data with a `file` field and a `workspaceId` field. Maximum file size is 100MB. Duplicate filenames within a workspace are not allowed.",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3573,7 +3762,10 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file", "workspaceId"],
+                "required": [
+                  "file",
+                  "workspaceId"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -3672,7 +3864,9 @@
         "operationId": "downloadFile",
         "summary": "Download File",
         "description": "Download a file's content. Returns the raw file bytes with appropriate Content-Type, Content-Disposition, and Content-Length headers. File metadata is included in custom response headers: X-File-Id, X-File-Name, X-Uploaded-At.",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3771,7 +3965,9 @@
         "operationId": "deleteFile",
         "summary": "Delete File",
         "description": "Delete a file from a workspace. This removes both the file content and its metadata. This action is irreversible.",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3851,7 +4047,9 @@
         "operationId": "listKnowledgeBases",
         "summary": "List Knowledge Bases",
         "description": "List all knowledge bases in a workspace.",
-        "tags": ["Knowledge Bases"],
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3935,7 +4133,9 @@
         "operationId": "createKnowledgeBase",
         "summary": "Create Knowledge Base",
         "description": "Create a new knowledge base in a workspace. Optionally configure chunking parameters for document processing.",
-        "tags": ["Knowledge Bases"],
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -3950,7 +4150,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId", "name"],
+                "required": [
+                  "workspaceId",
+                  "name"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -4048,7 +4251,9 @@
         "operationId": "getKnowledgeBase",
         "summary": "Get Knowledge Base",
         "description": "Get details of a specific knowledge base.",
-        "tags": ["Knowledge Bases"],
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4134,7 +4339,9 @@
         "operationId": "updateKnowledgeBase",
         "summary": "Update Knowledge Base",
         "description": "Update a knowledge base's name, description, or chunking configuration. At least one field must be provided.",
-        "tags": ["Knowledge Bases"],
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4160,7 +4367,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId"],
+                "required": [
+                  "workspaceId"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -4258,7 +4467,9 @@
         "operationId": "deleteKnowledgeBase",
         "summary": "Delete Knowledge Base",
         "description": "Soft-delete a knowledge base and all its documents.",
-        "tags": ["Knowledge Bases"],
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4334,7 +4545,9 @@
         "operationId": "listDocuments",
         "summary": "List Documents",
         "description": "List documents in a knowledge base with pagination, filtering, and sorting.",
-        "tags": ["Knowledge Bases"],
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4391,7 +4604,11 @@
             "description": "Filter by enabled status.",
             "schema": {
               "type": "string",
-              "enum": ["all", "enabled", "disabled"],
+              "enum": [
+                "all",
+                "enabled",
+                "disabled"
+              ],
               "default": "all"
             }
           },
@@ -4419,7 +4636,10 @@
             "description": "Sort direction.",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "default": "desc"
             }
           }
@@ -4522,7 +4742,9 @@
         "operationId": "uploadDocument",
         "summary": "Upload Document",
         "description": "Upload a document to a knowledge base. The document will be processed asynchronously (chunked and embedded). Maximum file size is 100MB.",
-        "tags": ["Knowledge Bases"],
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4548,7 +4770,10 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file", "workspaceId"],
+                "required": [
+                  "file",
+                  "workspaceId"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -4684,7 +4909,9 @@
         "operationId": "getDocument",
         "summary": "Get Document",
         "description": "Get details of a specific document in a knowledge base.",
-        "tags": ["Knowledge Bases"],
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4779,7 +5006,9 @@
         "operationId": "deleteDocument",
         "summary": "Delete Document",
         "description": "Soft-delete a document from a knowledge base. For connector-sourced documents, this also prevents re-import on future syncs.",
-        "tags": ["Knowledge Bases"],
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4864,7 +5093,9 @@
         "operationId": "searchKnowledgeBase",
         "summary": "Search Knowledge Base",
         "description": "Perform vector similarity search across one or more knowledge bases. Supports semantic search via query text, tag-based filtering, or a combination of both.",
-        "tags": ["Knowledge Bases"],
+        "tags": [
+          "Knowledge Bases"
+        ],
         "x-codeSamples": [
           {
             "id": "curl",
@@ -4879,7 +5110,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["workspaceId", "knowledgeBaseIds"],
+                "required": [
+                  "workspaceId",
+                  "knowledgeBaseIds"
+                ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
@@ -4923,7 +5157,9 @@
               },
               "example": {
                 "workspaceId": "wsp_abc123",
-                "knowledgeBaseIds": ["kb_abc123"],
+                "knowledgeBaseIds": [
+                  "kb_abc123"
+                ],
                 "query": "How do I reset my password?",
                 "topK": 5
               }
@@ -4990,7 +5226,9 @@
                       }
                     ],
                     "query": "How do I reset my password?",
-                    "knowledgeBaseIds": ["kb_abc123"],
+                    "knowledgeBaseIds": [
+                      "kb_abc123"
+                    ],
                     "topK": 5,
                     "totalResults": 1
                   }
@@ -5062,7 +5300,10 @@
       "ColumnDefinition": {
         "type": "object",
         "description": "Definition of a table column including its type and constraints.",
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -5072,7 +5313,13 @@
           },
           "type": {
             "type": "string",
-            "enum": ["string", "number", "boolean", "date", "json"],
+            "enum": [
+              "string",
+              "number",
+              "boolean",
+              "date",
+              "json"
+            ],
             "description": "Data type of the column."
           },
           "required": {
@@ -5737,7 +5984,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["queued", "processing", "completed", "failed"],
+            "enum": [
+              "queued",
+              "processing",
+              "completed",
+              "failed"
+            ],
             "description": "Current status of the job.",
             "example": "completed"
           },
@@ -6095,7 +6347,12 @@
           },
           "processingStatus": {
             "type": "string",
-            "enum": ["pending", "processing", "completed", "failed"],
+            "enum": [
+              "pending",
+              "processing",
+              "completed",
+              "failed"
+            ],
             "description": "Current processing status."
           },
           "chunkCount": {
@@ -6147,7 +6404,12 @@
           },
           "processingStatus": {
             "type": "string",
-            "enum": ["pending", "processing", "completed", "failed"],
+            "enum": [
+              "pending",
+              "processing",
+              "completed",
+              "failed"
+            ],
             "description": "Current processing status."
           },
           "processingError": {
@@ -6240,7 +6502,10 @@
       "TagFilter": {
         "type": "object",
         "description": "A tag-based filter for knowledge base search.",
-        "required": ["tagName", "value"],
+        "required": [
+          "tagName",
+          "value"
+        ],
         "properties": {
           "tagName": {
             "type": "string",
@@ -6248,7 +6513,12 @@
           },
           "fieldType": {
             "type": "string",
-            "enum": ["text", "number", "date", "boolean"],
+            "enum": [
+              "text",
+              "number",
+              "date",
+              "boolean"
+            ],
             "default": "text",
             "description": "Data type of the tag field."
           },
@@ -6375,7 +6645,13 @@
           },
           "resumeStatus": {
             "type": "string",
-            "enum": ["paused", "resumed", "failed", "queued", "resuming"],
+            "enum": [
+              "paused",
+              "resumed",
+              "failed",
+              "queued",
+              "resuming"
+            ],
             "description": "Current status of this pause point."
           },
           "snapshotReady": {
@@ -6585,7 +6861,12 @@
           "status": {
             "type": "string",
             "description": "Execution status.",
-            "enum": ["completed", "failed", "paused", "cancelled"],
+            "enum": [
+              "completed",
+              "failed",
+              "paused",
+              "cancelled"
+            ],
             "example": "completed"
           },
           "executionId": {
@@ -6760,7 +7041,10 @@
               "data": {
                 "message": "Rows updated successfully",
                 "updatedCount": 2,
-                "updatedRowIds": ["row_abc123", "row_def456"]
+                "updatedRowIds": [
+                  "row_abc123",
+                  "row_def456"
+                ]
               }
             }
           }

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -26,6 +26,10 @@
       "description": "Execute workflows and manage workflow resources"
     },
     {
+      "name": "Human in the Loop",
+      "description": "Manage paused workflow executions and resume them with input"
+    },
+    {
       "name": "Logs",
       "description": "Query execution logs and retrieve details"
     },
@@ -231,6 +235,497 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/workflows/{id}/paused": {
+      "get": {
+        "operationId": "listPausedExecutions",
+        "summary": "List Paused Executions",
+        "description": "List all paused executions for a workflow. Workflows pause at Human in the Loop blocks and wait for input before continuing. Use this endpoint to discover which executions need attention.",
+        "tags": ["Human in the Loop"],
+        "x-codeSamples": [
+          {
+            "id": "curl",
+            "label": "cURL",
+            "lang": "bash",
+            "source": "curl -X GET \\\n  \"https://www.sim.ai/api/workflows/{id}/paused?status=paused\" \\\n  -H \"X-API-Key: YOUR_API_KEY\""
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the workflow.",
+            "schema": {
+              "type": "string",
+              "example": "wf_1a2b3c4d5e"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter paused executions by status.",
+            "schema": {
+              "type": "string",
+              "example": "paused"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of paused executions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "pausedExecutions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PausedExecutionSummary"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "pausedExecutions": [
+                    {
+                      "id": "pe_abc123",
+                      "workflowId": "wf_1a2b3c4d5e",
+                      "executionId": "exec_9f8e7d6c5b",
+                      "status": "paused",
+                      "totalPauseCount": 1,
+                      "resumedCount": 0,
+                      "pausedAt": "2026-01-15T10:30:00Z",
+                      "updatedAt": "2026-01-15T10:30:00Z",
+                      "expiresAt": null,
+                      "metadata": null,
+                      "triggerIds": [],
+                      "pausePoints": [
+                        {
+                          "contextId": "ctx_xyz789",
+                          "blockId": "block_hitl_1",
+                          "registeredAt": "2026-01-15T10:30:00Z",
+                          "resumeStatus": "paused",
+                          "snapshotReady": true,
+                          "resumeLinks": {
+                            "apiUrl": "https://www.sim.ai/api/resume/wf_1a2b3c4d5e/exec_9f8e7d6c5b/ctx_xyz789",
+                            "uiUrl": "https://www.sim.ai/resume/wf_1a2b3c4d5e/exec_9f8e7d6c5b",
+                            "contextId": "ctx_xyz789",
+                            "executionId": "exec_9f8e7d6c5b",
+                            "workflowId": "wf_1a2b3c4d5e"
+                          },
+                          "response": {
+                            "displayData": {
+                              "title": "Approval Required",
+                              "message": "Please review this request"
+                            },
+                            "formFields": []
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/workflows/{id}/paused/{executionId}": {
+      "get": {
+        "operationId": "getPausedExecution",
+        "summary": "Get Paused Execution",
+        "description": "Get detailed information about a specific paused execution, including its pause points, execution snapshot, and resume queue. Use this to inspect the state before resuming.",
+        "tags": ["Human in the Loop"],
+        "x-codeSamples": [
+          {
+            "id": "curl",
+            "label": "cURL",
+            "lang": "bash",
+            "source": "curl -X GET \\\n  \"https://www.sim.ai/api/workflows/{id}/paused/{executionId}\" \\\n  -H \"X-API-Key: YOUR_API_KEY\""
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the workflow.",
+            "schema": {
+              "type": "string",
+              "example": "wf_1a2b3c4d5e"
+            }
+          },
+          {
+            "name": "executionId",
+            "in": "path",
+            "required": true,
+            "description": "The execution ID of the paused execution.",
+            "schema": {
+              "type": "string",
+              "example": "exec_9f8e7d6c5b"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paused execution details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PausedExecutionDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/resume/{workflowId}/{executionId}": {
+      "get": {
+        "operationId": "getPausedExecutionByResumePath",
+        "summary": "Get Paused Execution (Resume Path)",
+        "description": "Get detailed information about a specific paused execution using the resume URL path. Returns the same data as the workflow paused execution detail endpoint.",
+        "tags": ["Human in the Loop"],
+        "x-codeSamples": [
+          {
+            "id": "curl",
+            "label": "cURL",
+            "lang": "bash",
+            "source": "curl -X GET \\\n  \"https://www.sim.ai/api/resume/{workflowId}/{executionId}\" \\\n  -H \"X-API-Key: YOUR_API_KEY\""
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the workflow.",
+            "schema": {
+              "type": "string",
+              "example": "wf_1a2b3c4d5e"
+            }
+          },
+          {
+            "name": "executionId",
+            "in": "path",
+            "required": true,
+            "description": "The execution ID of the paused execution.",
+            "schema": {
+              "type": "string",
+              "example": "exec_9f8e7d6c5b"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paused execution details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PausedExecutionDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/resume/{workflowId}/{executionId}/{contextId}": {
+      "get": {
+        "operationId": "getPauseContext",
+        "summary": "Get Pause Context",
+        "description": "Get detailed information about a specific pause context within a paused execution. Returns the pause point details, resume queue state, and any active resume entry.",
+        "tags": ["Human in the Loop"],
+        "x-codeSamples": [
+          {
+            "id": "curl",
+            "label": "cURL",
+            "lang": "bash",
+            "source": "curl -X GET \\\n  \"https://www.sim.ai/api/resume/{workflowId}/{executionId}/{contextId}\" \\\n  -H \"X-API-Key: YOUR_API_KEY\""
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the workflow.",
+            "schema": {
+              "type": "string",
+              "example": "wf_1a2b3c4d5e"
+            }
+          },
+          {
+            "name": "executionId",
+            "in": "path",
+            "required": true,
+            "description": "The execution ID of the paused execution.",
+            "schema": {
+              "type": "string",
+              "example": "exec_9f8e7d6c5b"
+            }
+          },
+          {
+            "name": "contextId",
+            "in": "path",
+            "required": true,
+            "description": "The pause context ID to retrieve details for.",
+            "schema": {
+              "type": "string",
+              "example": "ctx_xyz789"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pause context details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PauseContextDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "post": {
+        "operationId": "resumeExecution",
+        "summary": "Resume Execution",
+        "description": "Resume a paused workflow execution by providing input for a specific pause context. The execution continues from where it paused, using the provided input. Supports synchronous, asynchronous, and streaming modes (determined by the original execution's configuration).",
+        "tags": ["Human in the Loop"],
+        "x-codeSamples": [
+          {
+            "id": "curl",
+            "label": "cURL",
+            "lang": "bash",
+            "source": "curl -X POST \\\n  \"https://www.sim.ai/api/resume/{workflowId}/{executionId}/{contextId}\" \\\n  -H \"X-API-Key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"input\": {\n      \"approved\": true,\n      \"comment\": \"Looks good to me\"\n    }\n  }'"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the workflow.",
+            "schema": {
+              "type": "string",
+              "example": "wf_1a2b3c4d5e"
+            }
+          },
+          {
+            "name": "executionId",
+            "in": "path",
+            "required": true,
+            "description": "The execution ID of the paused execution.",
+            "schema": {
+              "type": "string",
+              "example": "exec_9f8e7d6c5b"
+            }
+          },
+          {
+            "name": "contextId",
+            "in": "path",
+            "required": true,
+            "description": "The pause context ID to resume. Found in the pause point's contextId field or resumeLinks.",
+            "schema": {
+              "type": "string",
+              "example": "ctx_xyz789"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Input data for the resumed execution. The structure depends on the workflow's Human in the Loop block configuration.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "input": {
+                    "type": "object",
+                    "description": "Key-value pairs to pass as input to the resumed execution. If omitted, the entire request body is used as input.",
+                    "additionalProperties": true
+                  }
+                }
+              },
+              "example": {
+                "input": {
+                  "approved": true,
+                  "comment": "Looks good to me"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Resume execution completed synchronously, or resume was queued behind another in-progress resume.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ResumeResult"
+                    },
+                    {
+                      "type": "object",
+                      "description": "Resume has been queued behind another in-progress resume.",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": ["queued"],
+                          "description": "Indicates the resume is queued."
+                        },
+                        "executionId": {
+                          "type": "string",
+                          "description": "The execution ID assigned to this resume."
+                        },
+                        "queuePosition": {
+                          "type": "integer",
+                          "description": "Position in the resume queue."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable status message."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "description": "Resume execution started (non-API-key callers). The execution runs asynchronously.",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": ["started"],
+                          "description": "Indicates the resume execution has started."
+                        },
+                        "executionId": {
+                          "type": "string",
+                          "description": "The execution ID for the resumed workflow."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable status message."
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "sync": {
+                    "summary": "Synchronous completion",
+                    "value": {
+                      "success": true,
+                      "status": "completed",
+                      "executionId": "exec_new123",
+                      "output": {
+                        "result": "Approved and processed"
+                      },
+                      "error": null,
+                      "metadata": {
+                        "duration": 850,
+                        "startTime": "2026-01-15T10:35:00Z",
+                        "endTime": "2026-01-15T10:35:01Z"
+                      }
+                    }
+                  },
+                  "queued": {
+                    "summary": "Queued behind another resume",
+                    "value": {
+                      "status": "queued",
+                      "executionId": "exec_new123",
+                      "queuePosition": 2,
+                      "message": "Resume queued. It will run after current resumes finish."
+                    }
+                  },
+                  "started": {
+                    "summary": "Execution started (fire and forget)",
+                    "value": {
+                      "status": "started",
+                      "executionId": "exec_new123",
+                      "message": "Resume execution started."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Resume execution has been queued for asynchronous processing. Poll the statusUrl for results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncExecutionResult"
+                },
+                "example": {
+                  "success": true,
+                  "async": true,
+                  "jobId": "job_4a3b2c1d0e",
+                  "executionId": "exec_new123",
+                  "message": "Resume execution queued",
+                  "statusUrl": "https://www.sim.ai/api/jobs/job_4a3b2c1d0e"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "503": {
+            "description": "Failed to queue the resume execution. Retry the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "Error message."
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -5786,6 +6281,346 @@
               }
             ],
             "description": "Upper bound value for 'between' operator."
+          }
+        }
+      },
+      "PausedExecutionSummary": {
+        "type": "object",
+        "description": "Summary of a paused workflow execution.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the paused execution record."
+          },
+          "workflowId": {
+            "type": "string",
+            "description": "The workflow this execution belongs to."
+          },
+          "executionId": {
+            "type": "string",
+            "description": "The execution that was paused."
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the paused execution.",
+            "example": "paused"
+          },
+          "totalPauseCount": {
+            "type": "integer",
+            "description": "Total number of pause points in this execution."
+          },
+          "resumedCount": {
+            "type": "integer",
+            "description": "Number of pause points that have been resumed."
+          },
+          "pausedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When the execution was paused."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When the paused execution record was last updated."
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When the paused execution will expire and be cleaned up."
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true,
+            "description": "Additional metadata associated with the paused execution.",
+            "additionalProperties": true
+          },
+          "triggerIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "IDs of triggers that initiated the original execution."
+          },
+          "pausePoints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PausePoint"
+            },
+            "description": "List of pause points in the execution."
+          }
+        }
+      },
+      "PausePoint": {
+        "type": "object",
+        "description": "A point in the workflow where execution has been paused awaiting human input.",
+        "properties": {
+          "contextId": {
+            "type": "string",
+            "description": "Unique identifier for this pause context. Used when resuming execution."
+          },
+          "blockId": {
+            "type": "string",
+            "description": "The block ID where execution paused."
+          },
+          "response": {
+            "description": "Data returned by the block before pausing, including display data and form fields."
+          },
+          "registeredAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this pause point was registered."
+          },
+          "resumeStatus": {
+            "type": "string",
+            "enum": ["paused", "resumed", "failed", "queued", "resuming"],
+            "description": "Current status of this pause point."
+          },
+          "snapshotReady": {
+            "type": "boolean",
+            "description": "Whether the execution snapshot is ready for resumption."
+          },
+          "resumeLinks": {
+            "type": "object",
+            "description": "Links for resuming this pause point.",
+            "properties": {
+              "apiUrl": {
+                "type": "string",
+                "format": "uri",
+                "description": "API endpoint URL to POST resume input to."
+              },
+              "uiUrl": {
+                "type": "string",
+                "format": "uri",
+                "description": "UI URL for a human to review and approve."
+              },
+              "contextId": {
+                "type": "string",
+                "description": "The context ID for this pause point."
+              },
+              "executionId": {
+                "type": "string",
+                "description": "The execution ID."
+              },
+              "workflowId": {
+                "type": "string",
+                "description": "The workflow ID."
+              }
+            }
+          },
+          "queuePosition": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Position in the resume queue, if queued."
+          },
+          "latestResumeEntry": {
+            "$ref": "#/components/schemas/ResumeQueueEntry",
+            "nullable": true,
+            "description": "The most recent resume queue entry for this pause point."
+          },
+          "parallelScope": {
+            "type": "object",
+            "description": "Scope information when the pause occurs inside a parallel branch.",
+            "properties": {
+              "parallelId": {
+                "type": "string",
+                "description": "Identifier of the parallel execution group."
+              },
+              "branchIndex": {
+                "type": "integer",
+                "description": "Index of the branch within the parallel group."
+              },
+              "branchTotal": {
+                "type": "integer",
+                "description": "Total number of branches in the parallel group."
+              }
+            }
+          },
+          "loopScope": {
+            "type": "object",
+            "description": "Scope information when the pause occurs inside a loop.",
+            "properties": {
+              "loopId": {
+                "type": "string",
+                "description": "Identifier of the loop."
+              },
+              "iteration": {
+                "type": "integer",
+                "description": "Current loop iteration number."
+              }
+            }
+          }
+        }
+      },
+      "ResumeQueueEntry": {
+        "type": "object",
+        "description": "An entry in the resume execution queue.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this queue entry."
+          },
+          "pausedExecutionId": {
+            "type": "string",
+            "description": "The paused execution this entry belongs to."
+          },
+          "parentExecutionId": {
+            "type": "string",
+            "description": "The original execution that was paused."
+          },
+          "newExecutionId": {
+            "type": "string",
+            "description": "The new execution ID created for the resume."
+          },
+          "contextId": {
+            "type": "string",
+            "description": "The pause context ID being resumed."
+          },
+          "resumeInput": {
+            "description": "The input provided when resuming."
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of this queue entry (e.g., pending, claimed, completed, failed)."
+          },
+          "queuedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When the entry was added to the queue."
+          },
+          "claimedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When execution started processing this entry."
+          },
+          "completedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When execution completed."
+          },
+          "failureReason": {
+            "type": "string",
+            "nullable": true,
+            "description": "Reason for failure, if the resume failed."
+          }
+        }
+      },
+      "PausedExecutionDetail": {
+        "type": "object",
+        "description": "Detailed information about a paused execution, including the execution snapshot and resume queue.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PausedExecutionSummary"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "executionSnapshot": {
+                "type": "object",
+                "description": "Serialized execution state for resumption.",
+                "properties": {
+                  "snapshot": {
+                    "type": "string",
+                    "description": "Serialized execution snapshot data."
+                  },
+                  "triggerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Trigger IDs from the snapshot."
+                  }
+                }
+              },
+              "queue": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ResumeQueueEntry"
+                },
+                "description": "Resume queue entries for this execution."
+              }
+            }
+          }
+        ]
+      },
+      "PauseContextDetail": {
+        "type": "object",
+        "description": "Detailed information about a specific pause context within a paused execution.",
+        "properties": {
+          "execution": {
+            "$ref": "#/components/schemas/PausedExecutionSummary",
+            "description": "Summary of the parent paused execution."
+          },
+          "pausePoint": {
+            "$ref": "#/components/schemas/PausePoint",
+            "description": "The specific pause point for this context."
+          },
+          "queue": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResumeQueueEntry"
+            },
+            "description": "Resume queue entries for this context."
+          },
+          "activeResumeEntry": {
+            "$ref": "#/components/schemas/ResumeQueueEntry",
+            "nullable": true,
+            "description": "The currently active resume entry, if any."
+          }
+        }
+      },
+      "ResumeResult": {
+        "type": "object",
+        "description": "Result of a synchronous resume execution.",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the resume execution completed successfully."
+          },
+          "status": {
+            "type": "string",
+            "description": "Execution status.",
+            "enum": ["completed", "failed", "paused", "cancelled"],
+            "example": "completed"
+          },
+          "executionId": {
+            "type": "string",
+            "description": "The new execution ID for the resumed workflow."
+          },
+          "output": {
+            "type": "object",
+            "description": "Workflow output from the resumed execution.",
+            "additionalProperties": true
+          },
+          "error": {
+            "type": "string",
+            "nullable": true,
+            "description": "Error message if the execution failed."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Execution timing metadata.",
+            "properties": {
+              "duration": {
+                "type": "integer",
+                "description": "Total execution duration in milliseconds."
+              },
+              "startTime": {
+                "type": "string",
+                "format": "date-time",
+                "description": "When the resume execution started."
+              },
+              "endTime": {
+                "type": "string",
+                "format": "date-time",
+                "description": "When the resume execution completed."
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- Add HITL pause/resume endpoints to OpenAPI spec
- New endpoints: list paused executions, get paused execution detail, get pause context, resume execution
- New schemas: `PausedExecutionSummary`, `PausedExecutionDetail`, `PausePoint`, `PauseContextDetail`, `ResumeQueueEntry`, `ResumeResult`
- Covers all response variants (sync, async, stream, queued, started)
- Includes `parallelScope`/`loopScope` fields for pause points in parallel branches and loops

## Type of Change
- [x] Documentation update

## Testing
Validated JSON structure, all `$ref` targets resolve, verified against source route handlers and TypeScript interfaces

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)