### PR TITLE
fix(ui): fix resource tag transition from home to task

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -296,6 +296,14 @@ export function Home({ chatId }: HomeProps = {}) {
     [resolveResourceFromContext, addResource, handleResourceEvent]
   )
 
+  const handleInitialContextRemove = useCallback(
+    (context: ChatContext) => {
+      const resolved = resolveResourceFromContext(context)
+      if (resolved) removeResource(resolved.type, resolved.id)
+    },
+    [resolveResourceFromContext, removeResource]
+  )
+
   const handleWorkspaceResourceSelect = useCallback(
     (resource: MothershipResource) => {
       const wasAdded = addResource(resource)
@@ -345,6 +353,7 @@ export function Home({ chatId }: HomeProps = {}) {
               onStopGeneration={handleStopGeneration}
               userId={session?.user?.id}
               onContextAdd={handleContextAdd}
+              onContextRemove={handleInitialContextRemove}
             />
           </div>
         </div>

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
@@ -951,7 +951,7 @@ export function useChat(
   selectedChatIdRef.current = initialChatId
   const appliedChatHistoryKeyRef = useRef<string | undefined>(undefined)
   const activeTurnRef = useRef<ActiveTurn | null>(null)
-  const pendingUserMsgRef = useRef<{ id: string; content: string } | null>(null)
+  const pendingUserMsgRef = useRef<PersistedMessage | null>(null)
   const streamIdRef = useRef<string | undefined>(undefined)
   const locallyTerminalStreamIdRef = useRef<string | undefined>(undefined)
   const lastCursorRef = useRef('0')
@@ -1079,6 +1079,7 @@ export function useChat(
 
   const removeResource = useCallback((resourceType: MothershipResourceType, resourceId: string) => {
     setResources((prev) => prev.filter((r) => !(r.type === resourceType && r.id === resourceId)))
+    setActiveResourceId((prev) => (prev === resourceId ? null : prev))
   }, [])
 
   const reorderResources = useCallback((newOrder: MothershipResource[]) => {
@@ -1594,16 +1595,9 @@ export function useChat(
                     queryClient.setQueryData<TaskChatHistory>(taskKeys.detail(payloadChatId), {
                       id: payloadChatId,
                       title: null,
-                      messages: [
-                        {
-                          id: userMsg.id,
-                          role: 'user',
-                          content: userMsg.content,
-                          timestamp: new Date().toISOString(),
-                        },
-                      ],
+                      messages: [userMsg],
                       activeStreamId,
-                      resources: [],
+                      resources: resourcesRef.current,
                     })
                   }
                   if (!workflowIdRef.current) {
@@ -2652,7 +2646,6 @@ export function useChat(
       const userMessageId = generateId()
       const assistantId = generateId()
 
-      pendingUserMsgRef.current = { id: userMessageId, content: message }
       streamIdRef.current = userMessageId
       lastCursorRef.current = '0'
       resetStreamingBuffers()
@@ -2686,6 +2679,7 @@ export function useChat(
         ...(storedAttachments && { fileAttachments: storedAttachments }),
         ...(messageContexts && messageContexts.length > 0 ? { contexts: messageContexts } : {}),
       }
+      pendingUserMsgRef.current = cachedUserMsg
 
       const userAttachments = storedAttachments?.map((f) => ({
         id: f.id,

--- a/apps/sim/lib/copilot/chat/post.ts
+++ b/apps/sim/lib/copilot/chat/post.ts
@@ -30,6 +30,7 @@ import {
   releasePendingChatStream,
 } from '@/lib/copilot/request/session'
 import type { ExecutionContext, OrchestratorResult } from '@/lib/copilot/request/types'
+import { persistChatResources } from '@/lib/copilot/resources/persistence'
 import { taskPubSub } from '@/lib/copilot/tasks'
 import { prepareExecutionContext } from '@/lib/copilot/tools/handlers/context'
 import { getEffectiveDecryptedEnv } from '@/lib/environment/utils'
@@ -56,6 +57,14 @@ const ResourceAttachmentSchema = z.object({
   title: z.string().optional(),
   active: z.boolean().optional(),
 })
+
+const GENERIC_RESOURCE_TITLE: Record<z.infer<typeof ResourceAttachmentSchema>['type'], string> = {
+  workflow: 'Workflow',
+  table: 'Table',
+  file: 'File',
+  knowledgebase: 'Knowledge Base',
+  folder: 'Folder',
+}
 
 const ChatContextSchema = z.object({
   kind: z.enum([
@@ -549,6 +558,7 @@ export async function handleUnifiedChatPost(req: NextRequest) {
 
     let currentChat: ChatLoadResult['chat'] = null
     let conversationHistory: unknown[] = []
+    let chatIsNew = false
     actualChatId = body.chatId
 
     if (body.chatId || body.createNewChat) {
@@ -562,6 +572,7 @@ export async function handleUnifiedChatPost(req: NextRequest) {
       })
       currentChat = chatResult.chat
       actualChatId = chatResult.chatId || body.chatId
+      chatIsNew = chatResult.isNew
       conversationHistory = Array.isArray(chatResult.conversationHistory)
         ? chatResult.conversationHistory
         : []
@@ -569,6 +580,17 @@ export async function handleUnifiedChatPost(req: NextRequest) {
       if (body.chatId && !currentChat) {
         return NextResponse.json({ error: 'Chat not found' }, { status: 404 })
       }
+    }
+
+    if (chatIsNew && actualChatId && body.resourceAttachments?.length) {
+      await persistChatResources(
+        actualChatId,
+        body.resourceAttachments.map((r) => ({
+          type: r.type,
+          id: r.id,
+          title: r.title ?? GENERIC_RESOURCE_TITLE[r.type],
+        }))
+      )
     }
 
     if (actualChatId) {


### PR DESCRIPTION
## Summary
Resource tags were getting lost between home and task pages. This was because:
1. Backend post didn't receive tagged resources and didn't save them
2. Frontend ui didn't optimistically save the tag/item, so the @ symbol wasn't rendering as the resource and the resource tab didn't open until later

Fixed both by persisting tagged resources to initial chat request and optimistically using tag between home and resource page.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Tested locally, deleting resources, multiple resources, copilot chats.
## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
