### PR TITLE
feat(models): add gpt-5.5 models

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -183,6 +183,47 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         contextWindow: 1047576,
         releaseDate: '2025-04-14',
       },
+      // GPT-5.5 family
+      {
+        id: 'gpt-5.5-pro',
+        pricing: {
+          input: 30.0,
+          output: 180.0,
+          updatedAt: '2026-04-23',
+        },
+        capabilities: {
+          nativeStructuredOutputs: true,
+          reasoningEffort: {
+            values: ['medium', 'high', 'xhigh'],
+          },
+          maxOutputTokens: 128000,
+        },
+        contextWindow: 1050000,
+        releaseDate: '2026-04-23',
+      },
+      {
+        id: 'gpt-5.5',
+        pricing: {
+          input: 5.0,
+          cachedInput: 0.5,
+          output: 30.0,
+          updatedAt: '2026-04-23',
+        },
+        capabilities: {
+          nativeStructuredOutputs: true,
+          computerUse: true,
+          reasoningEffort: {
+            values: ['none', 'low', 'medium', 'high', 'xhigh'],
+          },
+          verbosity: {
+            values: ['low', 'medium', 'high'],
+          },
+          maxOutputTokens: 128000,
+        },
+        contextWindow: 1050000,
+        releaseDate: '2026-04-23',
+        recommended: true,
+      },
       // GPT-5.4 family
       {
         id: 'gpt-5.4-pro',

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -211,7 +211,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           nativeStructuredOutputs: true,
-          computerUse: true,
           reasoningEffort: {
             values: ['none', 'low', 'medium', 'high', 'xhigh'],
           },
@@ -260,7 +259,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1050000,
         releaseDate: '2026-03-05',
-        recommended: true,
       },
       {
         id: 'gpt-5.4-mini',

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -194,7 +194,10 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         capabilities: {
           nativeStructuredOutputs: true,
           reasoningEffort: {
-            values: ['medium', 'high', 'xhigh'],
+            values: ['none', 'low', 'medium', 'high', 'xhigh'],
+          },
+          verbosity: {
+            values: ['low', 'medium', 'high'],
           },
           maxOutputTokens: 128000,
         },

--- a/apps/sim/providers/utils.test.ts
+++ b/apps/sim/providers/utils.test.ts
@@ -524,7 +524,6 @@ describe('Model Capabilities', () => {
         (m) =>
           m.includes('gpt-5') &&
           !m.includes('chat-latest') &&
-          !m.includes('gpt-5.5-pro') &&
           !m.includes('gpt-5.4-pro') &&
           !m.includes('gpt-5.2-pro') &&
           !m.includes('gpt-5-pro')
@@ -533,9 +532,6 @@ describe('Model Capabilities', () => {
         (m) => m.includes('gpt-5') && !m.includes('chat-latest')
       )
       expect(gpt5ModelsWithReasoningEffort.sort()).toEqual(gpt5ModelsWithVerbosity.sort())
-
-      expect(MODELS_WITH_REASONING_EFFORT).toContain('gpt-5.5-pro')
-      expect(MODELS_WITH_VERBOSITY).not.toContain('gpt-5.5-pro')
 
       expect(MODELS_WITH_REASONING_EFFORT).toContain('gpt-5.4-pro')
       expect(MODELS_WITH_VERBOSITY).not.toContain('gpt-5.4-pro')

--- a/apps/sim/providers/utils.test.ts
+++ b/apps/sim/providers/utils.test.ts
@@ -524,6 +524,7 @@ describe('Model Capabilities', () => {
         (m) =>
           m.includes('gpt-5') &&
           !m.includes('chat-latest') &&
+          !m.includes('gpt-5.5-pro') &&
           !m.includes('gpt-5.4-pro') &&
           !m.includes('gpt-5.2-pro') &&
           !m.includes('gpt-5-pro')
@@ -532,6 +533,9 @@ describe('Model Capabilities', () => {
         (m) => m.includes('gpt-5') && !m.includes('chat-latest')
       )
       expect(gpt5ModelsWithReasoningEffort.sort()).toEqual(gpt5ModelsWithVerbosity.sort())
+
+      expect(MODELS_WITH_REASONING_EFFORT).toContain('gpt-5.5-pro')
+      expect(MODELS_WITH_VERBOSITY).not.toContain('gpt-5.5-pro')
 
       expect(MODELS_WITH_REASONING_EFFORT).toContain('gpt-5.4-pro')
       expect(MODELS_WITH_VERBOSITY).not.toContain('gpt-5.4-pro')


### PR DESCRIPTION
## Summary
- Add GPT-5.5 and GPT-5.5 Pro to the OpenAI model catalog
- Include documented pricing, context windows, output limits, and capability flags

## Type of Change
- [x] Feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)