### PR TITLE
feat(files): embed sim files and render mermaid diagrams in markdown preview

### DIFF
--- a/apps/sim/app/api/files/view/[id]/route.ts
+++ b/apps/sim/app/api/files/view/[id]/route.ts
@@ -1,0 +1,44 @@
+import { createLogger } from '@sim/logger'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { fileViewContract } from '@/lib/api/contracts/storage-transfer'
+import { parseRequest } from '@/lib/api/server'
+import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
+import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { USE_BLOB_STORAGE } from '@/lib/uploads/config'
+import { getFileMetadataById } from '@/lib/uploads/server/metadata'
+import { verifyFileAccess } from '@/app/api/files/authorization'
+
+const logger = createLogger('FilesViewAPI')
+
+export const GET = withRouteHandler(
+  async (request: NextRequest, context: { params: Promise<{ id: string }> }) => {
+    const parsed = await parseRequest(fileViewContract, request, await context.params)
+    if (!parsed.success) return parsed.response
+
+    const { id } = parsed.data.params
+
+    const authResult = await checkSessionOrInternalAuth(request, { requireWorkflowId: false })
+    if (!authResult.success || !authResult.userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const record = await getFileMetadataById(id)
+    if (!record) {
+      logger.warn('File not found by ID', { id })
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+
+    const hasAccess = await verifyFileAccess(record.key, authResult.userId)
+    if (!hasAccess) {
+      logger.warn('Unauthorized file view attempt', { id, userId: authResult.userId })
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const storagePrefix = USE_BLOB_STORAGE ? 'blob' : 's3'
+    const servePath = `/api/files/serve/${storagePrefix}/${encodeURIComponent(record.key)}`
+    logger.info('Redirecting file view to serve path', { id, servePath })
+
+    return NextResponse.redirect(new URL(servePath, request.url), { status: 302 })
+  }
+)

--- a/apps/sim/app/api/files/view/[id]/route.ts
+++ b/apps/sim/app/api/files/view/[id]/route.ts
@@ -13,7 +13,7 @@ const logger = createLogger('FilesViewAPI')
 
 export const GET = withRouteHandler(
   async (request: NextRequest, context: { params: Promise<{ id: string }> }) => {
-    const parsed = await parseRequest(fileViewContract, request, await context.params)
+    const parsed = await parseRequest(fileViewContract, request, context)
     if (!parsed.success) return parsed.response
 
     const { id } = parsed.data.params

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -449,19 +449,19 @@ const MermaidDiagram = memo(function MermaidDiagram({
       return (
         <div className='flex h-full items-center justify-center bg-[var(--surface-1)] p-8'>
           <div
-            className='w-full max-w-[720px] rounded-md bg-[var(--surface-2)] p-8 shadow-medium'
+            className='w-full max-w-[720px] shrink-0 rounded-md bg-[var(--surface-2)] p-8 shadow-medium'
             style={{ aspectRatio: '4 / 3' }}
           >
-            <div className='flex h-full flex-col items-center justify-center gap-5'>
-              <Skeleton className='h-[40px] w-[140px] rounded-md' />
-              <Skeleton className='h-[32px] w-[2px]' />
-              <div className='flex items-center gap-4'>
-                <Skeleton className='h-[40px] w-[110px] rounded-md' />
-                <Skeleton className='h-[2px] w-[32px]' />
-                <Skeleton className='h-[40px] w-[110px] rounded-md' />
+            <div className='flex h-full flex-col justify-between'>
+              <div className='flex flex-col gap-3'>
+                <Skeleton className='h-[18px] w-[45%]' />
+                <Skeleton className='h-[14px] w-[65%]' />
+                <Skeleton className='h-[14px] w-[55%]' />
               </div>
-              <Skeleton className='h-[32px] w-[2px]' />
-              <Skeleton className='h-[40px] w-[140px] rounded-md' />
+              <div className='flex flex-col gap-2'>
+                <Skeleton className='h-[14px] w-[75%]' />
+                <Skeleton className='h-[14px] w-[60%]' />
+              </div>
             </div>
           </div>
         </div>

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -448,8 +448,23 @@ const MermaidDiagram = memo(function MermaidDiagram({
   if (!trimmedDefinition || !svg || renderedDefinition !== trimmedDefinition) {
     if (zoomable) {
       return (
-        <div className='flex h-full items-center justify-center p-8'>
-          <Skeleton className='w-full rounded-lg' style={{ aspectRatio: '4 / 3' }} />
+        <div className='flex h-full items-center justify-center bg-[var(--surface-1)] p-8'>
+          <div
+            className='w-full max-w-[720px] rounded-md bg-[var(--surface-2)] p-8 shadow-medium'
+            style={{ aspectRatio: '4 / 3' }}
+          >
+            <div className='flex h-full flex-col items-center justify-center gap-5'>
+              <Skeleton className='h-[40px] w-[140px] rounded-md' />
+              <Skeleton className='h-[32px] w-[2px]' />
+              <div className='flex items-center gap-4'>
+                <Skeleton className='h-[40px] w-[110px] rounded-md' />
+                <Skeleton className='h-[2px] w-[32px]' />
+                <Skeleton className='h-[40px] w-[110px] rounded-md' />
+              </div>
+              <Skeleton className='h-[32px] w-[2px]' />
+              <Skeleton className='h-[40px] w-[140px] rounded-md' />
+            </div>
+          </div>
         </div>
       )
     }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -606,8 +606,8 @@ const STATIC_MARKDOWN_COMPONENTS = {
     )
   },
   hr: () => <hr className='my-6 border-[var(--border)]' />,
-  img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => {
-    const resolvedSrc = resolveSimFileUrl(typeof src === 'string' ? src : undefined)
+  img: ({ src, alt }: { src?: string; alt?: string }) => {
+    const resolvedSrc = resolveSimFileUrl(src)
     return (
       <img
         src={resolvedSrc}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -607,7 +607,7 @@ const STATIC_MARKDOWN_COMPONENTS = {
   },
   hr: () => <hr className='my-6 border-[var(--border)]' />,
   img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => {
-    const resolvedSrc = resolveSimFileUrl(src)
+    const resolvedSrc = resolveSimFileUrl(typeof src === 'string' ? src : undefined)
     return (
       <img
         src={resolvedSrc}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -562,14 +562,17 @@ const STATIC_MARKDOWN_COMPONENTS = {
     )
   },
   hr: () => <hr className='my-6 border-[var(--border)]' />,
-  img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => (
-    <img
-      src={src as string}
-      alt={alt ?? ''}
-      className='my-3 max-w-full rounded-md'
-      loading='lazy'
-    />
-  ),
+  img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    const resolvedSrc = resolveSimFileUrl(src)
+    return (
+      <img
+        src={resolvedSrc}
+        alt={alt ?? ''}
+        className='my-3 max-w-full rounded-md'
+        loading='lazy'
+      />
+    )
+  },
   table: ({ children }: { children?: React.ReactNode }) => (
     <div className='my-4 max-w-full overflow-x-auto'>
       <table className='w-full border-collapse text-[13px]'>{children}</table>
@@ -734,6 +737,16 @@ function AnchorRenderer({ href, children }: { href?: string; children?: React.Re
       {children}
     </a>
   )
+}
+
+const SIM_FILES_PAGE_PATTERN =
+  /(?:https?:\/\/[^/]+)?\/workspace\/[a-f0-9-]{36}\/files\/([a-f0-9-]{36})(?:[?#].*)?$/
+
+function resolveSimFileUrl(src: string | undefined): string | undefined {
+  if (!src) return src
+  const match = SIM_FILES_PAGE_PATTERN.exec(src)
+  if (!match) return src
+  return `/api/files/view/${match[1]}`
 }
 
 const MARKDOWN_COMPONENTS = {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -456,7 +456,9 @@ function resolveSimFileUrl(src: string | undefined): string | undefined {
   try {
     const parsed = new URL(src, 'http://placeholder')
     const isRelative = parsed.origin === 'http://placeholder'
-    const isSameOrigin = parsed.origin === getBrowserOrigin()
+    const browserOrigin = getBrowserOrigin()
+    // null means SSR — treat as same-origin so server and client produce identical output
+    const isSameOrigin = browserOrigin === null || parsed.origin === browserOrigin
     if (!isRelative && !isSameOrigin) return src
     const [, seg1, , seg3, fileId] = parsed.pathname.split('/')
     if (seg1 === 'workspace' && seg3 === 'files' && fileId) {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -423,6 +423,20 @@ const MermaidDiagram = memo(function MermaidDiagram({
   return null
 })
 
+function resolveSimFileUrl(src: string | undefined): string | undefined {
+  if (!src) return src
+  try {
+    const { pathname } = new URL(src, 'http://placeholder')
+    const [, seg1, , seg3, fileId] = pathname.split('/')
+    if (seg1 === 'workspace' && seg3 === 'files' && fileId) {
+      return `/api/files/view/${fileId}`
+    }
+  } catch {
+    // not a parseable URL
+  }
+  return src
+}
+
 const STATIC_MARKDOWN_COMPONENTS = {
   pre: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   p: ({ children }: { children?: React.ReactNode }) => (
@@ -737,16 +751,6 @@ function AnchorRenderer({ href, children }: { href?: string; children?: React.Re
       {children}
     </a>
   )
-}
-
-const SIM_FILES_PAGE_PATTERN =
-  /(?:https?:\/\/[^/]+)?\/workspace\/[a-f0-9-]{36}\/files\/([a-f0-9-]{36})(?:[?#].*)?$/
-
-function resolveSimFileUrl(src: string | undefined): string | undefined {
-  if (!src) return src
-  const match = SIM_FILES_PAGE_PATTERN.exec(src)
-  if (!match) return src
-  return `/api/files/view/${match[1]}`
 }
 
 const MARKDOWN_COMPONENTS = {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -22,7 +22,6 @@ import 'prismjs/components/prism-sql'
 import 'prismjs/components/prism-python'
 import { cn } from '@/lib/core/utils/cn'
 import { extractTextContent } from '@/lib/core/utils/react-node-text'
-import { getBrowserOrigin } from '@/lib/core/utils/urls'
 import { getFileExtension } from '@/lib/uploads/utils/file-utils'
 import { useAutoScroll } from '@/hooks/use-auto-scroll'
 import { DataTable } from './data-table'
@@ -477,11 +476,7 @@ function resolveSimFileUrl(src: string | undefined): string | undefined {
   if (!src) return src
   try {
     const parsed = new URL(src, 'http://placeholder')
-    const isRelative = parsed.origin === 'http://placeholder'
-    const browserOrigin = getBrowserOrigin()
-    // null means SSR — treat as same-origin so server and client produce identical output
-    const isSameOrigin = browserOrigin === null || parsed.origin === browserOrigin
-    if (!isRelative && !isSameOrigin) return src
+    if (parsed.origin !== 'http://placeholder') return src
     const [, seg1, , seg3, fileId] = parsed.pathname.split('/')
     if (seg1 === 'workspace' && seg3 === 'files' && fileId) {
       return `/api/files/view/${fileId}`

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -22,6 +22,7 @@ import 'prismjs/components/prism-sql'
 import 'prismjs/components/prism-python'
 import { cn } from '@/lib/core/utils/cn'
 import { extractTextContent } from '@/lib/core/utils/react-node-text'
+import { getBrowserOrigin } from '@/lib/core/utils/urls'
 import { getFileExtension } from '@/lib/uploads/utils/file-utils'
 import { useAutoScroll } from '@/hooks/use-auto-scroll'
 import { DataTable } from './data-table'
@@ -455,7 +456,7 @@ function resolveSimFileUrl(src: string | undefined): string | undefined {
   try {
     const parsed = new URL(src, 'http://placeholder')
     const isRelative = parsed.origin === 'http://placeholder'
-    const isSameOrigin = typeof window !== 'undefined' && parsed.origin === window.location.origin
+    const isSameOrigin = parsed.origin === getBrowserOrigin()
     if (!isRelative && !isSameOrigin) return src
     const [, seg1, , seg3, fileId] = parsed.pathname.split('/')
     if (seg1 === 'workspace' && seg3 === 'files' && fileId) {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -10,7 +10,7 @@ import { Streamdown } from 'streamdown'
 import 'streamdown/styles.css'
 import { toError } from '@sim/utils/errors'
 import { generateShortId } from '@sim/utils/id'
-import { Checkbox, CopyCodeButton, highlight, languages } from '@/components/emcn'
+import { Checkbox, CopyCodeButton, highlight, languages, Skeleton } from '@/components/emcn'
 import '@/components/emcn/components/code/code.css'
 import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-css'
@@ -446,6 +446,13 @@ const MermaidDiagram = memo(function MermaidDiagram({
   }
 
   if (!trimmedDefinition || !svg || renderedDefinition !== trimmedDefinition) {
+    if (zoomable) {
+      return (
+        <div className='flex h-full items-center justify-center p-8'>
+          <Skeleton className='w-full rounded-lg' style={{ aspectRatio: '4 / 3' }} />
+        </div>
+      )
+    }
     return <MermaidCodeBlockSkeleton />
   }
   return null

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -98,6 +98,33 @@ export const PreviewPanel = memo(function PreviewPanel({
 
 const CALLOUT_TYPES = new Set(['NOTE', 'TIP', 'WARNING', 'IMPORTANT', 'CAUTION'])
 
+function remarkMermaid() {
+  return (tree: { type: string; children?: unknown[] }) => {
+    function processNode(node: {
+      type: string
+      children?: unknown[]
+      lang?: string
+      value?: string
+      data?: Record<string, unknown>
+    }) {
+      if (!node.children) return
+      for (const child of node.children) {
+        const c = child as typeof node
+        if (c.type === 'code' && c.lang === 'mermaid') {
+          c.data = {
+            hName: 'mermaid-diagram',
+            hProperties: { definition: c.value ?? '' },
+            hChildren: [],
+          }
+        } else {
+          processNode(c)
+        }
+      }
+    }
+    processNode(tree)
+  }
+}
+
 function remarkCallouts() {
   return (tree: { type: string; children?: unknown[] }) => {
     function processNode(node: { type: string; children?: unknown[] }) {
@@ -142,7 +169,7 @@ function remarkCallouts() {
   }
 }
 
-const REMARK_PLUGINS = [remarkGfm, remarkBreaks, remarkCallouts]
+const REMARK_PLUGINS = [remarkGfm, remarkBreaks, remarkMermaid, remarkCallouts]
 const REHYPE_PLUGINS = [rehypeSlug]
 
 /**
@@ -439,6 +466,10 @@ function resolveSimFileUrl(src: string | undefined): string | undefined {
 
 const STATIC_MARKDOWN_COMPONENTS = {
   pre: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  'mermaid-diagram': ({ definition }: { definition?: string }) => {
+    const isStreaming = useContext(MermaidStreamingCtx)
+    return <MermaidDiagram definition={definition ?? ''} isStreaming={isStreaming} />
+  },
   p: ({ children }: { children?: React.ReactNode }) => (
     <p className='mb-3 break-words text-[14px] text-[var(--text-primary)] leading-[1.6] last:mb-0'>
       {children}
@@ -507,14 +538,9 @@ const STATIC_MARKDOWN_COMPONENTS = {
     )
   },
   code: ({ children, className }: { children?: React.ReactNode; className?: string }) => {
-    const isMarkdownStreaming = useContext(MermaidStreamingCtx)
     const langMatch = className?.match(/language-(\w+)/)
     const langRaw = langMatch?.[1] ?? ''
     const codeString = extractTextContent(children)
-
-    if (langRaw === 'mermaid') {
-      return <MermaidDiagram definition={codeString} isStreaming={isMarkdownStreaming} />
-    }
 
     if (!codeString) {
       return (
@@ -849,6 +875,7 @@ const MarkdownPreview = memo(function MarkdownPreview({
           remarkPlugins={REMARK_PLUGINS}
           rehypePlugins={REHYPE_PLUGINS}
           components={MARKDOWN_COMPONENTS}
+          allowedTags={{ 'mermaid-diagram': ['definition'] }}
         >
           {markdownContent}
         </Streamdown>

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -453,8 +453,11 @@ const MermaidDiagram = memo(function MermaidDiagram({
 function resolveSimFileUrl(src: string | undefined): string | undefined {
   if (!src) return src
   try {
-    const { pathname } = new URL(src, 'http://placeholder')
-    const [, seg1, , seg3, fileId] = pathname.split('/')
+    const parsed = new URL(src, 'http://placeholder')
+    const isRelative = parsed.origin === 'http://placeholder'
+    const isSameOrigin = typeof window !== 'undefined' && parsed.origin === window.location.origin
+    if (!isRelative && !isSameOrigin) return src
+    const [, seg1, , seg3, fileId] = parsed.pathname.split('/')
     if (seg1 === 'workspace' && seg3 === 'files' && fileId) {
       return `/api/files/view/${fileId}`
     }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -606,8 +606,8 @@ const STATIC_MARKDOWN_COMPONENTS = {
     )
   },
   hr: () => <hr className='my-6 border-[var(--border)]' />,
-  img: ({ src, alt }: { src?: string; alt?: string }) => {
-    const resolvedSrc = resolveSimFileUrl(src)
+  img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    const resolvedSrc = resolveSimFileUrl(typeof src === 'string' ? src : undefined)
     return (
       <img
         src={resolvedSrc}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -447,23 +447,8 @@ const MermaidDiagram = memo(function MermaidDiagram({
   if (!trimmedDefinition || !svg || renderedDefinition !== trimmedDefinition) {
     if (zoomable) {
       return (
-        <div className='flex h-full items-center justify-center bg-[var(--surface-1)] p-8'>
-          <div
-            className='w-full max-w-[720px] shrink-0 rounded-md bg-[var(--surface-2)] p-8 shadow-medium'
-            style={{ aspectRatio: '4 / 3' }}
-          >
-            <div className='flex h-full flex-col justify-between'>
-              <div className='flex flex-col gap-3'>
-                <Skeleton className='h-[18px] w-[45%]' />
-                <Skeleton className='h-[14px] w-[65%]' />
-                <Skeleton className='h-[14px] w-[55%]' />
-              </div>
-              <div className='flex flex-col gap-2'>
-                <Skeleton className='h-[14px] w-[75%]' />
-                <Skeleton className='h-[14px] w-[60%]' />
-              </div>
-            </div>
-          </div>
+        <div className='h-full p-6'>
+          <Skeleton className='h-full w-full rounded-lg' />
         </div>
       )
     }

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/trace-view/trace-view.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/trace-view/trace-view.tsx
@@ -45,7 +45,7 @@ import {
 } from '@/app/workspace/[workspaceId]/logs/components/log-details/utils'
 import { useCodeViewerFeatures } from '@/hooks/use-code-viewer'
 
-const DEFAULT_TREE_PANE_WIDTH = 360
+const DEFAULT_TREE_PANE_WIDTH = 280
 const MIN_TREE_PANE_WIDTH = 200
 const MAX_TREE_PANE_WIDTH = 600
 const INDENT_PX = 12

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/trace-view/trace-view.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/trace-view/trace-view.tsx
@@ -45,7 +45,7 @@ import {
 } from '@/app/workspace/[workspaceId]/logs/components/log-details/utils'
 import { useCodeViewerFeatures } from '@/hooks/use-code-viewer'
 
-const DEFAULT_TREE_PANE_WIDTH = 280
+const DEFAULT_TREE_PANE_WIDTH = 240
 const MIN_TREE_PANE_WIDTH = 200
 const MAX_TREE_PANE_WIDTH = 600
 const INDENT_PX = 12

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -545,18 +545,20 @@ export function FolderItem({
           />
         ) : (
           <div className='flex min-w-0 flex-1 items-center gap-2'>
-            <span
-              className='min-w-0 flex-1 truncate font-base text-[var(--text-body)]'
-              onDoubleClick={handleDoubleClick}
-            >
-              {folder.name}
-            </span>
-            {folder.locked && (
-              <Lock
-                className='h-[12px] w-[12px] flex-shrink-0 pointer-events-none text-[var(--text-icon)]'
-                aria-label='Folder is locked'
-              />
-            )}
+            <div className='flex min-w-0 flex-1 items-center gap-1'>
+              <span
+                className='min-w-0 truncate font-base text-[var(--text-body)]'
+                onDoubleClick={handleDoubleClick}
+              >
+                {folder.name}
+              </span>
+              {folder.locked && (
+                <Lock
+                  className='h-[12px] w-[12px] flex-shrink-0 pointer-events-none text-[var(--text-icon)]'
+                  aria-label='Folder is locked'
+                />
+              )}
+            </div>
             <button
               type='button'
               aria-label='Folder options'

--- a/apps/sim/lib/api/contracts/storage-transfer.ts
+++ b/apps/sim/lib/api/contracts/storage-transfer.ts
@@ -450,6 +450,10 @@ export const fileServeQuerySchema = z.object({
   raw: z.string().nullish(),
 })
 
+export const fileViewParamsSchema = z.object({
+  id: z.string().uuid('File ID must be a valid UUID'),
+})
+
 export const boxUploadContract = defineRouteContract({
   method: 'POST',
   path: '/api/tools/box/upload',
@@ -696,6 +700,13 @@ export const fileServeContract = defineRouteContract({
   response: { mode: 'binary' },
 })
 
+export const fileViewContract = defineRouteContract({
+  method: 'GET',
+  path: '/api/files/view/[id]',
+  params: fileViewParamsSchema,
+  response: { mode: 'binary' },
+})
+
 export type BoxUploadBody = ContractBodyInput<typeof boxUploadContract>
 export type BoxUploadResponse = ContractJsonResponse<typeof boxUploadContract>
 export type DropboxUploadBody = ContractBodyInput<typeof dropboxUploadContract>
@@ -737,3 +748,4 @@ export type TokenBoundMultipartBody = z.output<typeof tokenBoundMultipartBodySch
 export type GetMultipartPartUrlsBody = z.output<typeof getMultipartPartUrlsBodySchema>
 export type FileServeParams = ContractParamsInput<typeof fileServeContract>
 export type FileServeQuery = ContractQueryInput<typeof fileServeContract>
+export type FileViewParams = ContractParamsInput<typeof fileViewContract>

--- a/apps/sim/lib/uploads/server/metadata.ts
+++ b/apps/sim/lib/uploads/server/metadata.ts
@@ -141,6 +141,24 @@ export async function getFileMetadataByKey(
 }
 
 /**
+ * Get file metadata by ID
+ */
+export async function getFileMetadataById(
+  id: string,
+  options?: { includeDeleted?: boolean }
+): Promise<FileMetadataRecord | null> {
+  const { includeDeleted = false } = options ?? {}
+  const conditions = [eq(workspaceFiles.id, id)]
+  if (!includeDeleted) conditions.push(isNull(workspaceFiles.deletedAt))
+  const [record] = await db
+    .select()
+    .from(workspaceFiles)
+    .where(conditions.length > 1 ? and(...conditions) : conditions[0])
+    .limit(1)
+  return record ?? null
+}
+
+/**
  * Get file metadata by context with optional workspaceId/userId filters
  */
 export async function getFileMetadataByContext(


### PR DESCRIPTION
## Summary
- Add \`/api/files/view/[id]\` route that resolves a file ID to its serve URL via 302 redirect (auth + access-checked)
- Detect relative workspace file page URLs in markdown \`img\` tags and rewrite them to the view API so embedded Sim files render correctly; only relative paths are rewritten to avoid SSR hydration mismatches and cross-origin URL hijacking
- Fix mermaid diagrams in markdown previews — add a \`remarkMermaid\` remark plugin that intercepts mermaid code blocks at the MDAST stage and routes them through our \`MermaidDiagram\` component with correct design tokens (Streamdown's built-in renderer uses mismatched Tailwind semantic classes)
- Reduce default trace view tree pane width from 360 → 240

## Type of Change
- [x] New feature
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)