### PR TITLE
chore(bun): bump bun to 1.3.13

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.11-alpine
+FROM oven/bun:1.3.13-alpine
 
 # Install necessary packages for development
 RUN apk add --no-cache \

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.13
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.13
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4
@@ -122,7 +122,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.13
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.13
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.13
 
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.13
 
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@v4

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.13
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Debian-based Bun with Node.js 22
 # ========================================
-FROM oven/bun:1.3.11-slim AS base
+FROM oven/bun:1.3.13-slim AS base
 
 # Install Node.js 22 and common dependencies once in base stage
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/docker/db.Dockerfile
+++ b/docker/db.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Alpine Linux with Bun
 # ========================================
-FROM oven/bun:1.3.11-alpine AS base
+FROM oven/bun:1.3.13-alpine AS base
 
 # ========================================
 # Dependencies Stage: Install Dependencies

--- a/docker/realtime.Dockerfile
+++ b/docker/realtime.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Alpine Linux with Bun
 # ========================================
-FROM oven/bun:1.3.11-alpine AS base
+FROM oven/bun:1.3.13-alpine AS base
 
 RUN apk add --no-cache libc6-compat curl
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simstudio",
-  "packageManager": "bun@1.3.11",
+  "packageManager": "bun@1.3.13",
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- bumped bun from 1.3.11 to 1.3.13 across Dockerfiles, GitHub Actions, and `packageManager` pin
- verified no usage of breaking APIs introduced in 1.3.12 (URLPattern, RegExp.lastMatch, Unix domain socket lifecycle)
- left `engines.bun >=1.2.13` floors as-is — still the honest minimum

## Type of Change
- [x] Chore

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)