### PR TITLE
fix(table): return 400 instead of 500 on empty batch insert

### DIFF
--- a/apps/sim/app/api/table/[tableId]/rows/route.ts
+++ b/apps/sim/app/api/table/[tableId]/rows/route.ts
@@ -232,7 +232,7 @@ export const POST = withRouteHandler(
         'rows' in body &&
         Array.isArray((body as Record<string, unknown>).rows)
       ) {
-        return handleBatchInsert(
+        return await handleBatchInsert(
           requestId,
           tableId,
           body as z.infer<typeof BatchInsertRowsSchema>,


### PR DESCRIPTION
## Summary
- POST `/api/table/[tableId]/rows` called `handleBatchInsert` without `await`, so ZodError rejections (e.g. empty `rows` array) bypassed the route's try/catch and were caught by `withRouteHandler` as an unhandled error — returning a generic 500 "Internal server error"
- Add `await` so validation errors surface as proper 400s with the actual message (e.g. "At least one row is required")

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)