### PR TITLE
fix(docker): use full bun.lock + bump deprecated GHA actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.DEV_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.DEV_AWS_REGION }}
@@ -80,7 +80,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ github.ref == 'refs/heads/main' && secrets.AWS_ROLE_TO_ASSUME || secrets.STAGING_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ github.ref == 'refs/heads/main' && secrets.AWS_REGION || secrets.STAGING_AWS_REGION }}
@@ -145,14 +145,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
         if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -234,7 +234,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -286,7 +286,7 @@ jobs:
 
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -23,12 +23,12 @@ jobs:
           bun-version: 1.3.13
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -26,7 +26,7 @@ jobs:
           bun-version: 1.3.13
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -125,7 +125,7 @@ jobs:
           bun-version: 1.3.13
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ github.ref == 'refs/heads/main' && secrets.AWS_ROLE_TO_ASSUME || github.ref == 'refs/heads/dev' && secrets.DEV_AWS_ROLE_TO_ASSUME || secrets.STAGING_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ github.ref == 'refs/heads/main' && secrets.AWS_REGION || github.ref == 'refs/heads/dev' && secrets.DEV_AWS_REGION || secrets.STAGING_AWS_REGION }}
@@ -44,14 +44,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
         if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -22,7 +22,7 @@ jobs:
           bun-version: 1.3.13
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -22,13 +22,13 @@ jobs:
           bun-version: 1.3.13
 
       - name: Setup Node.js for npm publishing
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -22,13 +22,13 @@ jobs:
           bun-version: 1.3.13
 
       - name: Setup Node.js for npm publishing
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -22,7 +22,7 @@ jobs:
           bun-version: 1.3.13
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: latest
 
@@ -45,7 +45,7 @@ jobs:
           path: ./.turbo
 
       - name: Restore Next.js build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ./apps/sim/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -29,10 +29,14 @@ RUN turbo prune sim --docker
 FROM base AS deps
 WORKDIR /app
 
-# Pruned manifests + lockfile from the pruner stage. This layer only invalidates
-# when package.json/bun.lock content changes — not on source edits.
+# Pruned manifests from the pruner stage. This layer only invalidates when
+# package.json/bun.lock content changes — not on source edits.
 COPY --from=pruner /app/out/json/ ./
-COPY --from=pruner /app/out/bun.lock ./bun.lock
+# Use the full bun.lock (not the pruned out/bun.lock). turbo prune emits a
+# bun.lock that bun 1.3.x rejects with "Failed to resolve prod dependency",
+# forcing a slow fresh resolve. The full lockfile parses cleanly and bun
+# only installs what the pruned package.jsons reference.
+COPY --from=pruner /app/bun.lock ./bun.lock
 
 # Install all dependencies (including devDependencies — tailwindcss/postcss are
 # devDeps but required at build time). Then rebuild isolated-vm against Node.js.
@@ -54,6 +58,12 @@ COPY --from=deps /app/node_modules ./node_modules
 
 # Copy pruned source tree (apps/sim + workspace packages it depends on)
 COPY --from=pruner /app/out/full/ ./
+
+# Next.js 16 / Turbopack workspace-root detection looks for a lockfile next to
+# the workspace package.json. Without it, `next build` fails with
+# "couldn't find next/package.json from /app/apps/sim". turbo also warns
+# "Lockfile not found at /app/bun.lock" without it.
+COPY --from=pruner /app/bun.lock ./bun.lock
 
 ENV NEXT_TELEMETRY_DISABLED=1 \
     VERCEL_TELEMETRY_DISABLED=1 \


### PR DESCRIPTION
## Summary

Two fixes to unbreak staging and clear the Node.js 20 deprecation warnings flagged on the failed run.

### 1. Docker: use full \`bun.lock\` and copy it into the builder stage

The staging image build is currently broken (CI run [25075037330](https://github.com/simstudioai/sim/actions/runs/25075037330) — the merge of #4322). Two nested issues, both rooted in \`bun.lock\`:

- **\`turbo prune\` emits a malformed \`bun.lock\`** for bun 1.3.x:
  \`\`\`
  error: Failed to resolve prod dependency 'wrap-ansi' for package 'log-update' at bun.lock:2688:5
  warn: Ignoring lockfile
  \`\`\`
  Bun then does a fresh resolve (~7 minutes for the deps stage).

- **Next.js 16.1.6 / Turbopack production builds** need a lockfile at the workspace root to detect it. The builder was copying \`out/full/\` (no \`bun.lock\`) which left \`/app/\` without one:
  \`\`\`
  Error: We couldn't find the Next.js package (next/package.json) from the project directory: /app/apps/sim
  \`\`\`
  This is the actual blocking error.

**Fix**:
- \`deps\` stage: copy the full \`/app/bun.lock\` from the pruner stage (the original after \`COPY . .\`), not the broken pruned \`/app/out/bun.lock\`.
- \`builder\` stage: add \`COPY --from=pruner /app/bun.lock ./bun.lock\` so Turbopack/turborepo can detect the workspace root.

### 2. CI: bump deprecated Node.js 20 actions

GitHub Actions emits deprecation warnings on the Build AMD64 / Test and Build jobs. Node.js 20 will be force-upgraded by GitHub on 2026-06-02 and removed on 2026-09-16. Bumped to the latest stable majors (all use Node.js 24):

| Action | Before | After |
|---|---|---|
| \`actions/cache\` | v4 | v5 |
| \`actions/setup-node\` | v4 | v6 |
| \`aws-actions/configure-aws-credentials\` | v4 | v6 |
| \`docker/login-action\` | v3 | v4 |

All require GHA runner v2.327.1+, which Blacksmith already runs.

## Test plan

- [x] Build AMD64 / app.Dockerfile completes end-to-end on staging
- [x] \`deps\` install completes from lockfile (no \"Ignoring lockfile\" warning, ~minute instead of ~7m)
- [x] No Turbopack workspace-root error during \`bun run build\`
- [x] Resulting container runs and serves traffic
- [x] No more Node.js 20 deprecation warnings on subsequent runs