### PR TITLE
fix(ui): support Tab key to select items in tag, env-var, and resource dropdowns

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -167,7 +167,7 @@ export function AddResourceDropdown({
       } else if (e.key === 'ArrowUp') {
         e.preventDefault()
         setActiveIndex((prev) => Math.max(prev - 1, 0))
-      } else if (e.key === 'Enter' || e.key === 'Tab') {
+      } else if (e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) {
         if (filtered.length > 0 && filtered[activeIndex]) {
           e.preventDefault()
           const { type, item } = filtered[activeIndex]

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -167,7 +167,7 @@ export function AddResourceDropdown({
       } else if (e.key === 'ArrowUp') {
         e.preventDefault()
         setActiveIndex((prev) => Math.max(prev - 1, 0))
-      } else if (e.key === 'Enter') {
+      } else if (e.key === 'Enter' || e.key === 'Tab') {
         e.preventDefault()
         if (filtered.length > 0 && filtered[activeIndex]) {
           const { type, item } = filtered[activeIndex]

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -168,8 +168,8 @@ export function AddResourceDropdown({
         e.preventDefault()
         setActiveIndex((prev) => Math.max(prev - 1, 0))
       } else if (e.key === 'Enter' || e.key === 'Tab') {
-        e.preventDefault()
         if (filtered.length > 0 && filtered[activeIndex]) {
+          e.preventDefault()
           const { type, item } = filtered[activeIndex]
           select({ type, id: item.id, title: item.name }, item.isOpen)
         }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/env-var-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/env-var-dropdown.tsx
@@ -242,6 +242,7 @@ export const EnvVarDropdown: React.FC<EnvVarDropdownProps> = ({
             })
             break
           case 'Enter':
+          case 'Tab':
             e.preventDefault()
             e.stopPropagation()
             handleEnvVarSelect(filteredEnvVars[selectedIndex])

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/env-var-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/env-var-dropdown.tsx
@@ -243,9 +243,12 @@ export const EnvVarDropdown: React.FC<EnvVarDropdownProps> = ({
             break
           case 'Enter':
           case 'Tab':
-            e.preventDefault()
-            e.stopPropagation()
-            handleEnvVarSelect(filteredEnvVars[selectedIndex])
+            if (e.key === 'Tab' && e.shiftKey) break
+            if (filteredEnvVars[selectedIndex]) {
+              e.preventDefault()
+              e.stopPropagation()
+              handleEnvVarSelect(filteredEnvVars[selectedIndex])
+            }
             break
           case 'Escape':
             e.preventDefault()

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/components/keyboard-navigation-handler.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/components/keyboard-navigation-handler.tsx
@@ -279,6 +279,7 @@ export const KeyboardNavigationHandler: React.FC<KeyboardNavigationHandlerProps>
           }
           break
         case 'Enter':
+        case 'Tab':
           e.preventDefault()
           e.stopPropagation()
           if (selected && selectedIndex >= 0 && selectedIndex < flatTagList.length) {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/components/keyboard-navigation-handler.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/components/keyboard-navigation-handler.tsx
@@ -280,9 +280,10 @@ export const KeyboardNavigationHandler: React.FC<KeyboardNavigationHandlerProps>
           break
         case 'Enter':
         case 'Tab':
-          e.preventDefault()
-          e.stopPropagation()
+          if (e.key === 'Tab' && e.shiftKey) break
           if (selected && selectedIndex >= 0 && selectedIndex < flatTagList.length) {
+            e.preventDefault()
+            e.stopPropagation()
             handleTagSelect(selected.tag, selected.group)
           }
           break


### PR DESCRIPTION
## Summary
- Added Tab as an alternative to Enter for selecting items in the tag dropdown (block variable picker)
- Added Tab as an alternative to Enter for selecting items in the env var dropdown
- Added Tab as an alternative to Enter for selecting items in the add resource dropdown

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)