### PR TITLE
fix(csp): allow https images in markdown preview and html sandbox

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -734,7 +734,7 @@ const HTML_PREVIEW_CSP = [
   "default-src 'none'",
   "script-src 'unsafe-inline'",
   "style-src 'unsafe-inline'",
-  'img-src data: blob:',
+  "img-src 'self' https: data: blob:",
   'font-src data:',
   'media-src data: blob:',
   "connect-src 'none'",

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -734,7 +734,7 @@ const HTML_PREVIEW_CSP = [
   "default-src 'none'",
   "script-src 'unsafe-inline'",
   "style-src 'unsafe-inline'",
-  'img-src https: data: blob:',
+  'img-src data: blob:',
   'font-src data:',
   'media-src data: blob:',
   "connect-src 'none'",

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -734,7 +734,7 @@ const HTML_PREVIEW_CSP = [
   "default-src 'none'",
   "script-src 'unsafe-inline'",
   "style-src 'unsafe-inline'",
-  "img-src 'self' https: data: blob:",
+  'img-src https: data: blob:',
   'font-src data:',
   'media-src data: blob:',
   "connect-src 'none'",

--- a/apps/sim/lib/core/security/csp.ts
+++ b/apps/sim/lib/core/security/csp.ts
@@ -131,20 +131,7 @@ export const buildTimeCSPDirectives: CSPDirectives = {
   'script-src': [...STATIC_SCRIPT_SRC],
   'style-src': ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
 
-  'img-src': [
-    ...STATIC_IMG_SRC,
-    ...(env.S3_BUCKET_NAME && env.AWS_REGION
-      ? [`https://${env.S3_BUCKET_NAME}.s3.${env.AWS_REGION}.amazonaws.com`]
-      : []),
-    ...(env.S3_KB_BUCKET_NAME && env.AWS_REGION
-      ? [`https://${env.S3_KB_BUCKET_NAME}.s3.${env.AWS_REGION}.amazonaws.com`]
-      : []),
-    ...(env.S3_CHAT_BUCKET_NAME && env.AWS_REGION
-      ? [`https://${env.S3_CHAT_BUCKET_NAME}.s3.${env.AWS_REGION}.amazonaws.com`]
-      : []),
-    ...getHostnameFromUrl(env.NEXT_PUBLIC_BRAND_LOGO_URL),
-    ...getHostnameFromUrl(env.NEXT_PUBLIC_BRAND_FAVICON_URL),
-  ],
+  'img-src': [...STATIC_IMG_SRC],
 
   'media-src': ["'self'", 'blob:'],
   'worker-src': ["'self'", 'blob:'],
@@ -200,14 +187,13 @@ export function generateRuntimeCSP(): string {
   const ollamaUrl = getEnv('OLLAMA_URL') || (isDev ? DEFAULT_OLLAMA_URL : '')
 
   const brandLogoDomains = getHostnameFromUrl(getEnv('NEXT_PUBLIC_BRAND_LOGO_URL'))
-  const brandFaviconDomains = getHostnameFromUrl(getEnv('NEXT_PUBLIC_BRAND_FAVICON_URL'))
   const privacyDomains = getHostnameFromUrl(getEnv('NEXT_PUBLIC_PRIVACY_URL'))
   const termsDomains = getHostnameFromUrl(getEnv('NEXT_PUBLIC_TERMS_URL'))
 
   const runtimeDirectives: CSPDirectives = {
     ...buildTimeCSPDirectives,
 
-    'img-src': [...STATIC_IMG_SRC, ...brandLogoDomains, ...brandFaviconDomains],
+    'img-src': [...STATIC_IMG_SRC],
 
     'connect-src': [
       ...STATIC_CONNECT_SRC,

--- a/apps/sim/lib/core/security/csp.ts
+++ b/apps/sim/lib/core/security/csp.ts
@@ -61,23 +61,7 @@ const STATIC_SCRIPT_SRC = [
     : []),
 ] as const
 
-const STATIC_IMG_SRC = [
-  "'self'",
-  'data:',
-  'blob:',
-  'https://*.googleusercontent.com',
-  'https://*.google.com',
-  'https://*.atlassian.com',
-  'https://cdn.discordapp.com',
-  'https://*.githubusercontent.com',
-  'https://*.s3.amazonaws.com',
-  'https://s3.amazonaws.com',
-  'https://*.amazonaws.com',
-  'https://*.blob.core.windows.net',
-  'https://github.com/*',
-  'https://cursor.com',
-  ...(isHosted ? ['https://www.googletagmanager.com', 'https://www.google-analytics.com'] : []),
-] as const
+const STATIC_IMG_SRC = ["'self'", 'data:', 'blob:', 'https:'] as const
 
 const STATIC_CONNECT_SRC = [
   "'self'",


### PR DESCRIPTION
## Summary
- Replaced the hardcoded domain allowlist in \`img-src\` with \`https:\` — allows users to embed any HTTPS image in markdown files without CSP violations
- Updated HTML preview sandbox CSP from \`img-src data: blob:\` to \`img-src 'self' https: data: blob:\` — enables external images and Sim-hosted files to render in HTML previews
- Sim files (\`/api/files/serve/...\`) work via \`'self'\` with automatic cookie-based auth; no extra plumbing needed

## Type of Change
- [x] Bug fix

## Testing
Tested manually — external images now render in markdown preview; all 25 CSP unit tests pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)