### PR TITLE
improvement(copilot): replace crypto.randomUUID() with generateId() per project rule

### DIFF
--- a/apps/sim/lib/copilot/chat/persisted-message.ts
+++ b/apps/sim/lib/copilot/chat/persisted-message.ts
@@ -1,3 +1,4 @@
+import { generateId } from '@sim/utils/id'
 import {
   MothershipStreamV1CompletionStatus,
   MothershipStreamV1EventType,
@@ -191,7 +192,7 @@ export function buildPersistedAssistantMessage(
   requestId?: string
 ): PersistedMessage {
   const message: PersistedMessage = {
-    id: crypto.randomUUID(),
+    id: generateId(),
     role: 'assistant',
     content: result.content,
     timestamp: new Date().toISOString(),
@@ -488,7 +489,7 @@ function normalizeBlocks(rawBlocks: RawBlock[], messageContent: string): Persist
 
 export function normalizeMessage(raw: Record<string, unknown>): PersistedMessage {
   const msg: PersistedMessage = {
-    id: (raw.id as string) ?? crypto.randomUUID(),
+    id: (raw.id as string) ?? generateId(),
     role: (raw.role as 'user' | 'assistant') ?? 'assistant',
     content: (raw.content as string) ?? '',
     timestamp: (raw.timestamp as string) ?? new Date().toISOString(),

--- a/apps/sim/lib/copilot/chat/post.ts
+++ b/apps/sim/lib/copilot/chat/post.ts
@@ -2,6 +2,7 @@ import { type Context as OtelContext, context as otelContextApi } from '@opentel
 import { db } from '@sim/db'
 import { copilotChats } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
+import { generateId } from '@sim/utils/id'
 import { eq, sql } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
@@ -615,8 +616,8 @@ export async function handleUnifiedChatPost(req: NextRequest) {
   // trace ID) as soon as startCopilotOtelRoot runs. Empty only in the
   // narrow pre-otelRoot window where errors don't correlate anyway.
   let requestId = ''
-  const executionId = crypto.randomUUID()
-  const runId = crypto.randomUUID()
+  const executionId = generateId()
+  const runId = generateId()
 
   try {
     const session = await getSession()
@@ -628,7 +629,7 @@ export async function handleUnifiedChatPost(req: NextRequest) {
 
     const body = ChatMessageSchema.parse(await req.json())
     const normalizedContexts = normalizeContexts(body.contexts) ?? []
-    userMessageId = body.userMessageId || crypto.randomUUID()
+    userMessageId = body.userMessageId || generateId()
 
     otelRoot = startCopilotOtelRoot({
       streamId: userMessageId,

--- a/apps/sim/lib/copilot/request/tools/tables.ts
+++ b/apps/sim/lib/copilot/request/tools/tables.ts
@@ -2,6 +2,7 @@ import { db } from '@sim/db'
 import { userTableRows } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
+import { generateId } from '@sim/utils/id'
 import { parse as csvParse } from 'csv-parse/sync'
 import { eq } from 'drizzle-orm'
 import { FunctionExecute, Read as ReadTool } from '@/lib/copilot/generated/tool-catalog-v1'
@@ -107,7 +108,7 @@ export async function maybeWriteOutputToTable(
             }
             const chunk = rows.slice(i, i + BATCH_CHUNK_SIZE)
             const values = chunk.map((rowData, j) => ({
-              id: `row_${crypto.randomUUID().replace(/-/g, '')}`,
+              id: `row_${generateId().replace(/-/g, '')}`,
               tableId: outputTable,
               workspaceId: context.workspaceId!,
               data: rowData,
@@ -251,7 +252,7 @@ export async function maybeWriteReadCsvToTable(
             }
             const chunk = rows.slice(i, i + BATCH_CHUNK_SIZE)
             const values = chunk.map((rowData, j) => ({
-              id: `row_${crypto.randomUUID().replace(/-/g, '')}`,
+              id: `row_${generateId().replace(/-/g, '')}`,
               tableId: outputTable,
               workspaceId: context.workspaceId!,
               data: rowData,

--- a/apps/sim/lib/copilot/tools/handlers/oauth.ts
+++ b/apps/sim/lib/copilot/tools/handlers/oauth.ts
@@ -1,6 +1,7 @@
 import { db } from '@sim/db'
 import { pendingCredentialDraft, user } from '@sim/db/schema'
 import { toError } from '@sim/utils/errors'
+import { generateId } from '@sim/utils/id'
 import { and, eq, lt } from 'drizzle-orm'
 import type { ExecutionContext, ToolCallResult } from '@/lib/copilot/request/types'
 import { getBaseUrl } from '@/lib/core/utils/urls'
@@ -140,7 +141,7 @@ export async function generateOAuthLink(
   await db
     .insert(pendingCredentialDraft)
     .values({
-      id: crypto.randomUUID(),
+      id: generateId(),
       userId,
       workspaceId,
       providerId,


### PR DESCRIPTION
## Problem

`AGENTS.md` / `CLAUDE.md` forbid `crypto.randomUUID()`:

> **ID Generation**: Never use `crypto.randomUUID()`, `nanoid`, or `uuid` package. Use `generateId()` (UUID v4) or `generateShortId()` (compact) from `@sim/utils/id`

`generateId` exists for a reason: `crypto.randomUUID()` is unavailable on non-secure (plain HTTP) browser contexts — the root cause of #3393, where self-hosted Sim served over `http://192.168.x.x:3000` white-screens with `TypeError: crypto.randomUUID is not a function`. PR #3397 polyfilled the client, but four copilot server-side files still call `crypto.randomUUID()` directly, in violation of the project rule.

```
apps/sim/lib/copilot/chat/persisted-message.ts   (2 sites)
apps/sim/lib/copilot/chat/post.ts                (3 sites: executionId, runId, userMessageId)
apps/sim/lib/copilot/request/tools/tables.ts     (2 sites: row_ ID prefix)
apps/sim/lib/copilot/tools/handlers/oauth.ts     (1 site: pendingCredentialDraft.id)
```

## Fix

Replace every `crypto.randomUUID()` call in `apps/sim/lib/copilot/**` with `generateId()` imported from `@sim/utils/id`. `generateId` is a drop-in: it returns a lowercase RFC 4122 UUID v4 string, using `crypto.randomUUID` when available and falling back to `crypto.getRandomValues` otherwise. In `tables.ts` the `.replace(/-/g, '')` suffix is preserved so row-ID shape (`row_<32-hex>`) is unchanged.

Server-side Node 22 always has `randomUUID`, so behavior is identical today — this is about obeying the project's own hard rule and not leaving the copilot subtree as a footgun if any of these call paths ever reach a non-secure-context runtime (e.g. future edge-runtime migration, Workers, Deno, or an imported shared module).

## Why small

PRs #3485 and #3574 tried to sweep the whole repo (100 / 42 files, new parallel `generateId` utilities); both stalled. This PR is four files, uses the canonical `@sim/utils/id` that already ships, and touches only the copilot subtree that was missed in the earlier cleanup. No new utilities, no behavior change.

## Verification

Run from repo root:

- `bun run lint:check` — ✅ clean (6594 sim files checked)
- `bun run format:check` — ✅ clean
- `bun run turbo run type-check --filter=sim` — ✅ clean
- `cd apps/sim && bunx vitest run lib/copilot` — ✅ 40 files / 218 tests pass

Refs #3393.