### PR TITLE
fix(trigger): show selector display names on canvas for trigger file/sheet selectors

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -534,7 +534,6 @@ const SubBlockRow = memo(function SubBlockRow({
     workspaceId
   )
 
-  const credentialId = dependencyValues.credential
   const knowledgeBaseId = dependencyValues.knowledgeBaseId
 
   const dropdownLabel = useMemo(() => {
@@ -576,6 +575,7 @@ const SubBlockRow = memo(function SubBlockRow({
   const collectionIdValue = resolveContextValue('collectionId')
   const spreadsheetIdValue = resolveContextValue('spreadsheetId')
   const fileIdValue = resolveContextValue('fileId')
+  const credentialId = dependencyValues.credential ?? resolveContextValue('oauthCredential')
 
   const { displayName: selectorDisplayName } = useSelectorDisplayName({
     subBlock,

--- a/apps/sim/lib/workflows/subblocks/visibility.ts
+++ b/apps/sim/lib/workflows/subblocks/visibility.ts
@@ -286,7 +286,18 @@ export function resolveDependencyValue(
   const mode = resolveCanonicalMode(group, values, overrides)
   const canonicalResult =
     mode === 'advanced' ? (advancedValue ?? basicValue) : (basicValue ?? advancedValue)
-  return canonicalResult ?? values[dependencyKey]
+
+  if (canonicalResult != null) return canonicalResult
+
+  for (const [memberId, memberCanonicalId] of Object.entries(
+    canonicalIndex.canonicalIdBySubBlockId
+  )) {
+    if (memberCanonicalId === canonicalId && values[memberId] != null) {
+      return values[memberId]
+    }
+  }
+
+  return values[dependencyKey]
 }
 
 /**

--- a/apps/sim/lib/workflows/subblocks/visibility.ts
+++ b/apps/sim/lib/workflows/subblocks/visibility.ts
@@ -292,7 +292,7 @@ export function resolveDependencyValue(
   for (const [memberId, memberCanonicalId] of Object.entries(
     canonicalIndex.canonicalIdBySubBlockId
   )) {
-    if (memberCanonicalId === canonicalId && values[memberId] != null) {
+    if (memberCanonicalId === canonicalId && isNonEmptyValue(values[memberId])) {
       return values[memberId]
     }
   }


### PR DESCRIPTION
## Summary
- Fixes trigger block canvas preview showing '-' for file-selector and sheet-selector fields even when values are selected
- Root cause 1: \`resolveDependencyValue\` only checked \`group.basicId\` and \`group.advancedIds\` when resolving a canonical group, missing trigger-mode subblocks (e.g. \`triggerCredentials\`) that are registered in \`canonicalIdBySubBlockId\` but deliberately excluded from the group struct to avoid corrupting regular block canonical groups — added a fallback scan over all registered canonical members
- Root cause 2: \`credentialId\` in \`SubBlockRow\` was read from \`dependencyValues.credential\`, but trigger subblocks use \`triggerCredentials\` as their dep key so \`dependencyValues.credential\` was always undefined — now falls back to \`resolveContextValue('oauthCredential')\` which finds the credential via the extended canonical resolution

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)