### PR TITLE
fix(security): resolve ReDoS vulnerability in function execute tag pattern

### DIFF
--- a/apps/sim/app/api/function/execute/route.ts
+++ b/apps/sim/app/api/function/execute/route.ts
@@ -28,7 +28,7 @@ export const MAX_DURATION = 210
 const logger = createLogger('FunctionExecuteAPI')
 
 const TAG_PATTERN = new RegExp(
-  `${REFERENCE.START}([a-zA-Z_](?:\\${REFERENCE.PATH_DELIMITER}[a-zA-Z0-9_]+|[a-zA-Z0-9_])*)${REFERENCE.END}`,
+  `${REFERENCE.START}([^${REFERENCE.START}${REFERENCE.END}]+)${REFERENCE.END}`,
   'g'
 )
 

--- a/apps/sim/app/api/function/execute/route.ts
+++ b/apps/sim/app/api/function/execute/route.ts
@@ -27,6 +27,11 @@ export const MAX_DURATION = 210
 
 const logger = createLogger('FunctionExecuteAPI')
 
+const TAG_PATTERN = new RegExp(
+  `${REFERENCE.START}([a-zA-Z_](?:\\${REFERENCE.PATH_DELIMITER}[a-zA-Z0-9_]+|[a-zA-Z0-9_])*)${REFERENCE.END}`,
+  'g'
+)
+
 const E2B_JS_WRAPPER_LINES = 3
 const E2B_PYTHON_WRAPPER_LINES = 1
 
@@ -493,11 +498,7 @@ function resolveTagVariables(
   let resolvedCode = code
   const undefinedLiteral = language === 'python' ? 'None' : 'undefined'
 
-  const tagPattern = new RegExp(
-    `${REFERENCE.START}([a-zA-Z_][a-zA-Z0-9_${REFERENCE.PATH_DELIMITER}]*)${REFERENCE.END}`,
-    'g'
-  )
-  const tagMatches = resolvedCode.match(tagPattern) || []
+  const tagMatches = resolvedCode.match(TAG_PATTERN) || []
 
   for (const match of tagMatches) {
     const tagName = match.slice(REFERENCE.START.length, -REFERENCE.END.length).trim()

--- a/apps/sim/app/api/function/execute/route.ts
+++ b/apps/sim/app/api/function/execute/route.ts
@@ -18,6 +18,7 @@ import { type OutputSchema, resolveBlockReference } from '@/executor/utils/block
 import { formatLiteralForCode } from '@/executor/utils/code-formatting'
 import {
   createEnvVarPattern,
+  createReferencePattern,
   createWorkflowVariablePattern,
 } from '@/executor/utils/reference-validation'
 export const dynamic = 'force-dynamic'
@@ -27,10 +28,7 @@ export const MAX_DURATION = 210
 
 const logger = createLogger('FunctionExecuteAPI')
 
-const TAG_PATTERN = new RegExp(
-  `${REFERENCE.START}([^${REFERENCE.START}${REFERENCE.END}]+)${REFERENCE.END}`,
-  'g'
-)
+const TAG_PATTERN = createReferencePattern()
 
 const E2B_JS_WRAPPER_LINES = 3
 const E2B_PYTHON_WRAPPER_LINES = 1

--- a/apps/sim/app/api/function/execute/route.ts
+++ b/apps/sim/app/api/function/execute/route.ts
@@ -494,7 +494,7 @@ function resolveTagVariables(
   const undefinedLiteral = language === 'python' ? 'None' : 'undefined'
 
   const tagPattern = new RegExp(
-    `${REFERENCE.START}([a-zA-Z_](?:[a-zA-Z0-9_${REFERENCE.PATH_DELIMITER}]*[a-zA-Z0-9_])?)${REFERENCE.END}`,
+    `${REFERENCE.START}([a-zA-Z_][a-zA-Z0-9_${REFERENCE.PATH_DELIMITER}]*)${REFERENCE.END}`,
     'g'
   )
   const tagMatches = resolvedCode.match(tagPattern) || []


### PR DESCRIPTION
## Summary
- Simplified regex in `resolveTagVariables` to eliminate overlapping quantifiers (`[a-zA-Z0-9_.]*[a-zA-Z0-9_]`) that caused exponential backtracking on malformed input (e.g., `<aaaa...` without closing `>`)
- Also dismissed 7 pre-existing CodeQL SSRF false positives across Confluence, TTS, STT, Google Sheets, and Excel routes — all use hardcoded domains with validated input

## Type of Change
- [x] Bug fix

## Testing
- `bun run lint` passes
- `bun run test` — all 5031 tests pass (5 pre-existing import failures unrelated)
- TypeScript compiles clean (pre-existing type errors only in templates/file-viewer)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)