### PR TITLE
fix(secrets): invalidate env queries so dropdown updates without refresh

### DIFF
--- a/apps/sim/hooks/queries/environment.ts
+++ b/apps/sim/hooks/queries/environment.ts
@@ -68,7 +68,7 @@ export function useSavePersonalEnvironment() {
       logger.info('Saved personal environment variables')
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: environmentKeys.personal() })
+      queryClient.invalidateQueries({ queryKey: environmentKeys.all })
     },
   })
 }

--- a/apps/sim/hooks/queries/environment.ts
+++ b/apps/sim/hooks/queries/environment.ts
@@ -12,7 +12,8 @@ const logger = createLogger('EnvironmentQueries')
 export const environmentKeys = {
   all: ['environment'] as const,
   personal: () => [...environmentKeys.all, 'personal'] as const,
-  workspace: (workspaceId: string) => [...environmentKeys.all, 'workspace', workspaceId] as const,
+  workspaces: () => [...environmentKeys.all, 'workspace'] as const,
+  workspace: (workspaceId: string) => [...environmentKeys.workspaces(), workspaceId] as const,
 }
 
 /**
@@ -68,7 +69,8 @@ export function useSavePersonalEnvironment() {
       logger.info('Saved personal environment variables')
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: environmentKeys.all })
+      queryClient.invalidateQueries({ queryKey: environmentKeys.personal() })
+      queryClient.invalidateQueries({ queryKey: environmentKeys.workspaces() })
     },
   })
 }


### PR DESCRIPTION
## Summary
- `useSavePersonalEnvironment` only invalidated `environmentKeys.personal()`, but the env-var dropdown reads personal vars from the workspace query (`workspaceEnvData.personal`) whenever there's a `workspaceId` — the workspace endpoint returns workspace + personal merged
- result: setting a personal secret in settings didn't refresh the dropdown until manual page refresh
- fix: invalidate `environmentKeys.all` from the personal-save mutation so every mounted workspace env query also refetches

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)