### PR TITLE
fix(security): require internal API key for copilot training endpoints

### DIFF
--- a/apps/sim/app/api/copilot/training/examples/route.ts
+++ b/apps/sim/app/api/copilot/training/examples/route.ts
@@ -1,10 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import {
-  authenticateCopilotRequestSessionOnly,
-  createUnauthorizedResponse,
-} from '@/lib/copilot/request/http'
+import { checkInternalApiKey, createUnauthorizedResponse } from '@/lib/copilot/request/http'
 import { env } from '@/lib/core/config/env'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 
@@ -21,8 +18,8 @@ const TrainingExampleSchema = z.object({
 })
 
 export const POST = withRouteHandler(async (request: NextRequest) => {
-  const { userId, isAuthenticated } = await authenticateCopilotRequestSessionOnly()
-  if (!isAuthenticated || !userId) {
+  const auth = checkInternalApiKey(request)
+  if (!auth.success) {
     return createUnauthorizedResponse()
   }
 

--- a/apps/sim/app/api/copilot/training/route.ts
+++ b/apps/sim/app/api/copilot/training/route.ts
@@ -1,10 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import {
-  authenticateCopilotRequestSessionOnly,
-  createUnauthorizedResponse,
-} from '@/lib/copilot/request/http'
+import { checkInternalApiKey, createUnauthorizedResponse } from '@/lib/copilot/request/http'
 import { env } from '@/lib/core/config/env'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 
@@ -27,8 +24,8 @@ const TrainingDataSchema = z.object({
 })
 
 export const POST = withRouteHandler(async (request: NextRequest) => {
-  const { userId, isAuthenticated } = await authenticateCopilotRequestSessionOnly()
-  if (!isAuthenticated || !userId) {
+  const auth = checkInternalApiKey(request)
+  if (!auth.success) {
     return createUnauthorizedResponse()
   }
 


### PR DESCRIPTION
## Summary
- `/api/copilot/training` and `/api/copilot/training/examples` previously accepted any authenticated session, letting any user inject arbitrary data into the global agent indexer
- Both routes now require `INTERNAL_API_SECRET` via the `x-api-key` header (existing `checkInternalApiKey` helper) — no in-app callers exist, these are internal-only endpoints

## Type of Change
- [x] Bug fix

## Testing
Tested manually; typecheck clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)