### PR TITLE
fix(landing): return 404 for invalid dynamic route slugs

### DIFF
--- a/apps/sim/app/(landing)/blog/[slug]/page.tsx
+++ b/apps/sim/app/(landing)/blog/[slug]/page.tsx
@@ -9,6 +9,8 @@ import { getBaseUrl } from '@/lib/core/utils/urls'
 import { BackLink } from '@/app/(landing)/blog/[slug]/back-link'
 import { ShareButton } from '@/app/(landing)/blog/[slug]/share-button'
 
+export const dynamicParams = false
+
 export async function generateStaticParams() {
   const posts = await getAllPostMeta()
   return posts.map((p) => ({ slug: p.slug }))

--- a/apps/sim/app/(landing)/integrations/[slug]/page.tsx
+++ b/apps/sim/app/(landing)/integrations/[slug]/page.tsx
@@ -20,6 +20,8 @@ const baseUrl = SITE_URL
 const bySlug = new Map(allIntegrations.map((i) => [i.slug, i]))
 const byType = new Map(allIntegrations.map((i) => [i.type, i]))
 
+export const dynamicParams = false
+
 /**
  * Returns up to `limit` related integration slugs.
  *

--- a/apps/sim/app/(landing)/models/[provider]/[model]/page.tsx
+++ b/apps/sim/app/(landing)/models/[provider]/[model]/page.tsx
@@ -20,6 +20,8 @@ import {
 
 const baseUrl = SITE_URL
 
+export const dynamicParams = false
+
 export async function generateStaticParams() {
   return ALL_CATALOG_MODELS.map((model) => ({
     provider: model.providerSlug,

--- a/apps/sim/app/(landing)/models/[provider]/page.tsx
+++ b/apps/sim/app/(landing)/models/[provider]/page.tsx
@@ -22,6 +22,8 @@ import {
 
 const baseUrl = SITE_URL
 
+export const dynamicParams = false
+
 export async function generateStaticParams() {
   return MODEL_PROVIDERS_WITH_CATALOGS.map((provider) => ({
     provider: provider.slug,

--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -229,6 +229,14 @@ export function Home({ chatId }: HomeProps = {}) {
     void stopGeneration().catch(() => {})
   }, [stopGeneration, workspaceId])
 
+  const handleStopGeneration = useCallback(() => {
+    captureEvent(posthogRef.current, 'task_generation_aborted', {
+      workspace_id: workspaceId,
+      view: 'mothership',
+    })
+    stopGeneration()
+  }, [stopGeneration, workspaceId])
+
   const handleSubmit = useCallback(
     (text: string, fileAttachments?: FileAttachmentForApi[], contexts?: ChatContext[]) => {
       const trimmed = text.trim()

--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -229,14 +229,6 @@ export function Home({ chatId }: HomeProps = {}) {
     void stopGeneration().catch(() => {})
   }, [stopGeneration, workspaceId])
 
-  const handleStopGeneration = useCallback(() => {
-    captureEvent(posthogRef.current, 'task_generation_aborted', {
-      workspace_id: workspaceId,
-      view: 'mothership',
-    })
-    stopGeneration()
-  }, [stopGeneration, workspaceId])
-
   const handleSubmit = useCallback(
     (text: string, fileAttachments?: FileAttachmentForApi[], contexts?: ChatContext[]) => {
       const trimmed = text.trim()


### PR DESCRIPTION
## Summary
- Add `dynamicParams = false` to all landing page dynamic routes (integrations, models, blog)
- Invalid slugs now show the custom 404 page instead of a client-side exception

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)