### PR TITLE
fix(trigger): skip canonical-paired members when validating required fields on deploy

### DIFF
--- a/apps/sim/lib/webhooks/deploy.ts
+++ b/apps/sim/lib/webhooks/deploy.ts
@@ -185,6 +185,7 @@ function buildProviderConfig(
 
   const canonicalIndex = buildCanonicalIndex(triggerDef.subBlocks)
   const satisfiedCanonicalIds = new Set<string>()
+  const filledSubBlockIds = new Set<string>()
 
   const relevantSubBlocks = triggerDef.subBlocks.filter(
     (subBlock) =>
@@ -196,13 +197,14 @@ function buildProviderConfig(
     const valueToUse = getConfigValue(block, subBlock)
     if (valueToUse !== null && valueToUse !== undefined && valueToUse !== '') {
       providerConfig[subBlock.id] = valueToUse
+      filledSubBlockIds.add(subBlock.id)
       const canonicalId = canonicalIndex.canonicalIdBySubBlockId[subBlock.id]
       if (canonicalId) satisfiedCanonicalIds.add(canonicalId)
     }
   }
 
   for (const subBlock of relevantSubBlocks) {
-    if (providerConfig[subBlock.id] !== undefined) continue
+    if (filledSubBlockIds.has(subBlock.id)) continue
     const canonicalId = canonicalIndex.canonicalIdBySubBlockId[subBlock.id]
     if (canonicalId && satisfiedCanonicalIds.has(canonicalId)) continue
     if (isFieldRequired(subBlock, subBlockValues)) {

--- a/apps/sim/lib/webhooks/deploy.ts
+++ b/apps/sim/lib/webhooks/deploy.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/webhooks/provider-subscriptions'
 import { getProviderHandler } from '@/lib/webhooks/providers'
 import { syncWebhooksForCredentialSet } from '@/lib/webhooks/utils.server'
+import { buildCanonicalIndex } from '@/lib/workflows/subblocks/visibility'
 import { getBlock } from '@/blocks'
 import type { SubBlockConfig } from '@/blocks/types'
 import type { BlockState } from '@/stores/workflows/workflow/types'
@@ -182,20 +183,32 @@ function buildProviderConfig(
     Object.entries(block.subBlocks || {}).map(([key, value]) => [key, { value: value.value }])
   )
 
-  triggerDef.subBlocks
-    .filter(
-      (subBlock) =>
-        (subBlock.mode === 'trigger' || subBlock.mode === 'trigger-advanced') &&
-        !SYSTEM_SUBBLOCK_IDS.includes(subBlock.id)
-    )
-    .forEach((subBlock) => {
-      const valueToUse = getConfigValue(block, subBlock)
-      if (valueToUse !== null && valueToUse !== undefined && valueToUse !== '') {
-        providerConfig[subBlock.id] = valueToUse
-      } else if (isFieldRequired(subBlock, subBlockValues)) {
-        missingFields.push(subBlock.title || subBlock.id)
-      }
-    })
+  const canonicalIndex = buildCanonicalIndex(triggerDef.subBlocks)
+  const satisfiedCanonicalIds = new Set<string>()
+
+  const relevantSubBlocks = triggerDef.subBlocks.filter(
+    (subBlock) =>
+      (subBlock.mode === 'trigger' || subBlock.mode === 'trigger-advanced') &&
+      !SYSTEM_SUBBLOCK_IDS.includes(subBlock.id)
+  )
+
+  for (const subBlock of relevantSubBlocks) {
+    const valueToUse = getConfigValue(block, subBlock)
+    if (valueToUse !== null && valueToUse !== undefined && valueToUse !== '') {
+      providerConfig[subBlock.id] = valueToUse
+      const canonicalId = canonicalIndex.canonicalIdBySubBlockId[subBlock.id]
+      if (canonicalId) satisfiedCanonicalIds.add(canonicalId)
+    }
+  }
+
+  for (const subBlock of relevantSubBlocks) {
+    if (providerConfig[subBlock.id] !== undefined) continue
+    const canonicalId = canonicalIndex.canonicalIdBySubBlockId[subBlock.id]
+    if (canonicalId && satisfiedCanonicalIds.has(canonicalId)) continue
+    if (isFieldRequired(subBlock, subBlockValues)) {
+      missingFields.push(subBlock.title || subBlock.id)
+    }
+  }
 
   const credentialConfig = triggerDef.subBlocks.find(
     (subBlock) => subBlock.id === 'triggerCredentials'


### PR DESCRIPTION
## Summary
- `buildProviderConfig` now uses `buildCanonicalIndex` to group canonical pairs before validating required fields
- Previously, both the basic (`spreadsheetId`) and advanced (`manualSpreadsheetId`) members of a canonical pair were validated independently — so selecting a spreadsheet via the file-selector still triggered a \"Missing required fields\" error because the advanced twin was empty
- Two-pass fix: first collect all values and track which canonical groups are satisfied, then only flag missing required fields for groups with no value from any member

## Type of Change
- [x] Bug fix

## Testing
Tested manually — Google Sheets trigger with Spreadsheet and Sheet Tab selected via file/sheet selectors now deploys without \"Missing required fields\" error

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)