### PR TITLE
feat(fork): optimistic sidebar entry + Fork | prefix for forked tasks

### DIFF
--- a/apps/sim/app/api/mothership/chats/[chatId]/fork/route.ts
+++ b/apps/sim/app/api/mothership/chats/[chatId]/fork/route.ts
@@ -74,8 +74,8 @@ export const POST = withRouteHandler(
         : []
 
       const newId = generateId()
-      const baseTitle = (parent.title ?? 'New task').replace(/ \| Fork$/, '')
-      const title = `${baseTitle} | Fork`
+      const baseTitle = (parent.title ?? 'New task').replace(/^Fork \| /, '')
+      const title = `Fork | ${baseTitle}`
       const now = new Date()
 
       const [newChat] = await db

--- a/apps/sim/hooks/queries/tasks.ts
+++ b/apps/sim/hooks/queries/tasks.ts
@@ -609,6 +609,24 @@ export function useForkTask(workspaceId?: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: forkChat,
+    onSuccess: (data, variables) => {
+      const existing = queryClient.getQueryData<TaskMetadata[]>(taskKeys.list(workspaceId))
+      if (existing) {
+        const sourceTask = existing.find((t) => t.id === variables.chatId)
+        const baseName = (sourceTask?.name ?? 'New task').replace(/^Fork \| /, '')
+        const optimisticTask: TaskMetadata = {
+          id: data.id,
+          name: `Fork | ${baseName}`,
+          updatedAt: new Date(),
+          isActive: false,
+          isUnread: false,
+        }
+        queryClient.setQueryData<TaskMetadata[]>(taskKeys.list(workspaceId), [
+          optimisticTask,
+          ...existing,
+        ])
+      }
+    },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: taskKeys.list(workspaceId) })
     },

--- a/apps/sim/hooks/queries/tasks.ts
+++ b/apps/sim/hooks/queries/tasks.ts
@@ -609,7 +609,8 @@ export function useForkTask(workspaceId?: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: forkChat,
-    onSuccess: (data, variables) => {
+    onSuccess: async (data, variables) => {
+      await queryClient.cancelQueries({ queryKey: taskKeys.list(workspaceId) })
       const existing = queryClient.getQueryData<TaskMetadata[]>(taskKeys.list(workspaceId))
       if (existing) {
         const sourceTask = existing.find((t) => t.id === variables.chatId)


### PR DESCRIPTION
## Summary
- Forked task now appears in sidebar immediately — optimistic `setQueryData` in `useForkTask.onSuccess` writes the new entry to the cache before the background refetch arrives, so navigation lands on a sidebar that already shows the fork
- Renamed forked task title format to `Fork | Chat Name` (prefix instead of suffix) for faster scannability; re-forking a fork strips the prefix first to avoid `Fork | Fork | ...`
- Scoped `useForkTask` list invalidation to the current workspace (`taskKeys.list(workspaceId)`) instead of all workspaces
- Removed mutation objects from `useCallback` deps in sidebar (`deleteTaskMutation`, `deleteTasksMutation`, `markTaskReadMutation`, `markTaskUnreadMutation`) — `.mutate()` is stable in TanStack Query v5

## Type of Change
- [x] Bug fix
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)