### PR TITLE
feat(contact): add contact page, migrate help/demo forms to useMutation

### DIFF
--- a/apps/sim/app/(landing)/components/contact/consts.ts
+++ b/apps/sim/app/(landing)/components/contact/consts.ts
@@ -65,3 +65,18 @@ export type ContactRequestPayload = z.infer<typeof contactRequestSchema>
 export function getContactTopicLabel(value: ContactRequestPayload['topic']): string {
   return CONTACT_TOPIC_OPTIONS.find((option) => option.value === value)?.label ?? value
 }
+
+export type HelpEmailType = 'bug' | 'feedback' | 'feature_request' | 'other'
+
+export function mapContactTopicToHelpType(topic: ContactRequestPayload['topic']): HelpEmailType {
+  switch (topic) {
+    case 'feature_request':
+      return 'feature_request'
+    case 'support':
+      return 'bug'
+    case 'integration':
+      return 'feedback'
+    default:
+      return 'other'
+  }
+}

--- a/apps/sim/app/(landing)/components/contact/consts.ts
+++ b/apps/sim/app/(landing)/components/contact/consts.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod'
+import { NO_EMAIL_HEADER_CONTROL_CHARS_REGEX } from '@/lib/messaging/email/utils'
+import { quickValidateEmail } from '@/lib/messaging/email/validation'
+
+export const CONTACT_TOPIC_VALUES = [
+  'general',
+  'support',
+  'integration',
+  'feature_request',
+  'sales',
+  'partnership',
+  'billing',
+  'other',
+] as const
+
+export const CONTACT_TOPIC_OPTIONS = [
+  { value: 'general', label: 'General question' },
+  { value: 'support', label: 'Technical support' },
+  { value: 'integration', label: 'Integration request' },
+  { value: 'feature_request', label: 'Feature request' },
+  { value: 'sales', label: 'Sales & pricing' },
+  { value: 'partnership', label: 'Partnership' },
+  { value: 'billing', label: 'Billing' },
+  { value: 'other', label: 'Other' },
+] as const
+
+export const contactRequestSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Name is required')
+    .max(120, 'Name must be 120 characters or less')
+    .regex(NO_EMAIL_HEADER_CONTROL_CHARS_REGEX, 'Invalid characters'),
+  email: z
+    .string()
+    .trim()
+    .min(1, 'Email is required')
+    .max(320)
+    .transform((value) => value.toLowerCase())
+    .refine((value) => quickValidateEmail(value).isValid, 'Enter a valid email'),
+  company: z
+    .string()
+    .trim()
+    .max(120, 'Company must be 120 characters or less')
+    .optional()
+    .transform((value) => (value && value.length > 0 ? value : undefined)),
+  topic: z.enum(CONTACT_TOPIC_VALUES, {
+    errorMap: () => ({ message: 'Please select a topic' }),
+  }),
+  subject: z
+    .string()
+    .trim()
+    .min(1, 'Subject is required')
+    .max(200, 'Subject must be 200 characters or less')
+    .regex(NO_EMAIL_HEADER_CONTROL_CHARS_REGEX, 'Invalid characters'),
+  message: z
+    .string()
+    .trim()
+    .min(1, 'Message is required')
+    .max(5000, 'Message must be 5,000 characters or less'),
+})
+
+export type ContactRequestPayload = z.infer<typeof contactRequestSchema>
+
+export function getContactTopicLabel(value: ContactRequestPayload['topic']): string {
+  return CONTACT_TOPIC_OPTIONS.find((option) => option.value === value)?.label ?? value
+}

--- a/apps/sim/app/(landing)/components/contact/contact-form.tsx
+++ b/apps/sim/app/(landing)/components/contact/contact-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { cloneElement, isValidElement, useState } from 'react'
+import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Combobox, Input, Textarea } from '@/components/emcn'
 import { Check } from '@/components/emcn/icons'
@@ -11,6 +11,7 @@ import {
   type ContactRequestPayload,
   contactRequestSchema,
 } from '@/app/(landing)/components/contact/consts'
+import { LandingField } from '@/app/(landing)/components/forms/landing-field'
 
 type ContactField = keyof ContactRequestPayload
 type ContactErrors = Partial<Record<ContactField, string>>
@@ -37,39 +38,6 @@ const COMBOBOX_TOPICS = [...CONTACT_TOPIC_OPTIONS]
 
 const LANDING_INPUT =
   'h-[36px] rounded-[5px] border border-[var(--border-1)] bg-[var(--surface-5)] px-3 font-[430] font-season text-[14px] text-[var(--text-primary)] outline-none transition-colors placeholder:text-[var(--text-muted)]'
-
-interface LandingFieldProps {
-  label: string
-  htmlFor: string
-  optional?: boolean
-  error?: string
-  children: React.ReactNode
-}
-
-function LandingField({ label, htmlFor, optional, error, children }: LandingFieldProps) {
-  const errorId = error ? `${htmlFor}-error` : undefined
-  const describedChild =
-    errorId && isValidElement<{ 'aria-describedby'?: string; 'aria-invalid'?: boolean }>(children)
-      ? cloneElement(children, { 'aria-describedby': errorId, 'aria-invalid': true })
-      : children
-  return (
-    <div className='flex flex-col gap-1.5'>
-      <label
-        htmlFor={htmlFor}
-        className='font-[430] font-season text-[13px] text-[var(--text-secondary)] tracking-[0.02em]'
-      >
-        {label}
-        {optional ? <span className='ml-1 text-[var(--text-muted)]'>(optional)</span> : null}
-      </label>
-      {describedChild}
-      {error ? (
-        <p id={errorId} role='alert' className='text-[12px] text-[var(--text-error)]'>
-          {error}
-        </p>
-      ) : null}
-    </div>
-  )
-}
 
 async function submitContactRequest(payload: ContactRequestPayload) {
   const response = await fetch('/api/contact', {

--- a/apps/sim/app/(landing)/components/contact/contact-form.tsx
+++ b/apps/sim/app/(landing)/components/contact/contact-form.tsx
@@ -1,0 +1,267 @@
+'use client'
+
+import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { Combobox, Input, Textarea } from '@/components/emcn'
+import { Check } from '@/components/emcn/icons'
+import { cn } from '@/lib/core/utils/cn'
+import { captureClientEvent } from '@/lib/posthog/client'
+import {
+  CONTACT_TOPIC_OPTIONS,
+  type ContactRequestPayload,
+  contactRequestSchema,
+} from '@/app/(landing)/components/contact/consts'
+
+type ContactField = keyof ContactRequestPayload
+type ContactErrors = Partial<Record<ContactField, string>>
+
+interface ContactFormState {
+  name: string
+  email: string
+  company: string
+  topic: ContactRequestPayload['topic'] | ''
+  subject: string
+  message: string
+}
+
+const INITIAL_FORM_STATE: ContactFormState = {
+  name: '',
+  email: '',
+  company: '',
+  topic: '',
+  subject: '',
+  message: '',
+}
+
+const COMBOBOX_TOPICS = [...CONTACT_TOPIC_OPTIONS]
+
+const LANDING_INPUT =
+  'h-[36px] rounded-[5px] border border-[var(--border-1)] bg-[var(--surface-5)] px-3 font-[430] font-season text-[14px] text-[var(--text-primary)] outline-none transition-colors placeholder:text-[var(--text-muted)]'
+
+interface LandingFieldProps {
+  label: string
+  htmlFor: string
+  optional?: boolean
+  error?: string
+  children: React.ReactNode
+}
+
+function LandingField({ label, htmlFor, optional, error, children }: LandingFieldProps) {
+  const errorId = error ? `${htmlFor}-error` : undefined
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <label
+        htmlFor={htmlFor}
+        className='font-[430] font-season text-[13px] text-[var(--text-secondary)] tracking-[0.02em]'
+      >
+        {label}
+        {optional ? <span className='ml-1 text-[var(--text-muted)]'>(optional)</span> : null}
+      </label>
+      {children}
+      {error ? (
+        <p id={errorId} role='alert' className='text-[12px] text-[var(--text-error)]'>
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+async function submitContactRequest(payload: ContactRequestPayload) {
+  const response = await fetch('/api/contact', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+
+  const result = (await response.json().catch(() => null)) as {
+    error?: string
+    message?: string
+  } | null
+
+  if (!response.ok) {
+    throw new Error(result?.error || 'Failed to send message')
+  }
+
+  return result
+}
+
+export function ContactForm() {
+  const [form, setForm] = useState<ContactFormState>(INITIAL_FORM_STATE)
+  const [errors, setErrors] = useState<ContactErrors>({})
+  const [submitSuccess, setSubmitSuccess] = useState(false)
+
+  const contactMutation = useMutation({
+    mutationFn: submitContactRequest,
+    onSuccess: (_data, variables) => {
+      captureClientEvent('landing_contact_submitted', { topic: variables.topic })
+      setForm(INITIAL_FORM_STATE)
+      setErrors({})
+      setSubmitSuccess(true)
+    },
+  })
+
+  function updateField<TField extends keyof ContactFormState>(
+    field: TField,
+    value: ContactFormState[TField]
+  ) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    setErrors((prev) => {
+      if (!prev[field as ContactField]) {
+        return prev
+      }
+      const nextErrors = { ...prev }
+      delete nextErrors[field as ContactField]
+      return nextErrors
+    })
+    if (contactMutation.isError) {
+      contactMutation.reset()
+    }
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (contactMutation.isPending) return
+
+    const parsed = contactRequestSchema.safeParse({
+      ...form,
+      company: form.company || undefined,
+    })
+
+    if (!parsed.success) {
+      const fieldErrors = parsed.error.flatten().fieldErrors
+      setErrors({
+        name: fieldErrors.name?.[0],
+        email: fieldErrors.email?.[0],
+        company: fieldErrors.company?.[0],
+        topic: fieldErrors.topic?.[0],
+        subject: fieldErrors.subject?.[0],
+        message: fieldErrors.message?.[0],
+      })
+      return
+    }
+
+    contactMutation.mutate(parsed.data)
+  }
+
+  const submitError = contactMutation.isError
+    ? contactMutation.error instanceof Error
+      ? contactMutation.error.message
+      : 'Failed to send message. Please try again.'
+    : null
+
+  if (submitSuccess) {
+    return (
+      <div className='flex min-h-[460px] flex-col items-center justify-center rounded-[8px] border border-[var(--border-1)] bg-[var(--surface-5)] px-8 py-16 text-center'>
+        <div className='flex h-16 w-16 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--bg-subtle)] text-[var(--text-primary)]'>
+          <Check className='h-8 w-8' />
+        </div>
+        <h2 className='mt-6 font-[430] font-season text-[24px] text-[var(--text-primary)] leading-[1.2] tracking-[-0.02em]'>
+          Message received
+        </h2>
+        <p className='mt-3 max-w-sm font-season text-[14px] text-[var(--text-secondary)] leading-[1.6]'>
+          Thanks for reaching out. We've sent a confirmation to your inbox and will get back to you
+          shortly.
+        </p>
+        <button
+          type='button'
+          onClick={() => setSubmitSuccess(false)}
+          className='mt-6 font-season text-[13px] text-[var(--text-primary)] underline underline-offset-2 transition-opacity hover:opacity-80'
+        >
+          Send another message
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className='flex flex-col gap-4 rounded-[8px] border border-[var(--border-1)] bg-[var(--surface-5)] p-6 sm:p-8'
+    >
+      <div className='grid gap-4 sm:grid-cols-2'>
+        <LandingField htmlFor='contact-name' label='Name' error={errors.name}>
+          <Input
+            id='contact-name'
+            value={form.name}
+            onChange={(event) => updateField('name', event.target.value)}
+            placeholder='Your name'
+            className={LANDING_INPUT}
+          />
+        </LandingField>
+        <LandingField htmlFor='contact-email' label='Email' error={errors.email}>
+          <Input
+            id='contact-email'
+            type='email'
+            value={form.email}
+            onChange={(event) => updateField('email', event.target.value)}
+            placeholder='you@company.com'
+            className={LANDING_INPUT}
+          />
+        </LandingField>
+      </div>
+
+      <div className='grid gap-4 sm:grid-cols-2'>
+        <LandingField htmlFor='contact-company' label='Company' optional error={errors.company}>
+          <Input
+            id='contact-company'
+            value={form.company}
+            onChange={(event) => updateField('company', event.target.value)}
+            placeholder='Company name'
+            className={LANDING_INPUT}
+          />
+        </LandingField>
+        <LandingField htmlFor='contact-topic' label='Topic' error={errors.topic}>
+          <Combobox
+            options={COMBOBOX_TOPICS}
+            value={form.topic}
+            selectedValue={form.topic}
+            onChange={(value) => updateField('topic', value as ContactRequestPayload['topic'])}
+            placeholder='Select a topic'
+            editable={false}
+            filterOptions={false}
+            className='h-[36px] rounded-[5px] px-3 font-[430] font-season text-[14px]'
+          />
+        </LandingField>
+      </div>
+
+      <LandingField htmlFor='contact-subject' label='Subject' error={errors.subject}>
+        <Input
+          id='contact-subject'
+          value={form.subject}
+          onChange={(event) => updateField('subject', event.target.value)}
+          placeholder='How can we help?'
+          className={LANDING_INPUT}
+        />
+      </LandingField>
+
+      <LandingField htmlFor='contact-message' label='Message' error={errors.message}>
+        <Textarea
+          id='contact-message'
+          value={form.message}
+          onChange={(event) => updateField('message', event.target.value)}
+          placeholder='Share details so we can help as quickly as possible'
+          className='min-h-[140px] rounded-[5px] border border-[var(--border-1)] bg-[var(--surface-5)] px-3 py-2.5 font-[430] font-season text-[14px] text-[var(--text-primary)] outline-none transition-colors placeholder:text-[var(--text-muted)]'
+        />
+      </LandingField>
+
+      {submitError ? (
+        <p role='alert' className='font-season text-[13px] text-[var(--text-error)]'>
+          {submitError}
+        </p>
+      ) : null}
+
+      <button
+        type='submit'
+        disabled={contactMutation.isPending}
+        className={cn(
+          'flex h-[40px] w-full items-center justify-center rounded-[5px] bg-[var(--text-primary)]',
+          'font-[430] font-season text-[14px] text-[var(--bg)] transition-opacity',
+          'hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60'
+        )}
+      >
+        {contactMutation.isPending ? 'Sending...' : 'Send message'}
+      </button>
+    </form>
+  )
+}

--- a/apps/sim/app/(landing)/components/contact/contact-form.tsx
+++ b/apps/sim/app/(landing)/components/contact/contact-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { cloneElement, isValidElement, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Combobox, Input, Textarea } from '@/components/emcn'
 import { Check } from '@/components/emcn/icons'
@@ -48,6 +48,10 @@ interface LandingFieldProps {
 
 function LandingField({ label, htmlFor, optional, error, children }: LandingFieldProps) {
   const errorId = error ? `${htmlFor}-error` : undefined
+  const describedChild =
+    errorId && isValidElement<{ 'aria-describedby'?: string; 'aria-invalid'?: boolean }>(children)
+      ? cloneElement(children, { 'aria-describedby': errorId, 'aria-invalid': true })
+      : children
   return (
     <div className='flex flex-col gap-1.5'>
       <label
@@ -57,7 +61,7 @@ function LandingField({ label, htmlFor, optional, error, children }: LandingFiel
         {label}
         {optional ? <span className='ml-1 text-[var(--text-muted)]'>(optional)</span> : null}
       </label>
-      {children}
+      {describedChild}
       {error ? (
         <p id={errorId} role='alert' className='text-[12px] text-[var(--text-error)]'>
           {error}

--- a/apps/sim/app/(landing)/components/demo-request/demo-request-modal.tsx
+++ b/apps/sim/app/(landing)/components/demo-request/demo-request-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { cloneElement, isValidElement, useState } from 'react'
+import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import {
   Combobox,
@@ -20,6 +20,7 @@ import {
   type DemoRequestPayload,
   demoRequestSchema,
 } from '@/app/(landing)/components/demo-request/consts'
+import { LandingField } from '@/app/(landing)/components/forms/landing-field'
 
 interface DemoRequestModalProps {
   children: React.ReactNode
@@ -48,39 +49,6 @@ const INITIAL_FORM_STATE: DemoRequestFormState = {
   phoneNumber: '',
   companySize: '',
   details: '',
-}
-
-interface LandingFieldProps {
-  label: string
-  htmlFor: string
-  optional?: boolean
-  error?: string
-  children: React.ReactNode
-}
-
-function LandingField({ label, htmlFor, optional, error, children }: LandingFieldProps) {
-  const errorId = error ? `${htmlFor}-error` : undefined
-  const describedChild =
-    errorId && isValidElement<{ 'aria-describedby'?: string; 'aria-invalid'?: boolean }>(children)
-      ? cloneElement(children, { 'aria-describedby': errorId, 'aria-invalid': true })
-      : children
-  return (
-    <div className='flex flex-col gap-1.5'>
-      <label
-        htmlFor={htmlFor}
-        className='font-[430] font-season text-[13px] text-[var(--text-secondary)] tracking-[0.02em]'
-      >
-        {label}
-        {optional ? <span className='ml-1 text-[var(--text-muted)]'>(optional)</span> : null}
-      </label>
-      {describedChild}
-      {error ? (
-        <p id={errorId} role='alert' className='text-[12px] text-[var(--text-error)]'>
-          {error}
-        </p>
-      ) : null}
-    </div>
-  )
 }
 
 const LANDING_INPUT =

--- a/apps/sim/app/(landing)/components/demo-request/demo-request-modal.tsx
+++ b/apps/sim/app/(landing)/components/demo-request/demo-request-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { cloneElement, isValidElement, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import {
   Combobox,
@@ -60,6 +60,10 @@ interface LandingFieldProps {
 
 function LandingField({ label, htmlFor, optional, error, children }: LandingFieldProps) {
   const errorId = error ? `${htmlFor}-error` : undefined
+  const describedChild =
+    errorId && isValidElement<{ 'aria-describedby'?: string; 'aria-invalid'?: boolean }>(children)
+      ? cloneElement(children, { 'aria-describedby': errorId, 'aria-invalid': true })
+      : children
   return (
     <div className='flex flex-col gap-1.5'>
       <label
@@ -69,7 +73,7 @@ function LandingField({ label, htmlFor, optional, error, children }: LandingFiel
         {label}
         {optional ? <span className='ml-1 text-[var(--text-muted)]'>(optional)</span> : null}
       </label>
-      {children}
+      {describedChild}
       {error ? (
         <p id={errorId} role='alert' className='text-[12px] text-[var(--text-error)]'>
           {error}

--- a/apps/sim/app/(landing)/components/demo-request/demo-request-modal.tsx
+++ b/apps/sim/app/(landing)/components/demo-request/demo-request-modal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
 import {
   Combobox,
   Input,
@@ -58,6 +59,7 @@ interface LandingFieldProps {
 }
 
 function LandingField({ label, htmlFor, optional, error, children }: LandingFieldProps) {
+  const errorId = error ? `${htmlFor}-error` : undefined
   return (
     <div className='flex flex-col gap-1.5'>
       <label
@@ -68,7 +70,11 @@ function LandingField({ label, htmlFor, optional, error, children }: LandingFiel
         {optional ? <span className='ml-1 text-[var(--text-muted)]'>(optional)</span> : null}
       </label>
       {children}
-      {error ? <p className='text-[12px] text-[var(--text-error)]'>{error}</p> : null}
+      {error ? (
+        <p id={errorId} role='alert' className='text-[12px] text-[var(--text-error)]'>
+          {error}
+        </p>
+      ) : null}
     </div>
   )
 }
@@ -76,109 +82,101 @@ function LandingField({ label, htmlFor, optional, error, children }: LandingFiel
 const LANDING_INPUT =
   'h-[32px] rounded-[5px] border border-[var(--border-1)] bg-[var(--surface-5)] px-2.5 font-[430] font-season text-[13.5px] text-[var(--text-primary)] transition-colors placeholder:text-[var(--text-muted)] outline-none'
 
+async function submitDemoRequest(payload: DemoRequestPayload) {
+  const response = await fetch('/api/demo-requests', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+
+  const result = (await response.json().catch(() => null)) as {
+    error?: string
+    message?: string
+  } | null
+
+  if (!response.ok) {
+    throw new Error(result?.error || 'Failed to submit demo request')
+  }
+
+  return result
+}
+
 export function DemoRequestModal({ children, theme = 'dark' }: DemoRequestModalProps) {
   const [open, setOpen] = useState(false)
   const [form, setForm] = useState<DemoRequestFormState>(INITIAL_FORM_STATE)
   const [errors, setErrors] = useState<DemoRequestErrors>({})
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submitError, setSubmitError] = useState<string | null>(null)
   const [submitSuccess, setSubmitSuccess] = useState(false)
 
-  const resetForm = useCallback(() => {
+  const demoMutation = useMutation({
+    mutationFn: submitDemoRequest,
+    onSuccess: (_data, variables) => {
+      captureClientEvent('landing_demo_request_submitted', {
+        company_size: variables.companySize,
+      })
+      setSubmitSuccess(true)
+    },
+  })
+
+  function resetForm() {
     setForm(INITIAL_FORM_STATE)
     setErrors({})
-    setIsSubmitting(false)
-    setSubmitError(null)
     setSubmitSuccess(false)
-  }, [])
+    demoMutation.reset()
+  }
 
-  const handleOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      setOpen(nextOpen)
-      resetForm()
-    },
-    [resetForm]
-  )
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen)
+    resetForm()
+  }
 
-  const updateField = useCallback(
-    <TField extends keyof DemoRequestFormState>(
-      field: TField,
-      value: DemoRequestFormState[TField]
-    ) => {
-      setForm((prev) => ({ ...prev, [field]: value }))
-      setErrors((prev) => {
-        if (!prev[field]) {
-          return prev
-        }
-
-        const nextErrors = { ...prev }
-        delete nextErrors[field]
-        return nextErrors
-      })
-      setSubmitError(null)
-      setSubmitSuccess(false)
-    },
-    []
-  )
-
-  const handleSubmit = useCallback(
-    async (event: React.FormEvent<HTMLFormElement>) => {
-      event.preventDefault()
-      setSubmitError(null)
-      setSubmitSuccess(false)
-
-      const parsed = demoRequestSchema.safeParse({
-        ...form,
-        phoneNumber: form.phoneNumber || undefined,
-      })
-
-      if (!parsed.success) {
-        const fieldErrors = parsed.error.flatten().fieldErrors
-        setErrors({
-          firstName: fieldErrors.firstName?.[0],
-          lastName: fieldErrors.lastName?.[0],
-          companyEmail: fieldErrors.companyEmail?.[0],
-          phoneNumber: fieldErrors.phoneNumber?.[0],
-          companySize: fieldErrors.companySize?.[0],
-          details: fieldErrors.details?.[0],
-        })
-        return
+  function updateField<TField extends keyof DemoRequestFormState>(
+    field: TField,
+    value: DemoRequestFormState[TField]
+  ) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    setErrors((prev) => {
+      if (!prev[field]) {
+        return prev
       }
+      const nextErrors = { ...prev }
+      delete nextErrors[field]
+      return nextErrors
+    })
+    if (demoMutation.isError) {
+      demoMutation.reset()
+    }
+  }
 
-      setIsSubmitting(true)
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (demoMutation.isPending) return
 
-      try {
-        const response = await fetch('/api/demo-requests', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(parsed.data),
-        })
+    const parsed = demoRequestSchema.safeParse({
+      ...form,
+      phoneNumber: form.phoneNumber || undefined,
+    })
 
-        const result = (await response.json().catch(() => null)) as {
-          error?: string
-          message?: string
-        } | null
+    if (!parsed.success) {
+      const fieldErrors = parsed.error.flatten().fieldErrors
+      setErrors({
+        firstName: fieldErrors.firstName?.[0],
+        lastName: fieldErrors.lastName?.[0],
+        companyEmail: fieldErrors.companyEmail?.[0],
+        phoneNumber: fieldErrors.phoneNumber?.[0],
+        companySize: fieldErrors.companySize?.[0],
+        details: fieldErrors.details?.[0],
+      })
+      return
+    }
 
-        if (!response.ok) {
-          throw new Error(result?.error || 'Failed to submit demo request')
-        }
+    demoMutation.mutate(parsed.data)
+  }
 
-        setSubmitSuccess(true)
-        captureClientEvent('landing_demo_request_submitted', {
-          company_size: parsed.data.companySize,
-        })
-      } catch (error) {
-        setSubmitError(
-          error instanceof Error
-            ? error.message
-            : 'Failed to submit demo request. Please try again.'
-        )
-      } finally {
-        setIsSubmitting(false)
-      }
-    },
-    [form, resetForm]
-  )
+  const submitError = demoMutation.isError
+    ? demoMutation.error instanceof Error
+      ? demoMutation.error.message
+      : 'Failed to submit demo request. Please try again.'
+    : null
 
   return (
     <Modal open={open} onOpenChange={handleOpenChange}>
@@ -284,14 +282,16 @@ export function DemoRequestModal({ children, theme = 'dark' }: DemoRequestModalP
 
             <ModalFooter className='flex-col items-stretch gap-3 border-t-0 bg-transparent pt-0'>
               {submitError && (
-                <p className='font-season text-[13px] text-[var(--text-error)]'>{submitError}</p>
+                <p role='alert' className='font-season text-[13px] text-[var(--text-error)]'>
+                  {submitError}
+                </p>
               )}
               <button
                 type='submit'
-                disabled={isSubmitting}
+                disabled={demoMutation.isPending}
                 className='flex h-[32px] w-full items-center justify-center rounded-[5px] bg-[var(--text-primary)] font-[430] font-season text-[13.5px] text-[var(--bg)] transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50'
               >
-                {isSubmitting ? 'Submitting...' : 'Submit'}
+                {demoMutation.isPending ? 'Submitting...' : 'Submit'}
               </button>
             </ModalFooter>
           </form>

--- a/apps/sim/app/(landing)/components/footer/footer.tsx
+++ b/apps/sim/app/(landing)/components/footer/footer.tsx
@@ -31,6 +31,7 @@ const RESOURCES_LINKS: FooterItem[] = [
   { label: 'Partners', href: '/partners' },
   { label: 'Careers', href: 'https://jobs.ashbyhq.com/sim', external: true, externalArrow: true },
   { label: 'Changelog', href: '/changelog' },
+  { label: 'Contact', href: '/contact' },
 ]
 
 const BLOCK_LINKS: FooterItem[] = [

--- a/apps/sim/app/(landing)/components/forms/landing-field.tsx
+++ b/apps/sim/app/(landing)/components/forms/landing-field.tsx
@@ -1,0 +1,34 @@
+import { cloneElement, isValidElement } from 'react'
+
+interface LandingFieldProps {
+  label: string
+  htmlFor: string
+  optional?: boolean
+  error?: string
+  children: React.ReactNode
+}
+
+export function LandingField({ label, htmlFor, optional, error, children }: LandingFieldProps) {
+  const errorId = error ? `${htmlFor}-error` : undefined
+  const describedChild =
+    errorId && isValidElement<{ 'aria-describedby'?: string; 'aria-invalid'?: boolean }>(children)
+      ? cloneElement(children, { 'aria-describedby': errorId, 'aria-invalid': true })
+      : children
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <label
+        htmlFor={htmlFor}
+        className='font-[430] font-season text-[13px] text-[var(--text-secondary)] tracking-[0.02em]'
+      >
+        {label}
+        {optional ? <span className='ml-1 text-[var(--text-muted)]'>(optional)</span> : null}
+      </label>
+      {describedChild}
+      {error ? (
+        <p id={errorId} role='alert' className='text-[12px] text-[var(--text-error)]'>
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/sim/app/(landing)/contact/page.tsx
+++ b/apps/sim/app/(landing)/contact/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from 'next'
+import { getNavBlogPosts } from '@/lib/blog/registry'
+import { isHosted } from '@/lib/core/config/feature-flags'
+import { SITE_URL } from '@/lib/core/utils/urls'
+import { ContactForm } from '@/app/(landing)/components/contact/contact-form'
+import Footer from '@/app/(landing)/components/footer/footer'
+import Navbar from '@/app/(landing)/components/navbar/navbar'
+
+export const metadata: Metadata = {
+  title: 'Contact Us',
+  description:
+    "Get in touch with Sim. Ask a general question, request an integration, or get help. We'll respond quickly.",
+  metadataBase: new URL(SITE_URL),
+  alternates: { canonical: '/contact' },
+  openGraph: {
+    title: 'Contact Us | Sim',
+    description: 'Get in touch with the Sim team for questions, integrations, and support.',
+    type: 'website',
+  },
+}
+
+interface DirectContact {
+  label: string
+  description: string
+  email: string
+}
+
+const DIRECT_CONTACTS: DirectContact[] = [
+  {
+    label: 'Support',
+    description: 'Bugs, account issues, and product help.',
+    email: 'help@sim.ai',
+  },
+  {
+    label: 'Sales',
+    description: 'Enterprise plans, demos, and procurement.',
+    email: 'enterprise@sim.ai',
+  },
+  {
+    label: 'Privacy',
+    description: 'Data requests and privacy questions.',
+    email: 'privacy@sim.ai',
+  },
+  {
+    label: 'Security',
+    description: 'Vulnerability reports and security disclosures.',
+    email: 'security@sim.ai',
+  },
+]
+
+export default async function ContactPage() {
+  const blogPosts = await getNavBlogPosts()
+
+  return (
+    <main className='min-h-screen bg-[var(--landing-bg)] font-[430] font-season text-[var(--landing-text)]'>
+      <header>
+        <Navbar blogPosts={blogPosts} />
+      </header>
+
+      <div className='mx-auto max-w-[1100px] px-6 pt-[72px] pb-24 sm:px-12'>
+        <div className='max-w-2xl'>
+          <span className='mb-4 block font-martian-mono text-[11px] text-[var(--landing-text-muted)] uppercase tracking-[0.12em]'>
+            Contact us
+          </span>
+          <h1 className='mb-5 text-balance font-[500] text-4xl text-[var(--landing-text)] leading-[1.05] tracking-[-0.02em] md:text-5xl'>
+            We're here to help
+          </h1>
+          <p className='text-[var(--landing-text-muted)] text-base leading-[1.7]'>
+            Got a general question, integration request, or need help? Send us a message and our
+            team will get back to you. For urgent issues, email the right team directly.
+          </p>
+        </div>
+
+        <div className='mt-14 grid gap-10 lg:grid-cols-[1fr_1.4fr] lg:gap-16'>
+          <aside className='flex flex-col gap-6'>
+            <div>
+              <h2 className='mb-1 font-[500] text-[var(--landing-text)] text-lg tracking-[-0.01em]'>
+                Other ways to reach us
+              </h2>
+              <p className='text-[var(--landing-text-muted)] text-sm leading-[1.6]'>
+                Prefer email? Reach the right team directly.
+              </p>
+            </div>
+            <ul className='flex flex-col gap-5'>
+              {DIRECT_CONTACTS.map(({ label, description, email }) => (
+                <li
+                  key={email}
+                  className='border-[var(--landing-bg-elevated)] border-t pt-5 first:border-t-0 first:pt-0'
+                >
+                  <p className='font-[500] text-[var(--landing-text)] text-sm'>{label}</p>
+                  <p className='mt-1 text-[13px] text-[var(--landing-text-muted)] leading-[1.6]'>
+                    {description}
+                  </p>
+                  <a
+                    href={`mailto:${email}`}
+                    className='mt-1.5 inline-block text-[13px] text-[var(--landing-text)] underline underline-offset-2 transition-opacity hover:opacity-80'
+                  >
+                    {email}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </aside>
+
+          <div className='dark'>
+            <ContactForm />
+          </div>
+        </div>
+      </div>
+
+      {isHosted && <Footer hideCTA />}
+    </main>
+  )
+}

--- a/apps/sim/app/api/contact/route.ts
+++ b/apps/sim/app/api/contact/route.ts
@@ -12,6 +12,7 @@ import { getFromEmailAddress } from '@/lib/messaging/email/utils'
 import {
   contactRequestSchema,
   getContactTopicLabel,
+  mapContactTopicToHelpType,
 } from '@/app/(landing)/components/contact/consts'
 
 const logger = createLogger('ContactAPI')
@@ -53,10 +54,7 @@ export const POST = withRouteHandler(async (req: NextRequest) => {
       logger.warn(`[${requestId}] Invalid contact request data`, {
         errors: validationResult.error.format(),
       })
-      return NextResponse.json(
-        { error: 'Invalid request data', details: validationResult.error.format() },
-        { status: 400 }
-      )
+      return NextResponse.json({ error: 'Invalid request data' }, { status: 400 })
     }
 
     const { name, email, company, topic, subject, message } = validationResult.data
@@ -98,7 +96,10 @@ ${message}
     logger.info(`[${requestId}] Contact request email sent successfully`)
 
     try {
-      const confirmationHtml = await renderHelpConfirmationEmail('other', 0)
+      const confirmationHtml = await renderHelpConfirmationEmail(
+        mapContactTopicToHelpType(topic),
+        0
+      )
 
       await sendEmail({
         to: [email],

--- a/apps/sim/app/api/contact/route.ts
+++ b/apps/sim/app/api/contact/route.ts
@@ -1,0 +1,128 @@
+import { createLogger } from '@sim/logger'
+import { type NextRequest, NextResponse } from 'next/server'
+import { renderHelpConfirmationEmail } from '@/components/emails'
+import { env } from '@/lib/core/config/env'
+import type { TokenBucketConfig } from '@/lib/core/rate-limiter'
+import { RateLimiter } from '@/lib/core/rate-limiter'
+import { generateRequestId, getClientIp } from '@/lib/core/utils/request'
+import { getEmailDomain } from '@/lib/core/utils/urls'
+import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { sendEmail } from '@/lib/messaging/email/mailer'
+import { getFromEmailAddress } from '@/lib/messaging/email/utils'
+import {
+  contactRequestSchema,
+  getContactTopicLabel,
+} from '@/app/(landing)/components/contact/consts'
+
+const logger = createLogger('ContactAPI')
+const rateLimiter = new RateLimiter()
+
+const PUBLIC_ENDPOINT_RATE_LIMIT: TokenBucketConfig = {
+  maxTokens: 10,
+  refillRate: 5,
+  refillIntervalMs: 60_000,
+}
+
+export const POST = withRouteHandler(async (req: NextRequest) => {
+  const requestId = generateRequestId()
+
+  try {
+    const ip = getClientIp(req)
+    const storageKey = `public:contact:${ip}`
+
+    const { allowed, remaining, resetAt } = await rateLimiter.checkRateLimitDirect(
+      storageKey,
+      PUBLIC_ENDPOINT_RATE_LIMIT
+    )
+
+    if (!allowed) {
+      logger.warn(`[${requestId}] Rate limit exceeded for IP ${ip}`, { remaining, resetAt })
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(Math.ceil((resetAt.getTime() - Date.now()) / 1000)) },
+        }
+      )
+    }
+
+    const body = await req.json()
+    const validationResult = contactRequestSchema.safeParse(body)
+
+    if (!validationResult.success) {
+      logger.warn(`[${requestId}] Invalid contact request data`, {
+        errors: validationResult.error.format(),
+      })
+      return NextResponse.json(
+        { error: 'Invalid request data', details: validationResult.error.format() },
+        { status: 400 }
+      )
+    }
+
+    const { name, email, company, topic, subject, message } = validationResult.data
+    const topicLabel = getContactTopicLabel(topic)
+
+    logger.info(`[${requestId}] Processing contact request`, {
+      email: `${email.substring(0, 3)}***`,
+      topic,
+    })
+
+    const emailText = `Contact form submission
+Submitted: ${new Date().toISOString()}
+Topic: ${topicLabel}
+Name: ${name}
+Email: ${email}
+Company: ${company ?? 'Not provided'}
+
+Subject: ${subject}
+
+Message:
+${message}
+`
+
+    const helpInboxDomain = env.EMAIL_DOMAIN || getEmailDomain()
+    const emailResult = await sendEmail({
+      to: [`help@${helpInboxDomain}`],
+      subject: `[CONTACT:${topic.toUpperCase()}] ${subject}`,
+      text: emailText,
+      from: getFromEmailAddress(),
+      replyTo: email,
+      emailType: 'transactional',
+    })
+
+    if (!emailResult.success) {
+      logger.error(`[${requestId}] Error sending contact request email`, emailResult.message)
+      return NextResponse.json({ error: 'Failed to send message' }, { status: 500 })
+    }
+
+    logger.info(`[${requestId}] Contact request email sent successfully`)
+
+    try {
+      const confirmationHtml = await renderHelpConfirmationEmail('other', 0)
+
+      await sendEmail({
+        to: [email],
+        subject: `We've received your message: ${subject}`,
+        html: confirmationHtml,
+        from: getFromEmailAddress(),
+        replyTo: `help@${helpInboxDomain}`,
+        emailType: 'transactional',
+      })
+    } catch (err) {
+      logger.warn(`[${requestId}] Failed to send contact confirmation email`, err)
+    }
+
+    return NextResponse.json(
+      { success: true, message: "Thanks — we'll be in touch soon." },
+      { status: 201 }
+    )
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('not configured')) {
+      logger.error(`[${requestId}] Email service configuration error`, error)
+      return NextResponse.json({ error: 'Email service configuration error.' }, { status: 500 })
+    }
+
+    logger.error(`[${requestId}] Error processing contact request`, error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+})

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/help-modal/help-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/help-modal/help-modal.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { createLogger } from '@sim/logger'
+import { useMutation } from '@tanstack/react-query'
 import imageCompression from 'browser-image-compression'
 import { X } from 'lucide-react'
 import Image from 'next/image'
@@ -23,8 +24,8 @@ import { cn } from '@/lib/core/utils/cn'
 
 const logger = createLogger('HelpModal')
 
-const MAX_FILE_SIZE = 20 * 1024 * 1024 // 20MB maximum upload size
-const TARGET_SIZE_MB = 2 // Target size after compression
+const MAX_FILE_SIZE = 20 * 1024 * 1024
+const TARGET_SIZE_MB = 2
 const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif']
 
 const SCROLL_DELAY_MS = 100
@@ -60,11 +61,69 @@ interface HelpModalProps {
   workspaceId: string
 }
 
+interface SubmitHelpVariables {
+  data: FormValues
+  images: ImageWithPreview[]
+  workflowId?: string
+  workspaceId: string
+}
+
+async function compressImage(file: File): Promise<File> {
+  if (file.size < TARGET_SIZE_MB * 1024 * 1024 || file.type === 'image/gif') {
+    return file
+  }
+
+  try {
+    const compressedFile = await imageCompression(file, {
+      maxSizeMB: TARGET_SIZE_MB,
+      maxWidthOrHeight: 1920,
+      useWebWorker: true,
+      fileType: file.type,
+      initialQuality: 0.8,
+      alwaysKeepResolution: true,
+    })
+
+    return new File([compressedFile], file.name, {
+      type: file.type,
+      lastModified: Date.now(),
+    })
+  } catch (error) {
+    logger.warn('Image compression failed, using original file:', { error })
+    return file
+  }
+}
+
+async function submitHelpRequest({ data, images, workflowId, workspaceId }: SubmitHelpVariables) {
+  const formData = new FormData()
+  formData.append('subject', data.subject)
+  formData.append('message', data.message)
+  formData.append('type', data.type)
+  formData.append('workspaceId', workspaceId)
+  formData.append('userAgent', navigator.userAgent)
+  if (workflowId) {
+    formData.append('workflowId', workflowId)
+  }
+
+  images.forEach((image, index) => {
+    formData.append(`image_${index}`, image)
+  })
+
+  const response = await fetch('/api/help', {
+    method: 'POST',
+    body: formData,
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => null)
+    throw new Error(errorData?.error || 'Failed to submit help request')
+  }
+}
+
 export function HelpModal({ open, onOpenChange, workflowId, workspaceId }: HelpModalProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const imagesRef = useRef<ImageWithPreview[]>([])
 
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitStatus, setSubmitStatus] = useState<'success' | 'error' | null>(null)
   const [images, setImages] = useState<ImageWithPreview[]>([])
   const [isProcessing, setIsProcessing] = useState(false)
@@ -87,119 +146,49 @@ export function HelpModal({ open, onOpenChange, workflowId, workspaceId }: HelpM
     mode: 'onSubmit',
   })
 
-  /**
-   * Reset all form and UI state to prepare for a fresh modal session
-   */
-  const resetModalState = useCallback(() => {
-    setSubmitStatus(null)
-    setImages([])
-    setIsDragging(false)
-    setIsProcessing(false)
-    reset({
-      subject: '',
-      message: '',
-      type: DEFAULT_REQUEST_TYPE,
-    })
-  }, [reset])
+  const helpMutation = useMutation({
+    mutationFn: submitHelpRequest,
+    onSuccess: (_data, variables) => {
+      setSubmitStatus('success')
+      reset()
+      variables.images.forEach((image) => URL.revokeObjectURL(image.preview))
+      setImages([])
+    },
+    onError: (error) => {
+      logger.error('Error submitting help request:', { error })
+      setSubmitStatus('error')
+    },
+  })
+
+  useEffect(() => {
+    imagesRef.current = images
+  }, [images])
 
   useEffect(() => {
     if (open) {
-      resetModalState()
-    }
-  }, [open, resetModalState])
-
-  /**
-   * Fix z-index for popover/dropdown when inside modal
-   */
-  useEffect(() => {
-    if (!open) return
-
-    const updatePopoverZIndex = () => {
-      const allDivs = document.querySelectorAll('div')
-      allDivs.forEach((div) => {
-        const element = div as HTMLElement
-        const computedZIndex = window.getComputedStyle(element).zIndex
-        const zIndexNum = Number.parseInt(computedZIndex) || 0
-
-        if (zIndexNum === 10000001 || (zIndexNum > 0 && zIndexNum <= 10000100)) {
-          const hasPopoverStructure =
-            element.hasAttribute('data-radix-popover-content') ||
-            (element.hasAttribute('role') && element.getAttribute('role') === 'dialog') ||
-            element.querySelector('[role="listbox"]') !== null ||
-            element.classList.contains('rounded-lg') ||
-            element.classList.contains('rounded-sm')
-
-          if (hasPopoverStructure && element.offsetParent !== null) {
-            element.style.zIndex = '10000101'
-          }
-        }
+      setSubmitStatus(null)
+      setIsDragging(false)
+      setIsProcessing(false)
+      reset({
+        subject: '',
+        message: '',
+        type: DEFAULT_REQUEST_TYPE,
       })
-    }
-
-    // Create a style element to override popover z-index
-    const styleId = 'help-modal-popover-z-index'
-    let styleElement = document.getElementById(styleId) as HTMLStyleElement | null
-
-    if (!styleElement) {
-      styleElement = document.createElement('style')
-      styleElement.id = styleId
-      document.head.appendChild(styleElement)
-    }
-
-    styleElement.textContent = `
-      [data-radix-popover-content] {
-        z-index: 10000101 !important;
+    } else {
+      const previewsToRevoke = imagesRef.current
+      if (previewsToRevoke.length > 0) {
+        previewsToRevoke.forEach((image) => URL.revokeObjectURL(image.preview))
+        setImages([])
       }
-      div[style*="z-index: 10000001"],
-      div[style*="z-index:10000001"] {
-        z-index: 10000101 !important;
-      }
-    `
-
-    const observer = new MutationObserver(() => {
-      updatePopoverZIndex()
-    })
-
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ['style', 'class'],
-    })
-
-    updatePopoverZIndex()
-
-    const intervalId = setInterval(updatePopoverZIndex, 100)
-
-    return () => {
-      const element = document.getElementById(styleId)
-      if (element) {
-        element.remove()
-      }
-      observer.disconnect()
-      clearInterval(intervalId)
     }
-  }, [open])
+  }, [open, reset])
 
-  /**
-   * Set default form value for request type
-   */
-  useEffect(() => {
-    setValue('type', DEFAULT_REQUEST_TYPE)
-  }, [setValue])
-
-  /**
-   * Clean up image preview URLs to prevent memory leaks
-   */
   useEffect(() => {
     return () => {
-      images.forEach((image) => URL.revokeObjectURL(image.preview))
+      imagesRef.current.forEach((image) => URL.revokeObjectURL(image.preview))
     }
-  }, [images])
+  }, [])
 
-  /**
-   * Reset submit status back to normal after showing success for 2 seconds
-   */
   useEffect(() => {
     if (submitStatus === 'success') {
       const timer = setTimeout(() => {
@@ -209,217 +198,106 @@ export function HelpModal({ open, onOpenChange, workflowId, workspaceId }: HelpM
     }
   }, [submitStatus])
 
-  /**
-   * Smooth scroll to bottom when new images are added
-   */
   useEffect(() => {
     if (images.length > 0 && scrollContainerRef.current) {
       const scrollContainer = scrollContainerRef.current
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         scrollContainer.scrollTo({
           top: scrollContainer.scrollHeight,
           behavior: 'smooth',
         })
       }, SCROLL_DELAY_MS)
+      return () => clearTimeout(timer)
     }
   }, [images.length])
 
-  /**
-   * Compress image files to reduce upload size while maintaining quality
-   * @param file - The image file to compress
-   * @returns The compressed file or original if compression fails/is unnecessary
-   */
-  const compressImage = useCallback(async (file: File): Promise<File> => {
-    // Skip compression for small files or GIFs (which don't compress well)
-    if (file.size < TARGET_SIZE_MB * 1024 * 1024 || file.type === 'image/gif') {
-      return file
-    }
+  async function processFiles(files: FileList | File[]) {
+    if (!files || files.length === 0) return
 
-    const options = {
-      maxSizeMB: TARGET_SIZE_MB,
-      maxWidthOrHeight: 1920,
-      useWebWorker: true,
-      fileType: file.type,
-      initialQuality: 0.8,
-      alwaysKeepResolution: true,
-    }
+    setIsProcessing(true)
 
     try {
-      const compressedFile = await imageCompression(file, options)
+      const newImages: ImageWithPreview[] = []
+      let hasError = false
 
-      // Preserve original file metadata for compatibility
-      return new File([compressedFile], file.name, {
-        type: file.type,
-        lastModified: Date.now(),
-      })
+      for (const file of Array.from(files)) {
+        if (file.size > MAX_FILE_SIZE) {
+          hasError = true
+          continue
+        }
+
+        if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+          hasError = true
+          continue
+        }
+
+        const compressedFile = await compressImage(file)
+        const imageWithPreview = Object.assign(compressedFile, {
+          preview: URL.createObjectURL(compressedFile),
+        }) as ImageWithPreview
+
+        newImages.push(imageWithPreview)
+      }
+
+      if (!hasError && newImages.length > 0) {
+        setImages((prev) => [...prev, ...newImages])
+      }
     } catch (error) {
-      logger.warn('Image compression failed, using original file:', { error })
-      return file
+      logger.error('Error processing images:', { error })
+    } finally {
+      setIsProcessing(false)
+
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ''
+      }
     }
-  }, [])
+  }
 
-  /**
-   * Process uploaded files: validate, compress, and prepare for preview
-   * @param files - FileList or array of files to process
-   */
-  const processFiles = useCallback(
-    async (files: FileList | File[]) => {
-      if (!files || files.length === 0) return
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (e.target.files) {
+      await processFiles(e.target.files)
+    }
+  }
 
-      setIsProcessing(true)
-
-      try {
-        const newImages: ImageWithPreview[] = []
-        let hasError = false
-
-        for (const file of Array.from(files)) {
-          // Validate file size
-          if (file.size > MAX_FILE_SIZE) {
-            hasError = true
-            continue
-          }
-
-          // Validate file type
-          if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
-            hasError = true
-            continue
-          }
-
-          // Compress and prepare image
-          const compressedFile = await compressImage(file)
-          const imageWithPreview = Object.assign(compressedFile, {
-            preview: URL.createObjectURL(compressedFile),
-          }) as ImageWithPreview
-
-          newImages.push(imageWithPreview)
-        }
-
-        if (!hasError && newImages.length > 0) {
-          setImages((prev) => [...prev, ...newImages])
-        }
-      } catch (error) {
-        logger.error('Error processing images:', { error })
-      } finally {
-        setIsProcessing(false)
-
-        // Reset file input
-        if (fileInputRef.current) {
-          fileInputRef.current.value = ''
-        }
-      }
-    },
-    [compressImage]
-  )
-
-  /**
-   * Handle file input change event
-   */
-  const handleFileChange = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e.target.files) {
-        await processFiles(e.target.files)
-      }
-    },
-    [processFiles]
-  )
-
-  /**
-   * Drag and drop event handlers
-   */
-  const handleDragEnter = useCallback((e: React.DragEvent) => {
+  function handleDragEnter(e: React.DragEvent) {
     e.preventDefault()
     e.stopPropagation()
     setIsDragging(true)
-  }, [])
+  }
 
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
+  function handleDragLeave(e: React.DragEvent) {
     e.preventDefault()
     e.stopPropagation()
     setIsDragging(false)
-  }, [])
+  }
 
-  const handleDragOver = useCallback((e: React.DragEvent) => {
+  function handleDragOver(e: React.DragEvent) {
     e.preventDefault()
     e.stopPropagation()
-  }, [])
+  }
 
-  const handleDrop = useCallback(
-    async (e: React.DragEvent) => {
-      e.preventDefault()
-      e.stopPropagation()
-      setIsDragging(false)
+  async function handleDrop(e: React.DragEvent) {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragging(false)
 
-      if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-        await processFiles(e.dataTransfer.files)
-      }
-    },
-    [processFiles]
-  )
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      await processFiles(e.dataTransfer.files)
+    }
+  }
 
-  /**
-   * Remove an uploaded image and clean up its preview URL
-   */
-  const removeImage = useCallback((index: number) => {
+  function removeImage(index: number) {
     setImages((prev) => {
       URL.revokeObjectURL(prev[index].preview)
       return prev.filter((_, i) => i !== index)
     })
-  }, [])
+  }
 
-  /**
-   * Handle form submission with image attachments
-   */
-  const onSubmit = useCallback(
-    async (data: FormValues) => {
-      setIsSubmitting(true)
-      setSubmitStatus(null)
-
-      try {
-        const formData = new FormData()
-        formData.append('subject', data.subject)
-        formData.append('message', data.message)
-        formData.append('type', data.type)
-        formData.append('workspaceId', workspaceId)
-        formData.append('userAgent', navigator.userAgent)
-        if (workflowId) {
-          formData.append('workflowId', workflowId)
-        }
-
-        images.forEach((image, index) => {
-          formData.append(`image_${index}`, image)
-        })
-
-        const response = await fetch('/api/help', {
-          method: 'POST',
-          body: formData,
-        })
-
-        if (!response.ok) {
-          const errorData = await response.json()
-          throw new Error(errorData.error || 'Failed to submit help request')
-        }
-
-        setSubmitStatus('success')
-        reset()
-
-        images.forEach((image) => URL.revokeObjectURL(image.preview))
-        setImages([])
-      } catch (error) {
-        logger.error('Error submitting help request:', { error })
-        setSubmitStatus('error')
-      } finally {
-        setIsSubmitting(false)
-      }
-    },
-    [images, reset, workflowId, workspaceId]
-  )
-
-  /**
-   * Handle modal close action
-   */
-  const handleClose = useCallback(() => {
-    onOpenChange(false)
-  }, [onOpenChange])
+  function onSubmit(data: FormValues) {
+    if (helpMutation.isPending) return
+    setSubmitStatus(null)
+    helpMutation.mutate({ data, images, workflowId, workspaceId })
+  }
 
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
@@ -513,7 +391,7 @@ export function HelpModal({ open, onOpenChange, workflowId, workspaceId }: HelpM
                       {images.map((image, index) => (
                         <div
                           className='group relative overflow-hidden rounded-sm border'
-                          key={index}
+                          key={image.preview}
                         >
                           <div className='relative flex max-h-[120px] min-h-[80px] w-full items-center justify-center'>
                             <Image
@@ -543,11 +421,20 @@ export function HelpModal({ open, onOpenChange, workflowId, workspaceId }: HelpM
           </ModalBody>
 
           <ModalFooter>
-            <Button variant='default' onClick={handleClose} type='button' disabled={isSubmitting}>
+            <Button
+              variant='default'
+              onClick={() => onOpenChange(false)}
+              type='button'
+              disabled={helpMutation.isPending}
+            >
               Cancel
             </Button>
-            <Button type='submit' variant='primary' disabled={isSubmitting || isProcessing}>
-              {isSubmitting
+            <Button
+              type='submit'
+              variant='primary'
+              disabled={helpMutation.isPending || isProcessing}
+            >
+              {helpMutation.isPending
                 ? 'Submitting...'
                 : submitStatus === 'error'
                   ? 'Error'

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/help-modal/help-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/help-modal/help-modal.tsx
@@ -169,6 +169,7 @@ export function HelpModal({ open, onOpenChange, workflowId, workspaceId }: HelpM
       setSubmitStatus(null)
       setIsDragging(false)
       setIsProcessing(false)
+      helpMutation.reset()
       reset({
         subject: '',
         message: '',

--- a/apps/sim/lib/posthog/events.ts
+++ b/apps/sim/lib/posthog/events.ts
@@ -47,6 +47,10 @@ export interface PostHogEventMap {
     company_size: string
   }
 
+  landing_contact_submitted: {
+    topic: string
+  }
+
   landing_prompt_submitted: Record<string, never>
 
   login_page_viewed: Record<string, never>


### PR DESCRIPTION
## Summary
- Add `/contact` page with rate-limited form that mirrors the in-product help ticket flow (forwards to `help@`, sends confirmation email via `renderHelpConfirmationEmail`)
- Link `/contact` from the landing footer; typed `landing_contact_submitted` PostHog event
- Migrate help modal and demo-request modal from raw `fetch` + `useState` to `useMutation`
- Remove stale z-index `MutationObserver` + `setInterval(100ms)` hack from help modal — emcn `--z-popover` (300) already renders above `--z-modal` (200)
- Fix help modal's image preview URL lifecycle (no longer revokes still-visible URLs on every upload)
- Guard all three forms against double-submit while a request is in flight
- Strip ~14 unnecessary `useCallback` wrappers from the two modals

## Type of Change
- [x] New feature

## Testing
Tested manually. Typecheck and biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)