### PR TITLE
fix(trigger): resolve dependsOn for trigger-mode subblocks sharing canonical groups with block subblocks

### DIFF
--- a/apps/sim/lib/workflows/subblocks/visibility.ts
+++ b/apps/sim/lib/workflows/subblocks/visibility.ts
@@ -284,8 +284,9 @@ export function resolveDependencyValue(
 
   const { basicValue, advancedValue } = getCanonicalValues(group, values)
   const mode = resolveCanonicalMode(group, values, overrides)
-  if (mode === 'advanced') return advancedValue ?? basicValue
-  return basicValue ?? advancedValue
+  const canonicalResult =
+    mode === 'advanced' ? (advancedValue ?? basicValue) : (basicValue ?? advancedValue)
+  return canonicalResult ?? values[dependencyKey]
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes `dependsOn` gating for trigger-mode subblocks (e.g. Google Sheets spreadsheet picker stays disabled after selecting credentials)
- Root cause: `resolveDependencyValue` resolves trigger subblock IDs through the canonical group from the full block definition, where the group's `basicId` is the regular block's subblock ID (e.g. `credential`), not the trigger's subblock ID (e.g. `triggerCredentials`) — so `values['credential']` is always undefined in trigger mode
- Fix: after canonical resolution, fall back to `values[dependencyKey]` when the canonical result is null/undefined — covers the case where the dependency key is a trigger-mode subblock that participates in a canonical group but isn't registered as the group's `basicId` or `advancedId`
- All existing blocks unaffected: the fallback only triggers when canonical resolution returns nothing, which doesn't happen for regular block subblocks where the `dependencyKey` IS the group's `basicId`

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)