### PR TITLE
fix(ui): stop terminal auto-select from stealing copilot input focus

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/terminal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/terminal.tsx
@@ -1115,7 +1115,6 @@ export const Terminal = memo(function Terminal() {
     if (selectedEntryId === lastNavEntry.entry.id) return
 
     setSelectedEntryId(lastNavEntry.entry.id)
-    focusTerminal()
 
     if (lastNavEntry.parentNodeIds.length > 0) {
       setExpandedNodes((prev) => {
@@ -1126,7 +1125,7 @@ export const Terminal = memo(function Terminal() {
         return next
       })
     }
-  }, [executionGroups, navigableEntries, autoSelectEnabled, selectedEntryId, focusTerminal])
+  }, [executionGroups, navigableEntries, autoSelectEnabled, selectedEntryId])
 
   /**
    * Clear filters when there are no logs


### PR DESCRIPTION
## Summary
- Remove `focusTerminal()` call from terminal's auto-select effect so new console entries don't steal focus from the copilot textarea
- Terminal still visually selects the latest entry — focus is only moved on explicit user interaction (clicking an entry or keyboard nav)

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)