### PR TITLE
improvement(docker): speed up app image build with cache mounts and parallel node-gyp

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -45,15 +45,17 @@ COPY packages/workflow-types/package.json ./packages/workflow-types/package.json
 
 # Install dependencies, then rebuild isolated-vm for Node.js
 # Use --linker=hoisted for flat node_modules layout (required for Docker multi-stage builds)
+# JOBS=4 caps node-gyp parallelism — higher values OOM isolated-vm (laverdet/isolated-vm#428)
 RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
     --mount=type=cache,id=npm-cache,target=/root/.npm \
     HUSKY=0 bun install --omit=dev --ignore-scripts --linker=hoisted && \
-    cd node_modules/isolated-vm && npx node-gyp rebuild --release
+    cd node_modules/isolated-vm && JOBS=4 npx node-gyp rebuild --release
 
 # ========================================
 # Builder Stage: Build the Application
 # ========================================
 FROM base AS builder
+ARG TARGETPLATFORM
 WORKDIR /app
 
 # Install turbo globally (cached for fast reinstall)
@@ -88,16 +90,9 @@ COPY apps/sim/postcss.config.mjs ./apps/sim/postcss.config.mjs
 COPY apps/sim ./apps/sim
 COPY packages ./packages
 
-# Required for standalone nextjs build
-WORKDIR /app/apps/sim
-RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
-    HUSKY=0 bun install sharp --linker=hoisted
-
 ENV NEXT_TELEMETRY_DISABLED=1 \
     VERCEL_TELEMETRY_DISABLED=1 \
     DOCKER_BUILD=1
-
-WORKDIR /app
 
 # Provide dummy database URLs during image build so server code that imports @sim/db
 # can be evaluated without crashing. Runtime environments should override these.
@@ -109,7 +104,10 @@ ENV DATABASE_URL=${DATABASE_URL}
 ARG NEXT_PUBLIC_APP_URL="http://localhost:3000"
 ENV NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
 
-RUN bun run build
+# Per-platform cache id keeps arm64/amd64 SWC artifacts isolated.
+RUN --mount=type=cache,id=next-cache-${TARGETPLATFORM},target=/app/apps/sim/.next/cache \
+    --mount=type=cache,id=turbo-cache-${TARGETPLATFORM},target=/app/.turbo \
+    bun run build
 
 # ========================================
 # Runner Stage: Run the actual app


### PR DESCRIPTION
## Summary
- Add `.next/cache` and `.turbo` BuildKit cache mounts on `bun run build` (per-platform `id=` to isolate arm64/amd64 SWC artifacts)
- Cap `node-gyp rebuild` of `isolated-vm` at `JOBS=4` (higher values OOM per laverdet/isolated-vm#428)
- Remove redundant `bun install sharp` step — sharp is already a regular dep, the second install just busts cache on every source change

## Type of Change
- [x] Improvement

## Testing
Tested manually — diff is local to docker/app.Dockerfile; will verify cold/warm ARM64 build times on first deploy after merge. Target: ~7–8 min cold, ~3–4 min warm (down from 11–12/6–7).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)