### PR TITLE
fix(webhooks): non-polling webhook executions silently dropped after worker removal

### DIFF
--- a/apps/sim/lib/webhooks/processor.ts
+++ b/apps/sim/lib/webhooks/processor.ts
@@ -591,32 +591,30 @@ export async function queueWebhookExecution(
         `[${options.requestId}] Queued ${foundWebhook.provider} webhook execution ${jobId} via inline backend`
       )
 
-      if (shouldExecuteInline()) {
-        void (async () => {
+      void (async () => {
+        try {
+          await jobQueue.startJob(jobId)
+          const output = await executeWebhookJob(payload)
+          await jobQueue.completeJob(jobId, output)
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error)
+          logger.error(`[${options.requestId}] Webhook execution failed`, {
+            jobId,
+            error: errorMessage,
+          })
           try {
-            await jobQueue.startJob(jobId)
-            const output = await executeWebhookJob(payload)
-            await jobQueue.completeJob(jobId, output)
-          } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error)
-            logger.error(`[${options.requestId}] Webhook execution failed`, {
+            await jobQueue.markJobFailed(jobId, errorMessage)
+          } catch (markFailedError) {
+            logger.error(`[${options.requestId}] Failed to mark job as failed`, {
               jobId,
-              error: errorMessage,
+              error:
+                markFailedError instanceof Error
+                  ? markFailedError.message
+                  : String(markFailedError),
             })
-            try {
-              await jobQueue.markJobFailed(jobId, errorMessage)
-            } catch (markFailedError) {
-              logger.error(`[${options.requestId}] Failed to mark job as failed`, {
-                jobId,
-                error:
-                  markFailedError instanceof Error
-                    ? markFailedError.message
-                    : String(markFailedError),
-              })
-            }
           }
-        })()
-      }
+        }
+      })()
     }
 
     const successResponse = handler.formatSuccessResponse?.(providerConfig) ?? null
@@ -780,32 +778,30 @@ export async function processPolledWebhookEvent(
       })
       logger.info(`[${requestId}] Queued ${provider} webhook execution ${jobId} via inline backend`)
 
-      if (shouldExecuteInline()) {
-        void (async () => {
+      void (async () => {
+        try {
+          await jobQueue.startJob(jobId)
+          const output = await executeWebhookJob(payload)
+          await jobQueue.completeJob(jobId, output)
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error)
+          logger.error(`[${requestId}] Webhook execution failed`, {
+            jobId,
+            error: errorMessage,
+          })
           try {
-            await jobQueue.startJob(jobId)
-            const output = await executeWebhookJob(payload)
-            await jobQueue.completeJob(jobId, output)
-          } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error)
-            logger.error(`[${requestId}] Webhook execution failed`, {
+            await jobQueue.markJobFailed(jobId, errorMessage)
+          } catch (markFailedError) {
+            logger.error(`[${requestId}] Failed to mark job as failed`, {
               jobId,
-              error: errorMessage,
+              error:
+                markFailedError instanceof Error
+                  ? markFailedError.message
+                  : String(markFailedError),
             })
-            try {
-              await jobQueue.markJobFailed(jobId, errorMessage)
-            } catch (markFailedError) {
-              logger.error(`[${requestId}] Failed to mark job as failed`, {
-                jobId,
-                error:
-                  markFailedError instanceof Error
-                    ? markFailedError.message
-                    : String(markFailedError),
-              })
-            }
           }
-        })()
-      }
+        }
+      })()
     }
 
     return { success: true }


### PR DESCRIPTION
## Summary
- PR #4090 replaced the `if (!isBullMQEnabled())` guard with `if (shouldExecuteInline())` in the webhook processor's inline execution path
- `shouldExecuteInline()` returns `false` when Trigger.dev is the async backend (which it is in production), so the fire-and-forget execution block was never running
- The BullMQ worker that previously picked up and executed these jobs was also deleted in the same PR, leaving no executor for non-polling webhook jobs
- Non-polling webhooks (Slack, GitHub, generic, Microsoft Teams, WhatsApp, Zoom, etc.) were being enqueued to the inline database queue but never executed — jobs silently disappeared
- Polling providers (Gmail, RSS, etc.) were unaffected since they route through Trigger.dev
- Removed the `shouldExecuteInline()` guard so the inline execution always runs when jobs are enqueued to the inline database queue

## Type of Change
- [x] Bug fix

## Testing
Verified via CloudWatch logs — confirmed webhook executions for workflow `1f83dd97` were passing preprocessing and being queued but never executing after the v0.6.40 deploy. Last successful execution was April 13 5:33 PM PST, matching the deploy timeline.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)