### PR TITLE
fix(tools): use OAuth-compatible URL for JSM Forms API

### DIFF
--- a/apps/sim/tools/jsm/utils.ts
+++ b/apps/sim/tools/jsm/utils.ts
@@ -19,7 +19,7 @@ export function getJsmApiBaseUrl(cloudId: string): string {
  * @returns The base URL for the JSM Forms API
  */
 export function getJsmFormsApiBaseUrl(cloudId: string): string {
-  return `https://api.atlassian.com/jira/forms/cloud/${cloudId}`
+  return `https://api.atlassian.com/ex/jira/${cloudId}/forms`
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes 401 Unauthorized errors when calling the JSM Forms (ProForma) API with OAuth
- The Forms API requires a different base URL for OAuth vs Basic Auth (confirmed by Atlassian support)
- **Before:** `https://api.atlassian.com/jira/forms/cloud/{cloudId}` (Basic Auth only)
- **After:** `https://api.atlassian.com/ex/jira/{cloudId}/forms` (OAuth compatible)

## Context
Atlassian support confirmed that the `/jira/forms/cloud/{cloudId}` URL pattern only works with Basic Auth. For OAuth 2.0 (3LO), the correct pattern is `/ex/jira/{cloudId}/forms/<resource-name>` per their [documentation](https://developer.atlassian.com/cloud/forms/rest/intro/#other-integrations).

## Changes
- **`apps/sim/tools/jsm/utils.ts`**: Updated `getJsmFormsApiBaseUrl()` to use the OAuth-compatible URL pattern

All three Forms API routes (templates, structure, issue) use this shared function, so they all pick up the fix.

## Test plan
- [x] Verify JSM Forms API calls no longer return 401 with OAuth credentials
- [x] Test Get Form Templates operation with a valid project key
- [x] Test Get Form Structure operation with a valid project key and form ID
- [x] Test Get Issue Forms operation with a valid issue key