### PR TITLE
docs(openapi): add Human in the Loop section to API reference sidebar

### DIFF
--- a/apps/docs/content/docs/en/api-reference/(generated)/human-in-the-loop/meta.json
+++ b/apps/docs/content/docs/en/api-reference/(generated)/human-in-the-loop/meta.json
@@ -1,0 +1,9 @@
+{
+  "pages": [
+    "listPausedExecutions",
+    "getPausedExecution",
+    "getPausedExecutionByResumePath",
+    "getPauseContext",
+    "resumeExecution"
+  ]
+}

--- a/apps/docs/content/docs/en/api-reference/meta.json
+++ b/apps/docs/content/docs/en/api-reference/meta.json
@@ -10,6 +10,7 @@
     "typescript",
     "---Endpoints---",
     "(generated)/workflows",
+    "(generated)/human-in-the-loop",
     "(generated)/logs",
     "(generated)/usage",
     "(generated)/audit-logs",


### PR DESCRIPTION
## Summary
- Add `(generated)/human-in-the-loop` to the API reference sidebar navigation
- Create `meta.json` listing all 5 HITL operation IDs so Fumadocs renders them in the docs

Follows up on #4079 which added the HITL endpoints to `openapi.json` — they weren't showing in the docs because the sidebar nav and generated folder config were missing.

## Type of Change
- [x] Documentation update

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)