### PR TITLE
seo(robots): disallow tag-filtered blog URLs

### DIFF
--- a/apps/sim/app/robots.ts
+++ b/apps/sim/app/robots.ts
@@ -22,6 +22,7 @@ export default function robots(): MetadataRoute.Robots {
           '/credential-account/',
           '/_next/',
           '/private/',
+          '/blog*tag=',
         ],
       },
     ],


### PR DESCRIPTION
## Summary
Adds `Disallow: /blog*tag=` to the generated robots.txt to prevent crawlers from indexing tag-filtered blog views (both `/blog?tag=X` and paginated `/blog?page=N&tag=X`). Per SEO team request to reduce duplicate content surfaced from tag filters.

## Type of Change
- [x] Other: SEO / robots.txt

## Testing
Visit `/robots.txt` after deploy and confirm the new `Disallow: /blog*tag=` line is present.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)