### PR TITLE
fix(agent): include model in structured response output

### DIFF
--- a/apps/sim/executor/handlers/agent/agent-handler.test.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.test.ts
@@ -667,6 +667,7 @@ describe('AgentBlockHandler', () => {
       expect(result).toEqual({
         result: 'Success',
         score: 0.95,
+        model: 'mock-model',
         tokens: { input: 10, output: 20, total: 30 },
         toolCalls: { list: [], count: 0 },
         providerTiming: { total: 100 },

--- a/apps/sim/executor/handlers/agent/agent-handler.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.ts
@@ -1070,19 +1070,20 @@ export class AgentBlockHandler implements BlockHandler {
   private processStandardResponse(result: any): BlockOutput {
     return {
       content: result.content,
-      model: result.model,
       ...this.createResponseMetadata(result),
       ...(result.interactionId && { interactionId: result.interactionId }),
     }
   }
 
   private createResponseMetadata(result: {
+    model?: string
     tokens?: { input?: number; output?: number; total?: number }
     toolCalls?: Array<any>
     timing?: any
     cost?: any
   }) {
     return {
+      model: result.model,
       tokens: result.tokens || {
         input: DEFAULTS.TOKENS.PROMPT,
         output: DEFAULTS.TOKENS.COMPLETION,


### PR DESCRIPTION
## Summary
- Moved `model` into `createResponseMetadata` so it's included in both standard and structured (custom response format) agent outputs
- Previously `agent.model` was missing when a custom response format was provided

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)