### PR TITLE
refactor(microsoft-excel): export GRAPH_ID_PATTERN and deduplicate validation

### DIFF
--- a/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
+++ b/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
@@ -3,8 +3,8 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validatePathSegment } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
-import { GRAPH_ID_PATTERN } from '@/tools/microsoft_excel/utils'
 import { getCredential, refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
+import { GRAPH_ID_PATTERN } from '@/tools/microsoft_excel/utils'
 
 export const dynamic = 'force-dynamic'
 

--- a/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
+++ b/apps/sim/app/api/auth/oauth/microsoft/files/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validatePathSegment } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
+import { GRAPH_ID_PATTERN } from '@/tools/microsoft_excel/utils'
 import { getCredential, refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
 export const dynamic = 'force-dynamic'
@@ -79,7 +80,7 @@ export async function GET(request: NextRequest) {
     if (driveId) {
       const driveIdValidation = validatePathSegment(driveId, {
         paramName: 'driveId',
-        customPattern: /^[a-zA-Z0-9!_-]+$/,
+        customPattern: GRAPH_ID_PATTERN,
       })
       if (!driveIdValidation.isValid) {
         return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })

--- a/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validatePathSegment, validateSharePointSiteId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
+import { GRAPH_ID_PATTERN } from '@/tools/microsoft_excel/utils'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
 export const dynamic = 'force-dynamic'
@@ -69,7 +70,7 @@ export async function POST(request: NextRequest) {
     if (driveId) {
       const driveIdValidation = validatePathSegment(driveId, {
         paramName: 'driveId',
-        customPattern: /^[a-zA-Z0-9!_-]+$/,
+        customPattern: GRAPH_ID_PATTERN,
       })
       if (!driveIdValidation.isValid) {
         return NextResponse.json({ error: driveIdValidation.error }, { status: 400 })

--- a/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
+++ b/apps/sim/app/api/tools/microsoft_excel/drives/route.ts
@@ -3,8 +3,8 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validatePathSegment, validateSharePointSiteId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
-import { GRAPH_ID_PATTERN } from '@/tools/microsoft_excel/utils'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
+import { GRAPH_ID_PATTERN } from '@/tools/microsoft_excel/utils'
 
 export const dynamic = 'force-dynamic'
 

--- a/apps/sim/tools/microsoft_excel/utils.ts
+++ b/apps/sim/tools/microsoft_excel/utils.ts
@@ -4,14 +4,14 @@ import type { ExcelCellValue } from '@/tools/microsoft_excel/types'
 
 const logger = createLogger('MicrosoftExcelUtils')
 
+/** Pattern for Microsoft Graph item/drive IDs: alphanumeric, hyphens, underscores, and ! (for SharePoint b!<base64> format) */
+export const GRAPH_ID_PATTERN = /^[a-zA-Z0-9!_-]+$/
+
 /**
  * Returns the Graph API base path for an Excel item.
  * When driveId is provided, uses /drives/{driveId}/items/{itemId} (SharePoint/shared drives).
  * When driveId is omitted, uses /me/drive/items/{itemId} (personal OneDrive).
  */
-/** Pattern for Microsoft Graph item/drive IDs: alphanumeric, hyphens, underscores, and ! (for SharePoint b!<base64> format) */
-const GRAPH_ID_PATTERN = /^[a-zA-Z0-9!_-]+$/
-
 export function getItemBasePath(spreadsheetId: string, driveId?: string): string {
   const spreadsheetValidation = validatePathSegment(spreadsheetId, {
     paramName: 'spreadsheetId',


### PR DESCRIPTION
## Summary
- Export `GRAPH_ID_PATTERN` from `utils.ts` instead of keeping it module-private, and reuse it in `files/route.ts` and `drives/route.ts` to eliminate duplicated inline regex patterns
- Reorder TSDoc comment to sit directly above `getItemBasePath` where it belongs
- Follow-up cleanup to #4162 (SharePoint drive support)

## Test plan
- [x] Verify `bun run build` passes with no type errors
- [x] Confirm existing OneDrive Excel workflows are unaffected
- [x] Confirm SharePoint drive selection still works end-to-end