### PR TITLE
improvement(sidebar): interleave folders and workflows by sort order in all resource pickers

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   Button,
   DropdownMenu,
@@ -13,7 +13,7 @@ import {
   DropdownMenuTrigger,
   Tooltip,
 } from '@/components/emcn'
-import { Plus } from '@/components/emcn/icons'
+import { Folder, Plus } from '@/components/emcn/icons'
 import { cn } from '@/lib/core/utils/cn'
 import { getResourceConfig } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry'
 import {
@@ -68,6 +68,8 @@ export function useAvailableResources(
           id: w.id,
           name: w.name,
           color: w.color,
+          folderId: w.folderId ?? null,
+          sortOrder: w.sortOrder,
           isOpen: existingKeys.has(`workflow:${w.id}`),
         })),
       },
@@ -76,6 +78,8 @@ export function useAvailableResources(
         items: folders.map((f) => ({
           id: f.id,
           name: f.name,
+          parentId: f.parentId ?? null,
+          sortOrder: f.sortOrder,
           isOpen: existingKeys.has(`folder:${f.id}`),
         })),
       },
@@ -116,6 +120,104 @@ export function useAvailableResources(
   }, [workflows, folders, tables, files, knowledgeBases, tasks, existingKeys, excludeTypes])
 }
 
+export type WorkflowTreeNode =
+  | { kind: 'workflow'; id: string; name: string; color: string; isOpen?: boolean }
+  | { kind: 'folder'; id: string; name: string; children: WorkflowTreeNode[] }
+
+export function buildWorkflowFolderTree(
+  workflowItems: AvailableItem[],
+  folderItems: AvailableItem[]
+): WorkflowTreeNode[] {
+  const knownFolderIds = new Set(folderItems.map((f) => f.id))
+
+  const byFolder = new Map<string | null, AvailableItem[]>()
+  for (const w of workflowItems) {
+    const fid = (w.folderId as string | null | undefined) ?? null
+    const key = fid && knownFolderIds.has(fid) ? fid : null
+    const bucket = byFolder.get(key) ?? []
+    bucket.push(w)
+    byFolder.set(key, bucket)
+  }
+
+  const toWorkflowNode = (w: AvailableItem): WorkflowTreeNode => ({
+    kind: 'workflow',
+    id: w.id,
+    name: w.name,
+    color: (w.color as string) ?? '#808080',
+    isOpen: w.isOpen,
+  })
+
+  const buildLevel = (parentId: string | null): WorkflowTreeNode[] => {
+    const childFolders = folderItems.filter(
+      (f) => ((f.parentId as string | null | undefined) ?? null) === parentId
+    )
+    const childWorkflows = byFolder.get(parentId) ?? []
+
+    const mixed: Array<{ sortOrder: number; name: string; node: WorkflowTreeNode }> = []
+
+    for (const f of childFolders) {
+      const children = buildLevel(f.id)
+      if (children.length === 0) continue
+      mixed.push({
+        sortOrder: (f.sortOrder as number) ?? 0,
+        name: f.name,
+        node: { kind: 'folder', id: f.id, name: f.name, children },
+      })
+    }
+
+    for (const w of childWorkflows) {
+      mixed.push({
+        sortOrder: (w.sortOrder as number) ?? 0,
+        name: w.name,
+        node: toWorkflowNode(w),
+      })
+    }
+
+    mixed.sort((a, b) =>
+      a.sortOrder !== b.sortOrder ? a.sortOrder - b.sortOrder : a.name.localeCompare(b.name)
+    )
+    return mixed.map((m) => m.node)
+  }
+
+  return buildLevel(null)
+}
+
+interface WorkflowFolderTreeItemsProps {
+  nodes: WorkflowTreeNode[]
+  onSelect: (resource: MothershipResource, isOpen?: boolean) => void
+}
+
+export function WorkflowFolderTreeItems({ nodes, onSelect }: WorkflowFolderTreeItemsProps) {
+  return (
+    <>
+      {nodes.map((node) =>
+        node.kind === 'workflow' ? (
+          <DropdownMenuItem
+            key={node.id}
+            onClick={() =>
+              onSelect({ type: 'workflow', id: node.id, title: node.name }, node.isOpen)
+            }
+          >
+            {getResourceConfig('workflow').renderDropdownItem({
+              item: { id: node.id, name: node.name, color: node.color },
+            })}
+          </DropdownMenuItem>
+        ) : (
+          <DropdownMenuSub key={node.id}>
+            <DropdownMenuSubTrigger>
+              <Folder className='h-[14px] w-[14px]' />
+              <span>{node.name}</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <WorkflowFolderTreeItems nodes={node.children} onSelect={onSelect} />
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        )
+      )}
+    </>
+  )
+}
+
 export function AddResourceDropdown({
   workspaceId,
   existingKeys,
@@ -128,27 +230,30 @@ export function AddResourceDropdown({
   const [activeIndex, setActiveIndex] = useState(0)
   const available = useAvailableResources(workspaceId, existingKeys, excludeTypes)
 
-  const handleOpenChange = useCallback((next: boolean) => {
+  const handleOpenChange = (next: boolean) => {
     setOpen(next)
     if (!next) {
       setSearch('')
       setActiveIndex(0)
     }
-  }, [])
+  }
 
-  const select = useCallback(
-    (resource: MothershipResource, isOpen?: boolean) => {
-      if (isOpen && onSwitch) {
-        onSwitch(resource.id)
-      } else {
-        onAdd(resource)
-      }
-      setOpen(false)
-      setSearch('')
-      setActiveIndex(0)
-    },
-    [onAdd, onSwitch]
-  )
+  const select = (resource: MothershipResource, isOpen?: boolean) => {
+    if (isOpen && onSwitch) {
+      onSwitch(resource.id)
+    } else {
+      onAdd(resource)
+    }
+    setOpen(false)
+    setSearch('')
+    setActiveIndex(0)
+  }
+
+  const workflowTree = useMemo(() => {
+    const workflowGroup = available.find((g) => g.type === 'workflow')
+    const folderGroup = available.find((g) => g.type === 'folder')
+    return buildWorkflowFolderTree(workflowGroup?.items ?? [], folderGroup?.items ?? [])
+  }, [available])
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase().trim()
@@ -158,25 +263,22 @@ export function AddResourceDropdown({
     )
   }, [search, available])
 
-  const handleSearchKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (!filtered) return
-      if (e.key === 'ArrowDown') {
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!filtered) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveIndex((prev) => Math.min(prev + 1, filtered.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveIndex((prev) => Math.max(prev - 1, 0))
+    } else if (e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) {
+      if (filtered.length > 0 && filtered[activeIndex]) {
         e.preventDefault()
-        setActiveIndex((prev) => Math.min(prev + 1, filtered.length - 1))
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault()
-        setActiveIndex((prev) => Math.max(prev - 1, 0))
-      } else if (e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) {
-        if (filtered.length > 0 && filtered[activeIndex]) {
-          e.preventDefault()
-          const { type, item } = filtered[activeIndex]
-          select({ type, id: item.id, title: item.name }, item.isOpen)
-        }
+        const { type, item } = filtered[activeIndex]
+        select({ type, id: item.id, title: item.name }, item.isOpen)
       }
-    },
-    [filtered, activeIndex, select]
-  )
+    }
+  }
 
   return (
     <DropdownMenu open={open} onOpenChange={handleOpenChange}>
@@ -199,7 +301,7 @@ export function AddResourceDropdown({
       <DropdownMenuContent
         align='start'
         sideOffset={8}
-        className='flex w-[240px] flex-col overflow-hidden'
+        className='flex w-[320px] flex-col overflow-hidden'
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
         <DropdownMenuSearchInput
@@ -224,9 +326,6 @@ export function AddResourceDropdown({
                     onClick={() => select({ type, id: item.id, title: item.name }, item.isOpen)}
                   >
                     {config.renderDropdownItem({ item })}
-                    <span className='ml-auto pl-2 text-[var(--text-tertiary)] text-xs'>
-                      {config.label}
-                    </span>
                   </DropdownMenuItem>
                 )
               })
@@ -237,25 +336,33 @@ export function AddResourceDropdown({
             )
           ) : (
             <>
+              {workflowTree.length > 0 && (
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <div
+                      className='h-[14px] w-[14px] flex-shrink-0 rounded-[3px] border-[2px]'
+                      style={{
+                        backgroundColor: '#808080',
+                        borderColor: '#80808060',
+                        backgroundClip: 'padding-box',
+                      }}
+                    />
+                    <span>Workflows</span>
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    <WorkflowFolderTreeItems nodes={workflowTree} onSelect={select} />
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+              )}
               {available.map(({ type, items }) => {
+                if (type === 'workflow' || type === 'folder') return null
                 if (items.length === 0) return null
                 const config = getResourceConfig(type)
                 const Icon = config.icon
                 return (
                   <DropdownMenuSub key={type}>
                     <DropdownMenuSubTrigger>
-                      {type === 'workflow' ? (
-                        <div
-                          className='h-[14px] w-[14px] flex-shrink-0 rounded-[3px] border-[2px]'
-                          style={{
-                            backgroundColor: '#808080',
-                            borderColor: '#80808060',
-                            backgroundClip: 'padding-box',
-                          }}
-                        />
-                      ) : (
-                        <Icon className='h-[14px] w-[14px]' />
-                      )}
+                      <Icon className='h-[14px] w-[14px]' />
                       <span>{config.label}</span>
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -157,7 +157,6 @@ export function buildWorkflowFolderTree(
 
     for (const f of childFolders) {
       const children = buildLevel(f.id)
-      // Folders with no descendant workflows are intentionally omitted; they are still reachable via search.
       if (children.length === 0) continue
       mixed.push({
         sortOrder: (f.sortOrder as number) ?? 0,

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -153,14 +153,15 @@ export function buildWorkflowFolderTree(
     )
     const childWorkflows = byFolder.get(parentId) ?? []
 
-    const mixed: Array<{ sortOrder: number; name: string; node: WorkflowTreeNode }> = []
+    const mixed: Array<{ sortOrder: number; id: string; node: WorkflowTreeNode }> = []
 
     for (const f of childFolders) {
       const children = buildLevel(f.id)
+      // Folders with no descendant workflows are intentionally omitted; they are still reachable via search.
       if (children.length === 0) continue
       mixed.push({
         sortOrder: (f.sortOrder as number) ?? 0,
-        name: f.name,
+        id: f.id,
         node: { kind: 'folder', id: f.id, name: f.name, children },
       })
     }
@@ -168,13 +169,13 @@ export function buildWorkflowFolderTree(
     for (const w of childWorkflows) {
       mixed.push({
         sortOrder: (w.sortOrder as number) ?? 0,
-        name: w.name,
+        id: w.id,
         node: toWorkflowNode(w),
       })
     }
 
     mixed.sort((a, b) =>
-      a.sortOrder !== b.sortOrder ? a.sortOrder - b.sortOrder : a.name.localeCompare(b.name)
+      a.sortOrder !== b.sortOrder ? a.sortOrder - b.sortOrder : a.id.localeCompare(b.id)
     )
     return mixed.map((m) => m.node)
   }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/index.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/index.ts
@@ -1,2 +1,11 @@
-export type { AddResourceDropdownProps, AvailableItem } from './add-resource-dropdown'
-export { AddResourceDropdown, useAvailableResources } from './add-resource-dropdown'
+export type {
+  AddResourceDropdownProps,
+  AvailableItem,
+  WorkflowTreeNode,
+} from './add-resource-dropdown'
+export {
+  AddResourceDropdown,
+  buildWorkflowFolderTree,
+  useAvailableResources,
+  WorkflowFolderTreeItems,
+} from './add-resource-dropdown'

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown.tsx
@@ -13,7 +13,11 @@ import {
   DropdownMenuTrigger,
 } from '@/components/emcn'
 import { Plus, Sim } from '@/components/emcn/icons'
-import type { useAvailableResources } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown'
+import {
+  buildWorkflowFolderTree,
+  type useAvailableResources,
+  WorkflowFolderTreeItems,
+} from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown'
 import { getResourceConfig } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry'
 import type { PlusMenuHandle } from '@/app/workspace/[workspaceId]/home/components/user-input/components/constants'
 import type { MothershipResource } from '@/app/workspace/[workspaceId]/home/types'
@@ -55,6 +59,12 @@ export const PlusMenuDropdown = React.memo(
 
     React.useImperativeHandle(ref, () => ({ open: doOpen }), [doOpen])
 
+    const workflowTree = useMemo(() => {
+      const workflowGroup = availableResources.find((g) => g.type === 'workflow')
+      const folderGroup = availableResources.find((g) => g.type === 'folder')
+      return buildWorkflowFolderTree(workflowGroup?.items ?? [], folderGroup?.items ?? [])
+    }, [availableResources])
+
     const filteredItems = useMemo(() => {
       const q = search.toLowerCase().trim()
       if (!q) return null
@@ -63,34 +73,25 @@ export const PlusMenuDropdown = React.memo(
       )
     }, [search, availableResources])
 
-    const handleSelect = useCallback(
-      (resource: MothershipResource) => {
-        onResourceSelect(resource)
-        setOpen(false)
-        setSearch('')
-      },
-      [onResourceSelect]
-    )
+    const handleSelect = (resource: MothershipResource) => {
+      onResourceSelect(resource)
+      setOpen(false)
+      setSearch('')
+    }
 
-    const filteredItemsRef = useRef(filteredItems)
-    filteredItemsRef.current = filteredItems
+    const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        const firstItem = contentRef.current?.querySelector<HTMLElement>('[role="menuitem"]')
+        firstItem?.focus()
+      } else if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault()
+        const first = filteredItems?.[0]
+        if (first) handleSelect({ type: first.type, id: first.item.id, title: first.item.name })
+      }
+    }
 
-    const handleSearchKeyDown = useCallback(
-      (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'ArrowDown') {
-          e.preventDefault()
-          const firstItem = contentRef.current?.querySelector<HTMLElement>('[role="menuitem"]')
-          firstItem?.focus()
-        } else if (e.key === 'Enter' || e.key === 'Tab') {
-          e.preventDefault()
-          const first = filteredItemsRef.current?.[0]
-          if (first) handleSelect({ type: first.type, id: first.item.id, title: first.item.name })
-        }
-      },
-      [handleSelect]
-    )
-
-    const handleContentKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    const handleContentKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.key === 'ArrowUp') {
         const items = Array.from(
           contentRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? []
@@ -106,33 +107,27 @@ export const PlusMenuDropdown = React.memo(
           focused.click()
         }
       }
-    }, [])
+    }
 
-    const handleOpenChange = useCallback(
-      (isOpen: boolean) => {
-        setOpen(isOpen)
-        if (!isOpen) {
-          setSearch('')
-          setAnchorPos(null)
-          onClose()
-        }
-      },
-      [onClose]
-    )
+    const handleOpenChange = (isOpen: boolean) => {
+      setOpen(isOpen)
+      if (!isOpen) {
+        setSearch('')
+        setAnchorPos(null)
+        onClose()
+      }
+    }
 
-    const handleCloseAutoFocus = useCallback(
-      (e: Event) => {
-        e.preventDefault()
-        const textarea = textareaRef.current
-        if (!textarea) return
-        if (pendingCursorRef.current !== null) {
-          textarea.setSelectionRange(pendingCursorRef.current, pendingCursorRef.current)
-          pendingCursorRef.current = null
-        }
-        textarea.focus()
-      },
-      [textareaRef, pendingCursorRef]
-    )
+    const handleCloseAutoFocus = (e: Event) => {
+      e.preventDefault()
+      const textarea = textareaRef.current
+      if (!textarea) return
+      if (pendingCursorRef.current !== null) {
+        textarea.setSelectionRange(pendingCursorRef.current, pendingCursorRef.current)
+        pendingCursorRef.current = null
+      }
+      textarea.focus()
+    }
 
     return (
       <>
@@ -154,7 +149,7 @@ export const PlusMenuDropdown = React.memo(
             align='start'
             side='top'
             sideOffset={8}
-            className='flex w-[240px] flex-col overflow-hidden'
+            className='flex w-[320px] flex-col overflow-hidden'
             onCloseAutoFocus={handleCloseAutoFocus}
             onKeyDown={handleContentKeyDown}
           >
@@ -168,7 +163,7 @@ export const PlusMenuDropdown = React.memo(
             <div className='min-h-0 flex-1 overflow-y-auto'>
               {filteredItems ? (
                 filteredItems.length > 0 ? (
-                  filteredItems.map(({ type, item }, index) => {
+                  filteredItems.map(({ type, item }) => {
                     const config = getResourceConfig(type)
                     return (
                       <DropdownMenuItem
@@ -182,14 +177,11 @@ export const PlusMenuDropdown = React.memo(
                         }}
                       >
                         {config.renderDropdownItem({ item })}
-                        <span className='ml-auto pl-2 text-[11px] text-[var(--text-tertiary)]'>
-                          {config.label}
-                        </span>
                       </DropdownMenuItem>
                     )
                   })
                 ) : (
-                  <div className='px-2 py-1.5 text-center font-medium text-[12px] text-[var(--text-tertiary)]'>
+                  <div className='px-2 py-1.5 text-center font-medium text-[var(--text-tertiary)] text-caption'>
                     No results
                   </div>
                 )
@@ -210,46 +202,51 @@ export const PlusMenuDropdown = React.memo(
                       <span>Workspace</span>
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent>
-                      {availableResources.map(({ type, items }) => {
-                        if (items.length === 0) return null
-                        const config = getResourceConfig(type)
-                        const Icon = config.icon
-                        return (
-                          <DropdownMenuSub key={type}>
-                            <DropdownMenuSubTrigger>
-                              {type === 'workflow' ? (
-                                <div
-                                  className='h-[14px] w-[14px] flex-shrink-0 rounded-[3px] border-[2px]'
-                                  style={{
-                                    backgroundColor: '#808080',
-                                    borderColor: '#80808060',
-                                    backgroundClip: 'padding-box',
-                                  }}
-                                />
-                              ) : (
+                      {workflowTree.length > 0 && (
+                        <DropdownMenuSub>
+                          <DropdownMenuSubTrigger>
+                            <div
+                              className='h-[14px] w-[14px] flex-shrink-0 rounded-[3px] border-[2px]'
+                              style={{
+                                backgroundColor: '#808080',
+                                borderColor: '#80808060',
+                                backgroundClip: 'padding-box',
+                              }}
+                            />
+                            <span>Workflows</span>
+                          </DropdownMenuSubTrigger>
+                          <DropdownMenuSubContent>
+                            <WorkflowFolderTreeItems nodes={workflowTree} onSelect={handleSelect} />
+                          </DropdownMenuSubContent>
+                        </DropdownMenuSub>
+                      )}
+                      {availableResources
+                        .filter(({ type }) => type !== 'workflow' && type !== 'folder')
+                        .map(({ type, items }) => {
+                          if (items.length === 0) return null
+                          const config = getResourceConfig(type)
+                          const Icon = config.icon
+                          return (
+                            <DropdownMenuSub key={type}>
+                              <DropdownMenuSubTrigger>
                                 <Icon className='h-[14px] w-[14px]' />
-                              )}
-                              <span>{config.label}</span>
-                            </DropdownMenuSubTrigger>
-                            <DropdownMenuSubContent>
-                              {items.map((item) => (
-                                <DropdownMenuItem
-                                  key={item.id}
-                                  onClick={() => {
-                                    handleSelect({
-                                      type,
-                                      id: item.id,
-                                      title: item.name,
-                                    })
-                                  }}
-                                >
-                                  {config.renderDropdownItem({ item })}
-                                </DropdownMenuItem>
-                              ))}
-                            </DropdownMenuSubContent>
-                          </DropdownMenuSub>
-                        )
-                      })}
+                                <span>{config.label}</span>
+                              </DropdownMenuSubTrigger>
+                              <DropdownMenuSubContent>
+                                {items.map((item) => (
+                                  <DropdownMenuItem
+                                    key={item.id}
+                                    onClick={() => {
+                                      handleSelect({ type, id: item.id, title: item.name })
+                                    }}
+                                  >
+                                    {config.renderDropdownItem({ item })}
+                                  </DropdownMenuItem>
+                                ))}
+                              </DropdownMenuSubContent>
+                            </DropdownMenuSub>
+                          )
+                        })}
                     </DropdownMenuSubContent>
                   </DropdownMenuSub>
                 </>
@@ -261,7 +258,7 @@ export const PlusMenuDropdown = React.memo(
           ref={buttonRef}
           type='button'
           onClick={() => doOpen()}
-          className='flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-full border border-[#F0F0F0] transition-colors hover:bg-[#F7F7F7] dark:border-[#3d3d3d] dark:hover:bg-[#303030]'
+          className='flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-full border border-[var(--border-1)] transition-colors hover:bg-[var(--surface-hover)]'
           title='Add attachments or resources'
         >
           <Plus className='h-[16px] w-[16px] text-[var(--text-icon)]' />

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -75,6 +75,7 @@ import {
   useWorkspaceManagement,
 } from '@/app/workspace/[workspaceId]/w/components/sidebar/hooks'
 import {
+  compareByOrder,
   createSidebarDragGhost,
   groupWorkflowsByFolder,
 } from '@/app/workspace/[workspaceId]/w/components/sidebar/utils'
@@ -506,6 +507,42 @@ export const Sidebar = memo(function Sidebar() {
     () => (isCollapsed ? groupWorkflowsByFolder(regularWorkflows) : {}),
     [isCollapsed, regularWorkflows]
   )
+
+  const collapsedRootItems = useMemo(() => {
+    type RootItem =
+      | {
+          kind: 'folder'
+          sortOrder: number
+          createdAt?: Date
+          id: string
+          node: (typeof folderTree)[number]
+        }
+      | {
+          kind: 'workflow'
+          sortOrder: number
+          createdAt?: Date
+          id: string
+          workflow: (typeof regularWorkflows)[number]
+        }
+    const items: RootItem[] = [
+      ...folderTree.map((node) => ({
+        kind: 'folder' as const,
+        sortOrder: node.sortOrder,
+        createdAt: node.createdAt,
+        id: node.id,
+        node,
+      })),
+      ...(workflowsByFolder.root ?? []).map((w) => ({
+        kind: 'workflow' as const,
+        sortOrder: w.sortOrder,
+        createdAt: w.createdAt,
+        id: w.id,
+        workflow: w,
+      })),
+    ]
+    items.sort(compareByOrder)
+    return items
+  }, [folderTree, workflowsByFolder])
 
   const [activeNavItemHref, setActiveNavItemHref] = useState<string | null>(null)
   const {
@@ -1655,42 +1692,46 @@ export const Sidebar = memo(function Sidebar() {
                             <DropdownMenuItem disabled>No workflows yet</DropdownMenuItem>
                           ) : (
                             <>
-                              <CollapsedFolderItems
-                                nodes={folderTree}
-                                workflowsByFolder={workflowsByFolder}
-                                workspaceId={workspaceId}
-                                currentWorkflowId={workflowId}
-                                editingWorkflowId={workflowFlyoutRename.editingId}
-                                editingValue={workflowFlyoutRename.value}
-                                editInputRef={workflowFlyoutRename.inputRef}
-                                isRenamingWorkflow={workflowFlyoutRename.isSaving}
-                                onEditValueChange={workflowFlyoutRename.setValue}
-                                onEditKeyDown={workflowFlyoutRename.handleKeyDown}
-                                onEditBlur={handleWorkflowRenameBlur}
-                                onWorkflowOpenInNewTab={handleCollapsedWorkflowOpenInNewTab}
-                                onWorkflowRename={handleCollapsedWorkflowRename}
-                                canRenameWorkflow={canEdit}
-                              />
-                              {(workflowsByFolder.root || []).map((workflow) => (
-                                <CollapsedWorkflowFlyoutItem
-                                  key={workflow.id}
-                                  workflow={workflow}
-                                  href={`/workspace/${workspaceId}/w/${workflow.id}`}
-                                  isCurrentRoute={workflow.id === workflowId}
-                                  isEditing={workflow.id === workflowFlyoutRename.editingId}
-                                  editValue={workflowFlyoutRename.value}
-                                  inputRef={workflowFlyoutRename.inputRef}
-                                  isRenaming={workflowFlyoutRename.isSaving}
-                                  onEditValueChange={workflowFlyoutRename.setValue}
-                                  onEditKeyDown={workflowFlyoutRename.handleKeyDown}
-                                  onEditBlur={handleWorkflowRenameBlur}
-                                  onOpenInNewTab={() =>
-                                    handleCollapsedWorkflowOpenInNewTab(workflow)
-                                  }
-                                  onRename={() => handleCollapsedWorkflowRename(workflow)}
-                                  canRename={canEdit}
-                                />
-                              ))}
+                              {collapsedRootItems.map((item) =>
+                                item.kind === 'folder' ? (
+                                  <CollapsedFolderItems
+                                    key={item.id}
+                                    nodes={[item.node]}
+                                    workflowsByFolder={workflowsByFolder}
+                                    workspaceId={workspaceId}
+                                    currentWorkflowId={workflowId}
+                                    editingWorkflowId={workflowFlyoutRename.editingId}
+                                    editingValue={workflowFlyoutRename.value}
+                                    editInputRef={workflowFlyoutRename.inputRef}
+                                    isRenamingWorkflow={workflowFlyoutRename.isSaving}
+                                    onEditValueChange={workflowFlyoutRename.setValue}
+                                    onEditKeyDown={workflowFlyoutRename.handleKeyDown}
+                                    onEditBlur={handleWorkflowRenameBlur}
+                                    onWorkflowOpenInNewTab={handleCollapsedWorkflowOpenInNewTab}
+                                    onWorkflowRename={handleCollapsedWorkflowRename}
+                                    canRenameWorkflow={canEdit}
+                                  />
+                                ) : (
+                                  <CollapsedWorkflowFlyoutItem
+                                    key={item.id}
+                                    workflow={item.workflow}
+                                    href={`/workspace/${workspaceId}/w/${item.workflow.id}`}
+                                    isCurrentRoute={item.workflow.id === workflowId}
+                                    isEditing={item.workflow.id === workflowFlyoutRename.editingId}
+                                    editValue={workflowFlyoutRename.value}
+                                    inputRef={workflowFlyoutRename.inputRef}
+                                    isRenaming={workflowFlyoutRename.isSaving}
+                                    onEditValueChange={workflowFlyoutRename.setValue}
+                                    onEditKeyDown={workflowFlyoutRename.handleKeyDown}
+                                    onEditBlur={handleWorkflowRenameBlur}
+                                    onOpenInNewTab={() =>
+                                      handleCollapsedWorkflowOpenInNewTab(item.workflow)
+                                    }
+                                    onRename={() => handleCollapsedWorkflowRename(item.workflow)}
+                                    canRename={canEdit}
+                                  />
+                                )
+                              )}
                             </>
                           )}
                         </CollapsedSidebarMenu>


### PR DESCRIPTION
## Summary

- Merged separate Folders/Workflows submenus into a single nested Workflows tree (matching the expanded sidebar's interleaved `sortOrder`-based ordering) in both the `@` plus-menu dropdown and the add-resource dropdown
- Widened both dropdowns from 240px → 320px and removed type labels from search results to reduce truncation
- Fixed `isOpen`/`onSwitch` regression: `WorkflowFolderTreeItems` now forwards `node.isOpen` so clicking an already-open workflow switches to its existing tab instead of creating a duplicate
- Applied the same interleaved `sortOrder` ordering to the collapsed sidebar's root-level folder+workflow flyout list

## Test plan

- [x] Open the `@` plus-menu in Mothership — Workspace submenu shows a single Workflows tree with folders and workflows interleaved by sort order
- [x] Open the add-resource dropdown (`+` in resource tabs) — same Workflows tree structure and ordering
- [x] Verify search results in both dropdowns show no type labels and fit in 320px width
- [x] Click a workflow already open as a tab from the tree — confirms it switches to the existing tab (not duplicated)
- [x] Collapse the sidebar and open the workflow flyout — root-level folders and workflows are interleaved by sort order, not folders-first