### PR TITLE
feat(jira): support raw ADF in description and environment fields

### DIFF
--- a/apps/sim/app/api/tools/jira/update/route.ts
+++ b/apps/sim/app/api/tools/jira/update/route.ts
@@ -3,7 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateJiraCloudId, validateJiraIssueKey } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage, toAdf } from '@/tools/jira/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,7 +15,7 @@ const jiraUpdateSchema = z.object({
   issueKey: z.string().min(1, 'Issue key is required'),
   summary: z.string().optional(),
   title: z.string().optional(),
-  description: z.string().optional(),
+  description: z.union([z.string(), z.record(z.unknown())]).optional(),
   priority: z.string().optional(),
   assignee: z.string().optional(),
   labels: z.array(z.string()).optional(),
@@ -91,21 +91,7 @@ export async function PUT(request: NextRequest) {
     }
 
     if (description !== undefined && description !== null && description !== '') {
-      fields.description = {
-        type: 'doc',
-        version: 1,
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: description,
-              },
-            ],
-          },
-        ],
-      }
+      fields.description = toAdf(description)
     }
 
     if (priority !== undefined && priority !== null && priority !== '') {
@@ -136,21 +122,7 @@ export async function PUT(request: NextRequest) {
     }
 
     if (environment !== undefined && environment !== null && environment !== '') {
-      fields.environment = {
-        type: 'doc',
-        version: 1,
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: environment,
-              },
-            ],
-          },
-        ],
-      }
+      fields.environment = toAdf(environment)
     }
 
     if (

--- a/apps/sim/app/api/tools/jira/update/route.ts
+++ b/apps/sim/app/api/tools/jira/update/route.ts
@@ -22,7 +22,7 @@ const jiraUpdateSchema = z.object({
   components: z.array(z.string()).optional(),
   duedate: z.string().optional(),
   fixVersions: z.array(z.string()).optional(),
-  environment: z.string().optional(),
+  environment: z.union([z.string(), z.record(z.unknown())]).optional(),
   customFieldId: z.string().optional(),
   customFieldValue: z.string().optional(),
   notifyUsers: z.boolean().optional(),

--- a/apps/sim/app/api/tools/jira/write/route.ts
+++ b/apps/sim/app/api/tools/jira/write/route.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security/input-validation'
-import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
+import { getJiraCloudId, parseAtlassianErrorMessage, toAdf } from '@/tools/jira/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -85,21 +85,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (description !== undefined && description !== null && description !== '') {
-      fields.description = {
-        type: 'doc',
-        version: 1,
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: description,
-              },
-            ],
-          },
-        ],
-      }
+      fields.description = toAdf(description)
     }
 
     if (parent !== undefined && parent !== null && parent !== '') {
@@ -144,21 +130,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (environment !== undefined && environment !== null && environment !== '') {
-      fields.environment = {
-        type: 'doc',
-        version: 1,
-        content: [
-          {
-            type: 'paragraph',
-            content: [
-              {
-                type: 'text',
-                text: environment,
-              },
-            ],
-          },
-        ],
-      }
+      fields.environment = toAdf(environment)
     }
 
     if (

--- a/apps/sim/tools/jira/update.ts
+++ b/apps/sim/tools/jira/update.ts
@@ -42,7 +42,8 @@ export const jiraUpdateTool: ToolConfig<JiraUpdateParams, JiraUpdateResponse> = 
       type: 'string',
       required: false,
       visibility: 'user-or-llm',
-      description: 'New description for the issue',
+      description:
+        'New description for the issue. Accepts plain text (auto-wrapped in ADF) or a raw ADF document object',
     },
     priority: {
       type: 'string',

--- a/apps/sim/tools/jira/utils.ts
+++ b/apps/sim/tools/jira/utils.ts
@@ -6,6 +6,26 @@ const logger = createLogger('JiraUtils')
 const MAX_ATTACHMENT_SIZE = 50 * 1024 * 1024
 
 /**
+ * Converts a value to ADF format. If the value is already an ADF document object,
+ * it is returned as-is. If it is a plain string, it is wrapped in a single-paragraph ADF doc.
+ */
+export function toAdf(value: string | Record<string, unknown>): Record<string, unknown> {
+  if (typeof value === 'object' && value.type === 'doc') {
+    return value
+  }
+  return {
+    type: 'doc',
+    version: 1,
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: String(value) }],
+      },
+    ],
+  }
+}
+
+/**
  * Extracts plain text from Atlassian Document Format (ADF) content.
  * Returns null if content is falsy.
  */

--- a/apps/sim/tools/jira/utils.ts
+++ b/apps/sim/tools/jira/utils.ts
@@ -18,6 +18,19 @@ export function toAdf(value: string | Record<string, unknown>): Record<string, u
       return { type: 'doc', version: 1, content: [value] }
     }
   }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      if (typeof parsed === 'object' && parsed !== null && parsed.type === 'doc') {
+        return parsed
+      }
+      if (typeof parsed === 'object' && parsed !== null && parsed.type && Array.isArray(parsed.content)) {
+        return { type: 'doc', version: 1, content: [parsed] }
+      }
+    } catch {
+      // Not JSON — treat as plain text below
+    }
+  }
   return {
     type: 'doc',
     version: 1,

--- a/apps/sim/tools/jira/utils.ts
+++ b/apps/sim/tools/jira/utils.ts
@@ -24,7 +24,12 @@ export function toAdf(value: string | Record<string, unknown>): Record<string, u
       if (typeof parsed === 'object' && parsed !== null && parsed.type === 'doc') {
         return parsed
       }
-      if (typeof parsed === 'object' && parsed !== null && parsed.type && Array.isArray(parsed.content)) {
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        parsed.type &&
+        Array.isArray(parsed.content)
+      ) {
         return { type: 'doc', version: 1, content: [parsed] }
       }
     } catch {

--- a/apps/sim/tools/jira/utils.ts
+++ b/apps/sim/tools/jira/utils.ts
@@ -10,8 +10,13 @@ const MAX_ATTACHMENT_SIZE = 50 * 1024 * 1024
  * it is returned as-is. If it is a plain string, it is wrapped in a single-paragraph ADF doc.
  */
 export function toAdf(value: string | Record<string, unknown>): Record<string, unknown> {
-  if (typeof value === 'object' && value.type === 'doc') {
-    return value
+  if (typeof value === 'object') {
+    if (value.type === 'doc') {
+      return value
+    }
+    if (value.type && Array.isArray(value.content)) {
+      return { type: 'doc', version: 1, content: [value] }
+    }
   }
   return {
     type: 'doc',
@@ -19,7 +24,7 @@ export function toAdf(value: string | Record<string, unknown>): Record<string, u
     content: [
       {
         type: 'paragraph',
-        content: [{ type: 'text', text: String(value) }],
+        content: [{ type: 'text', text: typeof value === 'string' ? value : JSON.stringify(value) }],
       },
     ],
   }

--- a/apps/sim/tools/jira/utils.ts
+++ b/apps/sim/tools/jira/utils.ts
@@ -24,7 +24,9 @@ export function toAdf(value: string | Record<string, unknown>): Record<string, u
     content: [
       {
         type: 'paragraph',
-        content: [{ type: 'text', text: typeof value === 'string' ? value : JSON.stringify(value) }],
+        content: [
+          { type: 'text', text: typeof value === 'string' ? value : JSON.stringify(value) },
+        ],
       },
     ],
   }

--- a/apps/sim/tools/jira/write.ts
+++ b/apps/sim/tools/jira/write.ts
@@ -42,7 +42,8 @@ export const jiraWriteTool: ToolConfig<JiraWriteParams, JiraWriteResponse> = {
       type: 'string',
       required: false,
       visibility: 'user-or-llm',
-      description: 'Description for the issue',
+      description:
+        'Description for the issue. Accepts plain text (auto-wrapped in ADF) or a raw ADF document object',
     },
     priority: {
       type: 'string',

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "husky": "9.1.7",
         "json-schema-to-typescript": "15.0.4",
         "lint-staged": "16.0.0",
-        "turbo": "2.9.6",
+        "turbo": "2.9.5",
       },
     },
     "apps/docs": {
@@ -1519,17 +1519,17 @@
 
     "@trigger.dev/sdk": ["@trigger.dev/sdk@4.4.3", "", { "dependencies": { "@opentelemetry/api": "1.9.0", "@opentelemetry/semantic-conventions": "1.36.0", "@trigger.dev/core": "4.4.3", "chalk": "^5.2.0", "cronstrue": "^2.21.0", "debug": "^4.3.4", "evt": "^2.4.13", "slug": "^6.0.0", "ulid": "^2.3.0", "uncrypto": "^0.1.3", "uuid": "^9.0.0", "ws": "^8.11.0" }, "peerDependencies": { "ai": "^4.2.0 || ^5.0.0 || ^6.0.0", "zod": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["ai"] }, "sha512-ghJkak+PTBJJ9HiHMcnahJmzjsgCzYiIHu5Qj5R7I9q5LS6i7mkx169rB/tOE9HLadd4HSu3yYA5DrH4wXhZuw=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-qPxhKsLMQP+9+dsmPgAGidi5uNifD4AoAOnEnljab3Qgn0QZRR31Hp+/CgW3Ia5AanWj6JuLLTBYvuQj4mqTWg=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vkF/9F/l3aWd4bHxTui5Hh0F5xrTZ4e3rbBsc57zA6O8gNbmHN3B6eZ5psAIP2CnJRZ8ZxRjV3WZHeNXMXkPBw=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.9.6", "", { "os": "linux", "cpu": "x64" }, "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.5", "", { "os": "linux", "cpu": "x64" }, "sha512-z/Get5NUaUxm5HSGFqVMICDRjFNsCUhSc4wnFa/PP1QD0NXCjr7bu9a2EM6md/KMCBW0Qe393Ac+UM7/ryDDTw=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-jyBifaNoI5/NheyswomiZXJvjdAdvT7hDRYzQ4meP0DKGvpXUjnqsD+4/J2YSDQ34OHxFkL30FnSCUIVOh2PHw=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.9.6", "", { "os": "win32", "cpu": "x64" }, "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.5", "", { "os": "win32", "cpu": "x64" }, "sha512-ph24K5uPtvo7UfuyDXnBiB/8XvrO+RQWbbw5zkA/bVNoy9HDiNoIJJj3s62MxT9tjEb6DnPje5PXSz1UR7QAyg=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-6c5RccT/+iR39SdT1G5HyZaD2n57W77o+l0TTfxG/cVlhV94Acyg2gTQW7zUOhW1BeQpBjHzu9x8yVBZwrHh7g=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 
@@ -3767,7 +3767,7 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
+    "turbo": ["turbo@2.9.5", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.5", "@turbo/darwin-arm64": "2.9.5", "@turbo/linux-64": "2.9.5", "@turbo/linux-arm64": "2.9.5", "@turbo/windows-64": "2.9.5", "@turbo/windows-arm64": "2.9.5" }, "bin": { "turbo": "bin/turbo" } }, "sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA=="],
 
     "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "husky": "9.1.7",
         "json-schema-to-typescript": "15.0.4",
         "lint-staged": "16.0.0",
-        "turbo": "2.9.5",
+        "turbo": "2.9.6",
       },
     },
     "apps/docs": {
@@ -1519,17 +1519,17 @@
 
     "@trigger.dev/sdk": ["@trigger.dev/sdk@4.4.3", "", { "dependencies": { "@opentelemetry/api": "1.9.0", "@opentelemetry/semantic-conventions": "1.36.0", "@trigger.dev/core": "4.4.3", "chalk": "^5.2.0", "cronstrue": "^2.21.0", "debug": "^4.3.4", "evt": "^2.4.13", "slug": "^6.0.0", "ulid": "^2.3.0", "uncrypto": "^0.1.3", "uuid": "^9.0.0", "ws": "^8.11.0" }, "peerDependencies": { "ai": "^4.2.0 || ^5.0.0 || ^6.0.0", "zod": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["ai"] }, "sha512-ghJkak+PTBJJ9HiHMcnahJmzjsgCzYiIHu5Qj5R7I9q5LS6i7mkx169rB/tOE9HLadd4HSu3yYA5DrH4wXhZuw=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-qPxhKsLMQP+9+dsmPgAGidi5uNifD4AoAOnEnljab3Qgn0QZRR31Hp+/CgW3Ia5AanWj6JuLLTBYvuQj4mqTWg=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vkF/9F/l3aWd4bHxTui5Hh0F5xrTZ4e3rbBsc57zA6O8gNbmHN3B6eZ5psAIP2CnJRZ8ZxRjV3WZHeNXMXkPBw=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.9.5", "", { "os": "linux", "cpu": "x64" }, "sha512-z/Get5NUaUxm5HSGFqVMICDRjFNsCUhSc4wnFa/PP1QD0NXCjr7bu9a2EM6md/KMCBW0Qe393Ac+UM7/ryDDTw=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.6", "", { "os": "linux", "cpu": "x64" }, "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-jyBifaNoI5/NheyswomiZXJvjdAdvT7hDRYzQ4meP0DKGvpXUjnqsD+4/J2YSDQ34OHxFkL30FnSCUIVOh2PHw=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.9.5", "", { "os": "win32", "cpu": "x64" }, "sha512-ph24K5uPtvo7UfuyDXnBiB/8XvrO+RQWbbw5zkA/bVNoy9HDiNoIJJj3s62MxT9tjEb6DnPje5PXSz1UR7QAyg=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.6", "", { "os": "win32", "cpu": "x64" }, "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-6c5RccT/+iR39SdT1G5HyZaD2n57W77o+l0TTfxG/cVlhV94Acyg2gTQW7zUOhW1BeQpBjHzu9x8yVBZwrHh7g=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 
@@ -3767,7 +3767,7 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "turbo": ["turbo@2.9.5", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.5", "@turbo/darwin-arm64": "2.9.5", "@turbo/linux-64": "2.9.5", "@turbo/linux-arm64": "2.9.5", "@turbo/windows-64": "2.9.5", "@turbo/windows-arm64": "2.9.5" }, "bin": { "turbo": "bin/turbo" } }, "sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA=="],
+    "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
 
     "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 


### PR DESCRIPTION
## Summary
- Add `toAdf()` helper to `jira/utils.ts` — passes through ADF document objects as-is, wraps plain text strings in single-paragraph ADF
- Update `write` and `update` routes to use `toAdf()`, replacing inline ADF wrapping
- Update `update` route Zod schema to accept `string | object` for description
- Fully backward compatible — plain text still works identically, but callers can now pass rich ADF with expand nodes, tables, code blocks, etc.

## Test plan
- [x] Create a Jira issue with a plain text description — verify it renders as before
- [x] Update a Jira issue with a plain text description — verify it renders as before
- [x] Update a Jira issue with a raw ADF object (e.g., with expand nodes) — verify rich formatting renders in Jira
- [x] Verify existing workflows using the Jira block are unaffected