### PR TITLE
fix(tools): add Atlassian error extractor to all Jira, JSM, and Confluence tools

### DIFF
--- a/apps/sim/tools/confluence/add_label.ts
+++ b/apps/sim/tools/confluence/add_label.ts
@@ -34,6 +34,8 @@ export const confluenceAddLabelTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_blogpost.ts
+++ b/apps/sim/tools/confluence/create_blogpost.ts
@@ -44,6 +44,8 @@ export const confluenceCreateBlogPostTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_comment.ts
+++ b/apps/sim/tools/confluence/create_comment.ts
@@ -31,6 +31,8 @@ export const confluenceCreateCommentTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_page.ts
+++ b/apps/sim/tools/confluence/create_page.ts
@@ -40,6 +40,8 @@ export const confluenceCreatePageTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_page_property.ts
+++ b/apps/sim/tools/confluence/create_page_property.ts
@@ -38,6 +38,8 @@ export const confluenceCreatePagePropertyTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_space.ts
+++ b/apps/sim/tools/confluence/create_space.ts
@@ -39,6 +39,8 @@ export const confluenceCreateSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_space_property.ts
+++ b/apps/sim/tools/confluence/create_space_property.ts
@@ -35,6 +35,8 @@ export const confluenceCreateSpacePropertyTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_attachment.ts
+++ b/apps/sim/tools/confluence/delete_attachment.ts
@@ -30,6 +30,8 @@ export const confluenceDeleteAttachmentTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_blogpost.ts
+++ b/apps/sim/tools/confluence/delete_blogpost.ts
@@ -31,6 +31,8 @@ export const confluenceDeleteBlogPostTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_comment.ts
+++ b/apps/sim/tools/confluence/delete_comment.ts
@@ -30,6 +30,8 @@ export const confluenceDeleteCommentTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_label.ts
+++ b/apps/sim/tools/confluence/delete_label.ts
@@ -33,6 +33,8 @@ export const confluenceDeleteLabelTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_page.ts
+++ b/apps/sim/tools/confluence/delete_page.ts
@@ -32,6 +32,8 @@ export const confluenceDeletePageTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_page_property.ts
+++ b/apps/sim/tools/confluence/delete_page_property.ts
@@ -33,6 +33,8 @@ export const confluenceDeletePagePropertyTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_space.ts
+++ b/apps/sim/tools/confluence/delete_space.ts
@@ -31,6 +31,8 @@ export const confluenceDeleteSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_space_property.ts
+++ b/apps/sim/tools/confluence/delete_space_property.ts
@@ -33,6 +33,8 @@ export const confluenceDeleteSpacePropertyTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_blogpost.ts
+++ b/apps/sim/tools/confluence/get_blogpost.ts
@@ -49,6 +49,8 @@ export const confluenceGetBlogPostTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_page_ancestors.ts
+++ b/apps/sim/tools/confluence/get_page_ancestors.ts
@@ -39,6 +39,8 @@ export const confluenceGetPageAncestorsTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_page_children.ts
+++ b/apps/sim/tools/confluence/get_page_children.ts
@@ -42,6 +42,8 @@ export const confluenceGetPageChildrenTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_page_descendants.ts
+++ b/apps/sim/tools/confluence/get_page_descendants.ts
@@ -43,6 +43,8 @@ export const confluenceGetPageDescendantsTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_page_version.ts
+++ b/apps/sim/tools/confluence/get_page_version.ts
@@ -54,6 +54,8 @@ export const confluenceGetPageVersionTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_pages_by_label.ts
+++ b/apps/sim/tools/confluence/get_pages_by_label.ts
@@ -47,6 +47,8 @@ export const confluenceGetPagesByLabelTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_space.ts
+++ b/apps/sim/tools/confluence/get_space.ts
@@ -42,6 +42,8 @@ export const confluenceGetSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_task.ts
+++ b/apps/sim/tools/confluence/get_task.ts
@@ -41,6 +41,8 @@ export const confluenceGetTaskTool: ToolConfig<ConfluenceGetTaskParams, Confluen
       provider: 'confluence',
     },
 
+    errorExtractor: 'atlassian-errors',
+
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/confluence/get_user.ts
+++ b/apps/sim/tools/confluence/get_user.ts
@@ -33,6 +33,8 @@ export const confluenceGetUserTool: ToolConfig<ConfluenceGetUserParams, Confluen
       provider: 'confluence',
     },
 
+    errorExtractor: 'atlassian-errors',
+
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/confluence/list_attachments.ts
+++ b/apps/sim/tools/confluence/list_attachments.ts
@@ -39,6 +39,8 @@ export const confluenceListAttachmentsTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_blogposts.ts
+++ b/apps/sim/tools/confluence/list_blogposts.ts
@@ -47,6 +47,8 @@ export const confluenceListBlogPostsTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_blogposts_in_space.ts
+++ b/apps/sim/tools/confluence/list_blogposts_in_space.ts
@@ -55,6 +55,8 @@ export const confluenceListBlogPostsInSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_comments.ts
+++ b/apps/sim/tools/confluence/list_comments.ts
@@ -39,6 +39,8 @@ export const confluenceListCommentsTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_labels.ts
+++ b/apps/sim/tools/confluence/list_labels.ts
@@ -37,6 +37,8 @@ export const confluenceListLabelsTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_page_properties.ts
+++ b/apps/sim/tools/confluence/list_page_properties.ts
@@ -43,6 +43,8 @@ export const confluenceListPagePropertiesTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_page_versions.ts
+++ b/apps/sim/tools/confluence/list_page_versions.ts
@@ -40,6 +40,8 @@ export const confluenceListPageVersionsTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_pages_in_space.ts
+++ b/apps/sim/tools/confluence/list_pages_in_space.ts
@@ -57,6 +57,8 @@ export const confluenceListPagesInSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_space_labels.ts
+++ b/apps/sim/tools/confluence/list_space_labels.ts
@@ -38,6 +38,8 @@ export const confluenceListSpaceLabelsTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_space_permissions.ts
+++ b/apps/sim/tools/confluence/list_space_permissions.ts
@@ -42,6 +42,8 @@ export const confluenceListSpacePermissionsTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_space_properties.ts
+++ b/apps/sim/tools/confluence/list_space_properties.ts
@@ -38,6 +38,8 @@ export const confluenceListSpacePropertiesTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_spaces.ts
+++ b/apps/sim/tools/confluence/list_spaces.ts
@@ -38,6 +38,8 @@ export const confluenceListSpacesTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_tasks.ts
+++ b/apps/sim/tools/confluence/list_tasks.ts
@@ -52,6 +52,8 @@ export const confluenceListTasksTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/retrieve.ts
+++ b/apps/sim/tools/confluence/retrieve.ts
@@ -21,6 +21,8 @@ export const confluenceRetrieveTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/search.ts
+++ b/apps/sim/tools/confluence/search.ts
@@ -34,6 +34,8 @@ export const confluenceSearchTool: ToolConfig<ConfluenceSearchParams, Confluence
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/search_in_space.ts
+++ b/apps/sim/tools/confluence/search_in_space.ts
@@ -44,6 +44,8 @@ export const confluenceSearchInSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/update.ts
+++ b/apps/sim/tools/confluence/update.ts
@@ -13,6 +13,8 @@ export const confluenceUpdateTool: ToolConfig<ConfluenceUpdateParams, Confluence
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/update_blogpost.ts
+++ b/apps/sim/tools/confluence/update_blogpost.ts
@@ -37,6 +37,8 @@ export const confluenceUpdateBlogPostTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/update_comment.ts
+++ b/apps/sim/tools/confluence/update_comment.ts
@@ -31,6 +31,8 @@ export const confluenceUpdateCommentTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/update_space.ts
+++ b/apps/sim/tools/confluence/update_space.ts
@@ -38,6 +38,8 @@ export const confluenceUpdateSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/update_task.ts
+++ b/apps/sim/tools/confluence/update_task.ts
@@ -44,6 +44,8 @@ export const confluenceUpdateTaskTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/upload_attachment.ts
+++ b/apps/sim/tools/confluence/upload_attachment.ts
@@ -37,6 +37,8 @@ export const confluenceUploadAttachmentTool: ToolConfig<
     provider: 'confluence',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/error-extractors.ts
+++ b/apps/sim/tools/error-extractors.ts
@@ -47,7 +47,10 @@ const ERROR_EXTRACTORS: ErrorExtractorConfig[] = [
       if (errorInfo?.data?.errorMessage) {
         return errorInfo.data.errorMessage
       }
-      if (Array.isArray(errorInfo?.data?.errorMessages) && errorInfo.data.errorMessages.length > 0) {
+      if (
+        Array.isArray(errorInfo?.data?.errorMessages) &&
+        errorInfo.data.errorMessages.length > 0
+      ) {
         return errorInfo.data.errorMessages.join(', ')
       }
       if (errorInfo?.data?.message) {

--- a/apps/sim/tools/error-extractors.ts
+++ b/apps/sim/tools/error-extractors.ts
@@ -41,18 +41,36 @@ export interface ErrorExtractorConfig {
 const ERROR_EXTRACTORS: ErrorExtractorConfig[] = [
   {
     id: 'atlassian-errors',
-    description: 'Atlassian REST API error formats (errorMessage, errorMessages array, message)',
-    examples: ['Jira', 'Jira Service Management', 'Confluence'],
+    description:
+      'Atlassian REST API error formats (errorMessage, errorMessages, errors[].title, message)',
+    examples: ['Jira', 'Jira Service Management', 'Confluence', 'JSM Forms/ProForma'],
     extract: (errorInfo) => {
+      // JSM Service Desk: singular errorMessage string
       if (errorInfo?.data?.errorMessage) {
         return errorInfo.data.errorMessage
       }
+      // Jira Platform: errorMessages array
       if (
         Array.isArray(errorInfo?.data?.errorMessages) &&
         errorInfo.data.errorMessages.length > 0
       ) {
         return errorInfo.data.errorMessages.join(', ')
       }
+      // Confluence v2 / Forms API: RFC 7807 errors array with title/detail
+      if (Array.isArray(errorInfo?.data?.errors) && errorInfo.data.errors.length > 0) {
+        const err = errorInfo.data.errors[0]
+        if (err?.title) {
+          return err.detail ? `${err.title}: ${err.detail}` : err.title
+        }
+      }
+      // Jira Platform field-level errors object
+      if (errorInfo?.data?.errors && !Array.isArray(errorInfo.data.errors)) {
+        const fieldErrors = Object.entries(errorInfo.data.errors)
+          .map(([field, msg]) => `${field}: ${msg}`)
+          .join(', ')
+        if (fieldErrors) return fieldErrors
+      }
+      // Generic message fallback (auth/gateway errors)
       if (errorInfo?.data?.message) {
         return errorInfo.data.message
       }

--- a/apps/sim/tools/error-extractors.ts
+++ b/apps/sim/tools/error-extractors.ts
@@ -41,9 +41,20 @@ export interface ErrorExtractorConfig {
 const ERROR_EXTRACTORS: ErrorExtractorConfig[] = [
   {
     id: 'atlassian-errors',
-    description: 'Atlassian REST API errorMessage field',
+    description: 'Atlassian REST API error formats (errorMessage, errorMessages array, message)',
     examples: ['Jira', 'Jira Service Management', 'Confluence'],
-    extract: (errorInfo) => errorInfo?.data?.errorMessage,
+    extract: (errorInfo) => {
+      if (errorInfo?.data?.errorMessage) {
+        return errorInfo.data.errorMessage
+      }
+      if (Array.isArray(errorInfo?.data?.errorMessages) && errorInfo.data.errorMessages.length > 0) {
+        return errorInfo.data.errorMessages.join(', ')
+      }
+      if (errorInfo?.data?.message) {
+        return errorInfo.data.message
+      }
+      return undefined
+    },
   },
   {
     id: 'graphql-errors',

--- a/apps/sim/tools/jira/add_attachment.ts
+++ b/apps/sim/tools/jira/add_attachment.ts
@@ -14,6 +14,8 @@ export const jiraAddAttachmentTool: ToolConfig<JiraAddAttachmentParams, JiraAddA
       provider: 'jira',
     },
 
+    errorExtractor: 'atlassian-errors',
+
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/add_comment.ts
+++ b/apps/sim/tools/jira/add_comment.ts
@@ -30,6 +30,8 @@ export const jiraAddCommentTool: ToolConfig<JiraAddCommentParams, JiraAddComment
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/add_watcher.ts
+++ b/apps/sim/tools/jira/add_watcher.ts
@@ -14,6 +14,8 @@ export const jiraAddWatcherTool: ToolConfig<JiraAddWatcherParams, JiraAddWatcher
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/add_worklog.ts
+++ b/apps/sim/tools/jira/add_worklog.ts
@@ -57,6 +57,8 @@ export const jiraAddWorklogTool: ToolConfig<JiraAddWorklogParams, JiraAddWorklog
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/assign_issue.ts
+++ b/apps/sim/tools/jira/assign_issue.ts
@@ -14,6 +14,8 @@ export const jiraAssignIssueTool: ToolConfig<JiraAssignIssueParams, JiraAssignIs
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/bulk_read.ts
+++ b/apps/sim/tools/jira/bulk_read.ts
@@ -14,6 +14,8 @@ export const jiraBulkRetrieveTool: ToolConfig<JiraRetrieveBulkParams, JiraRetrie
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/create_issue_link.ts
+++ b/apps/sim/tools/jira/create_issue_link.ts
@@ -17,6 +17,8 @@ export const jiraCreateIssueLinkTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/delete_attachment.ts
+++ b/apps/sim/tools/jira/delete_attachment.ts
@@ -17,6 +17,8 @@ export const jiraDeleteAttachmentTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/delete_comment.ts
+++ b/apps/sim/tools/jira/delete_comment.ts
@@ -15,6 +15,8 @@ export const jiraDeleteCommentTool: ToolConfig<JiraDeleteCommentParams, JiraDele
       provider: 'jira',
     },
 
+    errorExtractor: 'atlassian-errors',
+
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/delete_issue.ts
+++ b/apps/sim/tools/jira/delete_issue.ts
@@ -14,6 +14,8 @@ export const jiraDeleteIssueTool: ToolConfig<JiraDeleteIssueParams, JiraDeleteIs
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/delete_issue_link.ts
+++ b/apps/sim/tools/jira/delete_issue_link.ts
@@ -17,6 +17,8 @@ export const jiraDeleteIssueLinkTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/delete_worklog.ts
+++ b/apps/sim/tools/jira/delete_worklog.ts
@@ -15,6 +15,8 @@ export const jiraDeleteWorklogTool: ToolConfig<JiraDeleteWorklogParams, JiraDele
       provider: 'jira',
     },
 
+    errorExtractor: 'atlassian-errors',
+
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/get_attachments.ts
+++ b/apps/sim/tools/jira/get_attachments.ts
@@ -35,6 +35,8 @@ export const jiraGetAttachmentsTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/get_comments.ts
+++ b/apps/sim/tools/jira/get_comments.ts
@@ -32,6 +32,8 @@ export const jiraGetCommentsTool: ToolConfig<JiraGetCommentsParams, JiraGetComme
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/get_users.ts
+++ b/apps/sim/tools/jira/get_users.ts
@@ -32,6 +32,8 @@ export const jiraGetUsersTool: ToolConfig<JiraGetUsersParams, JiraGetUsersRespon
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/get_worklogs.ts
+++ b/apps/sim/tools/jira/get_worklogs.ts
@@ -32,6 +32,8 @@ export const jiraGetWorklogsTool: ToolConfig<JiraGetWorklogsParams, JiraGetWorkl
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/remove_watcher.ts
+++ b/apps/sim/tools/jira/remove_watcher.ts
@@ -15,6 +15,8 @@ export const jiraRemoveWatcherTool: ToolConfig<JiraRemoveWatcherParams, JiraRemo
       provider: 'jira',
     },
 
+    errorExtractor: 'atlassian-errors',
+
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/retrieve.ts
+++ b/apps/sim/tools/jira/retrieve.ts
@@ -195,6 +195,8 @@ export const jiraRetrieveTool: ToolConfig<JiraRetrieveParams, JiraRetrieveRespon
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/search_issues.ts
+++ b/apps/sim/tools/jira/search_issues.ts
@@ -81,6 +81,8 @@ export const jiraSearchIssuesTool: ToolConfig<JiraSearchIssuesParams, JiraSearch
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/search_users.ts
+++ b/apps/sim/tools/jira/search_users.ts
@@ -15,6 +15,8 @@ export const jiraSearchUsersTool: ToolConfig<JiraSearchUsersParams, JiraSearchUs
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/transition_issue.ts
+++ b/apps/sim/tools/jira/transition_issue.ts
@@ -17,6 +17,8 @@ export const jiraTransitionIssueTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/update.ts
+++ b/apps/sim/tools/jira/update.ts
@@ -13,6 +13,8 @@ export const jiraUpdateTool: ToolConfig<JiraUpdateParams, JiraUpdateResponse> = 
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/update_comment.ts
+++ b/apps/sim/tools/jira/update_comment.ts
@@ -31,6 +31,8 @@ export const jiraUpdateCommentTool: ToolConfig<JiraUpdateCommentParams, JiraUpda
       provider: 'jira',
     },
 
+    errorExtractor: 'atlassian-errors',
+
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/update_worklog.ts
+++ b/apps/sim/tools/jira/update_worklog.ts
@@ -58,6 +58,8 @@ export const jiraUpdateWorklogTool: ToolConfig<JiraUpdateWorklogParams, JiraUpda
       provider: 'jira',
     },
 
+    errorExtractor: 'atlassian-errors',
+
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/write.ts
+++ b/apps/sim/tools/jira/write.ts
@@ -13,6 +13,8 @@ export const jiraWriteTool: ToolConfig<JiraWriteParams, JiraWriteResponse> = {
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/add_comment.ts
+++ b/apps/sim/tools/jsm/add_comment.ts
@@ -13,6 +13,8 @@ export const jsmAddCommentTool: ToolConfig<JsmAddCommentParams, JsmAddCommentRes
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/add_customer.ts
+++ b/apps/sim/tools/jsm/add_customer.ts
@@ -12,6 +12,8 @@ export const jsmAddCustomerTool: ToolConfig<JsmAddCustomerParams, JsmAddCustomer
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/add_organization.ts
+++ b/apps/sim/tools/jsm/add_organization.ts
@@ -15,6 +15,8 @@ export const jsmAddOrganizationTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/add_participants.ts
+++ b/apps/sim/tools/jsm/add_participants.ts
@@ -16,6 +16,8 @@ export const jsmAddParticipantsTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/answer_approval.ts
+++ b/apps/sim/tools/jsm/answer_approval.ts
@@ -13,6 +13,8 @@ export const jsmAnswerApprovalTool: ToolConfig<JsmAnswerApprovalParams, JsmAnswe
       provider: 'jira',
     },
 
+    errorExtractor: 'atlassian-errors',
+
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jsm/create_organization.ts
+++ b/apps/sim/tools/jsm/create_organization.ts
@@ -15,6 +15,8 @@ export const jsmCreateOrganizationTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/create_request.ts
+++ b/apps/sim/tools/jsm/create_request.ts
@@ -12,6 +12,8 @@ export const jsmCreateRequestTool: ToolConfig<JsmCreateRequestParams, JsmCreateR
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_approvals.ts
+++ b/apps/sim/tools/jsm/get_approvals.ts
@@ -13,6 +13,8 @@ export const jsmGetApprovalsTool: ToolConfig<JsmGetApprovalsParams, JsmGetApprov
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_comments.ts
+++ b/apps/sim/tools/jsm/get_comments.ts
@@ -13,6 +13,8 @@ export const jsmGetCommentsTool: ToolConfig<JsmGetCommentsParams, JsmGetComments
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_customers.ts
+++ b/apps/sim/tools/jsm/get_customers.ts
@@ -13,6 +13,8 @@ export const jsmGetCustomersTool: ToolConfig<JsmGetCustomersParams, JsmGetCustom
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_form_structure.ts
+++ b/apps/sim/tools/jsm/get_form_structure.ts
@@ -16,6 +16,8 @@ export const jsmGetFormStructureTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_form_templates.ts
+++ b/apps/sim/tools/jsm/get_form_templates.ts
@@ -17,6 +17,8 @@ export const jsmGetFormTemplatesTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_issue_forms.ts
+++ b/apps/sim/tools/jsm/get_issue_forms.ts
@@ -14,6 +14,8 @@ export const jsmGetIssueFormsTool: ToolConfig<JsmGetIssueFormsParams, JsmGetIssu
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_organizations.ts
+++ b/apps/sim/tools/jsm/get_organizations.ts
@@ -16,6 +16,8 @@ export const jsmGetOrganizationsTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_participants.ts
+++ b/apps/sim/tools/jsm/get_participants.ts
@@ -16,6 +16,8 @@ export const jsmGetParticipantsTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_queues.ts
+++ b/apps/sim/tools/jsm/get_queues.ts
@@ -13,6 +13,8 @@ export const jsmGetQueuesTool: ToolConfig<JsmGetQueuesParams, JsmGetQueuesRespon
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_request.ts
+++ b/apps/sim/tools/jsm/get_request.ts
@@ -17,6 +17,8 @@ export const jsmGetRequestTool: ToolConfig<JsmGetRequestParams, JsmGetRequestRes
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_request_type_fields.ts
+++ b/apps/sim/tools/jsm/get_request_type_fields.ts
@@ -20,6 +20,8 @@ export const jsmGetRequestTypeFieldsTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_request_types.ts
+++ b/apps/sim/tools/jsm/get_request_types.ts
@@ -16,6 +16,8 @@ export const jsmGetRequestTypesTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_requests.ts
+++ b/apps/sim/tools/jsm/get_requests.ts
@@ -13,6 +13,8 @@ export const jsmGetRequestsTool: ToolConfig<JsmGetRequestsParams, JsmGetRequests
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_service_desks.ts
+++ b/apps/sim/tools/jsm/get_service_desks.ts
@@ -16,6 +16,8 @@ export const jsmGetServiceDesksTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_sla.ts
+++ b/apps/sim/tools/jsm/get_sla.ts
@@ -13,6 +13,8 @@ export const jsmGetSlaTool: ToolConfig<JsmGetSlaParams, JsmGetSlaResponse> = {
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_transitions.ts
+++ b/apps/sim/tools/jsm/get_transitions.ts
@@ -14,6 +14,8 @@ export const jsmGetTransitionsTool: ToolConfig<JsmGetTransitionsParams, JsmGetTr
       provider: 'jira',
     },
 
+    errorExtractor: 'atlassian-errors',
+
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jsm/transition_request.ts
+++ b/apps/sim/tools/jsm/transition_request.ts
@@ -15,6 +15,8 @@ export const jsmTransitionRequestTool: ToolConfig<
     provider: 'jira',
   },
 
+  errorExtractor: 'atlassian-errors',
+
   params: {
     accessToken: {
       type: 'string',


### PR DESCRIPTION
## Summary
- Wires up the existing `atlassian-errors` error extractor to all 95 Atlassian tool configs (25 Jira, 24 JSM, 46 Confluence) so the executor surfaces meaningful error messages instead of generic "Request failed with status X"
- Fixes the `atlassian-errors` extractor itself to handle all three Atlassian error response formats: `errorMessage` (JSM), `errorMessages` array (Jira), and `message` (Confluence)

## Test plan
- [x] Trigger an error on a Jira tool (e.g., retrieve non-existent issue) and verify the error message contains the actual Atlassian error text
- [x] Trigger an error on a JSM tool and verify meaningful error message
- [x] Trigger an error on a Confluence tool and verify meaningful error message
- [x] Verify happy-path execution is unaffected (errorExtractor only runs on error responses)