### PR TITLE
fix(ui): fix tasks loading being cancelled, disable fork button

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
@@ -164,7 +164,7 @@ export const MessageActions = memo(function MessageActions({
 
   const hasContent = Boolean(content)
   const canSubmitFeedback = Boolean(chatId && userQuery)
-  const canFork = Boolean(chatId && messageId)
+  const canFork = false
   if (!hasContent && !canSubmitFeedback && !canFork) return null
 
   return (

--- a/apps/sim/hooks/queries/tasks.ts
+++ b/apps/sim/hooks/queries/tasks.ts
@@ -490,9 +490,8 @@ export function useMarkTaskRead(workspaceId?: string) {
       if (!previousTasks) return { previousTasks: undefined }
 
       await queryClient.cancelQueries({ queryKey: taskKeys.list(workspaceId) })
-      queryClient.setQueryData<TaskMetadata[]>(
-        taskKeys.list(workspaceId),
-        previousTasks.map((task) => (task.id === chatId ? { ...task, isUnread: false } : task))
+      queryClient.setQueryData<TaskMetadata[]>(taskKeys.list(workspaceId), (old) =>
+        old?.map((task) => (task.id === chatId ? { ...task, isUnread: false } : task))
       )
 
       return { previousTasks }
@@ -520,9 +519,8 @@ export function useMarkTaskUnread(workspaceId?: string) {
       if (!previousTasks) return { previousTasks: undefined }
 
       await queryClient.cancelQueries({ queryKey: taskKeys.list(workspaceId) })
-      queryClient.setQueryData<TaskMetadata[]>(
-        taskKeys.list(workspaceId),
-        previousTasks.map((task) => (task.id === chatId ? { ...task, isUnread: true } : task))
+      queryClient.setQueryData<TaskMetadata[]>(taskKeys.list(workspaceId), (old) =>
+        old?.map((task) => (task.id === chatId ? { ...task, isUnread: true } : task))
       )
 
       return { previousTasks }

--- a/apps/sim/hooks/queries/tasks.ts
+++ b/apps/sim/hooks/queries/tasks.ts
@@ -311,12 +311,13 @@ export function useRenameTask(workspaceId?: string) {
   return useMutation({
     mutationFn: renameTask,
     onMutate: async ({ chatId, title }) => {
-      await queryClient.cancelQueries({ queryKey: taskKeys.list(workspaceId) })
-
       const previousTasks = queryClient.getQueryData<TaskMetadata[]>(taskKeys.list(workspaceId))
+      if (!previousTasks) return { previousTasks: undefined }
 
-      queryClient.setQueryData<TaskMetadata[]>(taskKeys.list(workspaceId), (old) =>
-        old?.map((task) => (task.id === chatId ? { ...task, name: title } : task))
+      await queryClient.cancelQueries({ queryKey: taskKeys.list(workspaceId) })
+      queryClient.setQueryData<TaskMetadata[]>(
+        taskKeys.list(workspaceId),
+        previousTasks.map((task) => (task.id === chatId ? { ...task, name: title } : task))
       )
 
       return { previousTasks }
@@ -486,12 +487,13 @@ export function useMarkTaskRead(workspaceId?: string) {
   return useMutation({
     mutationFn: markTaskRead,
     onMutate: async (chatId) => {
-      await queryClient.cancelQueries({ queryKey: taskKeys.list(workspaceId) })
-
       const previousTasks = queryClient.getQueryData<TaskMetadata[]>(taskKeys.list(workspaceId))
+      if (!previousTasks) return { previousTasks: undefined }
 
-      queryClient.setQueryData<TaskMetadata[]>(taskKeys.list(workspaceId), (old) =>
-        old?.map((task) => (task.id === chatId ? { ...task, isUnread: false } : task))
+      await queryClient.cancelQueries({ queryKey: taskKeys.list(workspaceId) })
+      queryClient.setQueryData<TaskMetadata[]>(
+        taskKeys.list(workspaceId),
+        previousTasks.map((task) => (task.id === chatId ? { ...task, isUnread: false } : task))
       )
 
       return { previousTasks }
@@ -515,12 +517,13 @@ export function useMarkTaskUnread(workspaceId?: string) {
   return useMutation({
     mutationFn: markTaskUnread,
     onMutate: async (chatId) => {
-      await queryClient.cancelQueries({ queryKey: taskKeys.list(workspaceId) })
-
       const previousTasks = queryClient.getQueryData<TaskMetadata[]>(taskKeys.list(workspaceId))
+      if (!previousTasks) return { previousTasks: undefined }
 
-      queryClient.setQueryData<TaskMetadata[]>(taskKeys.list(workspaceId), (old) =>
-        old?.map((task) => (task.id === chatId ? { ...task, isUnread: true } : task))
+      await queryClient.cancelQueries({ queryKey: taskKeys.list(workspaceId) })
+      queryClient.setQueryData<TaskMetadata[]>(
+        taskKeys.list(workspaceId),
+        previousTasks.map((task) => (task.id === chatId ? { ...task, isUnread: true } : task))
       )
 
       return { previousTasks }

--- a/apps/sim/hooks/queries/tasks.ts
+++ b/apps/sim/hooks/queries/tasks.ts
@@ -311,13 +311,12 @@ export function useRenameTask(workspaceId?: string) {
   return useMutation({
     mutationFn: renameTask,
     onMutate: async ({ chatId, title }) => {
-      const previousTasks = queryClient.getQueryData<TaskMetadata[]>(taskKeys.list(workspaceId))
-      if (!previousTasks) return { previousTasks: undefined }
-
       await queryClient.cancelQueries({ queryKey: taskKeys.list(workspaceId) })
-      queryClient.setQueryData<TaskMetadata[]>(
-        taskKeys.list(workspaceId),
-        previousTasks.map((task) => (task.id === chatId ? { ...task, name: title } : task))
+
+      const previousTasks = queryClient.getQueryData<TaskMetadata[]>(taskKeys.list(workspaceId))
+
+      queryClient.setQueryData<TaskMetadata[]>(taskKeys.list(workspaceId), (old) =>
+        old?.map((task) => (task.id === chatId ? { ...task, name: title } : task))
       )
 
       return { previousTasks }


### PR DESCRIPTION
## Summary
Our tasks fail to load when refreshing from a task page. This is because our mark task as read query cancels any in flight queries from the sidebar, cancelling the list tasks request and the tasks don't show up. 

Changed this to check if previous tasks are empty, and skips cancelling queries if so. 

Also disabled forking, needs more time in the oven. 

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
* Tested this fixes it locally. 
## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
