### PR TITLE
fix(mothership): stabilize task sidebar ordering on selection

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -206,10 +206,7 @@ const SidebarTaskItem = memo(function SidebarTaskItem({
             e.preventDefault()
             onMultiSelectClick(task.id, true)
           } else {
-            useFolderStore.setState({
-              selectedTasks: new Set<string>(),
-              lastSelectedTaskId: task.id,
-            })
+            useFolderStore.getState().selectTaskOnly(task.id)
           }
         }}
         onContextMenu={task.id !== 'new' ? (e) => onContextMenu(e, task.id) : undefined}

--- a/apps/sim/hooks/queries/tasks.ts
+++ b/apps/sim/hooks/queries/tasks.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { PersistedMessage } from '@/lib/copilot/chat/persisted-message'
 import { normalizeMessage } from '@/lib/copilot/chat/persisted-message'
 import {
@@ -254,7 +254,6 @@ export function useTasks(workspaceId?: string) {
     queryKey: taskKeys.list(workspaceId),
     queryFn: ({ signal }) => fetchTasks(workspaceId as string, signal),
     enabled: Boolean(workspaceId),
-    placeholderData: keepPreviousData,
     staleTime: 60 * 1000,
   })
 }
@@ -535,6 +534,10 @@ async function markTaskUnread(chatId: string): Promise<void> {
 
 /**
  * Marks a task as read with optimistic update.
+ *
+ * The server only updates `lastSeenAt`, never `updatedAt`, so we deliberately
+ * do not invalidate the list cache — that would trigger a refetch that can
+ * reorder the sidebar if any unrelated server-side update landed in between.
  */
 export function useMarkTaskRead(workspaceId?: string) {
   const queryClient = useQueryClient()
@@ -556,14 +559,14 @@ export function useMarkTaskRead(workspaceId?: string) {
         queryClient.setQueryData(taskKeys.list(workspaceId), context.previousTasks)
       }
     },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: taskKeys.list(workspaceId) })
-    },
   })
 }
 
 /**
  * Marks a task as unread with optimistic update.
+ *
+ * Same rationale as `useMarkTaskRead` — no list invalidation, since the server
+ * only flips `lastSeenAt` and the optimistic update fully reflects the change.
  */
 export function useMarkTaskUnread(workspaceId?: string) {
   const queryClient = useQueryClient()
@@ -584,9 +587,6 @@ export function useMarkTaskUnread(workspaceId?: string) {
       if (context?.previousTasks) {
         queryClient.setQueryData(taskKeys.list(workspaceId), context.previousTasks)
       }
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: taskKeys.list(workspaceId) })
     },
   })
 }

--- a/apps/sim/hooks/use-task-events.test.ts
+++ b/apps/sim/hooks/use-task-events.test.ts
@@ -50,12 +50,9 @@ describe('handleTaskStatusEvent', () => {
     })
   })
 
-  it('preserves list invalidation when task event payload is invalid', () => {
+  it('does not invalidate when task event payload is invalid', () => {
     handleTaskStatusEvent(queryClient, 'ws-1', '{')
 
-    expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(1)
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
-      queryKey: taskKeys.list('ws-1'),
-    })
+    expect(queryClient.invalidateQueries).not.toHaveBeenCalled()
   })
 })

--- a/apps/sim/hooks/use-task-events.ts
+++ b/apps/sim/hooks/use-task-events.ts
@@ -41,13 +41,13 @@ export function handleTaskStatusEvent(
   workspaceId: string,
   data: unknown
 ): void {
-  queryClient.invalidateQueries({ queryKey: taskKeys.list(workspaceId) })
-
   const payload = parseTaskStatusEventPayload(data)
   if (!payload) {
     logger.warn('Received invalid task_status payload')
     return
   }
+
+  queryClient.invalidateQueries({ queryKey: taskKeys.list(workspaceId) })
 }
 
 /**


### PR DESCRIPTION
## Summary
- drop `keepPreviousData` from `useTasks` — was on a static key, caused stale-then-snap reorders on invalidation
- remove list invalidation from `useMarkTaskRead`/`useMarkTaskUnread` — server only flips `lastSeenAt`, optimistic update is sufficient
- validate SSE `task_status` payload before invalidating the task list — drop bogus events instead of triggering a refetch
- use `selectTaskOnly` in sidebar click handler so non-shift clicks match the rest of the selection model (clears workflow/folder selections, populates `selectedTasks`)

## Type of Change
- [x] Bug fix

## Testing
Tested manually. 8/8 unit tests pass (`hooks/queries/tasks.test.ts`, `hooks/use-task-events.test.ts`).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)