### PR TITLE
fix(landing): render proper 404 for invalid /models and /integrations routes

### DIFF
--- a/apps/sim/app/(landing)/integrations/not-found.tsx
+++ b/apps/sim/app/(landing)/integrations/not-found.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { AUTH_PRIMARY_CTA_BASE } from '@/app/(auth)/components/auth-button-classes'
+
+export const metadata: Metadata = {
+  title: 'Page Not Found',
+  robots: { index: false, follow: true },
+}
+
+export default function IntegrationsNotFound() {
+  return (
+    <div className='flex min-h-[60vh] items-center justify-center px-4 py-24'>
+      <div className='flex flex-col items-center gap-3'>
+        <h1 className='text-balance font-[430] font-season text-[40px] text-white leading-[110%] tracking-[-0.02em]'>
+          Page not found
+        </h1>
+        <p className='font-[430] font-season text-[color-mix(in_srgb,var(--landing-text-subtle)_60%,transparent)] text-lg leading-[125%] tracking-[0.02em]'>
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+        <div className='mt-3 flex items-center gap-2'>
+          <Link href='/' className={AUTH_PRIMARY_CTA_BASE}>
+            Return to Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/sim/app/(landing)/models/not-found.tsx
+++ b/apps/sim/app/(landing)/models/not-found.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { AUTH_PRIMARY_CTA_BASE } from '@/app/(auth)/components/auth-button-classes'
+
+export const metadata: Metadata = {
+  title: 'Page Not Found',
+  robots: { index: false, follow: true },
+}
+
+export default function ModelsNotFound() {
+  return (
+    <div className='flex min-h-[60vh] items-center justify-center px-4 py-24'>
+      <div className='flex flex-col items-center gap-3'>
+        <h1 className='text-balance font-[430] font-season text-[40px] text-white leading-[110%] tracking-[-0.02em]'>
+          Page not found
+        </h1>
+        <p className='font-[430] font-season text-[color-mix(in_srgb,var(--landing-text-subtle)_60%,transparent)] text-lg leading-[125%] tracking-[0.02em]'>
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+        <div className='mt-3 flex items-center gap-2'>
+          <Link href='/' className={AUTH_PRIMARY_CTA_BASE}>
+            Return to Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add scoped `not-found.tsx` for `/models` and `/integrations` so invalid slugs (e.g. `/models/anthropic/123`, `/integrations/rand`) render the styled 404 instead of crashing with "Application error: a client-side exception has occurred"
- Root cause: both sections' `page.tsx` use `dynamicParams = false` and call `notFound()`, which fell back to `app/not-found.tsx`. That file renders its own `<Navbar>` + `<AuthBackground fixed inset-0>` on top of the section layout's `<Navbar>` + `<Footer>`, duplicating client hooks and conflicting positioning
- The new scoped 404s inherit the section Navbar/Footer from the layout and render only the centered message + "Return to Home" CTA

## Type of Change
- [x] Bug fix

## Testing
Tested manually — visiting `/models/anthropic/123`, `/models/not-a-real-provider`, and `/integrations/rand` now renders the styled 404. Valid URLs still render normally; root 404 behavior unchanged.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)