### PR TITLE
chore(docker): add packages/utils to app and realtime Dockerfiles

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -18,12 +18,13 @@ FROM base AS deps
 WORKDIR /app
 
 COPY package.json bun.lock turbo.json ./
-RUN mkdir -p apps packages/db packages/testing packages/logger packages/tsconfig
+RUN mkdir -p apps packages/db packages/testing packages/logger packages/tsconfig packages/utils
 COPY apps/sim/package.json ./apps/sim/package.json
 COPY packages/db/package.json ./packages/db/package.json
 COPY packages/testing/package.json ./packages/testing/package.json
 COPY packages/logger/package.json ./packages/logger/package.json
 COPY packages/tsconfig/package.json ./packages/tsconfig/package.json
+COPY packages/utils/package.json ./packages/utils/package.json
 
 # Install dependencies, then rebuild isolated-vm for Node.js
 # Use --linker=hoisted for flat node_modules layout (required for Docker multi-stage builds)
@@ -51,6 +52,7 @@ COPY apps/sim/package.json ./apps/sim/package.json
 COPY packages/db/package.json ./packages/db/package.json
 COPY packages/testing/package.json ./packages/testing/package.json
 COPY packages/logger/package.json ./packages/logger/package.json
+COPY packages/utils/package.json ./packages/utils/package.json
 
 # Copy workspace configuration files (needed for turbo)
 COPY apps/sim/next.config.ts ./apps/sim/next.config.ts

--- a/docker/realtime.Dockerfile
+++ b/docker/realtime.Dockerfile
@@ -70,6 +70,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/packages/db ./packages/db
 # Copy logger package (workspace dependency used by socket)
 COPY --from=builder --chown=nextjs:nodejs /app/packages/logger ./packages/logger
 
+# Copy utils package (workspace dependency used by socket)
+COPY --from=builder --chown=nextjs:nodejs /app/packages/utils ./packages/utils
+
 # Copy sim app (changes most frequently - placed last)
 COPY --from=builder --chown=nextjs:nodejs /app/apps/sim ./apps/sim
 

--- a/docker/realtime.Dockerfile
+++ b/docker/realtime.Dockerfile
@@ -12,12 +12,13 @@ FROM base AS deps
 WORKDIR /app
 
 COPY package.json bun.lock turbo.json ./
-RUN mkdir -p apps packages/db packages/testing packages/logger packages/tsconfig
+RUN mkdir -p apps packages/db packages/testing packages/logger packages/tsconfig packages/utils
 COPY apps/sim/package.json ./apps/sim/package.json
 COPY packages/db/package.json ./packages/db/package.json
 COPY packages/testing/package.json ./packages/testing/package.json
 COPY packages/logger/package.json ./packages/logger/package.json
 COPY packages/tsconfig/package.json ./packages/tsconfig/package.json
+COPY packages/utils/package.json ./packages/utils/package.json
 
 # Install dependencies with hoisted layout for Docker compatibility
 # Using --linker=hoisted to avoid .bun directory symlinks that don't copy between stages
@@ -39,6 +40,7 @@ COPY apps/sim/package.json ./apps/sim/package.json
 COPY packages/db/package.json ./packages/db/package.json
 COPY packages/testing/package.json ./packages/testing/package.json
 COPY packages/logger/package.json ./packages/logger/package.json
+COPY packages/utils/package.json ./packages/utils/package.json
 
 # Copy source code (changes most frequently - placed last to maximize cache hits)
 COPY apps/sim ./apps/sim


### PR DESCRIPTION
## Summary
- Add \`packages/utils\` to the deps and builder stages in \`app.Dockerfile\` and \`realtime.Dockerfile\`
- Required after \`@sim/utils\` was extracted as a workspace package in #4228 — bun install would fail to resolve it without the directory and \`package.json\` present in the deps stage

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)