### PR TITLE
improvement(docs): soften video hover opacity

### DIFF
--- a/apps/docs/components/ui/video.tsx
+++ b/apps/docs/components/ui/video.tsx
@@ -50,7 +50,7 @@ export function Video({
         height={height}
         className={cn(
           className,
-          enableLightbox && 'cursor-pointer transition-opacity hover:opacity-95'
+          enableLightbox && 'cursor-pointer transition-opacity hover:opacity-[0.97]'
         )}
         src={getAssetUrl(src)}
         onClick={handleVideoClick}


### PR DESCRIPTION
## Summary
- Reduce hover opacity change on docs video components from 95% to 97% for a subtler effect

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)