### PR TITLE
fix(landing): resolve error-page crash on invalid /models and /integrations routes

### DIFF
--- a/apps/sim/app/(landing)/integrations/[slug]/loading.tsx
+++ b/apps/sim/app/(landing)/integrations/[slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function IntegrationDetailLoading() {
+  return <div className='min-h-[60vh]' aria-hidden />
+}

--- a/apps/sim/app/(landing)/integrations/[slug]/loading.tsx
+++ b/apps/sim/app/(landing)/integrations/[slug]/loading.tsx
@@ -1,3 +1,9 @@
+import { Loader } from '@/components/emcn'
+
 export default function IntegrationDetailLoading() {
-  return <div className='min-h-[60vh]' aria-hidden />
+  return (
+    <div className='flex min-h-[60vh] items-center justify-center bg-[var(--landing-bg)]'>
+      <Loader animate className='h-6 w-6 text-[var(--landing-text-muted)]' />
+    </div>
+  )
 }

--- a/apps/sim/app/(landing)/models/[provider]/[model]/loading.tsx
+++ b/apps/sim/app/(landing)/models/[provider]/[model]/loading.tsx
@@ -1,0 +1,3 @@
+export default function ModelDetailLoading() {
+  return <div className='min-h-[60vh]' aria-hidden />
+}

--- a/apps/sim/app/(landing)/models/[provider]/[model]/loading.tsx
+++ b/apps/sim/app/(landing)/models/[provider]/[model]/loading.tsx
@@ -1,3 +1,9 @@
+import { Loader } from '@/components/emcn'
+
 export default function ModelDetailLoading() {
-  return <div className='min-h-[60vh]' aria-hidden />
+  return (
+    <div className='flex min-h-[60vh] items-center justify-center bg-[var(--landing-bg)]'>
+      <Loader animate className='h-6 w-6 text-[var(--landing-text-muted)]' />
+    </div>
+  )
 }

--- a/apps/sim/app/(landing)/models/[provider]/loading.tsx
+++ b/apps/sim/app/(landing)/models/[provider]/loading.tsx
@@ -1,0 +1,3 @@
+export default function ModelProviderLoading() {
+  return <div className='min-h-[60vh]' aria-hidden />
+}

--- a/apps/sim/app/(landing)/models/[provider]/loading.tsx
+++ b/apps/sim/app/(landing)/models/[provider]/loading.tsx
@@ -1,3 +1,9 @@
+import { Loader } from '@/components/emcn'
+
 export default function ModelProviderLoading() {
-  return <div className='min-h-[60vh]' aria-hidden />
+  return (
+    <div className='flex min-h-[60vh] items-center justify-center bg-[var(--landing-bg)]'>
+      <Loader animate className='h-6 w-6 text-[var(--landing-text-muted)]' />
+    </div>
+  )
 }

--- a/apps/sim/app/layout.tsx
+++ b/apps/sim/app/layout.tsx
@@ -239,7 +239,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </>
         )}
 
-        <PublicEnvScript />
+        <PublicEnvScript disableNextScript />
       </head>
       <body className={`${season.variable} font-season`} suppressHydrationWarning>
         {/* Google Tag Manager (noscript) — hosted only */}

--- a/apps/sim/app/layout.tsx
+++ b/apps/sim/app/layout.tsx
@@ -239,7 +239,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </>
         )}
 
-        <PublicEnvScript disableNextScript />
+        <PublicEnvScript />
       </head>
       <body className={`${season.variable} font-season`} suppressHydrationWarning>
         {/* Google Tag Manager (noscript) — hosted only */}

--- a/apps/sim/lib/auth/auth-client.ts
+++ b/apps/sim/lib/auth/auth-client.ts
@@ -15,8 +15,26 @@ import { isBillingEnabled, isOrganizationsEnabled } from '@/lib/core/config/feat
 import { getBaseUrl } from '@/lib/core/utils/urls'
 import { SessionContext, type SessionHookResult } from '@/app/_shell/providers/session-provider'
 
+/**
+ * On Next.js error-page renders (`<html id="__next_error__">`), scripts from the
+ * root layout — including the runtime env script that populates `window.__ENV`
+ * — are inserted but not executed by React (see vercel/next.js#63980, #82456).
+ * Calling `getBaseUrl()` here at module evaluation would then throw and cascade
+ * the error-page render into a blank "Application error" overlay. On the
+ * client, auth endpoints are same-origin, so `window.location.origin` is a
+ * correct fallback; server-side we still surface a genuine misconfig.
+ */
+function getAuthBaseUrl(): string {
+  try {
+    return getBaseUrl()
+  } catch (e) {
+    if (typeof window !== 'undefined') return window.location.origin
+    throw e
+  }
+}
+
 export const client = createAuthClient({
-  baseURL: getBaseUrl(),
+  baseURL: getAuthBaseUrl(),
   plugins: [
     adminClient(),
     emailOTPClient(),

--- a/apps/sim/lib/auth/auth-client.ts
+++ b/apps/sim/lib/auth/auth-client.ts
@@ -15,15 +15,6 @@ import { isBillingEnabled, isOrganizationsEnabled } from '@/lib/core/config/feat
 import { getBaseUrl } from '@/lib/core/utils/urls'
 import { SessionContext, type SessionHookResult } from '@/app/_shell/providers/session-provider'
 
-/**
- * On Next.js error-page renders (`<html id="__next_error__">`), scripts from the
- * root layout — including the runtime env script that populates `window.__ENV`
- * — are inserted but not executed by React (see vercel/next.js#63980, #82456).
- * Calling `getBaseUrl()` here at module evaluation would then throw and cascade
- * the error-page render into a blank "Application error" overlay. On the
- * client, auth endpoints are same-origin, so `window.location.origin` is a
- * correct fallback; server-side we still surface a genuine misconfig.
- */
 function getAuthBaseUrl(): string {
   try {
     return getBaseUrl()


### PR DESCRIPTION
## Summary
- Invalid URLs under `/models/*` and `/integrations/*` were rendering "Application error: a client-side exception has occurred" instead of the styled 404.
- Root cause is a React/Next.js interaction: React skips SSR on server errors and re-renders on the client ([React 18 RFC](https://github.com/reactjs/rfcs/blob/ba9bd5744cb922184ec9390515910cd104a30c6e/text/0215-server-errors-in-react-18.md), [vercel/next.js#63980](https://github.com/vercel/next.js/issues/63980), [#82456](https://github.com/vercel/next.js/issues/82456)). Root-layout scripts — including the runtime env script that populates `window.__ENV` — get inserted into the DOM but are not executed on that client re-render. Any client module that reads env at module evaluation (`lib/auth/auth-client.ts` → `getBaseUrl()`) throws and cascades the render into the error overlay.

## Changes
1. **`lib/auth/auth-client.ts`** — fall back to `window.location.origin` when `getBaseUrl()` throws on the client. Auth endpoints are same-origin, so this is the correct baseURL on the client. Server-side still throws on genuine misconfig, so webhooks/callbacks continue to surface misconfiguration loudly.
2. **Three `loading.tsx` files** at `/models/[provider]`, `/models/[provider]/[model]`, and `/integrations/[slug]` — establishes a Suspense boundary below the root layout so a page-level `notFound()` stops invalidating the layout's SSR output. This is the fix endorsed by Next.js maintainer `lubieowoce` in #63980.

## Type of Change
- [x] Bug fix

## Testing
Tested manually — invalid `/models/*` and `/integrations/*` URLs now render the styled 404 without the client-side exception overlay. Valid pages unchanged.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)