### PR TITLE
fix(mothership): parallel subagent rendering, exec stream re-attach

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
@@ -359,17 +359,17 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
         }
       } else {
         // Unparented end blocks come from legacy/partial persisted streams
-        // that predate parentToolCallId. Only collapse a lane this way when
-        // we have no parented groups, so we don't force-close legitimate
-        // parallel lanes mid-render.
-        const hasParentedGroup = [...groupsByKey.keys()].some((key) => !key.endsWith(':legacy'))
-        if (!hasParentedGroup) {
-          for (const g of groupsByKey.values()) {
-            if (g.agentName !== 'mothership') {
-              g.isOpen = false
-              g.isDelegating = false
-            }
+        // that predate parentToolCallId. Close lanes that are themselves
+        // legacy-keyed without touching parented lanes — this avoids
+        // force-closing legitimate parallel parented lanes while still
+        // releasing stranded legacy lanes in mixed/migration streams.
+        for (const [key, g] of groupsByKey) {
+          if (key.endsWith(':legacy') && g.agentName !== 'mothership') {
+            g.isOpen = false
+            g.isDelegating = false
           }
+        }
+        if (activeGroupKey?.endsWith(':legacy')) {
           activeGroupKey = null
         }
       }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
@@ -206,6 +206,15 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
   }
 
   const flushLanes = () => {
+    // Finalize state on the already-pushed segments before we drop them from
+    // the map. Without this, a thinking/main text/options/stopped block landing
+    // between a subagent's start and its end strands the lane with stale
+    // isOpen/isDelegating flags — the later subagent_end iterates groupsByKey
+    // and can't find it to close.
+    for (const g of groupsByKey.values()) {
+      g.isOpen = false
+      g.isDelegating = false
+    }
     groupsByKey.clear()
     activeGroupKey = null
   }
@@ -337,17 +346,24 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
             g.isDelegating = false
           }
         }
-      }
-      if (block.parentToolCallId && activeGroupKey?.endsWith(`:${block.parentToolCallId}`)) {
-        activeGroupKey = null
-      } else if (!block.parentToolCallId) {
-        for (const g of groupsByKey.values()) {
-          if (g.agentName !== 'mothership') {
-            g.isOpen = false
-            g.isDelegating = false
-          }
+        if (activeGroupKey?.endsWith(`:${block.parentToolCallId}`)) {
+          activeGroupKey = null
         }
-        activeGroupKey = null
+      } else {
+        // Unparented end blocks come from legacy/partial persisted streams
+        // that predate parentToolCallId. Only collapse a lane this way when
+        // we have no parented groups, so we don't force-close legitimate
+        // parallel lanes mid-render.
+        const hasParentedGroup = [...groupsByKey.keys()].some((key) => !key.endsWith(':legacy'))
+        if (!hasParentedGroup) {
+          for (const g of groupsByKey.values()) {
+            if (g.agentName !== 'mothership') {
+              g.isOpen = false
+              g.isDelegating = false
+            }
+          }
+          activeGroupKey = null
+        }
       }
       continue
     }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
@@ -295,6 +295,10 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
           }
         }
       }
+      // Subagent lanes break the mothership lane: any mothership tool that
+      // arrives after this subagent finishes should render below the lane,
+      // not get back-filled into the mothership group sitting above it.
+      groupsByKey.delete(groupKey('mothership', undefined))
       const g = ensureGroup(key, block.parentToolCallId)
       if (inheritedDelegation) g.isDelegating = true
       g.isOpen = block.endedAt === undefined
@@ -310,6 +314,7 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
       const isDispatch = SUBAGENT_KEYS.has(tc.name) && !tc.calledBy
 
       if (isDispatch) {
+        groupsByKey.delete(groupKey('mothership', undefined))
         const g = ensureGroup(tc.name, tc.id)
         g.isDelegating = isDelegatingTool(tc)
         g.isOpen = g.isDelegating

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
@@ -179,7 +179,10 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
     if (!g) {
       g = {
         type: 'agent_group',
-        id: `agent-${key}`,
+        // Suffix with segments.length so a later flushLanes / explicit delete
+        // followed by re-ensure for the same key produces a fresh React key
+        // instead of colliding with the stranded prior segment.
+        id: `agent-${key}-${segments.length}`,
         agentName: name,
         agentLabel: resolveAgentLabel(name),
         items: [],

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
@@ -182,9 +182,6 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
     if (existing) return { group: existing, created: false }
     const group: AgentGroupSegment = {
       type: 'agent_group',
-      // Suffix with segments.length so a later flushLanes / explicit delete
-      // followed by re-ensure for the same key produces a fresh React key
-      // instead of colliding with the stranded prior segment.
       id: `agent-${key}-${segments.length}`,
       agentName: name,
       agentLabel: resolveAgentLabel(name),
@@ -211,11 +208,6 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
   }
 
   const flushLanes = () => {
-    // Finalize state on the already-pushed segments before we drop them from
-    // the map. Without this, a thinking/main text/options/stopped block landing
-    // between a subagent's start and its end strands the lane with stale
-    // isOpen/isDelegating flags — the later subagent_end iterates groupsByKey
-    // and can't find it to close.
     for (const g of groupsByKey.values()) {
       g.isOpen = false
       g.isDelegating = false
@@ -300,13 +292,10 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
           }
         }
       }
-      // Subagent lanes break the mothership lane: any mothership tool that
-      // arrives after this subagent finishes should render below the lane,
-      // not get back-filled into the mothership group sitting above it.
       groupsByKey.delete(groupKey('mothership', undefined))
       const { group: g } = ensureGroup(key, block.parentToolCallId)
       if (inheritedDelegation) g.isDelegating = true
-      g.isOpen = block.endedAt === undefined
+      g.isOpen = true
       activeGroupKey = resolveGroupKey(key, block.parentToolCallId)
       continue
     }
@@ -331,9 +320,6 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
       if (tc.calledBy) {
         const { group: g, created } = ensureGroup(tc.calledBy, block.parentToolCallId)
         g.isDelegating = false
-        // Only mark the lane open when we just created it. Late tool_calls
-        // arriving after a subagent_end (out-of-order persistence, replay,
-        // partial state hand-off) must NOT reopen a closed lane.
         if (created && block.parentToolCallId) g.isOpen = true
         g.items.push({ type: 'tool', data: tool })
         activeGroupKey = resolveGroupKey(tc.calledBy, block.parentToolCallId)
@@ -363,11 +349,6 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
           activeGroupKey = null
         }
       } else {
-        // Unparented end blocks come from legacy/partial persisted streams
-        // that predate parentToolCallId. Close lanes that are themselves
-        // legacy-keyed without touching parented lanes — this avoids
-        // force-closing legitimate parallel parented lanes while still
-        // releasing stranded legacy lanes in mixed/migration streams.
         for (const [key, g] of groupsByKey) {
           if (key.endsWith(':legacy') && g.agentName !== 'mothership') {
             g.isOpen = false

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
@@ -199,6 +199,7 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
       for (const [key, g] of groupsByKey) {
         if (key.endsWith(`:${parentToolCallId}`)) return g
       }
+      return undefined
     }
     if (activeGroupKey) return groupsByKey.get(activeGroupKey)
     return undefined

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
@@ -173,26 +173,28 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
     return groupKey(name, undefined)
   }
 
-  const ensureGroup = (name: string, parentToolCallId: string | undefined): AgentGroupSegment => {
+  const ensureGroup = (
+    name: string,
+    parentToolCallId: string | undefined
+  ): { group: AgentGroupSegment; created: boolean } => {
     const key = resolveGroupKey(name, parentToolCallId)
-    let g = groupsByKey.get(key)
-    if (!g) {
-      g = {
-        type: 'agent_group',
-        // Suffix with segments.length so a later flushLanes / explicit delete
-        // followed by re-ensure for the same key produces a fresh React key
-        // instead of colliding with the stranded prior segment.
-        id: `agent-${key}-${segments.length}`,
-        agentName: name,
-        agentLabel: resolveAgentLabel(name),
-        items: [],
-        isDelegating: false,
-        isOpen: false,
-      }
-      segments.push(g)
-      groupsByKey.set(key, g)
+    const existing = groupsByKey.get(key)
+    if (existing) return { group: existing, created: false }
+    const group: AgentGroupSegment = {
+      type: 'agent_group',
+      // Suffix with segments.length so a later flushLanes / explicit delete
+      // followed by re-ensure for the same key produces a fresh React key
+      // instead of colliding with the stranded prior segment.
+      id: `agent-${key}-${segments.length}`,
+      agentName: name,
+      agentLabel: resolveAgentLabel(name),
+      items: [],
+      isDelegating: false,
+      isOpen: false,
     }
-    return g
+    segments.push(group)
+    groupsByKey.set(key, group)
+    return { group, created: true }
   }
 
   const findGroupForSubagentChunk = (
@@ -302,7 +304,7 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
       // arrives after this subagent finishes should render below the lane,
       // not get back-filled into the mothership group sitting above it.
       groupsByKey.delete(groupKey('mothership', undefined))
-      const g = ensureGroup(key, block.parentToolCallId)
+      const { group: g } = ensureGroup(key, block.parentToolCallId)
       if (inheritedDelegation) g.isDelegating = true
       g.isOpen = block.endedAt === undefined
       activeGroupKey = resolveGroupKey(key, block.parentToolCallId)
@@ -318,7 +320,7 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
 
       if (isDispatch) {
         groupsByKey.delete(groupKey('mothership', undefined))
-        const g = ensureGroup(tc.name, tc.id)
+        const { group: g } = ensureGroup(tc.name, tc.id)
         g.isDelegating = isDelegatingTool(tc)
         g.isOpen = g.isDelegating
         continue
@@ -327,13 +329,16 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
       const tool = toToolData(tc)
 
       if (tc.calledBy) {
-        const g = ensureGroup(tc.calledBy, block.parentToolCallId)
+        const { group: g, created } = ensureGroup(tc.calledBy, block.parentToolCallId)
         g.isDelegating = false
-        if (block.parentToolCallId) g.isOpen = true
+        // Only mark the lane open when we just created it. Late tool_calls
+        // arriving after a subagent_end (out-of-order persistence, replay,
+        // partial state hand-off) must NOT reopen a closed lane.
+        if (created && block.parentToolCallId) g.isOpen = true
         g.items.push({ type: 'tool', data: tool })
         activeGroupKey = resolveGroupKey(tc.calledBy, block.parentToolCallId)
       } else {
-        const g = ensureGroup('mothership', undefined)
+        const { group: g } = ensureGroup('mothership', undefined)
         g.items.push({ type: 'tool', data: tool })
       }
       continue

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
@@ -156,44 +156,79 @@ function toToolData(tc: NonNullable<ContentBlock['toolCall']>): ToolCallData {
  */
 function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
   const segments: MessageSegment[] = []
-  let group: AgentGroupSegment | null = null
-  const pushGroup = (nextGroup: AgentGroupSegment, isOpen = false) => {
-    segments.push({ ...nextGroup, isOpen })
+  const groupsByKey = new Map<string, AgentGroupSegment>()
+  let activeGroupKey: string | null = null
+
+  const groupKey = (name: string, parentToolCallId: string | undefined) =>
+    parentToolCallId ? `${name}:${parentToolCallId}` : `${name}:legacy`
+
+  const resolveGroupKey = (name: string, parentToolCallId: string | undefined) => {
+    if (parentToolCallId) return groupKey(name, parentToolCallId)
+    if (activeGroupKey && groupsByKey.get(activeGroupKey)?.agentName === name) {
+      return activeGroupKey
+    }
+    for (const [key, g] of groupsByKey) {
+      if (g.agentName === name && g.isOpen) return key
+    }
+    return groupKey(name, undefined)
   }
 
-  const lastSubagentBlockIndex = new Map<string, number>()
-  for (let i = 0; i < blocks.length; i++) {
-    const block = blocks[i]
-    if (block.type === 'subagent' && block.content) {
-      lastSubagentBlockIndex.set(block.content, i)
+  const ensureGroup = (name: string, parentToolCallId: string | undefined): AgentGroupSegment => {
+    const key = resolveGroupKey(name, parentToolCallId)
+    let g = groupsByKey.get(key)
+    if (!g) {
+      g = {
+        type: 'agent_group',
+        id: `agent-${key}`,
+        agentName: name,
+        agentLabel: resolveAgentLabel(name),
+        items: [],
+        isDelegating: false,
+        isOpen: false,
+      }
+      segments.push(g)
+      groupsByKey.set(key, g)
     }
+    return g
   }
-  const hasSubagentBlockAfter = (name: string, index: number): boolean => {
-    const last = lastSubagentBlockIndex.get(name)
-    return last !== undefined && last > index
+
+  const findGroupForSubagentChunk = (
+    parentToolCallId: string | undefined
+  ): AgentGroupSegment | undefined => {
+    if (parentToolCallId) {
+      for (const [key, g] of groupsByKey) {
+        if (key.endsWith(`:${parentToolCallId}`)) return g
+      }
+    }
+    if (activeGroupKey) return groupsByKey.get(activeGroupKey)
+    return undefined
+  }
+
+  const flushLanes = () => {
+    groupsByKey.clear()
+    activeGroupKey = null
   }
 
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i]
 
     if (block.type === 'subagent_text' || block.type === 'subagent_thinking') {
-      if (!block.content || !group) continue
-      group.isDelegating = false
-      const lastItem = group.items[group.items.length - 1]
+      if (!block.content) continue
+      const g = findGroupForSubagentChunk(block.parentToolCallId)
+      if (!g) continue
+      g.isDelegating = false
+      const lastItem = g.items[g.items.length - 1]
       if (lastItem?.type === 'text') {
         lastItem.content += block.content
       } else {
-        group.items.push({ type: 'text', content: block.content })
+        g.items.push({ type: 'text', content: block.content })
       }
       continue
     }
 
     if (block.type === 'thinking') {
       if (!block.content?.trim()) continue
-      if (group) {
-        pushGroup(group)
-        group = null
-      }
+      flushLanes()
       const last = segments[segments.length - 1]
       if (last?.type === 'thinking' && last.endedAt === undefined) {
         last.content += block.content
@@ -213,21 +248,19 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
     if (block.type === 'text') {
       if (!block.content) continue
       if (block.subagent) {
-        if (group && group.agentName === block.subagent) {
-          group.isDelegating = false
-          const lastItem = group.items[group.items.length - 1]
+        const g = groupsByKey.get(resolveGroupKey(block.subagent, block.parentToolCallId))
+        if (g) {
+          g.isDelegating = false
+          const lastItem = g.items[g.items.length - 1]
           if (lastItem?.type === 'text') {
             lastItem.content += block.content
           } else {
-            group.items.push({ type: 'text', content: block.content })
+            g.items.push({ type: 'text', content: block.content })
           }
           continue
         }
       }
-      if (group) {
-        pushGroup(group)
-        group = null
-      }
+      flushLanes()
       const last = segments[segments.length - 1]
       if (last?.type === 'text') {
         last.content += block.content
@@ -240,34 +273,22 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
     if (block.type === 'subagent') {
       if (!block.content) continue
       const key = block.content
-      if (group && group.agentName === key) continue
-
-      const dispatchToolName = SUBAGENT_DISPATCH_TOOLS[key]
       let inheritedDelegation = false
-      if (group && dispatchToolName) {
-        const last: AgentGroupItem | undefined = group.items[group.items.length - 1]
-        if (last?.type === 'tool' && last.data.toolName === dispatchToolName) {
-          inheritedDelegation = !isToolDone(last.data.status) && Boolean(last.data.streamingArgs)
-          group.items.pop()
+      const dispatchToolName = SUBAGENT_DISPATCH_TOOLS[key]
+      if (dispatchToolName) {
+        const mship = groupsByKey.get(groupKey('mothership', undefined))
+        if (mship) {
+          const last = mship.items[mship.items.length - 1]
+          if (last?.type === 'tool' && last.data.toolName === dispatchToolName) {
+            inheritedDelegation = !isToolDone(last.data.status) && Boolean(last.data.streamingArgs)
+            mship.items.pop()
+          }
         }
-        if (group.items.length > 0) {
-          pushGroup(group)
-        }
-        group = null
-      } else if (group) {
-        pushGroup(group)
-        group = null
       }
-
-      group = {
-        type: 'agent_group',
-        id: `agent-${key}-${i}`,
-        agentName: key,
-        agentLabel: resolveAgentLabel(key),
-        items: [],
-        isDelegating: inheritedDelegation,
-        isOpen: false,
-      }
+      const g = ensureGroup(key, block.parentToolCallId)
+      if (inheritedDelegation) g.isDelegating = true
+      g.isOpen = block.endedAt === undefined
+      activeGroupKey = resolveGroupKey(key, block.parentToolCallId)
       continue
     }
 
@@ -279,98 +300,72 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
       const isDispatch = SUBAGENT_KEYS.has(tc.name) && !tc.calledBy
 
       if (isDispatch) {
-        if (hasSubagentBlockAfter(tc.name, i)) {
-          continue
-        }
-        if (!group || group.agentName !== tc.name) {
-          if (group) {
-            pushGroup(group)
-            group = null
-          }
-          group = {
-            type: 'agent_group',
-            id: `agent-${tc.name}-${i}`,
-            agentName: tc.name,
-            agentLabel: resolveAgentLabel(tc.name),
-            items: [],
-            isDelegating: false,
-            isOpen: false,
-          }
-        }
-        group.isDelegating = isDelegatingTool(tc)
+        const g = ensureGroup(tc.name, tc.id)
+        g.isDelegating = isDelegatingTool(tc)
+        g.isOpen = g.isDelegating
         continue
       }
 
       const tool = toToolData(tc)
 
-      if (tc.calledBy && group && group.agentName === tc.calledBy) {
-        group.isDelegating = false
-        group.items.push({ type: 'tool', data: tool })
-      } else if (tc.calledBy) {
-        if (group) {
-          pushGroup(group)
-          group = null
-        }
-        group = {
-          type: 'agent_group',
-          id: `agent-${tc.calledBy}-${i}`,
-          agentName: tc.calledBy,
-          agentLabel: resolveAgentLabel(tc.calledBy),
-          items: [{ type: 'tool', data: tool }],
-          isDelegating: false,
-          isOpen: false,
-        }
+      if (tc.calledBy) {
+        const g = ensureGroup(tc.calledBy, block.parentToolCallId)
+        g.isDelegating = false
+        if (block.parentToolCallId) g.isOpen = true
+        g.items.push({ type: 'tool', data: tool })
+        activeGroupKey = resolveGroupKey(tc.calledBy, block.parentToolCallId)
       } else {
-        if (group && group.agentName === 'mothership') {
-          group.items.push({ type: 'tool', data: tool })
-        } else {
-          if (group) {
-            pushGroup(group)
-            group = null
-          }
-          group = {
-            type: 'agent_group',
-            id: `agent-mothership-${i}`,
-            agentName: 'mothership',
-            agentLabel: 'Mothership',
-            items: [{ type: 'tool', data: tool }],
-            isDelegating: false,
-            isOpen: false,
-          }
-        }
+        const g = ensureGroup('mothership', undefined)
+        g.items.push({ type: 'tool', data: tool })
       }
       continue
     }
 
     if (block.type === 'options') {
       if (!block.options?.length) continue
-      if (group) {
-        pushGroup(group)
-        group = null
-      }
+      flushLanes()
       segments.push({ type: 'options', items: block.options })
       continue
     }
 
     if (block.type === 'subagent_end') {
-      if (group) {
-        pushGroup(group)
-        group = null
+      if (block.parentToolCallId) {
+        for (const [key, g] of groupsByKey) {
+          if (key.endsWith(`:${block.parentToolCallId}`)) {
+            g.isOpen = false
+            g.isDelegating = false
+          }
+        }
+      }
+      if (block.parentToolCallId && activeGroupKey?.endsWith(`:${block.parentToolCallId}`)) {
+        activeGroupKey = null
+      } else if (!block.parentToolCallId) {
+        for (const g of groupsByKey.values()) {
+          if (g.agentName !== 'mothership') {
+            g.isOpen = false
+            g.isDelegating = false
+          }
+        }
+        activeGroupKey = null
       }
       continue
     }
 
     if (block.type === 'stopped') {
-      if (group) {
-        pushGroup(group)
-        group = null
-      }
+      flushLanes()
       segments.push({ type: 'stopped' })
     }
   }
 
-  if (group) pushGroup(group, true)
-  return segments
+  const visibleSegments = segments.filter(
+    (segment) =>
+      segment.type !== 'agent_group' ||
+      segment.items.length > 0 ||
+      segment.isDelegating ||
+      segment.isOpen
+  )
+
+  return visibleSegments
 }
 
 /**
@@ -443,12 +438,6 @@ export function MessageContent({
     isStreaming &&
     !hasTrailingContent &&
     (lastSegment.type === 'thinking' || hasSubagentEnded || allLastGroupToolsDone)
-  const lastOpenSubagentGroupId = [...segments]
-    .reverse()
-    .find(
-      (segment): segment is AgentGroupSegment =>
-        segment.type === 'agent_group' && segment.agentName !== 'mothership' && segment.isOpen
-    )?.id
 
   return (
     <div className='space-y-[10px]'>
@@ -503,8 +492,8 @@ export function MessageContent({
                   items={segment.items}
                   isDelegating={segment.isDelegating}
                   isStreaming={isStreaming}
-                  autoCollapse={allToolsDone && hasFollowingText}
-                  defaultExpanded={segment.id === lastOpenSubagentGroupId}
+                  autoCollapse={!segment.isOpen && allToolsDone && hasFollowingText}
+                  defaultExpanded={segment.isOpen}
                 />
               </div>
             )

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
@@ -161,6 +161,18 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
     segments.push({ ...nextGroup, isOpen })
   }
 
+  const lastSubagentBlockIndex = new Map<string, number>()
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i]
+    if (block.type === 'subagent' && block.content) {
+      lastSubagentBlockIndex.set(block.content, i)
+    }
+  }
+  const hasSubagentBlockAfter = (name: string, index: number): boolean => {
+    const last = lastSubagentBlockIndex.get(name)
+    return last !== undefined && last > index
+  }
+
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i]
 
@@ -267,6 +279,9 @@ function parseBlocks(blocks: ContentBlock[]): MessageSegment[] {
       const isDispatch = SUBAGENT_KEYS.has(tc.name) && !tc.calledBy
 
       if (isDispatch) {
+        if (hasSubagentBlockAfter(tc.name, i)) {
+          continue
+        }
         if (!group || group.agentName !== tc.name) {
           if (group) {
             pushGroup(group)

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
@@ -701,7 +701,9 @@ function parseStreamBatchResponse(value: unknown): StreamBatchResponse {
 
 function toRawPersistedContentBlock(block: ContentBlock): Record<string, unknown> | null {
   const persisted = toRawPersistedContentBlockBody(block)
-  return persisted ? withBlockTiming(persisted, block) : null
+  if (!persisted) return null
+  if (block.parentToolCallId) persisted.parentToolCallId = block.parentToolCallId
+  return withBlockTiming(persisted, block)
 }
 
 function toRawPersistedContentBlockBody(block: ContentBlock): Record<string, unknown> | null {
@@ -1731,6 +1733,7 @@ export function useChat(
         for (let i = blocks.length - 1; i >= 0; i--) {
           if (blocks[i].type === 'subagent' && blocks[i].content) {
             activeSubagent = blocks[i].content
+            activeSubagentParentToolCallId = blocks[i].parentToolCallId
             break
           }
           if (blocks[i].type === 'subagent_end') {
@@ -1760,23 +1763,45 @@ export function useChat(
         if (block && block.endedAt === undefined) block.endedAt = toEventMs(ts)
       }
 
-      const ensureTextBlock = (subagentName: string | undefined, ts?: string): ContentBlock => {
+      const ensureTextBlock = (
+        subagentName: string | undefined,
+        parentToolCallId: string | undefined,
+        ts?: string
+      ): ContentBlock => {
         const last = blocks[blocks.length - 1]
-        if (last?.type === 'text' && last.subagent === subagentName) return last
+        if (
+          last?.type === 'text' &&
+          last.subagent === subagentName &&
+          last.parentToolCallId === parentToolCallId
+        ) {
+          return last
+        }
         stampBlockEnd(last, ts)
         const b: ContentBlock = { type: 'text', content: '', timestamp: toEventMs(ts) }
         if (subagentName) b.subagent = subagentName
+        if (parentToolCallId) b.parentToolCallId = parentToolCallId
         blocks.push(b)
         return b
       }
 
-      const ensureThinkingBlock = (subagentName: string | undefined, ts?: string): ContentBlock => {
+      const ensureThinkingBlock = (
+        subagentName: string | undefined,
+        parentToolCallId: string | undefined,
+        ts?: string
+      ): ContentBlock => {
         const targetType = subagentName ? 'subagent_thinking' : 'thinking'
         const last = blocks[blocks.length - 1]
-        if (last?.type === targetType && last.subagent === subagentName) return last
+        if (
+          last?.type === targetType &&
+          last.subagent === subagentName &&
+          last.parentToolCallId === parentToolCallId
+        ) {
+          return last
+        }
         stampBlockEnd(last, ts)
         const b: ContentBlock = { type: targetType, content: '', timestamp: toEventMs(ts) }
         if (subagentName) b.subagent = subagentName
+        if (parentToolCallId) b.parentToolCallId = parentToolCallId
         blocks.push(b)
         return b
       }
@@ -1793,9 +1818,14 @@ export function useChat(
         return activeSubagent
       }
 
-      const appendInlineErrorTag = (tag: string, subagentName?: string, ts?: string) => {
+      const appendInlineErrorTag = (
+        tag: string,
+        subagentName?: string,
+        parentToolCallId?: string,
+        ts?: string
+      ) => {
         if (runningText.includes(tag)) return
-        const tb = ensureTextBlock(subagentName, ts)
+        const tb = ensureTextBlock(subagentName, parentToolCallId, ts)
         const prefix = runningText.length > 0 && !runningText.endsWith('\n') ? '\n' : ''
         tb.content = `${tb.content ?? ''}${prefix}${tag}`
         runningText += `${prefix}${tag}`
@@ -2008,7 +2038,10 @@ export function useChat(
               if (chunk) {
                 const eventTs = typeof parsed.ts === 'string' ? parsed.ts : undefined
                 if (parsed.payload.channel === MothershipStreamV1TextChannel.thinking) {
-                  const tb = ensureThinkingBlock(scopedSubagent, eventTs)
+                  const scopedParentForBlock = scopedSubagent
+                    ? (scopedParentToolCallId ?? activeSubagentParentToolCallId)
+                    : undefined
+                  const tb = ensureThinkingBlock(scopedSubagent, scopedParentForBlock, eventTs)
                   tb.content = (tb.content ?? '') + chunk
                   flushText()
                   break
@@ -2019,7 +2052,10 @@ export function useChat(
                   lastContentSource !== contentSource &&
                   runningText.length > 0 &&
                   !runningText.endsWith('\n')
-                const tb = ensureTextBlock(scopedSubagent, eventTs)
+                const scopedParentForBlock = scopedSubagent
+                  ? (scopedParentToolCallId ?? activeSubagentParentToolCallId)
+                  : undefined
+                const tb = ensureTextBlock(scopedSubagent, scopedParentForBlock, eventTs)
                 const normalizedChunk = needsBoundaryNewline ? `\n${chunk}` : chunk
                 tb.content = (tb.content ?? '') + normalizedChunk
                 runningText += normalizedChunk
@@ -2358,6 +2394,9 @@ export function useChat(
               if (!toolMap.has(id)) {
                 stampBlockEnd(blocks[blocks.length - 1])
                 toolMap.set(id, blocks.length)
+                const parentToolCallIdForBlock = scopedSubagent
+                  ? (scopedParentToolCallId ?? activeSubagentParentToolCallId)
+                  : undefined
                 blocks.push({
                   type: 'tool_call',
                   toolCall: {
@@ -2368,6 +2407,9 @@ export function useChat(
                     params: args,
                     calledBy: scopedSubagent,
                   },
+                  ...(parentToolCallIdForBlock
+                    ? { parentToolCallId: parentToolCallIdForBlock }
+                    : {}),
                   timestamp: Date.now(),
                 })
                 if (name === ReadTool.id || isResourceToolName(name)) {
@@ -2488,9 +2530,13 @@ export function useChat(
                 break
               }
               const spanData = asPayloadRecord(payload.data)
-              const parentToolCallId =
-                scopedParentToolCallId ??
-                (typeof spanData?.tool_call_id === 'string' ? spanData.tool_call_id : undefined)
+              const parentToolCallIdFromData =
+                typeof spanData?.tool_call_id === 'string'
+                  ? spanData.tool_call_id
+                  : typeof spanData?.toolCallId === 'string'
+                    ? spanData.toolCallId
+                    : undefined
+              const parentToolCallId = scopedParentToolCallId ?? parentToolCallIdFromData
               const isPendingPause = spanData?.pending === true
               const name = typeof payload.agent === 'string' ? payload.agent : scopedAgentId
               if (payload.event === MothershipStreamV1SpanLifecycleEvent.start && name) {
@@ -2505,7 +2551,12 @@ export function useChat(
                 activeSubagentParentToolCallId = parentToolCallId
                 if (!isSameActiveSubagent) {
                   stampBlockEnd(blocks[blocks.length - 1])
-                  blocks.push({ type: 'subagent', content: name, timestamp: Date.now() })
+                  blocks.push({
+                    type: 'subagent',
+                    content: name,
+                    ...(parentToolCallId ? { parentToolCallId } : {}),
+                    timestamp: Date.now(),
+                  })
                 }
                 if (name === FILE_SUBAGENT_ID && !isSameActiveSubagent) {
                   applyPreviewSessionUpdate({
@@ -2549,14 +2600,23 @@ export function useChat(
                 if (name) {
                   for (let i = blocks.length - 1; i >= 0; i--) {
                     const b = blocks[i]
-                    if (b.type === 'subagent' && b.content === name && b.endedAt === undefined) {
+                    if (
+                      b.type === 'subagent' &&
+                      b.content === name &&
+                      b.endedAt === undefined &&
+                      (!parentToolCallId || b.parentToolCallId === parentToolCallId)
+                    ) {
                       b.endedAt = endNow
                       break
                     }
                   }
                 }
                 stampBlockEnd(blocks[blocks.length - 1])
-                blocks.push({ type: 'subagent_end', timestamp: endNow })
+                blocks.push({
+                  type: 'subagent_end',
+                  ...(parentToolCallId ? { parentToolCallId } : {}),
+                  timestamp: endNow,
+                })
                 flush()
               }
               break
@@ -2567,6 +2627,9 @@ export function useChat(
               appendInlineErrorTag(
                 buildInlineErrorTag(parsed.payload),
                 scopedSubagent,
+                scopedSubagent
+                  ? (scopedParentToolCallId ?? activeSubagentParentToolCallId)
+                  : undefined,
                 typeof parsed.ts === 'string' ? parsed.ts : undefined
               )
               break
@@ -2998,6 +3061,7 @@ export function useChat(
               ...(display ? { display } : {}),
               calledBy: block.toolCall.calledBy,
             },
+            ...(block.parentToolCallId ? { parentToolCallId: block.parentToolCallId } : {}),
             ...timing,
           }
         }
@@ -3005,6 +3069,7 @@ export function useChat(
           type: block.type,
           content: block.content,
           ...(block.subagent ? { lane: 'subagent' } : {}),
+          ...(block.parentToolCallId ? { parentToolCallId: block.parentToolCallId } : {}),
           ...timing,
         }
       })

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
@@ -131,6 +131,7 @@ import type {
   MothershipResource,
   MothershipResourceType,
   QueuedMessage,
+  ToolCallInfo,
 } from '../types'
 import { ToolCallStatus } from '../types'
 
@@ -1217,7 +1218,7 @@ export function useChat(
       reader: ReadableStreamDefaultReader<Uint8Array>,
       assistantId: string,
       expectedGen?: number,
-      options?: { preserveExistingState?: boolean }
+      options?: { preserveExistingState?: boolean; suppressWorkflowToolStarts?: boolean }
     ) => Promise<{ sawStreamError: boolean; sawComplete: boolean }>
   >(async () => ({ sawStreamError: false, sawComplete: false }))
   const attachToExistingStreamRef = useRef<
@@ -1457,8 +1458,50 @@ export function useChat(
         return
       }
       if (handledClientWorkflowToolIdsRef.current.has(toolCallId)) {
+        // #region agent log
+        fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
+          body: JSON.stringify({
+            sessionId: '21c369',
+            location: 'use-chat.ts:startClientWorkflowTool',
+            message: 'SKIPPED:handled',
+            data: { toolCallId },
+            timestamp: Date.now(),
+          }),
+        }).catch(() => {})
+        // #endregion
         return
       }
+      if (recoveringClientWorkflowToolIdsRef.current.has(toolCallId)) {
+        // #region agent log
+        fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
+          body: JSON.stringify({
+            sessionId: '21c369',
+            location: 'use-chat.ts:startClientWorkflowTool',
+            message: 'SKIPPED:recovering',
+            data: { toolCallId },
+            timestamp: Date.now(),
+          }),
+        }).catch(() => {})
+        // #endregion
+        return
+      }
+      // #region agent log
+      fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
+        body: JSON.stringify({
+          sessionId: '21c369',
+          location: 'use-chat.ts:startClientWorkflowTool',
+          message: 'FIRING',
+          data: { toolCallId, toolName },
+          timestamp: Date.now(),
+        }),
+      }).catch(() => {})
+      // #endregion
       handledClientWorkflowToolIdsRef.current.add(toolCallId)
 
       ensureWorkflowToolResource(toolArgs)
@@ -1469,41 +1512,68 @@ export function useChat(
 
   const recoverPendingClientWorkflowTools = useCallback(
     async (nextMessages: ChatMessage[]) => {
+      const pending: ToolCallInfo[] = []
+
       for (const message of nextMessages) {
         for (const block of message.contentBlocks ?? []) {
           const toolCall = block.toolCall
-          if (!toolCall || !isWorkflowToolName(toolCall.name)) {
-            continue
-          }
-          if (toolCall.status !== 'executing') {
-            continue
-          }
-
+          if (!toolCall || !isWorkflowToolName(toolCall.name)) continue
+          if (toolCall.status !== 'executing') continue
           if (
             handledClientWorkflowToolIdsRef.current.has(toolCall.id) ||
             recoveringClientWorkflowToolIdsRef.current.has(toolCall.id)
           ) {
             continue
           }
-
           recoveringClientWorkflowToolIdsRef.current.add(toolCall.id)
+          pending.push(toolCall)
+        }
+      }
 
-          try {
-            const toolArgs = toolCall.params ?? {}
-            const targetWorkflowId = ensureWorkflowToolResource(toolArgs)
+      // #region agent log
+      fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
+        body: JSON.stringify({
+          sessionId: '21c369',
+          location: 'use-chat.ts:recoverPending',
+          message: 'scan complete',
+          data: { pendingCount: pending.length, pendingIds: pending.map((t) => t.id) },
+          timestamp: Date.now(),
+        }),
+      }).catch(() => {})
+      // #endregion
 
-            if (targetWorkflowId) {
-              const rebound = await bindRunToolToExecution(toolCall.id, targetWorkflowId)
-              if (rebound) {
-                handledClientWorkflowToolIdsRef.current.add(toolCall.id)
-                continue
-              }
+      for (const toolCall of pending) {
+        try {
+          const toolArgs = toolCall.params ?? {}
+          const targetWorkflowId = ensureWorkflowToolResource(toolArgs)
+
+          if (targetWorkflowId) {
+            const rebound = await bindRunToolToExecution(toolCall.id, targetWorkflowId)
+            // #region agent log
+            fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
+              body: JSON.stringify({
+                sessionId: '21c369',
+                location: 'use-chat.ts:recoverPending',
+                message: 'bind result',
+                data: { toolCallId: toolCall.id, targetWorkflowId, rebound },
+                timestamp: Date.now(),
+              }),
+            }).catch(() => {})
+            // #endregion
+            if (rebound) {
+              handledClientWorkflowToolIdsRef.current.add(toolCall.id)
+              continue
             }
-
-            startClientWorkflowTool(toolCall.id, toolCall.name, toolArgs)
-          } finally {
-            recoveringClientWorkflowToolIdsRef.current.delete(toolCall.id)
           }
+
+          recoveringClientWorkflowToolIdsRef.current.delete(toolCall.id)
+          startClientWorkflowTool(toolCall.id, toolCall.name, toolArgs)
+        } finally {
+          recoveringClientWorkflowToolIdsRef.current.delete(toolCall.id)
         }
       }
     },
@@ -1703,7 +1773,7 @@ export function useChat(
       reader: ReadableStreamDefaultReader<Uint8Array>,
       assistantId: string,
       expectedGen?: number,
-      options?: { preserveExistingState?: boolean }
+      options?: { preserveExistingState?: boolean; suppressWorkflowToolStarts?: boolean }
     ) => {
       const decoder = new TextDecoder()
       streamReaderRef.current = reader
@@ -1816,6 +1886,19 @@ export function useChat(
           if (scoped) return scoped
         }
         return activeSubagent
+      }
+
+      const resolveParentForSubagentBlock = (
+        subagent: string | undefined,
+        scopedParent: string | undefined
+      ): string | undefined => {
+        if (!subagent) return undefined
+        if (scopedParent) return scopedParent
+        if (activeSubagent === subagent) return activeSubagentParentToolCallId
+        for (const [parent, name] of subagentByParentToolCallId) {
+          if (name === subagent) return parent
+        }
+        return undefined
       }
 
       const appendInlineErrorTag = (
@@ -2038,9 +2121,10 @@ export function useChat(
               if (chunk) {
                 const eventTs = typeof parsed.ts === 'string' ? parsed.ts : undefined
                 if (parsed.payload.channel === MothershipStreamV1TextChannel.thinking) {
-                  const scopedParentForBlock = scopedSubagent
-                    ? (scopedParentToolCallId ?? activeSubagentParentToolCallId)
-                    : undefined
+                  const scopedParentForBlock = resolveParentForSubagentBlock(
+                    scopedSubagent,
+                    scopedParentToolCallId
+                  )
                   const tb = ensureThinkingBlock(scopedSubagent, scopedParentForBlock, eventTs)
                   tb.content = (tb.content ?? '') + chunk
                   flushText()
@@ -2052,9 +2136,10 @@ export function useChat(
                   lastContentSource !== contentSource &&
                   runningText.length > 0 &&
                   !runningText.endsWith('\n')
-                const scopedParentForBlock = scopedSubagent
-                  ? (scopedParentToolCallId ?? activeSubagentParentToolCallId)
-                  : undefined
+                const scopedParentForBlock = resolveParentForSubagentBlock(
+                  scopedSubagent,
+                  scopedParentToolCallId
+                )
                 const tb = ensureTextBlock(scopedSubagent, scopedParentForBlock, eventTs)
                 const normalizedChunk = needsBoundaryNewline ? `\n${chunk}` : chunk
                 tb.content = (tb.content ?? '') + normalizedChunk
@@ -2391,12 +2476,17 @@ export function useChat(
                 }
               }
 
-              if (!toolMap.has(id)) {
+              const existingToolCall = toolMap.has(id)
+                ? blocks[toolMap.get(id)!]?.toolCall
+                : undefined
+              const isNewToolCall = !existingToolCall
+              if (isNewToolCall) {
                 stampBlockEnd(blocks[blocks.length - 1])
                 toolMap.set(id, blocks.length)
-                const parentToolCallIdForBlock = scopedSubagent
-                  ? (scopedParentToolCallId ?? activeSubagentParentToolCallId)
-                  : undefined
+                const parentToolCallIdForBlock = resolveParentForSubagentBlock(
+                  scopedSubagent,
+                  scopedParentToolCallId
+                )
                 blocks.push({
                   type: 'tool_call',
                   toolCall: {
@@ -2427,7 +2517,28 @@ export function useChat(
               flush()
 
               if (isWorkflowToolName(name) && !isPartial) {
-                startClientWorkflowTool(id, name, args ?? {})
+                const shouldStartWorkflowTool =
+                  !options?.suppressWorkflowToolStarts &&
+                  (isNewToolCall ||
+                    (existingToolCall?.status === ToolCallStatus.executing &&
+                      !existingToolCall.result))
+                if (shouldStartWorkflowTool) {
+                  startClientWorkflowTool(id, name, args ?? {})
+                } else {
+                  // #region agent log
+                  fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
+                    body: JSON.stringify({
+                      sessionId: '21c369',
+                      location: 'use-chat.ts:processSSE',
+                      message: 'SKIPPED:replay',
+                      data: { toolCallId: id, toolName: name },
+                      timestamp: Date.now(),
+                    }),
+                  }).catch(() => {})
+                  // #endregion
+                }
               }
               break
             }
@@ -2627,9 +2738,7 @@ export function useChat(
               appendInlineErrorTag(
                 buildInlineErrorTag(parsed.payload),
                 scopedSubagent,
-                scopedSubagent
-                  ? (scopedParentToolCallId ?? activeSubagentParentToolCallId)
-                  : undefined,
+                resolveParentForSubagentBlock(scopedSubagent, scopedParentToolCallId),
                 typeof parsed.ts === 'string' ? parsed.ts : undefined
               )
               break
@@ -2734,6 +2843,7 @@ export function useChat(
       let latestCursor = afterCursor
       let seedEvents = opts.initialBatch?.events ?? []
       let streamStatus = opts.initialBatch?.status ?? 'unknown'
+      let suppressSeedWorkflowStarts = seedEvents.length > 0
 
       const isStaleReconnect = () =>
         streamGenRef.current !== expectedGen || abortControllerRef.current?.signal.aborted === true
@@ -2752,11 +2862,15 @@ export function useChat(
               buildReplayStream(seedEvents).getReader(),
               assistantId,
               expectedGen,
-              { preserveExistingState: true }
+              {
+                preserveExistingState: true,
+                suppressWorkflowToolStarts: suppressSeedWorkflowStarts,
+              }
             )
             latestCursor = String(seedEvents[seedEvents.length - 1]?.eventId ?? latestCursor)
             lastCursorRef.current = latestCursor
             seedEvents = []
+            suppressSeedWorkflowStarts = false
 
             if (replayResult.sawStreamError) {
               return { error: true, aborted: false }
@@ -2800,7 +2914,7 @@ export function useChat(
             sseRes.body.getReader(),
             assistantId,
             expectedGen,
-            { preserveExistingState: true }
+            { preserveExistingState: true, suppressWorkflowToolStarts: true }
           )
 
           if (liveResult.sawStreamError) {

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
@@ -1458,50 +1458,11 @@ export function useChat(
         return
       }
       if (handledClientWorkflowToolIdsRef.current.has(toolCallId)) {
-        // #region agent log
-        fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
-          body: JSON.stringify({
-            sessionId: '21c369',
-            location: 'use-chat.ts:startClientWorkflowTool',
-            message: 'SKIPPED:handled',
-            data: { toolCallId },
-            timestamp: Date.now(),
-          }),
-        }).catch(() => {})
-        // #endregion
         return
       }
       if (recoveringClientWorkflowToolIdsRef.current.has(toolCallId)) {
-        // #region agent log
-        fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
-          body: JSON.stringify({
-            sessionId: '21c369',
-            location: 'use-chat.ts:startClientWorkflowTool',
-            message: 'SKIPPED:recovering',
-            data: { toolCallId },
-            timestamp: Date.now(),
-          }),
-        }).catch(() => {})
-        // #endregion
         return
       }
-      // #region agent log
-      fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
-        body: JSON.stringify({
-          sessionId: '21c369',
-          location: 'use-chat.ts:startClientWorkflowTool',
-          message: 'FIRING',
-          data: { toolCallId, toolName },
-          timestamp: Date.now(),
-        }),
-      }).catch(() => {})
-      // #endregion
       handledClientWorkflowToolIdsRef.current.add(toolCallId)
 
       ensureWorkflowToolResource(toolArgs)
@@ -1530,20 +1491,6 @@ export function useChat(
         }
       }
 
-      // #region agent log
-      fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
-        body: JSON.stringify({
-          sessionId: '21c369',
-          location: 'use-chat.ts:recoverPending',
-          message: 'scan complete',
-          data: { pendingCount: pending.length, pendingIds: pending.map((t) => t.id) },
-          timestamp: Date.now(),
-        }),
-      }).catch(() => {})
-      // #endregion
-
       for (const toolCall of pending) {
         try {
           const toolArgs = toolCall.params ?? {}
@@ -1551,19 +1498,6 @@ export function useChat(
 
           if (targetWorkflowId) {
             const rebound = await bindRunToolToExecution(toolCall.id, targetWorkflowId)
-            // #region agent log
-            fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
-              body: JSON.stringify({
-                sessionId: '21c369',
-                location: 'use-chat.ts:recoverPending',
-                message: 'bind result',
-                data: { toolCallId: toolCall.id, targetWorkflowId, rebound },
-                timestamp: Date.now(),
-              }),
-            }).catch(() => {})
-            // #endregion
             if (rebound) {
               handledClientWorkflowToolIdsRef.current.add(toolCall.id)
               continue
@@ -2524,20 +2458,6 @@ export function useChat(
                       !existingToolCall.result))
                 if (shouldStartWorkflowTool) {
                   startClientWorkflowTool(id, name, args ?? {})
-                } else {
-                  // #region agent log
-                  fetch('http://127.0.0.1:1025/ingest/85045d0a-92f7-4ee2-9de1-e2f99930c6bc', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '21c369' },
-                    body: JSON.stringify({
-                      sessionId: '21c369',
-                      location: 'use-chat.ts:processSSE',
-                      message: 'SKIPPED:replay',
-                      data: { toolCallId: id, toolName: name },
-                      timestamp: Date.now(),
-                    }),
-                  }).catch(() => {})
-                  // #endregion
                 }
               }
               break
@@ -2914,7 +2834,7 @@ export function useChat(
             sseRes.body.getReader(),
             assistantId,
             expectedGen,
-            { preserveExistingState: true, suppressWorkflowToolStarts: true }
+            { preserveExistingState: true }
           )
 
           if (liveResult.sawStreamError) {

--- a/apps/sim/app/workspace/[workspaceId]/home/types.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/types.ts
@@ -133,6 +133,7 @@ export interface ContentBlock {
   options?: OptionItem[]
   timestamp?: number
   endedAt?: number
+  parentToolCallId?: string
 }
 
 export interface ChatMessageAttachment {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -34,7 +34,7 @@ import { hasExecutionResult } from '@/executor/utils/errors'
 import { coerceValue } from '@/executor/utils/start-block'
 import { subscriptionKeys } from '@/hooks/queries/subscription'
 import { getWorkflows } from '@/hooks/queries/utils/workflow-cache'
-import { useExecutionStream } from '@/hooks/use-execution-stream'
+import { isExecutionStreamHttpError, useExecutionStream } from '@/hooks/use-execution-stream'
 import { WorkflowValidationError } from '@/serializer'
 import { useCurrentWorkflowExecution, useExecutionStore } from '@/stores/execution'
 import { useNotificationStore } from '@/stores/notifications'
@@ -59,6 +59,13 @@ const logger = createLogger('useWorkflowExecution')
  * concurrent reconnection streams for the same workflow during the same mount cycle.
  */
 const activeReconnections = new Set<string>()
+
+function isReconnectTerminal(error: unknown): boolean {
+  return (
+    isExecutionStreamHttpError(error) &&
+    (error.httpStatus === 404 || error.httpStatus === 403 || error.httpStatus === 401)
+  )
+}
 
 interface DebugValidationResult {
   isValid: boolean
@@ -1283,8 +1290,7 @@ export function useWorkflowExecution() {
     } else {
       if (!executor) {
         try {
-          const httpStatus =
-            isRecord(error) && typeof error.httpStatus === 'number' ? error.httpStatus : undefined
+          const httpStatus = isExecutionStreamHttpError(error) ? error.httpStatus : undefined
           const storeAddConsole = useTerminalConsoleStore.getState().addConsole
 
           if (httpStatus && activeWorkflowId) {
@@ -1867,8 +1873,6 @@ export function useWorkflowExecution() {
       activeReconnections.add(reconnectWorkflowId)
 
       executionStream.cancel(reconnectWorkflowId)
-      setCurrentExecutionId(reconnectWorkflowId, executionId)
-      setIsExecuting(reconnectWorkflowId, true)
 
       const workflowEdges = useWorkflowStore.getState().edges
       const activeBlocksSet = new Set<string>()
@@ -1891,12 +1895,26 @@ export function useWorkflowExecution() {
         includeStartConsoleEntry: true,
       })
 
-      clearExecutionEntries(executionId)
-
       const capturedExecutionId = executionId
       const MAX_ATTEMPTS = 5
       const BASE_DELAY_MS = 1000
       const MAX_DELAY_MS = 15000
+
+      let activated = false
+      const ensureActivated = () => {
+        if (activated || cleanupRan) return
+        activated = true
+        setCurrentExecutionId(reconnectWorkflowId, capturedExecutionId)
+        setIsExecuting(reconnectWorkflowId, true)
+        clearExecutionEntries(capturedExecutionId)
+      }
+
+      const wrapHandler =
+        <T>(handler: (data: T) => void) =>
+        (data: T) => {
+          ensureActivated()
+          handler(data)
+        }
 
       const attemptReconnect = async (attempt: number): Promise<void> => {
         if (cleanupRan || reconnectionComplete) return
@@ -1914,38 +1932,39 @@ export function useWorkflowExecution() {
             fromEventId,
             callbacks: {
               onEventId: (eid) => {
+                ensureActivated()
                 fromEventId = eid
               },
-              onBlockStarted: handlers.onBlockStarted,
-              onBlockCompleted: handlers.onBlockCompleted,
-              onBlockError: handlers.onBlockError,
-              onBlockChildWorkflowStarted: handlers.onBlockChildWorkflowStarted,
+              onBlockStarted: wrapHandler(handlers.onBlockStarted),
+              onBlockCompleted: wrapHandler(handlers.onBlockCompleted),
+              onBlockError: wrapHandler(handlers.onBlockError),
+              onBlockChildWorkflowStarted: wrapHandler(handlers.onBlockChildWorkflowStarted),
               onExecutionCompleted: () => {
+                reconnectionComplete = true
+                activeReconnections.delete(reconnectWorkflowId)
+                if (!activated) {
+                  clearExecutionPointer(reconnectWorkflowId)
+                  return
+                }
                 const currentId = useExecutionStore
                   .getState()
                   .getCurrentExecutionId(reconnectWorkflowId)
-                if (currentId !== capturedExecutionId) {
-                  reconnectionComplete = true
-                  activeReconnections.delete(reconnectWorkflowId)
-                  return
-                }
-                reconnectionComplete = true
-                activeReconnections.delete(reconnectWorkflowId)
+                if (currentId !== capturedExecutionId) return
                 setCurrentExecutionId(reconnectWorkflowId, null)
                 setIsExecuting(reconnectWorkflowId, false)
                 setActiveBlocks(reconnectWorkflowId, new Set())
               },
               onExecutionError: (data) => {
+                reconnectionComplete = true
+                activeReconnections.delete(reconnectWorkflowId)
+                if (!activated) {
+                  clearExecutionPointer(reconnectWorkflowId)
+                  return
+                }
                 const currentId = useExecutionStore
                   .getState()
                   .getCurrentExecutionId(reconnectWorkflowId)
-                if (currentId !== capturedExecutionId) {
-                  reconnectionComplete = true
-                  activeReconnections.delete(reconnectWorkflowId)
-                  return
-                }
-                reconnectionComplete = true
-                activeReconnections.delete(reconnectWorkflowId)
+                if (currentId !== capturedExecutionId) return
                 setCurrentExecutionId(reconnectWorkflowId, null)
                 setIsExecuting(reconnectWorkflowId, false)
                 setActiveBlocks(reconnectWorkflowId, new Set())
@@ -1957,16 +1976,16 @@ export function useWorkflowExecution() {
                 })
               },
               onExecutionCancelled: () => {
+                reconnectionComplete = true
+                activeReconnections.delete(reconnectWorkflowId)
+                if (!activated) {
+                  clearExecutionPointer(reconnectWorkflowId)
+                  return
+                }
                 const currentId = useExecutionStore
                   .getState()
                   .getCurrentExecutionId(reconnectWorkflowId)
-                if (currentId !== capturedExecutionId) {
-                  reconnectionComplete = true
-                  activeReconnections.delete(reconnectWorkflowId)
-                  return
-                }
-                reconnectionComplete = true
-                activeReconnections.delete(reconnectWorkflowId)
+                if (currentId !== capturedExecutionId) return
                 setCurrentExecutionId(reconnectWorkflowId, null)
                 setIsExecuting(reconnectWorkflowId, false)
                 setActiveBlocks(reconnectWorkflowId, new Set())
@@ -1978,6 +1997,27 @@ export function useWorkflowExecution() {
             },
           })
         } catch (error) {
+          if (isReconnectTerminal(error)) {
+            logger.info('Reconnection skipped; run buffer no longer exists', {
+              executionId: capturedExecutionId,
+            })
+            reconnectionComplete = true
+            activeReconnections.delete(reconnectWorkflowId)
+            clearExecutionPointer(reconnectWorkflowId)
+            if (activated) {
+              const currentId = useExecutionStore
+                .getState()
+                .getCurrentExecutionId(reconnectWorkflowId)
+              if (currentId === capturedExecutionId) {
+                cancelRunningEntries(reconnectWorkflowId)
+                setCurrentExecutionId(reconnectWorkflowId, null)
+                setIsExecuting(reconnectWorkflowId, false)
+                setActiveBlocks(reconnectWorkflowId, new Set())
+              }
+            }
+            return
+          }
+
           logger.warn('Execution reconnection attempt failed', {
             executionId: capturedExecutionId,
             attempt,
@@ -1991,12 +2031,16 @@ export function useWorkflowExecution() {
         if (!reconnectionComplete && !cleanupRan) {
           reconnectionComplete = true
           activeReconnections.delete(reconnectWorkflowId)
-          const currentId = useExecutionStore.getState().getCurrentExecutionId(reconnectWorkflowId)
-          if (currentId === capturedExecutionId) {
-            cancelRunningEntries(reconnectWorkflowId)
-            setCurrentExecutionId(reconnectWorkflowId, null)
-            setIsExecuting(reconnectWorkflowId, false)
-            setActiveBlocks(reconnectWorkflowId, new Set())
+          if (activated) {
+            const currentId = useExecutionStore
+              .getState()
+              .getCurrentExecutionId(reconnectWorkflowId)
+            if (currentId === capturedExecutionId) {
+              cancelRunningEntries(reconnectWorkflowId)
+              setCurrentExecutionId(reconnectWorkflowId, null)
+              setIsExecuting(reconnectWorkflowId, false)
+              setActiveBlocks(reconnectWorkflowId, new Set())
+            }
           }
         }
       }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -1916,6 +1916,26 @@ export function useWorkflowExecution() {
           handler(data)
         }
 
+      const cleanupFailedReconnect = () => {
+        const currentId = useExecutionStore.getState().getCurrentExecutionId(reconnectWorkflowId)
+        if (currentId && currentId !== capturedExecutionId) return
+
+        const hasRunningEntry = useTerminalConsoleStore
+          .getState()
+          .getWorkflowEntries(reconnectWorkflowId)
+          .some((entry) => entry.isRunning && entry.executionId === capturedExecutionId)
+
+        if (activated || hasRunningEntry) {
+          cancelRunningEntries(reconnectWorkflowId)
+        }
+
+        if (currentId === capturedExecutionId) {
+          setCurrentExecutionId(reconnectWorkflowId, null)
+          setIsExecuting(reconnectWorkflowId, false)
+          setActiveBlocks(reconnectWorkflowId, new Set())
+        }
+      }
+
       const attemptReconnect = async (attempt: number): Promise<void> => {
         if (cleanupRan || reconnectionComplete) return
 
@@ -2004,17 +2024,7 @@ export function useWorkflowExecution() {
             reconnectionComplete = true
             activeReconnections.delete(reconnectWorkflowId)
             clearExecutionPointer(reconnectWorkflowId)
-            if (activated) {
-              const currentId = useExecutionStore
-                .getState()
-                .getCurrentExecutionId(reconnectWorkflowId)
-              if (currentId === capturedExecutionId) {
-                cancelRunningEntries(reconnectWorkflowId)
-                setCurrentExecutionId(reconnectWorkflowId, null)
-                setIsExecuting(reconnectWorkflowId, false)
-                setActiveBlocks(reconnectWorkflowId, new Set())
-              }
-            }
+            cleanupFailedReconnect()
             return
           }
 
@@ -2025,6 +2035,12 @@ export function useWorkflowExecution() {
           })
           if (!cleanupRan && !reconnectionComplete && attempt < MAX_ATTEMPTS) {
             return attemptReconnect(attempt + 1)
+          }
+          if (!cleanupRan && !reconnectionComplete) {
+            reconnectionComplete = true
+            activeReconnections.delete(reconnectWorkflowId)
+            cleanupFailedReconnect()
+            return
           }
         }
 

--- a/apps/sim/hooks/use-execution-stream.ts
+++ b/apps/sim/hooks/use-execution-stream.ts
@@ -18,6 +18,20 @@ import type { SerializableExecutionState } from '@/executor/execution/types'
 
 const logger = createLogger('useExecutionStream')
 
+export class ExecutionStreamHttpError extends Error {
+  constructor(
+    message: string,
+    public readonly httpStatus: number
+  ) {
+    super(message)
+    this.name = 'ExecutionStreamHttpError'
+  }
+}
+
+export function isExecutionStreamHttpError(error: unknown): error is ExecutionStreamHttpError {
+  return error instanceof ExecutionStreamHttpError
+}
+
 /**
  * Detects errors caused by the browser killing a fetch (page refresh, navigation, tab close).
  * These should be treated as clean disconnects, not execution errors.
@@ -205,11 +219,13 @@ export function useExecutionStream() {
 
       if (!response.ok) {
         const errorResponse = await response.json()
-        const error = new Error(errorResponse.error || 'Failed to start execution')
+        const error = new ExecutionStreamHttpError(
+          errorResponse.error || 'Failed to start execution',
+          response.status
+        )
         if (errorResponse && typeof errorResponse === 'object') {
           Object.assign(error, { executionResult: errorResponse })
         }
-        Object.assign(error, { httpStatus: response.status })
         throw error
       }
 
@@ -279,15 +295,18 @@ export function useExecutionStream() {
         try {
           errorResponse = await response.json()
         } catch {
-          const error = new Error(`Server error (${response.status}): ${response.statusText}`)
-          Object.assign(error, { httpStatus: response.status })
-          throw error
+          throw new ExecutionStreamHttpError(
+            `Server error (${response.status}): ${response.statusText}`,
+            response.status
+          )
         }
-        const error = new Error(errorResponse.error || 'Failed to start execution')
+        const error = new ExecutionStreamHttpError(
+          errorResponse.error || 'Failed to start execution',
+          response.status
+        )
         if (errorResponse && typeof errorResponse === 'object') {
           Object.assign(error, { executionResult: errorResponse })
         }
-        Object.assign(error, { httpStatus: response.status })
         throw error
       }
 
@@ -335,7 +354,9 @@ export function useExecutionStream() {
         `/api/workflows/${workflowId}/executions/${executionId}/stream?from=${fromEventId}`,
         { signal: abortController.signal }
       )
-      if (!response.ok) throw new Error(`Reconnect failed (${response.status})`)
+      if (!response.ok) {
+        throw new ExecutionStreamHttpError(`Reconnect failed (${response.status})`, response.status)
+      }
       if (!response.body) throw new Error('No response body')
 
       await processSSEStream(response.body.getReader(), callbacks, 'Reconnect')

--- a/apps/sim/lib/copilot/chat/display-message.ts
+++ b/apps/sim/lib/copilot/chat/display-message.ts
@@ -46,7 +46,11 @@ function toToolCallInfo(block: PersistedContentBlock): ToolCallInfo | undefined 
 
 function toDisplayBlock(block: PersistedContentBlock): ContentBlock | undefined {
   const displayed = toDisplayBlockBody(block)
-  return displayed ? withBlockTiming(displayed, block) : undefined
+  if (!displayed) return undefined
+  if (block.parentToolCallId && displayed.parentToolCallId === undefined) {
+    displayed.parentToolCallId = block.parentToolCallId
+  }
+  return withBlockTiming(displayed, block)
 }
 
 function toDisplayBlockBody(block: PersistedContentBlock): ContentBlock | undefined {

--- a/apps/sim/lib/copilot/chat/effective-transcript.ts
+++ b/apps/sim/lib/copilot/chat/effective-transcript.ts
@@ -128,6 +128,19 @@ function buildLiveAssistantMessage(params: {
     return activeSubagent
   }
 
+  const resolveParentForSubagentBlock = (
+    subagent: string | undefined,
+    scopedParent: string | undefined
+  ): string | undefined => {
+    if (!subagent) return undefined
+    if (scopedParent) return scopedParent
+    if (activeSubagent === subagent) return activeSubagentParentToolCallId
+    for (const [parent, name] of subagentByParentToolCallId) {
+      if (name === subagent) return parent
+    }
+    return undefined
+  }
+
   const ensureToolBlock = (input: {
     toolCallId: string
     toolName: string
@@ -228,13 +241,10 @@ function buildLiveAssistantMessage(params: {
           runningText.length > 0 &&
           !runningText.endsWith('\n')
         const normalizedChunk = needsBoundaryNewline ? `\n${chunk}` : chunk
+        const parentForBlock = resolveParentForSubagentBlock(scopedSubagent, scopedParentToolCallId)
         appendTextBlock(blocks, normalizedChunk, {
           ...(scopedSubagent ? { lane: 'subagent' as const } : {}),
-          ...(scopedSubagent && scopedParentToolCallId
-            ? { parentToolCallId: scopedParentToolCallId }
-            : scopedSubagent && activeSubagentParentToolCallId
-              ? { parentToolCallId: activeSubagentParentToolCallId }
-              : {}),
+          ...(parentForBlock ? { parentToolCallId: parentForBlock } : {}),
         })
         runningText += normalizedChunk
         lastContentSource = contentSource
@@ -253,16 +263,14 @@ function buildLiveAssistantMessage(params: {
           continue
         }
 
+        const parentForBlock = resolveParentForSubagentBlock(scopedSubagent, scopedParentToolCallId)
+
         if (payload.phase === MothershipStreamV1ToolPhase.result) {
           ensureToolBlock({
             toolCallId,
             toolName: payload.toolName,
             calledBy: scopedSubagent,
-            ...(scopedSubagent && scopedParentToolCallId
-              ? { parentToolCallId: scopedParentToolCallId }
-              : scopedSubagent && activeSubagentParentToolCallId
-                ? { parentToolCallId: activeSubagentParentToolCallId }
-                : {}),
+            ...(parentForBlock ? { parentToolCallId: parentForBlock } : {}),
             state: resolveStreamToolOutcome(payload),
             result: {
               success: payload.success,
@@ -277,11 +285,7 @@ function buildLiveAssistantMessage(params: {
           toolCallId,
           toolName: payload.toolName,
           calledBy: scopedSubagent,
-          ...(scopedSubagent && scopedParentToolCallId
-            ? { parentToolCallId: scopedParentToolCallId }
-            : scopedSubagent && activeSubagentParentToolCallId
-              ? { parentToolCallId: activeSubagentParentToolCallId }
-              : {}),
+          ...(parentForBlock ? { parentToolCallId: parentForBlock } : {}),
           displayTitle,
           params: isRecord(payload.arguments) ? payload.arguments : undefined,
           state: typeof payload.status === 'string' ? payload.status : 'executing',
@@ -373,13 +377,10 @@ function buildLiveAssistantMessage(params: {
         }
         const prefix = runningText.length > 0 && !runningText.endsWith('\n') ? '\n' : ''
         const content = `${prefix}${tag}`
+        const errorParent = resolveParentForSubagentBlock(scopedSubagent, scopedParentToolCallId)
         appendTextBlock(blocks, content, {
           ...(scopedSubagent ? { lane: 'subagent' as const } : {}),
-          ...(scopedSubagent && scopedParentToolCallId
-            ? { parentToolCallId: scopedParentToolCallId }
-            : scopedSubagent && activeSubagentParentToolCallId
-              ? { parentToolCallId: activeSubagentParentToolCallId }
-              : {}),
+          ...(errorParent ? { parentToolCallId: errorParent } : {}),
         })
         runningText += content
         continue

--- a/apps/sim/lib/copilot/chat/effective-transcript.ts
+++ b/apps/sim/lib/copilot/chat/effective-transcript.ts
@@ -77,11 +77,16 @@ function appendTextBlock(
   content: string,
   options: {
     lane?: 'subagent'
+    parentToolCallId?: string
   }
 ): void {
   if (!content) return
   const last = blocks[blocks.length - 1]
-  if (last?.type === MothershipStreamV1EventType.text && last.lane === options.lane) {
+  if (
+    last?.type === MothershipStreamV1EventType.text &&
+    last.lane === options.lane &&
+    last.parentToolCallId === options.parentToolCallId
+  ) {
     last.content = `${typeof last.content === 'string' ? last.content : ''}${content}`
     return
   }
@@ -89,6 +94,7 @@ function appendTextBlock(
   blocks.push({
     type: MothershipStreamV1EventType.text,
     ...(options.lane ? { lane: options.lane } : {}),
+    ...(options.parentToolCallId ? { parentToolCallId: options.parentToolCallId } : {}),
     content,
   })
 }
@@ -126,6 +132,7 @@ function buildLiveAssistantMessage(params: {
     toolCallId: string
     toolName: string
     calledBy?: string
+    parentToolCallId?: string
     displayTitle?: string
     params?: Record<string, unknown>
     result?: { success: boolean; output?: unknown; error?: string }
@@ -155,6 +162,7 @@ function buildLiveAssistantMessage(params: {
             ? { display: existingToolCall.display }
             : {}),
       }
+      if (input.parentToolCallId) existing.parentToolCallId = input.parentToolCallId
       return existing
     }
 
@@ -176,6 +184,7 @@ function buildLiveAssistantMessage(params: {
             }
           : {}),
       },
+      ...(input.parentToolCallId ? { parentToolCallId: input.parentToolCallId } : {}),
     }
     toolIndexById.set(input.toolCallId, blocks.length)
     blocks.push(nextBlock)
@@ -221,6 +230,11 @@ function buildLiveAssistantMessage(params: {
         const normalizedChunk = needsBoundaryNewline ? `\n${chunk}` : chunk
         appendTextBlock(blocks, normalizedChunk, {
           ...(scopedSubagent ? { lane: 'subagent' as const } : {}),
+          ...(scopedSubagent && scopedParentToolCallId
+            ? { parentToolCallId: scopedParentToolCallId }
+            : scopedSubagent && activeSubagentParentToolCallId
+              ? { parentToolCallId: activeSubagentParentToolCallId }
+              : {}),
         })
         runningText += normalizedChunk
         lastContentSource = contentSource
@@ -244,6 +258,11 @@ function buildLiveAssistantMessage(params: {
             toolCallId,
             toolName: payload.toolName,
             calledBy: scopedSubagent,
+            ...(scopedSubagent && scopedParentToolCallId
+              ? { parentToolCallId: scopedParentToolCallId }
+              : scopedSubagent && activeSubagentParentToolCallId
+                ? { parentToolCallId: activeSubagentParentToolCallId }
+                : {}),
             state: resolveStreamToolOutcome(payload),
             result: {
               success: payload.success,
@@ -258,6 +277,11 @@ function buildLiveAssistantMessage(params: {
           toolCallId,
           toolName: payload.toolName,
           calledBy: scopedSubagent,
+          ...(scopedSubagent && scopedParentToolCallId
+            ? { parentToolCallId: scopedParentToolCallId }
+            : scopedSubagent && activeSubagentParentToolCallId
+              ? { parentToolCallId: activeSubagentParentToolCallId }
+              : {}),
           displayTitle,
           params: isRecord(payload.arguments) ? payload.arguments : undefined,
           state: typeof payload.status === 'string' ? payload.status : 'executing',
@@ -270,9 +294,13 @@ function buildLiveAssistantMessage(params: {
         }
 
         const spanData = asPayloadRecord(parsed.payload.data)
-        const parentToolCallId =
-          scopedParentToolCallId ??
-          (typeof spanData?.tool_call_id === 'string' ? spanData.tool_call_id : undefined)
+        const parentToolCallIdFromData =
+          typeof spanData?.tool_call_id === 'string'
+            ? spanData.tool_call_id
+            : typeof spanData?.toolCallId === 'string'
+              ? spanData.toolCallId
+              : undefined
+        const parentToolCallId = scopedParentToolCallId ?? parentToolCallIdFromData
         const name = typeof parsed.payload.agent === 'string' ? parsed.payload.agent : scopedAgentId
         if (parsed.payload.event === MothershipStreamV1SpanLifecycleEvent.start && name) {
           if (parentToolCallId) {
@@ -285,6 +313,7 @@ function buildLiveAssistantMessage(params: {
             kind: MothershipStreamV1SpanPayloadKind.subagent,
             lifecycle: MothershipStreamV1SpanLifecycleEvent.start,
             content: name,
+            ...(parentToolCallId ? { parentToolCallId } : {}),
           })
           continue
         }
@@ -308,6 +337,7 @@ function buildLiveAssistantMessage(params: {
             type: MothershipStreamV1EventType.span,
             kind: MothershipStreamV1SpanPayloadKind.subagent,
             lifecycle: MothershipStreamV1SpanLifecycleEvent.end,
+            ...(parentToolCallId ? { parentToolCallId } : {}),
           })
         }
         continue
@@ -345,6 +375,11 @@ function buildLiveAssistantMessage(params: {
         const content = `${prefix}${tag}`
         appendTextBlock(blocks, content, {
           ...(scopedSubagent ? { lane: 'subagent' as const } : {}),
+          ...(scopedSubagent && scopedParentToolCallId
+            ? { parentToolCallId: scopedParentToolCallId }
+            : scopedSubagent && activeSubagentParentToolCallId
+              ? { parentToolCallId: activeSubagentParentToolCallId }
+              : {}),
         })
         runningText += content
         continue

--- a/apps/sim/lib/copilot/chat/persisted-message.ts
+++ b/apps/sim/lib/copilot/chat/persisted-message.ts
@@ -41,6 +41,7 @@ export interface PersistedContentBlock {
   toolCall?: PersistedToolCall
   timestamp?: number
   endedAt?: number
+  parentToolCallId?: string
 }
 
 export interface PersistedFileAttachment {
@@ -101,9 +102,16 @@ export function withBlockTiming<T>(target: T, src: { timestamp?: number; endedAt
   return target
 }
 
+function withBlockParent<T>(target: T, src: { parentToolCallId?: string }): T {
+  if (src.parentToolCallId) {
+    ;(target as { parentToolCallId?: string }).parentToolCallId = src.parentToolCallId
+  }
+  return target
+}
+
 function mapContentBlock(block: ContentBlock): PersistedContentBlock {
   const persisted = mapContentBlockBody(block)
-  return withBlockTiming(persisted, block)
+  return withBlockParent(withBlockTiming(persisted, block), block)
 }
 
 function mapContentBlockBody(block: ContentBlock): PersistedContentBlock {
@@ -265,6 +273,7 @@ interface RawBlock {
   status?: string
   timestamp?: number
   endedAt?: number
+  parentToolCallId?: string
   toolCall?: {
     id?: string
     name?: string
@@ -321,6 +330,7 @@ function normalizeCanonicalBlock(block: RawBlock): PersistedContentBlock {
   if (block.kind) result.kind = block.kind as MothershipStreamV1SpanPayloadKind
   if (block.lifecycle) result.lifecycle = block.lifecycle as MothershipStreamV1SpanLifecycleEvent
   if (block.status) result.status = block.status as MothershipStreamV1CompletionStatus
+  if (block.parentToolCallId) result.parentToolCallId = block.parentToolCallId
   if (block.toolCall) {
     result.toolCall = {
       id: block.toolCall.id ?? '',
@@ -437,6 +447,9 @@ function normalizeBlock(block: RawBlock): PersistedContentBlock {
   }
   if (typeof block.endedAt === 'number' && result.endedAt === undefined) {
     result.endedAt = block.endedAt
+  }
+  if (block.parentToolCallId && result.parentToolCallId === undefined) {
+    result.parentToolCallId = block.parentToolCallId
   }
   return result
 }

--- a/apps/sim/lib/copilot/request/go/stream.ts
+++ b/apps/sim/lib/copilot/request/go/stream.ts
@@ -361,29 +361,26 @@ export async function runStreamLoop(
           flushSubagentThinkingBlock(context)
           flushThinkingBlock(context)
           if (spanEvt === MothershipStreamV1SpanLifecycleEvent.start) {
-            const lastParent = context.subAgentParentStack[context.subAgentParentStack.length - 1]
-            const lastBlock = context.contentBlocks[context.contentBlocks.length - 1]
             if (toolCallId) {
-              if (lastParent !== toolCallId) {
+              if (!context.subAgentParentStack.includes(toolCallId)) {
                 context.subAgentParentStack.push(toolCallId)
               }
               context.subAgentParentToolCallId = toolCallId
               context.subAgentContent[toolCallId] ??= ''
               context.subAgentToolCalls[toolCallId] ??= []
             }
-            if (
-              subagentName &&
-              !(
-                lastParent === toolCallId &&
-                lastBlock?.type === 'subagent' &&
-                lastBlock.content === subagentName
+            if (subagentName) {
+              const alreadyOpen = context.contentBlocks.some(
+                (b) =>
+                  b.type === 'subagent' && b.content === subagentName && b.endedAt === undefined
               )
-            ) {
-              context.contentBlocks.push({
-                type: 'subagent',
-                content: subagentName,
-                timestamp: Date.now(),
-              })
+              if (!alreadyOpen) {
+                context.contentBlocks.push({
+                  type: 'subagent',
+                  content: subagentName,
+                  timestamp: Date.now(),
+                })
+              }
             }
             return
           }

--- a/apps/sim/lib/copilot/request/go/stream.ts
+++ b/apps/sim/lib/copilot/request/go/stream.ts
@@ -369,15 +369,14 @@ export async function runStreamLoop(
               context.subAgentContent[toolCallId] ??= ''
               context.subAgentToolCalls[toolCallId] ??= []
             }
-            if (subagentName) {
-              const alreadyOpen = context.contentBlocks.some(
-                (b) =>
-                  b.type === 'subagent' && b.content === subagentName && b.endedAt === undefined
-              )
-              if (!alreadyOpen) {
+            if (toolCallId && subagentName) {
+              const openParents = (context.openSubagentParents ??= new Set<string>())
+              if (!openParents.has(toolCallId)) {
+                openParents.add(toolCallId)
                 context.contentBlocks.push({
                   type: 'subagent',
                   content: subagentName,
+                  parentToolCallId: toolCallId,
                   timestamp: Date.now(),
                 })
               }
@@ -397,18 +396,19 @@ export async function runStreamLoop(
               context.subAgentParentStack.length > 0
                 ? context.subAgentParentStack[context.subAgentParentStack.length - 1]
                 : undefined
-            if (subagentName) {
+            if (toolCallId && subagentName) {
               for (let i = context.contentBlocks.length - 1; i >= 0; i--) {
                 const b = context.contentBlocks[i]
                 if (
                   b.type === 'subagent' &&
-                  b.content === subagentName &&
-                  b.endedAt === undefined
+                  b.endedAt === undefined &&
+                  b.parentToolCallId === toolCallId
                 ) {
                   b.endedAt = Date.now()
                   break
                 }
               }
+              context.openSubagentParents?.delete(toolCallId)
             }
             return
           }

--- a/apps/sim/lib/copilot/request/go/stream.ts
+++ b/apps/sim/lib/copilot/request/go/stream.ts
@@ -405,7 +405,11 @@ export async function runStreamLoop(
               context.subAgentParentStack.length > 0
                 ? context.subAgentParentStack[context.subAgentParentStack.length - 1]
                 : undefined
-            if (toolCallId && subagentName) {
+            if (toolCallId) {
+              // The matching subagent block is uniquely keyed by parentToolCallId.
+              // Don't gate on subagentName: end events occasionally arrive without
+              // payload.agent, but the toolCallId is enough to close the lane and
+              // free the parent slot for future invocations of the same id.
               for (let i = context.contentBlocks.length - 1; i >= 0; i--) {
                 const b = context.contentBlocks[i]
                 if (

--- a/apps/sim/lib/copilot/request/go/stream.ts
+++ b/apps/sim/lib/copilot/request/go/stream.ts
@@ -380,6 +380,15 @@ export async function runStreamLoop(
                   timestamp: Date.now(),
                 })
               }
+            } else {
+              // Protocol invariant: every subagent_start carries scope.parentToolCallId
+              // (or data.tool_call_id) and a subagent name. If we see otherwise the
+              // group cannot be keyed and the lane will not render — log so a
+              // server-side regression is visible.
+              logger.warn('subagent start missing toolCallId or agent name', {
+                hasToolCallId: Boolean(toolCallId),
+                hasSubagentName: Boolean(subagentName),
+              })
             }
             return
           }

--- a/apps/sim/lib/copilot/request/go/stream.ts
+++ b/apps/sim/lib/copilot/request/go/stream.ts
@@ -381,10 +381,6 @@ export async function runStreamLoop(
                 })
               }
             } else {
-              // Protocol invariant: every subagent_start carries scope.parentToolCallId
-              // (or data.tool_call_id) and a subagent name. If we see otherwise the
-              // group cannot be keyed and the lane will not render — log so a
-              // server-side regression is visible.
               logger.warn('subagent start missing toolCallId or agent name', {
                 hasToolCallId: Boolean(toolCallId),
                 hasSubagentName: Boolean(subagentName),
@@ -396,12 +392,6 @@ export async function runStreamLoop(
             if (isPendingPause) {
               return
             }
-            // Pop by id, not by position: parallel subagents can end out of
-            // order, and a positional pop would otherwise remove the wrong
-            // parent and leave subAgentParentToolCallId pointing at the
-            // just-ended lane. Every subagent_end carries a toolCallId in
-            // current protocol; if one ever doesn't, prefer leaving the stack
-            // intact over guessing the wrong parent.
             if (toolCallId) {
               const idx = context.subAgentParentStack.lastIndexOf(toolCallId)
               if (idx >= 0) {
@@ -417,10 +407,6 @@ export async function runStreamLoop(
                 ? context.subAgentParentStack[context.subAgentParentStack.length - 1]
                 : undefined
             if (toolCallId) {
-              // The matching subagent block is uniquely keyed by parentToolCallId.
-              // Don't gate on subagentName: end events occasionally arrive without
-              // payload.agent, but the toolCallId is enough to close the lane and
-              // free the parent slot for future invocations of the same id.
               for (let i = context.contentBlocks.length - 1; i >= 0; i--) {
                 const b = context.contentBlocks[i]
                 if (

--- a/apps/sim/lib/copilot/request/go/stream.ts
+++ b/apps/sim/lib/copilot/request/go/stream.ts
@@ -396,10 +396,21 @@ export async function runStreamLoop(
             if (isPendingPause) {
               return
             }
-            if (context.subAgentParentStack.length > 0) {
-              context.subAgentParentStack.pop()
+            // Pop by id, not by position: parallel subagents can end out of
+            // order, and a positional pop would otherwise remove the wrong
+            // parent and leave subAgentParentToolCallId pointing at the
+            // just-ended lane. Every subagent_end carries a toolCallId in
+            // current protocol; if one ever doesn't, prefer leaving the stack
+            // intact over guessing the wrong parent.
+            if (toolCallId) {
+              const idx = context.subAgentParentStack.lastIndexOf(toolCallId)
+              if (idx >= 0) {
+                context.subAgentParentStack.splice(idx, 1)
+              } else {
+                logger.warn('subagent end without matching start', { toolCallId })
+              }
             } else {
-              logger.warn('subagent end without matching start')
+              logger.warn('subagent end missing toolCallId')
             }
             context.subAgentParentToolCallId =
               context.subAgentParentStack.length > 0

--- a/apps/sim/lib/copilot/request/handlers/text.ts
+++ b/apps/sim/lib/copilot/request/handlers/text.ts
@@ -22,6 +22,15 @@ export function handleTextEvent(scope: ToolScope): StreamHandler {
       const parentToolCallId = getScopedParentToolCallId(event, context)
       if (!parentToolCallId) return
       if (event.payload.channel === MothershipStreamV1TextChannel.thinking) {
+        if (
+          context.currentSubagentThinkingBlock &&
+          context.currentSubagentThinkingBlock.parentToolCallId !== parentToolCallId
+        ) {
+          // Lane changed mid-stream (interleaved parallel subagents) — flush
+          // the prior block so the merged content stays attributed to the
+          // correct lane.
+          flushSubagentThinkingBlock(context)
+        }
         if (!context.currentSubagentThinkingBlock) {
           context.currentSubagentThinkingBlock = {
             type: 'subagent_thinking',

--- a/apps/sim/lib/copilot/request/handlers/text.ts
+++ b/apps/sim/lib/copilot/request/handlers/text.ts
@@ -26,6 +26,7 @@ export function handleTextEvent(scope: ToolScope): StreamHandler {
           context.currentSubagentThinkingBlock = {
             type: 'subagent_thinking',
             content: '',
+            parentToolCallId,
             timestamp: Date.now(),
           }
         }
@@ -40,7 +41,7 @@ export function handleTextEvent(scope: ToolScope): StreamHandler {
       }
       context.subAgentContent[parentToolCallId] =
         (context.subAgentContent[parentToolCallId] || '') + chunk
-      addContentBlock(context, { type: 'subagent_text', content: chunk })
+      addContentBlock(context, { type: 'subagent_text', content: chunk, parentToolCallId })
       return
     }
 

--- a/apps/sim/lib/copilot/request/handlers/text.ts
+++ b/apps/sim/lib/copilot/request/handlers/text.ts
@@ -26,9 +26,6 @@ export function handleTextEvent(scope: ToolScope): StreamHandler {
           context.currentSubagentThinkingBlock &&
           context.currentSubagentThinkingBlock.parentToolCallId !== parentToolCallId
         ) {
-          // Lane changed mid-stream (interleaved parallel subagents) — flush
-          // the prior block so the merged content stays attributed to the
-          // correct lane.
           flushSubagentThinkingBlock(context)
         }
         if (!context.currentSubagentThinkingBlock) {

--- a/apps/sim/lib/copilot/request/handlers/tool.ts
+++ b/apps/sim/lib/copilot/request/handlers/tool.ts
@@ -340,6 +340,7 @@ function registerSubagentToolCall(
         type: 'tool_call',
         toolCall,
         calledBy: parentToolCall?.name,
+        parentToolCallId,
       })
     }
   }

--- a/apps/sim/lib/copilot/request/types.ts
+++ b/apps/sim/lib/copilot/request/types.ts
@@ -56,6 +56,7 @@ export interface ContentBlock {
   calledBy?: string
   timestamp: number
   endedAt?: number
+  parentToolCallId?: string
 }
 
 export interface StreamingContext {
@@ -86,6 +87,7 @@ export interface StreamingContext {
   subAgentParentStack: string[]
   subAgentContent: Record<string, string>
   subAgentToolCalls: Record<string, ToolCallState[]>
+  openSubagentParents?: Set<string>
   pendingContent: string
   streamComplete: boolean
   wasAborted: boolean
@@ -136,31 +138,12 @@ export interface OrchestratorOptions {
   onComplete?: (result: OrchestratorResult) => void | Promise<void>
   onError?: (error: Error) => void | Promise<void>
   abortSignal?: AbortSignal
-  /**
-   * Invoked when the orchestrator infers that the run was aborted via
-   * an out-of-band signal (currently: a Redis abort marker observed
-   * at SSE body close). Callers wire this to fire their local
-   * `AbortController` so `signal.reason` is set and `recordCancelled`
-   * classifies as `explicit_stop` rather than `unknown`.
-   */
   onAbortObserved?: (reason: string) => void
   interactive?: boolean
 }
 
 export interface OrchestratorResult {
   success: boolean
-  /**
-   * True iff the non-success outcome was a user-initiated cancel
-   * (abort signal fired or client disconnected). Lets callers treat
-   * cancels differently from actual errors — notably, `buildOnComplete`
-   * must NOT finalize the chat row on cancel, because the browser's
-   * `/api/copilot/chat/stop` POST owns writing the partial assistant
-   * content and clearing `conversationId` in one UPDATE. Finalizing
-   * here would race and clear `conversationId` first, making the stop
-   * UPDATE match zero rows and the partial content vanish on refetch.
-   *
-   * Always false when `success=true`.
-   */
   cancelled?: boolean
   content: string
   contentBlocks: ContentBlock[]


### PR DESCRIPTION
## Summary
- Parallel subagent rendering would sometime leave lane looking like it was still running, even though everything works correctly.
- Race in workflow execution reattachment in reconnect path 


## Type of Change
- [x] Bug fix


## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)