### PR TITLE
perf(docker): use turbo prune for app.Dockerfile

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -12,43 +12,34 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get install -y nodejs
 
 # ========================================
+# Pruner Stage: Emit a minimal monorepo subset that sim depends on
+# ========================================
+FROM base AS pruner
+WORKDIR /app
+
+RUN bun install -g turbo
+
+COPY . .
+
+RUN turbo prune sim --docker
+
+# ========================================
 # Dependencies Stage: Install Dependencies
 # ========================================
 FROM base AS deps
 WORKDIR /app
 
-COPY package.json bun.lock turbo.json ./
-RUN mkdir -p apps \
-    packages/audit \
-    packages/db \
-    packages/logger \
-    packages/realtime-protocol \
-    packages/security \
-    packages/testing \
-    packages/tsconfig \
-    packages/utils \
-    packages/workflow-authz \
-    packages/workflow-persistence \
-    packages/workflow-types
-COPY apps/sim/package.json ./apps/sim/package.json
-COPY packages/audit/package.json ./packages/audit/package.json
-COPY packages/db/package.json ./packages/db/package.json
-COPY packages/logger/package.json ./packages/logger/package.json
-COPY packages/realtime-protocol/package.json ./packages/realtime-protocol/package.json
-COPY packages/security/package.json ./packages/security/package.json
-COPY packages/testing/package.json ./packages/testing/package.json
-COPY packages/tsconfig/package.json ./packages/tsconfig/package.json
-COPY packages/utils/package.json ./packages/utils/package.json
-COPY packages/workflow-authz/package.json ./packages/workflow-authz/package.json
-COPY packages/workflow-persistence/package.json ./packages/workflow-persistence/package.json
-COPY packages/workflow-types/package.json ./packages/workflow-types/package.json
+# Pruned manifests + lockfile from the pruner stage. This layer only invalidates
+# when package.json/bun.lock content changes — not on source edits.
+COPY --from=pruner /app/out/json/ ./
+COPY --from=pruner /app/out/bun.lock ./bun.lock
 
-# Install dependencies, then rebuild isolated-vm for Node.js
-# Use --linker=hoisted for flat node_modules layout (required for Docker multi-stage builds)
-# JOBS=4 caps node-gyp parallelism — higher values OOM isolated-vm (laverdet/isolated-vm#428)
+# Install all dependencies (including devDependencies — tailwindcss/postcss are
+# devDeps but required at build time). Then rebuild isolated-vm against Node.js.
+# JOBS=4 caps node-gyp parallelism — higher values OOM isolated-vm (laverdet/isolated-vm#428).
 RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
     --mount=type=cache,id=npm-cache,target=/root/.npm \
-    HUSKY=0 bun install --omit=dev --ignore-scripts --linker=hoisted && \
+    HUSKY=0 bun install --ignore-scripts --linker=hoisted && \
     cd node_modules/isolated-vm && JOBS=4 npx node-gyp rebuild --release
 
 # ========================================
@@ -58,37 +49,11 @@ FROM base AS builder
 ARG TARGETPLATFORM
 WORKDIR /app
 
-# Install turbo globally (cached for fast reinstall)
-RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
-    bun install -g turbo
-
 # Copy node_modules from deps stage (cached if dependencies don't change)
 COPY --from=deps /app/node_modules ./node_modules
 
-# Copy package configuration files (needed for build)
-COPY package.json bun.lock turbo.json ./
-COPY apps/sim/package.json ./apps/sim/package.json
-COPY packages/audit/package.json ./packages/audit/package.json
-COPY packages/db/package.json ./packages/db/package.json
-COPY packages/logger/package.json ./packages/logger/package.json
-COPY packages/realtime-protocol/package.json ./packages/realtime-protocol/package.json
-COPY packages/security/package.json ./packages/security/package.json
-COPY packages/testing/package.json ./packages/testing/package.json
-COPY packages/tsconfig/package.json ./packages/tsconfig/package.json
-COPY packages/utils/package.json ./packages/utils/package.json
-COPY packages/workflow-authz/package.json ./packages/workflow-authz/package.json
-COPY packages/workflow-persistence/package.json ./packages/workflow-persistence/package.json
-COPY packages/workflow-types/package.json ./packages/workflow-types/package.json
-
-# Copy workspace configuration files (needed for turbo)
-COPY apps/sim/next.config.ts ./apps/sim/next.config.ts
-COPY apps/sim/tsconfig.json ./apps/sim/tsconfig.json
-COPY apps/sim/tailwind.config.ts ./apps/sim/tailwind.config.ts
-COPY apps/sim/postcss.config.mjs ./apps/sim/postcss.config.mjs
-
-# Copy source code (changes most frequently - placed last to maximize cache hits)
-COPY apps/sim ./apps/sim
-COPY packages ./packages
+# Copy pruned source tree (apps/sim + workspace packages it depends on)
+COPY --from=pruner /app/out/full/ ./
 
 ENV NEXT_TELEMETRY_DISABLED=1 \
     VERCEL_TELEMETRY_DISABLED=1 \

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 FROM base AS pruner
 WORKDIR /app
 
-RUN bun install -g turbo
+RUN bun install -g turbo@2.9.6
 
 COPY . .
 


### PR DESCRIPTION
## Summary

Refactors `docker/app.Dockerfile` to use `turbo prune sim --docker` instead of hand-maintaining a list of `COPY packages/*/package.json` lines. This matches the canonical Vercel/Turborepo monorepo Docker pattern and our existing `realtime.Dockerfile`.

**Supersedes #4321** — that PR is a hotfix that adds a second \`bun install\` in the builder stage to recover devDependencies. This PR removes the need for that workaround entirely by installing the full dep set once in the \`deps\` stage against pruned manifests.

### What changed

- **New \`pruner\` stage** runs \`turbo prune sim --docker\`, emitting:
  - \`out/json/\` — pruned package manifests + \`bun.lock\` (cache key)
  - \`out/full/\` — only the sources sim transitively depends on
- **\`deps\` stage** now copies from \`out/json/\` and runs a single \`bun install\` (no \`--omit=dev\` — tailwindcss/postcss are devDeps required at build time).
- **\`builder\` stage** copies \`node_modules\` from deps + \`out/full/\` from pruner. Drops the global turbo install, manual workspace package.json copies, and individual config file copies.
- Net: **-59 / +24 lines**, build cache only invalidates on real dep changes.

### Why this is the right pattern

- It's what Vercel's [\`with-docker\` example](https://github.com/vercel/next.js/tree/canary/examples/with-docker) and Turborepo's [\`with-docker\`](https://github.com/vercel/turborepo/tree/main/examples/with-docker) ship as the recommended monorepo Dockerfile shape.
- Already in use in this repo via \`docker/realtime.Dockerfile\`.
- Each workspace package becomes a content-addressable cache layer: edit \`apps/sim/components/foo.tsx\` and the deps stage cache stays warm.

## Test plan

- [x] CI build (amd64) succeeds end-to-end
- [x] CI build (arm64, on main) succeeds end-to-end  
- [x] Image runs and serves traffic
- [x] Verify build is reproducible — re-run with no source changes hits the deps cache layer
