### PR TITLE
fix(log): log cleanup sql query

### DIFF
--- a/apps/sim/app/api/logs/cleanup/route.ts
+++ b/apps/sim/app/api/logs/cleanup/route.ts
@@ -26,13 +26,6 @@ export async function GET(request: NextRequest) {
     const retentionDate = new Date()
     retentionDate.setDate(retentionDate.getDate() - Number(env.FREE_PLAN_LOG_RETENTION_DAYS || '7'))
 
-    /**
-     * Subquery: workspace IDs whose billed account user has no active paid
-     * subscription. Kept as a subquery (not materialized into JS) so the
-     * generated SQL is `WHERE workspace_id IN (SELECT ...)` — this avoids
-     * PostgreSQL's 65535 bind-parameter limit that was breaking cleanup once
-     * the free-user count grew beyond ~65k.
-     */
     const freeWorkspacesSubquery = db
       .select({ id: workspace.id })
       .from(workspace)
@@ -94,7 +87,7 @@ export async function GET(request: NextRequest) {
         .where(
           and(
             inArray(workflowExecutionLogs.workspaceId, freeWorkspacesSubquery),
-            lt(workflowExecutionLogs.createdAt, retentionDate)
+            lt(workflowExecutionLogs.startedAt, retentionDate)
           )
         )
         .limit(BATCH_SIZE)

--- a/apps/sim/app/api/logs/cleanup/route.ts
+++ b/apps/sim/app/api/logs/cleanup/route.ts
@@ -1,5 +1,5 @@
 import { db } from '@sim/db'
-import { subscription, user, workflowExecutionLogs, workspace } from '@sim/db/schema'
+import { subscription, workflowExecutionLogs, workspace } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { and, eq, inArray, isNull, lt } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
@@ -26,37 +26,25 @@ export async function GET(request: NextRequest) {
     const retentionDate = new Date()
     retentionDate.setDate(retentionDate.getDate() - Number(env.FREE_PLAN_LOG_RETENTION_DAYS || '7'))
 
-    const freeUsers = await db
-      .select({ userId: user.id })
-      .from(user)
+    /**
+     * Subquery: workspace IDs whose billed account user has no active paid
+     * subscription. Kept as a subquery (not materialized into JS) so the
+     * generated SQL is `WHERE workspace_id IN (SELECT ...)` — this avoids
+     * PostgreSQL's 65535 bind-parameter limit that was breaking cleanup once
+     * the free-user count grew beyond ~65k.
+     */
+    const freeWorkspacesSubquery = db
+      .select({ id: workspace.id })
+      .from(workspace)
       .leftJoin(
         subscription,
         and(
-          eq(user.id, subscription.referenceId),
+          eq(subscription.referenceId, workspace.billedAccountUserId),
           inArray(subscription.status, ENTITLED_SUBSCRIPTION_STATUSES),
           sqlIsPaid(subscription.plan)
         )
       )
       .where(isNull(subscription.id))
-
-    if (freeUsers.length === 0) {
-      logger.info('No free users found for log cleanup')
-      return NextResponse.json({ message: 'No free users found for cleanup' })
-    }
-
-    const freeUserIds = freeUsers.map((u) => u.userId)
-
-    const workspacesQuery = await db
-      .select({ id: workspace.id })
-      .from(workspace)
-      .where(inArray(workspace.billedAccountUserId, freeUserIds))
-
-    if (workspacesQuery.length === 0) {
-      logger.info('No workspaces found for free users')
-      return NextResponse.json({ message: 'No workspaces found for cleanup' })
-    }
-
-    const workspaceIds = workspacesQuery.map((w) => w.id)
 
     const results = {
       enhancedLogs: {
@@ -83,7 +71,7 @@ export async function GET(request: NextRequest) {
     let batchesProcessed = 0
     let hasMoreLogs = true
 
-    logger.info(`Starting enhanced logs cleanup for ${workspaceIds.length} workspaces`)
+    logger.info('Starting enhanced logs cleanup for free-plan workspaces')
 
     while (hasMoreLogs && batchesProcessed < MAX_BATCHES) {
       const oldEnhancedLogs = await db
@@ -105,7 +93,7 @@ export async function GET(request: NextRequest) {
         .from(workflowExecutionLogs)
         .where(
           and(
-            inArray(workflowExecutionLogs.workspaceId, workspaceIds),
+            inArray(workflowExecutionLogs.workspaceId, freeWorkspacesSubquery),
             lt(workflowExecutionLogs.createdAt, retentionDate)
           )
         )


### PR DESCRIPTION
## Summary
Our log cleanup was failing due to too many params passed:
```
[ERROR] [LogsCleanupAPI] Error in log cleanup process: {"error":{"query":"select \"id\" from
  \"workspace\" where \"workspace\".\"billed_account_user_id\" in ($1, $2, $3, $4, $5, $6, $7...
```

This is because our old logic fetched every free user id into memory and then passed it to the second sql query. Changed this to use a subquery to fix free user log cleanup

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How has this been tested? What should reviewers focus on?

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
