### PR TITLE
fix(models): exclude reseller providers from model catalog pages

### DIFF
--- a/apps/sim/app/(landing)/models/page.tsx
+++ b/apps/sim/app/(landing)/models/page.tsx
@@ -11,7 +11,6 @@ import {
 import {
   ALL_CATALOG_MODELS,
   getPricingBounds,
-  MODEL_CATALOG_PROVIDERS,
   MODEL_PROVIDERS_WITH_CATALOGS,
   TOP_MODEL_PROVIDERS,
   TOTAL_MODEL_PROVIDERS,
@@ -90,7 +89,7 @@ export const metadata: Metadata = {
 }
 
 export default function ModelsPage() {
-  const flatModels = MODEL_CATALOG_PROVIDERS.flatMap((provider) =>
+  const flatModels = MODEL_PROVIDERS_WITH_CATALOGS.flatMap((provider) =>
     provider.models.map((model) => ({ provider, model }))
   )
   const featuredProviderOrder = ['anthropic', 'openai', 'google']

--- a/apps/sim/app/(landing)/models/utils.ts
+++ b/apps/sim/app/(landing)/models/utils.ts
@@ -552,7 +552,7 @@ assertUniqueGeneratedRoutes(rawProviders)
 
 export const MODEL_CATALOG_PROVIDERS: CatalogProvider[] = rawProviders
 export const MODEL_PROVIDERS_WITH_CATALOGS = MODEL_CATALOG_PROVIDERS.filter(
-  (provider) => provider.models.length > 0
+  (provider) => provider.models.length > 0 && !provider.isReseller
 )
 export const MODEL_PROVIDERS_WITH_DYNAMIC_CATALOGS = MODEL_CATALOG_PROVIDERS.filter(
   (provider) => provider.models.length === 0


### PR DESCRIPTION
## Summary
- Exclude reseller/aggregator providers (OpenRouter, Fireworks, Azure, Azure Anthropic, Vertex, Bedrock) from `MODEL_PROVIDERS_WITH_CATALOGS`
- Reseller models were generating broken detail page links on `/models` since their proxied models don't have valid catalog pages
- Uses the existing `isReseller` flag already set on all aggregator providers — single-line filter addition

## Test plan
- [x] Verify `/models` page loads without broken links
- [x] Verify reseller provider models (e.g. OpenRouter) no longer appear as clickable entries in the model directory
- [x] Verify non-reseller providers still display correctly with working detail pages