### PR TITLE
improvement(knowledge): tighten column widths for short numeric/badge values

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -84,11 +84,11 @@ const DOCUMENTS_PER_PAGE = 50
 
 const DOCUMENT_COLUMNS: ResourceColumn[] = [
   { id: 'name', header: 'Name' },
-  { id: 'size', header: 'Size' },
-  { id: 'tokens', header: 'Tokens' },
-  { id: 'chunks', header: 'Chunks' },
-  { id: 'uploaded', header: 'Uploaded' },
-  { id: 'status', header: 'Status' },
+  { id: 'size', header: 'Size', widthMultiplier: 0.625 },
+  { id: 'tokens', header: 'Tokens', widthMultiplier: 0.625 },
+  { id: 'chunks', header: 'Chunks', widthMultiplier: 0.5 },
+  { id: 'uploaded', header: 'Uploaded', widthMultiplier: 0.75 },
+  { id: 'status', header: 'Status', widthMultiplier: 0.875 },
   { id: 'tags', header: 'Tags' },
 ]
 


### PR DESCRIPTION
## Summary
- Tighten Size, Tokens, Chunks, Uploaded, and Status column widths on the KB documents page so short numeric values and badges aren't surrounded by huge gaps
- Status kept at 0.875× to leave room for "Processing" / "Embedding" badges with icons

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)