### PR TITLE
fix(table-block): resolve canonical tableId in filter/sort builders

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/filter-builder/filter-builder.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/filter-builder/filter-builder.tsx
@@ -6,6 +6,7 @@ import type { ComboboxOption } from '@/components/emcn'
 import { useTableColumns } from '@/lib/table/hooks'
 import type { FilterRule } from '@/lib/table/query-builder/constants'
 import { useFilterBuilder } from '@/lib/table/query-builder/use-query-builder'
+import { useCanonicalSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-canonical-sub-block-value'
 import { useSubBlockInput } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-sub-block-input'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-sub-block-value'
 import { FilterRuleRow } from './components/filter-rule-row'
@@ -40,7 +41,7 @@ export function FilterBuilder({
   tableIdSubBlockId = 'tableId',
 }: FilterBuilderProps) {
   const [storeValue, setStoreValue] = useSubBlockValue<FilterRule[]>(blockId, subBlockId)
-  const [tableIdValue] = useSubBlockValue<string>(blockId, tableIdSubBlockId)
+  const tableIdValue = useCanonicalSubBlockValue<string>(blockId, tableIdSubBlockId)
 
   const dynamicColumns = useTableColumns({ tableId: tableIdValue })
   const columns = useMemo(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/sort-builder/sort-builder.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/sort-builder/sort-builder.tsx
@@ -5,6 +5,7 @@ import { generateId } from '@sim/utils/id'
 import type { ComboboxOption } from '@/components/emcn'
 import { useTableColumns } from '@/lib/table/hooks'
 import { SORT_DIRECTIONS, type SortRule } from '@/lib/table/query-builder/constants'
+import { useCanonicalSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-canonical-sub-block-value'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-sub-block-value'
 import { SortRuleRow } from './components/sort-rule-row'
 
@@ -36,7 +37,7 @@ export function SortBuilder({
   tableIdSubBlockId = 'tableId',
 }: SortBuilderProps) {
   const [storeValue, setStoreValue] = useSubBlockValue<SortRule[]>(blockId, subBlockId)
-  const [tableIdValue] = useSubBlockValue<string>(blockId, tableIdSubBlockId)
+  const tableIdValue = useCanonicalSubBlockValue<string>(blockId, tableIdSubBlockId)
 
   const dynamicColumns = useTableColumns({ tableId: tableIdValue, includeBuiltIn: true })
   const columns = useMemo(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-canonical-sub-block-value.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-canonical-sub-block-value.ts
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from 'react'
+import { isEqual } from 'es-toolkit'
+import { useStoreWithEqualityFn } from 'zustand/traditional'
+import { buildCanonicalIndex, resolveDependencyValue } from '@/lib/workflows/subblocks/visibility'
+import { getBlock } from '@/blocks/registry'
+import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
+import { useSubBlockStore } from '@/stores/workflows/subblock/store'
+import { useWorkflowStore } from '@/stores/workflows/workflow/store'
+
+/**
+ * Read a sub-block value by either its raw subBlockId or its canonicalParamId.
+ *
+ * `useSubBlockValue` only looks up the raw subBlockId. For fields that use
+ * `canonicalParamId` to unify basic/advanced inputs (e.g. `tableSelector` vs
+ * `manualTableId` both mapping to `tableId`), this hook resolves to whichever
+ * member of the canonical group currently holds the value.
+ */
+export function useCanonicalSubBlockValue<T = unknown>(
+  blockId: string,
+  canonicalOrSubBlockId: string
+): T | null {
+  const activeWorkflowId = useWorkflowRegistry((s) => s.activeWorkflowId)
+  const blockState = useWorkflowStore((state) => state.blocks[blockId])
+  const blockConfig = blockState?.type ? getBlock(blockState.type) : null
+  const canonicalIndex = useMemo(
+    () => buildCanonicalIndex(blockConfig?.subBlocks || []),
+    [blockConfig?.subBlocks]
+  )
+  const canonicalModeOverrides = blockState?.data?.canonicalModes
+
+  return useStoreWithEqualityFn(
+    useSubBlockStore,
+    useCallback(
+      (state) => {
+        if (!activeWorkflowId) return null
+        const blockValues = state.workflowValues[activeWorkflowId]?.[blockId] || {}
+        const resolved = resolveDependencyValue(
+          canonicalOrSubBlockId,
+          blockValues,
+          canonicalIndex,
+          canonicalModeOverrides
+        )
+        return (resolved ?? null) as T | null
+      },
+      [activeWorkflowId, blockId, canonicalOrSubBlockId, canonicalIndex, canonicalModeOverrides]
+    ),
+    (a, b) => isEqual(a, b)
+  )
+}


### PR DESCRIPTION
## Summary
- Filter/sort builders in the Table block were always showing "no options available" in the column picker
- They read the selected tableId from subBlock id `'tableId'`, but the Table block stores the value under `'tableSelector'` (basic) or `'manualTableId'` (advanced) via `canonicalParamId` — the lookup always returned null, so `useTable` stayed disabled and columns never loaded
- Added `useCanonicalSubBlockValue` which resolves a value by canonicalParamId through the canonical index (same pattern dropdowns use for `dependsOn`), and swapped it into `FilterBuilder` and `SortBuilder`

## Type of Change
- [x] Bug fix

## Testing
Tested manually — columns now populate in the Query Rows filter/sort builders and the Update/Delete by filter builder when a table is selected in either basic or advanced mode.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)