### PR TITLE
fix(files): use incremental applyEdits to prevent streaming flicker in Monaco editor

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -443,8 +443,7 @@ export const TextEditor = memo(function TextEditor({
         }
       }
       suppressScrollListenerRef.current = true
-      const prev = lastSyncedContentRef.current
-      if (content.startsWith(prev) && prev.length < content.length) {
+      if (content.startsWith(monacoValue) && monacoValue.length < content.length) {
         const lastLine = model.getLineCount()
         const lastCol = model.getLineMaxColumn(lastLine)
         model.applyEdits([
@@ -455,7 +454,7 @@ export const TextEditor = memo(function TextEditor({
               endLineNumber: lastLine,
               endColumn: lastCol,
             },
-            text: content.slice(prev.length),
+            text: content.slice(monacoValue.length),
           },
         ])
       } else {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -446,19 +446,27 @@ export const TextEditor = memo(function TextEditor({
       if (content.startsWith(monacoValue) && monacoValue.length < content.length) {
         const lastLine = model.getLineCount()
         const lastCol = model.getLineMaxColumn(lastLine)
-        model.applyEdits([
-          {
-            range: {
-              startLineNumber: lastLine,
-              startColumn: lastCol,
-              endLineNumber: lastLine,
-              endColumn: lastCol,
+        model.pushEditOperations(
+          null,
+          [
+            {
+              range: {
+                startLineNumber: lastLine,
+                startColumn: lastCol,
+                endLineNumber: lastLine,
+                endColumn: lastCol,
+              },
+              text: content.slice(monacoValue.length),
             },
-            text: content.slice(monacoValue.length),
-          },
-        ])
+          ],
+          () => null
+        )
       } else {
-        model.applyEdits([{ range: model.getFullModelRange(), text: content }])
+        model.pushEditOperations(
+          null,
+          [{ range: model.getFullModelRange(), text: content }],
+          () => null
+        )
       }
       suppressScrollListenerRef.current = false
       lastSyncedContentRef.current = content

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -446,27 +446,19 @@ export const TextEditor = memo(function TextEditor({
       if (content.startsWith(monacoValue) && monacoValue.length < content.length) {
         const lastLine = model.getLineCount()
         const lastCol = model.getLineMaxColumn(lastLine)
-        model.pushEditOperations(
-          null,
-          [
-            {
-              range: {
-                startLineNumber: lastLine,
-                startColumn: lastCol,
-                endLineNumber: lastLine,
-                endColumn: lastCol,
-              },
-              text: content.slice(monacoValue.length),
+        model.applyEdits([
+          {
+            range: {
+              startLineNumber: lastLine,
+              startColumn: lastCol,
+              endLineNumber: lastLine,
+              endColumn: lastCol,
             },
-          ],
-          () => null
-        )
+            text: content.slice(monacoValue.length),
+          },
+        ])
       } else {
-        model.pushEditOperations(
-          null,
-          [{ range: model.getFullModelRange(), text: content }],
-          () => null
-        )
+        model.applyEdits([{ range: model.getFullModelRange(), text: content }])
       }
       suppressScrollListenerRef.current = false
       lastSyncedContentRef.current = content

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -442,11 +442,25 @@ export const TextEditor = memo(function TextEditor({
           textareaStuckRef.current = true
         }
       }
-      const viewState =
-        isStreamInteractionLocked && !textareaStuckRef.current ? editor.saveViewState() : null
       suppressScrollListenerRef.current = true
-      model.setValue(content)
-      if (viewState) editor.restoreViewState(viewState)
+      const prev = lastSyncedContentRef.current
+      if (content.startsWith(prev) && prev.length < content.length) {
+        const lastLine = model.getLineCount()
+        const lastCol = model.getLineMaxColumn(lastLine)
+        model.applyEdits([
+          {
+            range: {
+              startLineNumber: lastLine,
+              startColumn: lastCol,
+              endLineNumber: lastLine,
+              endColumn: lastCol,
+            },
+            text: content.slice(prev.length),
+          },
+        ])
+      } else {
+        model.applyEdits([{ range: model.getFullModelRange(), text: content }])
+      }
       suppressScrollListenerRef.current = false
       lastSyncedContentRef.current = content
     }


### PR DESCRIPTION
## Summary
- Replace `model.setValue()` with `model.applyEdits()` when syncing streamed content into the Monaco editor during Mothership file generation
- When content is purely additive (each chunk is a superset of the previous), only insert the new suffix — no re-tokenization of existing content, no scroll/selection reset
- Fall back to a full-range `applyEdits` for non-additive changes (e.g. patch operations)
- Remove the now-unnecessary `saveViewState`/`restoreViewState` pair — `applyEdits` preserves scroll and cursor state natively

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)