### PR TITLE
fix(tools): pass errorExtractor to executor and handle all Atlassian error formats

### DIFF
--- a/apps/sim/tools/jsm/utils.ts
+++ b/apps/sim/tools/jsm/utils.ts
@@ -50,13 +50,36 @@ export function parseJsmErrorMessage(
 ): string {
   try {
     const errorData = JSON.parse(errorText)
+    // JSM Service Desk: singular errorMessage
     if (errorData.errorMessage) {
-      return `JSM Forms API error: ${errorData.errorMessage}`
+      return errorData.errorMessage
+    }
+    // Jira Platform: errorMessages array
+    if (Array.isArray(errorData.errorMessages) && errorData.errorMessages.length > 0) {
+      return errorData.errorMessages.join(', ')
+    }
+    // Confluence v2 / Forms API: RFC 7807 errors array
+    if (Array.isArray(errorData.errors) && errorData.errors.length > 0) {
+      const err = errorData.errors[0]
+      if (err?.title) {
+        return err.detail ? `${err.title}: ${err.detail}` : err.title
+      }
+    }
+    // Jira Platform field-level errors object
+    if (errorData.errors && !Array.isArray(errorData.errors)) {
+      const fieldErrors = Object.entries(errorData.errors)
+        .map(([field, msg]) => `${field}: ${msg}`)
+        .join(', ')
+      if (fieldErrors) return fieldErrors
+    }
+    // Generic message fallback
+    if (errorData.message) {
+      return errorData.message
     }
   } catch {
     if (errorText) {
-      return `JSM Forms API error: ${errorText}`
+      return errorText
     }
   }
-  return `JSM Forms API error: ${status} ${statusText}`
+  return `${status} ${statusText}`
 }


### PR DESCRIPTION
## Summary
- Pass `tool.errorExtractor` to `extractErrorMessage` in the executor — previously the tool-specific extractor ID was never used, so all tools fell back to the generic extraction loop
- Update `parseJsmErrorMessage` to handle all Atlassian error formats (errorMessage, errorMessages[], errors[].title RFC 7807, message) instead of only JSM's singular errorMessage
- Add internal proxy route `data.error` string fallback to the `atlassian-errors` extractor so errors from our API routes are properly surfaced

## Test plan
- [x] Trigger an error on a JSM Forms tool and verify the actual Atlassian error message is returned instead of "Request failed with status X"
- [x] Verify Jira/Confluence error messages also surface correctly
- [x] Verify happy-path execution is unaffected