### PR TITLE
fix(aws): add validateAwsRegion to all AWS route schemas to prevent SSRF

### DIFF
--- a/apps/sim/app/api/tools/cloudwatch/describe-alarms/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/describe-alarms/route.ts
@@ -9,12 +9,19 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 
 const logger = createLogger('CloudWatchDescribeAlarms')
 
 const DescribeAlarmsSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   alarmNamePrefix: z.string().optional(),

--- a/apps/sim/app/api/tools/cloudwatch/describe-alarms/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/describe-alarms/route.ts
@@ -18,10 +18,9 @@ const DescribeAlarmsSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   alarmNamePrefix: z.string().optional(),

--- a/apps/sim/app/api/tools/cloudwatch/describe-log-groups/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/describe-log-groups/route.ts
@@ -14,10 +14,9 @@ const DescribeLogGroupsSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   prefix: z.string().optional(),

--- a/apps/sim/app/api/tools/cloudwatch/describe-log-groups/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/describe-log-groups/route.ts
@@ -4,13 +4,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createCloudWatchLogsClient } from '@/app/api/tools/cloudwatch/utils'
 
 const logger = createLogger('CloudWatchDescribeLogGroups')
 
 const DescribeLogGroupsSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   prefix: z.string().optional(),

--- a/apps/sim/app/api/tools/cloudwatch/describe-log-streams/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/describe-log-streams/route.ts
@@ -13,10 +13,9 @@ const DescribeLogStreamsSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   logGroupName: z.string().min(1, 'Log group name is required'),

--- a/apps/sim/app/api/tools/cloudwatch/describe-log-streams/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/describe-log-streams/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createCloudWatchLogsClient, describeLogStreams } from '@/app/api/tools/cloudwatch/utils'
 
 const logger = createLogger('CloudWatchDescribeLogStreams')
 
 const DescribeLogStreamsSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   logGroupName: z.string().min(1, 'Log group name is required'),

--- a/apps/sim/app/api/tools/cloudwatch/get-log-events/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/get-log-events/route.ts
@@ -13,10 +13,9 @@ const GetLogEventsSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   logGroupName: z.string().min(1, 'Log group name is required'),

--- a/apps/sim/app/api/tools/cloudwatch/get-log-events/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/get-log-events/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createCloudWatchLogsClient, getLogEvents } from '@/app/api/tools/cloudwatch/utils'
 
 const logger = createLogger('CloudWatchGetLogEvents')
 
 const GetLogEventsSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   logGroupName: z.string().min(1, 'Log group name is required'),

--- a/apps/sim/app/api/tools/cloudwatch/get-metric-statistics/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/get-metric-statistics/route.ts
@@ -4,12 +4,19 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 
 const logger = createLogger('CloudWatchGetMetricStatistics')
 
 const GetMetricStatisticsSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   namespace: z.string().min(1, 'Namespace is required'),

--- a/apps/sim/app/api/tools/cloudwatch/get-metric-statistics/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/get-metric-statistics/route.ts
@@ -13,10 +13,9 @@ const GetMetricStatisticsSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   namespace: z.string().min(1, 'Namespace is required'),

--- a/apps/sim/app/api/tools/cloudwatch/list-metrics/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/list-metrics/route.ts
@@ -4,12 +4,19 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 
 const logger = createLogger('CloudWatchListMetrics')
 
 const ListMetricsSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   namespace: z.string().optional(),

--- a/apps/sim/app/api/tools/cloudwatch/list-metrics/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/list-metrics/route.ts
@@ -13,10 +13,9 @@ const ListMetricsSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   namespace: z.string().optional(),

--- a/apps/sim/app/api/tools/cloudwatch/put-metric-data/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/put-metric-data/route.ts
@@ -8,6 +8,7 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 
 const logger = createLogger('CloudWatchPutMetricData')
@@ -43,7 +44,13 @@ const VALID_UNITS = [
 ] as const
 
 const PutMetricDataSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   namespace: z.string().min(1, 'Namespace is required'),

--- a/apps/sim/app/api/tools/cloudwatch/put-metric-data/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/put-metric-data/route.ts
@@ -47,10 +47,9 @@ const PutMetricDataSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   namespace: z.string().min(1, 'Namespace is required'),

--- a/apps/sim/app/api/tools/cloudwatch/query-logs/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/query-logs/route.ts
@@ -14,10 +14,9 @@ const QueryLogsSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   logGroupNames: z.array(z.string().min(1)).min(1, 'At least one log group name is required'),

--- a/apps/sim/app/api/tools/cloudwatch/query-logs/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/query-logs/route.ts
@@ -4,13 +4,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createCloudWatchLogsClient, pollQueryResults } from '@/app/api/tools/cloudwatch/utils'
 
 const logger = createLogger('CloudWatchQueryLogs')
 
 const QueryLogsSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   logGroupNames: z.array(z.string().min(1)).min(1, 'At least one log group name is required'),

--- a/apps/sim/app/api/tools/dynamodb/delete/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/delete/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createDynamoDBClient, deleteItem } from '@/app/api/tools/dynamodb/utils'
 
 const logger = createLogger('DynamoDBDeleteAPI')
 
 const DeleteSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/delete/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/delete/route.ts
@@ -13,10 +13,9 @@ const DeleteSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/get/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/get/route.ts
@@ -13,10 +13,9 @@ const GetSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/get/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/get/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createDynamoDBClient, getItem } from '@/app/api/tools/dynamodb/utils'
 
 const logger = createLogger('DynamoDBGetAPI')
 
 const GetSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/introspect/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/introspect/route.ts
@@ -13,10 +13,9 @@ const IntrospectSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().optional(),

--- a/apps/sim/app/api/tools/dynamodb/introspect/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/introspect/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createRawDynamoDBClient, describeTable, listTables } from '@/app/api/tools/dynamodb/utils'
 
 const logger = createLogger('DynamoDBIntrospectAPI')
 
 const IntrospectSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().optional(),

--- a/apps/sim/app/api/tools/dynamodb/put/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/put/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createDynamoDBClient, putItem } from '@/app/api/tools/dynamodb/utils'
 
 const logger = createLogger('DynamoDBPutAPI')
 
 const PutSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/put/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/put/route.ts
@@ -13,10 +13,9 @@ const PutSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/query/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/query/route.ts
@@ -13,10 +13,9 @@ const QuerySchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/query/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/query/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createDynamoDBClient, queryItems } from '@/app/api/tools/dynamodb/utils'
 
 const logger = createLogger('DynamoDBQueryAPI')
 
 const QuerySchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/scan/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/scan/route.ts
@@ -13,10 +13,9 @@ const ScanSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/scan/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/scan/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createDynamoDBClient, scanItems } from '@/app/api/tools/dynamodb/utils'
 
 const logger = createLogger('DynamoDBScanAPI')
 
 const ScanSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/update/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/update/route.ts
@@ -13,10 +13,9 @@ const UpdateSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/dynamodb/update/route.ts
+++ b/apps/sim/app/api/tools/dynamodb/update/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createDynamoDBClient, updateItem } from '@/app/api/tools/dynamodb/utils'
 
 const logger = createLogger('DynamoDBUpdateAPI')
 
 const UpdateSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   tableName: z.string().min(1, 'Table name is required'),

--- a/apps/sim/app/api/tools/iam/add-user-to-group/route.ts
+++ b/apps/sim/app/api/tools/iam/add-user-to-group/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/add-user-to-group/route.ts
+++ b/apps/sim/app/api/tools/iam/add-user-to-group/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { addUserToGroup, createIAMClient } from '../utils'
 
 const logger = createLogger('IAMAddUserToGroupAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/attach-role-policy/route.ts
+++ b/apps/sim/app/api/tools/iam/attach-role-policy/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { attachRolePolicy, createIAMClient } from '../utils'
 
 const logger = createLogger('IAMAttachRolePolicyAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/attach-role-policy/route.ts
+++ b/apps/sim/app/api/tools/iam/attach-role-policy/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/attach-user-policy/route.ts
+++ b/apps/sim/app/api/tools/iam/attach-user-policy/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { attachUserPolicy, createIAMClient } from '../utils'
 
 const logger = createLogger('IAMAttachUserPolicyAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/attach-user-policy/route.ts
+++ b/apps/sim/app/api/tools/iam/attach-user-policy/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/create-access-key/route.ts
+++ b/apps/sim/app/api/tools/iam/create-access-key/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createAccessKey, createIAMClient } from '../utils'
 
 const logger = createLogger('IAMCreateAccessKeyAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().optional().nullable(),

--- a/apps/sim/app/api/tools/iam/create-access-key/route.ts
+++ b/apps/sim/app/api/tools/iam/create-access-key/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().optional().nullable(),

--- a/apps/sim/app/api/tools/iam/create-role/route.ts
+++ b/apps/sim/app/api/tools/iam/create-role/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, createRole } from '../utils'
 
 const logger = createLogger('IAMCreateRoleAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/create-role/route.ts
+++ b/apps/sim/app/api/tools/iam/create-role/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/create-user/route.ts
+++ b/apps/sim/app/api/tools/iam/create-user/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/create-user/route.ts
+++ b/apps/sim/app/api/tools/iam/create-user/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, createUser } from '../utils'
 
 const logger = createLogger('IAMCreateUserAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/delete-access-key/route.ts
+++ b/apps/sim/app/api/tools/iam/delete-access-key/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   accessKeyIdToDelete: z.string().min(1, 'Access key ID to delete is required'),

--- a/apps/sim/app/api/tools/iam/delete-access-key/route.ts
+++ b/apps/sim/app/api/tools/iam/delete-access-key/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, deleteAccessKey } from '../utils'
 
 const logger = createLogger('IAMDeleteAccessKeyAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   accessKeyIdToDelete: z.string().min(1, 'Access key ID to delete is required'),

--- a/apps/sim/app/api/tools/iam/delete-role/route.ts
+++ b/apps/sim/app/api/tools/iam/delete-role/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, deleteRole } from '../utils'
 
 const logger = createLogger('IAMDeleteRoleAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/delete-role/route.ts
+++ b/apps/sim/app/api/tools/iam/delete-role/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/delete-user/route.ts
+++ b/apps/sim/app/api/tools/iam/delete-user/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, deleteUser } from '../utils'
 
 const logger = createLogger('IAMDeleteUserAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/delete-user/route.ts
+++ b/apps/sim/app/api/tools/iam/delete-user/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/detach-role-policy/route.ts
+++ b/apps/sim/app/api/tools/iam/detach-role-policy/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/detach-role-policy/route.ts
+++ b/apps/sim/app/api/tools/iam/detach-role-policy/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, detachRolePolicy } from '../utils'
 
 const logger = createLogger('IAMDetachRolePolicyAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/detach-user-policy/route.ts
+++ b/apps/sim/app/api/tools/iam/detach-user-policy/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, detachUserPolicy } from '../utils'
 
 const logger = createLogger('IAMDetachUserPolicyAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/detach-user-policy/route.ts
+++ b/apps/sim/app/api/tools/iam/detach-user-policy/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/get-role/route.ts
+++ b/apps/sim/app/api/tools/iam/get-role/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/get-role/route.ts
+++ b/apps/sim/app/api/tools/iam/get-role/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, getRole } from '../utils'
 
 const logger = createLogger('IAMGetRoleAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/get-user/route.ts
+++ b/apps/sim/app/api/tools/iam/get-user/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, getUser } from '../utils'
 
 const logger = createLogger('IAMGetUserAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1).optional().nullable(),

--- a/apps/sim/app/api/tools/iam/get-user/route.ts
+++ b/apps/sim/app/api/tools/iam/get-user/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1).optional().nullable(),

--- a/apps/sim/app/api/tools/iam/list-attached-role-policies/route.ts
+++ b/apps/sim/app/api/tools/iam/list-attached-role-policies/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/list-attached-role-policies/route.ts
+++ b/apps/sim/app/api/tools/iam/list-attached-role-policies/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, listAttachedRolePolicies } from '../utils'
 
 const logger = createLogger('IAMListAttachedRolePoliciesAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleName: z.string().min(1, 'Role name is required'),

--- a/apps/sim/app/api/tools/iam/list-attached-user-policies/route.ts
+++ b/apps/sim/app/api/tools/iam/list-attached-user-policies/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/list-attached-user-policies/route.ts
+++ b/apps/sim/app/api/tools/iam/list-attached-user-policies/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, listAttachedUserPolicies } from '../utils'
 
 const logger = createLogger('IAMListAttachedUserPoliciesAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/list-groups/route.ts
+++ b/apps/sim/app/api/tools/iam/list-groups/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   pathPrefix: z.string().optional().nullable(),

--- a/apps/sim/app/api/tools/iam/list-groups/route.ts
+++ b/apps/sim/app/api/tools/iam/list-groups/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, listGroups } from '../utils'
 
 const logger = createLogger('IAMListGroupsAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   pathPrefix: z.string().optional().nullable(),

--- a/apps/sim/app/api/tools/iam/list-policies/route.ts
+++ b/apps/sim/app/api/tools/iam/list-policies/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   scope: z.string().optional().nullable(),

--- a/apps/sim/app/api/tools/iam/list-policies/route.ts
+++ b/apps/sim/app/api/tools/iam/list-policies/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, listPolicies } from '../utils'
 
 const logger = createLogger('IAMListPoliciesAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   scope: z.string().optional().nullable(),

--- a/apps/sim/app/api/tools/iam/list-roles/route.ts
+++ b/apps/sim/app/api/tools/iam/list-roles/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, listRoles } from '../utils'
 
 const logger = createLogger('IAMListRolesAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   pathPrefix: z.string().optional().nullable(),

--- a/apps/sim/app/api/tools/iam/list-roles/route.ts
+++ b/apps/sim/app/api/tools/iam/list-roles/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   pathPrefix: z.string().optional().nullable(),

--- a/apps/sim/app/api/tools/iam/list-users/route.ts
+++ b/apps/sim/app/api/tools/iam/list-users/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   pathPrefix: z.string().optional().nullable(),

--- a/apps/sim/app/api/tools/iam/list-users/route.ts
+++ b/apps/sim/app/api/tools/iam/list-users/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, listUsers } from '../utils'
 
 const logger = createLogger('IAMListUsersAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   pathPrefix: z.string().optional().nullable(),

--- a/apps/sim/app/api/tools/iam/remove-user-from-group/route.ts
+++ b/apps/sim/app/api/tools/iam/remove-user-from-group/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/remove-user-from-group/route.ts
+++ b/apps/sim/app/api/tools/iam/remove-user-from-group/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, removeUserFromGroup } from '../utils'
 
 const logger = createLogger('IAMRemoveUserFromGroupAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   userName: z.string().min(1, 'User name is required'),

--- a/apps/sim/app/api/tools/iam/simulate-principal-policy/route.ts
+++ b/apps/sim/app/api/tools/iam/simulate-principal-policy/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   policySourceArn: z.string().min(1, 'Policy source ARN is required'),

--- a/apps/sim/app/api/tools/iam/simulate-principal-policy/route.ts
+++ b/apps/sim/app/api/tools/iam/simulate-principal-policy/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIAMClient, simulatePrincipalPolicy } from '../utils'
 
 const logger = createLogger('IAMSimulatePrincipalPolicyAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   policySourceArn: z.string().min(1, 'Policy source ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/check-assignment-deletion-status/route.ts
+++ b/apps/sim/app/api/tools/identity-center/check-assignment-deletion-status/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { checkAssignmentDeletionStatus, createSSOAdminClient } from '../utils'
 
 const logger = createLogger('IdentityCenterCheckAssignmentDeletionStatusAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/check-assignment-deletion-status/route.ts
+++ b/apps/sim/app/api/tools/identity-center/check-assignment-deletion-status/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/check-assignment-status/route.ts
+++ b/apps/sim/app/api/tools/identity-center/check-assignment-status/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { checkAssignmentCreationStatus, createSSOAdminClient } from '../utils'
 
 const logger = createLogger('IdentityCenterCheckAssignmentStatusAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/check-assignment-status/route.ts
+++ b/apps/sim/app/api/tools/identity-center/check-assignment-status/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/create-account-assignment/route.ts
+++ b/apps/sim/app/api/tools/identity-center/create-account-assignment/route.ts
@@ -8,13 +8,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSSOAdminClient, mapAssignmentStatus } from '../utils'
 
 const logger = createLogger('IdentityCenterCreateAccountAssignmentAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/create-account-assignment/route.ts
+++ b/apps/sim/app/api/tools/identity-center/create-account-assignment/route.ts
@@ -18,10 +18,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/delete-account-assignment/route.ts
+++ b/apps/sim/app/api/tools/identity-center/delete-account-assignment/route.ts
@@ -8,13 +8,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSSOAdminClient, mapAssignmentStatus } from '../utils'
 
 const logger = createLogger('IdentityCenterDeleteAccountAssignmentAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/delete-account-assignment/route.ts
+++ b/apps/sim/app/api/tools/identity-center/delete-account-assignment/route.ts
@@ -18,10 +18,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/describe-account/route.ts
+++ b/apps/sim/app/api/tools/identity-center/describe-account/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   accountId: z.string().min(12, 'Account ID must be 12 digits').max(12),

--- a/apps/sim/app/api/tools/identity-center/describe-account/route.ts
+++ b/apps/sim/app/api/tools/identity-center/describe-account/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createOrganizationsClient, describeAccount } from '../utils'
 
 const logger = createLogger('IdentityCenterDescribeAccountAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   accountId: z.string().min(12, 'Account ID must be 12 digits').max(12),

--- a/apps/sim/app/api/tools/identity-center/get-group/route.ts
+++ b/apps/sim/app/api/tools/identity-center/get-group/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   identityStoreId: z.string().min(1, 'Identity Store ID is required'),

--- a/apps/sim/app/api/tools/identity-center/get-group/route.ts
+++ b/apps/sim/app/api/tools/identity-center/get-group/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIdentityStoreClient, getGroupByDisplayName } from '../utils'
 
 const logger = createLogger('IdentityCenterGetGroupAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   identityStoreId: z.string().min(1, 'Identity Store ID is required'),

--- a/apps/sim/app/api/tools/identity-center/get-user/route.ts
+++ b/apps/sim/app/api/tools/identity-center/get-user/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   identityStoreId: z.string().min(1, 'Identity Store ID is required'),

--- a/apps/sim/app/api/tools/identity-center/get-user/route.ts
+++ b/apps/sim/app/api/tools/identity-center/get-user/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIdentityStoreClient, getUserByEmail } from '../utils'
 
 const logger = createLogger('IdentityCenterGetUserAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   identityStoreId: z.string().min(1, 'Identity Store ID is required'),

--- a/apps/sim/app/api/tools/identity-center/list-account-assignments/route.ts
+++ b/apps/sim/app/api/tools/identity-center/list-account-assignments/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSSOAdminClient, listAccountAssignmentsForPrincipal } from '../utils'
 
 const logger = createLogger('IdentityCenterListAccountAssignmentsAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/list-account-assignments/route.ts
+++ b/apps/sim/app/api/tools/identity-center/list-account-assignments/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/list-accounts/route.ts
+++ b/apps/sim/app/api/tools/identity-center/list-accounts/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createOrganizationsClient, listAccounts } from '../utils'
 
 const logger = createLogger('IdentityCenterListAccountsAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   maxResults: z.number().min(1).max(20).optional(),

--- a/apps/sim/app/api/tools/identity-center/list-accounts/route.ts
+++ b/apps/sim/app/api/tools/identity-center/list-accounts/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   maxResults: z.number().min(1).max(20).optional(),

--- a/apps/sim/app/api/tools/identity-center/list-groups/route.ts
+++ b/apps/sim/app/api/tools/identity-center/list-groups/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   identityStoreId: z.string().min(1, 'Identity Store ID is required'),

--- a/apps/sim/app/api/tools/identity-center/list-groups/route.ts
+++ b/apps/sim/app/api/tools/identity-center/list-groups/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createIdentityStoreClient, listGroups } from '../utils'
 
 const logger = createLogger('IdentityCenterListGroupsAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   identityStoreId: z.string().min(1, 'Identity Store ID is required'),

--- a/apps/sim/app/api/tools/identity-center/list-instances/route.ts
+++ b/apps/sim/app/api/tools/identity-center/list-instances/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSSOAdminClient, listInstances } from '../utils'
 
 const logger = createLogger('IdentityCenterListInstancesAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   maxResults: z.number().min(1).max(100).optional(),

--- a/apps/sim/app/api/tools/identity-center/list-instances/route.ts
+++ b/apps/sim/app/api/tools/identity-center/list-instances/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   maxResults: z.number().min(1).max(100).optional(),

--- a/apps/sim/app/api/tools/identity-center/list-permission-sets/route.ts
+++ b/apps/sim/app/api/tools/identity-center/list-permission-sets/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSSOAdminClient, listPermissionSets } from '../utils'
 
 const logger = createLogger('IdentityCenterListPermissionSetsAPI')
 
 const Schema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/identity-center/list-permission-sets/route.ts
+++ b/apps/sim/app/api/tools/identity-center/list-permission-sets/route.ts
@@ -13,10 +13,9 @@ const Schema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   instanceArn: z.string().min(1, 'Instance ARN is required'),

--- a/apps/sim/app/api/tools/ses/create-template/route.ts
+++ b/apps/sim/app/api/tools/ses/create-template/route.ts
@@ -14,10 +14,9 @@ const CreateTemplateSchema = z
     region: z
       .string()
       .min(1, 'AWS region is required')
-      .refine(
-        (v) => validateAwsRegion(v).isValid,
-        (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-      ),
+      .refine((v) => validateAwsRegion(v).isValid, {
+        message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+      }),
     accessKeyId: z.string().min(1, 'AWS access key ID is required'),
     secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
     templateName: z.string().min(1, 'Template name is required'),

--- a/apps/sim/app/api/tools/ses/create-template/route.ts
+++ b/apps/sim/app/api/tools/ses/create-template/route.ts
@@ -3,6 +3,7 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSESClient, createTemplate } from '../utils'
 
@@ -10,7 +11,13 @@ const logger = createLogger('SESCreateTemplateAPI')
 
 const CreateTemplateSchema = z
   .object({
-    region: z.string().min(1, 'AWS region is required'),
+    region: z
+      .string()
+      .min(1, 'AWS region is required')
+      .refine(
+        (v) => validateAwsRegion(v).isValid,
+        (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+      ),
     accessKeyId: z.string().min(1, 'AWS access key ID is required'),
     secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
     templateName: z.string().min(1, 'Template name is required'),

--- a/apps/sim/app/api/tools/ses/delete-template/route.ts
+++ b/apps/sim/app/api/tools/ses/delete-template/route.ts
@@ -13,10 +13,9 @@ const DeleteTemplateSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   templateName: z.string().min(1, 'Template name is required'),

--- a/apps/sim/app/api/tools/ses/delete-template/route.ts
+++ b/apps/sim/app/api/tools/ses/delete-template/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSESClient, deleteTemplate } from '../utils'
 
 const logger = createLogger('SESDeleteTemplateAPI')
 
 const DeleteTemplateSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   templateName: z.string().min(1, 'Template name is required'),

--- a/apps/sim/app/api/tools/ses/get-account/route.ts
+++ b/apps/sim/app/api/tools/ses/get-account/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSESClient, getAccount } from '../utils'
 
 const logger = createLogger('SESGetAccountAPI')
 
 const GetAccountSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
 })

--- a/apps/sim/app/api/tools/ses/get-account/route.ts
+++ b/apps/sim/app/api/tools/ses/get-account/route.ts
@@ -13,10 +13,9 @@ const GetAccountSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
 })

--- a/apps/sim/app/api/tools/ses/get-template/route.ts
+++ b/apps/sim/app/api/tools/ses/get-template/route.ts
@@ -13,10 +13,9 @@ const GetTemplateSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   templateName: z.string().min(1, 'Template name is required'),

--- a/apps/sim/app/api/tools/ses/get-template/route.ts
+++ b/apps/sim/app/api/tools/ses/get-template/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSESClient, getTemplate } from '../utils'
 
 const logger = createLogger('SESGetTemplateAPI')
 
 const GetTemplateSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   templateName: z.string().min(1, 'Template name is required'),

--- a/apps/sim/app/api/tools/ses/list-identities/route.ts
+++ b/apps/sim/app/api/tools/ses/list-identities/route.ts
@@ -13,10 +13,9 @@ const ListIdentitiesSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   pageSize: z.number().int().min(0).max(1000).nullish(),

--- a/apps/sim/app/api/tools/ses/list-identities/route.ts
+++ b/apps/sim/app/api/tools/ses/list-identities/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSESClient, listIdentities } from '../utils'
 
 const logger = createLogger('SESListIdentitiesAPI')
 
 const ListIdentitiesSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   pageSize: z.number().int().min(0).max(1000).nullish(),

--- a/apps/sim/app/api/tools/ses/list-templates/route.ts
+++ b/apps/sim/app/api/tools/ses/list-templates/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSESClient, listTemplates } from '../utils'
 
 const logger = createLogger('SESListTemplatesAPI')
 
 const ListTemplatesSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   pageSize: z.number().int().min(1).max(100).nullish(),

--- a/apps/sim/app/api/tools/ses/list-templates/route.ts
+++ b/apps/sim/app/api/tools/ses/list-templates/route.ts
@@ -13,10 +13,9 @@ const ListTemplatesSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   pageSize: z.number().int().min(1).max(100).nullish(),

--- a/apps/sim/app/api/tools/ses/send-bulk-email/route.ts
+++ b/apps/sim/app/api/tools/ses/send-bulk-email/route.ts
@@ -18,10 +18,9 @@ const SendBulkEmailSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   fromAddress: z.string().email('Valid sender email address is required'),

--- a/apps/sim/app/api/tools/ses/send-bulk-email/route.ts
+++ b/apps/sim/app/api/tools/ses/send-bulk-email/route.ts
@@ -3,6 +3,7 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSESClient, sendBulkEmail } from '../utils'
 
@@ -14,7 +15,13 @@ const DestinationSchema = z.object({
 })
 
 const SendBulkEmailSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   fromAddress: z.string().email('Valid sender email address is required'),

--- a/apps/sim/app/api/tools/ses/send-email/route.ts
+++ b/apps/sim/app/api/tools/ses/send-email/route.ts
@@ -3,6 +3,7 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSESClient, sendEmail } from '../utils'
 
@@ -10,7 +11,13 @@ const logger = createLogger('SESSendEmailAPI')
 
 const SendEmailSchema = z
   .object({
-    region: z.string().min(1, 'AWS region is required'),
+    region: z
+      .string()
+      .min(1, 'AWS region is required')
+      .refine(
+        (v) => validateAwsRegion(v).isValid,
+        (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+      ),
     accessKeyId: z.string().min(1, 'AWS access key ID is required'),
     secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
     fromAddress: z.string().email('Valid sender email address is required'),

--- a/apps/sim/app/api/tools/ses/send-email/route.ts
+++ b/apps/sim/app/api/tools/ses/send-email/route.ts
@@ -14,10 +14,9 @@ const SendEmailSchema = z
     region: z
       .string()
       .min(1, 'AWS region is required')
-      .refine(
-        (v) => validateAwsRegion(v).isValid,
-        (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-      ),
+      .refine((v) => validateAwsRegion(v).isValid, {
+        message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+      }),
     accessKeyId: z.string().min(1, 'AWS access key ID is required'),
     secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
     fromAddress: z.string().email('Valid sender email address is required'),

--- a/apps/sim/app/api/tools/ses/send-templated-email/route.ts
+++ b/apps/sim/app/api/tools/ses/send-templated-email/route.ts
@@ -13,10 +13,9 @@ const SendTemplatedEmailSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   fromAddress: z.string().email('Valid sender email address is required'),

--- a/apps/sim/app/api/tools/ses/send-templated-email/route.ts
+++ b/apps/sim/app/api/tools/ses/send-templated-email/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSESClient, sendTemplatedEmail } from '../utils'
 
 const logger = createLogger('SESSendTemplatedEmailAPI')
 
 const SendTemplatedEmailSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   fromAddress: z.string().email('Valid sender email address is required'),

--- a/apps/sim/app/api/tools/sts/assume-role/route.ts
+++ b/apps/sim/app/api/tools/sts/assume-role/route.ts
@@ -13,10 +13,9 @@ const AssumeRoleSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleArn: z.string().min(1, 'Role ARN is required'),

--- a/apps/sim/app/api/tools/sts/assume-role/route.ts
+++ b/apps/sim/app/api/tools/sts/assume-role/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { assumeRole, createSTSClient } from '../utils'
 
 const logger = createLogger('STSAssumeRoleAPI')
 
 const AssumeRoleSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   roleArn: z.string().min(1, 'Role ARN is required'),

--- a/apps/sim/app/api/tools/sts/get-access-key-info/route.ts
+++ b/apps/sim/app/api/tools/sts/get-access-key-info/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSTSClient, getAccessKeyInfo } from '../utils'
 
 const logger = createLogger('STSGetAccessKeyInfoAPI')
 
 const GetAccessKeyInfoSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   targetAccessKeyId: z.string().min(1, 'Target access key ID is required'),

--- a/apps/sim/app/api/tools/sts/get-access-key-info/route.ts
+++ b/apps/sim/app/api/tools/sts/get-access-key-info/route.ts
@@ -13,10 +13,9 @@ const GetAccessKeyInfoSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   targetAccessKeyId: z.string().min(1, 'Target access key ID is required'),

--- a/apps/sim/app/api/tools/sts/get-caller-identity/route.ts
+++ b/apps/sim/app/api/tools/sts/get-caller-identity/route.ts
@@ -13,10 +13,9 @@ const GetCallerIdentitySchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
 })

--- a/apps/sim/app/api/tools/sts/get-caller-identity/route.ts
+++ b/apps/sim/app/api/tools/sts/get-caller-identity/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSTSClient, getCallerIdentity } from '../utils'
 
 const logger = createLogger('STSGetCallerIdentityAPI')
 
 const GetCallerIdentitySchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
 })

--- a/apps/sim/app/api/tools/sts/get-session-token/route.ts
+++ b/apps/sim/app/api/tools/sts/get-session-token/route.ts
@@ -13,10 +13,9 @@ const GetSessionTokenSchema = z.object({
   region: z
     .string()
     .min(1, 'AWS region is required')
-    .refine(
-      (v) => validateAwsRegion(v).isValid,
-      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
-    ),
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   durationSeconds: z.number().int().min(900).max(129600).nullish(),

--- a/apps/sim/app/api/tools/sts/get-session-token/route.ts
+++ b/apps/sim/app/api/tools/sts/get-session-token/route.ts
@@ -3,13 +3,20 @@ import { toError } from '@sim/utils/errors'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { createSTSClient, getSessionToken } from '../utils'
 
 const logger = createLogger('STSGetSessionTokenAPI')
 
 const GetSessionTokenSchema = z.object({
-  region: z.string().min(1, 'AWS region is required'),
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine(
+      (v) => validateAwsRegion(v).isValid,
+      (v) => validateAwsRegion(v).error ?? 'Invalid AWS region'
+    ),
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   durationSeconds: z.number().int().min(900).max(129600).nullish(),

--- a/apps/sim/lib/core/security/input-validation.test.ts
+++ b/apps/sim/lib/core/security/input-validation.test.ts
@@ -1311,8 +1311,27 @@ describe('validateAwsRegion', () => {
       expect(result.isValid).toBe(true)
     })
 
+    it.concurrent('should accept us-iso-west-1', () => {
+      const result = validateAwsRegion('us-iso-west-1')
+      expect(result.isValid).toBe(true)
+    })
+
     it.concurrent('should accept us-isob-east-1', () => {
       const result = validateAwsRegion('us-isob-east-1')
+      expect(result.isValid).toBe(true)
+    })
+  })
+
+  describe('valid Mexico regions', () => {
+    it.concurrent('should accept mx-central-1', () => {
+      const result = validateAwsRegion('mx-central-1')
+      expect(result.isValid).toBe(true)
+    })
+  })
+
+  describe('valid EU Sovereign Cloud regions', () => {
+    it.concurrent('should accept eu-isoe-west-1', () => {
+      const result = validateAwsRegion('eu-isoe-west-1')
       expect(result.isValid).toBe(true)
     })
   })

--- a/apps/sim/lib/core/security/input-validation.ts
+++ b/apps/sim/lib/core/security/input-validation.ts
@@ -885,7 +885,7 @@ export function validateAwsRegion(
   }
 
   const awsRegionPattern =
-    /^(af|ap|ca|cn|eu|eu-isoe|il|me|mx|sa|us|us-gov|us-iso|us-isob)-(central|north|northeast|northwest|south|southeast|southwest|east|west)-\d{1,2}$/
+    /^(eu-isoe|us-isob|us-iso|us-gov|af|ap|ca|cn|eu|il|me|mx|sa|us)-(central|north|northeast|northwest|south|southeast|southwest|east|west)-\d{1,2}$/
 
   if (!awsRegionPattern.test(value)) {
     logger.warn('Invalid AWS region format', {

--- a/apps/sim/lib/core/security/input-validation.ts
+++ b/apps/sim/lib/core/security/input-validation.ts
@@ -857,7 +857,9 @@ export function validateAirtableId(
  * - GovCloud: us-gov-east-1, us-gov-west-1
  * - China: cn-north-1, cn-northwest-1
  * - Israel: il-central-1
- * - ISO partitions: us-iso-east-1, us-isob-east-1
+ * - ISO partitions: us-iso-east-1, us-iso-west-1, us-isob-east-1
+ * - Mexico: mx-central-1
+ * - EU Sovereign Cloud: eu-isoe-west-1
  *
  * @param value - The AWS region to validate
  * @param paramName - Name of the parameter for error messages
@@ -883,7 +885,7 @@ export function validateAwsRegion(
   }
 
   const awsRegionPattern =
-    /^(af|ap|ca|cn|eu|il|me|sa|us|us-gov|us-iso|us-isob)-(central|north|northeast|northwest|south|southeast|southwest|east|west)-\d{1,2}$/
+    /^(af|ap|ca|cn|eu|eu-isoe|il|me|mx|sa|us|us-gov|us-iso|us-isob)-(central|north|northeast|northwest|south|southeast|southwest|east|west)-\d{1,2}$/
 
   if (!awsRegionPattern.test(value)) {
     logger.warn('Invalid AWS region format', {


### PR DESCRIPTION
## Summary
- Added \`validateAwsRegion\` from the existing input-validation module to all 61 AWS route Zod schemas (IAM, Identity Center, STS, CloudWatch, DynamoDB, SES) — the \`region\` field was previously accepted as a bare string and passed directly to the AWS SDK for endpoint URL construction, which is an SSRF vector
- Fixed the \`validateAwsRegion\` regex to cover two missing regions: \`mx-central-1\` (Mexico, launched Nov 2024) and \`eu-isoe-west-1\` (EU Sovereign Cloud) — all 41 known AWS regions now pass, all injection strings are blocked
- Added test cases for the two new prefixes plus \`us-iso-west-1\`

## Type of Change
- [x] Bug fix

## Testing
- 366 tests passing in \`input-validation.test.ts\`
- Verified all 41 known AWS regions pass the regex
- Verified attack strings (\`us-east-1.evil.com\`, \`us-east-1@attacker.com\`, \`169.254.169.254\`, path traversal, null bytes) are all blocked

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)