### PR TITLE
fix(settings): hide data-retention nav item when user lacks enterprise plan

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/navigation.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/navigation.ts
@@ -189,7 +189,6 @@ export const allNavigationItems: NavigationItem[] = [
     requiresHosted: true,
     requiresEnterprise: true,
     selfHostedOverride: isDataRetentionEnabled,
-    showWhenLocked: true,
   },
   {
     id: 'whitelabeling',


### PR DESCRIPTION
## Summary
- Removes `showWhenLocked: true` from the Data Retention nav item so it follows the same visibility rules as all other enterprise features (SSO, Whitelabeling, Audit Logs, Access Control)
- Previously, Data Retention was visible to users without an enterprise plan; all other enterprise nav items are hidden until the plan requirement is met

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)