### PR TITLE
fix(fork): cancel in-flight queries + clear selection on fork

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
@@ -21,6 +21,7 @@ import {
 import { cn } from '@/lib/core/utils/cn'
 import { useSubmitCopilotFeedback } from '@/hooks/queries/copilot-feedback'
 import { useForkTask } from '@/hooks/queries/tasks'
+import { useFolderStore } from '@/stores/folders/store'
 
 const SPECIAL_TAGS = 'thinking|options|usage_upgrade|credential|mothership-error|file'
 
@@ -154,6 +155,7 @@ export const MessageActions = memo(function MessageActions({
     if (!chatId || !messageId || forkTask.isPending) return
     try {
       const result = await forkTask.mutateAsync({ chatId, upToMessageId: messageId })
+      useFolderStore.getState().clearTaskSelection()
       router.push(`/workspace/${params.workspaceId}/task/${result.id}`)
     } catch {
       toast.error('Failed to fork chat')


### PR DESCRIPTION
## Summary
- Cancel in-flight task list queries before the optimistic `setQueryData` write in `useForkTask.onSuccess` — prevents a stale refetch from overwriting the new sidebar entry if one was already in flight
- Clear `selectedTasks` Zustand state before navigating to the forked chat — without this, the source task stays visually selected in the sidebar alongside the new fork

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)