### PR TITLE
fix(gemini): support structured output with tools on Gemini 3 models

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -229,6 +229,14 @@ export function Home({ chatId }: HomeProps = {}) {
     void stopGeneration().catch(() => {})
   }, [stopGeneration, workspaceId])
 
+  const handleStopGeneration = useCallback(() => {
+    captureEvent(posthogRef.current, 'task_generation_aborted', {
+      workspace_id: workspaceId,
+      view: 'mothership',
+    })
+    stopGeneration()
+  }, [stopGeneration, workspaceId])
+
   const handleSubmit = useCallback(
     (text: string, fileAttachments?: FileAttachmentForApi[], contexts?: ChatContext[]) => {
       const trimmed = text.trim()

--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -229,14 +229,6 @@ export function Home({ chatId }: HomeProps = {}) {
     void stopGeneration().catch(() => {})
   }, [stopGeneration, workspaceId])
 
-  const handleStopGeneration = useCallback(() => {
-    captureEvent(posthogRef.current, 'task_generation_aborted', {
-      workspace_id: workspaceId,
-      view: 'mothership',
-    })
-    stopGeneration()
-  }, [stopGeneration, workspaceId])
-
   const handleSubmit = useCallback(
     (text: string, fileAttachments?: FileAttachmentForApi[], contexts?: ChatContext[]) => {
       const trimmed = text.trim()

--- a/apps/sim/providers/gemini/core.ts
+++ b/apps/sim/providers/gemini/core.ts
@@ -29,6 +29,7 @@ import type { FunctionCallResponse, ProviderRequest, ProviderResponse } from '@/
 import {
   calculateCost,
   isDeepResearchModel,
+  isGemini3Model,
   prepareToolExecution,
   prepareToolsWithUsageControl,
   sumToolCosts,
@@ -295,7 +296,8 @@ function buildNextConfig(
   state: ExecutionState,
   forcedTools: string[],
   request: ProviderRequest,
-  logger: ReturnType<typeof createLogger>
+  logger: ReturnType<typeof createLogger>,
+  model: string
 ): GenerateContentConfig {
   const nextConfig = { ...baseConfig }
   const allForcedToolsUsed =
@@ -304,9 +306,13 @@ function buildNextConfig(
   if (allForcedToolsUsed && request.responseFormat) {
     nextConfig.tools = undefined
     nextConfig.toolConfig = undefined
-    nextConfig.responseMimeType = 'application/json'
-    nextConfig.responseSchema = cleanSchemaForGemini(request.responseFormat.schema) as Schema
-    logger.info('Using structured output for final response after tool execution')
+    if (isGemini3Model(model)) {
+      logger.info('Gemini 3: Stripping tools after forced tool execution, schema already set')
+    } else {
+      nextConfig.responseMimeType = 'application/json'
+      nextConfig.responseSchema = cleanSchemaForGemini(request.responseFormat.schema) as Schema
+      logger.info('Using structured output for final response after tool execution')
+    }
   } else if (state.currentToolConfig) {
     nextConfig.toolConfig = state.currentToolConfig
   } else {
@@ -921,13 +927,19 @@ export async function executeGeminiRequest(
       geminiConfig.systemInstruction = systemInstruction
     }
 
-    // Handle response format (only when no tools)
+    // Handle response format
     if (request.responseFormat && !tools?.length) {
       geminiConfig.responseMimeType = 'application/json'
       geminiConfig.responseSchema = cleanSchemaForGemini(request.responseFormat.schema) as Schema
       logger.info('Using Gemini native structured output format')
+    } else if (request.responseFormat && tools?.length && isGemini3Model(model)) {
+      geminiConfig.responseMimeType = 'application/json'
+      geminiConfig.responseJsonSchema = request.responseFormat.schema
+      logger.info('Using Gemini 3 structured output with tools (responseJsonSchema)')
     } else if (request.responseFormat && tools?.length) {
-      logger.warn('Gemini does not support responseFormat with tools. Structured output ignored.')
+      logger.warn(
+        'Gemini 2 does not support responseFormat with tools. Structured output will be applied after tool execution.'
+      )
     }
 
     // Configure thinking only when the user explicitly selects a thinking level
@@ -1099,7 +1111,7 @@ export async function executeGeminiRequest(
         }
 
         state = { ...updatedState, iterationCount: updatedState.iterationCount + 1 }
-        const nextConfig = buildNextConfig(geminiConfig, state, forcedTools, request, logger)
+        const nextConfig = buildNextConfig(geminiConfig, state, forcedTools, request, logger, model)
 
         // Stream final response if requested
         if (request.stream) {
@@ -1120,10 +1132,12 @@ export async function executeGeminiRequest(
           if (request.responseFormat) {
             nextConfig.tools = undefined
             nextConfig.toolConfig = undefined
-            nextConfig.responseMimeType = 'application/json'
-            nextConfig.responseSchema = cleanSchemaForGemini(
-              request.responseFormat.schema
-            ) as Schema
+            if (!isGemini3Model(model)) {
+              nextConfig.responseMimeType = 'application/json'
+              nextConfig.responseSchema = cleanSchemaForGemini(
+                request.responseFormat.schema
+              ) as Schema
+            }
           }
 
           // Capture accumulated cost before streaming

--- a/apps/sim/providers/utils.ts
+++ b/apps/sim/providers/utils.ts
@@ -1064,19 +1064,9 @@ export function isDeepResearchModel(model: string): boolean {
   return MODELS_WITH_DEEP_RESEARCH.includes(model.toLowerCase())
 }
 
-const GEMINI_3_MODELS = [
-  'gemini-3.1-pro-preview',
-  'gemini-3.1-flash-lite-preview',
-  'gemini-3-flash-preview',
-  'gemini-3-pro-preview',
-  'vertex/gemini-3.1-pro-preview',
-  'vertex/gemini-3.1-flash-lite-preview',
-  'vertex/gemini-3-pro-preview',
-  'vertex/gemini-3-flash-preview',
-]
-
 export function isGemini3Model(model: string): boolean {
-  return GEMINI_3_MODELS.includes(model.toLowerCase())
+  const normalized = model.toLowerCase().replace(/^vertex\//, '')
+  return normalized.startsWith('gemini-3')
 }
 
 /**

--- a/apps/sim/providers/utils.ts
+++ b/apps/sim/providers/utils.ts
@@ -1064,6 +1064,21 @@ export function isDeepResearchModel(model: string): boolean {
   return MODELS_WITH_DEEP_RESEARCH.includes(model.toLowerCase())
 }
 
+const GEMINI_3_MODELS = [
+  'gemini-3.1-pro-preview',
+  'gemini-3.1-flash-lite-preview',
+  'gemini-3-flash-preview',
+  'gemini-3-pro-preview',
+  'vertex/gemini-3.1-pro-preview',
+  'vertex/gemini-3.1-flash-lite-preview',
+  'vertex/gemini-3-pro-preview',
+  'vertex/gemini-3-flash-preview',
+]
+
+export function isGemini3Model(model: string): boolean {
+  return GEMINI_3_MODELS.includes(model.toLowerCase())
+}
+
 /**
  * Get the maximum temperature value for a model
  * @returns Maximum temperature value (1 or 2) or undefined if temperature not supported


### PR DESCRIPTION
## Summary
- Gemini 3 models support `responseJsonSchema` alongside tools/function declarations in the same request — Gemini 2 does not
- When an Agent block uses a Gemini 3 model with both tools and a response format, structured output was silently skipped, returning plain text instead of JSON
- Added `isGemini3Model()` helper and branching logic to use `responseJsonSchema` (not `responseSchema`) for Gemini 3 + tools, preserving existing Gemini 2 behavior
- Verified all scenarios against the live Gemini API: Gemini 3 + tools + schema, Gemini 3 no tools, Gemini 2 + tools (400 rejection), Gemini 2 no tools

## Type of Change
- [x] Bug fix

## Testing
Tested manually against the live Gemini API with comprehensive matrix covering all model/tools/schema combinations.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)