### PR TITLE
fix(workflow-block): webhook URL never hydrates on canvas

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -640,7 +640,7 @@ const SubBlockRow = memo(function SubBlockRow({
   }, [subBlock?.id, rawValue, tables])
 
   const webhookUrlDisplayValue = useMemo(() => {
-    if (subBlock?.id !== 'webhookUrlDisplay' || !blockId) {
+    if (!subBlock?.id?.startsWith('webhookUrlDisplay') || !blockId) {
       return null
     }
     const baseUrl = getBaseUrl()


### PR DESCRIPTION
## Summary
- Webhook URL on trigger block cards always showed `-` instead of the actual URL
- Root cause: `getTrigger()` namespaces condition-gated subBlock IDs (e.g. `webhookUrlDisplay` → `webhookUrlDisplay_github_release_published`), but the block card's useMemo checked for an exact match on `'webhookUrlDisplay'` which never matched
- Fix: use `startsWith('webhookUrlDisplay')` instead of exact equality

## Test plan
- [x] Open a workflow with a GitHub (or other webhook) trigger block in trigger mode
- [x] Verify the block card on the canvas shows the webhook URL instead of `-`
- [x] Verify the editor panel still shows the webhook URL correctly (was not affected)
- [x] Verify non-webhook trigger blocks (polling triggers like Gmail) are unaffected