### PR TITLE
fix(posthog): set email and name on person profile at signup

### DIFF
--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -80,7 +80,7 @@ import { sendEmail } from '@/lib/messaging/email/mailer'
 import { getFromEmailAddress, getPersonalEmailFrom } from '@/lib/messaging/email/utils'
 import { quickValidateEmail } from '@/lib/messaging/email/validation'
 import { scheduleLifecycleEmail } from '@/lib/messaging/lifecycle'
-import { captureServerEvent } from '@/lib/posthog/server'
+import { captureServerEvent, getPostHogClient } from '@/lib/posthog/server'
 import { syncAllWebhooksForCredentialSet } from '@/lib/webhooks/utils.server'
 import { disableUserResources } from '@/lib/workflows/lifecycle'
 import { SSO_TRUSTED_PROVIDERS } from '@/ee/sso/constants'
@@ -192,6 +192,21 @@ export const auth = betterAuth({
               userId: user.id,
               authMethod: 'email',
             })
+          } catch {
+            // Telemetry should not fail the operation
+          }
+
+          try {
+            const client = getPostHogClient()
+            if (client) {
+              client.identify({
+                distinctId: user.id,
+                properties: {
+                  ...(user.email ? { email: user.email } : {}),
+                  ...(user.name ? { name: user.name } : {}),
+                },
+              })
+            }
           } catch {
             // Telemetry should not fail the operation
           }
@@ -396,6 +411,7 @@ export const auth = betterAuth({
                   : SSO_TRUSTED_PROVIDERS.includes(providerId)
                     ? 'sso'
                     : 'oauth'
+
               captureServerEvent(
                 account.userId,
                 'user_created',


### PR DESCRIPTION
## Summary
- Add server-side `posthog.identify()` in `user.create.after` hook to `$set` email and name on the person profile
- Previously, person properties were only set client-side via `posthog.identify()` in session-provider, which gets blocked by ad blockers
- No-op when PostHog is disabled (env var not set)

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)