### PR TITLE
feat(tools): add fields parameter to Jira search block

### DIFF
--- a/apps/sim/blocks/blocks/jira.ts
+++ b/apps/sim/blocks/blocks/jira.ts
@@ -479,6 +479,13 @@ Return ONLY the JQL query - no explanations or markdown formatting.`,
       placeholder: 'Maximum results to return (default: 50)',
       condition: { field: 'operation', value: ['search', 'get_comments', 'get_worklogs'] },
     },
+    {
+      id: 'fields',
+      title: 'Fields',
+      type: 'short-input',
+      placeholder: 'Comma-separated fields to return (e.g., key,summary,status)',
+      condition: { field: 'operation', value: 'search' },
+    },
     // Comment fields
     {
       id: 'commentBody',
@@ -922,6 +929,12 @@ Return ONLY the comment text - no explanations.`,
               jql: params.jql,
               nextPageToken: params.nextPageToken || undefined,
               maxResults: params.maxResults ? Number.parseInt(params.maxResults) : undefined,
+              fields: params.fields
+                ? params.fields
+                    .split(',')
+                    .map((f: string) => f.trim())
+                    .filter(Boolean)
+                : undefined,
             }
           }
           case 'add_comment': {
@@ -1114,6 +1127,10 @@ Return ONLY the comment text - no explanations.`,
     startAt: { type: 'string', description: 'Pagination start index' },
     jql: { type: 'string', description: 'JQL (Jira Query Language) search query' },
     maxResults: { type: 'string', description: 'Maximum number of results to return' },
+    fields: {
+      type: 'string',
+      description: 'Comma-separated field names to return (e.g., key,summary,status)',
+    },
     // Comment operation inputs
     commentBody: { type: 'string', description: 'Text content for comment operations' },
     commentId: { type: 'string', description: 'Comment ID for update/delete operations' },

--- a/apps/sim/blocks/blocks/jira.ts
+++ b/apps/sim/blocks/blocks/jira.ts
@@ -932,7 +932,7 @@ Return ONLY the comment text - no explanations.`,
               fields: params.fields
                 ? params.fields
                     .split(',')
-                    .map((f: string) => f.trim())
+                    .map((f) => f.trim())
                     .filter(Boolean)
                 : undefined,
             }

--- a/apps/sim/blocks/blocks/jira.ts
+++ b/apps/sim/blocks/blocks/jira.ts
@@ -932,7 +932,7 @@ Return ONLY the comment text - no explanations.`,
               fields: params.fields
                 ? params.fields
                     .split(',')
-                    .map((f) => f.trim())
+                    .map((f: string) => f.trim())
                     .filter(Boolean)
                 : undefined,
             }


### PR DESCRIPTION
## Summary
- Exposes the Jira REST API `fields` query parameter on the Search Issues operation
- Users can now specify a comma-separated list of fields (e.g., `key,summary,status,priority`) to return only what they need
- Fully backwards compatible — when omitted, all fields are returned (existing behavior)

## Motivation
Users with moderate-to-high ticket volume hit the 10MB workflow execution state limit because the search returns 21+ fields per issue. The `fields` parameter reduces per-issue payload by 10-15x (e.g., ~2-3KB → ~200 bytes), keeping workflows well under the limit.

## Changes
- **`apps/sim/blocks/blocks/jira.ts`**: Added `fields` subBlock (short-input, search operation only), wired through `tools.config.params` (splits comma string → array), added to block inputs definition
- The search tool (`tools/jira/search_issues.ts`) already had full `fields` support — no tool changes needed

## Test plan
- [x] Set operation to "Search Issues" and verify the Fields input appears
- [x] Enter `key,summary,status` and run — verify only those fields are returned
- [x] Leave Fields empty and run — verify all fields are returned (backwards compat)
- [x] Verify fields with spaces like `key, summary, status` are trimmed correctly