### PR TITLE
fix(home): restore folder search in @-mention and plus-menu dropdown

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown.tsx
@@ -80,13 +80,12 @@ export const PlusMenuDropdown = React.memo(
       const q = rawQuery.toLowerCase().trim()
       // In mention mode always render a flat filtered list — empty query = show everything.
       if (!isMention && !q) return null
-      // Folders organize resources but aren't a valid mention/insertable target — drop them
-      // from the flat list (matches the nested rendering, which also excludes them).
-      const flatGroups = availableResources.filter(({ type }) => type !== 'folder')
       if (isMention && !q) {
-        return flatGroups.flatMap(({ type, items }) => items.map((item) => ({ type, item })))
+        return availableResources.flatMap(({ type, items }) =>
+          items.map((item) => ({ type, item }))
+        )
       }
-      return flatGroups.flatMap(({ type, items }) =>
+      return availableResources.flatMap(({ type, items }) =>
         items.filter((item) => item.name.toLowerCase().includes(q)).map((item) => ({ type, item }))
       )
     }, [isMention, mentionQuery, search, availableResources])

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -554,7 +554,7 @@ export function FolderItem({
               </span>
               {folder.locked && (
                 <Lock
-                  className='h-[12px] w-[12px] flex-shrink-0 pointer-events-none text-[var(--text-icon)]'
+                  className='pointer-events-none h-[12px] w-[12px] flex-shrink-0 text-[var(--text-icon)]'
                   aria-label='Folder is locked'
                 />
               )}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -470,7 +470,7 @@ export function WorkflowItem({
             )}
             {!isEditing && workflow.locked && (
               <Lock
-                className='h-[12px] w-[12px] flex-shrink-0 pointer-events-none text-[var(--text-icon)]'
+                className='pointer-events-none h-[12px] w-[12px] flex-shrink-0 text-[var(--text-icon)]'
                 aria-label='Workflow is locked'
               />
             )}


### PR DESCRIPTION
## Summary
- Removed the `type !== 'folder'` filter from the flat search list in `plus-menu-dropdown.tsx`. Folder search regressed in #4362 on the assumption that folders weren't insertable mention targets, but `'folder'` is a valid `MothershipResourceType` and is rendered as a selectable item in the nested view.
- Both `@`-mention search and plus-click search now surface folders by name again, matching what users see in the nested tree.
- Bundled two unrelated Tailwind class-order fixups from the lint-staged hook.

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)