### PR TITLE
fix(fork): scope task list invalidation to current workspace

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
@@ -72,7 +72,7 @@ export const MessageActions = memo(function MessageActions({
   const resetTimeoutRef = useRef<number | null>(null)
   const requestIdTimeoutRef = useRef<number | null>(null)
   const submitFeedback = useSubmitCopilotFeedback()
-  const forkTask = useForkTask()
+  const forkTask = useForkTask(params.workspaceId)
 
   useEffect(() => {
     return () => {

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -896,7 +896,7 @@ export const Sidebar = memo(function Sidebar() {
       deleteTasksMutation.mutate(taskIdsToDelete, { onSuccess: onDeleteSuccess })
     }
     setIsTaskDeleteModalOpen(false)
-  }, [pathname, workspaceId, deleteTaskMutation, deleteTasksMutation, navigateToPage])
+  }, [pathname, workspaceId, navigateToPage])
 
   const [visibleTaskCount, setVisibleTaskCount] = useState(5)
   const taskFlyoutRename = useFlyoutInlineRename({
@@ -935,13 +935,13 @@ export const Sidebar = memo(function Sidebar() {
     const { taskIds: ids } = contextMenuSelectionRef.current
     if (ids.length !== 1) return
     markTaskReadMutation.mutate(ids[0])
-  }, [markTaskReadMutation])
+  }, [])
 
   const handleMarkTaskAsUnread = useCallback(() => {
     const { taskIds: ids } = contextMenuSelectionRef.current
     if (ids.length !== 1) return
     markTaskUnreadMutation.mutate(ids[0])
-  }, [markTaskUnreadMutation])
+  }, [])
 
   const handleStartTaskRename = useCallback(() => {
     const { taskIds: ids } = contextMenuSelectionRef.current

--- a/apps/sim/hooks/queries/tasks.ts
+++ b/apps/sim/hooks/queries/tasks.ts
@@ -605,12 +605,12 @@ async function forkChat(params: {
   return { id: data.id }
 }
 
-export function useForkTask() {
+export function useForkTask(workspaceId?: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: forkChat,
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: taskKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: taskKeys.list(workspaceId) })
     },
   })
 }


### PR DESCRIPTION
## Summary
- \`useForkTask\` was invalidating \`taskKeys.lists()\` (all workspaces) instead of \`taskKeys.list(workspaceId)\` (current workspace only)
- Pass \`workspaceId\` through to the hook so invalidation is scoped correctly, matching the pattern of every other task mutation hook (\`useDeleteTask\`, \`useRenameTask\`, \`useMarkTaskRead\`, etc.)
- Sidebar already refreshes via SSE (\`useTaskEvents\`) when the fork API publishes a \`created\` event — the \`onSettled\` invalidation is a backup and both are now correctly scoped

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)