### PR TITLE
fix(socket): stop infinite reconnection on Invalid namespace error

### DIFF
--- a/apps/sim/app/workspace/providers/socket-provider.tsx
+++ b/apps/sim/app/workspace/providers/socket-provider.tsx
@@ -409,9 +409,22 @@ export function SocketProvider({ children, user }: SocketProviderProps) {
             error.message?.includes('Authentication failed') ||
             error.message?.includes('Authentication required')
 
+          // Check if this is a permanent configuration error — retrying won't help
+          const isNamespaceError = error.message?.includes('Invalid namespace')
+
           if (isAuthError) {
             logger.warn(
               'Authentication failed - stopping reconnection attempts. User may need to refresh/re-login.'
+            )
+            socketInstance.disconnect()
+            setSocket(null)
+            setAuthFailed(true)
+            setIsReconnecting(false)
+            initializedRef.current = false
+          } else if (isNamespaceError) {
+            logger.warn(
+              'Invalid namespace error - stopping reconnection attempts. Check NEXT_PUBLIC_SOCKET_URL configuration.',
+              { message: error.message }
             )
             socketInstance.disconnect()
             setSocket(null)


### PR DESCRIPTION
## Summary

- Detect  Socket.IO errors as permanent failures, not transient ones
- Stop infinite reconnection loop when the server rejects the namespace connection
- Log a diagnostic hint pointing to  as the likely cause

## Problem

When the Socket.IO server responds with an  error (e.g. because `NEXT_PUBLIC_SOCKET_URL` points to the wrong host or the client has cached code that references a removed namespace), the `connect_error` handler did not recognise this as a permanent error. It fell through to the `else if (socketInstance.active)` branch, set `isReconnecting = true`, and let Socket.IO (configured with `reconnectionAttempts: Infinity`) retry forever.

The result was an endless **"Reconnecting..."** notification in the UI with no way to recover short of a hard page reload.

## Fix

Added an `isNamespaceError` check alongside the existing `isAuthError` check. When the error message contains `'Invalid namespace'`, the handler now:
1. Disconnects the socket
2. Clears socket state
3. Sets `authFailed = true` to prevent the initialization `useEffect` from re-running
4. Logs a warning pointing to `NEXT_PUBLIC_SOCKET_URL` misconfiguration

This mirrors the existing auth-failure handling and stops the reconnection loop.

## Type of Change
- [x] Bug fix

## Testing
Manually verified that the `connect_error` handler correctly branches to the new path when the error message is `'Invalid namespace'`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

Fixes #2704