### PR TITLE
fix(docker): install devDeps in builder stage for build

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -80,6 +80,12 @@ COPY packages/workflow-authz/package.json ./packages/workflow-authz/package.json
 COPY packages/workflow-persistence/package.json ./packages/workflow-persistence/package.json
 COPY packages/workflow-types/package.json ./packages/workflow-types/package.json
 
+# Install full dependency set. The deps stage installed --omit=dev for the
+# runtime image; the build needs devDeps like tailwindcss/postcss. Placed
+# before source copy so it stays cached on source-only changes.
+RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
+    HUSKY=0 bun install --ignore-scripts --linker=hoisted
+
 # Copy workspace configuration files (needed for turbo)
 COPY apps/sim/next.config.ts ./apps/sim/next.config.ts
 COPY apps/sim/tsconfig.json ./apps/sim/tsconfig.json


### PR DESCRIPTION
## Summary
Hotfix for staging build break introduced by #4310.

The previous `bun install sharp` step in the builder stage looked redundant (sharp is already a regular dep), but it was secretly doing the heavy lifting: with no `--omit=dev`, it pulled in **all devDeps** as a side effect — including `tailwindcss`, `postcss`, etc. that `bun run build` needs. Removing it broke the build with the misleading "tailwindcss as PostCSS plugin" error.

This restores an explicit `bun install --ignore-scripts --linker=hoisted` (no `--omit=dev`) in the builder stage, placed after the package.json copies and before source copy so it stays cached on source-only changes.

## Type of Change
- [x] Bug fix

## Testing
Will verify on first deploy after merge — this is the same install the original code was doing as a side effect of `bun install sharp`, just made explicit.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)