### PR TITLE
feat(tables): column selection, keyboard shortcuts, drag reorder, and undo improvements

### DIFF
--- a/apps/sim/app/api/table/[tableId]/rows/[rowId]/route.ts
+++ b/apps/sim/app/api/table/[tableId]/rows/[rowId]/route.ts
@@ -135,32 +135,11 @@ export async function PATCH(request: NextRequest, { params }: RowRouteParams) {
       return NextResponse.json({ error: 'Invalid workspace ID' }, { status: 400 })
     }
 
-    const [existingRow] = await db
-      .select({ data: userTableRows.data })
-      .from(userTableRows)
-      .where(
-        and(
-          eq(userTableRows.id, rowId),
-          eq(userTableRows.tableId, tableId),
-          eq(userTableRows.workspaceId, validated.workspaceId)
-        )
-      )
-      .limit(1)
-
-    if (!existingRow) {
-      return NextResponse.json({ error: 'Row not found' }, { status: 404 })
-    }
-
-    const mergedData = {
-      ...(existingRow.data as RowData),
-      ...(validated.data as RowData),
-    }
-
     const updatedRow = await updateRow(
       {
         tableId,
         rowId,
-        data: mergedData,
+        data: validated.data as RowData,
         workspaceId: validated.workspaceId,
       },
       table,

--- a/apps/sim/app/api/v1/tables/[tableId]/rows/[rowId]/route.ts
+++ b/apps/sim/app/api/v1/tables/[tableId]/rows/[rowId]/route.ts
@@ -137,33 +137,11 @@ export async function PATCH(request: NextRequest, { params }: RowRouteParams) {
       return NextResponse.json({ error: 'Invalid workspace ID' }, { status: 400 })
     }
 
-    // Fetch existing row to merge partial update
-    const [existingRow] = await db
-      .select({ data: userTableRows.data })
-      .from(userTableRows)
-      .where(
-        and(
-          eq(userTableRows.id, rowId),
-          eq(userTableRows.tableId, tableId),
-          eq(userTableRows.workspaceId, validated.workspaceId)
-        )
-      )
-      .limit(1)
-
-    if (!existingRow) {
-      return NextResponse.json({ error: 'Row not found' }, { status: 404 })
-    }
-
-    const mergedData = {
-      ...(existingRow.data as RowData),
-      ...(validated.data as RowData),
-    }
-
     const updatedRow = await updateRow(
       {
         tableId,
         rowId,
-        data: mergedData,
+        data: validated.data as RowData,
         workspaceId: validated.workspaceId,
       },
       table,

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -158,6 +158,7 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     isLoading: isSending,
   })
   const hasFiles = files.attachedFiles.some((f) => !f.uploading && f.key)
+  const hasUploadingFiles = files.attachedFiles.some((f) => f.uploading)
 
   const contextManagement = useContextManagement({ message: value })
 
@@ -232,7 +233,7 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     setSelectedContexts: contextManagement.setSelectedContexts,
   })
 
-  const canSubmit = (value.trim().length > 0 || hasFiles) && !isSending
+  const canSubmit = (value.trim().length > 0 || hasFiles) && !isSending && !hasUploadingFiles
 
   const valueRef = useRef(value)
   valueRef.current = value
@@ -507,6 +508,8 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
 
       if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault()
+        // Mirror canSubmit's uploading guard; Enter reads refs, not rendered state.
+        if (filesRef.current.attachedFiles.some((f) => f.uploading)) return
         const hasSubmitPayload =
           valueRef.current.trim().length > 0 ||
           filesRef.current.attachedFiles.some((file) => !file.uploading && file.key)

--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -206,7 +206,7 @@ export function Home({ chatId }: HomeProps = {}) {
       workspace_id: workspaceId,
       view: 'mothership',
     })
-    stopGeneration()
+    void stopGeneration().catch(() => {})
   }, [stopGeneration, workspaceId])
 
   const handleSubmit = useCallback(

--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -206,7 +206,7 @@ export function Home({ chatId }: HomeProps = {}) {
       workspace_id: workspaceId,
       view: 'mothership',
     })
-    void stopGeneration().catch(() => {})
+    stopGeneration()
   }, [stopGeneration, workspaceId])
 
   const handleSubmit = useCallback(

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -1028,18 +1028,13 @@ export function Table({
       if (e.key === ' ' && e.shiftKey) {
         const a = selectionAnchorRef.current
         if (!a || editingCellRef.current) return
+        const currentCols = columnsRef.current
+        if (currentCols.length === 0) return
         e.preventDefault()
-        setSelectionFocus(null)
-        setCheckedRows((prev) => {
-          const next = new Set(prev)
-          if (next.has(a.rowIndex)) {
-            next.delete(a.rowIndex)
-          } else {
-            next.add(a.rowIndex)
-          }
-          return next
-        })
-        lastCheckboxRowRef.current = a.rowIndex
+        setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+        setIsColumnSelection(false)
+        setSelectionAnchor({ rowIndex: a.rowIndex, colIndex: 0 })
+        setSelectionFocus({ rowIndex: a.rowIndex, colIndex: currentCols.length - 1 })
         return
       }
 
@@ -1221,6 +1216,40 @@ export function Table({
         } else {
           setSelectionAnchor({ rowIndex: newRow, colIndex: anchor.colIndex })
           setSelectionFocus(null)
+        }
+        return
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.key === 'd') {
+        if (!canEditRef.current) return
+        const sel = computeNormalizedSelection(anchor, selectionFocusRef.current)
+        if (!sel || sel.startRow === sel.endRow) return
+        e.preventDefault()
+        const pMap = positionMapRef.current
+        const sourceRow = pMap.get(sel.startRow)
+        if (!sourceRow) return
+        const undoCells: Array<{
+          rowId: string
+          oldData: Record<string, unknown>
+          newData: Record<string, unknown>
+        }> = []
+        for (let r = sel.startRow + 1; r <= sel.endRow; r++) {
+          const row = pMap.get(r)
+          if (!row) continue
+          const oldData: Record<string, unknown> = {}
+          const newData: Record<string, unknown> = {}
+          for (let c = sel.startCol; c <= sel.endCol; c++) {
+            if (c < cols.length) {
+              const colName = cols[c].name
+              oldData[colName] = row.data[colName] ?? null
+              newData[colName] = sourceRow.data[colName] ?? null
+            }
+          }
+          undoCells.push({ rowId: row.id, oldData, newData })
+          mutateRef.current({ rowId: row.id, data: newData })
+        }
+        if (undoCells.length > 0) {
+          pushUndoRef.current({ type: 'update-cells', cells: undoCells })
         }
         return
       }

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -199,7 +199,9 @@ export function Table({
   const [selectionAnchor, setSelectionAnchor] = useState<CellCoord | null>(null)
   const [selectionFocus, setSelectionFocus] = useState<CellCoord | null>(null)
   const [checkedRows, setCheckedRows] = useState(EMPTY_CHECKED_ROWS)
+  const [isColumnSelection, setIsColumnSelection] = useState(false)
   const lastCheckboxRowRef = useRef<number | null>(null)
+  const isColumnSelectionRef = useRef(false)
   const [showDeleteTableConfirm, setShowDeleteTableConfirm] = useState(false)
   const [deletingColumn, setDeletingColumn] = useState<string | null>(null)
   const [isImportCsvOpen, setIsImportCsvOpen] = useState(false)
@@ -362,6 +364,7 @@ export function Table({
   rowsRef.current = rows
   selectionAnchorRef.current = selectionAnchor
   selectionFocusRef.current = selectionFocus
+  isColumnSelectionRef.current = isColumnSelection
 
   const deleteTableMutation = useDeleteTable(workspaceId)
   const renameTableMutation = useRenameTable(workspaceId)
@@ -578,6 +581,7 @@ export function Table({
   const handleCellMouseDown = useCallback(
     (rowIndex: number, colIndex: number, shiftKey: boolean) => {
       setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+      setIsColumnSelection(false)
       lastCheckboxRowRef.current = null
       if (shiftKey && selectionAnchorRef.current) {
         setSelectionFocus({ rowIndex, colIndex })
@@ -600,6 +604,7 @@ export function Table({
     setEditingCell(null)
     setSelectionAnchor(null)
     setSelectionFocus(null)
+    setIsColumnSelection(false)
 
     if (shiftKey && lastCheckboxRowRef.current !== null) {
       const from = Math.min(lastCheckboxRowRef.current, rowIndex)
@@ -631,7 +636,27 @@ export function Table({
     setSelectionAnchor(null)
     setSelectionFocus(null)
     setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+    setIsColumnSelection(false)
     lastCheckboxRowRef.current = null
+  }, [])
+
+  const handleColumnSelect = useCallback((colIndex: number, shiftKey: boolean) => {
+    const lastRow = maxPositionRef.current
+    if (lastRow < 0) return
+
+    setEditingCell(null)
+    setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+    lastCheckboxRowRef.current = null
+
+    if (shiftKey && isColumnSelectionRef.current && selectionAnchorRef.current) {
+      setSelectionFocus({ rowIndex: lastRow, colIndex })
+    } else {
+      setSelectionAnchor({ rowIndex: 0, colIndex })
+      setSelectionFocus({ rowIndex: lastRow, colIndex })
+      setIsColumnSelection(true)
+    }
+
+    scrollRef.current?.focus({ preventScroll: true })
   }, [])
 
   const handleSelectAllRows = useCallback(() => {
@@ -724,6 +749,16 @@ export function Table({
   }, [tableData?.metadata])
 
   useEffect(() => {
+    if (!isColumnSelection || !selectionAnchor) return
+    setSelectionFocus((prev) => {
+      if (!prev || prev.rowIndex !== maxPosition) {
+        return { rowIndex: maxPosition, colIndex: prev?.colIndex ?? selectionAnchor.colIndex }
+      }
+      return prev
+    })
+  }, [isColumnSelection, maxPosition, selectionAnchor])
+
+  useEffect(() => {
     const handleMouseUp = () => {
       isDraggingRef.current = false
     }
@@ -814,6 +849,7 @@ export function Table({
         setSelectionAnchor(null)
         setSelectionFocus(null)
         setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+        setIsColumnSelection(false)
         lastCheckboxRowRef.current = null
         return
       }
@@ -821,16 +857,30 @@ export function Table({
       if ((e.metaKey || e.ctrlKey) && e.key === 'a') {
         e.preventDefault()
         const rws = rowsRef.current
-        if (rws.length > 0) {
+        const currentCols = columnsRef.current
+        if (rws.length > 0 && currentCols.length > 0) {
           setEditingCell(null)
-          setSelectionAnchor(null)
-          setSelectionFocus(null)
-          const all = new Set<number>()
-          for (const row of rws) {
-            all.add(row.position)
-          }
-          setCheckedRows(all)
+          setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+          setSelectionAnchor({ rowIndex: 0, colIndex: 0 })
+          setSelectionFocus({
+            rowIndex: maxPositionRef.current,
+            colIndex: currentCols.length - 1,
+          })
+          setIsColumnSelection(false)
         }
+        return
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.key === ' ') {
+        const a = selectionAnchorRef.current
+        if (!a || editingCellRef.current) return
+        const lastRow = maxPositionRef.current
+        if (lastRow < 0) return
+        e.preventDefault()
+        setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+        setSelectionAnchor({ rowIndex: 0, colIndex: a.colIndex })
+        setSelectionFocus({ rowIndex: lastRow, colIndex: a.colIndex })
+        setIsColumnSelection(true)
         return
       }
 
@@ -939,6 +989,7 @@ export function Table({
       if (e.key === 'Tab') {
         e.preventDefault()
         setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+        setIsColumnSelection(false)
         lastCheckboxRowRef.current = null
         setSelectionAnchor(moveCell(anchor, cols.length, totalRows, e.shiftKey ? -1 : 1))
         setSelectionFocus(null)
@@ -948,6 +999,7 @@ export function Table({
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
         e.preventDefault()
         setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+        setIsColumnSelection(false)
         lastCheckboxRowRef.current = null
         const focus = selectionFocusRef.current ?? anchor
         const origin = e.shiftKey ? focus : anchor
@@ -974,6 +1026,59 @@ export function Table({
           setSelectionFocus({ rowIndex: newRow, colIndex: newCol })
         } else {
           setSelectionAnchor({ rowIndex: newRow, colIndex: newCol })
+          setSelectionFocus(null)
+        }
+        return
+      }
+
+      if (e.key === 'Home') {
+        e.preventDefault()
+        setIsColumnSelection(false)
+        const jump = e.metaKey || e.ctrlKey
+        if (e.shiftKey) {
+          setSelectionFocus({ rowIndex: jump ? 0 : anchor.rowIndex, colIndex: 0 })
+        } else {
+          setSelectionAnchor({ rowIndex: jump ? 0 : anchor.rowIndex, colIndex: 0 })
+          setSelectionFocus(null)
+        }
+        return
+      }
+
+      if (e.key === 'End') {
+        e.preventDefault()
+        setIsColumnSelection(false)
+        const jump = e.metaKey || e.ctrlKey
+        if (e.shiftKey) {
+          setSelectionFocus({
+            rowIndex: jump ? totalRows - 1 : anchor.rowIndex,
+            colIndex: cols.length - 1,
+          })
+        } else {
+          setSelectionAnchor({
+            rowIndex: jump ? totalRows - 1 : anchor.rowIndex,
+            colIndex: cols.length - 1,
+          })
+          setSelectionFocus(null)
+        }
+        return
+      }
+
+      if (e.key === 'PageUp' || e.key === 'PageDown') {
+        e.preventDefault()
+        setIsColumnSelection(false)
+        const scrollEl = scrollRef.current
+        const viewportHeight = scrollEl ? scrollEl.clientHeight : ROW_HEIGHT_ESTIMATE * 10
+        const rowsPerPage = Math.max(1, Math.floor(viewportHeight / ROW_HEIGHT_ESTIMATE))
+        const direction = e.key === 'PageUp' ? -1 : 1
+        const origin = e.shiftKey ? (selectionFocusRef.current ?? anchor) : anchor
+        const newRow = Math.max(
+          0,
+          Math.min(totalRows - 1, origin.rowIndex + direction * rowsPerPage)
+        )
+        if (e.shiftKey) {
+          setSelectionFocus({ rowIndex: newRow, colIndex: origin.colIndex })
+        } else {
+          setSelectionAnchor({ rowIndex: newRow, colIndex: anchor.colIndex })
           setSelectionFocus(null)
         }
         return
@@ -1714,12 +1819,19 @@ export function Table({
                     checked={isAllRowsSelected}
                     onCheckedChange={handleSelectAllToggle}
                   />
-                  {displayColumns.map((column) => (
+                  {displayColumns.map((column, idx) => (
                     <ColumnHeaderMenu
                       key={column.name}
                       column={column}
+                      colIndex={idx}
                       readOnly={!userPermissions.canEdit}
                       isRenaming={columnRename.editingId === column.name}
+                      isColumnSelected={
+                        isColumnSelection &&
+                        normalizedSelection !== null &&
+                        idx >= normalizedSelection.startCol &&
+                        idx <= normalizedSelection.endCol
+                      }
                       renameValue={
                         columnRename.editingId === column.name ? columnRename.editValue : ''
                       }
@@ -1727,6 +1839,7 @@ export function Table({
                       onRenameSubmit={columnRename.submitRename}
                       onRenameCancel={columnRename.cancelRename}
                       onRenameColumn={handleRenameColumn}
+                      onColumnSelect={handleColumnSelect}
                       onChangeType={handleChangeType}
                       onInsertLeft={handleInsertColumnLeft}
                       onInsertRight={handleInsertColumnRight}
@@ -2635,13 +2748,16 @@ const COLUMN_TYPE_OPTIONS: { type: string; label: string; icon: React.ElementTyp
 
 const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
   column,
+  colIndex,
   readOnly,
   isRenaming,
+  isColumnSelected,
   renameValue,
   onRenameValueChange,
   onRenameSubmit,
   onRenameCancel,
   onRenameColumn,
+  onColumnSelect,
   onChangeType,
   onInsertLeft,
   onInsertRight,
@@ -2657,13 +2773,16 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
   onDragLeave,
 }: {
   column: ColumnDefinition
+  colIndex: number
   readOnly?: boolean
   isRenaming: boolean
+  isColumnSelected: boolean
   renameValue: string
   onRenameValueChange: (value: string) => void
   onRenameSubmit: () => void
   onRenameCancel: () => void
   onRenameColumn: (columnName: string) => void
+  onColumnSelect: (colIndex: number, shiftKey: boolean) => void
   onChangeType: (columnName: string, newType: string) => void
   onInsertLeft: (columnName: string) => void
   onInsertRight: (columnName: string) => void
@@ -2679,6 +2798,8 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
   onDragLeave?: () => void
 }) {
   const renameInputRef = useRef<HTMLInputElement>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 })
 
   useEffect(() => {
     if (isRenaming && renameInputRef.current) {
@@ -2761,15 +2882,35 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
     [onDragLeave]
   )
 
+  const handleHeaderClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (isRenaming) return
+      onColumnSelect(colIndex, e.shiftKey)
+    },
+    [colIndex, isRenaming, onColumnSelect]
+  )
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      if (readOnly || isRenaming) return
+      e.preventDefault()
+      setMenuPosition({ x: e.clientX, y: e.clientY })
+      setMenuOpen(true)
+    },
+    [readOnly, isRenaming]
+  )
+
   return (
     <th
       className={cn(
         'group relative border-[var(--border)] border-r border-b bg-[var(--bg)] p-0 text-left align-middle',
-        isDragging && 'opacity-40'
+        isDragging && 'opacity-40',
+        isColumnSelected && 'bg-[rgba(37,99,235,0.06)]'
       )}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
       onDragLeave={handleDragLeave}
+      onContextMenu={handleContextMenu}
     >
       {isRenaming ? (
         <div className='flex h-full w-full min-w-0 items-center px-2 py-[7px]'>
@@ -2796,20 +2937,38 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
         </div>
       ) : (
         <div className='flex h-full w-full min-w-0 items-center'>
-          <DropdownMenu>
+          <button
+            type='button'
+            className='flex min-w-0 flex-1 cursor-pointer items-center px-2 py-[7px] outline-none'
+            onClick={handleHeaderClick}
+          >
+            <ColumnTypeIcon type={column.type} />
+            <span className='ml-1.5 min-w-0 overflow-clip text-ellipsis whitespace-nowrap font-medium text-[var(--text-primary)] text-small'>
+              {column.name}
+            </span>
+            <ChevronDown className='ml-1.5 h-[7px] w-[9px] shrink-0 text-[var(--text-muted)]' />
+          </button>
+          <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
             <DropdownMenuTrigger asChild>
-              <button
-                type='button'
-                className='flex min-w-0 flex-1 cursor-pointer items-center px-2 py-[7px] outline-none'
-              >
-                <ColumnTypeIcon type={column.type} />
-                <span className='ml-1.5 min-w-0 overflow-clip text-ellipsis whitespace-nowrap font-medium text-[var(--text-primary)] text-small'>
-                  {column.name}
-                </span>
-                <ChevronDown className='ml-1.5 h-[7px] w-[9px] shrink-0 text-[var(--text-muted)]' />
-              </button>
+              <div
+                style={{
+                  position: 'fixed',
+                  left: `${menuPosition.x}px`,
+                  top: `${menuPosition.y}px`,
+                  width: '1px',
+                  height: '1px',
+                  pointerEvents: 'none',
+                }}
+                tabIndex={-1}
+                aria-hidden
+              />
             </DropdownMenuTrigger>
-            <DropdownMenuContent align='start'>
+            <DropdownMenuContent
+              align='start'
+              side='bottom'
+              sideOffset={4}
+              onCloseAutoFocus={(e) => e.preventDefault()}
+            >
               <DropdownMenuItem onSelect={() => onRenameColumn(column.name)}>
                 <Pencil />
                 Rename column

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -812,6 +812,7 @@ export function Table({
       setDropSide('left')
       return
     }
+    dragColumnNameRef.current = null
     const target = dropTargetColumnNameRef.current
     const side = dropSideRef.current
     if (target && dragged !== target) {

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -266,7 +266,7 @@ export function Table({
     if (updatedOrder) setColumnOrder(updatedOrder)
     updateMetadataRef.current({
       columnWidths: updatedWidths,
-      columnOrder: updatedOrder,
+      ...(updatedOrder ? { columnOrder: updatedOrder } : {}),
     })
   }, [])
 
@@ -758,7 +758,7 @@ export function Table({
     let maxWidth = COL_WIDTH_MIN
 
     const measure = document.createElement('span')
-    measure.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap;font:inherit'
+    measure.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap'
     document.body.appendChild(measure)
 
     try {

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -1755,6 +1755,7 @@ export function Table({
           columnType: colDef?.type ?? 'string',
           columnPosition: colPosition >= 0 ? colPosition : cols.length,
           columnUnique: colDef?.unique ?? false,
+          columnRequired: colDef?.required ?? false,
           cellData,
           previousOrder: orderAtDelete ? [...orderAtDelete] : null,
           previousWidth,

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -272,11 +272,16 @@ export function Table({
 
   const getColumnWidths = useCallback(() => columnWidthsRef.current, [])
 
+  const handleColumnWidthsChange = useCallback((widths: Record<string, number>) => {
+    setColumnWidths(widths)
+  }, [])
+
   const { pushUndo, undo, redo } = useTableUndo({
     workspaceId,
     tableId,
     onColumnOrderChange: handleColumnOrderChange,
     onColumnRename: handleColumnRename,
+    onColumnWidthsChange: handleColumnWidthsChange,
     getColumnWidths,
   })
   const undoRef = useRef(undo)

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -3099,6 +3099,7 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
   onDragLeave?: () => void
 }) {
   const renameInputRef = useRef<HTMLInputElement>(null)
+  const didDragRef = useRef(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 })
 
@@ -3146,6 +3147,7 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
         e.preventDefault()
         return
       }
+      didDragRef.current = true
       e.dataTransfer.effectAllowed = 'move'
       e.dataTransfer.setData('text/plain', column.name)
 
@@ -3194,6 +3196,10 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
 
   const handleHeaderClick = useCallback(
     (e: React.MouseEvent) => {
+      if (didDragRef.current) {
+        didDragRef.current = false
+        return
+      }
       if (isRenaming) return
       onColumnSelect(colIndex, e.shiftKey)
     },

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -624,6 +624,7 @@ export function Table({
           if (!isWithinSelection) {
             setSelectionAnchor({ rowIndex, colIndex })
             setSelectionFocus(null)
+            setIsColumnSelection(false)
           }
         }
       }
@@ -904,6 +905,7 @@ export function Table({
   }, [])
 
   useEffect(() => {
+    if (isColumnSelection) return
     const target = selectionFocus ?? selectionAnchor
     if (!target) return
     const { rowIndex, colIndex } = target
@@ -914,7 +916,7 @@ export function Table({
       cell?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
     })
     return () => cancelAnimationFrame(rafId)
-  }, [selectionAnchor, selectionFocus])
+  }, [selectionAnchor, selectionFocus, isColumnSelection])
 
   const handleCellClick = useCallback((rowId: string, columnName: string) => {
     const column = columnsRef.current.find((c) => c.name === columnName)
@@ -939,6 +941,7 @@ export function Table({
     if (!column || column.type === 'boolean') return
 
     setSelectionFocus(null)
+    setIsColumnSelection(false)
     setEditingCell({ rowId, columnName })
     setInitialCharacter(null)
   }, [])

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -754,20 +754,19 @@ export function Table({
     let maxWidth = COL_WIDTH_MIN
 
     const measure = document.createElement('span')
-    measure.style.cssText =
-      'position:absolute;visibility:hidden;white-space:nowrap;font:inherit;padding:0 8px'
+    measure.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap;font:inherit'
     document.body.appendChild(measure)
 
     measure.className = 'font-medium text-small'
     measure.textContent = columnName
-    maxWidth = Math.max(maxWidth, measure.offsetWidth + 48)
+    maxWidth = Math.max(maxWidth, measure.offsetWidth + 36)
 
     measure.className = 'text-small'
     for (const row of currentRows) {
       const val = row.data[columnName]
       if (val == null) continue
       measure.textContent = String(val)
-      maxWidth = Math.max(maxWidth, measure.offsetWidth + 20)
+      maxWidth = Math.max(maxWidth, measure.offsetWidth + 17)
     }
 
     document.body.removeChild(measure)

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { GripVertical } from 'lucide-react'
 import { useParams, useRouter } from 'next/navigation'
 import { usePostHog } from 'posthog-js/react'
 import {
@@ -2890,6 +2889,15 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
     [colIndex, isRenaming, onColumnSelect]
   )
 
+  const handleChevronClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    const rect = (e.currentTarget as HTMLElement).closest('th')?.getBoundingClientRect()
+    if (rect) {
+      setMenuPosition({ x: rect.left, y: rect.bottom })
+    }
+    setMenuOpen(true)
+  }, [])
+
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
       if (readOnly || isRenaming) return
@@ -2907,6 +2915,9 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
         isDragging && 'opacity-40',
         isColumnSelected && 'bg-[rgba(37,99,235,0.06)]'
       )}
+      draggable={!readOnly && !isRenaming}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
       onDragLeave={handleDragLeave}
@@ -2941,12 +2952,20 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
             type='button'
             className='flex min-w-0 flex-1 cursor-pointer items-center px-2 py-[7px] outline-none'
             onClick={handleHeaderClick}
+            draggable={false}
           >
             <ColumnTypeIcon type={column.type} />
             <span className='ml-1.5 min-w-0 overflow-clip text-ellipsis whitespace-nowrap font-medium text-[var(--text-primary)] text-small'>
               {column.name}
             </span>
-            <ChevronDown className='ml-1.5 h-[7px] w-[9px] shrink-0 text-[var(--text-muted)]' />
+          </button>
+          <button
+            type='button'
+            className='flex h-full shrink-0 cursor-pointer items-center pr-2 pl-0.5 text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] group-hover:opacity-100'
+            onClick={handleChevronClick}
+            draggable={false}
+          >
+            <ChevronDown className='h-[7px] w-[9px]' />
           </button>
           <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
             <DropdownMenuTrigger asChild>
@@ -3012,14 +3031,6 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <div
-            draggable
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-            className='flex h-full cursor-grab items-center pr-1.5 pl-0.5 opacity-0 transition-opacity active:cursor-grabbing group-hover:opacity-100'
-          >
-            <GripVertical className='h-3 w-3 shrink-0 text-[var(--text-muted)]' />
-          </div>
         </div>
       )}
       <div

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -1773,13 +1773,23 @@ export function Table({
     setDeletingColumns(null)
 
     let currentOrder = columnOrderRef.current ? [...columnOrderRef.current] : null
+    const cols = schemaColumnsRef.current
+    const originalPositions = new Map<
+      string,
+      { position: number; def: (typeof cols)[number] | undefined }
+    >()
+    for (const name of columnsToDelete) {
+      const def = cols.find((c) => c.name === name)
+      originalPositions.set(name, { position: def ? cols.indexOf(def) : cols.length, def })
+    }
+    const deletedOriginalPositions: number[] = []
 
     const deleteNext = (index: number) => {
       if (index >= columnsToDelete.length) return
       const columnToDelete = columnsToDelete[index]
-      const cols = schemaColumnsRef.current
-      const colDef = cols.find((c) => c.name === columnToDelete)
-      const colPosition = colDef ? cols.indexOf(colDef) : cols.length
+      const entry = originalPositions.get(columnToDelete)!
+      const adjustedPosition =
+        entry.position - deletedOriginalPositions.filter((p) => p < entry.position).length
       const currentRows = rowsRef.current
       const cellData = currentRows
         .filter((r) => r.data[columnToDelete] != null)
@@ -1789,13 +1799,14 @@ export function Table({
 
       deleteColumnMutation.mutate(columnToDelete, {
         onSuccess: () => {
+          deletedOriginalPositions.push(entry.position)
           pushUndoRef.current({
             type: 'delete-column',
             columnName: columnToDelete,
-            columnType: colDef?.type ?? 'string',
-            columnPosition: colPosition >= 0 ? colPosition : cols.length,
-            columnUnique: colDef?.unique ?? false,
-            columnRequired: colDef?.required ?? false,
+            columnType: entry.def?.type ?? 'string',
+            columnPosition: adjustedPosition >= 0 ? adjustedPosition : cols.length,
+            columnUnique: entry.def?.unique ?? false,
+            columnRequired: entry.def?.required ?? false,
             cellData,
             previousOrder: orderSnapshot,
             previousWidth,

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -367,17 +367,6 @@ export function Table({
     return null
   }, [dropTargetColumnName, dragColumnName, dropSide, displayColumns, columnWidths])
 
-  const dragSourceBounds = useMemo(() => {
-    if (!dragColumnName) return null
-    let left = CHECKBOX_COL_WIDTH
-    for (const col of displayColumns) {
-      const w = columnWidths[col.name] ?? COL_WIDTH
-      if (col.name === dragColumnName) return { left, width: w }
-      left += w
-    }
-    return null
-  }, [dragColumnName, displayColumns, columnWidths])
-
   const isAllRowsSelected = useMemo(() => {
     if (checkedRows.size > 0 && rows.length > 0 && checkedRows.size >= rows.length) {
       for (const row of rows) {
@@ -1968,7 +1957,6 @@ export function Table({
                       onResizeStart={handleColumnResizeStart}
                       onResize={handleColumnResize}
                       onResizeEnd={handleColumnResizeEnd}
-                      isDragging={dragColumnName === column.name}
                       onDragStart={handleColumnDragStart}
                       onDragOver={handleColumnDragOver}
                       onDragEnd={handleColumnDragEnd}
@@ -2043,12 +2031,6 @@ export function Table({
             <div
               className='-translate-x-[1.5px] pointer-events-none absolute top-0 z-20 h-full w-[2px] bg-[var(--selection)]'
               style={{ left: resizeIndicatorLeft }}
-            />
-          )}
-          {dragSourceBounds !== null && (
-            <div
-              className='pointer-events-none absolute top-0 z-[15] h-full bg-[var(--bg)] opacity-50'
-              style={{ left: dragSourceBounds.left, width: dragSourceBounds.width }}
             />
           )}
           {dropColumnBounds !== null && (
@@ -2898,7 +2880,6 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
   onResizeStart,
   onResize,
   onResizeEnd,
-  isDragging,
   onDragStart,
   onDragOver,
   onDragEnd,
@@ -2923,7 +2904,6 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
   onResizeStart: (columnName: string) => void
   onResize: (columnName: string, width: number) => void
   onResizeEnd: () => void
-  isDragging?: boolean
   onDragStart?: (columnName: string) => void
   onDragOver?: (columnName: string, side: 'left' | 'right') => void
   onDragEnd?: () => void
@@ -3045,7 +3025,6 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
     <th
       className={cn(
         'group relative border-[var(--border)] border-r border-b bg-[var(--bg)] p-0 text-left align-middle',
-        isDragging && 'opacity-40',
         isColumnSelected && 'bg-[rgba(37,99,235,0.06)]'
       )}
       draggable={!readOnly && !isRenaming}

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -459,7 +459,8 @@ export function Table({
     } catch {
       setShowDeleteTableConfirm(false)
     }
-  }, [deleteTableMutation, tableId, router, workspaceId])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tableId, router, workspaceId])
 
   const toggleBooleanCell = useCallback(
     (rowId: string, columnName: string, currentValue: unknown) => {

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -780,6 +780,10 @@ export function Table({
 
   const handleColumnDragStart = useCallback((columnName: string) => {
     setDragColumnName(columnName)
+    setSelectionAnchor(null)
+    setSelectionFocus(null)
+    setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+    setIsColumnSelection(false)
   }, [])
 
   const handleColumnDragOver = useCallback((columnName: string, side: 'left' | 'right') => {
@@ -3012,6 +3016,15 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
       }
       e.dataTransfer.effectAllowed = 'move'
       e.dataTransfer.setData('text/plain', column.name)
+
+      const ghost = document.createElement('div')
+      ghost.textContent = column.name
+      ghost.style.cssText =
+        'position:absolute;top:-9999px;padding:4px 8px;background:var(--bg);border:1px solid var(--border);border-radius:4px;font-size:13px;font-weight:500;white-space:nowrap;color:var(--text-primary)'
+      document.body.appendChild(ghost)
+      e.dataTransfer.setDragImage(ghost, ghost.offsetWidth / 2, ghost.offsetHeight / 2)
+      requestAnimationFrame(() => document.body.removeChild(ghost))
+
       onDragStart?.(column.name)
     },
     [column.name, readOnly, isRenaming, onDragStart]

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -270,11 +270,14 @@ export function Table({
     })
   }, [])
 
+  const getColumnWidths = useCallback(() => columnWidthsRef.current, [])
+
   const { pushUndo, undo, redo } = useTableUndo({
     workspaceId,
     tableId,
     onColumnOrderChange: handleColumnOrderChange,
     onColumnRename: handleColumnRename,
+    getColumnWidths,
   })
   const undoRef = useRef(undo)
   undoRef.current = undo
@@ -757,19 +760,21 @@ export function Table({
     measure.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap;font:inherit'
     document.body.appendChild(measure)
 
-    measure.className = 'font-medium text-small'
-    measure.textContent = columnName
-    maxWidth = Math.max(maxWidth, measure.offsetWidth + 36)
+    try {
+      measure.className = 'font-medium text-small'
+      measure.textContent = columnName
+      maxWidth = Math.max(maxWidth, measure.offsetWidth + 36)
 
-    measure.className = 'text-small'
-    for (const row of currentRows) {
-      const val = row.data[columnName]
-      if (val == null) continue
-      measure.textContent = String(val)
-      maxWidth = Math.max(maxWidth, measure.offsetWidth + 17)
+      measure.className = 'text-small'
+      for (const row of currentRows) {
+        const val = row.data[columnName]
+        if (val == null) continue
+        measure.textContent = String(val)
+        maxWidth = Math.max(maxWidth, measure.offsetWidth + 17)
+      }
+    } finally {
+      document.body.removeChild(measure)
     }
-
-    document.body.removeChild(measure)
 
     const newWidth = Math.min(Math.ceil(maxWidth), 600)
     setColumnWidths((prev) => ({ ...prev, [columnName]: newWidth }))

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -3130,6 +3130,7 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
             className='flex h-full shrink-0 cursor-pointer items-center pr-2 pl-0.5 text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] group-hover:opacity-100'
             onClick={handleChevronClick}
             draggable={false}
+            aria-label='Column options'
           >
             <ChevronDown className='h-[7px] w-[9px]' />
           </button>
@@ -3145,7 +3146,7 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
                   pointerEvents: 'none',
                 }}
                 tabIndex={-1}
-                aria-hidden
+                aria-hidden='true'
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -202,7 +202,7 @@ export function Table({
   const lastCheckboxRowRef = useRef<number | null>(null)
   const isColumnSelectionRef = useRef(false)
   const [showDeleteTableConfirm, setShowDeleteTableConfirm] = useState(false)
-  const [deletingColumn, setDeletingColumn] = useState<string | null>(null)
+  const [deletingColumns, setDeletingColumns] = useState<string[] | null>(null)
   const [isImportCsvOpen, setIsImportCsvOpen] = useState(false)
 
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({})
@@ -716,15 +716,16 @@ export function Table({
 
   const handleSelectAllRows = useCallback(() => {
     const rws = rowsRef.current
-    if (rws.length === 0) return
+    const currentCols = columnsRef.current
+    if (rws.length === 0 || currentCols.length === 0) return
     setEditingCell(null)
-    setSelectionAnchor(null)
-    setSelectionFocus(null)
-    const all = new Set<number>()
-    for (const row of rws) {
-      all.add(row.position)
-    }
-    setCheckedRows(all)
+    setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+    setSelectionAnchor({ rowIndex: 0, colIndex: 0 })
+    setSelectionFocus({
+      rowIndex: maxPositionRef.current,
+      colIndex: currentCols.length - 1,
+    })
+    setIsColumnSelection(false)
     scrollRef.current?.focus({ preventScroll: true })
   }, [])
 
@@ -1372,6 +1373,7 @@ export function Table({
       const cols = columnsRef.current
       const pMap = positionMapRef.current
       const undoCells: Array<{ rowId: string; data: Record<string, unknown> }> = []
+      const batchUpdates: Array<{ rowId: string; data: Record<string, unknown> }> = []
 
       if (checked.size > 0) {
         e.preventDefault()
@@ -1393,7 +1395,7 @@ export function Table({
             updates[col.name] = null
           }
           undoCells.push({ rowId: row.id, data: previousData })
-          mutateRef.current({ rowId: row.id, data: updates })
+          batchUpdates.push({ rowId: row.id, data: updates })
         }
         e.clipboardData?.setData('text/plain', lines.join('\n'))
       } else {
@@ -1426,11 +1428,14 @@ export function Table({
           }
           lines.push(cells.join('\t'))
           undoCells.push({ rowId: row.id, data: previousData })
-          mutateRef.current({ rowId: row.id, data: updates })
+          batchUpdates.push({ rowId: row.id, data: updates })
         }
         e.clipboardData?.setData('text/plain', lines.join('\n'))
       }
 
+      if (batchUpdates.length > 0) {
+        batchUpdateRef.current({ updates: batchUpdates })
+      }
       if (undoCells.length > 0) {
         pushUndoRef.current({ type: 'clear-cells', cells: undoCells })
       }
@@ -1732,48 +1737,76 @@ export function Table({
   )
 
   const handleDeleteColumn = useCallback((columnName: string) => {
-    setDeletingColumn(columnName)
+    const cols = columnsRef.current
+    if (isColumnSelectionRef.current && selectionAnchorRef.current) {
+      const sel = computeNormalizedSelection(selectionAnchorRef.current, selectionFocusRef.current)
+      if (sel && sel.startCol !== sel.endCol) {
+        const names: string[] = []
+        for (let c = sel.startCol; c <= sel.endCol; c++) {
+          if (c < cols.length) names.push(cols[c].name)
+        }
+        if (names.length > 0) {
+          setDeletingColumns(names)
+          return
+        }
+      }
+    }
+    setDeletingColumns([columnName])
   }, [])
 
   const handleDeleteColumnConfirm = useCallback(() => {
-    if (!deletingColumn) return
-    const columnToDelete = deletingColumn
-    const orderAtDelete = columnOrderRef.current
-    const cols = schemaColumnsRef.current
-    const colDef = cols.find((c) => c.name === columnToDelete)
-    const colPosition = colDef ? cols.indexOf(colDef) : cols.length
-    const currentRows = rowsRef.current
-    const cellData = currentRows
-      .filter((r) => r.data[columnToDelete] != null)
-      .map((r) => ({ rowId: r.id, value: r.data[columnToDelete] }))
-    const previousWidth = columnWidthsRef.current[columnToDelete] ?? null
+    if (!deletingColumns || deletingColumns.length === 0) return
+    const columnsToDelete = [...deletingColumns]
+    setDeletingColumns(null)
 
-    setDeletingColumn(null)
-    deleteColumnMutation.mutate(columnToDelete, {
-      onSuccess: () => {
-        pushUndoRef.current({
-          type: 'delete-column',
-          columnName: columnToDelete,
-          columnType: colDef?.type ?? 'string',
-          columnPosition: colPosition >= 0 ? colPosition : cols.length,
-          columnUnique: colDef?.unique ?? false,
-          columnRequired: colDef?.required ?? false,
-          cellData,
-          previousOrder: orderAtDelete ? [...orderAtDelete] : null,
-          previousWidth,
-        })
+    let currentOrder = columnOrderRef.current ? [...columnOrderRef.current] : null
 
-        if (orderAtDelete) {
-          const newOrder = orderAtDelete.filter((n) => n !== columnToDelete)
-          setColumnOrder(newOrder)
-          updateMetadataRef.current({
-            columnWidths: columnWidthsRef.current,
-            columnOrder: newOrder,
+    const deleteNext = (index: number) => {
+      if (index >= columnsToDelete.length) return
+      const columnToDelete = columnsToDelete[index]
+      const cols = schemaColumnsRef.current
+      const colDef = cols.find((c) => c.name === columnToDelete)
+      const colPosition = colDef ? cols.indexOf(colDef) : cols.length
+      const currentRows = rowsRef.current
+      const cellData = currentRows
+        .filter((r) => r.data[columnToDelete] != null)
+        .map((r) => ({ rowId: r.id, value: r.data[columnToDelete] }))
+      const previousWidth = columnWidthsRef.current[columnToDelete] ?? null
+      const orderSnapshot = currentOrder ? [...currentOrder] : null
+
+      deleteColumnMutation.mutate(columnToDelete, {
+        onSuccess: () => {
+          pushUndoRef.current({
+            type: 'delete-column',
+            columnName: columnToDelete,
+            columnType: colDef?.type ?? 'string',
+            columnPosition: colPosition >= 0 ? colPosition : cols.length,
+            columnUnique: colDef?.unique ?? false,
+            columnRequired: colDef?.required ?? false,
+            cellData,
+            previousOrder: orderSnapshot,
+            previousWidth,
           })
-        }
-      },
-    })
-  }, [deletingColumn])
+
+          if (currentOrder) {
+            currentOrder = currentOrder.filter((n) => n !== columnToDelete)
+            setColumnOrder(currentOrder)
+            updateMetadataRef.current({
+              columnWidths: columnWidthsRef.current,
+              columnOrder: currentOrder,
+            })
+          }
+
+          deleteNext(index + 1)
+        },
+      })
+    }
+
+    setSelectionAnchor(null)
+    setSelectionFocus(null)
+    setIsColumnSelection(false)
+    deleteNext(0)
+  }, [deletingColumns])
 
   const handleSortChange = useCallback((column: string, direction: SortDirection) => {
     setQueryOptions((prev) => ({ ...prev, sort: { [column]: direction } }))
@@ -2241,25 +2274,45 @@ export function Table({
       )}
 
       <Modal
-        open={deletingColumn !== null}
+        open={deletingColumns !== null}
         onOpenChange={(open) => {
-          if (!open) setDeletingColumn(null)
+          if (!open) setDeletingColumns(null)
         }}
       >
         <ModalContent size='sm'>
-          <ModalHeader>Delete Column</ModalHeader>
+          <ModalHeader>
+            {deletingColumns && deletingColumns.length > 1
+              ? `Delete ${deletingColumns.length} Columns`
+              : 'Delete Column'}
+          </ModalHeader>
           <ModalBody>
             <p className='text-[var(--text-secondary)]'>
-              Are you sure you want to delete{' '}
-              <span className='font-medium text-[var(--text-primary)]'>{deletingColumn}</span>?{' '}
+              {deletingColumns && deletingColumns.length > 1 ? (
+                <>
+                  Are you sure you want to delete{' '}
+                  <span className='font-medium text-[var(--text-primary)]'>
+                    {deletingColumns.length} columns
+                  </span>
+                  ?{' '}
+                </>
+              ) : (
+                <>
+                  Are you sure you want to delete{' '}
+                  <span className='font-medium text-[var(--text-primary)]'>
+                    {deletingColumns?.[0]}
+                  </span>
+                  ?{' '}
+                </>
+              )}
               <span className='text-[var(--text-error)]'>
-                This will remove all data in this column.
+                This will remove all data in{' '}
+                {deletingColumns && deletingColumns.length > 1 ? 'these columns' : 'this column'}.
               </span>{' '}
               You can undo this action.
             </p>
           </ModalBody>
           <ModalFooter>
-            <Button variant='default' onClick={() => setDeletingColumn(null)}>
+            <Button variant='default' onClick={() => setDeletingColumns(null)}>
               Cancel
             </Button>
             <Button variant='destructive' onClick={handleDeleteColumnConfirm}>
@@ -3190,7 +3243,7 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
           </button>
           <button
             type='button'
-            className='flex h-full shrink-0 cursor-pointer items-center pr-2 pl-0.5 text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] group-hover:opacity-100'
+            className='flex h-full shrink-0 cursor-pointer items-center pr-2.5 pl-0.5 text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] group-hover:opacity-100'
             onClick={handleChevronClick}
             draggable={false}
             aria-label='Column options'

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -604,10 +604,24 @@ export function Table({
         const rowIndex = Number.parseInt(td.getAttribute('data-row') || '-1', 10)
         const colIndex = Number.parseInt(td.getAttribute('data-col') || '-1', 10)
         if (rowIndex >= 0 && colIndex >= 0) {
-          setSelectionAnchor({ rowIndex, colIndex })
-          setSelectionFocus(null)
           columnName =
             colIndex < columnsRef.current.length ? columnsRef.current[colIndex].name : null
+
+          const sel = computeNormalizedSelection(
+            selectionAnchorRef.current,
+            selectionFocusRef.current
+          )
+          const isWithinSelection =
+            sel !== null &&
+            rowIndex >= sel.startRow &&
+            rowIndex <= sel.endRow &&
+            colIndex >= sel.startCol &&
+            colIndex <= sel.endCol
+
+          if (!isWithinSelection) {
+            setSelectionAnchor({ rowIndex, colIndex })
+            setSelectionFocus(null)
+          }
         }
       }
       baseHandleRowContextMenu(e, row, columnName)
@@ -729,6 +743,40 @@ export function Table({
   const handleColumnResizeEnd = useCallback(() => {
     setResizingColumn(null)
     updateMetadataRef.current({ columnWidths: columnWidthsRef.current })
+  }, [])
+
+  const handleColumnAutoResize = useCallback((columnName: string) => {
+    const cols = columnsRef.current
+    const colIndex = cols.findIndex((c) => c.name === columnName)
+    if (colIndex === -1) return
+
+    const currentRows = rowsRef.current
+    let maxWidth = COL_WIDTH_MIN
+
+    const measure = document.createElement('span')
+    measure.style.cssText =
+      'position:absolute;visibility:hidden;white-space:nowrap;font:inherit;padding:0 8px'
+    document.body.appendChild(measure)
+
+    measure.className = 'font-medium text-small'
+    measure.textContent = columnName
+    maxWidth = Math.max(maxWidth, measure.offsetWidth + 48)
+
+    measure.className = 'text-small'
+    for (const row of currentRows) {
+      const val = row.data[columnName]
+      if (val == null) continue
+      measure.textContent = String(val)
+      maxWidth = Math.max(maxWidth, measure.offsetWidth + 20)
+    }
+
+    document.body.removeChild(measure)
+
+    const newWidth = Math.min(Math.ceil(maxWidth), 600)
+    setColumnWidths((prev) => ({ ...prev, [columnName]: newWidth }))
+    const updated = { ...columnWidthsRef.current, [columnName]: newWidth }
+    columnWidthsRef.current = updated
+    updateMetadataRef.current({ columnWidths: updated })
   }, [])
 
   const handleColumnDragStart = useCallback((columnName: string) => {
@@ -928,6 +976,9 @@ export function Table({
       if (e.key === 'Escape') {
         e.preventDefault()
         if (dragColumnNameRef.current) {
+          dragColumnNameRef.current = null
+          dropTargetColumnNameRef.current = null
+          dropSideRef.current = 'left'
           setDragColumnName(null)
           setDropTargetColumnName(null)
           setDropSide('left')
@@ -1957,6 +2008,7 @@ export function Table({
                       onResizeStart={handleColumnResizeStart}
                       onResize={handleColumnResize}
                       onResizeEnd={handleColumnResizeEnd}
+                      onAutoResize={handleColumnAutoResize}
                       onDragStart={handleColumnDragStart}
                       onDragOver={handleColumnDragOver}
                       onDragEnd={handleColumnDragEnd}
@@ -2880,6 +2932,7 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
   onResizeStart,
   onResize,
   onResizeEnd,
+  onAutoResize,
   onDragStart,
   onDragOver,
   onDragEnd,
@@ -2904,6 +2957,7 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
   onResizeStart: (columnName: string) => void
   onResize: (columnName: string, width: number) => void
   onResizeEnd: () => void
+  onAutoResize: (columnName: string) => void
   onDragStart?: (columnName: string) => void
   onDragOver?: (columnName: string, side: 'left' | 'right') => void
   onDragEnd?: () => void
@@ -3150,6 +3204,11 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
         draggable={false}
         onDragStart={(e) => e.stopPropagation()}
         onPointerDown={handleResizePointerDown}
+        onDoubleClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          onAutoResize(column.name)
+        }}
       />
     </th>
   )

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -1061,6 +1061,7 @@ export function Table({
         const pMap = positionMapRef.current
         const currentCols = columnsRef.current
         const undoCells: Array<{ rowId: string; data: Record<string, unknown> }> = []
+        const batchUpdates: Array<{ rowId: string; data: Record<string, unknown> }> = []
         for (const pos of checked) {
           const row = pMap.get(pos)
           if (!row) continue
@@ -1071,7 +1072,10 @@ export function Table({
             updates[col.name] = null
           }
           undoCells.push({ rowId: row.id, data: previousData })
-          mutateRef.current({ rowId: row.id, data: updates })
+          batchUpdates.push({ rowId: row.id, data: updates })
+        }
+        if (batchUpdates.length > 0) {
+          batchUpdateRef.current({ updates: batchUpdates })
         }
         if (undoCells.length > 0) {
           pushUndoRef.current({ type: 'clear-cells', cells: undoCells })
@@ -1238,10 +1242,10 @@ export function Table({
       }
 
       if ((e.metaKey || e.ctrlKey) && e.key === 'd') {
+        e.preventDefault()
         if (!canEditRef.current) return
         const sel = computeNormalizedSelection(anchor, selectionFocusRef.current)
         if (!sel || sel.startRow === sel.endRow) return
-        e.preventDefault()
         const pMap = positionMapRef.current
         const sourceRow = pMap.get(sel.startRow)
         if (!sourceRow) return
@@ -1280,6 +1284,7 @@ export function Table({
         if (!sel) return
         const pMap = positionMapRef.current
         const undoCells: Array<{ rowId: string; data: Record<string, unknown> }> = []
+        const batchUpdates: Array<{ rowId: string; data: Record<string, unknown> }> = []
         for (let r = sel.startRow; r <= sel.endRow; r++) {
           const row = pMap.get(r)
           if (!row) continue
@@ -1293,7 +1298,10 @@ export function Table({
             }
           }
           undoCells.push({ rowId: row.id, data: previousData })
-          mutateRef.current({ rowId: row.id, data: updates })
+          batchUpdates.push({ rowId: row.id, data: updates })
+        }
+        if (batchUpdates.length > 0) {
+          batchUpdateRef.current({ updates: batchUpdates })
         }
         if (undoCells.length > 0) {
           pushUndoRef.current({ type: 'clear-cells', cells: undoCells })

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -251,7 +251,15 @@ export function Table({
   const deleteColumnMutation = useDeleteColumn({ workspaceId, tableId })
   const updateMetadataMutation = useUpdateTableMetadata({ workspaceId, tableId })
 
-  const { pushUndo, undo, redo } = useTableUndo({ workspaceId, tableId })
+  const handleColumnOrderChange = useCallback((order: string[]) => {
+    setColumnOrder(order)
+  }, [])
+
+  const { pushUndo, undo, redo } = useTableUndo({
+    workspaceId,
+    tableId,
+    onColumnOrderChange: handleColumnOrderChange,
+  })
   const undoRef = useRef(undo)
   undoRef.current = undo
   const redoRef = useRef(redo)
@@ -750,6 +758,11 @@ export function Table({
         newOrder.splice(insertIndex, 0, dragged)
         const orderChanged = newOrder.some((name, i) => currentOrder[i] !== name)
         if (orderChanged) {
+          pushUndoRef.current({
+            type: 'reorder-columns',
+            previousOrder: currentOrder,
+            newOrder,
+          })
           setColumnOrder(newOrder)
           updateMetadataRef.current({
             columnWidths: columnWidthsRef.current,
@@ -766,6 +779,37 @@ export function Table({
   const handleColumnDragLeave = useCallback(() => {
     dropTargetColumnNameRef.current = null
     setDropTargetColumnName(null)
+  }, [])
+
+  const handleScrollDragOver = useCallback((e: React.DragEvent) => {
+    if (!dragColumnNameRef.current) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+
+    const scrollEl = scrollRef.current
+    if (!scrollEl) return
+    const scrollRect = scrollEl.getBoundingClientRect()
+    const cursorX = e.clientX - scrollRect.left + scrollEl.scrollLeft
+
+    const cols = columnsRef.current
+    let left = CHECKBOX_COL_WIDTH
+    for (const col of cols) {
+      const w = columnWidthsRef.current[col.name] ?? COL_WIDTH
+      if (cursorX < left + w) {
+        const midX = left + w / 2
+        const side = cursorX < midX ? 'left' : 'right'
+        if (col.name !== dropTargetColumnNameRef.current || side !== dropSideRef.current) {
+          setDropTargetColumnName(col.name)
+          setDropSide(side)
+        }
+        return
+      }
+      left += w
+    }
+  }, [])
+
+  const handleScrollDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
   }, [])
 
   useEffect(() => {
@@ -878,6 +922,12 @@ export function Table({
 
       if (e.key === 'Escape') {
         e.preventDefault()
+        if (dragColumnNameRef.current) {
+          setDragColumnName(null)
+          setDropTargetColumnName(null)
+          setDropSide('left')
+          return
+        }
         setSelectionAnchor(null)
         setSelectionFocus(null)
         setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
@@ -1805,6 +1855,8 @@ export function Table({
           resizingColumn && 'select-none'
         )}
         data-table-scroll
+        onDragOver={handleScrollDragOver}
+        onDrop={handleScrollDrop}
       >
         <div className='relative h-fit' style={{ width: `${tableWidth}px` }}>
           <table

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -431,18 +431,7 @@ export function Table({
   const columnRename = useInlineRename({
     onSave: (columnName, newName) => {
       pushUndoRef.current({ type: 'rename-column', oldName: columnName, newName })
-      let updatedWidths = columnWidthsRef.current
-      if (columnName in updatedWidths) {
-        const { [columnName]: width, ...rest } = updatedWidths
-        updatedWidths = { ...rest, [newName]: width }
-        setColumnWidths(updatedWidths)
-      }
-      const updatedOrder = columnOrderRef.current?.map((n) => (n === columnName ? newName : n))
-      if (updatedOrder) setColumnOrder(updatedOrder)
-      updateMetadataRef.current({
-        columnWidths: updatedWidths,
-        columnOrder: updatedOrder,
-      })
+      handleColumnRename(columnName, newName)
       updateColumnMutation.mutate({ columnName, updates: { name: newName } })
     },
   })
@@ -771,7 +760,7 @@ export function Table({
     try {
       measure.className = 'font-medium text-small'
       measure.textContent = columnName
-      maxWidth = Math.max(maxWidth, measure.offsetWidth + 36)
+      maxWidth = Math.max(maxWidth, measure.offsetWidth + 57)
 
       measure.className = 'text-small'
       for (const row of currentRows) {

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -320,6 +320,17 @@ export function Table({
 
   const dropColumnBounds = useMemo(() => {
     if (!dropTargetColumnName || !dragColumnName) return null
+    if (dropTargetColumnName === dragColumnName) return null
+
+    const dragIndex = displayColumns.findIndex((c) => c.name === dragColumnName)
+    const targetIndex = displayColumns.findIndex((c) => c.name === dropTargetColumnName)
+    if (dragIndex === -1 || targetIndex === -1) return null
+
+    const wouldBeNoOp =
+      (dropSide === 'right' && targetIndex === dragIndex - 1) ||
+      (dropSide === 'left' && targetIndex === dragIndex + 1)
+    if (wouldBeNoOp) return null
+
     let left = CHECKBOX_COL_WIDTH
     for (const col of displayColumns) {
       const w = columnWidths[col.name] ?? COL_WIDTH
@@ -331,6 +342,17 @@ export function Table({
     }
     return null
   }, [dropTargetColumnName, dragColumnName, dropSide, displayColumns, columnWidths])
+
+  const dragSourceBounds = useMemo(() => {
+    if (!dragColumnName) return null
+    let left = CHECKBOX_COL_WIDTH
+    for (const col of displayColumns) {
+      const w = columnWidths[col.name] ?? COL_WIDTH
+      if (col.name === dragColumnName) return { left, width: w }
+      left += w
+    }
+    return null
+  }, [dragColumnName, displayColumns, columnWidths])
 
   const isAllRowsSelected = useMemo(() => {
     if (checkedRows.size > 0 && rows.length > 0 && checkedRows.size >= rows.length) {
@@ -708,7 +730,12 @@ export function Table({
 
   const handleColumnDragEnd = useCallback(() => {
     const dragged = dragColumnNameRef.current
-    if (!dragged) return
+    if (!dragged) {
+      setDragColumnName(null)
+      setDropTargetColumnName(null)
+      setDropSide('left')
+      return
+    }
     const target = dropTargetColumnNameRef.current
     const side = dropSideRef.current
     if (target && dragged !== target) {
@@ -721,11 +748,14 @@ export function Table({
         let insertIndex = newOrder.indexOf(target)
         if (side === 'right') insertIndex += 1
         newOrder.splice(insertIndex, 0, dragged)
-        setColumnOrder(newOrder)
-        updateMetadataRef.current({
-          columnWidths: columnWidthsRef.current,
-          columnOrder: newOrder,
-        })
+        const orderChanged = newOrder.some((name, i) => currentOrder[i] !== name)
+        if (orderChanged) {
+          setColumnOrder(newOrder)
+          updateMetadataRef.current({
+            columnWidths: columnWidthsRef.current,
+            columnOrder: newOrder,
+          })
+        }
       }
     }
     setDragColumnName(null)
@@ -1925,6 +1955,12 @@ export function Table({
             <div
               className='-translate-x-[1.5px] pointer-events-none absolute top-0 z-20 h-full w-[2px] bg-[var(--selection)]'
               style={{ left: resizeIndicatorLeft }}
+            />
+          )}
+          {dragSourceBounds !== null && (
+            <div
+              className='pointer-events-none absolute top-0 z-[15] h-full bg-[var(--bg)] opacity-50'
+              style={{ left: dragSourceBounds.left, width: dragSourceBounds.width }}
             />
           )}
           {dropColumnBounds !== null && (

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -1257,9 +1257,11 @@ export function Table({
             }
           }
           undoCells.push({ rowId: row.id, oldData, newData })
-          mutateRef.current({ rowId: row.id, data: newData })
         }
         if (undoCells.length > 0) {
+          batchUpdateRef.current({
+            updates: undoCells.map((c) => ({ rowId: c.rowId, data: c.newData })),
+          })
           pushUndoRef.current({ type: 'update-cells', cells: undoCells })
         }
         return

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -318,16 +318,19 @@ export function Table({
     return 0
   }, [resizingColumn, displayColumns, columnWidths])
 
-  const dropIndicatorLeft = useMemo(() => {
-    if (!dropTargetColumnName) return null
+  const dropColumnBounds = useMemo(() => {
+    if (!dropTargetColumnName || !dragColumnName) return null
     let left = CHECKBOX_COL_WIDTH
     for (const col of displayColumns) {
-      if (dropSide === 'left' && col.name === dropTargetColumnName) return left
-      left += columnWidths[col.name] ?? COL_WIDTH
-      if (dropSide === 'right' && col.name === dropTargetColumnName) return left
+      const w = columnWidths[col.name] ?? COL_WIDTH
+      if (col.name === dropTargetColumnName) {
+        const lineLeft = dropSide === 'left' ? left : left + w
+        return { left, width: w, lineLeft }
+      }
+      left += w
     }
     return null
-  }, [dropTargetColumnName, dropSide, displayColumns, columnWidths])
+  }, [dropTargetColumnName, dragColumnName, dropSide, displayColumns, columnWidths])
 
   const isAllRowsSelected = useMemo(() => {
     if (checkedRows.size > 0 && rows.length > 0 && checkedRows.size >= rows.length) {
@@ -1924,11 +1927,17 @@ export function Table({
               style={{ left: resizeIndicatorLeft }}
             />
           )}
-          {dropIndicatorLeft !== null && (
-            <div
-              className='-translate-x-[1px] pointer-events-none absolute top-0 z-20 h-full w-[2px] bg-[var(--selection)]'
-              style={{ left: dropIndicatorLeft }}
-            />
+          {dropColumnBounds !== null && (
+            <>
+              <div
+                className='pointer-events-none absolute top-0 z-[15] h-full bg-[rgba(37,99,235,0.06)]'
+                style={{ left: dropColumnBounds.left, width: dropColumnBounds.width }}
+              />
+              <div
+                className='-translate-x-[1px] pointer-events-none absolute top-0 z-20 h-full w-[2px] bg-[var(--selection)]'
+                style={{ left: dropColumnBounds.lineLeft }}
+              />
+            </>
           )}
         </div>
         {!isLoadingTable && !isLoadingRows && userPermissions.canEdit && (

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -1025,6 +1025,7 @@ export function Table({
         if (lastRow < 0) return
         e.preventDefault()
         setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+        lastCheckboxRowRef.current = null
         setSelectionAnchor({ rowIndex: 0, colIndex: a.colIndex })
         setSelectionFocus({ rowIndex: lastRow, colIndex: a.colIndex })
         setIsColumnSelection(true)
@@ -1038,6 +1039,7 @@ export function Table({
         if (currentCols.length === 0) return
         e.preventDefault()
         setCheckedRows((prev) => (prev.size === 0 ? prev : EMPTY_CHECKED_ROWS))
+        lastCheckboxRowRef.current = null
         setIsColumnSelection(false)
         setSelectionAnchor({ rowIndex: a.rowIndex, colIndex: 0 })
         setSelectionFocus({ rowIndex: a.rowIndex, colIndex: currentCols.length - 1 })
@@ -1354,6 +1356,7 @@ export function Table({
       for (let r = sel.startRow; r <= sel.endRow; r++) {
         const cells: string[] = []
         for (let c = sel.startCol; c <= sel.endCol; c++) {
+          if (c >= cols.length) break
           const row = pMap.get(r)
           const value: unknown = row ? row.data[cols[c].name] : null
           if (value === null || value === undefined) {
@@ -1593,15 +1596,16 @@ export function Table({
         return
       }
 
-      const oldValue = row.data[columnName]
-      const changed = !(oldValue === value) && !(oldValue === null && value === null)
+      const oldValue = row.data[columnName] ?? null
+      const normalizedValue = value ?? null
+      const changed = oldValue !== normalizedValue
 
       if (changed) {
         pushUndoRef.current({
           type: 'update-cell',
           rowId,
           columnName,
-          previousValue: oldValue ?? null,
+          previousValue: oldValue,
           newValue: value,
         })
         mutateRef.current({ rowId, data: { [columnName]: value } })
@@ -1806,13 +1810,19 @@ export function Table({
             previousWidth,
           })
 
+          const { [columnToDelete]: _removedWidth, ...cleanedWidths } = columnWidthsRef.current
+          setColumnWidths(cleanedWidths)
+          columnWidthsRef.current = cleanedWidths
+
           if (currentOrder) {
             currentOrder = currentOrder.filter((n) => n !== columnToDelete)
             setColumnOrder(currentOrder)
             updateMetadataRef.current({
-              columnWidths: columnWidthsRef.current,
+              columnWidths: cleanedWidths,
               columnOrder: currentOrder,
             })
+          } else {
+            updateMetadataRef.current({ columnWidths: cleanedWidths })
           }
 
           deleteNext(index + 1)
@@ -3147,7 +3157,7 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
         'position:absolute;top:-9999px;padding:4px 8px;background:var(--bg);border:1px solid var(--border);border-radius:4px;font-size:13px;font-weight:500;white-space:nowrap;color:var(--text-primary)'
       document.body.appendChild(ghost)
       e.dataTransfer.setDragImage(ghost, ghost.offsetWidth / 2, ghost.offsetHeight / 2)
-      requestAnimationFrame(() => document.body.removeChild(ghost))
+      requestAnimationFrame(() => ghost.parentNode?.removeChild(ghost))
 
       onDragStart?.(column.name)
     },

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -899,8 +899,9 @@ export function Table({
   }, [])
 
   useEffect(() => {
-    if (!selectionAnchor) return
-    const { rowIndex, colIndex } = selectionAnchor
+    const target = selectionFocus ?? selectionAnchor
+    if (!target) return
+    const { rowIndex, colIndex } = target
     const rafId = requestAnimationFrame(() => {
       const cell = document.querySelector(
         `[data-table-scroll] [data-row="${rowIndex}"][data-col="${colIndex}"]`
@@ -908,7 +909,7 @@ export function Table({
       cell?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
     })
     return () => cancelAnimationFrame(rafId)
-  }, [selectionAnchor])
+  }, [selectionAnchor, selectionFocus])
 
   const handleCellClick = useCallback((rowId: string, columnName: string) => {
     const column = columnsRef.current.find((c) => c.name === columnName)
@@ -1172,7 +1173,8 @@ export function Table({
         setIsColumnSelection(false)
         const jump = e.metaKey || e.ctrlKey
         if (e.shiftKey) {
-          setSelectionFocus({ rowIndex: jump ? 0 : anchor.rowIndex, colIndex: 0 })
+          const focus = selectionFocusRef.current ?? anchor
+          setSelectionFocus({ rowIndex: jump ? 0 : focus.rowIndex, colIndex: 0 })
         } else {
           setSelectionAnchor({ rowIndex: jump ? 0 : anchor.rowIndex, colIndex: 0 })
           setSelectionFocus(null)
@@ -1185,8 +1187,9 @@ export function Table({
         setIsColumnSelection(false)
         const jump = e.metaKey || e.ctrlKey
         if (e.shiftKey) {
+          const focus = selectionFocusRef.current ?? anchor
           setSelectionFocus({
-            rowIndex: jump ? totalRows - 1 : anchor.rowIndex,
+            rowIndex: jump ? totalRows - 1 : focus.rowIndex,
             colIndex: cols.length - 1,
           })
         } else {
@@ -1728,34 +1731,35 @@ export function Table({
     const orderAtDelete = columnOrderRef.current
     const cols = schemaColumnsRef.current
     const colDef = cols.find((c) => c.name === columnToDelete)
-    const colPosition = cols.indexOf(colDef!)
+    const colPosition = colDef ? cols.indexOf(colDef) : cols.length
     const currentRows = rowsRef.current
     const cellData = currentRows
       .filter((r) => r.data[columnToDelete] != null)
       .map((r) => ({ rowId: r.id, value: r.data[columnToDelete] }))
     const previousWidth = columnWidthsRef.current[columnToDelete] ?? null
 
-    pushUndoRef.current({
-      type: 'delete-column',
-      columnName: columnToDelete,
-      columnType: colDef?.type ?? 'string',
-      columnPosition: colPosition >= 0 ? colPosition : cols.length,
-      columnUnique: colDef?.unique ?? false,
-      cellData,
-      previousOrder: orderAtDelete ? [...orderAtDelete] : null,
-      previousWidth,
-    })
-
     setDeletingColumn(null)
     deleteColumnMutation.mutate(columnToDelete, {
       onSuccess: () => {
-        if (!orderAtDelete) return
-        const newOrder = orderAtDelete.filter((n) => n !== columnToDelete)
-        setColumnOrder(newOrder)
-        updateMetadataRef.current({
-          columnWidths: columnWidthsRef.current,
-          columnOrder: newOrder,
+        pushUndoRef.current({
+          type: 'delete-column',
+          columnName: columnToDelete,
+          columnType: colDef?.type ?? 'string',
+          columnPosition: colPosition >= 0 ? colPosition : cols.length,
+          columnUnique: colDef?.unique ?? false,
+          cellData,
+          previousOrder: orderAtDelete ? [...orderAtDelete] : null,
+          previousWidth,
         })
+
+        if (orderAtDelete) {
+          const newOrder = orderAtDelete.filter((n) => n !== columnToDelete)
+          setColumnOrder(newOrder)
+          updateMetadataRef.current({
+            columnWidths: columnWidthsRef.current,
+            columnOrder: newOrder,
+          })
+        }
       },
     })
   }, [deletingColumn])
@@ -2240,7 +2244,7 @@ export function Table({
               <span className='text-[var(--text-error)]'>
                 This will remove all data in this column.
               </span>{' '}
-              This action cannot be undone.
+              You can undo this action.
             </p>
           </ModalBody>
           <ModalFooter>

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -255,10 +255,26 @@ export function Table({
     setColumnOrder(order)
   }, [])
 
+  const handleColumnRename = useCallback((oldName: string, newName: string) => {
+    let updatedWidths = columnWidthsRef.current
+    if (oldName in updatedWidths) {
+      const { [oldName]: width, ...rest } = updatedWidths
+      updatedWidths = { ...rest, [newName]: width }
+      setColumnWidths(updatedWidths)
+    }
+    const updatedOrder = columnOrderRef.current?.map((n) => (n === oldName ? newName : n))
+    if (updatedOrder) setColumnOrder(updatedOrder)
+    updateMetadataRef.current({
+      columnWidths: updatedWidths,
+      columnOrder: updatedOrder,
+    })
+  }, [])
+
   const { pushUndo, undo, redo } = useTableUndo({
     workspaceId,
     tableId,
     onColumnOrderChange: handleColumnOrderChange,
+    onColumnRename: handleColumnRename,
   })
   const undoRef = useRef(undo)
   undoRef.current = undo
@@ -1631,6 +1647,26 @@ export function Table({
     if (!deletingColumn) return
     const columnToDelete = deletingColumn
     const orderAtDelete = columnOrderRef.current
+    const cols = schemaColumnsRef.current
+    const colDef = cols.find((c) => c.name === columnToDelete)
+    const colPosition = cols.indexOf(colDef!)
+    const currentRows = rowsRef.current
+    const cellData = currentRows
+      .filter((r) => r.data[columnToDelete] != null)
+      .map((r) => ({ rowId: r.id, value: r.data[columnToDelete] }))
+    const previousWidth = columnWidthsRef.current[columnToDelete] ?? null
+
+    pushUndoRef.current({
+      type: 'delete-column',
+      columnName: columnToDelete,
+      columnType: colDef?.type ?? 'string',
+      columnPosition: colPosition >= 0 ? colPosition : cols.length,
+      columnUnique: colDef?.unique ?? false,
+      cellData,
+      previousOrder: orderAtDelete ? [...orderAtDelete] : null,
+      previousWidth,
+    })
+
     setDeletingColumn(null)
     deleteColumnMutation.mutate(columnToDelete, {
       onSuccess: () => {

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -1624,15 +1624,22 @@ export function Table({
 
   const handleChangeType = useCallback((columnName: string, newType: string) => {
     const column = columnsRef.current.find((c) => c.name === columnName)
-    if (column) {
-      pushUndoRef.current({
-        type: 'update-column-type',
-        columnName,
-        previousType: column.type,
-        newType,
-      })
-    }
-    updateColumnMutation.mutate({ columnName, updates: { type: newType } })
+    const previousType = column?.type
+    updateColumnMutation.mutate(
+      { columnName, updates: { type: newType } },
+      {
+        onSuccess: () => {
+          if (previousType) {
+            pushUndoRef.current({
+              type: 'update-column-type',
+              columnName,
+              previousType,
+              newType,
+            })
+          }
+        },
+      }
+    )
   }, [])
 
   const insertColumnInOrder = useCallback(

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -3181,6 +3181,7 @@ const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
   }, [])
 
   const handleDragEnd = useCallback(() => {
+    didDragRef.current = false
     onDragEnd?.()
   }, [onDragEnd])
 

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -1754,13 +1754,16 @@ export function Table({
     if (isColumnSelectionRef.current && selectionAnchorRef.current) {
       const sel = computeNormalizedSelection(selectionAnchorRef.current, selectionFocusRef.current)
       if (sel && sel.startCol !== sel.endCol) {
-        const names: string[] = []
-        for (let c = sel.startCol; c <= sel.endCol; c++) {
-          if (c < cols.length) names.push(cols[c].name)
-        }
-        if (names.length > 0) {
-          setDeletingColumns(names)
-          return
+        const clickedIdx = cols.findIndex((c) => c.name === columnName)
+        if (clickedIdx >= sel.startCol && clickedIdx <= sel.endCol) {
+          const names: string[] = []
+          for (let c = sel.startCol; c <= sel.endCol; c++) {
+            if (c < cols.length) names.push(cols[c].name)
+          }
+          if (names.length > 0) {
+            setDeletingColumns(names)
+            return
+          }
         }
       }
     }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments.ts
@@ -104,8 +104,8 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
   }, [])
 
   /**
-   * Processes and uploads files to S3
-   * @param fileList - Files to process
+   * Uploads files in parallel so a slow file does not block faster ones queued
+   * behind it. All placeholders insert in a single state update for a stable row.
    */
   const processFiles = useCallback(
     async (fileList: FileList) => {
@@ -114,67 +114,69 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
         return
       }
 
-      for (const file of Array.from(fileList)) {
-        let previewUrl: string | undefined
-        if (file.type.startsWith('image/')) {
-          previewUrl = URL.createObjectURL(file)
-        }
+      const files = Array.from(fileList)
+      if (files.length === 0) return
 
-        const resolvedType = resolveFileType(file)
+      const placeholders: AttachedFile[] = files.map((file) => ({
+        id: generateId(),
+        name: file.name,
+        size: file.size,
+        type: resolveFileType(file),
+        path: '',
+        uploading: true,
+        previewUrl: file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined,
+      }))
 
-        const tempFile: AttachedFile = {
-          id: generateId(),
-          name: file.name,
-          size: file.size,
-          type: resolvedType,
-          path: '',
-          uploading: true,
-          previewUrl,
-        }
+      setAttachedFiles((prev) => [...prev, ...placeholders])
 
-        setAttachedFiles((prev) => [...prev, tempFile])
+      await Promise.all(
+        files.map(async (file, i) => {
+          const placeholder = placeholders[i]
+          try {
+            const formData = new FormData()
+            formData.append('file', file)
+            formData.append('context', 'mothership')
+            if (workspaceId) {
+              formData.append('workspaceId', workspaceId)
+            }
 
-        try {
-          const formData = new FormData()
-          formData.append('file', file)
-          formData.append('context', 'mothership')
-          if (workspaceId) {
-            formData.append('workspaceId', workspaceId)
-          }
+            const uploadResponse = await fetch('/api/files/upload', {
+              method: 'POST',
+              body: formData,
+            })
 
-          const uploadResponse = await fetch('/api/files/upload', {
-            method: 'POST',
-            body: formData,
-          })
+            if (!uploadResponse.ok) {
+              const errorData = await uploadResponse.json().catch(() => ({
+                error: `Upload failed: ${uploadResponse.status}`,
+              }))
+              throw new Error(errorData.error || `Failed to upload file: ${uploadResponse.status}`)
+            }
 
-          if (!uploadResponse.ok) {
-            const errorData = await uploadResponse.json().catch(() => ({
-              error: `Upload failed: ${uploadResponse.status}`,
-            }))
-            throw new Error(errorData.error || `Failed to upload file: ${uploadResponse.status}`)
-          }
+            const uploadData = await uploadResponse.json()
 
-          const uploadData = await uploadResponse.json()
-
-          logger.info(`File uploaded successfully: ${uploadData.fileInfo?.path || uploadData.path}`)
-
-          setAttachedFiles((prev) =>
-            prev.map((f) =>
-              f.id === tempFile.id
-                ? {
-                    ...f,
-                    path: uploadData.fileInfo?.path || uploadData.path || uploadData.url,
-                    key: uploadData.fileInfo?.key || uploadData.key,
-                    uploading: false,
-                  }
-                : f
+            logger.info(
+              `File uploaded successfully: ${uploadData.fileInfo?.path || uploadData.path}`
             )
-          )
-        } catch (error) {
-          logger.error(`File upload failed: ${error}`)
-          setAttachedFiles((prev) => prev.filter((f) => f.id !== tempFile.id))
-        }
-      }
+
+            setAttachedFiles((prev) =>
+              prev.map((f) =>
+                f.id === placeholder.id
+                  ? {
+                      ...f,
+                      path: uploadData.fileInfo?.path || uploadData.path || uploadData.url,
+                      key: uploadData.fileInfo?.key || uploadData.key,
+                      uploading: false,
+                    }
+                  : f
+              )
+            )
+          } catch (error) {
+            logger.error(`File upload failed: ${error}`)
+            if (placeholder.previewUrl) URL.revokeObjectURL(placeholder.previewUrl)
+            setAttachedFiles((prev) => prev.filter((f) => f.id !== placeholder.id))
+          }
+        })
+      )
     },
     [userId, workspaceId]
   )

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -676,6 +676,9 @@ export function useUpdateColumn({ workspaceId, tableId }: RowMutationContext) {
 
       return res.json()
     },
+    onError: (error) => {
+      toast.error(error.message, { duration: 5000 })
+    },
     onSettled: () => {
       invalidateTableSchema(queryClient, workspaceId, tableId)
     },

--- a/apps/sim/hooks/use-table-undo.ts
+++ b/apps/sim/hooks/use-table-undo.ts
@@ -2,7 +2,7 @@
  * Hook that connects the table undo/redo store to React Query mutations.
  */
 
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { createLogger } from '@sim/logger'
 import {
   useAddTableColumn,
@@ -14,6 +14,7 @@ import {
   useDeleteTableRows,
   useRenameTable,
   useUpdateColumn,
+  useUpdateTableMetadata,
   useUpdateTableRow,
 } from '@/hooks/queries/tables'
 import { runWithoutRecording, useTableUndoStore } from '@/stores/table/store'
@@ -33,9 +34,10 @@ export function extractCreatedRowId(response: Record<string, unknown>): string |
 interface UseTableUndoProps {
   workspaceId: string
   tableId: string
+  onColumnOrderChange?: (order: string[]) => void
 }
 
-export function useTableUndo({ workspaceId, tableId }: UseTableUndoProps) {
+export function useTableUndo({ workspaceId, tableId, onColumnOrderChange }: UseTableUndoProps) {
   const push = useTableUndoStore((s) => s.push)
   const popUndo = useTableUndoStore((s) => s.popUndo)
   const popRedo = useTableUndoStore((s) => s.popRedo)
@@ -55,6 +57,10 @@ export function useTableUndo({ workspaceId, tableId }: UseTableUndoProps) {
   const updateColumnMutation = useUpdateColumn({ workspaceId, tableId })
   const deleteColumnMutation = useDeleteColumn({ workspaceId, tableId })
   const renameTableMutation = useRenameTable(workspaceId)
+  const updateMetadataMutation = useUpdateTableMetadata({ workspaceId, tableId })
+
+  const onColumnOrderChangeRef = useRef(onColumnOrderChange)
+  onColumnOrderChangeRef.current = onColumnOrderChange
 
   useEffect(() => {
     return () => clear(tableId)
@@ -227,6 +233,13 @@ export function useTableUndo({ workspaceId, tableId }: UseTableUndoProps) {
           case 'rename-table': {
             const name = direction === 'undo' ? action.previousName : action.newName
             renameTableMutation.mutate({ tableId: action.tableId, name })
+            break
+          }
+
+          case 'reorder-columns': {
+            const order = direction === 'undo' ? action.previousOrder : action.newOrder
+            onColumnOrderChangeRef.current?.(order)
+            updateMetadataMutation.mutate({ columnOrder: order })
             break
           }
         }

--- a/apps/sim/hooks/use-table-undo.ts
+++ b/apps/sim/hooks/use-table-undo.ts
@@ -36,6 +36,7 @@ interface UseTableUndoProps {
   tableId: string
   onColumnOrderChange?: (order: string[]) => void
   onColumnRename?: (oldName: string, newName: string) => void
+  getColumnWidths?: () => Record<string, number>
 }
 
 export function useTableUndo({
@@ -43,6 +44,7 @@ export function useTableUndo({
   tableId,
   onColumnOrderChange,
   onColumnRename,
+  getColumnWidths,
 }: UseTableUndoProps) {
   const push = useTableUndoStore((s) => s.push)
   const popUndo = useTableUndoStore((s) => s.popUndo)
@@ -69,6 +71,8 @@ export function useTableUndo({
   onColumnOrderChangeRef.current = onColumnOrderChange
   const onColumnRenameRef = useRef(onColumnRename)
   onColumnRenameRef.current = onColumnRename
+  const getColumnWidthsRef = useRef(getColumnWidths)
+  getColumnWidthsRef.current = getColumnWidths
 
   useEffect(() => {
     return () => clear(tableId)
@@ -230,7 +234,7 @@ export function useTableUndo({
                         ...(action.previousWidth !== null
                           ? {
                               columnWidths: {
-                                ...({} as Record<string, number>),
+                                ...(getColumnWidthsRef.current?.() ?? {}),
                                 [action.columnName]: action.previousWidth,
                               },
                             }

--- a/apps/sim/hooks/use-table-undo.ts
+++ b/apps/sim/hooks/use-table-undo.ts
@@ -254,10 +254,20 @@ export function useTableUndo({
             } else {
               deleteColumnMutation.mutate(action.columnName, {
                 onSuccess: () => {
+                  const metadata: Record<string, unknown> = {}
                   if (action.previousOrder) {
                     const newOrder = action.previousOrder.filter((n) => n !== action.columnName)
                     onColumnOrderChangeRef.current?.(newOrder)
-                    updateMetadataMutation.mutate({ columnOrder: newOrder })
+                    metadata.columnOrder = newOrder
+                  }
+                  if (action.previousWidth !== null) {
+                    const currentWidths = getColumnWidthsRef.current?.() ?? {}
+                    const { [action.columnName]: _, ...rest } = currentWidths
+                    metadata.columnWidths = rest
+                    onColumnWidthsChangeRef.current?.(rest)
+                  }
+                  if (Object.keys(metadata).length > 0) {
+                    updateMetadataMutation.mutate(metadata)
                   }
                 },
               })

--- a/apps/sim/hooks/use-table-undo.ts
+++ b/apps/sim/hooks/use-table-undo.ts
@@ -35,9 +35,15 @@ interface UseTableUndoProps {
   workspaceId: string
   tableId: string
   onColumnOrderChange?: (order: string[]) => void
+  onColumnRename?: (oldName: string, newName: string) => void
 }
 
-export function useTableUndo({ workspaceId, tableId, onColumnOrderChange }: UseTableUndoProps) {
+export function useTableUndo({
+  workspaceId,
+  tableId,
+  onColumnOrderChange,
+  onColumnRename,
+}: UseTableUndoProps) {
   const push = useTableUndoStore((s) => s.push)
   const popUndo = useTableUndoStore((s) => s.popUndo)
   const popRedo = useTableUndoStore((s) => s.popRedo)
@@ -61,6 +67,8 @@ export function useTableUndo({ workspaceId, tableId, onColumnOrderChange }: UseT
 
   const onColumnOrderChangeRef = useRef(onColumnOrderChange)
   onColumnOrderChangeRef.current = onColumnOrderChange
+  const onColumnRenameRef = useRef(onColumnRename)
+  onColumnRenameRef.current = onColumnRename
 
   useEffect(() => {
     return () => clear(tableId)
@@ -197,18 +205,63 @@ export function useTableUndo({ workspaceId, tableId, onColumnOrderChange }: UseT
             break
           }
 
-          case 'rename-column': {
+          case 'delete-column': {
             if (direction === 'undo') {
-              updateColumnMutation.mutate({
-                columnName: action.newName,
-                updates: { name: action.oldName },
-              })
+              addColumnMutation.mutate(
+                {
+                  name: action.columnName,
+                  type: action.columnType,
+                  unique: action.columnUnique,
+                  position: action.columnPosition,
+                },
+                {
+                  onSuccess: () => {
+                    if (action.cellData.length > 0) {
+                      const updates = action.cellData.map((c) => ({
+                        rowId: c.rowId,
+                        data: { [action.columnName]: c.value },
+                      }))
+                      batchUpdateRowsMutation.mutate({ updates })
+                    }
+                    if (action.previousOrder) {
+                      onColumnOrderChangeRef.current?.(action.previousOrder)
+                      updateMetadataMutation.mutate({
+                        columnOrder: action.previousOrder,
+                        ...(action.previousWidth !== null
+                          ? {
+                              columnWidths: {
+                                ...({} as Record<string, number>),
+                                [action.columnName]: action.previousWidth,
+                              },
+                            }
+                          : {}),
+                      })
+                    }
+                  },
+                }
+              )
             } else {
-              updateColumnMutation.mutate({
-                columnName: action.oldName,
-                updates: { name: action.newName },
+              deleteColumnMutation.mutate(action.columnName, {
+                onSuccess: () => {
+                  if (action.previousOrder) {
+                    const newOrder = action.previousOrder.filter((n) => n !== action.columnName)
+                    onColumnOrderChangeRef.current?.(newOrder)
+                    updateMetadataMutation.mutate({ columnOrder: newOrder })
+                  }
+                },
               })
             }
+            break
+          }
+
+          case 'rename-column': {
+            const fromName = direction === 'undo' ? action.newName : action.oldName
+            const toName = direction === 'undo' ? action.oldName : action.newName
+            updateColumnMutation.mutate({
+              columnName: fromName,
+              updates: { name: toName },
+            })
+            onColumnRenameRef.current?.(fromName, toName)
             break
           }
 

--- a/apps/sim/hooks/use-table-undo.ts
+++ b/apps/sim/hooks/use-table-undo.ts
@@ -228,19 +228,19 @@ export function useTableUndo({
                       }))
                       batchUpdateRowsMutation.mutate({ updates })
                     }
+                    const metadata: Record<string, unknown> = {}
                     if (action.previousOrder) {
                       onColumnOrderChangeRef.current?.(action.previousOrder)
-                      updateMetadataMutation.mutate({
-                        columnOrder: action.previousOrder,
-                        ...(action.previousWidth !== null
-                          ? {
-                              columnWidths: {
-                                ...(getColumnWidthsRef.current?.() ?? {}),
-                                [action.columnName]: action.previousWidth,
-                              },
-                            }
-                          : {}),
-                      })
+                      metadata.columnOrder = action.previousOrder
+                    }
+                    if (action.previousWidth !== null) {
+                      metadata.columnWidths = {
+                        ...(getColumnWidthsRef.current?.() ?? {}),
+                        [action.columnName]: action.previousWidth,
+                      }
+                    }
+                    if (Object.keys(metadata).length > 0) {
+                      updateMetadataMutation.mutate(metadata)
                     }
                   },
                 }

--- a/apps/sim/hooks/use-table-undo.ts
+++ b/apps/sim/hooks/use-table-undo.ts
@@ -202,7 +202,16 @@ export function useTableUndo({
 
           case 'create-column': {
             if (direction === 'undo') {
-              deleteColumnMutation.mutate(action.columnName)
+              deleteColumnMutation.mutate(action.columnName, {
+                onSuccess: () => {
+                  const currentWidths = getColumnWidthsRef.current?.() ?? {}
+                  if (action.columnName in currentWidths) {
+                    const { [action.columnName]: _, ...rest } = currentWidths
+                    onColumnWidthsChangeRef.current?.(rest)
+                    updateMetadataMutation.mutate({ columnWidths: rest })
+                  }
+                },
+              })
             } else {
               addColumnMutation.mutate({
                 name: action.columnName,

--- a/apps/sim/hooks/use-table-undo.ts
+++ b/apps/sim/hooks/use-table-undo.ts
@@ -215,6 +215,7 @@ export function useTableUndo({
                 {
                   name: action.columnName,
                   type: action.columnType,
+                  required: action.columnRequired,
                   unique: action.columnUnique,
                   position: action.columnPosition,
                 },

--- a/apps/sim/hooks/use-table-undo.ts
+++ b/apps/sim/hooks/use-table-undo.ts
@@ -230,7 +230,17 @@ export function useTableUndo({
                         rowId: c.rowId,
                         data: { [action.columnName]: c.value },
                       }))
-                      batchUpdateRowsMutation.mutate({ updates })
+                      batchUpdateRowsMutation.mutate(
+                        { updates },
+                        {
+                          onError: (error) => {
+                            logger.error('Failed to restore cell data on delete-column undo', {
+                              columnName: action.columnName,
+                              error,
+                            })
+                          },
+                        }
+                      )
                     }
                     const metadata: Record<string, unknown> = {}
                     if (action.previousOrder) {

--- a/apps/sim/hooks/use-table-undo.ts
+++ b/apps/sim/hooks/use-table-undo.ts
@@ -36,6 +36,7 @@ interface UseTableUndoProps {
   tableId: string
   onColumnOrderChange?: (order: string[]) => void
   onColumnRename?: (oldName: string, newName: string) => void
+  onColumnWidthsChange?: (widths: Record<string, number>) => void
   getColumnWidths?: () => Record<string, number>
 }
 
@@ -44,6 +45,7 @@ export function useTableUndo({
   tableId,
   onColumnOrderChange,
   onColumnRename,
+  onColumnWidthsChange,
   getColumnWidths,
 }: UseTableUndoProps) {
   const push = useTableUndoStore((s) => s.push)
@@ -71,6 +73,8 @@ export function useTableUndo({
   onColumnOrderChangeRef.current = onColumnOrderChange
   const onColumnRenameRef = useRef(onColumnRename)
   onColumnRenameRef.current = onColumnRename
+  const onColumnWidthsChangeRef = useRef(onColumnWidthsChange)
+  onColumnWidthsChangeRef.current = onColumnWidthsChange
   const getColumnWidthsRef = useRef(getColumnWidths)
   getColumnWidthsRef.current = getColumnWidths
 
@@ -234,10 +238,12 @@ export function useTableUndo({
                       metadata.columnOrder = action.previousOrder
                     }
                     if (action.previousWidth !== null) {
-                      metadata.columnWidths = {
+                      const merged = {
                         ...(getColumnWidthsRef.current?.() ?? {}),
                         [action.columnName]: action.previousWidth,
                       }
+                      metadata.columnWidths = merged
+                      onColumnWidthsChangeRef.current?.(merged)
                     }
                     if (Object.keys(metadata).length > 0) {
                       updateMetadataMutation.mutate(metadata)

--- a/apps/sim/lib/table/__tests__/update-row.test.ts
+++ b/apps/sim/lib/table/__tests__/update-row.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment node
+ */
+import { databaseMock } from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { updateRow } from '../service'
+import type { TableDefinition } from '../types'
+
+const EXISTING_ROW = {
+  id: 'row-1',
+  tableId: 'tbl-1',
+  workspaceId: 'ws-1',
+  data: { name: 'Alice', age: 30 },
+  position: 1,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+}
+
+const TABLE: TableDefinition = {
+  id: 'tbl-1',
+  name: 'People',
+  description: null,
+  schema: {
+    columns: [
+      { name: 'name', type: 'string' },
+      { name: 'age', type: 'number' },
+    ],
+  },
+  metadata: null,
+  rowCount: 0,
+  maxRows: 1000,
+  workspaceId: 'ws-1',
+  createdBy: 'user-1',
+  archivedAt: null,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+}
+
+describe('updateRow — partial merge', () => {
+  let mockSet: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // db.select() → used by getRowById to fetch the existing row
+    const mockLimit = vi.fn().mockResolvedValue([EXISTING_ROW])
+    const mockSelectWhere = vi.fn().mockReturnValue({ limit: mockLimit })
+    const mockFrom = vi.fn().mockReturnValue({ where: mockSelectWhere })
+    databaseMock.db.select.mockReturnValue({ from: mockFrom })
+
+    // db.update() → captures what merged data gets written
+    const mockUpdateWhere = vi.fn().mockResolvedValue([])
+    mockSet = vi.fn().mockReturnValue({ where: mockUpdateWhere })
+    databaseMock.db.update.mockReturnValue({ set: mockSet })
+  })
+
+  it('preserves columns not included in the partial update', async () => {
+    const result = await updateRow(
+      { tableId: 'tbl-1', rowId: 'row-1', data: { age: 31 }, workspaceId: 'ws-1' },
+      TABLE,
+      'req-1'
+    )
+
+    expect(result.data).toEqual({ name: 'Alice', age: 31 })
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { name: 'Alice', age: 31 } })
+    )
+  })
+
+  it('allows updating a single column without affecting others', async () => {
+    const result = await updateRow(
+      { tableId: 'tbl-1', rowId: 'row-1', data: { name: 'Bob' }, workspaceId: 'ws-1' },
+      TABLE,
+      'req-1'
+    )
+
+    expect(result.data).toEqual({ name: 'Bob', age: 30 })
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { name: 'Bob', age: 30 } })
+    )
+  })
+
+  it('allows explicitly nulling a field while preserving others', async () => {
+    const result = await updateRow(
+      { tableId: 'tbl-1', rowId: 'row-1', data: { age: null }, workspaceId: 'ws-1' },
+      TABLE,
+      'req-1'
+    )
+
+    expect(result.data).toEqual({ name: 'Alice', age: null })
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { name: 'Alice', age: null } })
+    )
+  })
+
+  it('handles a full-row update correctly (idempotent merge)', async () => {
+    const result = await updateRow(
+      { tableId: 'tbl-1', rowId: 'row-1', data: { name: 'Bob', age: 25 }, workspaceId: 'ws-1' },
+      TABLE,
+      'req-1'
+    )
+
+    expect(result.data).toEqual({ name: 'Bob', age: 25 })
+  })
+
+  it('throws when the row does not exist', async () => {
+    const mockLimit = vi.fn().mockResolvedValue([])
+    const mockSelectWhere = vi.fn().mockReturnValue({ limit: mockLimit })
+    const mockFrom = vi.fn().mockReturnValue({ where: mockSelectWhere })
+    databaseMock.db.select.mockReturnValue({ from: mockFrom })
+
+    await expect(
+      updateRow(
+        { tableId: 'tbl-1', rowId: 'row-missing', data: { age: 31 }, workspaceId: 'ws-1' },
+        TABLE,
+        'req-1'
+      )
+    ).rejects.toThrow('Row not found')
+  })
+})

--- a/apps/sim/lib/table/service.ts
+++ b/apps/sim/lib/table/service.ts
@@ -1207,14 +1207,20 @@ export async function updateRow(
     throw new Error('Row not found')
   }
 
+  // Merge partial update with existing row data so callers can pass only changed fields
+  const mergedData = {
+    ...(existingRow.data as RowData),
+    ...data.data,
+  }
+
   // Validate size
-  const sizeValidation = validateRowSize(data.data)
+  const sizeValidation = validateRowSize(mergedData)
   if (!sizeValidation.valid) {
     throw new Error(sizeValidation.errors.join(', '))
   }
 
   // Validate against schema
-  const schemaValidation = validateRowAgainstSchema(data.data, table.schema)
+  const schemaValidation = validateRowAgainstSchema(mergedData, table.schema)
   if (!schemaValidation.valid) {
     throw new Error(`Schema validation failed: ${schemaValidation.errors.join(', ')}`)
   }
@@ -1224,7 +1230,7 @@ export async function updateRow(
   if (uniqueColumns.length > 0) {
     const uniqueValidation = await checkUniqueConstraintsDb(
       data.tableId,
-      data.data,
+      mergedData,
       table.schema,
       data.rowId // Exclude current row
     )
@@ -1237,14 +1243,14 @@ export async function updateRow(
 
   await db
     .update(userTableRows)
-    .set({ data: data.data, updatedAt: now })
+    .set({ data: mergedData, updatedAt: now })
     .where(eq(userTableRows.id, data.rowId))
 
   logger.info(`[${requestId}] Updated row ${data.rowId} in table ${data.tableId}`)
 
   return {
     id: data.rowId,
-    data: data.data,
+    data: mergedData,
     position: existingRow.position,
     createdAt: existingRow.createdAt,
     updatedAt: now,

--- a/apps/sim/stores/table/store.ts
+++ b/apps/sim/stores/table/store.ts
@@ -150,31 +150,35 @@ export const useTableUndoStore = create<TableUndoState>()(
       },
 
       patchRedoRowId: (tableId: string, oldRowId: string, newRowId: string) => {
-        const stacks = get().stacks[tableId]
-        if (!stacks) return
-
-        const patchedRedo = stacks.redo.map((entry) => patchRowIdInEntry(entry, oldRowId, newRowId))
-
-        set((state) => ({
-          stacks: {
-            ...state.stacks,
-            [tableId]: { ...stacks, redo: patchedRedo },
-          },
-        }))
+        set((state) => {
+          const stacks = state.stacks[tableId]
+          if (!stacks) return state
+          const patchedRedo = stacks.redo.map((entry) =>
+            patchRowIdInEntry(entry, oldRowId, newRowId)
+          )
+          return {
+            stacks: {
+              ...state.stacks,
+              [tableId]: { ...stacks, redo: patchedRedo },
+            },
+          }
+        })
       },
 
       patchUndoRowId: (tableId: string, oldRowId: string, newRowId: string) => {
-        const stacks = get().stacks[tableId]
-        if (!stacks) return
-
-        const patchedUndo = stacks.undo.map((entry) => patchRowIdInEntry(entry, oldRowId, newRowId))
-
-        set((state) => ({
-          stacks: {
-            ...state.stacks,
-            [tableId]: { ...stacks, undo: patchedUndo },
-          },
-        }))
+        set((state) => {
+          const stacks = state.stacks[tableId]
+          if (!stacks) return state
+          const patchedUndo = stacks.undo.map((entry) =>
+            patchRowIdInEntry(entry, oldRowId, newRowId)
+          )
+          return {
+            stacks: {
+              ...state.stacks,
+              [tableId]: { ...stacks, undo: patchedUndo },
+            },
+          }
+        })
       },
 
       clear: (tableId: string) => {

--- a/apps/sim/stores/table/store.ts
+++ b/apps/sim/stores/table/store.ts
@@ -13,6 +13,73 @@ const EMPTY_STACKS: TableUndoStacks = { undo: [], redo: [] }
 
 let undoRedoInProgress = false
 
+function patchRowIdInEntry(entry: UndoEntry, oldRowId: string, newRowId: string): UndoEntry {
+  const { action } = entry
+  switch (action.type) {
+    case 'update-cell':
+      if (action.rowId === oldRowId) {
+        return { ...entry, action: { ...action, rowId: newRowId } }
+      }
+      break
+    case 'clear-cells': {
+      const hasMatch = action.cells.some((c) => c.rowId === oldRowId)
+      if (hasMatch) {
+        const patched = action.cells.map((c) =>
+          c.rowId === oldRowId ? { ...c, rowId: newRowId } : c
+        )
+        return { ...entry, action: { ...action, cells: patched } }
+      }
+      break
+    }
+    case 'update-cells': {
+      const hasMatch = action.cells.some((c) => c.rowId === oldRowId)
+      if (hasMatch) {
+        const patched = action.cells.map((c) =>
+          c.rowId === oldRowId ? { ...c, rowId: newRowId } : c
+        )
+        return { ...entry, action: { ...action, cells: patched } }
+      }
+      break
+    }
+    case 'create-row':
+      if (action.rowId === oldRowId) {
+        return { ...entry, action: { ...action, rowId: newRowId } }
+      }
+      break
+    case 'create-rows': {
+      const hasMatch = action.rows.some((r) => r.rowId === oldRowId)
+      if (hasMatch) {
+        const patched = action.rows.map((r) =>
+          r.rowId === oldRowId ? { ...r, rowId: newRowId } : r
+        )
+        return { ...entry, action: { ...action, rows: patched } }
+      }
+      break
+    }
+    case 'delete-rows': {
+      const hasMatch = action.rows.some((r) => r.rowId === oldRowId)
+      if (hasMatch) {
+        const patched = action.rows.map((r) =>
+          r.rowId === oldRowId ? { ...r, rowId: newRowId } : r
+        )
+        return { ...entry, action: { ...action, rows: patched } }
+      }
+      break
+    }
+    case 'delete-column': {
+      const hasMatch = action.cellData.some((c) => c.rowId === oldRowId)
+      if (hasMatch) {
+        const patched = action.cellData.map((c) =>
+          c.rowId === oldRowId ? { ...c, rowId: newRowId } : c
+        )
+        return { ...entry, action: { ...action, cellData: patched } }
+      }
+      break
+    }
+  }
+  return entry
+}
+
 /**
  * Run a function without recording undo entries.
  * Used by the hook when executing undo/redo mutations to prevent recursive recording.
@@ -86,16 +153,7 @@ export const useTableUndoStore = create<TableUndoState>()(
         const stacks = get().stacks[tableId]
         if (!stacks) return
 
-        const patchedRedo = stacks.redo.map((entry) => {
-          const { action } = entry
-          if (action.type === 'delete-rows') {
-            const patchedRows = action.rows.map((r) =>
-              r.rowId === oldRowId ? { ...r, rowId: newRowId } : r
-            )
-            return { ...entry, action: { ...action, rows: patchedRows } }
-          }
-          return entry
-        })
+        const patchedRedo = stacks.redo.map((entry) => patchRowIdInEntry(entry, oldRowId, newRowId))
 
         set((state) => ({
           stacks: {
@@ -109,13 +167,7 @@ export const useTableUndoStore = create<TableUndoState>()(
         const stacks = get().stacks[tableId]
         if (!stacks) return
 
-        const patchedUndo = stacks.undo.map((entry) => {
-          const { action } = entry
-          if (action.type === 'create-row' && action.rowId === oldRowId) {
-            return { ...entry, action: { ...action, rowId: newRowId } }
-          }
-          return entry
-        })
+        const patchedUndo = stacks.undo.map((entry) => patchRowIdInEntry(entry, oldRowId, newRowId))
 
         set((state) => ({
           stacks: {

--- a/apps/sim/stores/table/types.ts
+++ b/apps/sim/stores/table/types.ts
@@ -42,6 +42,7 @@ export type TableUndoAction =
       newValue: boolean
     }
   | { type: 'rename-table'; tableId: string; previousName: string; newName: string }
+  | { type: 'reorder-columns'; previousOrder: string[]; newOrder: string[] }
 
 export interface UndoEntry {
   id: string

--- a/apps/sim/stores/table/types.ts
+++ b/apps/sim/stores/table/types.ts
@@ -38,6 +38,7 @@ export type TableUndoAction =
       columnType: string
       columnPosition: number
       columnUnique: boolean
+      columnRequired: boolean
       cellData: Array<{ rowId: string; value: unknown }>
       previousOrder: string[] | null
       previousWidth: number | null

--- a/apps/sim/stores/table/types.ts
+++ b/apps/sim/stores/table/types.ts
@@ -32,6 +32,16 @@ export type TableUndoAction =
     }
   | { type: 'delete-rows'; rows: DeletedRowSnapshot[] }
   | { type: 'create-column'; columnName: string; position: number }
+  | {
+      type: 'delete-column'
+      columnName: string
+      columnType: string
+      columnPosition: number
+      columnUnique: boolean
+      cellData: Array<{ rowId: string; value: unknown }>
+      previousOrder: string[] | null
+      previousWidth: number | null
+    }
   | { type: 'rename-column'; oldName: string; newName: string }
   | { type: 'update-column-type'; columnName: string; previousType: string; newType: string }
   | {


### PR DESCRIPTION
## Summary

- **Column selection**: Click column header to select entire column, Shift+click to extend range, Ctrl+Space from any cell
- **Keyboard shortcuts**: Home/End, Ctrl+Home/End, PageUp/PageDown, Shift variants for extending selection, Shift+Space for full row selection, Ctrl+D fill down, Ctrl+A select all cells
- **Column drag reorder**: Drag via grip handle, body-level drop targets, custom drag ghost, Escape to cancel, full undo/redo
- **Column header context menu**: Left-click selects column, right-click opens dropdown (rename, type, sort, insert, delete)
- **Delete column undo/redo**: Captures column definition, cell data, order, and width for full restoration
- **Auto-resize on double-click**: Double-click column border to fit content, padding matches Google Sheets
- **Right-click preserves selection**: Right-clicking within an existing selection keeps it intact
- **Error feedback**: Column type change incompatibility now shows toast notification instead of failing silently
- **Partial update fix**: `updateRow` now merges partial updates to prevent column data loss from Mothership calls
- **Scroll-into-view**: Selection focus (not just anchor) is scrolled into view during Shift-extend operations
- **Accessibility**: Proper `aria-hidden` values and `aria-label` on column header controls

## Test plan

- [x] Click column header to select full column, Shift+click another header to extend
- [x] Right-click column header opens context menu (rename, change type, sort, insert, delete)
- [x] Drag column via grip handle to reorder, press Escape mid-drag to cancel
- [x] Ctrl+Z/Y undoes/redoes column reorder, column delete, and type changes
- [x] Delete column, then Ctrl+Z restores column with all data, order, and width
- [x] Change column type to incompatible type (e.g. text with letters to number) shows toast error
- [x] Home/End/PageUp/PageDown navigate correctly, Shift variants extend selection
- [x] Ctrl+D copies top cell value down through multi-row selection
- [x] Shift+Space selects entire row
- [x] Double-click column border auto-resizes to fit content
- [x] Right-click within existing selection preserves it
- [x] Shift+Arrow scrolls viewport to keep focus cell visible