### PR TITLE
feat(logs): add cancel execution to log row context menu

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-row-context-menu/log-row-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-row-context-menu/log-row-context-menu.tsx
@@ -22,6 +22,7 @@ interface LogRowContextMenuProps {
   onOpenPreview: () => void
   onToggleWorkflowFilter: () => void
   onClearAllFilters: () => void
+  onCancelExecution: () => void
   isFilteredByThisWorkflow: boolean
   hasActiveFilters: boolean
 }
@@ -41,11 +42,13 @@ export const LogRowContextMenu = memo(function LogRowContextMenu({
   onOpenPreview,
   onToggleWorkflowFilter,
   onClearAllFilters,
+  onCancelExecution,
   isFilteredByThisWorkflow,
   hasActiveFilters,
 }: LogRowContextMenuProps) {
   const hasExecutionId = Boolean(log?.executionId)
   const hasWorkflow = Boolean(log?.workflow?.id || log?.workflowId)
+  const isRunning = log?.status === 'running' && hasExecutionId && hasWorkflow
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={(open) => !open && onClose()} modal={false}>
@@ -69,6 +72,15 @@ export const LogRowContextMenu = memo(function LogRowContextMenu({
         sideOffset={4}
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
+        {isRunning && (
+          <>
+            <DropdownMenuItem onSelect={onCancelExecution} className='text-destructive'>
+              <X />
+              Cancel Execution
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
         <DropdownMenuItem disabled={!hasExecutionId} onSelect={onCopyExecutionId}>
           <Copy />
           Copy Execution ID

--- a/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
@@ -54,6 +54,7 @@ import { getBlock } from '@/blocks/registry'
 import { useFolderMap, useFolders } from '@/hooks/queries/folders'
 import {
   prefetchLogDetail,
+  useCancelExecution,
   useDashboardStats,
   useLogDetail,
   useLogsList,
@@ -532,6 +533,17 @@ export default function Logs() {
       setPreviewLogId(contextMenuLog.id)
       setIsPreviewOpen(true)
     }
+  }, [contextMenuLog])
+
+  const cancelExecution = useCancelExecution()
+
+  const handleCancelExecution = useCallback(() => {
+    const workflowId = contextMenuLog?.workflow?.id || contextMenuLog?.workflowId
+    const executionId = contextMenuLog?.executionId
+    if (workflowId && executionId) {
+      cancelExecution.mutate({ workflowId, executionId })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contextMenuLog])
 
   const contextMenuWorkflowId = contextMenuLog?.workflow?.id || contextMenuLog?.workflowId
@@ -1178,6 +1190,7 @@ export default function Logs() {
         onCopyLink={handleCopyLink}
         onOpenWorkflow={handleOpenWorkflow}
         onOpenPreview={handleOpenPreview}
+        onCancelExecution={handleCancelExecution}
         onToggleWorkflowFilter={handleToggleWorkflowFilter}
         onClearAllFilters={handleClearAllFilters}
         isFilteredByThisWorkflow={isFilteredByThisWorkflow}

--- a/apps/sim/hooks/queries/logs.ts
+++ b/apps/sim/hooks/queries/logs.ts
@@ -2,7 +2,9 @@ import {
   keepPreviousData,
   type QueryClient,
   useInfiniteQuery,
+  useMutation,
   useQuery,
+  useQueryClient,
 } from '@tanstack/react-query'
 import { getEndDateFromTimeRange, getStartDateFromTimeRange } from '@/lib/logs/filters'
 import { parseQuery, queryToApiParams } from '@/lib/logs/query-parser'
@@ -271,5 +273,21 @@ export function useExecutionSnapshot(executionId: string | undefined) {
     queryFn: ({ signal }) => fetchExecutionSnapshot(executionId as string, signal),
     enabled: Boolean(executionId),
     staleTime: 5 * 60 * 1000, // 5 minutes - execution snapshots don't change
+  })
+}
+
+export function useCancelExecution() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ workflowId, executionId }: { workflowId: string; executionId: string }) => {
+      const res = await fetch(`/api/workflows/${workflowId}/executions/${executionId}/cancel`, {
+        method: 'POST',
+      })
+      if (!res.ok) throw new Error('Failed to cancel execution')
+      return res.json()
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: logKeys.all })
+    },
   })
 }

--- a/apps/sim/hooks/queries/logs.ts
+++ b/apps/sim/hooks/queries/logs.ts
@@ -290,10 +290,14 @@ export function useCancelExecution() {
         method: 'POST',
       })
       if (!res.ok) throw new Error('Failed to cancel execution')
-      return res.json()
+      const data = await res.json()
+      if (!data.success) throw new Error('Failed to cancel execution')
+      return data
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: logKeys.all })
+      queryClient.invalidateQueries({ queryKey: logKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: logKeys.details() })
+      queryClient.invalidateQueries({ queryKey: [...logKeys.all, 'stats'] })
     },
   })
 }

--- a/apps/sim/hooks/queries/logs.ts
+++ b/apps/sim/hooks/queries/logs.ts
@@ -279,7 +279,13 @@ export function useExecutionSnapshot(executionId: string | undefined) {
 export function useCancelExecution() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async ({ workflowId, executionId }: { workflowId: string; executionId: string }) => {
+    mutationFn: async ({
+      workflowId,
+      executionId,
+    }: {
+      workflowId: string
+      executionId: string
+    }) => {
       const res = await fetch(`/api/workflows/${workflowId}/executions/${executionId}/cancel`, {
         method: 'POST',
       })


### PR DESCRIPTION
## Summary
- Add "Cancel Execution" option to the log row right-click context menu for running logs
- Wire existing cancel API endpoint (`/api/workflows/{id}/executions/{executionId}/cancel`) to the logs UI
- Add `useCancelExecution` mutation hook with full log cache invalidation

## Type of Change
- [x] New feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)