### PR TITLE
fix(security): credential-set invite email check + shopify authorize XSS

### DIFF
--- a/apps/sim/app/api/auth/shopify/authorize/route.ts
+++ b/apps/sim/app/api/auth/shopify/authorize/route.ts
@@ -32,7 +32,9 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     const returnUrl = request.nextUrl.searchParams.get('returnUrl')
 
     if (!shopDomain) {
-      const returnUrlParam = returnUrl ? encodeURIComponent(returnUrl) : ''
+      const safeReturnUrl =
+        returnUrl && isSameOrigin(returnUrl) ? encodeURIComponent(returnUrl) : ''
+      const returnUrlJsLiteral = JSON.stringify(safeReturnUrl)
       return new NextResponse(
         `<!DOCTYPE html>
 <html>
@@ -120,7 +122,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     </div>
 
     <script>
-      const returnUrl = '${returnUrlParam}';
+      const returnUrl = ${returnUrlJsLiteral};
       function handleSubmit(e) {
         e.preventDefault();
         let shop = document.getElementById('shop').value.trim().toLowerCase();

--- a/apps/sim/app/api/credential-sets/invite/[token]/route.ts
+++ b/apps/sim/app/api/credential-sets/invite/[token]/route.ts
@@ -12,6 +12,7 @@ import { and, eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { normalizeEmail } from '@/lib/invitations/core'
 import { syncAllWebhooksForCredentialSet } from '@/lib/webhooks/utils.server'
 
 const logger = createLogger('CredentialSetInviteToken')
@@ -109,6 +110,21 @@ export const POST = withRouteHandler(
           .where(eq(credentialSetInvitation.id, invitation.id))
 
         return NextResponse.json({ error: 'Invitation has expired' }, { status: 410 })
+      }
+
+      if (invitation.email) {
+        const sessionEmail = session.user.email
+        if (!sessionEmail || normalizeEmail(sessionEmail) !== normalizeEmail(invitation.email)) {
+          logger.warn('Rejected credential set invitation accept due to email mismatch', {
+            invitationId: invitation.id,
+            credentialSetId: invitation.credentialSetId,
+            userId: session.user.id,
+          })
+          return NextResponse.json(
+            { error: 'This invitation was sent to a different email address' },
+            { status: 403 }
+          )
+        }
       }
 
       const existingMember = await db


### PR DESCRIPTION
## Summary
- credential-set invite accept now verifies the session user's email matches the invitation email (uses `normalizeEmail` from the org-invite path); open invites with no bound email still work
- shopify authorize page reflects `returnUrl` via `JSON.stringify` after `isSameOrigin` validation, replacing the unsafe `'${encodeURIComponent(returnUrl)}'` JS-string interpolation that left `'` unescaped

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)