### PR TITLE
fix(db): revert statement_timeout startup options breaking pooled connections

### DIFF
--- a/apps/realtime/src/database/operations.ts
+++ b/apps/realtime/src/database/operations.ts
@@ -23,10 +23,6 @@ import { env } from '@/env'
 const logger = createLogger('SocketDatabase')
 
 const connectionString = env.DATABASE_URL
-/**
- * Server-side safety net for runaway queries and abandoned transactions.
- * See `packages/db/index.ts` for rationale.
- */
 const socketDb = drizzle(
   postgres(connectionString, {
     prepare: false,
@@ -34,9 +30,6 @@ const socketDb = drizzle(
     connect_timeout: 20,
     max: 30,
     onnotice: () => {},
-    connection: {
-      options: '-c statement_timeout=90000 -c idle_in_transaction_session_timeout=90000',
-    },
   }),
   { schema }
 )

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -10,27 +10,12 @@ if (!connectionString) {
   throw new Error('Missing DATABASE_URL environment variable')
 }
 
-/**
- * Server-side safety net for runaway queries and abandoned transactions:
- * - `statement_timeout=90000` kills any single statement still running
- *   after 90s. Protects against pathological queries.
- * - `idle_in_transaction_session_timeout=90000` kills a session that has
- *   opened a transaction and gone idle for 90s. Protects against
- *   transactions that hold row locks while waiting on external I/O.
- *
- * These are last-resort caps — application code should never approach
- * them. Migrations or admin scripts that legitimately need longer limits
- * must construct their own client with overrides.
- */
 const postgresClient = postgres(connectionString, {
   prepare: false,
   idle_timeout: 20,
   connect_timeout: 30,
   max: 30,
   onnotice: () => {},
-  connection: {
-    options: '-c statement_timeout=90000 -c idle_in_transaction_session_timeout=90000',
-  },
 })
 
 export const db = drizzle(postgresClient, { schema })


### PR DESCRIPTION
## Summary
- Reverts #4276 — `connection.options` startup params are incompatible with the PlanetScale/PgBouncer pooler (prod already runs `prepare: false`), killing every new DB connection
- Caused sign-in/social 500s, socket-token 500s, workspace UI stuck loading, and widespread "Failed query" errors in prod after v0.6.56 rolled out
- Will re-land as `SET LOCAL statement_timeout` per-transaction (or via pooler-compatible URL param) in a follow-up

## Type of Change
- [x] Bug fix

## Testing
Tested manually — verified DB client opens without the broken startup options

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)