### PR TITLE
fix(knowledge): skip sync and document processing when KB is deleted

### DIFF
--- a/apps/sim/lib/knowledge/connectors/sync-engine.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-engine.ts
@@ -305,6 +305,15 @@ export async function executeSync(
     logger.warn(
       `Skipping sync: knowledge base ${connector.knowledgeBaseId} is deleted (connector ${connectorId})`
     )
+    await db
+      .update(knowledgeConnector)
+      .set({
+        status: 'error',
+        nextSyncAt: null,
+        lastSyncError: 'Knowledge base deleted',
+        updatedAt: new Date(),
+      })
+      .where(eq(knowledgeConnector.id, connectorId))
     return { ...result, error: 'knowledge_base_deleted' }
   }
 

--- a/apps/sim/lib/knowledge/connectors/sync-engine.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-engine.ts
@@ -156,8 +156,11 @@ export async function dispatchSync(
     const connectorRows = await db
       .select({
         knowledgeBaseId: knowledgeConnector.knowledgeBaseId,
+        connectorArchivedAt: knowledgeConnector.archivedAt,
+        connectorDeletedAt: knowledgeConnector.deletedAt,
         workspaceId: knowledgeBase.workspaceId,
         userId: knowledgeBase.userId,
+        kbDeletedAt: knowledgeBase.deletedAt,
       })
       .from(knowledgeConnector)
       .innerJoin(knowledgeBase, eq(knowledgeBase.id, knowledgeConnector.knowledgeBaseId))
@@ -165,10 +168,30 @@ export async function dispatchSync(
       .limit(1)
 
     const row = connectorRows[0]
+    if (!row) {
+      logger.warn(`Skipping sync dispatch: connector not found`, { connectorId, requestId })
+      return
+    }
+    if (row.kbDeletedAt) {
+      logger.warn(`Skipping sync dispatch: knowledge base is deleted`, {
+        connectorId,
+        knowledgeBaseId: row.knowledgeBaseId,
+        requestId,
+      })
+      return
+    }
+    if (row.connectorArchivedAt || row.connectorDeletedAt) {
+      logger.warn(`Skipping sync dispatch: connector is archived or deleted`, {
+        connectorId,
+        requestId,
+      })
+      return
+    }
+
     const tags = [`connectorId:${connectorId}`]
-    if (row?.knowledgeBaseId) tags.push(`knowledgeBaseId:${row.knowledgeBaseId}`)
-    if (row?.workspaceId) tags.push(`workspaceId:${row.workspaceId}`)
-    if (row?.userId) tags.push(`userId:${row.userId}`)
+    if (row.knowledgeBaseId) tags.push(`knowledgeBaseId:${row.knowledgeBaseId}`)
+    if (row.workspaceId) tags.push(`workspaceId:${row.workspaceId}`)
+    if (row.userId) tags.push(`userId:${row.userId}`)
 
     await knowledgeConnectorSync.trigger(
       {
@@ -261,7 +284,8 @@ export async function executeSync(
     .limit(1)
 
   if (connectorRows.length === 0) {
-    throw new Error(`Connector not found: ${connectorId}`)
+    logger.warn(`Skipping sync: connector ${connectorId} not found, archived, or deleted`)
+    return { ...result, error: 'connector_unavailable' }
   }
 
   const connector = connectorRows[0]
@@ -278,7 +302,10 @@ export async function executeSync(
     .limit(1)
 
   if (kbRows.length === 0) {
-    throw new Error(`Knowledge base not found: ${connector.knowledgeBaseId}`)
+    logger.warn(
+      `Skipping sync: knowledge base ${connector.knowledgeBaseId} is deleted (connector ${connectorId})`
+    )
+    return { ...result, error: 'knowledge_base_deleted' }
   }
 
   const userId = kbRows[0].userId

--- a/apps/sim/lib/knowledge/connectors/sync-engine.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-engine.ts
@@ -178,6 +178,15 @@ export async function dispatchSync(
         knowledgeBaseId: row.knowledgeBaseId,
         requestId,
       })
+      await db
+        .update(knowledgeConnector)
+        .set({
+          status: 'error',
+          nextSyncAt: null,
+          lastSyncError: 'Knowledge base deleted',
+          updatedAt: new Date(),
+        })
+        .where(eq(knowledgeConnector.id, connectorId))
       return
     }
     if (row.connectorArchivedAt || row.connectorDeletedAt) {

--- a/apps/sim/lib/knowledge/documents/service.ts
+++ b/apps/sim/lib/knowledge/documents/service.ts
@@ -386,7 +386,10 @@ export async function processDocumentAsync(
       .limit(1)
 
     if (kb.length === 0) {
-      throw new Error(`Knowledge base not found: ${knowledgeBaseId}`)
+      logger.warn(
+        `[${documentId}] Skipping document processing: knowledge base ${knowledgeBaseId} is deleted`
+      )
+      return
     }
 
     await db

--- a/apps/sim/lib/knowledge/documents/service.ts
+++ b/apps/sim/lib/knowledge/documents/service.ts
@@ -389,6 +389,16 @@ export async function processDocumentAsync(
       logger.warn(
         `[${documentId}] Skipping document processing: knowledge base ${knowledgeBaseId} is deleted`
       )
+      await db
+        .update(document)
+        .set({
+          processingStatus: 'failed',
+          processingError: 'Knowledge base deleted',
+          processingCompletedAt: new Date(),
+        })
+        .where(
+          and(eq(document.id, documentId), isNull(document.archivedAt), isNull(document.deletedAt))
+        )
       return
     }
 


### PR DESCRIPTION
## Summary
- Guard `dispatchSync` to refuse enqueueing the connector-sync trigger task when the KB is deleted or the connector is archived/deleted
- `executeSync` now returns a `SyncResult` with `error` instead of throwing on missing connector / deleted KB, so the connector-sync task succeeds without 3x retries
- `processDocumentAsync` logs a warn and returns when the KB is deleted instead of throwing — stops the retry flood on `knowledge-process-document`

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)