### PR TITLE
feat(microsoft-excel): add SharePoint drive support for Excel integration

### DIFF
--- a/apps/docs/content/docs/en/tools/microsoft_excel.mdx
+++ b/apps/docs/content/docs/en/tools/microsoft_excel.mdx
@@ -45,6 +45,7 @@ Read data from a specific sheet in a Microsoft Excel spreadsheet
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
 | `spreadsheetId` | string | Yes | The ID of the spreadsheet/workbook to read from \(e.g., "01ABC123DEF456"\) |
+| `driveId` | string | No | The ID of the drive containing the spreadsheet. Required for SharePoint files. If omitted, uses personal OneDrive. |
 | `range` | string | No | The range of cells to read from. Accepts "SheetName!A1:B2" for explicit ranges or just "SheetName" to read the used range of that sheet. If omitted, reads the used range of the first sheet. |
 
 #### Output
@@ -67,6 +68,7 @@ Write data to a specific sheet in a Microsoft Excel spreadsheet
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
 | `spreadsheetId` | string | Yes | The ID of the spreadsheet/workbook to write to \(e.g., "01ABC123DEF456"\) |
+| `driveId` | string | No | The ID of the drive containing the spreadsheet. Required for SharePoint files. If omitted, uses personal OneDrive. |
 | `range` | string | No | The range of cells to write to \(e.g., "Sheet1!A1:B2"\) |
 | `values` | array | Yes | The data to write as a 2D array \(e.g., \[\["Name", "Age"\], \["Alice", 30\]\]\) or array of objects |
 | `valueInputOption` | string | No | The format of the data to write |

--- a/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
+++ b/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
-import { validateAlphanumericId } from '@/lib/core/security/input-validation'
+import { validateMicrosoftGraphId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { getCredential, refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
@@ -77,7 +77,7 @@ export async function GET(request: NextRequest) {
     // When driveId is provided (SharePoint), search within that specific drive.
     // Otherwise, search the user's personal OneDrive.
     if (driveId) {
-      const driveIdValidation = validateAlphanumericId(driveId, 'driveId')
+      const driveIdValidation = validateMicrosoftGraphId(driveId, 'driveId')
       if (!driveIdValidation.isValid) {
         return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })
       }

--- a/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
+++ b/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
@@ -75,6 +75,9 @@ export async function GET(request: NextRequest) {
 
     // When driveId is provided (SharePoint), search within that specific drive.
     // Otherwise, search the user's personal OneDrive.
+    if (driveId && !/^[\w-]+$/.test(driveId)) {
+      return NextResponse.json({ error: 'Invalid drive ID format' }, { status: 400 })
+    }
     const drivePath = driveId ? `drives/${driveId}` : 'me/drive'
 
     const response = await fetch(

--- a/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
+++ b/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
-import { validateMicrosoftGraphId } from '@/lib/core/security/input-validation'
+import { validatePathSegment } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { getCredential, refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
@@ -77,7 +77,10 @@ export async function GET(request: NextRequest) {
     // When driveId is provided (SharePoint), search within that specific drive.
     // Otherwise, search the user's personal OneDrive.
     if (driveId) {
-      const driveIdValidation = validateMicrosoftGraphId(driveId, 'driveId')
+      const driveIdValidation = validatePathSegment(driveId, {
+        paramName: 'driveId',
+        customPattern: /^[a-zA-Z0-9!_-]+$/,
+      })
       if (!driveIdValidation.isValid) {
         return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })
       }

--- a/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
+++ b/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
@@ -19,6 +19,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const credentialId = searchParams.get('credentialId')
     const query = searchParams.get('query') || ''
+    const driveId = searchParams.get('driveId') || undefined
     const workflowId = searchParams.get('workflowId') || undefined
 
     if (!credentialId) {
@@ -72,8 +73,12 @@ export async function GET(request: NextRequest) {
     )
     searchParams_new.append('$top', '50')
 
+    // When driveId is provided (SharePoint), search within that specific drive.
+    // Otherwise, search the user's personal OneDrive.
+    const drivePath = driveId ? `drives/${driveId}` : 'me/drive'
+
     const response = await fetch(
-      `https://graph.microsoft.com/v1.0/me/drive/root/search(q='${encodeURIComponent(searchQuery)}')?${searchParams_new.toString()}`,
+      `https://graph.microsoft.com/v1.0/${drivePath}/root/search(q='${encodeURIComponent(searchQuery)}')?${searchParams_new.toString()}`,
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,

--- a/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
+++ b/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
+import { validateAlphanumericId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { getCredential, refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
@@ -75,8 +76,11 @@ export async function GET(request: NextRequest) {
 
     // When driveId is provided (SharePoint), search within that specific drive.
     // Otherwise, search the user's personal OneDrive.
-    if (driveId && !/^[\w-]+$/.test(driveId)) {
-      return NextResponse.json({ error: 'Invalid drive ID format' }, { status: 400 })
+    if (driveId) {
+      const driveIdValidation = validateAlphanumericId(driveId, 'driveId')
+      if (!driveIdValidation.isValid) {
+        return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })
+      }
     }
     const drivePath = driveId ? `drives/${driveId}` : 'me/drive'
 

--- a/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import {
-  validateMicrosoftGraphId,
+  validatePathSegment,
   validateSharePointSiteId,
 } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
@@ -70,7 +70,10 @@ export async function POST(request: NextRequest) {
 
     // Single-drive lookup when driveId is provided (used by fetchById)
     if (driveId) {
-      const driveIdValidation = validateMicrosoftGraphId(driveId, 'driveId')
+      const driveIdValidation = validatePathSegment(driveId, {
+        paramName: 'driveId',
+        customPattern: /^[a-zA-Z0-9!_-]+$/,
+      })
       if (!driveIdValidation.isValid) {
         return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })
       }

--- a/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
@@ -1,10 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
-import {
-  validatePathSegment,
-  validateSharePointSiteId,
-} from '@/lib/core/security/input-validation'
+import { validatePathSegment, validateSharePointSiteId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 

--- a/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
@@ -1,0 +1,94 @@
+import { createLogger } from '@sim/logger'
+import { NextResponse } from 'next/server'
+import { authorizeCredentialUse } from '@/lib/auth/credential-access'
+import { generateRequestId } from '@/lib/core/utils/request'
+import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
+
+export const dynamic = 'force-dynamic'
+
+const logger = createLogger('MicrosoftExcelDrivesAPI')
+
+interface GraphDrive {
+  id: string
+  name: string
+  driveType: string
+  webUrl?: string
+}
+
+/**
+ * List document libraries (drives) for a SharePoint site.
+ * Used by the microsoft.excel.drives selector to let users pick
+ * which drive contains their Excel file.
+ */
+export async function POST(request: Request) {
+  const requestId = generateRequestId()
+
+  try {
+    const body = await request.json()
+    const { credential, workflowId, siteId } = body
+
+    if (!credential) {
+      logger.warn(`[${requestId}] Missing credential in request`)
+      return NextResponse.json({ error: 'Credential is required' }, { status: 400 })
+    }
+
+    if (!siteId) {
+      logger.warn(`[${requestId}] Missing siteId in request`)
+      return NextResponse.json({ error: 'Site ID is required' }, { status: 400 })
+    }
+
+    const authz = await authorizeCredentialUse(request as Request, {
+      credentialId: credential,
+      workflowId,
+    })
+    if (!authz.ok || !authz.credentialOwnerUserId) {
+      return NextResponse.json({ error: authz.error || 'Unauthorized' }, { status: 403 })
+    }
+
+    const accessToken = await refreshAccessTokenIfNeeded(
+      credential,
+      authz.credentialOwnerUserId,
+      requestId
+    )
+    if (!accessToken) {
+      logger.warn(`[${requestId}] Failed to obtain valid access token`)
+      return NextResponse.json(
+        { error: 'Failed to obtain valid access token', authRequired: true },
+        { status: 401 }
+      )
+    }
+
+    const url = `https://graph.microsoft.com/v1.0/sites/${siteId}/drives?$select=id,name,driveType,webUrl`
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ error: { message: 'Unknown error' } }))
+      logger.error(`[${requestId}] Microsoft Graph API error fetching drives`, {
+        status: response.status,
+        error: errorData.error?.message,
+      })
+      return NextResponse.json(
+        { error: errorData.error?.message || 'Failed to fetch drives' },
+        { status: response.status }
+      )
+    }
+
+    const data = await response.json()
+    const drives = (data.value || []).map((drive: GraphDrive) => ({
+      id: drive.id,
+      name: drive.name,
+      driveType: drive.driveType,
+    }))
+
+    logger.info(`[${requestId}] Successfully fetched ${drives.length} drives for site ${siteId}`)
+    return NextResponse.json({ drives }, { status: 200 })
+  } catch (error) {
+    logger.error(`[${requestId}] Error fetching drives`, error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@sim/logger'
-import { NextResponse } from 'next/server'
+import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
@@ -20,12 +20,12 @@ interface GraphDrive {
  * Used by the microsoft.excel.drives selector to let users pick
  * which drive contains their Excel file.
  */
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
   const requestId = generateRequestId()
 
   try {
     const body = await request.json()
-    const { credential, workflowId, siteId } = body
+    const { credential, workflowId, siteId, driveId } = body
 
     if (!credential) {
       logger.warn(`[${requestId}] Missing credential in request`)
@@ -37,7 +37,12 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Site ID is required' }, { status: 400 })
     }
 
-    const authz = await authorizeCredentialUse(request as Request, {
+    if (!/^[\w.,;:-]+$/.test(siteId)) {
+      logger.warn(`[${requestId}] Invalid siteId format`)
+      return NextResponse.json({ error: 'Invalid site ID format' }, { status: 400 })
+    }
+
+    const authz = await authorizeCredentialUse(request, {
       credentialId: credential,
       workflowId,
     })
@@ -58,6 +63,35 @@ export async function POST(request: Request) {
       )
     }
 
+    // Single-drive lookup when driveId is provided (used by fetchById)
+    if (driveId) {
+      if (!/^[\w-]+$/.test(driveId)) {
+        return NextResponse.json({ error: 'Invalid drive ID format' }, { status: 400 })
+      }
+
+      const url = `https://graph.microsoft.com/v1.0/sites/${siteId}/drives/${driveId}?$select=id,name,driveType,webUrl`
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      })
+
+      if (!response.ok) {
+        const errorData = await response
+          .json()
+          .catch(() => ({ error: { message: 'Unknown error' } }))
+        return NextResponse.json(
+          { error: errorData.error?.message || 'Failed to fetch drive' },
+          { status: response.status }
+        )
+      }
+
+      const data: GraphDrive = await response.json()
+      return NextResponse.json(
+        { drive: { id: data.id, name: data.name, driveType: data.driveType } },
+        { status: 200 }
+      )
+    }
+
+    // List all drives for the site
     const url = `https://graph.microsoft.com/v1.0/sites/${siteId}/drives?$select=id,name,driveType,webUrl`
 
     const response = await fetch(url, {

--- a/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
@@ -1,6 +1,10 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
+import {
+  validateAlphanumericId,
+  validateSharePointSiteId,
+} from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
@@ -37,9 +41,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Site ID is required' }, { status: 400 })
     }
 
-    if (!/^[\w.,;:-]+$/.test(siteId)) {
+    const siteIdValidation = validateSharePointSiteId(siteId, 'siteId')
+    if (!siteIdValidation.isValid) {
       logger.warn(`[${requestId}] Invalid siteId format`)
-      return NextResponse.json({ error: 'Invalid site ID format' }, { status: 400 })
+      return NextResponse.json({ error: siteIdValidation.error }, { status: 400 })
     }
 
     const authz = await authorizeCredentialUse(request, {
@@ -65,8 +70,9 @@ export async function POST(request: NextRequest) {
 
     // Single-drive lookup when driveId is provided (used by fetchById)
     if (driveId) {
-      if (!/^[\w-]+$/.test(driveId)) {
-        return NextResponse.json({ error: 'Invalid drive ID format' }, { status: 400 })
+      const driveIdValidation = validateAlphanumericId(driveId, 'driveId')
+      if (!driveIdValidation.isValid) {
+        return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })
       }
 
       const url = `https://graph.microsoft.com/v1.0/sites/${siteId}/drives/${driveId}?$select=id,name,driveType,webUrl`

--- a/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import {
-  validateAlphanumericId,
+  validateMicrosoftGraphId,
   validateSharePointSiteId,
 } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
@@ -70,7 +70,7 @@ export async function POST(request: NextRequest) {
 
     // Single-drive lookup when driveId is provided (used by fetchById)
     if (driveId) {
-      const driveIdValidation = validateAlphanumericId(driveId, 'driveId')
+      const driveIdValidation = validateMicrosoftGraphId(driveId, 'driveId')
       if (!driveIdValidation.isValid) {
         return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })
       }

--- a/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
@@ -2,8 +2,8 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { generateRequestId } from '@/lib/core/utils/request'
-import { getItemBasePath } from '@/tools/microsoft_excel/utils'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
+import { getItemBasePath } from '@/tools/microsoft_excel/utils'
 
 export const dynamic = 'force-dynamic'
 

--- a/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
+import { validateAlphanumericId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
@@ -62,8 +63,11 @@ export async function GET(request: NextRequest) {
       `[${requestId}] Fetching worksheets from Microsoft Graph API for workbook ${spreadsheetId}`
     )
 
-    if (driveId && !/^[\w-]+$/.test(driveId)) {
-      return NextResponse.json({ error: 'Invalid drive ID format' }, { status: 400 })
+    if (driveId) {
+      const driveIdValidation = validateAlphanumericId(driveId, 'driveId')
+      if (!driveIdValidation.isValid) {
+        return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })
+      }
     }
 
     const basePath = driveId

--- a/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
@@ -1,7 +1,10 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
-import { validateAlphanumericId } from '@/lib/core/security/input-validation'
+import {
+  validateAlphanumericId,
+  validateMicrosoftGraphId,
+} from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
@@ -62,6 +65,11 @@ export async function GET(request: NextRequest) {
     logger.info(
       `[${requestId}] Fetching worksheets from Microsoft Graph API for workbook ${spreadsheetId}`
     )
+
+    const spreadsheetValidation = validateMicrosoftGraphId(spreadsheetId, 'spreadsheetId')
+    if (!spreadsheetValidation.isValid) {
+      return NextResponse.json({ error: spreadsheetValidation.error }, { status: 400 })
+    }
 
     if (driveId) {
       const driveIdValidation = validateAlphanumericId(driveId, 'driveId')

--- a/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
-import { validateMicrosoftGraphId } from '@/lib/core/security/input-validation'
+import { validatePathSegment } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
@@ -63,13 +63,21 @@ export async function GET(request: NextRequest) {
       `[${requestId}] Fetching worksheets from Microsoft Graph API for workbook ${spreadsheetId}`
     )
 
-    const spreadsheetValidation = validateMicrosoftGraphId(spreadsheetId, 'spreadsheetId')
+    const graphIdPattern = /^[a-zA-Z0-9!_-]+$/
+
+    const spreadsheetValidation = validatePathSegment(spreadsheetId, {
+      paramName: 'spreadsheetId',
+      customPattern: graphIdPattern,
+    })
     if (!spreadsheetValidation.isValid) {
       return NextResponse.json({ error: spreadsheetValidation.error }, { status: 400 })
     }
 
     if (driveId) {
-      const driveIdValidation = validateMicrosoftGraphId(driveId, 'driveId')
+      const driveIdValidation = validatePathSegment(driveId, {
+        paramName: 'driveId',
+        customPattern: graphIdPattern,
+      })
       if (!driveIdValidation.isValid) {
         return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })
       }

--- a/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
@@ -30,6 +30,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const credentialId = searchParams.get('credentialId')
     const spreadsheetId = searchParams.get('spreadsheetId')
+    const driveId = searchParams.get('driveId') || undefined
     const workflowId = searchParams.get('workflowId') || undefined
 
     if (!credentialId) {
@@ -61,17 +62,17 @@ export async function GET(request: NextRequest) {
       `[${requestId}] Fetching worksheets from Microsoft Graph API for workbook ${spreadsheetId}`
     )
 
-    // Fetch worksheets from Microsoft Graph API
-    const worksheetsResponse = await fetch(
-      `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}/workbook/worksheets`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'Content-Type': 'application/json',
-        },
-      }
-    )
+    const basePath = driveId
+      ? `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${spreadsheetId}`
+      : `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}`
+
+    const worksheetsResponse = await fetch(`${basePath}/workbook/worksheets`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+    })
 
     if (!worksheetsResponse.ok) {
       const errorData = await worksheetsResponse

--- a/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
@@ -1,10 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
-import {
-  validateAlphanumericId,
-  validateMicrosoftGraphId,
-} from '@/lib/core/security/input-validation'
+import { validateMicrosoftGraphId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
@@ -72,7 +69,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (driveId) {
-      const driveIdValidation = validateAlphanumericId(driveId, 'driveId')
+      const driveIdValidation = validateMicrosoftGraphId(driveId, 'driveId')
       if (!driveIdValidation.isValid) {
         return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })
       }

--- a/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
@@ -1,8 +1,8 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
-import { validatePathSegment } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
+import { getItemBasePath } from '@/tools/microsoft_excel/utils'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
 export const dynamic = 'force-dynamic'
@@ -63,29 +63,15 @@ export async function GET(request: NextRequest) {
       `[${requestId}] Fetching worksheets from Microsoft Graph API for workbook ${spreadsheetId}`
     )
 
-    const graphIdPattern = /^[a-zA-Z0-9!_-]+$/
-
-    const spreadsheetValidation = validatePathSegment(spreadsheetId, {
-      paramName: 'spreadsheetId',
-      customPattern: graphIdPattern,
-    })
-    if (!spreadsheetValidation.isValid) {
-      return NextResponse.json({ error: spreadsheetValidation.error }, { status: 400 })
+    let basePath: string
+    try {
+      basePath = getItemBasePath(spreadsheetId, driveId)
+    } catch (error) {
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : 'Invalid parameters' },
+        { status: 400 }
+      )
     }
-
-    if (driveId) {
-      const driveIdValidation = validatePathSegment(driveId, {
-        paramName: 'driveId',
-        customPattern: graphIdPattern,
-      })
-      if (!driveIdValidation.isValid) {
-        return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })
-      }
-    }
-
-    const basePath = driveId
-      ? `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${spreadsheetId}`
-      : `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}`
 
     const worksheetsResponse = await fetch(`${basePath}/workbook/worksheets`, {
       method: 'GET',

--- a/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/sheets/route.ts
@@ -62,6 +62,10 @@ export async function GET(request: NextRequest) {
       `[${requestId}] Fetching worksheets from Microsoft Graph API for workbook ${spreadsheetId}`
     )
 
+    if (driveId && !/^[\w-]+$/.test(driveId)) {
+      return NextResponse.json({ error: 'Invalid drive ID format' }, { status: 400 })
+    }
+
     const basePath = driveId
       ? `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${spreadsheetId}`
       : `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}`

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -431,7 +431,7 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       requiredScopes: [],
       mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
       placeholder: 'Select a spreadsheet',
-      dependsOn: ['credential'],
+      dependsOn: { all: ['credential'], any: ['driveSelector'] },
       mode: 'basic',
     },
     // Manual Spreadsheet ID (advanced mode)
@@ -441,7 +441,7 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       type: 'short-input',
       canonicalParamId: 'spreadsheetId',
       placeholder: 'Enter spreadsheet ID',
-      dependsOn: ['credential'],
+      dependsOn: { all: ['credential'], any: ['manualDriveId'] },
       mode: 'advanced',
     },
     // Drive ID for SharePoint (advanced mode)
@@ -464,7 +464,10 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       selectorAllowSearch: false,
       placeholder: 'Select a sheet',
       required: true,
-      dependsOn: { all: ['credential'], any: ['spreadsheetId', 'manualSpreadsheetId'] },
+      dependsOn: {
+        all: ['credential'],
+        any: ['spreadsheetId', 'manualSpreadsheetId', 'driveSelector'],
+      },
       mode: 'basic',
     },
     // Manual Sheet Name (advanced mode)
@@ -475,7 +478,10 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       canonicalParamId: 'sheetName',
       placeholder: 'Name of the sheet/tab (e.g., Sheet1)',
       required: true,
-      dependsOn: ['credential'],
+      dependsOn: {
+        all: ['credential'],
+        any: ['manualDriveId'],
+      },
       mode: 'advanced',
     },
     // Cell Range (optional for read/write)

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -78,6 +78,13 @@ export const MicrosoftExcelBlock: BlockConfig<MicrosoftExcelResponse> = {
       mode: 'advanced',
     },
     {
+      id: 'driveId',
+      title: 'Drive ID (SharePoint)',
+      type: 'short-input',
+      placeholder: 'Leave empty for OneDrive, or enter drive ID for SharePoint',
+      mode: 'advanced',
+    },
+    {
       id: 'range',
       title: 'Range',
       type: 'short-input',
@@ -249,9 +256,17 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
         }
       },
       params: (params) => {
-        const { oauthCredential, values, spreadsheetId, tableName, worksheetName, ...rest } = params
+        const {
+          oauthCredential,
+          values,
+          spreadsheetId,
+          tableName,
+          worksheetName,
+          driveId,
+          siteId: _siteId,
+          ...rest
+        } = params
 
-        // Use canonical param ID (raw subBlock IDs are deleted after serialization)
         const effectiveSpreadsheetId = spreadsheetId ? String(spreadsheetId).trim() : ''
 
         let parsedValues
@@ -276,6 +291,7 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
         const baseParams = {
           ...rest,
           spreadsheetId: effectiveSpreadsheetId,
+          driveId: driveId ? String(driveId).trim() : undefined,
           values: parsedValues,
           oauthCredential,
         }
@@ -302,6 +318,7 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
     operation: { type: 'string', description: 'Operation to perform' },
     oauthCredential: { type: 'string', description: 'Microsoft Excel access token' },
     spreadsheetId: { type: 'string', description: 'Spreadsheet identifier (canonical param)' },
+    driveId: { type: 'string', description: 'Drive ID for SharePoint document libraries' },
     range: { type: 'string', description: 'Cell range' },
     tableName: { type: 'string', description: 'Table name' },
     worksheetName: { type: 'string', description: 'Worksheet name' },
@@ -377,6 +394,32 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       placeholder: 'Enter credential ID',
       required: true,
     },
+    // SharePoint Site Selector (basic mode, optional)
+    {
+      id: 'siteSelector',
+      title: 'SharePoint Site (Optional)',
+      type: 'file-selector',
+      canonicalParamId: 'siteId',
+      serviceId: 'sharepoint',
+      selectorKey: 'sharepoint.sites',
+      requiredScopes: [],
+      placeholder: 'Select a SharePoint site (leave empty for OneDrive)',
+      dependsOn: ['credential'],
+      mode: 'basic',
+    },
+    // SharePoint Drive Selector (basic mode, depends on site)
+    {
+      id: 'driveSelector',
+      title: 'Document Library',
+      type: 'file-selector',
+      canonicalParamId: 'driveId',
+      serviceId: 'microsoft-excel',
+      selectorKey: 'microsoft.excel.drives',
+      selectorAllowSearch: false,
+      placeholder: 'Select a document library',
+      dependsOn: ['credential', 'siteSelector'],
+      mode: 'basic',
+    },
     // Spreadsheet Selector (basic mode)
     {
       id: 'spreadsheetId',
@@ -399,6 +442,15 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       canonicalParamId: 'spreadsheetId',
       placeholder: 'Enter spreadsheet ID',
       dependsOn: ['credential'],
+      mode: 'advanced',
+    },
+    // Drive ID for SharePoint (advanced mode)
+    {
+      id: 'manualDriveId',
+      title: 'Drive ID (SharePoint)',
+      type: 'short-input',
+      canonicalParamId: 'driveId',
+      placeholder: 'Leave empty for OneDrive, or enter drive ID for SharePoint',
       mode: 'advanced',
     },
     // Sheet Name Selector (basic mode)
@@ -514,11 +566,19 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
         fallbackToolId: 'microsoft_excel_read_v2',
       }),
       params: (params) => {
-        const { oauthCredential, values, spreadsheetId, sheetName, cellRange, ...rest } = params
+        const {
+          oauthCredential,
+          values,
+          spreadsheetId,
+          sheetName,
+          cellRange,
+          driveId,
+          siteId: _siteId,
+          ...rest
+        } = params
 
         const parsedValues = values ? JSON.parse(values as string) : undefined
 
-        // Use canonical param IDs (raw subBlock IDs are deleted after serialization)
         const effectiveSpreadsheetId = spreadsheetId ? String(spreadsheetId).trim() : ''
         const effectiveSheetName = sheetName ? String(sheetName).trim() : ''
 
@@ -535,6 +595,7 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
           spreadsheetId: effectiveSpreadsheetId,
           sheetName: effectiveSheetName,
           cellRange: cellRange ? (cellRange as string).trim() : undefined,
+          driveId: driveId ? String(driveId).trim() : undefined,
           values: parsedValues,
           oauthCredential,
         }
@@ -544,6 +605,8 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
   inputs: {
     operation: { type: 'string', description: 'Operation to perform' },
     oauthCredential: { type: 'string', description: 'Microsoft Excel access token' },
+    siteId: { type: 'string', description: 'SharePoint site ID (used for drive/file browsing)' },
+    driveId: { type: 'string', description: 'Drive ID for SharePoint document libraries' },
     spreadsheetId: { type: 'string', description: 'Spreadsheet identifier (canonical param)' },
     sheetName: { type: 'string', description: 'Name of the sheet/tab (canonical param)' },
     cellRange: { type: 'string', description: 'Cell range (e.g., A1:D10)' },

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -431,7 +431,7 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       requiredScopes: [],
       mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
       placeholder: 'Select a spreadsheet',
-      dependsOn: { all: ['credential'], any: ['driveSelector'] },
+      dependsOn: { all: ['credential'], any: ['credential', 'driveSelector'] },
       mode: 'basic',
     },
     // Manual Spreadsheet ID (advanced mode)
@@ -441,7 +441,7 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       type: 'short-input',
       canonicalParamId: 'spreadsheetId',
       placeholder: 'Enter spreadsheet ID',
-      dependsOn: { all: ['credential'], any: ['manualDriveId'] },
+      dependsOn: { all: ['credential'], any: ['credential', 'manualDriveId'] },
       mode: 'advanced',
     },
     // Drive ID for SharePoint (advanced mode)
@@ -480,7 +480,7 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       required: true,
       dependsOn: {
         all: ['credential'],
-        any: ['manualDriveId'],
+        any: ['credential', 'manualDriveId'],
       },
       mode: 'advanced',
     },

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -394,20 +394,34 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       placeholder: 'Enter credential ID',
       required: true,
     },
-    // SharePoint Site Selector (basic mode, optional)
+    // File Source selector (basic mode)
+    {
+      id: 'fileSource',
+      title: 'File Source',
+      type: 'dropdown',
+      options: [
+        { label: 'OneDrive', id: 'onedrive' },
+        { label: 'SharePoint', id: 'sharepoint' },
+      ],
+      value: () => 'onedrive',
+      mode: 'basic',
+    },
+    // SharePoint Site Selector (basic mode, only when SharePoint is selected)
     {
       id: 'siteSelector',
-      title: 'SharePoint Site (Optional)',
+      title: 'SharePoint Site',
       type: 'file-selector',
       canonicalParamId: 'siteId',
       serviceId: 'sharepoint',
       selectorKey: 'sharepoint.sites',
       requiredScopes: [],
-      placeholder: 'Select a SharePoint site (leave empty for OneDrive)',
+      placeholder: 'Select a SharePoint site',
       dependsOn: ['credential'],
+      condition: { field: 'fileSource', value: 'sharepoint' },
+      required: { field: 'fileSource', value: 'sharepoint' },
       mode: 'basic',
     },
-    // SharePoint Drive Selector (basic mode, only visible when a site is selected)
+    // SharePoint Drive Selector (basic mode, only when SharePoint is selected)
     {
       id: 'driveSelector',
       title: 'Document Library',
@@ -418,6 +432,8 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       selectorAllowSearch: false,
       placeholder: 'Select a document library',
       dependsOn: ['credential', 'siteSelector'],
+      condition: { field: 'fileSource', value: 'sharepoint' },
+      required: { field: 'fileSource', value: 'sharepoint' },
       mode: 'basic',
     },
     // Spreadsheet Selector (basic mode)
@@ -580,6 +596,7 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
           cellRange,
           driveId,
           siteId: _siteId,
+          fileSource: _fileSource,
           ...rest
         } = params
 
@@ -610,6 +627,7 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
   },
   inputs: {
     operation: { type: 'string', description: 'Operation to perform' },
+    fileSource: { type: 'string', description: 'File source (onedrive or sharepoint)' },
     oauthCredential: { type: 'string', description: 'Microsoft Excel access token' },
     siteId: { type: 'string', description: 'SharePoint site ID (used for drive/file browsing)' },
     driveId: { type: 'string', description: 'Drive ID for SharePoint document libraries' },

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -457,6 +457,7 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       canonicalParamId: 'driveId',
       placeholder: 'Enter the SharePoint drive ID',
       condition: { field: 'fileSource', value: 'sharepoint' },
+      dependsOn: ['fileSource'],
       mode: 'advanced',
     },
     // Manual Spreadsheet ID (advanced mode)

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -407,7 +407,7 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       dependsOn: ['credential'],
       mode: 'basic',
     },
-    // SharePoint Drive Selector (basic mode, depends on site)
+    // SharePoint Drive Selector (basic mode, only visible when a site is selected)
     {
       id: 'driveSelector',
       title: 'Document Library',

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -415,7 +415,7 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       selectorKey: 'sharepoint.sites',
       requiredScopes: [],
       placeholder: 'Select a SharePoint site',
-      dependsOn: ['credential'],
+      dependsOn: ['credential', 'fileSource'],
       condition: { field: 'fileSource', value: 'sharepoint' },
       required: { field: 'fileSource', value: 'sharepoint' },
       mode: 'basic',
@@ -430,7 +430,7 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       selectorKey: 'microsoft.excel.drives',
       selectorAllowSearch: false,
       placeholder: 'Select a document library',
-      dependsOn: ['credential', 'siteSelector'],
+      dependsOn: ['credential', 'siteSelector', 'fileSource'],
       condition: { field: 'fileSource', value: 'sharepoint' },
       required: { field: 'fileSource', value: 'sharepoint' },
       mode: 'basic',
@@ -446,18 +446,8 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       requiredScopes: [],
       mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
       placeholder: 'Select a spreadsheet',
-      dependsOn: { all: ['credential'], any: ['credential', 'driveSelector'] },
+      dependsOn: { all: ['credential', 'fileSource'], any: ['credential', 'driveSelector'] },
       mode: 'basic',
-    },
-    // Manual Spreadsheet ID (advanced mode)
-    {
-      id: 'manualSpreadsheetId',
-      title: 'Spreadsheet ID',
-      type: 'short-input',
-      canonicalParamId: 'spreadsheetId',
-      placeholder: 'Enter spreadsheet ID',
-      dependsOn: { all: ['credential'], any: ['credential', 'manualDriveId'] },
-      mode: 'advanced',
     },
     // Drive ID for SharePoint (advanced mode, only when SharePoint is selected)
     {
@@ -467,6 +457,16 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       canonicalParamId: 'driveId',
       placeholder: 'Enter the SharePoint drive ID',
       condition: { field: 'fileSource', value: 'sharepoint' },
+      mode: 'advanced',
+    },
+    // Manual Spreadsheet ID (advanced mode)
+    {
+      id: 'manualSpreadsheetId',
+      title: 'Spreadsheet ID',
+      type: 'short-input',
+      canonicalParamId: 'spreadsheetId',
+      placeholder: 'Enter spreadsheet ID',
+      dependsOn: { all: ['credential'], any: ['credential', 'manualDriveId'] },
       mode: 'advanced',
     },
     // Sheet Name Selector (basic mode)

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -69,19 +69,19 @@ export const MicrosoftExcelBlock: BlockConfig<MicrosoftExcelResponse> = {
       mode: 'basic',
     },
     {
+      id: 'driveId',
+      title: 'Drive ID (SharePoint)',
+      type: 'short-input',
+      placeholder: 'Leave empty for OneDrive, or enter drive ID for SharePoint',
+      mode: 'advanced',
+    },
+    {
       id: 'manualSpreadsheetId',
       title: 'Spreadsheet ID',
       type: 'short-input',
       canonicalParamId: 'spreadsheetId',
       placeholder: 'Enter spreadsheet ID',
       dependsOn: ['credential'],
-      mode: 'advanced',
-    },
-    {
-      id: 'driveId',
-      title: 'Drive ID (SharePoint)',
-      type: 'short-input',
-      placeholder: 'Leave empty for OneDrive, or enter drive ID for SharePoint',
       mode: 'advanced',
     },
     {

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -394,7 +394,7 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       placeholder: 'Enter credential ID',
       required: true,
     },
-    // File Source selector (basic mode)
+    // File Source selector (both modes)
     {
       id: 'fileSource',
       title: 'File Source',
@@ -404,7 +404,6 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
         { label: 'SharePoint', id: 'sharepoint' },
       ],
       value: () => 'onedrive',
-      mode: 'basic',
     },
     // SharePoint Site Selector (basic mode, only when SharePoint is selected)
     {
@@ -460,13 +459,14 @@ export const MicrosoftExcelV2Block: BlockConfig<MicrosoftExcelV2Response> = {
       dependsOn: { all: ['credential'], any: ['credential', 'manualDriveId'] },
       mode: 'advanced',
     },
-    // Drive ID for SharePoint (advanced mode)
+    // Drive ID for SharePoint (advanced mode, only when SharePoint is selected)
     {
       id: 'manualDriveId',
-      title: 'Drive ID (SharePoint)',
+      title: 'Drive ID',
       type: 'short-input',
       canonicalParamId: 'driveId',
-      placeholder: 'Leave empty for OneDrive, or enter drive ID for SharePoint',
+      placeholder: 'Enter the SharePoint drive ID',
+      condition: { field: 'fileSource', value: 'sharepoint' },
       mode: 'advanced',
     },
     // Sheet Name Selector (basic mode)

--- a/apps/sim/hooks/selectors/registry.ts
+++ b/apps/sim/hooks/selectors/registry.ts
@@ -1561,18 +1561,20 @@ const registry: Record<SelectorKey, SelectorDefinition> = {
     fetchById: async ({ context, detailId }: SelectorQueryArgs) => {
       if (!detailId || !context.siteId) return null
       const credentialId = ensureCredential(context, 'microsoft.excel.drives')
-      const body = JSON.stringify({
-        credential: credentialId,
-        workflowId: context.workflowId,
-        siteId: context.siteId,
-      })
-      const data = await fetchJson<{ drives: { id: string; name: string }[] }>(
+      const data = await fetchJson<{ drive: { id: string; name: string } }>(
         '/api/tools/microsoft_excel/drives',
-        { method: 'POST', body }
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            credential: credentialId,
+            workflowId: context.workflowId,
+            siteId: context.siteId,
+            driveId: detailId,
+          }),
+        }
       )
-      const drive = (data.drives || []).find((d) => d.id === detailId) ?? null
-      if (!drive) return null
-      return { id: drive.id, label: drive.name }
+      if (!data.drive) return null
+      return { id: data.drive.id, label: data.drive.name }
     },
   },
   'microsoft.excel': {

--- a/apps/sim/hooks/selectors/registry.ts
+++ b/apps/sim/hooks/selectors/registry.ts
@@ -1504,6 +1504,7 @@ const registry: Record<SelectorKey, SelectorDefinition> = {
       'microsoft.excel.sheets',
       context.oauthCredential ?? 'none',
       context.spreadsheetId ?? 'none',
+      context.driveId ?? 'none',
     ],
     enabled: ({ context }) => Boolean(context.oauthCredential && context.spreadsheetId),
     fetchList: async ({ context }: SelectorQueryArgs) => {
@@ -1517,6 +1518,7 @@ const registry: Record<SelectorKey, SelectorDefinition> = {
           searchParams: {
             credentialId,
             spreadsheetId: context.spreadsheetId,
+            driveId: context.driveId,
             workflowId: context.workflowId,
           },
         }
@@ -1527,6 +1529,52 @@ const registry: Record<SelectorKey, SelectorDefinition> = {
       }))
     },
   },
+  'microsoft.excel.drives': {
+    key: 'microsoft.excel.drives',
+    staleTime: SELECTOR_STALE,
+    getQueryKey: ({ context }: SelectorQueryArgs) => [
+      'selectors',
+      'microsoft.excel.drives',
+      context.oauthCredential ?? 'none',
+      context.siteId ?? 'none',
+    ],
+    enabled: ({ context }) => Boolean(context.oauthCredential && context.siteId),
+    fetchList: async ({ context }: SelectorQueryArgs) => {
+      const credentialId = ensureCredential(context, 'microsoft.excel.drives')
+      if (!context.siteId) {
+        throw new Error('Missing site ID for microsoft.excel.drives selector')
+      }
+      const body = JSON.stringify({
+        credential: credentialId,
+        workflowId: context.workflowId,
+        siteId: context.siteId,
+      })
+      const data = await fetchJson<{ drives: { id: string; name: string }[] }>(
+        '/api/tools/microsoft_excel/drives',
+        { method: 'POST', body }
+      )
+      return (data.drives || []).map((drive) => ({
+        id: drive.id,
+        label: drive.name,
+      }))
+    },
+    fetchById: async ({ context, detailId }: SelectorQueryArgs) => {
+      if (!detailId || !context.siteId) return null
+      const credentialId = ensureCredential(context, 'microsoft.excel.drives')
+      const body = JSON.stringify({
+        credential: credentialId,
+        workflowId: context.workflowId,
+        siteId: context.siteId,
+      })
+      const data = await fetchJson<{ drives: { id: string; name: string }[] }>(
+        '/api/tools/microsoft_excel/drives',
+        { method: 'POST', body }
+      )
+      const drive = (data.drives || []).find((d) => d.id === detailId) ?? null
+      if (!drive) return null
+      return { id: drive.id, label: drive.name }
+    },
+  },
   'microsoft.excel': {
     key: 'microsoft.excel',
     staleTime: SELECTOR_STALE,
@@ -1534,6 +1582,7 @@ const registry: Record<SelectorKey, SelectorDefinition> = {
       'selectors',
       'microsoft.excel',
       context.oauthCredential ?? 'none',
+      context.driveId ?? 'none',
       search ?? '',
     ],
     enabled: ({ context }) => Boolean(context.oauthCredential),
@@ -1545,6 +1594,7 @@ const registry: Record<SelectorKey, SelectorDefinition> = {
           searchParams: {
             credentialId,
             query: search,
+            driveId: context.driveId,
             workflowId: context.workflowId,
           },
         }

--- a/apps/sim/hooks/selectors/types.ts
+++ b/apps/sim/hooks/selectors/types.ts
@@ -40,6 +40,7 @@ export type SelectorKey =
   | 'onedrive.folders'
   | 'sharepoint.sites'
   | 'microsoft.excel'
+  | 'microsoft.excel.drives'
   | 'microsoft.excel.sheets'
   | 'microsoft.word'
   | 'microsoft.planner'
@@ -75,6 +76,7 @@ export interface SelectorContext {
   siteId?: string
   collectionId?: string
   spreadsheetId?: string
+  driveId?: string
   excludeWorkflowId?: string
   baseId?: string
   datasetId?: string

--- a/apps/sim/lib/workflows/subblocks/context.ts
+++ b/apps/sim/lib/workflows/subblocks/context.ts
@@ -17,6 +17,7 @@ export const SELECTOR_CONTEXT_FIELDS = new Set<keyof SelectorContext>([
   'siteId',
   'collectionId',
   'spreadsheetId',
+  'driveId',
   'fileId',
   'baseId',
   'datasetId',

--- a/apps/sim/tools/microsoft_excel/read.ts
+++ b/apps/sim/tools/microsoft_excel/read.ts
@@ -6,6 +6,7 @@ import type {
   MicrosoftExcelV2ToolParams,
 } from '@/tools/microsoft_excel/types'
 import {
+  getItemBasePath,
   getSpreadsheetWebUrl,
   trimTrailingEmptyRowsAndColumns,
 } from '@/tools/microsoft_excel/utils'
@@ -35,6 +36,13 @@ export const readTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelReadRe
       visibility: 'user-or-llm',
       description: 'The ID of the spreadsheet/workbook to read from (e.g., "01ABC123DEF456")',
     },
+    driveId: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description:
+        'The ID of the drive containing the spreadsheet. Required for SharePoint files. If omitted, uses personal OneDrive.',
+    },
     range: {
       type: 'string',
       required: false,
@@ -51,18 +59,17 @@ export const readTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelReadRe
         throw new Error('Spreadsheet ID is required')
       }
 
+      const basePath = getItemBasePath(spreadsheetId, params.driveId)
+
       if (!params.range) {
-        // When no range is provided, first fetch the first worksheet name (to avoid hardcoding "Sheet1")
-        // We'll read its default range after in transformResponse
-        return `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}/workbook/worksheets?$select=name&$orderby=position&$top=1`
+        return `${basePath}/workbook/worksheets?$select=name&$orderby=position&$top=1`
       }
 
       const rangeInput = params.range.trim()
 
-      // If the input contains no '!', treat it as a sheet name only and fetch usedRange
       if (!rangeInput.includes('!')) {
         const sheetOnly = encodeURIComponent(rangeInput)
-        return `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}/workbook/worksheets('${sheetOnly}')/usedRange(valuesOnly=true)`
+        return `${basePath}/workbook/worksheets('${sheetOnly}')/usedRange(valuesOnly=true)`
       }
 
       const match = rangeInput.match(/^([^!]+)!(.+)$/)
@@ -76,7 +83,7 @@ export const readTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelReadRe
       const sheetName = encodeURIComponent(match[1])
       const address = encodeURIComponent(match[2])
 
-      return `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}/workbook/worksheets('${sheetName}')/range(address='${address}')`
+      return `${basePath}/workbook/worksheets('${sheetName}')/range(address='${address}')`
     },
     method: 'GET',
     headers: (params) => {
@@ -91,6 +98,9 @@ export const readTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelReadRe
   },
 
   transformResponse: async (response: Response, params?: MicrosoftExcelToolParams) => {
+    const spreadsheetId = params?.spreadsheetId?.trim() || ''
+    const driveId = params?.driveId
+
     // If we came from the worksheets listing (no range provided), resolve first sheet name then fetch range
     if (response.url.includes('/workbook/worksheets?')) {
       const listData = await response.json()
@@ -100,23 +110,19 @@ export const readTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelReadRe
         throw new Error('No worksheets found in the Excel workbook')
       }
 
-      const spreadsheetIdFromUrl = response.url.split('/drive/items/')[1]?.split('/')[0] || ''
       const accessToken = params?.accessToken
       if (!accessToken) {
         throw new Error('Access token is required to read Excel range')
       }
 
-      // Use usedRange(valuesOnly=true) to fetch only populated cells, avoiding thousands of empty rows
-      const rangeUrl = `https://graph.microsoft.com/v1.0/me/drive/items/${encodeURIComponent(
-        spreadsheetIdFromUrl
-      )}/workbook/worksheets('${encodeURIComponent(firstSheetName)}')/usedRange(valuesOnly=true)`
+      const basePath = getItemBasePath(spreadsheetId, driveId)
+      const rangeUrl = `${basePath}/workbook/worksheets('${encodeURIComponent(firstSheetName)}')/usedRange(valuesOnly=true)`
 
       const rangeResp = await fetch(rangeUrl, {
         headers: { Authorization: `Bearer ${accessToken}` },
       })
 
       if (!rangeResp.ok) {
-        // Normalize Microsoft Graph sheet/range errors to a friendly message
         throw new Error(
           'Invalid range provided or worksheet not found. Provide a range like "Sheet1!A1:B2" or just the sheet name to read the whole sheet'
         )
@@ -124,20 +130,12 @@ export const readTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelReadRe
 
       const data = await rangeResp.json()
 
-      // usedRange returns an address (A1 notation) and values matrix
       const address: string = data.address || data.addressLocal || `${firstSheetName}!A1`
       const rawValues: ExcelCellValue[][] = data.values || []
 
       const values = trimTrailingEmptyRowsAndColumns(rawValues)
 
-      // Fetch the browser-accessible web URL
-      const webUrl = await getSpreadsheetWebUrl(spreadsheetIdFromUrl, accessToken)
-
-      const metadata = {
-        spreadsheetId: spreadsheetIdFromUrl,
-        properties: {},
-        spreadsheetUrl: webUrl,
-      }
+      const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken, driveId)
 
       const result: MicrosoftExcelReadResponse = {
         success: true,
@@ -147,8 +145,8 @@ export const readTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelReadRe
             values,
           },
           metadata: {
-            spreadsheetId: metadata.spreadsheetId,
-            spreadsheetUrl: metadata.spreadsheetUrl,
+            spreadsheetId,
+            spreadsheetUrl: webUrl,
           },
         },
       }
@@ -159,21 +157,11 @@ export const readTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelReadRe
     // Normal path: caller supplied a range; just return the parsed result
     const data = await response.json()
 
-    const urlParts = response.url.split('/drive/items/')
-    const spreadsheetId = urlParts[1]?.split('/')[0] || ''
-
-    // Fetch the browser-accessible web URL
     const accessToken = params?.accessToken
     if (!accessToken) {
       throw new Error('Access token is required')
     }
-    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken)
-
-    const metadata = {
-      spreadsheetId,
-      properties: {},
-      spreadsheetUrl: webUrl,
-    }
+    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken, driveId)
 
     const address: string = data.address || data.addressLocal || data.range || ''
     const rawValues: ExcelCellValue[][] = data.values || []
@@ -187,8 +175,8 @@ export const readTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelReadRe
           values,
         },
         metadata: {
-          spreadsheetId: metadata.spreadsheetId,
-          spreadsheetUrl: metadata.spreadsheetUrl,
+          spreadsheetId,
+          spreadsheetUrl: webUrl,
         },
       },
     }
@@ -240,6 +228,13 @@ export const readV2Tool: ToolConfig<MicrosoftExcelV2ToolParams, MicrosoftExcelV2
       visibility: 'user-or-llm',
       description: 'The ID of the spreadsheet/workbook to read from (e.g., "01ABC123DEF456")',
     },
+    driveId: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description:
+        'The ID of the drive containing the spreadsheet. Required for SharePoint files. If omitted, uses personal OneDrive.',
+    },
     sheetName: {
       type: 'string',
       required: true,
@@ -267,17 +262,17 @@ export const readV2Tool: ToolConfig<MicrosoftExcelV2ToolParams, MicrosoftExcelV2
         throw new Error('Sheet name is required')
       }
 
+      const basePath = getItemBasePath(spreadsheetId, params.driveId)
       const encodedSheetName = encodeURIComponent(sheetName)
 
-      // If no cell range specified, fetch usedRange
       if (!params.cellRange) {
-        return `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}/workbook/worksheets('${encodedSheetName}')/usedRange(valuesOnly=true)`
+        return `${basePath}/workbook/worksheets('${encodedSheetName}')/usedRange(valuesOnly=true)`
       }
 
       const cellRange = params.cellRange.trim()
       const encodedAddress = encodeURIComponent(cellRange)
 
-      return `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}/workbook/worksheets('${encodedSheetName}')/range(address='${encodedAddress}')`
+      return `${basePath}/workbook/worksheets('${encodedSheetName}')/range(address='${encodedAddress}')`
     },
     method: 'GET',
     headers: (params) => {
@@ -294,20 +289,19 @@ export const readV2Tool: ToolConfig<MicrosoftExcelV2ToolParams, MicrosoftExcelV2
   transformResponse: async (response: Response, params?: MicrosoftExcelV2ToolParams) => {
     const data = await response.json()
 
-    const urlParts = response.url.split('/drive/items/')
-    const spreadsheetId = urlParts[1]?.split('/')[0] || ''
+    const spreadsheetId = params?.spreadsheetId?.trim() || ''
+    const driveId = params?.driveId
 
     const accessToken = params?.accessToken
     if (!accessToken) {
       throw new Error('Access token is required')
     }
-    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken)
+    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken, driveId)
 
     const address: string = data.address || data.addressLocal || ''
     const rawValues: ExcelCellValue[][] = data.values || []
     const values = trimTrailingEmptyRowsAndColumns(rawValues)
 
-    // Extract sheet name from address (format: SheetName!A1:B2)
     const sheetName = params?.sheetName || address.split('!')[0] || ''
 
     return {

--- a/apps/sim/tools/microsoft_excel/table_add.ts
+++ b/apps/sim/tools/microsoft_excel/table_add.ts
@@ -2,7 +2,7 @@ import type {
   MicrosoftExcelTableAddResponse,
   MicrosoftExcelTableToolParams,
 } from '@/tools/microsoft_excel/types'
-import { getSpreadsheetWebUrl } from '@/tools/microsoft_excel/utils'
+import { getItemBasePath, getSpreadsheetWebUrl } from '@/tools/microsoft_excel/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const tableAddTool: ToolConfig<
@@ -33,6 +33,13 @@ export const tableAddTool: ToolConfig<
       description:
         'The ID of the spreadsheet/workbook containing the table (e.g., "01ABC123DEF456")',
     },
+    driveId: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description:
+        'The ID of the drive containing the spreadsheet. Required for SharePoint files. If omitted, uses personal OneDrive.',
+    },
     tableName: {
       type: 'string',
       required: true,
@@ -51,7 +58,8 @@ export const tableAddTool: ToolConfig<
   request: {
     url: (params) => {
       const tableName = encodeURIComponent(params.tableName)
-      return `https://graph.microsoft.com/v1.0/me/drive/items/${params.spreadsheetId}/workbook/tables('${tableName}')/rows/add`
+      const basePath = getItemBasePath(params.spreadsheetId, params.driveId)
+      return `${basePath}/workbook/tables('${tableName}')/rows/add`
     },
     method: 'POST',
     headers: (params) => ({
@@ -106,34 +114,26 @@ export const tableAddTool: ToolConfig<
   transformResponse: async (response: Response, params?: MicrosoftExcelTableToolParams) => {
     const data = await response.json()
 
-    const urlParts = response.url.split('/drive/items/')
-    const spreadsheetId = urlParts[1]?.split('/')[0] || ''
+    const spreadsheetId = params?.spreadsheetId?.trim() || ''
+    const driveId = params?.driveId
 
-    // Fetch the browser-accessible web URL
     const accessToken = params?.accessToken
     if (!accessToken) {
       throw new Error('Access token is required')
     }
-    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken)
+    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken, driveId)
 
-    const metadata = {
-      spreadsheetId,
-      spreadsheetUrl: webUrl,
-    }
-
-    const result = {
+    return {
       success: true,
       output: {
         index: data.index || 0,
         values: data.values || [],
         metadata: {
-          spreadsheetId: metadata.spreadsheetId,
-          spreadsheetUrl: metadata.spreadsheetUrl,
+          spreadsheetId,
+          spreadsheetUrl: webUrl,
         },
       },
     }
-
-    return result
   },
 
   outputs: {

--- a/apps/sim/tools/microsoft_excel/types.ts
+++ b/apps/sim/tools/microsoft_excel/types.ts
@@ -63,6 +63,7 @@ export interface MicrosoftExcelWorksheetAddResponse extends ToolResponse {
 export interface MicrosoftExcelToolParams {
   accessToken: string
   spreadsheetId: string
+  driveId?: string
   range?: string
   values?: ExcelCellValue[][]
   valueInputOption?: 'RAW' | 'USER_ENTERED'
@@ -75,6 +76,7 @@ export interface MicrosoftExcelToolParams {
 export interface MicrosoftExcelTableToolParams {
   accessToken: string
   spreadsheetId: string
+  driveId?: string
   tableName: string
   values: ExcelCellValue[][]
   rowIndex?: number
@@ -83,6 +85,7 @@ export interface MicrosoftExcelTableToolParams {
 export interface MicrosoftExcelWorksheetToolParams {
   accessToken: string
   spreadsheetId: string
+  driveId?: string
   worksheetName: string
 }
 
@@ -96,6 +99,7 @@ export type MicrosoftExcelResponse =
 export interface MicrosoftExcelV2ToolParams {
   accessToken: string
   spreadsheetId: string
+  driveId?: string
   sheetName: string
   cellRange?: string
   values?: ExcelCellValue[][]

--- a/apps/sim/tools/microsoft_excel/utils.ts
+++ b/apps/sim/tools/microsoft_excel/utils.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@sim/logger'
-import type { ExcelCellValue } from '@/tools/microsoft_excel/types'
 import { validateAlphanumericId } from '@/lib/core/security/input-validation'
+import type { ExcelCellValue } from '@/tools/microsoft_excel/types'
 
 const logger = createLogger('MicrosoftExcelUtils')
 

--- a/apps/sim/tools/microsoft_excel/utils.ts
+++ b/apps/sim/tools/microsoft_excel/utils.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ExcelCellValue } from '@/tools/microsoft_excel/types'
+import { validateAlphanumericId } from '@/lib/core/security/input-validation'
 
 const logger = createLogger('MicrosoftExcelUtils')
 
@@ -10,8 +11,9 @@ const logger = createLogger('MicrosoftExcelUtils')
  */
 export function getItemBasePath(spreadsheetId: string, driveId?: string): string {
   if (driveId) {
-    if (!/^[\w-]+$/.test(driveId)) {
-      throw new Error('Invalid drive ID format')
+    const validation = validateAlphanumericId(driveId, 'driveId')
+    if (!validation.isValid) {
+      throw new Error(validation.error)
     }
     return `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${spreadsheetId}`
   }

--- a/apps/sim/tools/microsoft_excel/utils.ts
+++ b/apps/sim/tools/microsoft_excel/utils.ts
@@ -1,8 +1,5 @@
 import { createLogger } from '@sim/logger'
-import {
-  validateAlphanumericId,
-  validateMicrosoftGraphId,
-} from '@/lib/core/security/input-validation'
+import { validateMicrosoftGraphId } from '@/lib/core/security/input-validation'
 import type { ExcelCellValue } from '@/tools/microsoft_excel/types'
 
 const logger = createLogger('MicrosoftExcelUtils')
@@ -19,7 +16,7 @@ export function getItemBasePath(spreadsheetId: string, driveId?: string): string
   }
 
   if (driveId) {
-    const driveValidation = validateAlphanumericId(driveId, 'driveId')
+    const driveValidation = validateMicrosoftGraphId(driveId, 'driveId')
     if (!driveValidation.isValid) {
       throw new Error(driveValidation.error)
     }

--- a/apps/sim/tools/microsoft_excel/utils.ts
+++ b/apps/sim/tools/microsoft_excel/utils.ts
@@ -3,6 +3,18 @@ import type { ExcelCellValue } from '@/tools/microsoft_excel/types'
 
 const logger = createLogger('MicrosoftExcelUtils')
 
+/**
+ * Returns the Graph API base path for an Excel item.
+ * When driveId is provided, uses /drives/{driveId}/items/{itemId} (SharePoint/shared drives).
+ * When driveId is omitted, uses /me/drive/items/{itemId} (personal OneDrive).
+ */
+export function getItemBasePath(spreadsheetId: string, driveId?: string): string {
+  if (driveId) {
+    return `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${spreadsheetId}`
+  }
+  return `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}`
+}
+
 export function trimTrailingEmptyRowsAndColumns(matrix: ExcelCellValue[][]): ExcelCellValue[][] {
   if (!Array.isArray(matrix) || matrix.length === 0) return []
 
@@ -43,33 +55,32 @@ export function trimTrailingEmptyRowsAndColumns(matrix: ExcelCellValue[][]): Exc
  */
 export async function getSpreadsheetWebUrl(
   spreadsheetId: string,
-  accessToken: string
+  accessToken: string,
+  driveId?: string
 ): Promise<string> {
+  const basePath = getItemBasePath(spreadsheetId, driveId)
   try {
-    const response = await fetch(
-      `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}?$select=id,webUrl`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      }
-    )
+    const response = await fetch(`${basePath}?$select=id,webUrl`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
 
     if (!response.ok) {
       logger.warn('Failed to fetch spreadsheet webUrl, using Graph API URL as fallback', {
         spreadsheetId,
         status: response.status,
       })
-      return `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}`
+      return basePath
     }
 
     const data = await response.json()
-    return data.webUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}`
+    return data.webUrl || basePath
   } catch (error) {
     logger.warn('Error fetching spreadsheet webUrl, using Graph API URL as fallback', {
       spreadsheetId,
       error,
     })
-    return `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}`
+    return basePath
   }
 }

--- a/apps/sim/tools/microsoft_excel/utils.ts
+++ b/apps/sim/tools/microsoft_excel/utils.ts
@@ -10,6 +10,9 @@ const logger = createLogger('MicrosoftExcelUtils')
  */
 export function getItemBasePath(spreadsheetId: string, driveId?: string): string {
   if (driveId) {
+    if (!/^[\w-]+$/.test(driveId)) {
+      throw new Error('Invalid drive ID format')
+    }
     return `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${spreadsheetId}`
   }
   return `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}`

--- a/apps/sim/tools/microsoft_excel/utils.ts
+++ b/apps/sim/tools/microsoft_excel/utils.ts
@@ -1,5 +1,8 @@
 import { createLogger } from '@sim/logger'
-import { validateAlphanumericId } from '@/lib/core/security/input-validation'
+import {
+  validateAlphanumericId,
+  validateMicrosoftGraphId,
+} from '@/lib/core/security/input-validation'
 import type { ExcelCellValue } from '@/tools/microsoft_excel/types'
 
 const logger = createLogger('MicrosoftExcelUtils')
@@ -10,10 +13,15 @@ const logger = createLogger('MicrosoftExcelUtils')
  * When driveId is omitted, uses /me/drive/items/{itemId} (personal OneDrive).
  */
 export function getItemBasePath(spreadsheetId: string, driveId?: string): string {
+  const spreadsheetValidation = validateMicrosoftGraphId(spreadsheetId, 'spreadsheetId')
+  if (!spreadsheetValidation.isValid) {
+    throw new Error(spreadsheetValidation.error)
+  }
+
   if (driveId) {
-    const validation = validateAlphanumericId(driveId, 'driveId')
-    if (!validation.isValid) {
-      throw new Error(validation.error)
+    const driveValidation = validateAlphanumericId(driveId, 'driveId')
+    if (!driveValidation.isValid) {
+      throw new Error(driveValidation.error)
     }
     return `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${spreadsheetId}`
   }

--- a/apps/sim/tools/microsoft_excel/utils.ts
+++ b/apps/sim/tools/microsoft_excel/utils.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@sim/logger'
-import { validateMicrosoftGraphId } from '@/lib/core/security/input-validation'
+import { validatePathSegment } from '@/lib/core/security/input-validation'
 import type { ExcelCellValue } from '@/tools/microsoft_excel/types'
 
 const logger = createLogger('MicrosoftExcelUtils')
@@ -9,14 +9,23 @@ const logger = createLogger('MicrosoftExcelUtils')
  * When driveId is provided, uses /drives/{driveId}/items/{itemId} (SharePoint/shared drives).
  * When driveId is omitted, uses /me/drive/items/{itemId} (personal OneDrive).
  */
+/** Pattern for Microsoft Graph item/drive IDs: alphanumeric, hyphens, underscores, and ! (for SharePoint b!<base64> format) */
+const GRAPH_ID_PATTERN = /^[a-zA-Z0-9!_-]+$/
+
 export function getItemBasePath(spreadsheetId: string, driveId?: string): string {
-  const spreadsheetValidation = validateMicrosoftGraphId(spreadsheetId, 'spreadsheetId')
+  const spreadsheetValidation = validatePathSegment(spreadsheetId, {
+    paramName: 'spreadsheetId',
+    customPattern: GRAPH_ID_PATTERN,
+  })
   if (!spreadsheetValidation.isValid) {
     throw new Error(spreadsheetValidation.error)
   }
 
   if (driveId) {
-    const driveValidation = validateMicrosoftGraphId(driveId, 'driveId')
+    const driveValidation = validatePathSegment(driveId, {
+      paramName: 'driveId',
+      customPattern: GRAPH_ID_PATTERN,
+    })
     if (!driveValidation.isValid) {
       throw new Error(driveValidation.error)
     }

--- a/apps/sim/tools/microsoft_excel/worksheet_add.ts
+++ b/apps/sim/tools/microsoft_excel/worksheet_add.ts
@@ -2,7 +2,7 @@ import type {
   MicrosoftExcelWorksheetAddResponse,
   MicrosoftExcelWorksheetToolParams,
 } from '@/tools/microsoft_excel/types'
-import { getSpreadsheetWebUrl } from '@/tools/microsoft_excel/utils'
+import { getItemBasePath, getSpreadsheetWebUrl } from '@/tools/microsoft_excel/utils'
 import type { ToolConfig } from '@/tools/types'
 
 /**
@@ -36,6 +36,13 @@ export const worksheetAddTool: ToolConfig<
       visibility: 'user-or-llm',
       description: 'The ID of the Excel workbook to add the worksheet to (e.g., "01ABC123DEF456")',
     },
+    driveId: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description:
+        'The ID of the drive containing the spreadsheet. Required for SharePoint files. If omitted, uses personal OneDrive.',
+    },
     worksheetName: {
       type: 'string',
       required: true,
@@ -51,7 +58,8 @@ export const worksheetAddTool: ToolConfig<
       if (!spreadsheetId) {
         throw new Error('Spreadsheet ID is required')
       }
-      return `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}/workbook/worksheets/add`
+      const basePath = getItemBasePath(spreadsheetId, params.driveId)
+      return `${basePath}/workbook/worksheets/add`
     },
     method: 'POST',
     headers: (params) => {
@@ -106,15 +114,14 @@ export const worksheetAddTool: ToolConfig<
 
     const data = await response.json()
 
-    const urlParts = response.url.split('/drive/items/')
-    const spreadsheetId = urlParts[1]?.split('/')[0] || ''
+    const spreadsheetId = params?.spreadsheetId?.trim() || ''
+    const driveId = params?.driveId
 
-    // Fetch the browser-accessible web URL
     const accessToken = params?.accessToken
     if (!accessToken) {
       throw new Error('Access token is required')
     }
-    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken)
+    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken, driveId)
 
     const result: MicrosoftExcelWorksheetAddResponse = {
       success: true,

--- a/apps/sim/tools/microsoft_excel/write.ts
+++ b/apps/sim/tools/microsoft_excel/write.ts
@@ -4,7 +4,7 @@ import type {
   MicrosoftExcelV2WriteResponse,
   MicrosoftExcelWriteResponse,
 } from '@/tools/microsoft_excel/types'
-import { getSpreadsheetWebUrl } from '@/tools/microsoft_excel/utils'
+import { getItemBasePath, getSpreadsheetWebUrl } from '@/tools/microsoft_excel/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const writeTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelWriteResponse> = {
@@ -30,6 +30,13 @@ export const writeTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelWrite
       required: true,
       visibility: 'user-or-llm',
       description: 'The ID of the spreadsheet/workbook to write to (e.g., "01ABC123DEF456")',
+    },
+    driveId: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description:
+        'The ID of the drive containing the spreadsheet. Required for SharePoint files. If omitted, uses personal OneDrive.',
     },
     range: {
       type: 'string',
@@ -70,8 +77,9 @@ export const writeTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelWrite
       const sheetName = encodeURIComponent(match[1])
       const address = encodeURIComponent(match[2])
 
+      const basePath = getItemBasePath(params.spreadsheetId!, params.driveId)
       const url = new URL(
-        `https://graph.microsoft.com/v1.0/me/drive/items/${params.spreadsheetId}/workbook/worksheets('${sheetName}')/range(address='${address}')`
+        `${basePath}/workbook/worksheets('${sheetName}')/range(address='${address}')`
       )
 
       const valueInputOption = params.valueInputOption || 'USER_ENTERED'
@@ -137,23 +145,16 @@ export const writeTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelWrite
   transformResponse: async (response: Response, params?: MicrosoftExcelToolParams) => {
     const data = await response.json()
 
-    const urlParts = response.url.split('/drive/items/')
-    const spreadsheetId = urlParts[1]?.split('/')[0] || ''
+    const spreadsheetId = params?.spreadsheetId?.trim() || ''
+    const driveId = params?.driveId
 
-    // Fetch the browser-accessible web URL
     const accessToken = params?.accessToken
     if (!accessToken) {
       throw new Error('Access token is required')
     }
-    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken)
+    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken, driveId)
 
-    const metadata = {
-      spreadsheetId,
-      properties: {},
-      spreadsheetUrl: webUrl,
-    }
-
-    const result = {
+    return {
       success: true,
       output: {
         updatedRange: data.updatedRange,
@@ -161,13 +162,11 @@ export const writeTool: ToolConfig<MicrosoftExcelToolParams, MicrosoftExcelWrite
         updatedColumns: data.updatedColumns,
         updatedCells: data.updatedCells,
         metadata: {
-          spreadsheetId: metadata.spreadsheetId,
-          spreadsheetUrl: metadata.spreadsheetUrl,
+          spreadsheetId,
+          spreadsheetUrl: webUrl,
         },
       },
     }
-
-    return result
   },
 
   outputs: {
@@ -209,6 +208,13 @@ export const writeV2Tool: ToolConfig<MicrosoftExcelV2ToolParams, MicrosoftExcelV
       required: true,
       visibility: 'user-or-llm',
       description: 'The ID of the spreadsheet/workbook to write to (e.g., "01ABC123DEF456")',
+    },
+    driveId: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description:
+        'The ID of the drive containing the spreadsheet. Required for SharePoint files. If omitted, uses personal OneDrive.',
     },
     sheetName: {
       type: 'string',
@@ -260,8 +266,9 @@ export const writeV2Tool: ToolConfig<MicrosoftExcelV2ToolParams, MicrosoftExcelV
       const encodedSheetName = encodeURIComponent(sheetName)
       const encodedAddress = encodeURIComponent(cellRange)
 
+      const basePath = getItemBasePath(spreadsheetId, params.driveId)
       const url = new URL(
-        `https://graph.microsoft.com/v1.0/me/drive/items/${spreadsheetId}/workbook/worksheets('${encodedSheetName}')/range(address='${encodedAddress}')`
+        `${basePath}/workbook/worksheets('${encodedSheetName}')/range(address='${encodedAddress}')`
       )
 
       const valueInputOption = params.valueInputOption || 'USER_ENTERED'
@@ -324,14 +331,14 @@ export const writeV2Tool: ToolConfig<MicrosoftExcelV2ToolParams, MicrosoftExcelV
   transformResponse: async (response: Response, params?: MicrosoftExcelV2ToolParams) => {
     const data = await response.json()
 
-    const urlParts = response.url.split('/drive/items/')
-    const spreadsheetId = urlParts[1]?.split('/')[0] || ''
+    const spreadsheetId = params?.spreadsheetId?.trim() || ''
+    const driveId = params?.driveId
 
     const accessToken = params?.accessToken
     if (!accessToken) {
       throw new Error('Access token is required')
     }
-    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken)
+    const webUrl = await getSpreadsheetWebUrl(spreadsheetId, accessToken, driveId)
 
     return {
       success: true,


### PR DESCRIPTION
## Summary
- Add optional `driveId` parameter to all Microsoft Excel tools for SharePoint file access
- Add cascading site/drive selectors in basic mode (site → document library → spreadsheet → sheet)
- Add manual drive ID input in advanced mode
- Create `/api/tools/microsoft_excel/drives` route to list SharePoint document libraries
- Update file and sheet selectors to pass driveId context through the selector chain
- Fully backward-compatible — OneDrive users unaffected when driveId is omitted

## Type of Change
- [x] New feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)