### PR TITLE
feat(ui): show folder path in search modal

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items.tsx
@@ -51,12 +51,14 @@ export const MemoizedWorkflowItem = memo(
     onSelect,
     color,
     name,
+    folderPath,
     isCurrent,
   }: {
     value: string
     onSelect: () => void
     color: string
     name: string
+    folderPath?: string
     isCurrent?: boolean
   }) {
     return (
@@ -73,6 +75,11 @@ export const MemoizedWorkflowItem = memo(
           {name}
           {isCurrent && ' (current)'}
         </span>
+        {folderPath && (
+          <span className='ml-auto flex-shrink-0 truncate pl-2 font-base text-[var(--text-subtle)] text-small'>
+            {folderPath}
+          </span>
+        )}
       </Command.Item>
     )
   },
@@ -80,6 +87,7 @@ export const MemoizedWorkflowItem = memo(
     prev.value === next.value &&
     prev.color === next.color &&
     prev.name === next.name &&
+    prev.folderPath === next.folderPath &&
     prev.isCurrent === next.isCurrent
 )
 

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items.tsx
@@ -76,7 +76,7 @@ export const MemoizedWorkflowItem = memo(
           {isCurrent && ' (current)'}
         </span>
         {folderPath && (
-          <span className='ml-auto flex-shrink-0 truncate pl-2 font-base text-[var(--text-subtle)] text-small'>
+          <span className='ml-auto min-w-0 truncate pl-2 font-base text-[var(--text-subtle)] text-small'>
             {folderPath}
           </span>
         )}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/search-groups.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/search-groups.tsx
@@ -163,10 +163,11 @@ export const WorkflowsGroup = memo(function WorkflowsGroup({
       {items.map((workflow) => (
         <MemoizedWorkflowItem
           key={workflow.id}
-          value={`${workflow.name} workflow-${workflow.id}`}
+          value={`${workflow.name} ${workflow.folderPath ?? ''} workflow-${workflow.id}`}
           onSelect={() => onSelect(workflow)}
           color={workflow.color}
           name={workflow.name}
+          folderPath={workflow.folderPath}
           isCurrent={workflow.isCurrent}
         />
       ))}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/utils.ts
@@ -11,6 +11,7 @@ export interface WorkflowItem {
   name: string
   href: string
   color: string
+  folderPath?: string
   isCurrent?: boolean
 }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -40,7 +40,7 @@ import { useSession } from '@/lib/auth/auth-client'
 import { SIM_RESOURCES_DRAG_TYPE } from '@/lib/copilot/resource-types'
 import { cn } from '@/lib/core/utils/cn'
 import { isMacPlatform } from '@/lib/core/utils/platform'
-import { buildFolderTree } from '@/lib/folders/tree'
+import { buildFolderTree, getFolderPath } from '@/lib/folders/tree'
 import { captureEvent } from '@/lib/posthog/client'
 import {
   START_NAV_TOUR_EVENT,
@@ -613,14 +613,22 @@ export const Sidebar = memo(function Sidebar() {
 
   const searchModalWorkflows = useMemo(
     () =>
-      regularWorkflows.map((workflow) => ({
-        id: workflow.id,
-        name: workflow.name,
-        href: `/workspace/${workspaceId}/w/${workflow.id}`,
-        color: workflow.color,
-        isCurrent: workflow.id === workflowId,
-      })),
-    [regularWorkflows, workspaceId, workflowId]
+      regularWorkflows.map((workflow) => {
+        const folderPath = workflow.folderId
+          ? getFolderPath(folderMap, workflow.folderId)
+              .map((folder) => folder.name)
+              .join(' / ')
+          : ''
+        return {
+          id: workflow.id,
+          name: workflow.name,
+          href: `/workspace/${workspaceId}/w/${workflow.id}`,
+          color: workflow.color,
+          folderPath: folderPath || undefined,
+          isCurrent: workflow.id === workflowId,
+        }
+      }),
+    [regularWorkflows, folderMap, workspaceId, workflowId]
   )
 
   const searchModalWorkspaces = useMemo(


### PR DESCRIPTION
## Summary
Currently the search modal doesn't show folders, meaning that workflows with the same name have no distinguishing features. Added folder path to the right side of the modal. 


## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
* Tested search modal in local 
## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<img width="1291" height="677" alt="image" src="https://github.com/user-attachments/assets/38c50d07-2e9a-45ba-b36e-4c0c1a2f2bd0" />

<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
