### PR TITLE
fix(ui): handle long file paths and names in search modal

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items.tsx
@@ -78,13 +78,14 @@ export const MemoizedWorkflowItem = memo(
         {folderPath && folderPath.length > 0 && (
           <span className='ml-auto flex min-w-0 pl-2 font-base text-[var(--text-subtle)] text-small'>
             {folderPath.length > 1 && (
-              <span className='min-w-0 flex-shrink truncate'>
-                {folderPath.slice(0, -1).join(' / ')}
-              </span>
+              <>
+                <span className='min-w-0 truncate [flex-shrink:9999]'>
+                  {folderPath.slice(0, -1).join(' / ')}
+                </span>
+                <span className='flex-shrink-0 whitespace-pre'> / </span>
+              </>
             )}
-            <span className='flex-shrink-0 whitespace-pre'>
-              {folderPath.length > 1 ? ` / ${folderPath[folderPath.length - 1]}` : folderPath[0]}
-            </span>
+            <span className='min-w-0 truncate'>{folderPath[folderPath.length - 1]}</span>
           </span>
         )}
       </Command.Item>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items.tsx
@@ -58,7 +58,7 @@ export const MemoizedWorkflowItem = memo(
     onSelect: () => void
     color: string
     name: string
-    folderPath?: string
+    folderPath?: string[]
     isCurrent?: boolean
   }) {
     return (
@@ -71,13 +71,20 @@ export const MemoizedWorkflowItem = memo(
             backgroundClip: 'padding-box',
           }}
         />
-        <span className='truncate font-base text-[var(--text-body)]'>
-          {name}
-          {isCurrent && ' (current)'}
+        <span className='flex min-w-0 max-w-[75%] flex-shrink-0 font-base text-[var(--text-body)]'>
+          <span className='truncate'>{name}</span>
+          {isCurrent && <span className='flex-shrink-0 whitespace-pre'> (current)</span>}
         </span>
-        {folderPath && (
-          <span className='ml-auto min-w-0 truncate pl-2 font-base text-[var(--text-subtle)] text-small'>
-            {folderPath}
+        {folderPath && folderPath.length > 0 && (
+          <span className='ml-auto flex min-w-0 pl-2 font-base text-[var(--text-subtle)] text-small'>
+            {folderPath.length > 1 && (
+              <span className='min-w-0 flex-shrink truncate'>
+                {folderPath.slice(0, -1).join(' / ')}
+              </span>
+            )}
+            <span className='flex-shrink-0 whitespace-pre'>
+              {folderPath.length > 1 ? ` / ${folderPath[folderPath.length - 1]}` : folderPath[0]}
+            </span>
           </span>
         )}
       </Command.Item>
@@ -127,9 +134,9 @@ export const MemoizedWorkspaceItem = memo(
   }) {
     return (
       <Command.Item value={value} onSelect={onSelect} className={COMMAND_ITEM_CLASSNAME}>
-        <span className='truncate font-base text-[var(--text-body)]'>
-          {name}
-          {isCurrent && ' (current)'}
+        <span className='flex min-w-0 font-base text-[var(--text-body)]'>
+          <span className='truncate'>{name}</span>
+          {isCurrent && <span className='flex-shrink-0 whitespace-pre'> (current)</span>}
         </span>
       </Command.Item>
     )

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items.tsx
@@ -95,8 +95,10 @@ export const MemoizedWorkflowItem = memo(
     prev.value === next.value &&
     prev.color === next.color &&
     prev.name === next.name &&
-    prev.folderPath === next.folderPath &&
-    prev.isCurrent === next.isCurrent
+    prev.isCurrent === next.isCurrent &&
+    (prev.folderPath === next.folderPath ||
+      (prev.folderPath?.length === next.folderPath?.length &&
+        (prev.folderPath ?? []).every((segment, i) => segment === next.folderPath?.[i])))
 )
 
 export const MemoizedTaskItem = memo(

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/search-groups.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/search-groups.tsx
@@ -163,7 +163,7 @@ export const WorkflowsGroup = memo(function WorkflowsGroup({
       {items.map((workflow) => (
         <MemoizedWorkflowItem
           key={workflow.id}
-          value={`${workflow.name} ${workflow.folderPath ?? ''} workflow-${workflow.id}`}
+          value={`${workflow.name} ${workflow.folderPath?.join(' / ') ?? ''} workflow-${workflow.id}`}
           onSelect={() => onSelect(workflow)}
           color={workflow.color}
           name={workflow.name}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/utils.ts
@@ -11,7 +11,7 @@ export interface WorkflowItem {
   name: string
   href: string
   color: string
-  folderPath?: string
+  folderPath?: string[]
   isCurrent?: boolean
 }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -637,16 +637,14 @@ export const Sidebar = memo(function Sidebar() {
     () =>
       regularWorkflows.map((workflow) => {
         const folderPath = workflow.folderId
-          ? getFolderPath(folderMap, workflow.folderId)
-              .map((folder) => folder.name)
-              .join(' / ')
-          : ''
+          ? getFolderPath(folderMap, workflow.folderId).map((folder) => folder.name)
+          : []
         return {
           id: workflow.id,
           name: workflow.name,
           href: `/workspace/${workspaceId}/w/${workflow.id}`,
           color: workflow.color,
-          folderPath: folderPath || undefined,
+          folderPath: folderPath.length > 0 ? folderPath : undefined,
           isCurrent: workflow.id === workflowId,
         }
       }),


### PR DESCRIPTION
## Summary
Search modal truncated poorly for nested folders and long workflow names.

Adjusted folder truncation to truncate middle folders first. Always prioritize workflow names over folder path up to 75% of the modal width. 

Pass in whole folder path so we don't need to do ugly string parsing. 

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
* Tested with long workflow names, paths, etc.
## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
<img width="909" height="394" alt="image" src="https://github.com/user-attachments/assets/008f0465-b232-4d77-b5a7-5c995d829f02" />
<img width="909" height="394" alt="image" src="https://github.com/user-attachments/assets/26be2f1f-01f1-4fcf-b450-10fc519b8115" />
<img width="909" height="394" alt="image" src="https://github.com/user-attachments/assets/70d988a8-ae36-40ce-af95-cdff0b9ad67e" />
<img width="909" height="394" alt="image" src="https://github.com/user-attachments/assets/1449defa-5b78-43f2-970c-c6cfe2b2bc92" />
<img width="909" height="394" alt="image" src="https://github.com/user-attachments/assets/2c86ba49-7be2-4fc5-906e-02fcce6188d8" />

