### PR TITLE
improvement(landing): optimize core web vitals and accessibility

### DIFF
--- a/apps/sim/app/(landing)/components/collaboration/collaboration.tsx
+++ b/apps/sim/app/(landing)/components/collaboration/collaboration.tsx
@@ -1,11 +1,15 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
 import { Badge } from '@/components/emcn'
-import { AuthModal } from '@/app/(landing)/components/auth-modal/auth-modal'
 import { trackLandingCta } from '@/app/(landing)/landing-analytics'
+
+const AuthModal = dynamic(() =>
+  import('@/app/(landing)/components/auth-modal/auth-modal').then((m) => m.AuthModal)
+)
 
 interface DotGridProps {
   className?: string

--- a/apps/sim/app/(landing)/components/features/features.tsx
+++ b/apps/sim/app/(landing)/components/features/features.tsx
@@ -2,11 +2,15 @@
 
 import { useRef, useState } from 'react'
 import { type MotionValue, motion, useScroll, useTransform } from 'framer-motion'
+import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import { Badge } from '@/components/emcn'
-import { AuthModal } from '@/app/(landing)/components/auth-modal/auth-modal'
 import { FeaturesPreview } from '@/app/(landing)/components/features/components/features-preview'
 import { trackLandingCta } from '@/app/(landing)/landing-analytics'
+
+const AuthModal = dynamic(() =>
+  import('@/app/(landing)/components/auth-modal/auth-modal').then((m) => m.AuthModal)
+)
 
 function hexToRgba(hex: string, alpha: number): string {
   const r = Number.parseInt(hex.slice(1, 3), 16)

--- a/apps/sim/app/(landing)/components/footer/footer-cta.tsx
+++ b/apps/sim/app/(landing)/components/footer/footer-cta.tsx
@@ -2,12 +2,16 @@
 
 import { useCallback, useRef, useState } from 'react'
 import { ArrowUp } from 'lucide-react'
+import dynamic from 'next/dynamic'
 import { cn } from '@/lib/core/utils/cn'
 import { captureClientEvent } from '@/lib/posthog/client'
-import { AuthModal } from '@/app/(landing)/components/auth-modal/auth-modal'
 import { useLandingSubmit } from '@/app/(landing)/components/landing-preview/components/landing-preview-panel/landing-preview-panel'
 import { trackLandingCta } from '@/app/(landing)/landing-analytics'
 import { useAnimatedPlaceholder } from '@/hooks/use-animated-placeholder'
+
+const AuthModal = dynamic(() =>
+  import('@/app/(landing)/components/auth-modal/auth-modal').then((m) => m.AuthModal)
+)
 
 const MAX_HEIGHT = 120
 

--- a/apps/sim/app/(landing)/components/footer/footer.tsx
+++ b/apps/sim/app/(landing)/components/footer/footer.tsx
@@ -38,7 +38,7 @@ const BLOCK_LINKS: FooterItem[] = [
   { label: 'Router', href: 'https://docs.sim.ai/blocks/router', external: true },
   { label: 'Function', href: 'https://docs.sim.ai/blocks/function', external: true },
   { label: 'Condition', href: 'https://docs.sim.ai/blocks/condition', external: true },
-  { label: 'API', href: 'https://docs.sim.ai/blocks/api', external: true },
+  { label: 'API Block', href: 'https://docs.sim.ai/blocks/api', external: true },
   { label: 'Workflow', href: 'https://docs.sim.ai/blocks/workflow', external: true },
   { label: 'Parallel', href: 'https://docs.sim.ai/blocks/parallel', external: true },
   { label: 'Guardrails', href: 'https://docs.sim.ai/blocks/guardrails', external: true },
@@ -194,7 +194,7 @@ export default function Footer({ hideCTA }: FooterProps) {
               <Link href='/' aria-label='Sim home'>
                 <Image
                   src='/logo/sim-landing.svg'
-                  alt='Sim'
+                  alt=''
                   width={85}
                   height={26}
                   className='h-[26.4px] w-auto'

--- a/apps/sim/app/(landing)/components/hero/hero.tsx
+++ b/apps/sim/app/(landing)/components/hero/hero.tsx
@@ -2,9 +2,17 @@
 
 import dynamic from 'next/dynamic'
 import { cn } from '@/lib/core/utils/cn'
-import { AuthModal } from '@/app/(landing)/components/auth-modal/auth-modal'
-import { DemoRequestModal } from '@/app/(landing)/components/demo-request/demo-request-modal'
 import { trackLandingCta } from '@/app/(landing)/landing-analytics'
+
+const AuthModal = dynamic(() =>
+  import('@/app/(landing)/components/auth-modal/auth-modal').then((m) => m.AuthModal)
+)
+
+const DemoRequestModal = dynamic(() =>
+  import('@/app/(landing)/components/demo-request/demo-request-modal').then(
+    (m) => m.DemoRequestModal
+  )
+)
 
 const LandingPreview = dynamic(
   () =>

--- a/apps/sim/app/(landing)/components/landing-preview/components/landing-preview-home/landing-preview-home.tsx
+++ b/apps/sim/app/(landing)/components/landing-preview/components/landing-preview-home/landing-preview-home.tsx
@@ -334,6 +334,7 @@ export const LandingPreviewHome = memo(function LandingPreviewHome({
               type='button'
               onClick={handleSubmit}
               disabled={isEmpty}
+              aria-label='Submit message'
               className='flex h-[28px] w-[28px] items-center justify-center rounded-full border-0 p-0 transition-colors'
               style={{
                 background: isEmpty ? '#808080' : '#e0e0e0',

--- a/apps/sim/app/(landing)/components/landing-preview/components/landing-preview-panel/landing-preview-panel.tsx
+++ b/apps/sim/app/(landing)/components/landing-preview/components/landing-preview-panel/landing-preview-panel.tsx
@@ -3,13 +3,13 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ArrowUp } from 'lucide-react'
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
 import { createPortal } from 'react-dom'
 import { Blimp, BubbleChatPreview, ChevronDown, MoreHorizontal, Play } from '@/components/emcn'
 import { AgentIcon, HubspotIcon, OpenAIIcon, SalesforceIcon } from '@/components/icons'
 import { LandingPromptStorage } from '@/lib/core/utils/browser-storage'
 import { captureClientEvent } from '@/lib/posthog/client'
-import { AuthModal } from '@/app/(landing)/components/auth-modal/auth-modal'
 import {
   EASE_OUT,
   type EditorPromptData,
@@ -20,6 +20,10 @@ import {
   TYPE_START_BUFFER_MS,
 } from '@/app/(landing)/components/landing-preview/components/landing-preview-workflow/workflow-data'
 import { trackLandingCta } from '@/app/(landing)/landing-analytics'
+
+const AuthModal = dynamic(() =>
+  import('@/app/(landing)/components/auth-modal/auth-modal').then((m) => m.AuthModal)
+)
 
 type PanelTab = 'copilot' | 'editor'
 

--- a/apps/sim/app/(landing)/components/navbar/navbar.tsx
+++ b/apps/sim/app/(landing)/components/navbar/navbar.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { useCallback, useContext, useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { GithubOutlineIcon } from '@/components/icons'
-import { useSession } from '@/lib/auth/auth-client'
 import { cn } from '@/lib/core/utils/cn'
-import { AuthModal } from '@/app/(landing)/components/auth-modal/auth-modal'
+import { SessionContext } from '@/app/_shell/providers/session-provider'
 import {
   BlogDropdown,
   type NavBlogPost,
@@ -16,6 +16,10 @@ import { DocsDropdown } from '@/app/(landing)/components/navbar/components/docs-
 import { GitHubStars } from '@/app/(landing)/components/navbar/components/github-stars'
 import { trackLandingCta } from '@/app/(landing)/landing-analytics'
 import { getBrandConfig } from '@/ee/whitelabeling'
+
+const AuthModal = dynamic(() =>
+  import('@/app/(landing)/components/auth-modal/auth-modal').then((m) => m.AuthModal)
+)
 
 type DropdownId = 'docs' | 'blog' | null
 
@@ -48,7 +52,9 @@ interface NavbarProps {
 export default function Navbar({ logoOnly = false, blogPosts = [] }: NavbarProps) {
   const brand = getBrandConfig()
   const searchParams = useSearchParams()
-  const { data: session, isPending: isSessionPending } = useSession()
+  const sessionCtx = useContext(SessionContext)
+  const session = sessionCtx?.data ?? null
+  const isSessionPending = sessionCtx?.isPending ?? true
   const isAuthenticated = Boolean(session?.user?.id)
   const isBrowsingHome = searchParams.has('home')
   const useHomeLinks = isAuthenticated || isBrowsingHome
@@ -125,7 +131,7 @@ export default function Navbar({ logoOnly = false, blogPosts = [] }: NavbarProps
         ) : (
           <Image
             src='/logo/sim-landing.svg'
-            alt='Sim'
+            alt=''
             width={71}
             height={22}
             className='h-[22px] w-auto'

--- a/apps/sim/app/(landing)/components/pricing/pricing.tsx
+++ b/apps/sim/app/(landing)/components/pricing/pricing.tsx
@@ -1,9 +1,18 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { Badge } from '@/components/emcn'
-import { AuthModal } from '@/app/(landing)/components/auth-modal/auth-modal'
-import { DemoRequestModal } from '@/app/(landing)/components/demo-request/demo-request-modal'
 import { trackLandingCta } from '@/app/(landing)/landing-analytics'
+
+const AuthModal = dynamic(() =>
+  import('@/app/(landing)/components/auth-modal/auth-modal').then((m) => m.AuthModal)
+)
+
+const DemoRequestModal = dynamic(() =>
+  import('@/app/(landing)/components/demo-request/demo-request-modal').then(
+    (m) => m.DemoRequestModal
+  )
+)
 
 interface PricingTier {
   id: string

--- a/apps/sim/app/(landing)/components/templates/templates.tsx
+++ b/apps/sim/app/(landing)/components/templates/templates.tsx
@@ -470,7 +470,7 @@ export default function Templates() {
                 aria-labelledby={`template-tab-${activeIndex}`}
                 className='relative hidden flex-1 lg:block'
               >
-                <div aria-hidden='true' className='h-full'>
+                <div aria-hidden='true' inert className='h-full'>
                   <LandingPreviewWorkflow
                     key={activeIndex}
                     workflow={activeWorkflow}

--- a/apps/sim/app/_shell/providers/posthog-provider.tsx
+++ b/apps/sim/app/_shell/providers/posthog-provider.tsx
@@ -35,6 +35,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
             capture_performance: false,
             capture_dead_clicks: false,
             enable_heatmaps: false,
+            disable_session_recording: true,
             session_recording: {
               maskAllInputs: false,
               maskInputOptions: {

--- a/apps/sim/app/_shell/providers/session-provider.tsx
+++ b/apps/sim/app/_shell/providers/session-provider.tsx
@@ -92,7 +92,10 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
               email_verified: data.user.emailVerified,
               created_at: data.user.createdAt,
             })
-            if (typeof posthog.startSessionRecording === 'function') {
+            if (
+              typeof posthog.startSessionRecording === 'function' &&
+              !posthog.sessionRecordingStarted()
+            ) {
               posthog.startSessionRecording()
             }
           } else {

--- a/apps/sim/app/_shell/providers/session-provider.tsx
+++ b/apps/sim/app/_shell/providers/session-provider.tsx
@@ -92,6 +92,9 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
               email_verified: data.user.emailVerified,
               created_at: data.user.createdAt,
             })
+            if (typeof posthog.startSessionRecording === 'function') {
+              posthog.startSessionRecording()
+            }
           } else {
             posthog.reset()
           }

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -150,15 +150,6 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        source: '/_next/static/:path*',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable',
-          },
-        ],
-      },
-      {
         source: '/:all*(svg|jpg|jpeg|png|gif|ico|webp|avif|woff|woff2|ttf|eot)',
         headers: [
           {

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -150,6 +150,15 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: '/_next/static/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
         source: '/:all*(svg|jpg|jpeg|png|gif|ico|webp|avif|woff|woff2|ttf|eot)',
         headers: [
           {


### PR DESCRIPTION
## Summary
- Code-split `AuthModal` and `DemoRequestModal` via `next/dynamic` across 7 landing components to move the auth-client bundle out of the initial JS payload
- Replace `useSession` import in navbar with direct `SessionContext` read to avoid pulling the entire better-auth client into the landing page bundle
- Add immutable `Cache-Control` header for content-hashed `_next/static` assets
- Defer PostHog session recording until user identification to skip loading the recorder on anonymous visits
- Fix accessibility issues flagged by Lighthouse: missing `aria-label`, `inert` on `aria-hidden` wrapper, decorative `alt` on logos, duplicate link labels

## Context
PageSpeed Insights (Apr 15, 2026) shows sim.ai failing Core Web Vitals — LCP 3.4s (mobile) / 2.6s (desktop), Performance score 75 (mobile) / 82 (desktop). Root causes: ~675KB unused JS on landing page, 3.0s JS execution time, poor cache lifetimes for hashed static assets, and PostHog recorder loading on anonymous visits. Accessibility score was 88 (desktop) / 92 (mobile) due to missing labels and focusable elements inside `aria-hidden` containers.

## Changes

**Code-split auth modals** (`hero.tsx`, `navbar.tsx`, `features.tsx`, `collaboration.tsx`, `pricing.tsx`, `footer-cta.tsx`, `landing-preview-panel.tsx`)
- Replace static `import { AuthModal }` / `import { DemoRequestModal }` with `dynamic()` (SSR preserved, client-side code-split)
- Moves auth-client bundle (better-auth + SSO/Stripe/org plugins) into a separate chunk loaded on interaction

**Navbar session optimization** (`navbar.tsx`)
- Replace `import { useSession } from '@/lib/auth/auth-client'` with `useContext(SessionContext)` from session-provider
- `useSession` in auth-client.ts is a thin wrapper around the same context, but importing it forces bundling the entire `createAuthClient()` call with all plugins
- Direct context read is semantically identical, avoids the bundle cost

**Cache headers** (`next.config.ts`)
- Add `Cache-Control: public, max-age=31536000, immutable` for `/_next/static/:path*`
- These assets have content hashes in filenames — URL changes on deploy, safe to cache indefinitely
- Matches Vercel's default behavior, ensures parity for self-hosted (Docker) deployments

**PostHog session recording deferral** (`posthog-provider.tsx`, `session-provider.tsx`)
- Add `disable_session_recording: true` to PostHog init config — prevents recorder JS (~80KB) from loading on anonymous visits
- Call `posthog.startSessionRecording()` after `posthog.identify()` for authenticated users
- Called without overrides to respect dashboard-level sampling and linked flag config

**Accessibility fixes** (`footer.tsx`, `navbar.tsx`, `landing-preview-home.tsx`, `templates.tsx`)
- Set `alt=''` on logo images inside links that already have `aria-label` and sr-only text (image is decorative)
- Add `aria-label='Submit message'` to icon-only button in landing preview
- Add `inert` attribute alongside `aria-hidden='true'` on ReactFlow preview wrapper to prevent focusable descendants from tab order
- Rename duplicate "API" footer link to "API Block" to disambiguate from "API" in Product column

## Type of Change
- [x] Improvement
- [x] Bug fix

## Testing
- Pre-commit hooks (biome lint/format) pass
- All modal triggers render in SSR (no `ssr: false` — buttons visible in initial HTML)
- Auth state in navbar reads from same `SessionContext` provided by root layout `SessionProvider`
- PostHog `disable_session_recording` and `startSessionRecording()` verified against posthog-js 1.364.4 type definitions
- `_next/static` cache rule only applies to content-hashed assets — safe for immutable caching
- No styling changes — all diffs are import swaps, config additions, or HTML attribute additions

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)