### PR TITLE
fix(blocks): correct required field validation for Jira and Confluence blocks

### DIFF
--- a/apps/docs/content/docs/en/tools/jira.mdx
+++ b/apps/docs/content/docs/en/tools/jira.mdx
@@ -251,7 +251,7 @@ Update a Jira issue
 | `domain` | string | Yes | Your Jira domain \(e.g., yourcompany.atlassian.net\) |
 | `issueKey` | string | Yes | Jira issue key to update \(e.g., PROJ-123\) |
 | `summary` | string | No | New summary for the issue |
-| `description` | string | No | New description for the issue |
+| `description` | string | No | New description for the issue. Accepts plain text \(auto-wrapped in ADF\) or a raw ADF document object |
 | `priority` | string | No | New priority ID or name for the issue \(e.g., "High"\) |
 | `assignee` | string | No | New assignee account ID for the issue |
 | `labels` | json | No | Labels to set on the issue \(array of label name strings\) |
@@ -284,7 +284,7 @@ Create a new Jira issue
 | `domain` | string | Yes | Your Jira domain \(e.g., yourcompany.atlassian.net\) |
 | `projectId` | string | Yes | Jira project key \(e.g., PROJ\) |
 | `summary` | string | Yes | Summary for the issue |
-| `description` | string | No | Description for the issue |
+| `description` | string | No | Description for the issue. Accepts plain text \(auto-wrapped in ADF\) or a raw ADF document object |
 | `priority` | string | No | Priority ID or name for the issue \(e.g., "10000" or "High"\) |
 | `assignee` | string | No | Assignee account ID for the issue |
 | `cloudId` | string | No | Jira Cloud ID for the instance. If not provided, it will be fetched using the domain. |

--- a/apps/sim/blocks/blocks/confluence.ts
+++ b/apps/sim/blocks/blocks/confluence.ts
@@ -779,7 +779,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
       title: 'Content',
       type: 'long-input',
       placeholder: 'Enter content',
-      required: { field: 'operation', value: 'create' },
+      required: { field: 'operation', value: ['create', 'create_blogpost'] },
       condition: {
         field: 'operation',
         value: ['create', 'update', 'create_blogpost', 'update_blogpost'],

--- a/apps/sim/blocks/blocks/confluence.ts
+++ b/apps/sim/blocks/blocks/confluence.ts
@@ -128,6 +128,7 @@ export const ConfluenceBlock: BlockConfig<ConfluenceResponse> = {
       title: 'Title',
       type: 'short-input',
       placeholder: 'Enter title for the page',
+      required: { field: 'operation', value: 'create' },
       condition: { field: 'operation', value: ['create', 'update'] },
     },
     {
@@ -135,6 +136,7 @@ export const ConfluenceBlock: BlockConfig<ConfluenceResponse> = {
       title: 'Content',
       type: 'long-input',
       placeholder: 'Enter content for the page',
+      required: { field: 'operation', value: 'create' },
       condition: { field: 'operation', value: ['create', 'update'] },
     },
     {
@@ -766,6 +768,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
       title: 'Title',
       type: 'short-input',
       placeholder: 'Enter title',
+      required: { field: 'operation', value: ['create', 'create_blogpost'] },
       condition: {
         field: 'operation',
         value: ['create', 'update', 'create_blogpost', 'update_blogpost', 'update_space'],
@@ -776,6 +779,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
       title: 'Content',
       type: 'long-input',
       placeholder: 'Enter content',
+      required: { field: 'operation', value: 'create' },
       condition: {
         field: 'operation',
         value: ['create', 'update', 'create_blogpost', 'update_blogpost'],

--- a/apps/sim/blocks/blocks/jira.ts
+++ b/apps/sim/blocks/blocks/jira.ts
@@ -91,7 +91,7 @@ export const JiraBlock: BlockConfig<JiraResponse> = {
       placeholder: 'Select Jira project',
       dependsOn: ['credential', 'domain'],
       mode: 'basic',
-      required: { field: 'operation', value: ['write', 'update', 'read-bulk'] },
+      required: { field: 'operation', value: ['write', 'read-bulk'] },
     },
     // Manual project ID input (advanced mode)
     {
@@ -102,7 +102,7 @@ export const JiraBlock: BlockConfig<JiraResponse> = {
       placeholder: 'Enter Jira project ID',
       dependsOn: ['credential', 'domain'],
       mode: 'advanced',
-      required: { field: 'operation', value: ['write', 'update', 'read-bulk'] },
+      required: { field: 'operation', value: ['write', 'read-bulk'] },
     },
     // Issue selector (basic mode)
     {
@@ -218,7 +218,7 @@ export const JiraBlock: BlockConfig<JiraResponse> = {
       id: 'summary',
       title: 'New Summary',
       type: 'short-input',
-      required: true,
+      required: { field: 'operation', value: 'write' },
       placeholder: 'Enter new summary for the issue',
       dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['update', 'write'] },

--- a/apps/sim/blocks/blocks/jira.ts
+++ b/apps/sim/blocks/blocks/jira.ts
@@ -220,7 +220,6 @@ export const JiraBlock: BlockConfig<JiraResponse> = {
       type: 'short-input',
       required: { field: 'operation', value: 'write' },
       placeholder: 'Enter new summary for the issue',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['update', 'write'] },
       wandConfig: {
         enabled: true,
@@ -240,7 +239,6 @@ Return ONLY the summary text - no explanations.`,
       title: 'New Description',
       type: 'long-input',
       placeholder: 'Enter new description for the issue',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['update', 'write'] },
       wandConfig: {
         enabled: true,
@@ -279,7 +277,6 @@ Return ONLY the description text - no explanations.`,
       title: 'Assignee Account ID',
       type: 'short-input',
       placeholder: 'Assignee account ID (e.g., 5b109f2e9729b51b54dc274d)',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['write', 'update'] },
     },
     {
@@ -287,7 +284,6 @@ Return ONLY the description text - no explanations.`,
       title: 'Priority',
       type: 'short-input',
       placeholder: 'Priority ID or name (e.g., "10000" or "High")',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['write', 'update'] },
     },
     {
@@ -295,7 +291,6 @@ Return ONLY the description text - no explanations.`,
       title: 'Labels',
       type: 'short-input',
       placeholder: 'Comma-separated labels (e.g., bug, urgent)',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['write', 'update'] },
     },
     {
@@ -303,7 +298,6 @@ Return ONLY the description text - no explanations.`,
       title: 'Due Date',
       type: 'short-input',
       placeholder: 'YYYY-MM-DD (e.g., 2024-12-31)',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['write', 'update'] },
       wandConfig: {
         enabled: true,
@@ -332,7 +326,6 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
       title: 'Environment',
       type: 'long-input',
       placeholder: 'Environment information (e.g., Production, Staging)',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['write', 'update'] },
     },
     {
@@ -340,7 +333,6 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
       title: 'Custom Field ID',
       type: 'short-input',
       placeholder: 'e.g., customfield_10001 or 10001',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['write', 'update'] },
     },
     {
@@ -348,7 +340,6 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
       title: 'Custom Field Value',
       type: 'short-input',
       placeholder: 'Value for the custom field',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['write', 'update'] },
     },
     {
@@ -356,7 +347,6 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
       title: 'Components',
       type: 'short-input',
       placeholder: 'Comma-separated component names',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['write', 'update'] },
     },
     {
@@ -364,7 +354,6 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
       title: 'Fix Versions',
       type: 'short-input',
       placeholder: 'Comma-separated fix version names',
-      dependsOn: ['projectId'],
       condition: { field: 'operation', value: ['write', 'update'] },
     },
     {


### PR DESCRIPTION
## Summary
- **Jira block**: `summary` is now only required for create issue (not update — partial updates are supported). `projectId` is no longer required for update (API uses `issueKey` in the URL path, and the update tool doesn't even accept `projectId`).
- **Confluence block (both Legacy and V2)**: `title` and `content` are now required for page creation (backend rejects without them). `title` is also required for blog post creation in V2.
- All changes verified against the Atlassian REST API docs and our backend route validation.

## Test plan
- [x] Jira: Create issue — verify summary shows as required
- [x] Jira: Update issue — verify summary is optional, projectId is optional
- [x] Confluence: Create page — verify title and content show as required
- [x] Confluence V2: Create blog post — verify title shows as required
- [x] Confluence: Update page — verify title and content remain optional