### PR TITLE
fix(mail): use html-to-text for plaintext email fallback

### DIFF
--- a/apps/sim/app/api/tools/mail/send/route.ts
+++ b/apps/sim/app/api/tools/mail/send/route.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@sim/logger'
+import { convert } from 'html-to-text'
 import { type NextRequest, NextResponse } from 'next/server'
 import { Resend } from 'resend'
 import { mailSendContract } from '@/lib/api/contracts/tools/mail'
@@ -74,7 +75,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       emailData = {
         ...emailBase,
         html: validatedData.body,
-        text: validatedData.body.replace(/<[^>]*>/g, ''),
+        text: convert(validatedData.body, { wordwrap: false }),
       }
     } else {
       emailData = {


### PR DESCRIPTION
## Summary
- Replace incomplete regex `body.replace(/<[^>]*>/g, '')` with `html-to-text`'s `convert()` for the plaintext alternative on HTML emails
- Resolves CodeQL "Incomplete multi-character sanitization" alert flagged on PR #4390; the regex wasn't a security boundary (output goes to `text/plain` part), but `convert()` produces higher-fidelity plaintext (entity decoding, link/list formatting) and silences the alert

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)