### PR TITLE
fix(trigger): use @react-email/render v2 to fix renderToPipeableStream error

### DIFF
--- a/apps/sim/components/emails/render.ts
+++ b/apps/sim/components/emails/render.ts
@@ -1,4 +1,4 @@
-import { render } from '@react-email/components'
+import { render } from '@react-email/render'
 import {
   OnboardingFollowupEmail,
   OTPVerificationEmail,

--- a/apps/sim/lib/billing/webhooks/invoices.ts
+++ b/apps/sim/lib/billing/webhooks/invoices.ts
@@ -1,4 +1,4 @@
-import { render } from '@react-email/components'
+import { render } from '@react-email/render'
 import { db } from '@sim/db'
 import {
   member,

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
           'isolated-vm',
           'pptxgenjs',
           'react-dom',
-          '@react-email/components',
           '@react-email/render',
         ],
       }),


### PR DESCRIPTION
## Summary
- Import `render` from `@react-email/render` (v2.0.0) instead of `@react-email/components` (which uses a nested v1.0.5 with broken CJS/ESM interop)
- Remove unnecessary `@react-email/components` from Trigger.dev `additionalPackages`
- Fixes `reactDOMServer.renderToPipeableStream is not a function` error in lifecycle email task

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)