### PR TITLE
feat(exa): add x-exa-integration header for usage attribution

### DIFF
--- a/apps/sim/tools/exa/answer.ts
+++ b/apps/sim/tools/exa/answer.ts
@@ -53,6 +53,7 @@ export const answerTool: ToolConfig<ExaAnswerParams, ExaAnswerResponse> = {
     headers: (params) => ({
       'Content-Type': 'application/json',
       'x-api-key': params.apiKey,
+      'x-exa-integration': 'sim',
     }),
     body: (params) => {
       const body: Record<string, any> = {

--- a/apps/sim/tools/exa/find_similar_links.ts
+++ b/apps/sim/tools/exa/find_similar_links.ts
@@ -102,6 +102,7 @@ export const findSimilarLinksTool: ToolConfig<
     headers: (params) => ({
       'Content-Type': 'application/json',
       'x-api-key': params.apiKey,
+      'x-exa-integration': 'sim',
     }),
     body: (params) => {
       const body: Record<string, any> = {

--- a/apps/sim/tools/exa/get_contents.ts
+++ b/apps/sim/tools/exa/get_contents.ts
@@ -87,6 +87,7 @@ export const getContentsTool: ToolConfig<ExaGetContentsParams, ExaGetContentsRes
     headers: (params) => ({
       'Content-Type': 'application/json',
       'x-api-key': params.apiKey,
+      'x-exa-integration': 'sim',
     }),
     body: (params) => {
       // Parse the comma-separated URLs into an array

--- a/apps/sim/tools/exa/research.ts
+++ b/apps/sim/tools/exa/research.ts
@@ -42,6 +42,7 @@ export const researchTool: ToolConfig<ExaResearchParams, ExaResearchResponse> = 
     headers: (params) => ({
       'Content-Type': 'application/json',
       'x-api-key': params.apiKey,
+      'x-exa-integration': 'sim',
     }),
     body: (params) => {
       const body: any = {
@@ -85,6 +86,7 @@ export const researchTool: ToolConfig<ExaResearchParams, ExaResearchResponse> = 
           headers: {
             'x-api-key': params.apiKey,
             'Content-Type': 'application/json',
+            'x-exa-integration': 'sim',
           },
         })
 

--- a/apps/sim/tools/exa/search.ts
+++ b/apps/sim/tools/exa/search.ts
@@ -112,6 +112,7 @@ export const searchTool: ToolConfig<ExaSearchParams, ExaSearchResponse> = {
     headers: (params) => ({
       'Content-Type': 'application/json',
       'x-api-key': params.apiKey,
+      'x-exa-integration': 'sim',
     }),
     body: (params) => {
       const body: Record<string, any> = {


### PR DESCRIPTION
## Summary

Adds an `x-exa-integration: sim` header to every request the Exa tools send to `api.exa.ai`. This is a request header Exa uses on their side to attribute API traffic to the integration that originated it; it has no effect on the response or on user-facing behavior.

Updated:
- `apps/sim/tools/exa/search.ts`
- `apps/sim/tools/exa/get_contents.ts`
- `apps/sim/tools/exa/find_similar_links.ts`
- `apps/sim/tools/exa/answer.ts`
- `apps/sim/tools/exa/research.ts` (both the create-task POST and the polling GET)

## Example

```ts
headers: (params) => ({
  'Content-Type': 'application/json',
  'x-api-key': params.apiKey,
  'x-exa-integration': 'sim',
}),
```

## Test plan

- [x] `grep -n "x-exa-integration" apps/sim/tools/exa/*.ts` shows the header set in all 6 request sites (5 tools, plus the research polling fetch)
- [ ] Existing Exa tool tests still pass (no behavioral change to params/response handling)