### PR TITLE
fix(billing): gate org billing query to invite modal open state and allow GA doubleclick in CSP

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/components/invite-modal/invite-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/components/invite-modal/invite-modal.tsx
@@ -79,7 +79,9 @@ export function InviteModal({
   const { data: pendingInvitations = [], isLoading: isPendingInvitationsLoading } =
     usePendingInvitations(open ? workspaceId : undefined)
 
-  const { data: organizationBillingData } = useOrganizationBilling(organizationId ?? '')
+  const { data: organizationBillingData } = useOrganizationBilling(organizationId ?? '', {
+    enabled: open,
+  })
 
   const batchSendInvitations = useBatchSendWorkspaceInvitations()
   const cancelInvitation = useCancelWorkspaceInvitation()

--- a/apps/sim/hooks/queries/organization.ts
+++ b/apps/sim/hooks/queries/organization.ts
@@ -201,11 +201,11 @@ async function fetchOrganizationBilling(orgId: string, signal?: AbortSignal) {
 /**
  * Hook to fetch organization billing data
  */
-export function useOrganizationBilling(orgId: string) {
+export function useOrganizationBilling(orgId: string, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: organizationKeys.billing(orgId),
     queryFn: ({ signal }) => fetchOrganizationBilling(orgId, signal),
-    enabled: !!orgId,
+    enabled: !!orgId && (options?.enabled ?? true),
     retry: false,
     staleTime: 30 * 1000,
     placeholderData: keepPreviousData,

--- a/apps/sim/lib/core/security/csp.ts
+++ b/apps/sim/lib/core/security/csp.ts
@@ -105,6 +105,8 @@ const STATIC_CONNECT_SRC = [
         'https://analytics.google.com',
         'https://www.google.com',
         'https://analytics.ahrefs.com',
+        'https://*.g.doubleclick.net',
+        'https://stats.g.doubleclick.net',
       ]
     : []),
 ] as const

--- a/apps/sim/lib/core/security/csp.ts
+++ b/apps/sim/lib/core/security/csp.ts
@@ -106,7 +106,6 @@ const STATIC_CONNECT_SRC = [
         'https://www.google.com',
         'https://analytics.ahrefs.com',
         'https://*.g.doubleclick.net',
-        'https://stats.g.doubleclick.net',
       ]
     : []),
 ] as const


### PR DESCRIPTION
## Summary
- Gate `useOrganizationBilling` behind the invite modal's `open` state so it stops firing on app load (was returning 403 for users whose active workspace points at an org they aren't a member of)
- Add `enabled` option to `useOrganizationBilling` matching the documented React Query pattern
- Allow `https://*.g.doubleclick.net` and `https://stats.g.doubleclick.net` in CSP `connect-src` (hosted only) so GA conversion-linker pings stop violating CSP and flooding the console on the app + 404 page

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)