### PR TITLE
fix(export): preserve unicode characters in workflow filenames

### DIFF
--- a/apps/sim/lib/workflows/operations/import-export.test.ts
+++ b/apps/sim/lib/workflows/operations/import-export.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { sanitizePathSegment } from '@/lib/workflows/operations/import-export'
+
+describe('sanitizePathSegment', () => {
+  it('should preserve ASCII alphanumeric characters', () => {
+    expect(sanitizePathSegment('workflow-123_abc')).toBe('workflow-123_abc')
+  })
+
+  it('should replace spaces with dashes', () => {
+    expect(sanitizePathSegment('my workflow')).toBe('my-workflow')
+  })
+
+  it('should replace special characters with dashes', () => {
+    expect(sanitizePathSegment('workflow!@#')).toBe('workflow-')
+  })
+
+  it('should preserve Korean characters (BUG REPRODUCTION)', () => {
+    expect(sanitizePathSegment('한글')).toBe('한글')
+  })
+
+  it('should preserve other Unicode characters', () => {
+    expect(sanitizePathSegment('日本語')).toBe('日本語')
+  })
+
+  it('should remove filesystem unsafe characters', () => {
+    expect(sanitizePathSegment('work/flow?name*')).not.toContain('/')
+    expect(sanitizePathSegment('work/flow?name*')).not.toContain('?')
+    expect(sanitizePathSegment('work/flow?name*')).not.toContain('*')
+  })
+})

--- a/apps/sim/lib/workflows/operations/import-export.ts
+++ b/apps/sim/lib/workflows/operations/import-export.ts
@@ -48,7 +48,7 @@ export interface WorkspaceExportStructure {
  * Sanitizes a string for use as a path segment in a ZIP file.
  */
 export function sanitizePathSegment(name: string): string {
-  return name.replace(/[^a-z0-9-_]/gi, '-')
+  return name.replace(/[^\p{L}\p{N}\-_]/gu, '-').replace(/-+/g, '-')
 }
 
 /**


### PR DESCRIPTION
## Summary
Workflow names containing Non-ASCII characters (like Korean) were being sanitized into dashes because of a restrictive regex in `sanitizePathSegment`.

This PR updates the regex to be Unicode-aware, allowing letters and numbers from any language while still stripping truly unsafe filesystem characters.

## Changes
- Updated `sanitizePathSegment` in `apps/sim/lib/workflows/operations/import-export.ts`
- Added unit tests in `apps/sim/lib/workflows/operations/import-export.test.ts`

Fixes #4119