### PR TITLE
fix(blocks): resolve variable display in mothership resource preview

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -862,8 +862,6 @@ export const WorkflowBlock = memo(function WorkflowBlock({
   const contentRef = useRef<HTMLDivElement>(null)
 
   const params = useParams()
-  // In sandbox mode pass empty strings so all workspace-scoped queries are disabled
-  const currentWorkflowId = isSandbox ? '' : (params.workflowId as string)
   const workspaceId = isSandbox ? '' : (params.workspaceId as string)
 
   const {
@@ -876,6 +874,8 @@ export const WorkflowBlock = memo(function WorkflowBlock({
     ringStyles,
     runPathStatus,
   } = useBlockVisual({ blockId: id, data, isPending, isSelected: selected })
+
+  const currentWorkflowId = isSandbox ? '' : (params.workflowId as string) || activeWorkflowId
 
   const currentBlock = currentWorkflow.getBlockById(id)
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -875,7 +875,7 @@ export const WorkflowBlock = memo(function WorkflowBlock({
     runPathStatus,
   } = useBlockVisual({ blockId: id, data, isPending, isSelected: selected })
 
-  const currentWorkflowId = isSandbox ? '' : (params.workflowId as string) || activeWorkflowId
+  const currentWorkflowId = isSandbox ? '' : (params.workflowId as string) || activeWorkflowId || ''
 
   const currentBlock = currentWorkflow.getBlockById(id)
 


### PR DESCRIPTION
## Summary
- Variables block showed empty assignments in mothership resource preview but worked on the actual canvas
- `currentWorkflowId` was read from URL params, which don't include `workflowId` in the mothership route
- Fall back to `activeWorkflowId` from the workflow registry for embedded contexts

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)