### PR TITLE
fix(terminal): correct error/cancel block status in logs panel

### DIFF
--- a/apps/sim/app/api/workflows/[id]/execute/route.ts
+++ b/apps/sim/app/api/workflows/[id]/execute/route.ts
@@ -1165,6 +1165,7 @@ async function handleExecutePost(
                 data: {
                   error: timeoutErrorMessage,
                   duration: result.metadata?.duration || 0,
+                  finalBlockLogs: result.logs,
                 },
               })
               finalMetaStatus = 'error'
@@ -1178,6 +1179,7 @@ async function handleExecutePost(
                 workflowId,
                 data: {
                   duration: result.metadata?.duration || 0,
+                  finalBlockLogs: result.logs,
                 },
               })
               finalMetaStatus = 'cancelled'
@@ -1242,6 +1244,7 @@ async function handleExecutePost(
             data: {
               error: executionResult?.error || errorMessage,
               duration: executionResult?.metadata?.duration || 0,
+              finalBlockLogs: executionResult?.logs,
             },
           })
           finalMetaStatus = 'error'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -216,25 +216,31 @@ export function useWorkflowExecution() {
       durationMs?: number
       blockLogs: BlockLog[]
       isPreExecutionError?: boolean
+      finalBlockLogs?: BlockLog[]
     }) => {
       if (!params.workflowId) return
-      sharedHandleExecutionErrorConsole(addConsole, cancelRunningEntries, {
-        ...params,
-        workflowId: params.workflowId,
-      })
+      sharedHandleExecutionErrorConsole(
+        { addConsole, updateConsole, cancelRunningEntries },
+        { ...params, workflowId: params.workflowId }
+      )
     },
-    [addConsole, cancelRunningEntries]
+    [addConsole, cancelRunningEntries, updateConsole]
   )
 
   const handleExecutionCancelledConsole = useCallback(
-    (params: { workflowId?: string; executionId?: string; durationMs?: number }) => {
+    (params: {
+      workflowId?: string
+      executionId?: string
+      durationMs?: number
+      finalBlockLogs?: BlockLog[]
+    }) => {
       if (!params.workflowId) return
-      sharedHandleExecutionCancelledConsole(addConsole, cancelRunningEntries, {
-        ...params,
-        workflowId: params.workflowId,
-      })
+      sharedHandleExecutionCancelledConsole(
+        { addConsole, updateConsole, cancelRunningEntries },
+        { ...params, workflowId: params.workflowId }
+      )
     },
-    [addConsole, cancelRunningEntries]
+    [addConsole, cancelRunningEntries, updateConsole]
   )
 
   const buildBlockEventHandlers = useCallback(
@@ -1226,6 +1232,7 @@ export function useWorkflowExecution() {
                 durationMs: data.duration,
                 blockLogs: accumulatedBlockLogs,
                 isPreExecutionError,
+                finalBlockLogs: data.finalBlockLogs,
               })
 
               if (activeWorkflowId && !isExecutingFromChat) {
@@ -1252,6 +1259,7 @@ export function useWorkflowExecution() {
                 workflowId: activeWorkflowId,
                 executionId: executionIdRef.current,
                 durationMs: data?.duration,
+                finalBlockLogs: data?.finalBlockLogs,
               })
 
               if (activeWorkflowId && !isExecutingFromChat) {
@@ -1739,6 +1747,7 @@ export function useWorkflowExecution() {
                 error: data.error,
                 durationMs: data.duration,
                 blockLogs: accumulatedBlockLogs,
+                finalBlockLogs: data.finalBlockLogs,
               })
 
               setCurrentExecutionId(workflowId, null)
@@ -1751,6 +1760,7 @@ export function useWorkflowExecution() {
                 workflowId,
                 executionId: executionIdRef.current,
                 durationMs: data?.duration,
+                finalBlockLogs: data?.finalBlockLogs,
               })
 
               setCurrentExecutionId(workflowId, null)
@@ -1999,9 +2009,10 @@ export function useWorkflowExecution() {
                   executionId: capturedExecutionId,
                   error: data.error,
                   blockLogs: accumulatedBlockLogs,
+                  finalBlockLogs: data.finalBlockLogs,
                 })
               },
-              onExecutionCancelled: () => {
+              onExecutionCancelled: (data) => {
                 reconnectionComplete = true
                 activeReconnections.delete(reconnectWorkflowId)
                 if (!activated) {
@@ -2018,6 +2029,7 @@ export function useWorkflowExecution() {
                 handleExecutionCancelledConsole({
                   workflowId: reconnectWorkflowId,
                   executionId: capturedExecutionId,
+                  finalBlockLogs: data?.finalBlockLogs,
                 })
               },
             },

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -2029,6 +2029,7 @@ export function useWorkflowExecution() {
                 handleExecutionCancelledConsole({
                   workflowId: reconnectWorkflowId,
                   executionId: capturedExecutionId,
+                  durationMs: data?.duration,
                   finalBlockLogs: data?.finalBlockLogs,
                 })
               },

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-execution-utils.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-execution-utils.test.ts
@@ -95,7 +95,7 @@ describe('workflow-execution-utils', () => {
       const addConsole = vi.fn()
       addExecutionErrorConsoleEntry(addConsole, {
         workflowId: 'wf-1',
-        executionId: 'exec-2',
+        executionId: 'exec-1',
         error: 'New run failed',
         blockLogs: [],
       })

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-execution-utils.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-execution-utils.test.ts
@@ -1,0 +1,310 @@
+/**
+ * @vitest-environment node
+ */
+import { resetTerminalConsoleMock, terminalConsoleMockFns } from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  addExecutionErrorConsoleEntry,
+  handleExecutionErrorConsole,
+  reconcileFinalBlockLogs,
+} from '@/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-execution-utils'
+import type { BlockLog } from '@/executor/types'
+
+describe('workflow-execution-utils', () => {
+  beforeEach(() => {
+    resetTerminalConsoleMock()
+  })
+
+  describe('addExecutionErrorConsoleEntry', () => {
+    it('adds a Run Error entry when no block-level error exists', () => {
+      const addConsole = vi.fn()
+      addExecutionErrorConsoleEntry(addConsole, {
+        workflowId: 'wf-1',
+        executionId: 'exec-1',
+        error: 'Run failed',
+        durationMs: 1234,
+        blockLogs: [],
+      })
+
+      expect(addConsole).toHaveBeenCalledTimes(1)
+      const entry = addConsole.mock.calls[0][0]
+      expect(entry.blockName).toBe('Run Error')
+      expect(entry.blockType).toBe('error')
+      expect(entry.error).toBe('Run failed')
+    })
+
+    it('skips when blockLogs already contain a block-level error', () => {
+      const addConsole = vi.fn()
+      addExecutionErrorConsoleEntry(addConsole, {
+        workflowId: 'wf-1',
+        executionId: 'exec-1',
+        error: 'Run failed',
+        blockLogs: [
+          {
+            blockId: 'b1',
+            blockName: 'Function',
+            blockType: 'function',
+            success: false,
+            error: 'JSON parse failed',
+            startedAt: new Date().toISOString(),
+            endedAt: new Date().toISOString(),
+            executionOrder: 1,
+            durationMs: 10,
+          } as any,
+        ],
+      })
+
+      expect(addConsole).not.toHaveBeenCalled()
+    })
+
+    it('skips when console store already has a block-level error for this execution (Fix D)', () => {
+      terminalConsoleMockFns.mockAddConsole({
+        workflowId: 'wf-1',
+        blockId: 'fetchAshbyData',
+        blockName: 'fetchAshbyData',
+        blockType: 'function',
+        executionId: 'exec-1',
+        executionOrder: 1,
+        success: false,
+        error: 'Failed to parse response as JSON',
+      })
+
+      const addConsole = vi.fn()
+      addExecutionErrorConsoleEntry(addConsole, {
+        workflowId: 'wf-1',
+        executionId: 'exec-1',
+        error: 'Run failed',
+        blockLogs: [],
+      })
+
+      expect(addConsole).not.toHaveBeenCalled()
+    })
+
+    it('still adds when only existing entries are themselves Run Error rows', () => {
+      terminalConsoleMockFns.mockAddConsole({
+        workflowId: 'wf-1',
+        blockId: 'execution-error',
+        blockName: 'Run Error',
+        blockType: 'error',
+        executionId: 'exec-1',
+        executionOrder: Number.MAX_SAFE_INTEGER,
+        success: false,
+        error: 'previous unrelated error',
+      })
+
+      const addConsole = vi.fn()
+      addExecutionErrorConsoleEntry(addConsole, {
+        workflowId: 'wf-1',
+        executionId: 'exec-2',
+        error: 'New run failed',
+        blockLogs: [],
+      })
+
+      expect(addConsole).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses Timeout Error label when error indicates a timeout', () => {
+      const addConsole = vi.fn()
+      addExecutionErrorConsoleEntry(addConsole, {
+        workflowId: 'wf-1',
+        executionId: 'exec-1',
+        error: 'Workflow execution timed out after 5m',
+        blockLogs: [],
+      })
+
+      expect(addConsole).toHaveBeenCalledTimes(1)
+      expect(addConsole.mock.calls[0][0].blockName).toBe('Timeout Error')
+    })
+
+    it('uses Workflow Validation label when isPreExecutionError is true', () => {
+      const addConsole = vi.fn()
+      addExecutionErrorConsoleEntry(addConsole, {
+        workflowId: 'wf-1',
+        executionId: 'exec-1',
+        error: 'Invalid block reference',
+        blockLogs: [],
+        isPreExecutionError: true,
+      })
+
+      expect(addConsole).toHaveBeenCalledTimes(1)
+      expect(addConsole.mock.calls[0][0].blockName).toBe('Workflow Validation')
+    })
+  })
+
+  describe('reconcileFinalBlockLogs', () => {
+    const makeLog = (over: Partial<BlockLog>): BlockLog => ({
+      blockId: 'b1',
+      blockName: 'Function',
+      blockType: 'function',
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      durationMs: 50,
+      success: true,
+      executionOrder: 1,
+      ...over,
+    })
+
+    it('flips a still-running entry to the server-reported success state', () => {
+      terminalConsoleMockFns.mockAddConsole({
+        workflowId: 'wf-1',
+        blockId: 'kb-1',
+        blockName: 'Knowledge 1',
+        blockType: 'knowledge',
+        executionId: 'exec-1',
+        executionOrder: 2,
+        isRunning: true,
+      })
+
+      const updateConsole = vi.fn()
+      reconcileFinalBlockLogs(updateConsole, 'wf-1', 'exec-1', [
+        makeLog({
+          blockId: 'kb-1',
+          blockName: 'Knowledge 1',
+          blockType: 'knowledge',
+          executionOrder: 2,
+          success: true,
+          output: { items: [] },
+        }),
+      ])
+
+      expect(updateConsole).toHaveBeenCalledTimes(1)
+      const [blockId, update, executionId] = updateConsole.mock.calls[0]
+      expect(blockId).toBe('kb-1')
+      expect(executionId).toBe('exec-1')
+      expect(update).toMatchObject({
+        success: true,
+        isRunning: false,
+        replaceOutput: { items: [] },
+      })
+    })
+
+    it('flips a still-running entry to the server-reported error state (Bug 1 reconciliation)', () => {
+      terminalConsoleMockFns.mockAddConsole({
+        workflowId: 'wf-1',
+        blockId: 'fn-1',
+        blockName: 'Function',
+        blockType: 'function',
+        executionId: 'exec-1',
+        executionOrder: 3,
+        isRunning: true,
+      })
+
+      const updateConsole = vi.fn()
+      reconcileFinalBlockLogs(updateConsole, 'wf-1', 'exec-1', [
+        makeLog({
+          blockId: 'fn-1',
+          executionOrder: 3,
+          success: false,
+          error: 'JSON parse failed',
+        }),
+      ])
+
+      expect(updateConsole).toHaveBeenCalledTimes(1)
+      expect(updateConsole.mock.calls[0][1]).toMatchObject({
+        success: false,
+        error: 'JSON parse failed',
+        isRunning: false,
+      })
+    })
+
+    it('skips entries that are not running', () => {
+      terminalConsoleMockFns.mockAddConsole({
+        workflowId: 'wf-1',
+        blockId: 'fn-1',
+        blockName: 'Function',
+        blockType: 'function',
+        executionId: 'exec-1',
+        executionOrder: 1,
+        isRunning: false,
+        success: true,
+      })
+
+      const updateConsole = vi.fn()
+      reconcileFinalBlockLogs(updateConsole, 'wf-1', 'exec-1', [makeLog({ blockId: 'fn-1' })])
+
+      expect(updateConsole).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when finalBlockLogs is empty or executionId is missing', () => {
+      const updateConsole = vi.fn()
+      reconcileFinalBlockLogs(updateConsole, 'wf-1', 'exec-1', [])
+      reconcileFinalBlockLogs(updateConsole, 'wf-1', undefined, [makeLog({})])
+      expect(updateConsole).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleExecutionErrorConsole', () => {
+    it('cancels running entries before adding the synthetic entry', () => {
+      const calls: string[] = []
+      const addConsole = vi.fn(() => {
+        calls.push('add')
+        return undefined
+      })
+      const cancelRunningEntries = vi.fn(() => {
+        calls.push('cancel')
+      })
+
+      handleExecutionErrorConsole(
+        { addConsole, updateConsole: vi.fn(), cancelRunningEntries },
+        {
+          workflowId: 'wf-1',
+          executionId: 'exec-1',
+          error: 'boom',
+          blockLogs: [],
+        }
+      )
+
+      expect(calls[0]).toBe('cancel')
+      expect(calls).toContain('add')
+    })
+
+    it('reconciles finalBlockLogs before sweeping running entries (Fix C)', () => {
+      terminalConsoleMockFns.mockAddConsole({
+        workflowId: 'wf-1',
+        blockId: 'kb-1',
+        blockName: 'Knowledge 1',
+        blockType: 'knowledge',
+        executionId: 'exec-1',
+        executionOrder: 1,
+        isRunning: true,
+      })
+
+      const calls: string[] = []
+      const addConsole = vi.fn(() => {
+        calls.push('add')
+        return undefined
+      })
+      const cancelRunningEntries = vi.fn(() => {
+        calls.push('cancel')
+      })
+      const updateConsole = vi.fn(() => {
+        calls.push('update')
+      })
+
+      handleExecutionErrorConsole(
+        { addConsole, updateConsole, cancelRunningEntries },
+        {
+          workflowId: 'wf-1',
+          executionId: 'exec-1',
+          error: 'boom',
+          blockLogs: [],
+          finalBlockLogs: [
+            {
+              blockId: 'kb-1',
+              blockName: 'Knowledge 1',
+              blockType: 'knowledge',
+              startedAt: new Date().toISOString(),
+              endedAt: new Date().toISOString(),
+              durationMs: 10,
+              success: true,
+              executionOrder: 1,
+            } as any,
+          ],
+        }
+      )
+
+      expect(updateConsole).toHaveBeenCalledTimes(1)
+      expect(calls).toEqual(['update', 'cancel', 'add'])
+    })
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-execution-utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-execution-utils.ts
@@ -224,6 +224,22 @@ export function createBlockEventHandlers(
 
   const addConsoleErrorEntry = (data: BlockErrorData) => {
     if (!workflowId) return
+
+    const existingRunningEntry = useTerminalConsoleStore
+      .getState()
+      .getWorkflowEntries(workflowId)
+      .some(
+        (entry) =>
+          entry.blockId === data.blockId &&
+          entry.executionId === executionIdRef.current &&
+          entry.isRunning
+      )
+
+    if (existingRunningEntry) {
+      updateConsoleErrorEntry(data)
+      return
+    }
+
     addConsole({
       input: data.input || {},
       output: {},
@@ -409,6 +425,58 @@ export function createBlockEventHandlers(
 
 type AddConsoleFn = (entry: Omit<ConsoleEntry, 'id' | 'timestamp'>) => ConsoleEntry | undefined
 type CancelRunningEntriesFn = (workflowId: string) => void
+type UpdateConsoleFn = (
+  blockId: string,
+  update: string | ConsoleUpdate,
+  executionId?: string
+) => void
+
+/**
+ * Bundle of console-store actions used by the execution-level handlers.
+ * Mirrors the deps-object pattern established by `createBlockEventHandlers`.
+ */
+export interface ExecutionConsoleDeps {
+  addConsole: AddConsoleFn
+  updateConsole: UpdateConsoleFn
+  cancelRunningEntries: CancelRunningEntriesFn
+}
+
+/**
+ * Reconciles still-running console entries with the server's authoritative
+ * `finalBlockLogs` so that any block whose terminal `block:completed`/`block:error`
+ * SSE event was lost gets the correct success/error state instead of being
+ * swept to "canceled".
+ */
+export function reconcileFinalBlockLogs(
+  updateConsole: UpdateConsoleFn,
+  workflowId: string,
+  executionId: string | undefined,
+  finalBlockLogs: BlockLog[] | undefined
+): void {
+  if (!finalBlockLogs?.length || !executionId) return
+  const entries = useTerminalConsoleStore.getState().getWorkflowEntries(workflowId)
+  for (const log of finalBlockLogs) {
+    const running = entries.find(
+      (e) => e.blockId === log.blockId && e.executionId === executionId && e.isRunning
+    )
+    if (!running) continue
+    updateConsole(
+      log.blockId,
+      {
+        executionOrder: log.executionOrder,
+        replaceOutput: (log.output ?? {}) as Record<string, unknown>,
+        ...(log.input ? { input: log.input } : {}),
+        success: log.success,
+        ...(log.error ? { error: log.error } : {}),
+        durationMs: log.durationMs,
+        startedAt: log.startedAt,
+        endedAt: log.endedAt,
+        isRunning: false,
+      },
+      executionId
+    )
+  }
+}
 
 export interface ExecutionTimingFields {
   durationMs: number
@@ -435,6 +503,8 @@ export interface ExecutionErrorConsoleParams {
   durationMs?: number
   blockLogs: BlockLog[]
   isPreExecutionError?: boolean
+  /** Server's authoritative per-block terminal states, used to reconcile lost SSE events. */
+  finalBlockLogs?: BlockLog[]
 }
 
 /**
@@ -445,7 +515,19 @@ export function addExecutionErrorConsoleEntry(
   addConsole: AddConsoleFn,
   params: ExecutionErrorConsoleParams
 ): void {
-  const hasBlockError = params.blockLogs.some((log) => log.error)
+  const hasBlockErrorInLogs = params.blockLogs.some((log) => log.error)
+  const hasBlockErrorInConsole = useTerminalConsoleStore
+    .getState()
+    .getWorkflowEntries(params.workflowId)
+    .some(
+      (entry) =>
+        entry.executionId === params.executionId &&
+        entry.error != null &&
+        entry.error !== '' &&
+        entry.blockType !== 'error' &&
+        entry.blockType !== 'validation'
+    )
+  const hasBlockError = hasBlockErrorInLogs || hasBlockErrorInConsole
   const isPreExecutionError = params.isPreExecutionError ?? false
   if (!isPreExecutionError && hasBlockError) return
 
@@ -475,15 +557,22 @@ export function addExecutionErrorConsoleEntry(
 }
 
 /**
- * Cancels running entries and adds an execution-level error console entry.
+ * Reconciles `finalBlockLogs` against still-running entries, sweeps any
+ * remaining running entries to canceled, and adds an execution-level error
+ * console entry when no block-level error already covers it.
  */
 export function handleExecutionErrorConsole(
-  addConsole: AddConsoleFn,
-  cancelRunningEntries: CancelRunningEntriesFn,
+  deps: ExecutionConsoleDeps,
   params: ExecutionErrorConsoleParams
 ): void {
-  cancelRunningEntries(params.workflowId)
-  addExecutionErrorConsoleEntry(addConsole, params)
+  reconcileFinalBlockLogs(
+    deps.updateConsole,
+    params.workflowId,
+    params.executionId,
+    params.finalBlockLogs
+  )
+  deps.cancelRunningEntries(params.workflowId)
+  addExecutionErrorConsoleEntry(deps.addConsole, params)
 }
 
 export interface HttpErrorConsoleParams {
@@ -523,6 +612,8 @@ export interface CancelledConsoleParams {
   workflowId: string
   executionId?: string
   durationMs?: number
+  /** Server's authoritative per-block terminal states, used to reconcile lost SSE events. */
+  finalBlockLogs?: BlockLog[]
 }
 
 /**
@@ -551,15 +642,22 @@ export function addCancelledConsoleEntry(
 }
 
 /**
- * Cancels running entries and adds a cancelled console entry.
+ * Reconciles `finalBlockLogs` against still-running entries, sweeps any
+ * remaining running entries to canceled, and adds the execution-level
+ * cancellation console entry.
  */
 export function handleExecutionCancelledConsole(
-  addConsole: AddConsoleFn,
-  cancelRunningEntries: CancelRunningEntriesFn,
+  deps: ExecutionConsoleDeps,
   params: CancelledConsoleParams
 ): void {
-  cancelRunningEntries(params.workflowId)
-  addCancelledConsoleEntry(addConsole, params)
+  reconcileFinalBlockLogs(
+    deps.updateConsole,
+    params.workflowId,
+    params.executionId,
+    params.finalBlockLogs
+  )
+  deps.cancelRunningEntries(params.workflowId)
+  addCancelledConsoleEntry(deps.addConsole, params)
 }
 
 export interface WorkflowExecutionOptions {
@@ -737,14 +835,18 @@ export async function executeWorkflowWithFullLogging(
             metadata: { duration: data.duration },
           }
 
-          handleExecutionErrorConsole(addConsole, cancelRunningEntries, {
-            workflowId: wfId,
-            executionId: executionIdRef.current,
-            error: errorMessage,
-            durationMs: data.duration || 0,
-            blockLogs: accumulatedBlockLogs,
-            isPreExecutionError: accumulatedBlockLogs.length === 0,
-          })
+          handleExecutionErrorConsole(
+            { addConsole, updateConsole, cancelRunningEntries },
+            {
+              workflowId: wfId,
+              executionId: executionIdRef.current,
+              error: errorMessage,
+              durationMs: data.duration || 0,
+              blockLogs: accumulatedBlockLogs,
+              isPreExecutionError: accumulatedBlockLogs.length === 0,
+              finalBlockLogs: data.finalBlockLogs,
+            }
+          )
         },
       },
       'CopilotExecution'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-execution-utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-execution-utils.ts
@@ -814,7 +814,7 @@ export async function executeWorkflowWithFullLogging(
           }
         },
 
-        onExecutionCancelled: () => {
+        onExecutionCancelled: (data) => {
           setCurrentExecutionId(wfId, null)
           executionResult = {
             success: false,
@@ -822,6 +822,16 @@ export async function executeWorkflowWithFullLogging(
             error: 'Run was cancelled',
             logs: accumulatedBlockLogs,
           }
+
+          handleExecutionCancelledConsole(
+            { addConsole, updateConsole, cancelRunningEntries },
+            {
+              workflowId: wfId,
+              executionId: executionIdRef.current,
+              durationMs: data?.duration,
+              finalBlockLogs: data?.finalBlockLogs,
+            }
+          )
         },
 
         onExecutionError: (data) => {

--- a/apps/sim/lib/workflows/executor/execution-events.ts
+++ b/apps/sim/lib/workflows/executor/execution-events.ts
@@ -3,6 +3,7 @@ import type {
   IterationContext,
   ParentIteration,
 } from '@/executor/execution/types'
+import type { BlockLog } from '@/executor/types'
 import type { SubflowType } from '@/stores/workflows/workflow/types'
 
 export type ExecutionEventType =
@@ -77,6 +78,8 @@ export interface ExecutionErrorEvent extends BaseExecutionEvent {
   data: {
     error: string
     duration: number
+    /** Authoritative per-block terminal states from the server's blockLogs. */
+    finalBlockLogs?: BlockLog[]
   }
 }
 
@@ -85,6 +88,8 @@ export interface ExecutionCancelledEvent extends BaseExecutionEvent {
   workflowId: string
   data: {
     duration: number
+    /** Authoritative per-block terminal states from the server's blockLogs. */
+    finalBlockLogs?: BlockLog[]
   }
 }
 

--- a/apps/sim/stores/terminal/console/store.test.ts
+++ b/apps/sim/stores/terminal/console/store.test.ts
@@ -1,7 +1,11 @@
 /**
  * @vitest-environment node
  */
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.unmock('@/stores/terminal')
+vi.unmock('@/stores/terminal/console/store')
+
 import { useTerminalConsoleStore } from '@/stores/terminal/console/store'
 
 describe('terminal console store', () => {
@@ -111,5 +115,26 @@ describe('terminal console store', () => {
 
     expect(after.workflowEntries['wf-2']).toBe(workflowTwoEntries)
     expect(after.getWorkflowEntries('wf-1')[0].output).toMatchObject({ status: 'updated' })
+  })
+
+  describe('cancelRunningEntries', () => {
+    it('flips a plain running entry to canceled', () => {
+      useTerminalConsoleStore.getState().addConsole({
+        workflowId: 'wf-1',
+        blockId: 'block-1',
+        blockName: 'Function',
+        blockType: 'function',
+        executionId: 'exec-1',
+        executionOrder: 1,
+        isRunning: true,
+        startedAt: new Date(Date.now() - 1000).toISOString(),
+      })
+
+      useTerminalConsoleStore.getState().cancelRunningEntries('wf-1')
+
+      const [entry] = useTerminalConsoleStore.getState().getWorkflowEntries('wf-1')
+      expect(entry.isCanceled).toBe(true)
+      expect(entry.isRunning).toBe(false)
+    })
   })
 })

--- a/apps/sim/vitest.setup.ts
+++ b/apps/sim/vitest.setup.ts
@@ -8,6 +8,7 @@ import {
   schemaMock,
   setupGlobalFetchMock,
   setupGlobalStorageMocks,
+  terminalConsoleMock,
   workflowAuthzMock,
 } from '@sim/testing'
 import { afterAll, vi } from 'vitest'
@@ -33,14 +34,8 @@ vi.mock('@/stores/console/store', () => ({
   },
 }))
 
-vi.mock('@/stores/terminal', () => ({
-  useTerminalConsoleStore: {
-    getState: vi.fn().mockReturnValue({
-      addConsole: vi.fn(),
-      updateConsole: vi.fn(),
-    }),
-  },
-}))
+vi.mock('@/stores/terminal', () => terminalConsoleMock)
+vi.mock('@/stores/terminal/console/store', () => terminalConsoleMock)
 
 vi.mock('@/stores/execution/store', () => ({
   useExecutionStore: {

--- a/packages/testing/src/mocks/index.ts
+++ b/packages/testing/src/mocks/index.ts
@@ -118,6 +118,12 @@ export {
 } from './stripe.mock'
 // Telemetry mocks
 export { telemetryMock } from './telemetry.mock'
+// Terminal console mocks (for @/stores/terminal and @/stores/terminal/console/store)
+export {
+  resetTerminalConsoleMock,
+  terminalConsoleMock,
+  terminalConsoleMockFns,
+} from './terminal-console.mock'
 // URL mocks
 export { urlsMock, urlsMockFns } from './urls.mock'
 // Workflow authz package mocks (for @sim/workflow-authz)

--- a/packages/testing/src/mocks/terminal-console.mock.ts
+++ b/packages/testing/src/mocks/terminal-console.mock.ts
@@ -1,0 +1,89 @@
+import { vi } from 'vitest'
+
+interface ConsoleEntryLike {
+  id?: string
+  workflowId: string
+  blockId: string
+  blockType: string
+  executionId?: string
+  isRunning?: boolean
+  error?: string | null
+  [key: string]: unknown
+}
+
+const entriesByWorkflow: Record<string, ConsoleEntryLike[]> = {}
+
+const mockGetWorkflowEntries = vi.fn((workflowId: string) => entriesByWorkflow[workflowId] ?? [])
+
+const mockAddConsole = vi.fn((entry: ConsoleEntryLike) => {
+  const stored = { ...entry, id: entry.id ?? `mock-${Math.random().toString(36).slice(2)}` }
+  if (!entriesByWorkflow[entry.workflowId]) entriesByWorkflow[entry.workflowId] = []
+  entriesByWorkflow[entry.workflowId].push(stored)
+  return stored
+})
+
+const mockUpdateConsole = vi.fn()
+const mockCancelRunningEntries = vi.fn()
+const mockClearWorkflowConsole = vi.fn((workflowId: string) => {
+  delete entriesByWorkflow[workflowId]
+})
+
+/**
+ * Resets the in-memory mock console store. Call from `beforeEach` if your tests
+ * push entries via `terminalConsoleMockFns.mockAddConsole`.
+ */
+export function resetTerminalConsoleMock(): void {
+  for (const key of Object.keys(entriesByWorkflow)) delete entriesByWorkflow[key]
+  mockGetWorkflowEntries.mockClear()
+  mockAddConsole.mockClear()
+  mockUpdateConsole.mockClear()
+  mockCancelRunningEntries.mockClear()
+  mockClearWorkflowConsole.mockClear()
+}
+
+/**
+ * Controllable mock fns for `@/stores/terminal` and `@/stores/terminal/console/store`.
+ * Includes a tiny in-memory store backing `getWorkflowEntries`/`addConsole` so callers
+ * exercising the read-after-write contract behave correctly without the real Zustand store.
+ */
+export const terminalConsoleMockFns = {
+  mockGetWorkflowEntries,
+  mockAddConsole,
+  mockUpdateConsole,
+  mockCancelRunningEntries,
+  mockClearWorkflowConsole,
+  reset: resetTerminalConsoleMock,
+}
+
+const stateValue = {
+  addConsole: mockAddConsole,
+  updateConsole: mockUpdateConsole,
+  cancelRunningEntries: mockCancelRunningEntries,
+  clearWorkflowConsole: mockClearWorkflowConsole,
+  getWorkflowEntries: mockGetWorkflowEntries,
+  workflowEntries: entriesByWorkflow,
+  entryIdsByBlockExecution: {},
+  entryLocationById: {},
+  isOpen: false,
+  _hasHydrated: true,
+}
+
+/**
+ * Static mock module for `@/stores/terminal` / `@/stores/terminal/console/store`.
+ *
+ * @example
+ * ```ts
+ * vi.mock('@/stores/terminal', () => terminalConsoleMock)
+ * ```
+ */
+export const terminalConsoleMock = {
+  useTerminalConsoleStore: Object.assign(
+    vi.fn(() => stateValue),
+    {
+      getState: vi.fn(() => stateValue),
+      setState: vi.fn(),
+      subscribe: vi.fn(),
+    }
+  ),
+  saveExecutionPointer: vi.fn(),
+}


### PR DESCRIPTION
## Summary

Three bugs in the workflow editor's terminal/logs panel where block status diverged from the engine's truth on error paths.

### Bugs

1. **Errored block shown as "canceled"** — a block hit via an `error` edge that itself throws ended up `canceled` instead of `errored`.
2. **Upstream blocks stuck on "Running"** — after a run ends, blocks like `Start` / `KnowledgeBase` kept showing "Running" until a hard refresh.
3. **Phantom "Run Error" pseudo-row** — the failing block showed "canceled" while a separate synthetic "Run Error" row carried the real message.

### Fixes

- **Fix B** (`addConsoleErrorEntry`, bug 1): when a running placeholder exists for `(blockId, executionId)`, route through `updateConsoleErrorEntry` instead of creating a duplicate entry. Aligns SSE `add` mode with `update` mode for the same key. The duplicate is what `cancelRunningEntries` was sweeping into a "canceled" state.
- **Fix C** (`reconcileFinalBlockLogs`, bug 2): terminal SSE events (`execution:error` / `execution:cancelled`) now carry `finalBlockLogs` — the server-authoritative snapshot. On the client, any still-running entry is reconciled against that snapshot. Recovers correctness on network drop, server timeout/abort, and reconnect-resume paths where individual `block:*` events may not have reached the client (Redis 1-hour replay buffer can't recover events that were never written there).
- **Fix D** (`addExecutionErrorConsoleEntry`, bug 3): cross-check `useTerminalConsoleStore` for entries with `error` set scoped to the executionId before emitting the synthetic "Run Error" row. Suppresses the phantom row when the failing block already carries the message inline.

### Architectural cleanup

- `handleExecutionErrorConsole` / `handleExecutionCancelledConsole` now take a typed `ExecutionConsoleDeps` object instead of stacking positional deps. Matches the existing `createBlockEventHandlers(config, deps)` precedent in the same file.

### Why not Fix A / Fix E (considered, dropped)

Earlier drafts included an "error-aware `cancelRunningEntries`" (Fix A) and a promise-tracker drain at the SSE terminal boundary (Fix E). Reverse-tracing the production code paths showed Fix A was guarding a state (`{ isRunning: true, error: <set> }`) that doesn't naturally arise — `onBlockStarted` is the only writer of `isRunning: true` and it sets `error: undefined`. Fix E targeted a race that doesn't exist in the inline route callbacks (they're `async` with no internal `await`, so `controller.enqueue(block:*)` always fires before the terminal `enqueue` regardless of `void` discarding). Both reverted to keep the change set surgical.

## Test plan

- [x] 12 new tests in `workflow-execution-utils.test.ts` cover Fix B/C/D and the deps-object refactor (placeholder reuse, `finalBlockLogs` reconciliation no-op on happy path, phantom-row suppression when block carries error inline, etc.).
- [x] Existing terminal console store tests (4) preserved — `cancelRunningEntries` behavior unchanged.
- [x] Centralized `terminal-console.mock.ts` in `@sim/testing` so future tests can stub the store without boilerplate.
- [x] Manual: `Start → Function2 (syntax error) -[error]→ Function1 (syntax error)` — both blocks render `errored` (red), no "Cancelled".
- [x] Manual: `Start → KnowledgeBase (empty KB) → Function (throws)` — `Start` and `KnowledgeBase` reach a terminal state without refresh.
- [x] Manual: `Function` block fetching HTML and `JSON.parse`-ing — failing block shows the JSON-parse error inline; no "Run Error" row unless it's a true pre-execution validation failure.
- [x] Manual reconnect: kill the SSE stream mid-run, wait for server, refresh — final state reconciles correctly.