### PR TITLE
fix(billing): add idempotency to billing

### DIFF
--- a/apps/sim/app/api/billing/update-cost/route.ts
+++ b/apps/sim/app/api/billing/update-cost/route.ts
@@ -6,6 +6,7 @@ import { recordUsage } from '@/lib/billing/core/usage-log'
 import { checkAndBillOverageThreshold } from '@/lib/billing/threshold-billing'
 import { checkInternalApiKey } from '@/lib/copilot/request/http'
 import { isBillingEnabled } from '@/lib/core/config/feature-flags'
+import { type AtomicClaimResult, billingIdempotency } from '@/lib/core/idempotency/service'
 import { generateRequestId } from '@/lib/core/utils/request'
 
 const logger = createLogger('BillingUpdateCostAPI')
@@ -19,6 +20,7 @@ const UpdateCostSchema = z.object({
   source: z
     .enum(['copilot', 'workspace-chat', 'mcp_copilot', 'mothership_block'])
     .default('copilot'),
+  idempotencyKey: z.string().min(1).optional(),
 })
 
 /**
@@ -28,6 +30,7 @@ const UpdateCostSchema = z.object({
 export async function POST(req: NextRequest) {
   const requestId = generateRequestId()
   const startTime = Date.now()
+  let claim: AtomicClaimResult | null = null
 
   try {
     logger.info(`[${requestId}] Update cost request started`)
@@ -75,8 +78,29 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    const { userId, cost, model, inputTokens, outputTokens, source } = validation.data
+    const { userId, cost, model, inputTokens, outputTokens, source, idempotencyKey } =
+      validation.data
     const isMcp = source === 'mcp_copilot'
+
+    claim = idempotencyKey
+      ? await billingIdempotency.atomicallyClaim('update-cost', idempotencyKey)
+      : null
+
+    if (claim && !claim.claimed) {
+      logger.warn(`[${requestId}] Duplicate billing update rejected`, {
+        idempotencyKey,
+        userId,
+        source,
+      })
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Duplicate request: idempotency key already processed',
+          requestId,
+        },
+        { status: 409 }
+      )
+    }
 
     logger.info(`[${requestId}] Processing cost update`, {
       userId,
@@ -148,6 +172,17 @@ export async function POST(req: NextRequest) {
       stack: error instanceof Error ? error.stack : undefined,
       duration,
     })
+
+    if (claim?.claimed) {
+      await billingIdempotency
+        .release(claim.normalizedKey, claim.storageMethod)
+        .catch((releaseErr) => {
+          logger.warn(`[${requestId}] Failed to release idempotency claim`, {
+            error: releaseErr instanceof Error ? releaseErr.message : String(releaseErr),
+            normalizedKey: claim?.normalizedKey,
+          })
+        })
+    }
 
     return NextResponse.json(
       {

--- a/apps/sim/app/api/billing/update-cost/route.ts
+++ b/apps/sim/app/api/billing/update-cost/route.ts
@@ -31,6 +31,7 @@ export async function POST(req: NextRequest) {
   const requestId = generateRequestId()
   const startTime = Date.now()
   let claim: AtomicClaimResult | null = null
+  let usageCommitted = false
 
   try {
     logger.info(`[${requestId}] Update cost request started`)
@@ -137,6 +138,7 @@ export async function POST(req: NextRequest) {
       ],
       additionalStats,
     })
+    usageCommitted = true
 
     logger.info(`[${requestId}] Recorded usage`, {
       userId,
@@ -173,7 +175,7 @@ export async function POST(req: NextRequest) {
       duration,
     })
 
-    if (claim?.claimed) {
+    if (claim?.claimed && !usageCommitted) {
       await billingIdempotency
         .release(claim.normalizedKey, claim.storageMethod)
         .catch((releaseErr) => {
@@ -182,6 +184,11 @@ export async function POST(req: NextRequest) {
             normalizedKey: claim?.normalizedKey,
           })
         })
+    } else if (claim?.claimed && usageCommitted) {
+      logger.warn(
+        `[${requestId}] Error occurred after usage committed; retaining idempotency claim to prevent double-billing`,
+        { normalizedKey: claim.normalizedKey }
+      )
     }
 
     return NextResponse.json(

--- a/apps/sim/lib/core/idempotency/service.ts
+++ b/apps/sim/lib/core/idempotency/service.ts
@@ -343,6 +343,10 @@ export class IdempotencyService {
     logger.debug(`Stored idempotency result in database: ${normalizedKey}`)
   }
 
+  async release(normalizedKey: string, storageMethod: 'redis' | 'database'): Promise<void> {
+    return this.deleteKey(normalizedKey, storageMethod)
+  }
+
   private async deleteKey(
     normalizedKey: string,
     storageMethod: 'redis' | 'database'
@@ -481,4 +485,9 @@ export const pollingIdempotency = new IdempotencyService({
   namespace: 'polling',
   ttlSeconds: 60 * 60 * 24 * 3, // 3 days
   retryFailures: true,
+})
+
+export const billingIdempotency = new IdempotencyService({
+  namespace: 'billing',
+  ttlSeconds: 60 * 60, // 1 hour
 })


### PR DESCRIPTION
## Summary
Our usage log has external dependencies to stripe. This can hang, causing copilot to retry and double-bill. 
Added a optional idempotency key to skip billing if a request is duplicated. 

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
* Tested locally. 
## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
