### PR TITLE
fix(fireflies): support V2 webhook payload format for meetingId mapping

### DIFF
--- a/apps/sim/blocks/blocks/fireflies.ts
+++ b/apps/sim/blocks/blocks/fireflies.ts
@@ -595,6 +595,10 @@ Return ONLY the summary text - no quotes, no labels.`,
     meetingId: { type: 'string', description: 'Meeting/transcript ID from webhook' },
     eventType: { type: 'string', description: 'Webhook event type' },
     clientReferenceId: { type: 'string', description: 'Custom reference ID if set during upload' },
+    timestamp: {
+      type: 'number',
+      description: 'Unix timestamp in milliseconds when the event was fired',
+    },
   },
   triggers: {
     enabled: true,

--- a/apps/sim/lib/webhooks/providers/fireflies.ts
+++ b/apps/sim/lib/webhooks/providers/fireflies.ts
@@ -45,11 +45,21 @@ function validateFirefliesSignature(secret: string, signature: string, body: str
 export const firefliesHandler: WebhookProviderHandler = {
   async formatInput({ body }: FormatInputContext): Promise<FormatInputResult> {
     const b = body as Record<string, unknown>
+
+    // Fireflies V2 webhooks use snake_case field names and "event" instead of "eventType"
+    const isV2 = typeof b.meeting_id === 'string' || typeof b.event === 'string'
+
+    const meetingId = ((isV2 ? b.meeting_id : b.meetingId) || '') as string
+    const eventType = ((isV2 ? b.event : b.eventType) || 'Transcription completed') as string
+    const clientReferenceId = ((isV2 ? b.client_reference_id : b.clientReferenceId) || '') as string
+    const timestamp = b.timestamp ? Number(b.timestamp) : null
+
     return {
       input: {
-        meetingId: (b.meetingId || '') as string,
-        eventType: (b.eventType || 'Transcription completed') as string,
-        clientReferenceId: (b.clientReferenceId || '') as string,
+        meetingId,
+        eventType,
+        clientReferenceId,
+        ...(timestamp !== null ? { timestamp } : {}),
       },
     }
   },

--- a/apps/sim/lib/webhooks/providers/fireflies.ts
+++ b/apps/sim/lib/webhooks/providers/fireflies.ts
@@ -46,13 +46,15 @@ export const firefliesHandler: WebhookProviderHandler = {
   async formatInput({ body }: FormatInputContext): Promise<FormatInputResult> {
     const b = body as Record<string, unknown>
 
-    // Fireflies V2 webhooks use snake_case field names and "event" instead of "eventType"
-    const isV2 = typeof b.meeting_id === 'string' || typeof b.event === 'string'
+    // Fireflies V2 webhooks use snake_case field names and "event" instead of "eventType".
+    // Both meeting_id and event are required in every V2 payload, so AND is the correct check.
+    const isV2 = typeof b.meeting_id === 'string' && typeof b.event === 'string'
 
     const meetingId = ((isV2 ? b.meeting_id : b.meetingId) || '') as string
     const eventType = ((isV2 ? b.event : b.eventType) || 'Transcription completed') as string
     const clientReferenceId = ((isV2 ? b.client_reference_id : b.clientReferenceId) || '') as string
-    const timestamp = b.timestamp ? Number(b.timestamp) : null
+    const rawTimestamp = b.timestamp != null ? Number(b.timestamp) : null
+    const timestamp = rawTimestamp !== null && Number.isFinite(rawTimestamp) ? rawTimestamp : null
 
     return {
       input: {

--- a/apps/sim/triggers/fireflies/transcription_complete.ts
+++ b/apps/sim/triggers/fireflies/transcription_complete.ts
@@ -38,10 +38,10 @@ export const firefliesTranscriptionCompleteTrigger: TriggerConfig = {
       defaultValue: [
         'Go to <a href="https://app.fireflies.ai/settings" target="_blank" rel="noopener noreferrer">app.fireflies.ai/settings</a>',
         'Navigate to the <strong>Developer settings</strong> tab',
-        'In the <strong>Webhook</strong> section, paste the Webhook URL above',
+        'In the <strong>Webhook</strong> or <strong>Webhooks V2</strong> section, paste the Webhook URL above',
         'Enter a <strong>Secret</strong> (16-32 characters) and save it here as well',
         'Click <strong>Save</strong> in Fireflies to activate the webhook',
-        'Your workflow will now trigger when any meeting transcription completes',
+        'Both Webhook V1 and V2 formats are supported automatically',
       ]
         .map(
           (instruction, index) =>
@@ -59,11 +59,15 @@ export const firefliesTranscriptionCompleteTrigger: TriggerConfig = {
     },
     eventType: {
       type: 'string',
-      description: 'The type of event (Transcription completed)',
+      description: 'The type of event (e.g. Transcription completed, meeting.transcribed)',
     },
     clientReferenceId: {
       type: 'string',
       description: 'Custom reference ID if set during upload',
+    },
+    timestamp: {
+      type: 'number',
+      description: 'Unix timestamp in milliseconds when the event was fired (V2 webhooks)',
     },
   },
 


### PR DESCRIPTION
## Summary
- Fireflies V2 webhooks use snake_case fields (`meeting_id`, `event`, `client_reference_id`) instead of V1 camelCase (`meetingId`, `eventType`, `clientReferenceId`)
- `formatInput` now auto-detects V1 vs V2 payloads and maps fields correctly
- Added `timestamp` output field exposed by V2 webhooks
- Updated setup instructions to mention both V1 and V2 webhook support

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)