### PR TITLE
fix(loading): cursor positioning, render-phase defaultValue sync, remove unnecessary useMemo

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useLayoutEffect, useMemo, useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import { cn } from '@/lib/core/utils/cn'
 import { MessageActions } from '@/app/workspace/[workspaceId]/components'
 import { ChatMessageAttachments } from '@/app/workspace/[workspaceId]/home/components/chat-message-attachments'
@@ -111,17 +111,14 @@ export function MothershipChat({
   const { staged: stagedMessages, isStaging } = useProgressiveList(messages, stagingKey)
   const stagedMessageCount = stagedMessages.length
   const stagedOffset = messages.length - stagedMessages.length
-  const precedingUserContentByIndex = useMemo(() => {
-    const contentByIndex: Array<string | undefined> = []
-    let lastUserContent: string | undefined
-    for (const [index, message] of messages.entries()) {
-      contentByIndex[index] = lastUserContent
-      if (message.role === 'user') {
-        lastUserContent = message.content
-      }
+  const precedingUserContentByIndex: Array<string | undefined> = []
+  let lastUserContent: string | undefined
+  for (const [index, message] of messages.entries()) {
+    precedingUserContentByIndex[index] = lastUserContent
+    if (message.role === 'user') {
+      lastUserContent = message.content
     }
-    return contentByIndex
-  }, [messages])
+  }
   const initialScrollDoneRef = useRef(false)
   const userInputRef = useRef<UserInputHandle>(null)
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -216,8 +216,6 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps -- intentional mount-only restore
 
-  // Skip the initial save — restore's setState calls haven't propagated yet, so
-  // files/contexts are still empty and would transiently wipe a file-only draft.
   const isFirstSaveRef = useRef(true)
   useEffect(() => {
     if (isFirstSaveRef.current) {
@@ -426,7 +424,6 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
 
         const newValue = `${before}${insertText}${after}`
         pendingCursorRef.current = newPos
-        // Eagerly sync refs so successive drop-handler iterations see the updated position
         valueRef.current = newValue
         atInsertPosRef.current = newPos
         mentionRangeRef.current = null
@@ -536,9 +533,6 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     wasSendingRef.current = isSending
   }, [isSending, textareaRef])
 
-  // Auto-focus on mount. The RAF runs after all synchronous mount effects, so if
-  // the draft-restore effect already focused the textarea the isEditingElsewhere
-  // guard below will be true and we skip the re-focus, preserving cursor position.
   useEffect(() => {
     const raf = window.requestAnimationFrame(() => {
       const active = document.activeElement

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -153,12 +153,13 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
   const overlayRef = useRef<HTMLDivElement>(null)
   const plusMenuRef = useRef<PlusMenuHandle>(null)
 
-  const prevDefaultValueRef = useRef(defaultValue)
-  useEffect(() => {
-    if (defaultValue === prevDefaultValueRef.current) return
-    prevDefaultValueRef.current = defaultValue
-    if (defaultValue) setValue(defaultValue)
-  }, [defaultValue])
+  const [prevDefaultValue, setPrevDefaultValue] = useState(defaultValue)
+  if (defaultValue && defaultValue !== prevDefaultValue) {
+    setPrevDefaultValue(defaultValue)
+    setValue(defaultValue)
+  } else if (!defaultValue && prevDefaultValue) {
+    setPrevDefaultValue(defaultValue)
+  }
 
   const files = useFileAttachments({
     userId: userId || session?.user?.id,
@@ -205,6 +206,13 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
           uploading: false,
         }))
       )
+    }
+    if (draft.text) {
+      const textarea = textareaRef.current
+      if (textarea) {
+        textarea.focus()
+        textarea.setSelectionRange(draft.text.length, draft.text.length)
+      }
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps -- intentional mount-only restore
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -536,6 +536,9 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     wasSendingRef.current = isSending
   }, [isSending, textareaRef])
 
+  // Auto-focus on mount. The RAF runs after all synchronous mount effects, so if
+  // the draft-restore effect already focused the textarea the isEditingElsewhere
+  // guard below will be true and we skip the re-focus, preserving cursor position.
   useEffect(() => {
     const raf = window.requestAnimationFrame(() => {
       const active = document.activeElement


### PR DESCRIPTION
## Summary
- Restore cursor to end of textarea when navigating back to a task with a saved draft (canonical \`focus()\` + \`setSelectionRange\` pattern, no rAF)
- Replace \`useEffect\` + \`useRef\` defaultValue sync with render-phase state update to avoid stale-value flash
- Remove \`useMemo\` wrapper from \`precedingUserContentByIndex\` — deps changed every render so memo bought nothing, replaced with plain inline loop

## Type of Change
- [x] Bug fix
- [x] Improvement

## Testing
Tested manually — cursor lands at end of restored draft text, defaultValue sync correct, no regressions

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)