### PR TITLE
improvement(tables): bump column auto-fit cap from 600px to 1000px

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table/table.tsx
@@ -97,6 +97,7 @@ const EMPTY_COLUMNS: never[] = []
 const EMPTY_CHECKED_ROWS = new Set<number>()
 const COL_WIDTH = 160
 const COL_WIDTH_MIN = 80
+const COL_WIDTH_AUTO_FIT_MAX = 1000
 const CHECKBOX_COL_WIDTH = 40
 const ADD_COL_WIDTH = 120
 const SKELETON_COL_COUNT = 4
@@ -830,7 +831,7 @@ export function Table({
       host.removeChild(measure)
     }
 
-    const newWidth = Math.min(Math.ceil(maxWidth), 600)
+    const newWidth = Math.min(Math.ceil(maxWidth), COL_WIDTH_AUTO_FIT_MAX)
     setColumnWidths((prev) => ({ ...prev, [columnName]: newWidth }))
     const updated = { ...columnWidthsRef.current, [columnName]: newWidth }
     columnWidthsRef.current = updated


### PR DESCRIPTION
## Summary
- Raises the column auto-fit (double-click resize handle) cap from 600px to 1000px to match Google Sheets parity
- Long entries (e.g. company names in CRM-style tables) now fit without manual drag

## Type of Change
- [x] Improvement

## Testing
Tested manually — double-clicking the resize handle on a column with long entries now expands up to 1000px.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)