### PR TITLE
fix(ui): resource ui fixes

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -201,8 +201,13 @@ export function Home({ chatId }: HomeProps = {}) {
 
   useEffect(() => {
     wasSendingRef.current = false
-    if (resolvedChatId) markRead(resolvedChatId)
-  }, [resolvedChatId, markRead])
+    if (resolvedChatId) {
+      markRead(resolvedChatId)
+    } else {
+      clearWidth()
+      setIsResourceCollapsed(true)
+    }
+  }, [resolvedChatId, markRead, clearWidth])
 
   useEffect(() => {
     if (wasSendingRef.current && !isSending && resolvedChatId) {
@@ -291,14 +296,6 @@ export function Home({ chatId }: HomeProps = {}) {
     [resolveResourceFromContext, addResource, handleResourceEvent]
   )
 
-  const handleContextRemove = useCallback(
-    (context: ChatContext) => {
-      const resolved = resolveResourceFromContext(context)
-      if (resolved) removeResource(resolved.type, resolved.id)
-    },
-    [resolveResourceFromContext, removeResource]
-  )
-
   const handleWorkspaceResourceSelect = useCallback(
     (resource: MothershipResource) => {
       const wasAdded = addResource(resource)
@@ -348,7 +345,6 @@ export function Home({ chatId }: HomeProps = {}) {
               onStopGeneration={handleStopGeneration}
               userId={session?.user?.id}
               onContextAdd={handleContextAdd}
-              onContextRemove={handleContextRemove}
             />
           </div>
         </div>
@@ -380,7 +376,6 @@ export function Home({ chatId }: HomeProps = {}) {
           userId={session?.user?.id}
           chatId={resolvedChatId}
           onContextAdd={handleContextAdd}
-          onContextRemove={handleContextRemove}
           onWorkspaceResourceSelect={handleWorkspaceResourceSelect}
           editValue={editingInputValue}
           onEditValueConsumed={clearEditingValue}


### PR DESCRIPTION

## Summary
* Deleting an "@"ed resource shouldn't remove it from the resource bar.
handled by completely removing on context remove for resource (deleting resource tab functionality remains unchanged)
* Opening the resource tab, then starting new task shouldn't reopen the resource view since there's no resources.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
* Tested locally
## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
