### PR TITLE
fix(atlassian): unify error message extraction across all routes

### DIFF
--- a/apps/docs/content/docs/en/tools/jira_service_management.mdx
+++ b/apps/docs/content/docs/en/tools/jira_service_management.mdx
@@ -117,7 +117,7 @@ Create a new service request in Jira Service Management
 | `description` | string | No | Description for the service request |
 | `raiseOnBehalfOf` | string | No | Account ID of customer to raise request on behalf of |
 | `requestFieldValues` | json | No | Request field values as key-value pairs \(overrides summary/description if provided\) |
-| `formAnswers` | json | No | Form answers for form-based request types \(e.g., \{"summary": \{"text": "Title"\}, "customfield_10010": \{"choices": \["10320"\]\}\}\) |
+| `formAnswers` | json | No | Form answers using numeric form question IDs as keys \(e.g., \{"1": \{"text": "Title"\}, "4": \{"choices": \["5"\]\}\}\). Keys are question IDs from the Jira Form, not Jira field names. |
 | `requestParticipants` | string | No | Comma-separated account IDs to add as request participants |
 | `channel` | string | No | Channel the request originates from \(e.g., portal, email\) |
 

--- a/apps/docs/content/docs/en/tools/trello.mdx
+++ b/apps/docs/content/docs/en/tools/trello.mdx
@@ -36,6 +36,7 @@ Before connecting Trello in Sim, add your Sim app origin to the **Allowed Origin
 Trello's authorization flow redirects back to Sim using a `return_url`. If your Sim origin is not whitelisted in Trello, Trello will block the redirect and the connection flow will fail before Sim can save the token.
 {/* MANUAL-CONTENT-END */}
 
+
 Integrate with Trello to list board lists, list cards, create cards, update cards, review activity, and add comments.
 
 

--- a/apps/sim/app/(landing)/integrations/data/integrations.json
+++ b/apps/sim/app/(landing)/integrations/data/integrations.json
@@ -2374,7 +2374,7 @@
     "authType": "none",
     "category": "tools",
     "integrationTypes": ["security", "analytics", "developer-tools"],
-    "tags": ["monitoring", "security"]
+    "tags": ["identity", "monitoring"]
   },
   {
     "type": "cursor_v2",

--- a/apps/sim/app/api/tools/confluence/attachment/route.ts
+++ b/apps/sim/app/api/tools/confluence/attachment/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceAttachmentAPI')
 
@@ -53,15 +54,16 @@ export async function DELETE(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to delete Confluence attachment (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     return NextResponse.json({ attachmentId, deleted: true })

--- a/apps/sim/app/api/tools/confluence/attachments/route.ts
+++ b/apps/sim/app/api/tools/confluence/attachments/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceAttachmentsAPI')
 
@@ -64,15 +65,16 @@ export async function GET(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to list Confluence attachments (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/blogposts/route.ts
+++ b/apps/sim/app/api/tools/confluence/blogposts/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceBlogPostsAPI')
 
@@ -98,14 +99,16 @@ export async function GET(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to list blog posts (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -197,14 +200,16 @@ export async function POST(request: NextRequest) {
       })
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => null)
+        const errorText = await response.text()
         logger.error('Confluence API error response:', {
           status: response.status,
           statusText: response.statusText,
-          error: JSON.stringify(errorData, null, 2),
+          error: errorText,
         })
-        const errorMessage = errorData?.message || `Failed to create blog post (${response.status})`
-        return NextResponse.json({ error: errorMessage }, { status: response.status })
+        return NextResponse.json(
+          { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+          { status: response.status }
+        )
       }
 
       const data = await response.json()
@@ -253,14 +258,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to get blog post (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -326,7 +333,10 @@ export async function PUT(request: NextRequest) {
     })
 
     if (!currentResponse.ok) {
-      throw new Error(`Failed to fetch current blog post: ${currentResponse.status}`)
+      const errorText = await currentResponse.text()
+      throw new Error(
+        parseAtlassianErrorMessage(currentResponse.status, currentResponse.statusText, errorText)
+      )
     }
 
     const currentPost = await currentResponse.json()
@@ -362,14 +372,16 @@ export async function PUT(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to update blog post (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -426,14 +438,16 @@ export async function DELETE(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to delete blog post (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     return NextResponse.json({ blogPostId, deleted: true })

--- a/apps/sim/app/api/tools/confluence/comment/route.ts
+++ b/apps/sim/app/api/tools/confluence/comment/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceCommentAPI')
 
@@ -81,7 +82,10 @@ export async function PUT(request: NextRequest) {
     })
 
     if (!getResponse.ok) {
-      throw new Error(`Failed to fetch current comment: ${getResponse.status}`)
+      const errorText = await getResponse.text()
+      throw new Error(
+        parseAtlassianErrorMessage(getResponse.status, getResponse.statusText, errorText)
+      )
     }
 
     const currentComment = await getResponse.json()
@@ -111,15 +115,16 @@ export async function PUT(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to update Confluence comment (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -169,15 +174,16 @@ export async function DELETE(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to delete Confluence comment (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     return NextResponse.json({ commentId, deleted: true })

--- a/apps/sim/app/api/tools/confluence/comments/route.ts
+++ b/apps/sim/app/api/tools/confluence/comments/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceCommentsAPI')
 
@@ -69,15 +70,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to create Confluence comment (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -149,15 +151,16 @@ export async function GET(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to list Confluence comments (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/create-page/route.ts
+++ b/apps/sim/app/api/tools/confluence/create-page/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceCreatePageAPI')
 
@@ -101,31 +102,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-
-      let errorMessage = `Failed to create Confluence page (${response.status})`
-      if (errorData?.message) {
-        errorMessage = errorData.message
-      } else if (errorData?.errors && Array.isArray(errorData.errors)) {
-        const firstError = errorData.errors[0]
-        if (firstError?.title) {
-          if (firstError.title.includes("'spaceId'") && firstError.title.includes('Long')) {
-            errorMessage =
-              'Invalid Space ID. Use the list spaces operation to find valid space IDs.'
-          } else {
-            errorMessage = firstError.title
-          }
-        } else {
-          errorMessage = JSON.stringify(errorData.errors)
-        }
-      }
-
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/create-page/route.ts
+++ b/apps/sim/app/api/tools/confluence/create-page/route.ts
@@ -108,10 +108,11 @@ export async function POST(request: NextRequest) {
         statusText: response.statusText,
         error: errorText,
       })
-      return NextResponse.json(
-        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
-        { status: response.status }
-      )
+      let errorMessage = parseAtlassianErrorMessage(response.status, response.statusText, errorText)
+      if (errorMessage.includes("'spaceId'") && errorMessage.includes('Long')) {
+        errorMessage = 'Invalid Space ID. Use the list spaces operation to find valid space IDs.'
+      }
+      return NextResponse.json({ error: errorMessage }, { status: response.status })
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/labels/route.ts
+++ b/apps/sim/app/api/tools/confluence/labels/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceLabelsAPI')
 
@@ -73,15 +74,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to add Confluence label (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -158,15 +160,16 @@ export async function GET(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to list Confluence labels (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -248,15 +251,16 @@ export async function DELETE(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to delete Confluence label (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     return NextResponse.json({

--- a/apps/sim/app/api/tools/confluence/page-ancestors/route.ts
+++ b/apps/sim/app/api/tools/confluence/page-ancestors/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluencePageAncestorsAPI')
 
@@ -62,14 +63,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to get page ancestors (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/page-children/route.ts
+++ b/apps/sim/app/api/tools/confluence/page-children/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluencePageChildrenAPI')
 
@@ -66,14 +67,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to get child pages (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/page-descendants/route.ts
+++ b/apps/sim/app/api/tools/confluence/page-descendants/route.ts
@@ -7,6 +7,7 @@ import {
   validatePaginationCursor,
 } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluencePageDescendantsAPI')
 
@@ -74,15 +75,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to get page descendants (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/page-properties/route.ts
+++ b/apps/sim/app/api/tools/confluence/page-properties/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluencePagePropertiesAPI')
 
@@ -95,15 +96,16 @@ export async function GET(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to list page properties (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -176,15 +178,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to create page property (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -267,15 +270,16 @@ export async function PUT(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to update page property (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -343,15 +347,16 @@ export async function DELETE(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to delete page property (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     return NextResponse.json({ propertyId, pageId, deleted: true })

--- a/apps/sim/app/api/tools/confluence/page-versions/route.ts
+++ b/apps/sim/app/api/tools/confluence/page-versions/route.ts
@@ -8,6 +8,7 @@ import {
   validatePaginationCursor,
 } from '@/lib/core/security/input-validation'
 import { cleanHtmlContent, getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluencePageVersionsAPI')
 
@@ -91,15 +92,22 @@ export async function POST(request: NextRequest) {
       ])
 
       if (!versionResponse.ok) {
-        const errorData = await versionResponse.json().catch(() => null)
+        const errorText = await versionResponse.text()
         logger.error('Confluence API error response:', {
           status: versionResponse.status,
           statusText: versionResponse.statusText,
-          error: JSON.stringify(errorData, null, 2),
+          error: errorText,
         })
-        const errorMessage =
-          errorData?.message || `Failed to get page version (${versionResponse.status})`
-        return NextResponse.json({ error: errorMessage }, { status: versionResponse.status })
+        return NextResponse.json(
+          {
+            error: parseAtlassianErrorMessage(
+              versionResponse.status,
+              versionResponse.statusText,
+              errorText
+            ),
+          },
+          { status: versionResponse.status }
+        )
       }
 
       const versionData = await versionResponse.json()
@@ -166,14 +174,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to list page versions (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/page/route.ts
+++ b/apps/sim/app/api/tools/confluence/page/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluencePageAPI')
 
@@ -110,19 +111,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      logger.error(`Confluence API error: ${response.status} ${response.statusText}`)
-      let errorMessage
-
-      try {
-        const errorData = await response.json()
-        logger.error('Error details:', JSON.stringify(errorData, null, 2))
-        errorMessage = errorData.message || `Failed to fetch Confluence page (${response.status})`
-      } catch (e) {
-        logger.error('Could not parse error response as JSON:', e)
-        errorMessage = `Failed to fetch Confluence page: ${response.status} ${response.statusText}`
-      }
-
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      const errorText = await response.text()
+      logger.error('Confluence API error response:', {
+        status: response.status,
+        statusText: response.statusText,
+        error: errorText,
+      })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -194,7 +192,14 @@ export async function PUT(request: NextRequest) {
     })
 
     if (!currentPageResponse.ok) {
-      throw new Error(`Failed to fetch current page: ${currentPageResponse.status}`)
+      const errorText = await currentPageResponse.text()
+      throw new Error(
+        parseAtlassianErrorMessage(
+          currentPageResponse.status,
+          currentPageResponse.statusText,
+          errorText
+        )
+      )
     }
 
     const currentPage = await currentPageResponse.json()
@@ -238,17 +243,16 @@ export async function PUT(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message ||
-        (errorData?.errors && JSON.stringify(errorData.errors)) ||
-        `Failed to update Confluence page (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -302,15 +306,16 @@ export async function DELETE(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to delete Confluence page (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     return NextResponse.json({ pageId, deleted: true })

--- a/apps/sim/app/api/tools/confluence/pages-by-label/route.ts
+++ b/apps/sim/app/api/tools/confluence/pages-by-label/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluencePagesByLabelAPI')
 
@@ -63,14 +64,16 @@ export async function GET(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to get pages by label (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/pages/route.ts
+++ b/apps/sim/app/api/tools/confluence/pages/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluencePagesAPI')
 
@@ -66,26 +67,16 @@ export async function POST(request: NextRequest) {
     logger.info('Response status:', response.status, response.statusText)
 
     if (!response.ok) {
-      logger.error(`Confluence API error: ${response.status} ${response.statusText}`)
-      let errorMessage
-
-      try {
-        const errorData = await response.json()
-        logger.error('Error details:', JSON.stringify(errorData, null, 2))
-        errorMessage = errorData.message || `Failed to fetch Confluence pages (${response.status})`
-      } catch (e) {
-        logger.error('Could not parse error response as JSON:', e)
-
-        try {
-          const text = await response.text()
-          logger.error('Response text:', text)
-          errorMessage = `Failed to fetch Confluence pages: ${response.status} ${response.statusText}`
-        } catch (_textError) {
-          errorMessage = `Failed to fetch Confluence pages: ${response.status} ${response.statusText}`
-        }
-      }
-
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      const errorText = await response.text()
+      logger.error('Confluence API error response:', {
+        status: response.status,
+        statusText: response.statusText,
+        error: errorText,
+      })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/search-in-space/route.ts
+++ b/apps/sim/app/api/tools/confluence/search-in-space/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceSearchInSpaceAPI')
 
@@ -83,14 +84,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to search in space (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/search/route.ts
+++ b/apps/sim/app/api/tools/confluence/search/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -60,14 +61,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to search Confluence (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/selector-spaces/route.ts
+++ b/apps/sim/app/api/tools/confluence/selector-spaces/route.ts
@@ -5,6 +5,7 @@ import { validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceSelectorSpacesAPI')
 
@@ -67,15 +68,16 @@ export async function POST(request: Request) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
-      logger.error('Confluence API error:', {
+      const errorText = await response.text()
+      logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: errorData,
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to list Confluence spaces (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/space-blogposts/route.ts
+++ b/apps/sim/app/api/tools/confluence/space-blogposts/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceSpaceBlogPostsAPI')
 
@@ -83,15 +84,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to list blog posts in space (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/space-labels/route.ts
+++ b/apps/sim/app/api/tools/confluence/space-labels/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceSpaceLabelsAPI')
 
@@ -63,14 +64,16 @@ export async function GET(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to list space labels (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/space-pages/route.ts
+++ b/apps/sim/app/api/tools/confluence/space-pages/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceSpacePagesAPI')
 
@@ -83,15 +84,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to list pages in space (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/space-permissions/route.ts
+++ b/apps/sim/app/api/tools/confluence/space-permissions/route.ts
@@ -7,6 +7,7 @@ import {
   validatePaginationCursor,
 } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceSpacePermissionsAPI')
 
@@ -74,15 +75,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to list space permissions (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/space-properties/route.ts
+++ b/apps/sim/app/api/tools/confluence/space-properties/route.ts
@@ -7,6 +7,7 @@ import {
   validatePaginationCursor,
 } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceSpacePropertiesAPI')
 
@@ -99,15 +100,16 @@ export async function POST(request: NextRequest) {
       })
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => null)
+        const errorText = await response.text()
         logger.error('Confluence API error response:', {
           status: response.status,
           statusText: response.statusText,
-          error: JSON.stringify(errorData, null, 2),
+          error: errorText,
         })
-        const errorMessage =
-          errorData?.message || `Failed to delete space property (${response.status})`
-        return NextResponse.json({ error: errorMessage }, { status: response.status })
+        return NextResponse.json(
+          { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+          { status: response.status }
+        )
       }
 
       return NextResponse.json({ spaceId, propertyId, deleted: true })
@@ -128,15 +130,16 @@ export async function POST(request: NextRequest) {
       })
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => null)
+        const errorText = await response.text()
         logger.error('Confluence API error response:', {
           status: response.status,
           statusText: response.statusText,
-          error: JSON.stringify(errorData, null, 2),
+          error: errorText,
         })
-        const errorMessage =
-          errorData?.message || `Failed to create space property (${response.status})`
-        return NextResponse.json({ error: errorMessage }, { status: response.status })
+        return NextResponse.json(
+          { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+          { status: response.status }
+        )
       }
 
       const data = await response.json()
@@ -173,15 +176,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to list space properties (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/space/route.ts
+++ b/apps/sim/app/api/tools/confluence/space/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceSpaceAPI')
 
@@ -57,15 +58,16 @@ export async function GET(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to get Confluence space (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -136,14 +138,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to create space (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -216,8 +220,15 @@ export async function PUT(request: NextRequest) {
         },
       })
       if (!currentResponse.ok) {
+        const errorText = await currentResponse.text()
         return NextResponse.json(
-          { error: `Failed to fetch current space: ${currentResponse.status}` },
+          {
+            error: parseAtlassianErrorMessage(
+              currentResponse.status,
+              currentResponse.statusText,
+              errorText
+            ),
+          },
           { status: currentResponse.status }
         )
       }
@@ -242,14 +253,16 @@ export async function PUT(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to update space (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -314,14 +327,16 @@ export async function DELETE(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to delete space (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     return NextResponse.json({ spaceId, deleted: true })

--- a/apps/sim/app/api/tools/confluence/spaces/route.ts
+++ b/apps/sim/app/api/tools/confluence/spaces/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceSpacesAPI')
 
@@ -54,15 +55,16 @@ export async function GET(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to list Confluence spaces (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/tasks/route.ts
+++ b/apps/sim/app/api/tools/confluence/tasks/route.ts
@@ -8,6 +8,7 @@ import {
   validatePathSegment,
 } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceTasksAPI')
 
@@ -72,9 +73,17 @@ export async function POST(request: NextRequest) {
       })
 
       if (!getResponse.ok) {
-        const errorData = await getResponse.json().catch(() => null)
-        const errorMessage = errorData?.message || `Failed to fetch task (${getResponse.status})`
-        return NextResponse.json({ error: errorMessage }, { status: getResponse.status })
+        const errorText = await getResponse.text()
+        return NextResponse.json(
+          {
+            error: parseAtlassianErrorMessage(
+              getResponse.status,
+              getResponse.statusText,
+              errorText
+            ),
+          },
+          { status: getResponse.status }
+        )
       }
 
       const currentTask = await getResponse.json()
@@ -99,14 +108,16 @@ export async function POST(request: NextRequest) {
       })
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => null)
+        const errorText = await response.text()
         logger.error('Confluence API error response:', {
           status: response.status,
           statusText: response.statusText,
-          error: JSON.stringify(errorData, null, 2),
+          error: errorText,
         })
-        const errorMessage = errorData?.message || `Failed to update task (${response.status})`
-        return NextResponse.json({ error: errorMessage }, { status: response.status })
+        return NextResponse.json(
+          { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+          { status: response.status }
+        )
       }
 
       const data = await response.json()
@@ -150,14 +161,16 @@ export async function POST(request: NextRequest) {
       })
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => null)
+        const errorText = await response.text()
         logger.error('Confluence API error response:', {
           status: response.status,
           statusText: response.statusText,
-          error: JSON.stringify(errorData, null, 2),
+          error: errorText,
         })
-        const errorMessage = errorData?.message || `Failed to get task (${response.status})`
-        return NextResponse.json({ error: errorMessage }, { status: response.status })
+        return NextResponse.json(
+          { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+          { status: response.status }
+        )
       }
 
       const data = await response.json()
@@ -233,14 +246,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage = errorData?.message || `Failed to list tasks (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/upload-attachment/route.ts
+++ b/apps/sim/app/api/tools/confluence/upload-attachment/route.ts
@@ -5,6 +5,7 @@ import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security
 import { processSingleFileToUserFile } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceUploadAttachmentAPI')
 
@@ -105,21 +106,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-
-      let errorMessage = `Failed to upload attachment to Confluence (${response.status})`
-      if (errorData?.message) {
-        errorMessage = errorData.message
-      } else if (errorData?.errorMessage) {
-        errorMessage = errorData.errorMessage
-      }
-
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/confluence/user/route.ts
+++ b/apps/sim/app/api/tools/confluence/user/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validatePathSegment } from '@/lib/core/security/input-validation'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
+import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('ConfluenceUserAPI')
 
@@ -62,15 +63,16 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => null)
+      const errorText = await response.text()
       logger.error('Confluence API error response:', {
         status: response.status,
         statusText: response.statusText,
-        error: JSON.stringify(errorData, null, 2),
+        error: errorText,
       })
-      const errorMessage =
-        errorData?.message || `Failed to get Confluence user (${response.status})`
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()

--- a/apps/sim/app/api/tools/jira/add-attachment/route.ts
+++ b/apps/sim/app/api/tools/jira/add-attachment/route.ts
@@ -5,7 +5,7 @@ import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { RawFileInputArraySchema } from '@/lib/uploads/utils/file-schemas'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
-import { getJiraCloudId } from '@/tools/jira/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('JiraAddAttachmentAPI')
 
@@ -77,7 +77,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         {
           success: false,
-          error: `Failed to upload attachments: ${response.statusText}`,
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
         },
         { status: response.status }
       )

--- a/apps/sim/app/api/tools/jira/issues/route.ts
+++ b/apps/sim/app/api/tools/jira/issues/route.ts
@@ -2,19 +2,15 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import { getJiraCloudId } from '@/tools/jira/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 export const dynamic = 'force-dynamic'
 
 const logger = createLogger('JiraIssuesAPI')
 
-const createErrorResponse = async (response: Response, defaultMessage: string) => {
-  try {
-    const errorData = await response.json()
-    return errorData.message || errorData.errorMessages?.[0] || defaultMessage
-  } catch {
-    return defaultMessage
-  }
+const createErrorResponse = async (response: Response) => {
+  const errorText = await response.text().catch(() => '')
+  return parseAtlassianErrorMessage(response.status, response.statusText, errorText)
 }
 
 const validateRequiredParams = (domain: string | null, accessToken: string | null) => {
@@ -70,10 +66,7 @@ export async function POST(request: NextRequest) {
 
     if (!response.ok) {
       logger.error(`Jira API error: ${response.status} ${response.statusText}`)
-      const errorMessage = await createErrorResponse(
-        response,
-        `Failed to fetch Jira issues (${response.status})`
-      )
+      const errorMessage = await createErrorResponse(response)
       if (response.status === 401 || response.status === 403) {
         return NextResponse.json(
           {
@@ -199,10 +192,7 @@ export async function GET(request: NextRequest) {
         })
 
         if (!response.ok) {
-          const errorMessage = await createErrorResponse(
-            response,
-            `Failed to fetch issues (${response.status})`
-          )
+          const errorMessage = await createErrorResponse(response)
           if (response.status === 401 || response.status === 403) {
             return NextResponse.json(
               {

--- a/apps/sim/app/api/tools/jira/projects/route.ts
+++ b/apps/sim/app/api/tools/jira/projects/route.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import { getJiraCloudId } from '@/tools/jira/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -60,16 +60,12 @@ export async function GET(request: NextRequest) {
     logger.info(`Response status: ${response.status} ${response.statusText}`)
 
     if (!response.ok) {
-      logger.error(`Jira API error: ${response.status} ${response.statusText}`)
-      let errorMessage
-      try {
-        const errorData = await response.json()
-        logger.error('Error details:', errorData)
-        errorMessage = errorData.message || `Failed to fetch projects (${response.status})`
-      } catch (_e) {
-        errorMessage = `Failed to fetch projects: ${response.status} ${response.statusText}`
-      }
-      return NextResponse.json({ error: errorMessage }, { status: response.status })
+      const errorText = await response.text()
+      logger.error('Jira API error:', { status: response.status, error: errorText })
+      return NextResponse.json(
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        { status: response.status }
+      )
     }
 
     const data = await response.json()
@@ -148,10 +144,10 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const errorData = await response.json()
-      logger.error('Error details:', errorData)
+      const errorText = await response.text()
+      logger.error('Jira API error:', { status: response.status, error: errorText })
       return NextResponse.json(
-        { error: errorData.message || `Failed to fetch project (${response.status})` },
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jira/update/route.ts
+++ b/apps/sim/app/api/tools/jira/update/route.ts
@@ -3,7 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import { getJiraCloudId } from '@/tools/jira/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -188,7 +188,7 @@ export async function PUT(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `Jira API error: ${response.status} ${response.statusText}`, details: errorText },
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jira/update/route.ts
+++ b/apps/sim/app/api/tools/jira/update/route.ts
@@ -188,7 +188,10 @@ export async function PUT(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        {
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jira/write/route.ts
+++ b/apps/sim/app/api/tools/jira/write/route.ts
@@ -197,7 +197,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
+        {
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jira/write/route.ts
+++ b/apps/sim/app/api/tools/jira/write/route.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import { getJiraCloudId } from '@/tools/jira/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -197,7 +197,7 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `Jira API error: ${response.status} ${response.statusText}`, details: errorText },
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/approvals/route.ts
+++ b/apps/sim/app/api/tools/jsm/approvals/route.ts
@@ -7,12 +7,8 @@ import {
   validateJiraCloudId,
   validateJiraIssueKey,
 } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -104,7 +100,7 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json(
           {
-            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
             details: errorText,
           },
           { status: response.status }
@@ -160,7 +156,7 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json(
           {
-            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
             details: errorText,
           },
           { status: response.status }

--- a/apps/sim/app/api/tools/jsm/approvals/route.ts
+++ b/apps/sim/app/api/tools/jsm/approvals/route.ts
@@ -7,7 +7,12 @@ import {
   validateJiraCloudId,
   validateJiraIssueKey,
 } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -98,7 +103,10 @@ export async function POST(request: NextRequest) {
         })
 
         return NextResponse.json(
-          { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+          {
+            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            details: errorText,
+          },
           { status: response.status }
         )
       }
@@ -151,7 +159,10 @@ export async function POST(request: NextRequest) {
         })
 
         return NextResponse.json(
-          { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+          {
+            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            details: errorText,
+          },
           { status: response.status }
         )
       }

--- a/apps/sim/app/api/tools/jsm/comment/route.ts
+++ b/apps/sim/app/api/tools/jsm/comment/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -86,7 +82,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/comment/route.ts
+++ b/apps/sim/app/api/tools/jsm/comment/route.ts
@@ -2,7 +2,12 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -80,7 +85,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/comments/route.ts
+++ b/apps/sim/app/api/tools/jsm/comments/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -88,7 +84,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/comments/route.ts
+++ b/apps/sim/app/api/tools/jsm/comments/route.ts
@@ -2,7 +2,12 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -82,7 +87,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/customers/route.ts
+++ b/apps/sim/app/api/tools/jsm/customers/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -101,7 +97,7 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json(
           {
-            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
             details: errorText,
           },
           { status: response.status }
@@ -141,7 +137,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/customers/route.ts
+++ b/apps/sim/app/api/tools/jsm/customers/route.ts
@@ -2,7 +2,12 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -95,7 +100,10 @@ export async function POST(request: NextRequest) {
         })
 
         return NextResponse.json(
-          { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+          {
+            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            details: errorText,
+          },
           { status: response.status }
         )
       }
@@ -132,7 +140,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/forms/issue/route.ts
+++ b/apps/sim/app/api/tools/jsm/forms/issue/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmFormsApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmFormsApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -70,7 +66,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/forms/structure/route.ts
+++ b/apps/sim/app/api/tools/jsm/forms/structure/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmFormsApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmFormsApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -80,7 +76,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/forms/templates/route.ts
+++ b/apps/sim/app/api/tools/jsm/forms/templates/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmFormsApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmFormsApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -70,7 +66,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/organization/route.ts
+++ b/apps/sim/app/api/tools/jsm/organization/route.ts
@@ -6,7 +6,12 @@ import {
   validateEnum,
   validateJiraCloudId,
 } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -86,7 +91,10 @@ export async function POST(request: NextRequest) {
         })
 
         return NextResponse.json(
-          { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+          {
+            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            details: errorText,
+          },
           { status: response.status }
         )
       }
@@ -154,7 +162,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/organization/route.ts
+++ b/apps/sim/app/api/tools/jsm/organization/route.ts
@@ -6,12 +6,8 @@ import {
   validateEnum,
   validateJiraCloudId,
 } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -92,7 +88,7 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json(
           {
-            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
             details: errorText,
           },
           { status: response.status }
@@ -163,7 +159,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/organizations/route.ts
+++ b/apps/sim/app/api/tools/jsm/organizations/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -75,7 +71,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/organizations/route.ts
+++ b/apps/sim/app/api/tools/jsm/organizations/route.ts
@@ -2,7 +2,12 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -69,7 +74,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/participants/route.ts
+++ b/apps/sim/app/api/tools/jsm/participants/route.ts
@@ -6,12 +6,8 @@ import {
   validateJiraCloudId,
   validateJiraIssueKey,
 } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -101,7 +97,7 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json(
           {
-            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
             details: errorText,
           },
           { status: response.status }
@@ -155,7 +151,7 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json(
           {
-            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
             details: errorText,
           },
           { status: response.status }

--- a/apps/sim/app/api/tools/jsm/participants/route.ts
+++ b/apps/sim/app/api/tools/jsm/participants/route.ts
@@ -6,7 +6,12 @@ import {
   validateJiraCloudId,
   validateJiraIssueKey,
 } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -95,7 +100,10 @@ export async function POST(request: NextRequest) {
         })
 
         return NextResponse.json(
-          { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+          {
+            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            details: errorText,
+          },
           { status: response.status }
         )
       }
@@ -146,7 +154,10 @@ export async function POST(request: NextRequest) {
         })
 
         return NextResponse.json(
-          { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+          {
+            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            details: errorText,
+          },
           { status: response.status }
         )
       }

--- a/apps/sim/app/api/tools/jsm/queues/route.ts
+++ b/apps/sim/app/api/tools/jsm/queues/route.ts
@@ -2,7 +2,12 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -78,7 +83,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/queues/route.ts
+++ b/apps/sim/app/api/tools/jsm/queues/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -84,7 +80,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/request/route.ts
+++ b/apps/sim/app/api/tools/jsm/request/route.ts
@@ -76,12 +76,6 @@ export async function POST(request: NextRequest) {
       const url = `${baseUrl}/request`
 
       logger.info('Creating request at:', { url, serviceDeskId, requestTypeId })
-      logger.info('Raw formAnswers param:', {
-        formAnswers,
-        type: typeof formAnswers,
-        isObject: typeof formAnswers === 'object',
-        keys: formAnswers && typeof formAnswers === 'object' ? Object.keys(formAnswers) : null,
-      })
 
       const requestBody: Record<string, unknown> = {
         serviceDeskId,

--- a/apps/sim/app/api/tools/jsm/request/route.ts
+++ b/apps/sim/app/api/tools/jsm/request/route.ts
@@ -6,12 +6,8 @@ import {
   validateJiraCloudId,
   validateJiraIssueKey,
 } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -141,7 +137,7 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json(
           {
-            error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+            error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
             details: errorText,
           },
           { status: response.status }
@@ -210,7 +206,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/request/route.ts
+++ b/apps/sim/app/api/tools/jsm/request/route.ts
@@ -6,25 +6,16 @@ import {
   validateJiraCloudId,
   validateJiraIssueKey,
 } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
 const logger = createLogger('JsmRequestAPI')
-
-function parseJsmErrorMessage(status: number, statusText: string, errorText: string): string {
-  try {
-    const errorData = JSON.parse(errorText)
-    if (errorData.errorMessage) {
-      return `JSM API error: ${errorData.errorMessage}`
-    }
-  } catch {
-    if (errorText) {
-      return `JSM API error: ${errorText}`
-    }
-  }
-  return `JSM API error: ${status} ${statusText}`
-}
 
 export async function POST(request: NextRequest) {
   const auth = await checkInternalAuth(request)
@@ -85,13 +76,30 @@ export async function POST(request: NextRequest) {
       const url = `${baseUrl}/request`
 
       logger.info('Creating request at:', { url, serviceDeskId, requestTypeId })
+      logger.info('Raw formAnswers param:', {
+        formAnswers,
+        type: typeof formAnswers,
+        isObject: typeof formAnswers === 'object',
+        keys: formAnswers && typeof formAnswers === 'object' ? Object.keys(formAnswers) : null,
+      })
 
       const requestBody: Record<string, unknown> = {
         serviceDeskId,
         requestTypeId,
       }
 
-      if (summary || description || requestFieldValues) {
+      if (formAnswers && typeof formAnswers === 'object') {
+        // When form answers are provided, use them as the primary data source.
+        // Per Atlassian docs, fields linked to form questions must NOT also appear
+        // in requestFieldValues — doing so causes a 400 error.
+        requestBody.form = { answers: formAnswers }
+
+        // Only include explicit requestFieldValues if the caller provided them
+        // (they know which fields are safe to include alongside form answers).
+        if (requestFieldValues && typeof requestFieldValues === 'object') {
+          requestBody.requestFieldValues = requestFieldValues
+        }
+      } else if (summary || description || requestFieldValues) {
         const fieldValues =
           requestFieldValues && typeof requestFieldValues === 'object'
             ? {
@@ -104,10 +112,6 @@ export async function POST(request: NextRequest) {
                 ...(description && { description }),
               }
         requestBody.requestFieldValues = fieldValues
-      }
-
-      if (formAnswers && typeof formAnswers === 'object') {
-        requestBody.form = { answers: formAnswers }
       }
 
       if (raiseOnBehalfOf) {

--- a/apps/sim/app/api/tools/jsm/requests/route.ts
+++ b/apps/sim/app/api/tools/jsm/requests/route.ts
@@ -6,7 +6,12 @@ import {
   validateEnum,
   validateJiraCloudId,
 } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -118,7 +123,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/requests/route.ts
+++ b/apps/sim/app/api/tools/jsm/requests/route.ts
@@ -6,12 +6,8 @@ import {
   validateEnum,
   validateJiraCloudId,
 } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -124,7 +120,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/requesttypefields/route.ts
+++ b/apps/sim/app/api/tools/jsm/requesttypefields/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -80,7 +76,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/requesttypefields/route.ts
+++ b/apps/sim/app/api/tools/jsm/requesttypefields/route.ts
@@ -2,7 +2,12 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -74,7 +79,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/requesttypes/route.ts
+++ b/apps/sim/app/api/tools/jsm/requesttypes/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -88,7 +84,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/requesttypes/route.ts
+++ b/apps/sim/app/api/tools/jsm/requesttypes/route.ts
@@ -2,7 +2,12 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -82,7 +87,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/selector-requesttypes/route.ts
+++ b/apps/sim/app/api/tools/jsm/selector-requesttypes/route.ts
@@ -4,7 +4,12 @@ import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 const logger = createLogger('JsmSelectorRequestTypesAPI')
 
@@ -81,7 +86,7 @@ export async function POST(request: Request) {
         error: errorText,
       })
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}` },
+        { error: parseJsmErrorMessage(response.status, response.statusText, errorText) },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/selector-requesttypes/route.ts
+++ b/apps/sim/app/api/tools/jsm/selector-requesttypes/route.ts
@@ -4,12 +4,8 @@ import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 const logger = createLogger('JsmSelectorRequestTypesAPI')
 
@@ -86,7 +82,7 @@ export async function POST(request: Request) {
         error: errorText,
       })
       return NextResponse.json(
-        { error: parseJsmErrorMessage(response.status, response.statusText, errorText) },
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/selector-servicedesks/route.ts
+++ b/apps/sim/app/api/tools/jsm/selector-servicedesks/route.ts
@@ -4,7 +4,12 @@ import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 const logger = createLogger('JsmSelectorServiceDesksAPI')
 
@@ -72,7 +77,7 @@ export async function POST(request: Request) {
         error: errorText,
       })
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}` },
+        { error: parseJsmErrorMessage(response.status, response.statusText, errorText) },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/selector-servicedesks/route.ts
+++ b/apps/sim/app/api/tools/jsm/selector-servicedesks/route.ts
@@ -4,12 +4,8 @@ import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validateJiraCloudId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 const logger = createLogger('JsmSelectorServiceDesksAPI')
 
@@ -77,7 +73,7 @@ export async function POST(request: Request) {
         error: errorText,
       })
       return NextResponse.json(
-        { error: parseJsmErrorMessage(response.status, response.statusText, errorText) },
+        { error: parseAtlassianErrorMessage(response.status, response.statusText, errorText) },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/servicedesks/route.ts
+++ b/apps/sim/app/api/tools/jsm/servicedesks/route.ts
@@ -2,7 +2,12 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -60,7 +65,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/servicedesks/route.ts
+++ b/apps/sim/app/api/tools/jsm/servicedesks/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -66,7 +62,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/sla/route.ts
+++ b/apps/sim/app/api/tools/jsm/sla/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -75,7 +71,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/sla/route.ts
+++ b/apps/sim/app/api/tools/jsm/sla/route.ts
@@ -2,7 +2,12 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -69,7 +74,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/transition/route.ts
+++ b/apps/sim/app/api/tools/jsm/transition/route.ts
@@ -6,12 +6,8 @@ import {
   validateJiraCloudId,
   validateJiraIssueKey,
 } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -102,7 +98,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/transition/route.ts
+++ b/apps/sim/app/api/tools/jsm/transition/route.ts
@@ -6,7 +6,12 @@ import {
   validateJiraCloudId,
   validateJiraIssueKey,
 } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -96,7 +101,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/app/api/tools/jsm/transitions/route.ts
+++ b/apps/sim/app/api/tools/jsm/transitions/route.ts
@@ -2,12 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import {
-  getJiraCloudId,
-  getJsmApiBaseUrl,
-  getJsmHeaders,
-  parseJsmErrorMessage,
-} from '@/tools/jsm/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -75,7 +71,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          error: parseAtlassianErrorMessage(response.status, response.statusText, errorText),
           details: errorText,
         },
         { status: response.status }

--- a/apps/sim/app/api/tools/jsm/transitions/route.ts
+++ b/apps/sim/app/api/tools/jsm/transitions/route.ts
@@ -2,7 +2,12 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, getJsmApiBaseUrl, getJsmHeaders } from '@/tools/jsm/utils'
+import {
+  getJiraCloudId,
+  getJsmApiBaseUrl,
+  getJsmHeaders,
+  parseJsmErrorMessage,
+} from '@/tools/jsm/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -69,7 +74,10 @@ export async function POST(request: NextRequest) {
       })
 
       return NextResponse.json(
-        { error: `JSM API error: ${response.status} ${response.statusText}`, details: errorText },
+        {
+          error: parseJsmErrorMessage(response.status, response.statusText, errorText),
+          details: errorText,
+        },
         { status: response.status }
       )
     }

--- a/apps/sim/blocks/blocks/jira_service_management.ts
+++ b/apps/sim/blocks/blocks/jira_service_management.ts
@@ -290,7 +290,7 @@ Return ONLY the description text - no explanations.`,
       title: 'Form Answers',
       type: 'long-input',
       placeholder:
-        'JSON object for form-based request types (e.g., {"summary": {"text": "Title"}, "customfield_10010": {"choices": ["10320"]}})',
+        'JSON object using form question IDs as keys (e.g., {"1": {"text": "Title"}, "4": {"choices": ["5"]}, "14": {"text": "Details"}})',
       mode: 'advanced',
       condition: { field: 'operation', value: 'create_request' },
     },

--- a/apps/sim/tools/confluence/add_label.ts
+++ b/apps/sim/tools/confluence/add_label.ts
@@ -34,8 +34,6 @@ export const confluenceAddLabelTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_blogpost.ts
+++ b/apps/sim/tools/confluence/create_blogpost.ts
@@ -44,8 +44,6 @@ export const confluenceCreateBlogPostTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_comment.ts
+++ b/apps/sim/tools/confluence/create_comment.ts
@@ -31,8 +31,6 @@ export const confluenceCreateCommentTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_page.ts
+++ b/apps/sim/tools/confluence/create_page.ts
@@ -40,8 +40,6 @@ export const confluenceCreatePageTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_page_property.ts
+++ b/apps/sim/tools/confluence/create_page_property.ts
@@ -38,8 +38,6 @@ export const confluenceCreatePagePropertyTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_space.ts
+++ b/apps/sim/tools/confluence/create_space.ts
@@ -39,8 +39,6 @@ export const confluenceCreateSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/create_space_property.ts
+++ b/apps/sim/tools/confluence/create_space_property.ts
@@ -35,8 +35,6 @@ export const confluenceCreateSpacePropertyTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_attachment.ts
+++ b/apps/sim/tools/confluence/delete_attachment.ts
@@ -30,8 +30,6 @@ export const confluenceDeleteAttachmentTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_blogpost.ts
+++ b/apps/sim/tools/confluence/delete_blogpost.ts
@@ -31,8 +31,6 @@ export const confluenceDeleteBlogPostTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_comment.ts
+++ b/apps/sim/tools/confluence/delete_comment.ts
@@ -30,8 +30,6 @@ export const confluenceDeleteCommentTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_label.ts
+++ b/apps/sim/tools/confluence/delete_label.ts
@@ -33,8 +33,6 @@ export const confluenceDeleteLabelTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_page.ts
+++ b/apps/sim/tools/confluence/delete_page.ts
@@ -32,8 +32,6 @@ export const confluenceDeletePageTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_page_property.ts
+++ b/apps/sim/tools/confluence/delete_page_property.ts
@@ -33,8 +33,6 @@ export const confluenceDeletePagePropertyTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_space.ts
+++ b/apps/sim/tools/confluence/delete_space.ts
@@ -31,8 +31,6 @@ export const confluenceDeleteSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/delete_space_property.ts
+++ b/apps/sim/tools/confluence/delete_space_property.ts
@@ -33,8 +33,6 @@ export const confluenceDeleteSpacePropertyTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_blogpost.ts
+++ b/apps/sim/tools/confluence/get_blogpost.ts
@@ -49,8 +49,6 @@ export const confluenceGetBlogPostTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_page_ancestors.ts
+++ b/apps/sim/tools/confluence/get_page_ancestors.ts
@@ -39,8 +39,6 @@ export const confluenceGetPageAncestorsTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_page_children.ts
+++ b/apps/sim/tools/confluence/get_page_children.ts
@@ -42,8 +42,6 @@ export const confluenceGetPageChildrenTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_page_descendants.ts
+++ b/apps/sim/tools/confluence/get_page_descendants.ts
@@ -43,8 +43,6 @@ export const confluenceGetPageDescendantsTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_page_version.ts
+++ b/apps/sim/tools/confluence/get_page_version.ts
@@ -54,8 +54,6 @@ export const confluenceGetPageVersionTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_pages_by_label.ts
+++ b/apps/sim/tools/confluence/get_pages_by_label.ts
@@ -47,8 +47,6 @@ export const confluenceGetPagesByLabelTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_space.ts
+++ b/apps/sim/tools/confluence/get_space.ts
@@ -42,8 +42,6 @@ export const confluenceGetSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/get_task.ts
+++ b/apps/sim/tools/confluence/get_task.ts
@@ -41,8 +41,6 @@ export const confluenceGetTaskTool: ToolConfig<ConfluenceGetTaskParams, Confluen
       provider: 'confluence',
     },
 
-    errorExtractor: 'atlassian-errors',
-
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/confluence/get_user.ts
+++ b/apps/sim/tools/confluence/get_user.ts
@@ -33,8 +33,6 @@ export const confluenceGetUserTool: ToolConfig<ConfluenceGetUserParams, Confluen
       provider: 'confluence',
     },
 
-    errorExtractor: 'atlassian-errors',
-
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/confluence/list_attachments.ts
+++ b/apps/sim/tools/confluence/list_attachments.ts
@@ -39,8 +39,6 @@ export const confluenceListAttachmentsTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_blogposts.ts
+++ b/apps/sim/tools/confluence/list_blogposts.ts
@@ -47,8 +47,6 @@ export const confluenceListBlogPostsTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_blogposts_in_space.ts
+++ b/apps/sim/tools/confluence/list_blogposts_in_space.ts
@@ -55,8 +55,6 @@ export const confluenceListBlogPostsInSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_comments.ts
+++ b/apps/sim/tools/confluence/list_comments.ts
@@ -39,8 +39,6 @@ export const confluenceListCommentsTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_labels.ts
+++ b/apps/sim/tools/confluence/list_labels.ts
@@ -37,8 +37,6 @@ export const confluenceListLabelsTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_page_properties.ts
+++ b/apps/sim/tools/confluence/list_page_properties.ts
@@ -43,8 +43,6 @@ export const confluenceListPagePropertiesTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_page_versions.ts
+++ b/apps/sim/tools/confluence/list_page_versions.ts
@@ -40,8 +40,6 @@ export const confluenceListPageVersionsTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_pages_in_space.ts
+++ b/apps/sim/tools/confluence/list_pages_in_space.ts
@@ -57,8 +57,6 @@ export const confluenceListPagesInSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_space_labels.ts
+++ b/apps/sim/tools/confluence/list_space_labels.ts
@@ -38,8 +38,6 @@ export const confluenceListSpaceLabelsTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_space_permissions.ts
+++ b/apps/sim/tools/confluence/list_space_permissions.ts
@@ -42,8 +42,6 @@ export const confluenceListSpacePermissionsTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_space_properties.ts
+++ b/apps/sim/tools/confluence/list_space_properties.ts
@@ -38,8 +38,6 @@ export const confluenceListSpacePropertiesTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_spaces.ts
+++ b/apps/sim/tools/confluence/list_spaces.ts
@@ -38,8 +38,6 @@ export const confluenceListSpacesTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/list_tasks.ts
+++ b/apps/sim/tools/confluence/list_tasks.ts
@@ -52,8 +52,6 @@ export const confluenceListTasksTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/retrieve.ts
+++ b/apps/sim/tools/confluence/retrieve.ts
@@ -21,8 +21,6 @@ export const confluenceRetrieveTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/search.ts
+++ b/apps/sim/tools/confluence/search.ts
@@ -34,8 +34,6 @@ export const confluenceSearchTool: ToolConfig<ConfluenceSearchParams, Confluence
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/search_in_space.ts
+++ b/apps/sim/tools/confluence/search_in_space.ts
@@ -44,8 +44,6 @@ export const confluenceSearchInSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/update.ts
+++ b/apps/sim/tools/confluence/update.ts
@@ -13,8 +13,6 @@ export const confluenceUpdateTool: ToolConfig<ConfluenceUpdateParams, Confluence
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/update_blogpost.ts
+++ b/apps/sim/tools/confluence/update_blogpost.ts
@@ -37,8 +37,6 @@ export const confluenceUpdateBlogPostTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/update_comment.ts
+++ b/apps/sim/tools/confluence/update_comment.ts
@@ -31,8 +31,6 @@ export const confluenceUpdateCommentTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/update_space.ts
+++ b/apps/sim/tools/confluence/update_space.ts
@@ -38,8 +38,6 @@ export const confluenceUpdateSpaceTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/update_task.ts
+++ b/apps/sim/tools/confluence/update_task.ts
@@ -44,8 +44,6 @@ export const confluenceUpdateTaskTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/confluence/upload_attachment.ts
+++ b/apps/sim/tools/confluence/upload_attachment.ts
@@ -37,8 +37,6 @@ export const confluenceUploadAttachmentTool: ToolConfig<
     provider: 'confluence',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/add_attachment.ts
+++ b/apps/sim/tools/jira/add_attachment.ts
@@ -14,8 +14,6 @@ export const jiraAddAttachmentTool: ToolConfig<JiraAddAttachmentParams, JiraAddA
       provider: 'jira',
     },
 
-    errorExtractor: 'atlassian-errors',
-
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/add_comment.ts
+++ b/apps/sim/tools/jira/add_comment.ts
@@ -30,8 +30,6 @@ export const jiraAddCommentTool: ToolConfig<JiraAddCommentParams, JiraAddComment
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/add_watcher.ts
+++ b/apps/sim/tools/jira/add_watcher.ts
@@ -14,8 +14,6 @@ export const jiraAddWatcherTool: ToolConfig<JiraAddWatcherParams, JiraAddWatcher
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/add_worklog.ts
+++ b/apps/sim/tools/jira/add_worklog.ts
@@ -57,8 +57,6 @@ export const jiraAddWorklogTool: ToolConfig<JiraAddWorklogParams, JiraAddWorklog
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/assign_issue.ts
+++ b/apps/sim/tools/jira/assign_issue.ts
@@ -14,8 +14,6 @@ export const jiraAssignIssueTool: ToolConfig<JiraAssignIssueParams, JiraAssignIs
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/bulk_read.ts
+++ b/apps/sim/tools/jira/bulk_read.ts
@@ -14,8 +14,6 @@ export const jiraBulkRetrieveTool: ToolConfig<JiraRetrieveBulkParams, JiraRetrie
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/create_issue_link.ts
+++ b/apps/sim/tools/jira/create_issue_link.ts
@@ -17,8 +17,6 @@ export const jiraCreateIssueLinkTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/delete_attachment.ts
+++ b/apps/sim/tools/jira/delete_attachment.ts
@@ -17,8 +17,6 @@ export const jiraDeleteAttachmentTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/delete_comment.ts
+++ b/apps/sim/tools/jira/delete_comment.ts
@@ -15,8 +15,6 @@ export const jiraDeleteCommentTool: ToolConfig<JiraDeleteCommentParams, JiraDele
       provider: 'jira',
     },
 
-    errorExtractor: 'atlassian-errors',
-
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/delete_issue.ts
+++ b/apps/sim/tools/jira/delete_issue.ts
@@ -14,8 +14,6 @@ export const jiraDeleteIssueTool: ToolConfig<JiraDeleteIssueParams, JiraDeleteIs
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/delete_issue_link.ts
+++ b/apps/sim/tools/jira/delete_issue_link.ts
@@ -17,8 +17,6 @@ export const jiraDeleteIssueLinkTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/delete_worklog.ts
+++ b/apps/sim/tools/jira/delete_worklog.ts
@@ -15,8 +15,6 @@ export const jiraDeleteWorklogTool: ToolConfig<JiraDeleteWorklogParams, JiraDele
       provider: 'jira',
     },
 
-    errorExtractor: 'atlassian-errors',
-
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/get_attachments.ts
+++ b/apps/sim/tools/jira/get_attachments.ts
@@ -35,8 +35,6 @@ export const jiraGetAttachmentsTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/get_comments.ts
+++ b/apps/sim/tools/jira/get_comments.ts
@@ -32,8 +32,6 @@ export const jiraGetCommentsTool: ToolConfig<JiraGetCommentsParams, JiraGetComme
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/get_users.ts
+++ b/apps/sim/tools/jira/get_users.ts
@@ -32,8 +32,6 @@ export const jiraGetUsersTool: ToolConfig<JiraGetUsersParams, JiraGetUsersRespon
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/get_worklogs.ts
+++ b/apps/sim/tools/jira/get_worklogs.ts
@@ -32,8 +32,6 @@ export const jiraGetWorklogsTool: ToolConfig<JiraGetWorklogsParams, JiraGetWorkl
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/remove_watcher.ts
+++ b/apps/sim/tools/jira/remove_watcher.ts
@@ -15,8 +15,6 @@ export const jiraRemoveWatcherTool: ToolConfig<JiraRemoveWatcherParams, JiraRemo
       provider: 'jira',
     },
 
-    errorExtractor: 'atlassian-errors',
-
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/retrieve.ts
+++ b/apps/sim/tools/jira/retrieve.ts
@@ -195,8 +195,6 @@ export const jiraRetrieveTool: ToolConfig<JiraRetrieveParams, JiraRetrieveRespon
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/search_issues.ts
+++ b/apps/sim/tools/jira/search_issues.ts
@@ -81,8 +81,6 @@ export const jiraSearchIssuesTool: ToolConfig<JiraSearchIssuesParams, JiraSearch
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/search_users.ts
+++ b/apps/sim/tools/jira/search_users.ts
@@ -15,8 +15,6 @@ export const jiraSearchUsersTool: ToolConfig<JiraSearchUsersParams, JiraSearchUs
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/transition_issue.ts
+++ b/apps/sim/tools/jira/transition_issue.ts
@@ -17,8 +17,6 @@ export const jiraTransitionIssueTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/update.ts
+++ b/apps/sim/tools/jira/update.ts
@@ -13,8 +13,6 @@ export const jiraUpdateTool: ToolConfig<JiraUpdateParams, JiraUpdateResponse> = 
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jira/update_comment.ts
+++ b/apps/sim/tools/jira/update_comment.ts
@@ -31,8 +31,6 @@ export const jiraUpdateCommentTool: ToolConfig<JiraUpdateCommentParams, JiraUpda
       provider: 'jira',
     },
 
-    errorExtractor: 'atlassian-errors',
-
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/update_worklog.ts
+++ b/apps/sim/tools/jira/update_worklog.ts
@@ -58,8 +58,6 @@ export const jiraUpdateWorklogTool: ToolConfig<JiraUpdateWorklogParams, JiraUpda
       provider: 'jira',
     },
 
-    errorExtractor: 'atlassian-errors',
-
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jira/utils.ts
+++ b/apps/sim/tools/jira/utils.ts
@@ -145,3 +145,44 @@ export async function getJiraCloudId(domain: string, accessToken: string): Promi
       `Available sites: ${resources.map((r: { url: string }) => r.url).join(', ')}`
   )
 }
+
+/**
+ * Parse error messages from Atlassian API responses (Jira, JSM, Confluence).
+ * Handles all known error formats: errorMessage, errorMessages[], errors[].title/detail,
+ * field-level errors object, and generic message fallback.
+ */
+export function parseAtlassianErrorMessage(
+  status: number,
+  statusText: string,
+  errorText: string
+): string {
+  try {
+    const errorData = JSON.parse(errorText)
+    if (errorData.errorMessage) {
+      return errorData.errorMessage
+    }
+    if (Array.isArray(errorData.errorMessages) && errorData.errorMessages.length > 0) {
+      return errorData.errorMessages.join(', ')
+    }
+    if (Array.isArray(errorData.errors) && errorData.errors.length > 0) {
+      const err = errorData.errors[0]
+      if (err?.title) {
+        return err.detail ? `${err.title}: ${err.detail}` : err.title
+      }
+    }
+    if (errorData.errors && !Array.isArray(errorData.errors)) {
+      const fieldErrors = Object.entries(errorData.errors)
+        .map(([field, msg]) => `${field}: ${msg}`)
+        .join(', ')
+      if (fieldErrors) return fieldErrors
+    }
+    if (errorData.message) {
+      return errorData.message
+    }
+  } catch {
+    if (errorText) {
+      return errorText
+    }
+  }
+  return `${status} ${statusText}`
+}

--- a/apps/sim/tools/jira/write.ts
+++ b/apps/sim/tools/jira/write.ts
@@ -13,8 +13,6 @@ export const jiraWriteTool: ToolConfig<JiraWriteParams, JiraWriteResponse> = {
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/add_comment.ts
+++ b/apps/sim/tools/jsm/add_comment.ts
@@ -13,8 +13,6 @@ export const jsmAddCommentTool: ToolConfig<JsmAddCommentParams, JsmAddCommentRes
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/add_customer.ts
+++ b/apps/sim/tools/jsm/add_customer.ts
@@ -12,8 +12,6 @@ export const jsmAddCustomerTool: ToolConfig<JsmAddCustomerParams, JsmAddCustomer
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/add_organization.ts
+++ b/apps/sim/tools/jsm/add_organization.ts
@@ -15,8 +15,6 @@ export const jsmAddOrganizationTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/add_participants.ts
+++ b/apps/sim/tools/jsm/add_participants.ts
@@ -16,8 +16,6 @@ export const jsmAddParticipantsTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/answer_approval.ts
+++ b/apps/sim/tools/jsm/answer_approval.ts
@@ -13,8 +13,6 @@ export const jsmAnswerApprovalTool: ToolConfig<JsmAnswerApprovalParams, JsmAnswe
       provider: 'jira',
     },
 
-    errorExtractor: 'atlassian-errors',
-
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jsm/create_organization.ts
+++ b/apps/sim/tools/jsm/create_organization.ts
@@ -15,8 +15,6 @@ export const jsmCreateOrganizationTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/create_request.ts
+++ b/apps/sim/tools/jsm/create_request.ts
@@ -12,8 +12,6 @@ export const jsmCreateRequestTool: ToolConfig<JsmCreateRequestParams, JsmCreateR
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',
@@ -75,7 +73,7 @@ export const jsmCreateRequestTool: ToolConfig<JsmCreateRequestParams, JsmCreateR
       required: false,
       visibility: 'user-or-llm',
       description:
-        'Form answers for form-based request types (e.g., {"summary": {"text": "Title"}, "customfield_10010": {"choices": ["10320"]}})',
+        'Form answers using numeric form question IDs as keys (e.g., {"1": {"text": "Title"}, "4": {"choices": ["5"]}}). Keys are question IDs from the Jira Form, not Jira field names.',
     },
     requestParticipants: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_approvals.ts
+++ b/apps/sim/tools/jsm/get_approvals.ts
@@ -13,8 +13,6 @@ export const jsmGetApprovalsTool: ToolConfig<JsmGetApprovalsParams, JsmGetApprov
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_comments.ts
+++ b/apps/sim/tools/jsm/get_comments.ts
@@ -13,8 +13,6 @@ export const jsmGetCommentsTool: ToolConfig<JsmGetCommentsParams, JsmGetComments
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_customers.ts
+++ b/apps/sim/tools/jsm/get_customers.ts
@@ -13,8 +13,6 @@ export const jsmGetCustomersTool: ToolConfig<JsmGetCustomersParams, JsmGetCustom
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_form_structure.ts
+++ b/apps/sim/tools/jsm/get_form_structure.ts
@@ -16,8 +16,6 @@ export const jsmGetFormStructureTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_form_templates.ts
+++ b/apps/sim/tools/jsm/get_form_templates.ts
@@ -17,8 +17,6 @@ export const jsmGetFormTemplatesTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_issue_forms.ts
+++ b/apps/sim/tools/jsm/get_issue_forms.ts
@@ -14,8 +14,6 @@ export const jsmGetIssueFormsTool: ToolConfig<JsmGetIssueFormsParams, JsmGetIssu
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_organizations.ts
+++ b/apps/sim/tools/jsm/get_organizations.ts
@@ -16,8 +16,6 @@ export const jsmGetOrganizationsTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_participants.ts
+++ b/apps/sim/tools/jsm/get_participants.ts
@@ -16,8 +16,6 @@ export const jsmGetParticipantsTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_queues.ts
+++ b/apps/sim/tools/jsm/get_queues.ts
@@ -13,8 +13,6 @@ export const jsmGetQueuesTool: ToolConfig<JsmGetQueuesParams, JsmGetQueuesRespon
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_request.ts
+++ b/apps/sim/tools/jsm/get_request.ts
@@ -17,8 +17,6 @@ export const jsmGetRequestTool: ToolConfig<JsmGetRequestParams, JsmGetRequestRes
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_request_type_fields.ts
+++ b/apps/sim/tools/jsm/get_request_type_fields.ts
@@ -20,8 +20,6 @@ export const jsmGetRequestTypeFieldsTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_request_types.ts
+++ b/apps/sim/tools/jsm/get_request_types.ts
@@ -16,8 +16,6 @@ export const jsmGetRequestTypesTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_requests.ts
+++ b/apps/sim/tools/jsm/get_requests.ts
@@ -13,8 +13,6 @@ export const jsmGetRequestsTool: ToolConfig<JsmGetRequestsParams, JsmGetRequests
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_service_desks.ts
+++ b/apps/sim/tools/jsm/get_service_desks.ts
@@ -16,8 +16,6 @@ export const jsmGetServiceDesksTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_sla.ts
+++ b/apps/sim/tools/jsm/get_sla.ts
@@ -13,8 +13,6 @@ export const jsmGetSlaTool: ToolConfig<JsmGetSlaParams, JsmGetSlaResponse> = {
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/get_transitions.ts
+++ b/apps/sim/tools/jsm/get_transitions.ts
@@ -14,8 +14,6 @@ export const jsmGetTransitionsTool: ToolConfig<JsmGetTransitionsParams, JsmGetTr
       provider: 'jira',
     },
 
-    errorExtractor: 'atlassian-errors',
-
     params: {
       accessToken: {
         type: 'string',

--- a/apps/sim/tools/jsm/transition_request.ts
+++ b/apps/sim/tools/jsm/transition_request.ts
@@ -15,8 +15,6 @@ export const jsmTransitionRequestTool: ToolConfig<
     provider: 'jira',
   },
 
-  errorExtractor: 'atlassian-errors',
-
   params: {
     accessToken: {
       type: 'string',

--- a/apps/sim/tools/jsm/utils.ts
+++ b/apps/sim/tools/jsm/utils.ts
@@ -1,16 +1,6 @@
 /**
  * Shared utilities for Jira Service Management tools
- * Reuses the getJiraCloudId and parseAtlassianErrorMessage from the Jira integration
  */
-/**
- * Re-export parseAtlassianErrorMessage as parseJsmErrorMessage for backwards compatibility.
- * All JSM routes already import this name.
- */
-export {
-  getJiraCloudId,
-  parseAtlassianErrorMessage,
-  parseAtlassianErrorMessage as parseJsmErrorMessage,
-} from '@/tools/jira/utils'
 
 /**
  * Build the base URL for JSM Service Desk API

--- a/apps/sim/tools/jsm/utils.ts
+++ b/apps/sim/tools/jsm/utils.ts
@@ -1,8 +1,16 @@
 /**
  * Shared utilities for Jira Service Management tools
- * Reuses the getJiraCloudId from the Jira integration since JSM uses the same Atlassian Cloud ID
+ * Reuses the getJiraCloudId and parseAtlassianErrorMessage from the Jira integration
  */
-export { getJiraCloudId } from '@/tools/jira/utils'
+/**
+ * Re-export parseAtlassianErrorMessage as parseJsmErrorMessage for backwards compatibility.
+ * All JSM routes already import this name.
+ */
+export {
+  getJiraCloudId,
+  parseAtlassianErrorMessage,
+  parseAtlassianErrorMessage as parseJsmErrorMessage,
+} from '@/tools/jira/utils'
 
 /**
  * Build the base URL for JSM Service Desk API
@@ -34,52 +42,4 @@ export function getJsmHeaders(accessToken: string): Record<string, string> {
     'Content-Type': 'application/json',
     'X-ExperimentalApi': 'opt-in',
   }
-}
-
-/**
- * Parse error messages from JSM/Forms API responses
- * @param status - HTTP status code
- * @param statusText - HTTP status text
- * @param errorText - Raw error response body
- * @returns Formatted error message string
- */
-export function parseJsmErrorMessage(
-  status: number,
-  statusText: string,
-  errorText: string
-): string {
-  try {
-    const errorData = JSON.parse(errorText)
-    // JSM Service Desk: singular errorMessage
-    if (errorData.errorMessage) {
-      return errorData.errorMessage
-    }
-    // Jira Platform: errorMessages array
-    if (Array.isArray(errorData.errorMessages) && errorData.errorMessages.length > 0) {
-      return errorData.errorMessages.join(', ')
-    }
-    // Confluence v2 / Forms API: RFC 7807 errors array
-    if (Array.isArray(errorData.errors) && errorData.errors.length > 0) {
-      const err = errorData.errors[0]
-      if (err?.title) {
-        return err.detail ? `${err.title}: ${err.detail}` : err.title
-      }
-    }
-    // Jira Platform field-level errors object
-    if (errorData.errors && !Array.isArray(errorData.errors)) {
-      const fieldErrors = Object.entries(errorData.errors)
-        .map(([field, msg]) => `${field}: ${msg}`)
-        .join(', ')
-      if (fieldErrors) return fieldErrors
-    }
-    // Generic message fallback
-    if (errorData.message) {
-      return errorData.message
-    }
-  } catch {
-    if (errorText) {
-      return errorText
-    }
-  }
-  return `${status} ${statusText}`
 }


### PR DESCRIPTION
## Summary
- Add `parseAtlassianErrorMessage()` to `jira/utils.ts` as single source of truth for parsing all 5 Atlassian error formats (`errorMessage`, `errorMessages[]`, `errors[].title/detail`, field-level errors object, `message`)
- Update 51 proxy routes (18 JSM, 5 Jira, 28 Confluence) to extract and return actual Atlassian error messages instead of generic `"Request failed with status 400"` strings
- Remove dead `errorExtractor: 'atlassian-errors'` field from 95 Atlassian tool files — the compat loop in `extractErrorMessage()` handles all formats without it
- Consolidate duplicate `parseJsmErrorMessage` into a re-export from the shared utility

## Test plan
- [x] Trigger a 400 error from JSM (e.g., invalid serviceDeskId) and verify the actual error message is returned
- [x] Trigger a 400 error from Jira (e.g., missing required field) and verify field-level errors are returned
- [x] Trigger a 400 error from Confluence (e.g., invalid page ID) and verify the error message is returned
- [x] Verify tools with direct API calls (e.g., `jira_search_issues`) still extract errors via the compat loop