### PR TITLE
fix(connectors): harden 10 KB connectors after audit

### DIFF
--- a/apps/sim/connectors/confluence/confluence.ts
+++ b/apps/sim/connectors/confluence/confluence.ts
@@ -489,7 +489,11 @@ async function listAllContentTypes(
       pagesDone = parsed.pagesDone === true
       blogsDone = parsed.blogsDone === true
     } catch {
-      pageCursor = cursor
+      /**
+       * Older bare-string cursors are no longer emitted; fall through and
+       * restart instead of silently re-listing blogposts from page 0.
+       */
+      logger.warn('Ignoring unparseable Confluence cursor; restarting listing')
     }
   }
 

--- a/apps/sim/connectors/confluence/confluence.ts
+++ b/apps/sim/connectors/confluence/confluence.ts
@@ -80,33 +80,55 @@ async function fetchLabelsForPages(
 }
 
 /**
+ * Produces a canonical metadata stub with a deterministic contentHash that
+ * does not depend on which API surface (v1 CQL or v2) returned the page.
+ */
+function pageToStub(
+  page: Record<string, unknown>,
+  options: {
+    spaceId?: unknown
+    labels?: string[]
+    sourceUrl?: string
+  } = {}
+): ExternalDocument {
+  const version = page.version as Record<string, unknown> | undefined
+  const versionNumber = version?.number as number | undefined
+  const lastModified = (version?.createdAt ?? version?.when ?? '') as string
+  const versionKey = versionNumber ?? lastModified
+
+  return {
+    externalId: String(page.id),
+    title: (page.title as string) || 'Untitled',
+    content: '',
+    contentDeferred: true,
+    mimeType: 'text/plain',
+    sourceUrl: options.sourceUrl,
+    contentHash: `confluence:${page.id}:${versionKey}`,
+    metadata: {
+      spaceId: options.spaceId,
+      status: page.status,
+      version: versionNumber,
+      labels: options.labels ?? [],
+      lastModified,
+    },
+  }
+}
+
+/**
  * Converts a v1 CQL search result item to a lightweight metadata stub.
  */
 function cqlResultToStub(item: Record<string, unknown>, domain: string): ExternalDocument {
-  const version = item.version as Record<string, unknown> | undefined
   const links = item._links as Record<string, string> | undefined
   const metadata = item.metadata as Record<string, unknown> | undefined
   const labelsWrapper = metadata?.labels as Record<string, unknown> | undefined
   const labelResults = (labelsWrapper?.results || []) as Record<string, unknown>[]
   const labels = labelResults.map((l) => l.name as string)
-  const versionNumber = version?.number
 
-  return {
-    externalId: String(item.id),
-    title: (item.title as string) || 'Untitled',
-    content: '',
-    contentDeferred: true,
-    mimeType: 'text/plain',
+  return pageToStub(item, {
+    spaceId: (item.space as Record<string, unknown>)?.key,
+    labels,
     sourceUrl: links?.webui ? `https://${domain}/wiki${links.webui}` : undefined,
-    contentHash: `confluence:${item.id}:${versionNumber ?? ''}`,
-    metadata: {
-      spaceId: (item.space as Record<string, unknown>)?.key,
-      status: item.status,
-      version: versionNumber,
-      labels,
-      lastModified: version?.when,
-    },
-  }
+  })
 }
 
 export const confluenceConnector: ConnectorConfig = {
@@ -286,7 +308,9 @@ export const confluenceConnector: ConnectorConfig = {
 
     const links = page._links as Record<string, unknown> | undefined
     const version = page.version as Record<string, unknown> | undefined
-    const versionNumber = version?.number
+    const versionNumber = version?.number as number | undefined
+    const lastModified = (version?.createdAt ?? version?.when ?? '') as string
+    const versionKey = versionNumber ?? lastModified
 
     return {
       externalId: String(page.id),
@@ -295,13 +319,13 @@ export const confluenceConnector: ConnectorConfig = {
       contentDeferred: false,
       mimeType: 'text/plain',
       sourceUrl: links?.webui ? `https://${domain}/wiki${links.webui}` : undefined,
-      contentHash: `confluence:${page.id}:${versionNumber ?? ''}`,
+      contentHash: `confluence:${page.id}:${versionKey}`,
       metadata: {
         spaceId: page.spaceId,
         status: page.status,
         version: versionNumber,
         labels,
-        lastModified: version?.createdAt,
+        lastModified,
       },
     }
   },
@@ -420,28 +444,11 @@ async function listDocumentsV2(
   const results = data.results || []
 
   const documents: ExternalDocument[] = results.map((page: Record<string, unknown>) => {
-    const pageId = String(page.id)
-    const version = page.version as Record<string, unknown> | undefined
-    const versionNumber = version?.number
-
-    return {
-      externalId: pageId,
-      title: (page.title as string) || 'Untitled',
-      content: '',
-      contentDeferred: true,
-      mimeType: 'text/plain',
-      sourceUrl: (page._links as Record<string, string>)?.webui
-        ? `https://${domain}/wiki${(page._links as Record<string, string>).webui}`
-        : undefined,
-      contentHash: `confluence:${pageId}:${versionNumber ?? ''}`,
-      metadata: {
-        spaceId: page.spaceId,
-        status: page.status,
-        version: versionNumber,
-        labels: [],
-        lastModified: version?.createdAt,
-      },
-    }
+    const links = page._links as Record<string, string> | undefined
+    return pageToStub(page, {
+      spaceId: page.spaceId,
+      sourceUrl: links?.webui ? `https://${domain}/wiki${links.webui}` : undefined,
+    })
   })
 
   let nextCursor: string | undefined

--- a/apps/sim/connectors/confluence/confluence.ts
+++ b/apps/sim/connectors/confluence/confluence.ts
@@ -307,26 +307,16 @@ export const confluenceConnector: ConnectorConfig = {
     const labels = labelMap.get(String(page.id)) ?? []
 
     const links = page._links as Record<string, unknown> | undefined
-    const version = page.version as Record<string, unknown> | undefined
-    const versionNumber = version?.number as number | undefined
-    const lastModified = (version?.createdAt ?? version?.when ?? '') as string
-    const versionKey = versionNumber ?? lastModified
+    const stub = pageToStub(page, {
+      spaceId: page.spaceId,
+      labels,
+      sourceUrl: links?.webui ? `https://${domain}/wiki${links.webui}` : undefined,
+    })
 
     return {
-      externalId: String(page.id),
-      title: (page.title as string) || 'Untitled',
+      ...stub,
       content: plainText,
       contentDeferred: false,
-      mimeType: 'text/plain',
-      sourceUrl: links?.webui ? `https://${domain}/wiki${links.webui}` : undefined,
-      contentHash: `confluence:${page.id}:${versionKey}`,
-      metadata: {
-        spaceId: page.spaceId,
-        status: page.status,
-        version: versionNumber,
-        labels,
-        lastModified,
-      },
     }
   },
 

--- a/apps/sim/connectors/confluence/confluence.ts
+++ b/apps/sim/connectors/confluence/confluence.ts
@@ -347,7 +347,7 @@ export const confluenceConnector: ConnectorConfig = {
     }
 
     try {
-      const cloudId = await getConfluenceCloudId(domain, accessToken)
+      const cloudId = await getConfluenceCloudId(domain, accessToken, VALIDATE_RETRY_OPTIONS)
       const spaceUrl = `https://api.atlassian.com/ex/confluence/${cloudId}/wiki/api/v2/spaces?keys=${encodeURIComponent(spaceKey)}&limit=1`
       const response = await fetchWithRetry(
         spaceUrl,
@@ -369,8 +369,7 @@ export const confluenceConnector: ConnectorConfig = {
       }
       return { valid: true }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to validate configuration'
-      return { valid: false, error: message }
+      return { valid: false, error: toError(error).message || 'Failed to validate configuration' }
     }
   },
 

--- a/apps/sim/connectors/evernote/evernote.ts
+++ b/apps/sim/connectors/evernote/evernote.ts
@@ -464,7 +464,6 @@ export const evernoteConnector: ConnectorConfig = {
       const plainText = htmlToPlainText(note.content)
       const title = note.title || 'Untitled'
       const content = plainText.trim() ? plainText : title
-      if (!content.trim()) return null
 
       const shardId = extractShardId(accessToken)
       const userId = extractUserId(accessToken)

--- a/apps/sim/connectors/evernote/evernote.ts
+++ b/apps/sim/connectors/evernote/evernote.ts
@@ -462,7 +462,9 @@ export const evernoteConnector: ConnectorConfig = {
       const retryOptions = { maxRetries: 3, initialDelayMs: 500 }
       const note = await apiGetNote(accessToken, externalId, retryOptions)
       const plainText = htmlToPlainText(note.content)
-      if (!plainText.trim()) return null
+      const title = note.title || 'Untitled'
+      const content = plainText.trim() ? plainText : title
+      if (!content.trim()) return null
 
       const shardId = extractShardId(accessToken)
       const userId = extractUserId(accessToken)
@@ -494,8 +496,8 @@ export const evernoteConnector: ConnectorConfig = {
 
       return {
         externalId,
-        title: note.title || 'Untitled',
-        content: plainText,
+        title,
+        content,
         contentDeferred: false,
         mimeType: 'text/plain',
         sourceUrl: `https://${host}/shard/${shardId}/nl/${userId}/${externalId}/`,
@@ -539,7 +541,7 @@ export const evernoteConnector: ConnectorConfig = {
 
       return { valid: true }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to connect to Evernote'
+      const message = toError(error).message || 'Failed to connect to Evernote'
       return { valid: false, error: message }
     }
   },

--- a/apps/sim/connectors/github/github.ts
+++ b/apps/sim/connectors/github/github.ts
@@ -10,6 +10,7 @@ const logger = createLogger('GitHubConnector')
 const GITHUB_API_URL = 'https://api.github.com'
 const BATCH_SIZE = 30
 const GIT_SHA_PREFIX = 'git-sha:'
+const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB
 
 /**
  * Parses the repository string into owner and repo.
@@ -88,6 +89,44 @@ async function fetchTree(
   }
 
   return (data.tree || []).filter((item: TreeItem) => item.type === 'blob')
+}
+
+/**
+ * Fetches blob content via the Git Blobs API. Used as a fallback when the
+ * `/contents/` endpoint cannot return the file body (files larger than 1 MB
+ * return `content: ""` and `encoding: "none"`). Supports blobs up to 100 MB.
+ */
+async function fetchBlobContent(
+  accessToken: string,
+  owner: string,
+  repo: string,
+  sha: string
+): Promise<string> {
+  const url = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/blobs/${encodeURIComponent(sha)}`
+  const response = await fetchWithRetry(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${accessToken}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch git blob ${sha}: ${response.status}`)
+  }
+
+  const data = await response.json()
+  const content = (data.content as string) || ''
+  const encoding = data.encoding as string | undefined
+
+  if (encoding === 'base64') {
+    return Buffer.from(content, 'base64').toString('utf8')
+  }
+  if (encoding === 'utf-8') {
+    return content
+  }
+  return ''
 }
 
 /**
@@ -257,10 +296,27 @@ export const githubConnector: ConnectorConfig = {
 
       const lastModifiedHeader = response.headers.get('last-modified') || undefined
       const data = await response.json()
-      const content =
-        data.encoding === 'base64'
-          ? Buffer.from(data.content as string, 'base64').toString('utf-8')
-          : (data.content as string) || ''
+
+      const size = typeof data.size === 'number' ? data.size : 0
+      if (size > MAX_FILE_SIZE) {
+        logger.info('Skipping GitHub file exceeding size limit', {
+          path,
+          size,
+          limit: MAX_FILE_SIZE,
+        })
+        return null
+      }
+
+      const rawContent = (data.content as string) || ''
+      const encoding = data.encoding as string | undefined
+      let content: string
+      if (encoding === 'base64' && rawContent.length > 0) {
+        content = Buffer.from(rawContent, 'base64').toString('utf8')
+      } else if ((encoding === 'none' || rawContent.length === 0) && data.sha) {
+        content = await fetchBlobContent(accessToken, owner, repo, data.sha as string)
+      } else {
+        content = ''
+      }
 
       return {
         externalId,

--- a/apps/sim/connectors/github/github.ts
+++ b/apps/sim/connectors/github/github.ts
@@ -114,7 +114,7 @@ async function fetchBlobContent(
   owner: string,
   repo: string,
   sha: string
-): Promise<string> {
+): Promise<string | null> {
   const url = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/blobs/${encodeURIComponent(sha)}`
   const response = await fetchWithRetry(url, {
     method: 'GET',
@@ -134,7 +134,9 @@ async function fetchBlobContent(
   const encoding = data.encoding as string | undefined
 
   if (encoding === 'base64') {
-    return Buffer.from(content, 'base64').toString('utf8')
+    const buf = Buffer.from(content, 'base64')
+    if (isBinaryBuffer(buf)) return null
+    return buf.toString('utf8')
   }
   if (encoding === 'utf-8') {
     return content
@@ -332,7 +334,12 @@ export const githubConnector: ConnectorConfig = {
         }
         content = buf.toString('utf8')
       } else if (encoding === 'none' && data.sha && size > 0) {
-        content = await fetchBlobContent(accessToken, owner, repo, data.sha as string)
+        const blobContent = await fetchBlobContent(accessToken, owner, repo, data.sha as string)
+        if (blobContent === null) {
+          logger.info('Skipping binary GitHub file', { path, size })
+          return null
+        }
+        content = blobContent
       } else {
         content = ''
       }

--- a/apps/sim/connectors/github/github.ts
+++ b/apps/sim/connectors/github/github.ts
@@ -138,10 +138,12 @@ async function fetchBlobContent(
     if (isBinaryBuffer(buf)) return null
     return buf.toString('utf8')
   }
-  if (encoding === 'utf-8') {
-    return content
-  }
-  return ''
+  /**
+   * Per https://docs.github.com/en/rest/git/blobs the Blobs API only ever
+   * returns base64. Refuse to silently persist empty content for an
+   * unexpected encoding so a sync surfaces the error instead.
+   */
+  throw new Error(`Unexpected git blob encoding for ${sha}: ${encoding ?? 'undefined'}`)
 }
 
 /**
@@ -162,7 +164,7 @@ function treeItemToStub(
     content: '',
     contentDeferred: true,
     mimeType: 'text/plain',
-    sourceUrl: `https://github.com/${owner}/${repo}/blob/${encodeURIComponent(branch)}/${item.path.split('/').map(encodeURIComponent).join('/')}`,
+    sourceUrl: `https://github.com/${owner}/${repo}/blob/${branch.split('/').map(encodeURIComponent).join('/')}/${item.path.split('/').map(encodeURIComponent).join('/')}`,
     contentHash: `${GIT_SHA_PREFIX}${item.sha}`,
     metadata: {
       path: item.path,
@@ -307,6 +309,13 @@ export const githubConnector: ConnectorConfig = {
 
       if (!response.ok) {
         if (response.status === 404) return null
+        if (response.status === 403) {
+          logger.info('Skipping GitHub file rejected by Contents API', {
+            path,
+            status: response.status,
+          })
+          return null
+        }
         throw new Error(`Failed to fetch file ${path}: ${response.status}`)
       }
 
@@ -350,7 +359,7 @@ export const githubConnector: ConnectorConfig = {
         content,
         contentDeferred: false,
         mimeType: 'text/plain',
-        sourceUrl: `https://github.com/${owner}/${repo}/blob/${encodeURIComponent(branch)}/${path.split('/').map(encodeURIComponent).join('/')}`,
+        sourceUrl: `https://github.com/${owner}/${repo}/blob/${branch.split('/').map(encodeURIComponent).join('/')}/${path.split('/').map(encodeURIComponent).join('/')}`,
         contentHash: `${GIT_SHA_PREFIX}${data.sha as string}`,
         metadata: {
           path,

--- a/apps/sim/connectors/github/github.ts
+++ b/apps/sim/connectors/github/github.ts
@@ -312,7 +312,7 @@ export const githubConnector: ConnectorConfig = {
       let content: string
       if (encoding === 'base64' && rawContent.length > 0) {
         content = Buffer.from(rawContent, 'base64').toString('utf8')
-      } else if ((encoding === 'none' || rawContent.length === 0) && data.sha) {
+      } else if (encoding === 'none' && data.sha && size > 0) {
         content = await fetchBlobContent(accessToken, owner, repo, data.sha as string)
       } else {
         content = ''

--- a/apps/sim/connectors/github/github.ts
+++ b/apps/sim/connectors/github/github.ts
@@ -11,6 +11,19 @@ const GITHUB_API_URL = 'https://api.github.com'
 const BATCH_SIZE = 30
 const GIT_SHA_PREFIX = 'git-sha:'
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB
+const BINARY_SNIFF_BYTES = 8000
+
+/**
+ * Heuristic binary detection: Git treats files containing a NUL byte in the
+ * first 8000 bytes as binary. Matches `git diff` / `git grep` semantics.
+ */
+function isBinaryBuffer(buf: Buffer): boolean {
+  const len = Math.min(buf.length, BINARY_SNIFF_BYTES)
+  for (let i = 0; i < len; i++) {
+    if (buf[i] === 0) return true
+  }
+  return false
+}
 
 /**
  * Parses the repository string into owner and repo.
@@ -228,10 +241,11 @@ export const githubConnector: ConnectorConfig = {
     } else {
       const tree = await fetchTree(accessToken, owner, repo, branch)
 
-      // Filter by path prefix and extensions
+      // Filter by path prefix, extensions, and size
       const filtered = tree.filter((item) => {
         if (pathPrefix && !item.path.startsWith(pathPrefix)) return false
         if (!matchesExtension(item.path, extSet)) return false
+        if (typeof item.size === 'number' && item.size > MAX_FILE_SIZE) return false
         return true
       })
 
@@ -311,7 +325,12 @@ export const githubConnector: ConnectorConfig = {
       const encoding = data.encoding as string | undefined
       let content: string
       if (encoding === 'base64' && rawContent.length > 0) {
-        content = Buffer.from(rawContent, 'base64').toString('utf8')
+        const buf = Buffer.from(rawContent, 'base64')
+        if (isBinaryBuffer(buf)) {
+          logger.info('Skipping binary GitHub file', { path, size })
+          return null
+        }
+        content = buf.toString('utf8')
       } else if (encoding === 'none' && data.sha && size > 0) {
         content = await fetchBlobContent(accessToken, owner, repo, data.sha as string)
       } else {

--- a/apps/sim/connectors/google-docs/google-docs.ts
+++ b/apps/sim/connectors/google-docs/google-docs.ts
@@ -91,7 +91,7 @@ function extractTextFromDocsBody(doc: DocsDocument): string {
     }
   }
 
-  return parts.join('').trim()
+  return parts.join('\n').trim()
 }
 
 /**

--- a/apps/sim/connectors/google-docs/google-docs.ts
+++ b/apps/sim/connectors/google-docs/google-docs.ts
@@ -84,7 +84,15 @@ function extractTextFromDocsBody(doc: DocsDocument): string {
     if (!paragraph?.elements) continue
 
     const prefix = headingPrefix(paragraph.paragraphStyle?.namedStyleType)
-    const text = paragraph.elements.map((el) => el.textRun?.content ?? '').join('')
+    /**
+     * Each paragraph's final `textRun.content` already ends with `\n`. Strip
+     * it before joining with `\n` so a heading followed by a body paragraph
+     * is separated by a single newline, not two.
+     */
+    const text = paragraph.elements
+      .map((el) => el.textRun?.content ?? '')
+      .join('')
+      .replace(/\n+$/, '')
 
     if (text.trim()) {
       parts.push(`${prefix}${text}`)

--- a/apps/sim/connectors/google-docs/google-docs.ts
+++ b/apps/sim/connectors/google-docs/google-docs.ts
@@ -349,8 +349,7 @@ export const googleDocsConnector: ConnectorConfig = {
 
       return { valid: true }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to validate configuration'
-      return { valid: false, error: message }
+      return { valid: false, error: toError(error).message || 'Failed to validate configuration' }
     }
   },
 

--- a/apps/sim/connectors/jira/jira.ts
+++ b/apps/sim/connectors/jira/jira.ts
@@ -221,8 +221,14 @@ export const jiraConnector: ConnectorConfig = {
 
     const data = await response.json()
     let issues = (data.issues || []) as Record<string, unknown>[]
+    /**
+     * `/rest/api/3/search/jql` signals end-of-results purely by the absence
+     * of `nextPageToken`. `data.isLast` is unreliable on this endpoint and
+     * has been observed returning `true` alongside a valid token
+     * (JRACLOUD-95477), so we ignore it.
+     */
     const nextPageToken = data.nextPageToken as string | undefined
-    const isLast = Boolean(data.isLast) || !nextPageToken
+    const isLast = !nextPageToken
 
     if (maxIssues > 0 && issues.length > remaining) {
       issues = issues.slice(0, remaining)

--- a/apps/sim/connectors/jira/jira.ts
+++ b/apps/sim/connectors/jira/jira.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@sim/logger'
+import { toError } from '@sim/utils/errors'
 import { JiraIcon } from '@/components/icons'
 import { fetchWithRetry, VALIDATE_RETRY_OPTIONS } from '@/lib/knowledge/documents/utils'
 import type { ConnectorConfig, ExternalDocument, ExternalDocumentList } from '@/connectors/types'
@@ -164,24 +165,24 @@ export const jiraConnector: ConnectorConfig = {
       jql = `project = "${safeKey}" AND (${jqlFilter.trim()}) ORDER BY updated DESC`
     }
 
-    const startAt = cursor ? Number(cursor) : 0
+    const collectedSoFar = (syncContext?.collectedCount as number | undefined) ?? 0
+    const remaining = maxIssues > 0 ? Math.max(0, maxIssues - collectedSoFar) : PAGE_SIZE
+    if (maxIssues > 0 && remaining === 0) {
+      return { documents: [], hasMore: false }
+    }
 
     const params = new URLSearchParams()
     params.append('jql', jql)
-    params.append('startAt', String(startAt))
-    const remaining = maxIssues > 0 ? Math.max(0, maxIssues - startAt) : PAGE_SIZE
-    if (remaining === 0) {
-      return { documents: [], hasMore: false }
-    }
     params.append('maxResults', String(Math.min(PAGE_SIZE, remaining)))
     params.append(
       'fields',
       'summary,issuetype,status,priority,assignee,reporter,project,labels,created,updated'
     )
+    if (cursor) params.append('nextPageToken', cursor)
 
-    const url = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search?${params.toString()}`
+    const url = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search/jql?${params.toString()}`
 
-    logger.info(`Listing Jira issues for project ${projectKey}`, { startAt })
+    logger.info(`Listing Jira issues for project ${projectKey}`, { hasCursor: Boolean(cursor) })
 
     const response = await fetchWithRetry(url, {
       method: 'GET',
@@ -201,17 +202,25 @@ export const jiraConnector: ConnectorConfig = {
     }
 
     const data = await response.json()
-    const issues = (data.issues || []) as Record<string, unknown>[]
-    const total = (data.total as number) ?? 0
+    let issues = (data.issues || []) as Record<string, unknown>[]
+    const nextPageToken = data.nextPageToken as string | undefined
+    const isLast = Boolean(data.isLast) || !nextPageToken
+
+    if (maxIssues > 0 && issues.length > remaining) {
+      issues = issues.slice(0, remaining)
+    }
 
     const documents: ExternalDocument[] = issues.map((issue) => issueToStub(issue, domain))
 
-    const nextStart = startAt + issues.length
-    const hasMore = nextStart < total && (maxIssues <= 0 || nextStart < maxIssues)
+    const newCollected = collectedSoFar + issues.length
+    if (syncContext) syncContext.collectedCount = newCollected
+
+    const reachedCap = maxIssues > 0 && newCollected >= maxIssues
+    const hasMore = !isLast && !reachedCap
 
     return {
       documents,
-      nextCursor: hasMore ? String(nextStart) : undefined,
+      nextCursor: hasMore ? nextPageToken : undefined,
       hasMore,
     }
   },
@@ -278,9 +287,9 @@ export const jiraConnector: ConnectorConfig = {
       const params = new URLSearchParams()
       const safeKey = projectKey.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
       params.append('jql', `project = "${safeKey}"`)
-      params.append('maxResults', '0')
+      params.append('maxResults', '1')
 
-      const url = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search?${params.toString()}`
+      const url = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search/jql?${params.toString()}`
       const response = await fetchWithRetry(
         url,
         {
@@ -304,9 +313,9 @@ export const jiraConnector: ConnectorConfig = {
       if (jqlFilter) {
         const filterParams = new URLSearchParams()
         filterParams.append('jql', `project = "${safeKey}" AND (${jqlFilter})`)
-        filterParams.append('maxResults', '0')
+        filterParams.append('maxResults', '1')
 
-        const filterUrl = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search?${filterParams.toString()}`
+        const filterUrl = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search/jql?${filterParams.toString()}`
         const filterResponse = await fetchWithRetry(
           filterUrl,
           {
@@ -326,8 +335,7 @@ export const jiraConnector: ConnectorConfig = {
 
       return { valid: true }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to validate configuration'
-      return { valid: false, error: message }
+      return { valid: false, error: toError(error).message || 'Failed to validate configuration' }
     }
   },
 

--- a/apps/sim/connectors/jira/jira.ts
+++ b/apps/sim/connectors/jira/jira.ts
@@ -165,7 +165,25 @@ export const jiraConnector: ConnectorConfig = {
       jql = `project = "${safeKey}" AND (${jqlFilter.trim()}) ORDER BY updated DESC`
     }
 
-    const collectedSoFar = (syncContext?.collectedCount as number | undefined) ?? 0
+    /**
+     * Collected-count is encoded in the cursor as `${pageToken}|${count}` so
+     * the maxIssues cap works correctly even when the caller doesn't pass
+     * syncContext. Falls back to syncContext.collectedCount for backwards
+     * compatibility with cursors emitted before this format existed.
+     */
+    let pageToken: string | undefined
+    let collectedSoFar = (syncContext?.collectedCount as number | undefined) ?? 0
+    if (cursor) {
+      const sep = cursor.lastIndexOf('|')
+      if (sep > 0) {
+        pageToken = cursor.slice(0, sep)
+        const parsed = Number(cursor.slice(sep + 1))
+        if (Number.isFinite(parsed) && parsed >= 0) collectedSoFar = parsed
+      } else {
+        pageToken = cursor
+      }
+    }
+
     const remaining = maxIssues > 0 ? Math.max(0, maxIssues - collectedSoFar) : PAGE_SIZE
     if (maxIssues > 0 && remaining === 0) {
       return { documents: [], hasMore: false }
@@ -178,7 +196,7 @@ export const jiraConnector: ConnectorConfig = {
       'fields',
       'summary,issuetype,status,priority,assignee,reporter,project,labels,created,updated'
     )
-    if (cursor) params.append('nextPageToken', cursor)
+    if (pageToken) params.append('nextPageToken', pageToken)
 
     const url = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search/jql?${params.toString()}`
 
@@ -220,7 +238,7 @@ export const jiraConnector: ConnectorConfig = {
 
     return {
       documents,
-      nextCursor: hasMore ? nextPageToken : undefined,
+      nextCursor: hasMore && nextPageToken ? `${nextPageToken}|${newCollected}` : undefined,
       hasMore,
     }
   },

--- a/apps/sim/connectors/jira/jira.ts
+++ b/apps/sim/connectors/jira/jira.ts
@@ -282,7 +282,7 @@ export const jiraConnector: ConnectorConfig = {
     const jqlFilter = (sourceConfig.jql as string | undefined)?.trim() || ''
 
     try {
-      const cloudId = await getJiraCloudId(domain, accessToken)
+      const cloudId = await getJiraCloudId(domain, accessToken, VALIDATE_RETRY_OPTIONS)
 
       const params = new URLSearchParams()
       const safeKey = projectKey.replace(/\\/g, '\\\\').replace(/"/g, '\\"')

--- a/apps/sim/connectors/obsidian/obsidian.ts
+++ b/apps/sim/connectors/obsidian/obsidian.ts
@@ -216,12 +216,13 @@ export const obsidianConnector: ConnectorConfig = {
     const pageFiles = allFiles.slice(offset, offset + DOCS_PER_PAGE)
 
     /**
-     * Stub hash uses path only because the Obsidian Local REST API directory
-     * listing returns just `{ files: string[] }` — no `stat`/`mtime` and no
-     * `HEAD` support to read `Last-Modified`. A path-only stub is stable
-     * across syncs, so unchanged paths short-circuit re-hydration in the
-     * sync engine. `getDocument` always re-hashes with `mtime`, which
-     * triggers a refresh whenever the file actually changes.
+     * The Obsidian Local REST API directory listing returns just
+     * `{ files: string[] }` — no `stat`/`mtime` and no `HEAD` support to read
+     * `Last-Modified`, so the stub cannot encode change-detection state. Every
+     * file is therefore re-hydrated via `getDocument` on every sync. The
+     * post-hydration hash compare in the sync engine
+     * (`existing.contentHash === hydratedHash`) prevents redundant DB writes
+     * when `mtime` is unchanged.
      */
     const documents: ExternalDocument[] = pageFiles.map((filePath) => ({
       externalId: filePath,

--- a/apps/sim/connectors/obsidian/obsidian.ts
+++ b/apps/sim/connectors/obsidian/obsidian.ts
@@ -313,15 +313,21 @@ export const obsidianConnector: ConnectorConfig = {
         VALIDATE_RETRY_OPTIONS
       )
 
-      if (response.status === 401 || response.status === 403) {
+      if (!response.ok) {
+        return { valid: false, error: `Obsidian API returned status ${response.status}` }
+      }
+
+      /**
+       * `GET /` is the only public endpoint and returns 200 regardless of auth;
+       * the response body's `authenticated` field is the actual auth signal.
+       * See https://coddingtonbear.github.io/obsidian-local-rest-api/.
+       */
+      const data = (await response.json()) as { authenticated?: boolean }
+      if (!data?.authenticated) {
         return {
           valid: false,
           error: 'Invalid API key — check your Obsidian Local REST API settings',
         }
-      }
-
-      if (!response.ok) {
-        return { valid: false, error: `Obsidian API returned status ${response.status}` }
       }
 
       const folderPath = (sourceConfig.folderPath as string) || ''

--- a/apps/sim/connectors/obsidian/obsidian.ts
+++ b/apps/sim/connectors/obsidian/obsidian.ts
@@ -215,8 +215,14 @@ export const obsidianConnector: ConnectorConfig = {
     const offset = cursor ? Number(cursor) : 0
     const pageFiles = allFiles.slice(offset, offset + DOCS_PER_PAGE)
 
-    const syncRunId = (syncContext?.syncRunId as string) ?? ''
-
+    /**
+     * Stub hash uses path only because the Obsidian Local REST API directory
+     * listing returns just `{ files: string[] }` — no `stat`/`mtime` and no
+     * `HEAD` support to read `Last-Modified`. A path-only stub is stable
+     * across syncs, so unchanged paths short-circuit re-hydration in the
+     * sync engine. `getDocument` always re-hashes with `mtime`, which
+     * triggers a refresh whenever the file actually changes.
+     */
     const documents: ExternalDocument[] = pageFiles.map((filePath) => ({
       externalId: filePath,
       title: titleFromPath(filePath),
@@ -224,7 +230,7 @@ export const obsidianConnector: ConnectorConfig = {
       contentDeferred: true,
       mimeType: 'text/plain' as const,
       sourceUrl: `${baseUrl}/vault/${filePath.split('/').map(encodeURIComponent).join('/')}`,
-      contentHash: `obsidian:stub:${filePath}:${syncRunId}`,
+      contentHash: `obsidian:${filePath}`,
       metadata: {
         folder: filePath.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/')) : '',
       },

--- a/apps/sim/connectors/salesforce/salesforce.ts
+++ b/apps/sim/connectors/salesforce/salesforce.ts
@@ -42,7 +42,8 @@ const OBJECT_FIELDS: Record<string, string[]> = {
 
 /** SOQL WHERE clause additions per object type. */
 const OBJECT_WHERE: Record<string, string> = {
-  KnowledgeArticleVersion: " WHERE PublishStatus='Online' AND Language='en_US'",
+  KnowledgeArticleVersion:
+    " WHERE PublishStatus='Online' AND IsLatestVersion=true AND Language='en_US'",
 } as const
 
 /**
@@ -389,7 +390,7 @@ export const salesforceConnector: ConnectorConfig = {
       instanceUrl = await resolveInstanceUrl(accessToken, syncContext)
     }
 
-    const url = `${instanceUrl}sobjects/${objectType}/${externalId}?fields=${fields.join(',')}`
+    const url = `${instanceUrl}sobjects/${objectType}/${encodeURIComponent(externalId)}?fields=${fields.join(',')}`
 
     const response = await fetchWithRetry(url, {
       method: 'GET',

--- a/apps/sim/connectors/salesforce/salesforce.ts
+++ b/apps/sim/connectors/salesforce/salesforce.ts
@@ -479,7 +479,7 @@ export const salesforceConnector: ConnectorConfig = {
 
       return { valid: true }
     } catch (error) {
-      return { valid: false, error: toError(error).message }
+      return { valid: false, error: toError(error).message || 'Failed to validate configuration' }
     }
   },
 

--- a/apps/sim/connectors/salesforce/salesforce.ts
+++ b/apps/sim/connectors/salesforce/salesforce.ts
@@ -102,7 +102,7 @@ async function fetchUserinfo(
 
     // Only fall through to the next host on auth-shaped failures; surface
     // other errors (e.g. 5xx) immediately so we don't mask real problems.
-    if (response.status !== 401 && response.status !== 403) {
+    if (response.status !== 400 && response.status !== 401 && response.status !== 403) {
       break
     }
   }

--- a/apps/sim/connectors/salesforce/salesforce.ts
+++ b/apps/sim/connectors/salesforce/salesforce.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@sim/logger'
+import { toError } from '@sim/utils/errors'
 import { SalesforceIcon } from '@/components/icons'
 import { fetchWithRetry, VALIDATE_RETRY_OPTIONS } from '@/lib/knowledge/documents/utils'
 import type { ConnectorConfig, ExternalDocument, ExternalDocumentList } from '@/connectors/types'
@@ -6,7 +7,13 @@ import { htmlToPlainText, parseTagDate } from '@/connectors/utils'
 
 const logger = createLogger('SalesforceConnector')
 
-const USERINFO_URL = 'https://login.salesforce.com/services/oauth2/userinfo'
+/**
+ * Salesforce serves the userinfo endpoint at the org's authentication host.
+ * Tokens issued at test.salesforce.com (sandbox) are rejected at login.salesforce.com,
+ * so we try each host in order and cache the working one in syncContext.
+ */
+const USERINFO_HOSTS = ['https://login.salesforce.com', 'https://test.salesforce.com'] as const
+const USERINFO_PATH = '/services/oauth2/userinfo'
 const API_VERSION = 'v62.0'
 const PAGE_SIZE = 200
 
@@ -39,6 +46,71 @@ const OBJECT_WHERE: Record<string, string> = {
 } as const
 
 /**
+ * Result of a userinfo lookup: either the parsed payload + the auth host that
+ * served it, or a structured failure describing the last response we saw.
+ */
+type UserinfoResult =
+  | { ok: true; data: Record<string, unknown>; host: string }
+  | { ok: false; status: number | undefined; errorText: string }
+
+/**
+ * Fetches the Salesforce userinfo payload, trying each candidate auth host in
+ * order. Sandbox-issued tokens are rejected at login.salesforce.com with 401/403,
+ * so on those statuses we fall through to test.salesforce.com. The working host
+ * is cached in syncContext under `_salesforceInstanceUrl` so subsequent calls in
+ * the same sync run skip the fallback dance.
+ */
+async function fetchUserinfo(
+  accessToken: string,
+  retryOptions?: Parameters<typeof fetchWithRetry>[2],
+  syncContext?: Record<string, unknown>
+): Promise<UserinfoResult> {
+  const cachedHost =
+    typeof syncContext?._salesforceInstanceUrl === 'string'
+      ? (syncContext._salesforceInstanceUrl as string)
+      : undefined
+  const orderedHosts = cachedHost
+    ? [cachedHost, ...USERINFO_HOSTS.filter((h) => h !== cachedHost)]
+    : [...USERINFO_HOSTS]
+
+  let lastStatus: number | undefined
+  let lastErrorText = ''
+
+  for (const host of orderedHosts) {
+    const response = await fetchWithRetry(
+      `${host}${USERINFO_PATH}`,
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+      retryOptions
+    )
+
+    if (response.ok) {
+      const data = (await response.json()) as Record<string, unknown>
+      if (syncContext) {
+        syncContext._salesforceInstanceUrl = host
+      }
+      return { ok: true, data, host }
+    }
+
+    lastStatus = response.status
+    lastErrorText = await response.text()
+
+    // Only fall through to the next host on auth-shaped failures; surface
+    // other errors (e.g. 5xx) immediately so we don't mask real problems.
+    if (response.status !== 401 && response.status !== 403) {
+      break
+    }
+  }
+
+  return { ok: false, status: lastStatus, errorText: lastErrorText }
+}
+
+/**
  * Resolves the Salesforce instance REST URL from the userinfo endpoint.
  * Caches the result in syncContext to avoid repeated calls.
  */
@@ -50,21 +122,14 @@ async function resolveInstanceUrl(
     return syncContext.instanceUrl as string
   }
 
-  const response = await fetchWithRetry(USERINFO_URL, {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-    },
-  })
-
-  if (!response.ok) {
-    const errorText = await response.text()
-    throw new Error(`Failed to resolve Salesforce instance URL: ${response.status} - ${errorText}`)
+  const result = await fetchUserinfo(accessToken, undefined, syncContext)
+  if (!result.ok) {
+    throw new Error(
+      `Failed to resolve Salesforce instance URL: ${result.status ?? 'unknown'} - ${result.errorText}`
+    )
   }
 
-  const data = await response.json()
-  const urls = data.urls as Record<string, string> | undefined
+  const urls = result.data.urls as Record<string, string> | undefined
   let restUrl = urls?.rest
 
   if (!restUrl) {
@@ -321,8 +386,7 @@ export const salesforceConnector: ConnectorConfig = {
 
     let instanceUrl = syncContext?.instanceUrl as string | undefined
     if (!instanceUrl) {
-      instanceUrl = await resolveInstanceUrl(accessToken)
-      if (syncContext) syncContext.instanceUrl = instanceUrl
+      instanceUrl = await resolveInstanceUrl(accessToken, syncContext)
     }
 
     const url = `${instanceUrl}sobjects/${objectType}/${externalId}?fields=${fields.join(',')}`
@@ -372,28 +436,16 @@ export const salesforceConnector: ConnectorConfig = {
     }
 
     try {
-      const userinfoResponse = await fetchWithRetry(
-        USERINFO_URL,
-        {
-          method: 'GET',
-          headers: {
-            Accept: 'application/json',
-            Authorization: `Bearer ${accessToken}`,
-          },
-        },
-        VALIDATE_RETRY_OPTIONS
-      )
+      const userinfoResult = await fetchUserinfo(accessToken, VALIDATE_RETRY_OPTIONS)
 
-      if (!userinfoResponse.ok) {
-        const errorText = await userinfoResponse.text()
+      if (!userinfoResult.ok) {
         return {
           valid: false,
-          error: `Failed to authenticate with Salesforce: ${userinfoResponse.status} - ${errorText}`,
+          error: `Failed to authenticate with Salesforce: ${userinfoResult.status ?? 'unknown'} - ${userinfoResult.errorText}`,
         }
       }
 
-      const userinfo = await userinfoResponse.json()
-      const urls = userinfo.urls as Record<string, string> | undefined
+      const urls = userinfoResult.data.urls as Record<string, string> | undefined
       let restUrl = urls?.rest
 
       if (!restUrl) {
@@ -427,8 +479,7 @@ export const salesforceConnector: ConnectorConfig = {
 
       return { valid: true }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to validate configuration'
-      return { valid: false, error: message }
+      return { valid: false, error: toError(error).message }
     }
   },
 

--- a/apps/sim/connectors/salesforce/salesforce.ts
+++ b/apps/sim/connectors/salesforce/salesforce.ts
@@ -102,7 +102,7 @@ async function fetchUserinfo(
 
     // Only fall through to the next host on auth-shaped failures; surface
     // other errors (e.g. 5xx) immediately so we don't mask real problems.
-    if (response.status !== 400 && response.status !== 401 && response.status !== 403) {
+    if (response.status !== 401 && response.status !== 403) {
       break
     }
   }

--- a/apps/sim/connectors/servicenow/servicenow.ts
+++ b/apps/sim/connectors/servicenow/servicenow.ts
@@ -20,7 +20,9 @@ const PAGE_SIZE = 100
  * fetches (`/api/now/table/{table}/{sys_id}`) likewise treat the sys_id as a
  * URL path segment and must be constrained to safe characters.
  */
-const SYS_ID_PATTERN = /^[a-f0-9]{32}$/
+const SYS_ID_PATTERN = /^[a-f0-9]{32}$/i
+const NUMERIC_ID_PATTERN = /^\d+$/
+const KB_CATEGORY_PATTERN = /^[\w \-./]+$/
 
 interface ServiceNowRecord {
   sys_id: string
@@ -363,18 +365,22 @@ function buildKBQuery(sourceConfig: Record<string, unknown>): string {
 
   const workflowState = sourceConfig.workflowState as string | undefined
   if (workflowState && workflowState !== 'all') {
-    parts.push(`workflow_state=${workflowState}`)
+    if (NUMERIC_ID_PATTERN.test(workflowState)) {
+      parts.push(`workflow_state=${workflowState}`)
+    } else {
+      logger.warn('Skipping workflowState filter: value is not a numeric ID', { workflowState })
+    }
   }
 
   const kbCategory = sourceConfig.kbCategory as string | undefined
   const trimmedCategory = kbCategory?.trim()
   if (trimmedCategory) {
-    if (trimmedCategory.includes('^')) {
-      logger.warn('Skipping kbCategory filter: value contains "^" separator', {
+    if (KB_CATEGORY_PATTERN.test(trimmedCategory)) {
+      parts.push(`kb_category.label=${trimmedCategory}`)
+    } else {
+      logger.warn('Skipping kbCategory filter: value contains disallowed characters', {
         kbCategory: trimmedCategory,
       })
-    } else {
-      parts.push(`kb_category.label=${trimmedCategory}`)
     }
   }
 
@@ -390,12 +396,22 @@ function buildIncidentQuery(sourceConfig: Record<string, unknown>): string {
 
   const incidentState = sourceConfig.incidentState as string | undefined
   if (incidentState && incidentState !== 'all') {
-    parts.push(`state=${incidentState}`)
+    if (NUMERIC_ID_PATTERN.test(incidentState)) {
+      parts.push(`state=${incidentState}`)
+    } else {
+      logger.warn('Skipping incidentState filter: value is not a numeric ID', { incidentState })
+    }
   }
 
   const incidentPriority = sourceConfig.incidentPriority as string | undefined
   if (incidentPriority && incidentPriority !== 'all') {
-    parts.push(`priority=${incidentPriority}`)
+    if (NUMERIC_ID_PATTERN.test(incidentPriority)) {
+      parts.push(`priority=${incidentPriority}`)
+    } else {
+      logger.warn('Skipping incidentPriority filter: value is not a numeric ID', {
+        incidentPriority,
+      })
+    }
   }
 
   parts.push('ORDERBYDESCsys_updated_on')

--- a/apps/sim/connectors/servicenow/servicenow.ts
+++ b/apps/sim/connectors/servicenow/servicenow.ts
@@ -22,7 +22,13 @@ const PAGE_SIZE = 100
  */
 const SYS_ID_PATTERN = /^[a-f0-9]{32}$/i
 const NUMERIC_ID_PATTERN = /^\d+$/
-const KB_CATEGORY_PATTERN = /^[\w \-./]+$/
+/**
+ * Reject characters that have meaning in a ServiceNow encoded query
+ * (`^` is the operator separator; control chars and quotes can break the
+ * URL). All other Unicode characters — including accented letters used in
+ * categories like "Général" or "Ação" — are allowed.
+ */
+const KB_CATEGORY_DISALLOWED = /[\^"'`\u0000-\u001f\u007f]/
 const VALID_WORKFLOW_STATES = new Set(['published', 'draft', 'review', 'retired', 'outdated'])
 
 interface ServiceNowRecord {
@@ -377,7 +383,7 @@ function buildKBQuery(sourceConfig: Record<string, unknown>): string {
   const kbCategory = sourceConfig.kbCategory as string | undefined
   const trimmedCategory = kbCategory?.trim()
   if (trimmedCategory) {
-    if (KB_CATEGORY_PATTERN.test(trimmedCategory)) {
+    if (!KB_CATEGORY_DISALLOWED.test(trimmedCategory)) {
       parts.push(`kb_category.label=${trimmedCategory}`)
     } else {
       logger.warn('Skipping kbCategory filter: value contains disallowed characters', {

--- a/apps/sim/connectors/servicenow/servicenow.ts
+++ b/apps/sim/connectors/servicenow/servicenow.ts
@@ -23,7 +23,7 @@ const PAGE_SIZE = 100
 const SYS_ID_PATTERN = /^[a-f0-9]{32}$/i
 const NUMERIC_ID_PATTERN = /^\d+$/
 const KB_CATEGORY_PATTERN = /^[\w \-./]+$/
-const VALID_WORKFLOW_STATES = new Set(['published', 'draft', 'review', 'retired'])
+const VALID_WORKFLOW_STATES = new Set(['published', 'draft', 'review', 'retired', 'outdated'])
 
 interface ServiceNowRecord {
   sys_id: string
@@ -474,6 +474,7 @@ export const servicenowConnector: ConnectorConfig = {
         { label: 'Draft', id: 'draft' },
         { label: 'Review', id: 'review' },
         { label: 'Retired', id: 'retired' },
+        { label: 'Outdated', id: 'outdated' },
       ],
     },
     {
@@ -497,6 +498,7 @@ export const servicenowConnector: ConnectorConfig = {
         { label: 'On Hold', id: '3' },
         { label: 'Resolved', id: '6' },
         { label: 'Closed', id: '7' },
+        { label: 'Canceled', id: '8' },
       ],
     },
     {

--- a/apps/sim/connectors/servicenow/servicenow.ts
+++ b/apps/sim/connectors/servicenow/servicenow.ts
@@ -36,7 +36,6 @@ interface ServiceNowRecord {
 interface KBArticle extends ServiceNowRecord {
   short_description?: string
   text?: string
-  wiki?: string
   workflow_state?: string
   kb_category?: string | { display_value?: string }
   kb_knowledge_base?: string | { display_value?: string }
@@ -264,7 +263,7 @@ function priorityLabel(priority: string | undefined): string {
  */
 function kbArticleToDocument(article: KBArticle, instanceUrl: string): ExternalDocument {
   const title = rawValue(article.short_description) || rawValue(article.number) || article.sys_id
-  const articleText = rawValue(article.text) || rawValue(article.wiki) || ''
+  const articleText = rawValue(article.text) || ''
   const content = htmlToPlainText(articleText)
   const sysId = rawValue(article.sys_id) || article.sys_id
   const updatedOn = rawValue(article.sys_updated_on) || ''
@@ -549,7 +548,7 @@ export const servicenowConnector: ConnectorConfig = {
     const query = isKB ? buildKBQuery(sourceConfig) : buildIncidentQuery(sourceConfig)
 
     const fields = isKB
-      ? 'sys_id,short_description,text,wiki,workflow_state,kb_category,kb_knowledge_base,number,author,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
+      ? 'sys_id,short_description,text,workflow_state,kb_category,kb_knowledge_base,number,author,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
       : 'sys_id,number,short_description,description,state,priority,category,assigned_to,opened_by,close_notes,resolution_notes,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
 
     const params: Record<string, string> = {
@@ -625,7 +624,7 @@ export const servicenowConnector: ConnectorConfig = {
     }
 
     const fields = isKB
-      ? 'sys_id,short_description,text,wiki,workflow_state,kb_category,kb_knowledge_base,number,author,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
+      ? 'sys_id,short_description,text,workflow_state,kb_category,kb_knowledge_base,number,author,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
       : 'sys_id,number,short_description,description,state,priority,category,assigned_to,opened_by,close_notes,resolution_notes,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
 
     const instanceUrl = resolveServiceNowInstanceUrl(sourceConfig.instanceUrl as string)

--- a/apps/sim/connectors/servicenow/servicenow.ts
+++ b/apps/sim/connectors/servicenow/servicenow.ts
@@ -23,6 +23,7 @@ const PAGE_SIZE = 100
 const SYS_ID_PATTERN = /^[a-f0-9]{32}$/i
 const NUMERIC_ID_PATTERN = /^\d+$/
 const KB_CATEGORY_PATTERN = /^[\w \-./]+$/
+const VALID_WORKFLOW_STATES = new Set(['published', 'draft', 'review', 'retired'])
 
 interface ServiceNowRecord {
   sys_id: string
@@ -365,10 +366,12 @@ function buildKBQuery(sourceConfig: Record<string, unknown>): string {
 
   const workflowState = sourceConfig.workflowState as string | undefined
   if (workflowState && workflowState !== 'all') {
-    if (NUMERIC_ID_PATTERN.test(workflowState)) {
+    if (VALID_WORKFLOW_STATES.has(workflowState)) {
       parts.push(`workflow_state=${workflowState}`)
     } else {
-      logger.warn('Skipping workflowState filter: value is not a numeric ID', { workflowState })
+      logger.warn('Skipping workflowState filter: value is not in the allowed set', {
+        workflowState,
+      })
     }
   }
 

--- a/apps/sim/connectors/servicenow/servicenow.ts
+++ b/apps/sim/connectors/servicenow/servicenow.ts
@@ -11,6 +11,17 @@ const logger = createLogger('ServiceNowConnector')
 const DEFAULT_MAX_ITEMS = 500
 const PAGE_SIZE = 100
 
+/**
+ * ServiceNow sys_id whitelist: 32-character lowercase hex strings.
+ *
+ * The encoded query language uses `^` as the AND separator and `^OR` as the
+ * OR separator with no escape syntax, so any user-supplied value interpolated
+ * into a `sysparm_query` clause must be validated up front. Path-based
+ * fetches (`/api/now/table/{table}/{sys_id}`) likewise treat the sys_id as a
+ * URL path segment and must be constrained to safe characters.
+ */
+const SYS_ID_PATTERN = /^[a-f0-9]{32}$/
+
 interface ServiceNowRecord {
   sys_id: string
   sys_updated_on?: string
@@ -121,6 +132,50 @@ async function serviceNowApiGet(
     nextOffset,
     totalCount,
   }
+}
+
+/**
+ * Fetches a single ServiceNow record by sys_id via the path-based Table API
+ * endpoint (`GET /api/now/table/{tableName}/{sys_id}`), which returns a
+ * `{ result: <record> }` object rather than the array shape returned by the
+ * list endpoint. Returns `null` when the record is not found (404).
+ */
+async function serviceNowApiGetById(
+  instanceUrl: string,
+  tableName: string,
+  sysId: string,
+  authHeader: string,
+  params: Record<string, string>,
+  retryOptions?: Parameters<typeof fetchWithRetry>[2]
+): Promise<Record<string, unknown> | null> {
+  const queryParams = new URLSearchParams(params)
+  const queryString = queryParams.toString()
+  const url = `${instanceUrl}/api/now/table/${tableName}/${sysId}${queryString ? `?${queryString}` : ''}`
+
+  const response = await fetchWithRetry(
+    url,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: authHeader,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    },
+    retryOptions
+  )
+
+  if (response.status === 404) {
+    return null
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'Unknown error')
+    throw new Error(`ServiceNow API error (${response.status}): ${errorText}`)
+  }
+
+  const data = (await response.json()) as { result?: Record<string, unknown> }
+  return data.result ?? null
 }
 
 function isServiceNowRecord(record: unknown): record is ServiceNowRecord & Record<string, unknown> {
@@ -312,8 +367,15 @@ function buildKBQuery(sourceConfig: Record<string, unknown>): string {
   }
 
   const kbCategory = sourceConfig.kbCategory as string | undefined
-  if (kbCategory?.trim()) {
-    parts.push(`kb_category.label=${kbCategory.trim()}`)
+  const trimmedCategory = kbCategory?.trim()
+  if (trimmedCategory) {
+    if (trimmedCategory.includes('^')) {
+      logger.warn('Skipping kbCategory filter: value contains "^" separator', {
+        kbCategory: trimmedCategory,
+      })
+    } else {
+      parts.push(`kb_category.label=${trimmedCategory}`)
+    }
   }
 
   parts.push('ORDERBYDESCsys_updated_on')
@@ -533,6 +595,14 @@ export const servicenowConnector: ConnectorConfig = {
     const isKB = contentType === 'kb_knowledge'
     const tableName = isKB ? 'kb_knowledge' : 'incident'
 
+    if (!SYS_ID_PATTERN.test(externalId)) {
+      logger.warn('Rejecting ServiceNow getDocument with invalid sys_id', {
+        externalId,
+        table: tableName,
+      })
+      return null
+    }
+
     const fields = isKB
       ? 'sys_id,short_description,text,wiki,workflow_state,kb_category,kb_knowledge_base,number,author,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
       : 'sys_id,number,short_description,description,state,priority,category,assigned_to,opened_by,close_notes,resolution_notes,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
@@ -540,19 +610,11 @@ export const servicenowConnector: ConnectorConfig = {
     const instanceUrl = resolveServiceNowInstanceUrl(sourceConfig.instanceUrl as string)
 
     try {
-      const { result } = await serviceNowApiGet(instanceUrl, tableName, authHeader, {
-        sysparm_query: `sys_id=${externalId}`,
-        sysparm_limit: '1',
-        sysparm_offset: '0',
+      const record = await serviceNowApiGetById(instanceUrl, tableName, externalId, authHeader, {
         sysparm_fields: fields,
         sysparm_display_value: 'all',
       })
 
-      if (!result || result.length === 0) {
-        return null
-      }
-
-      const record = result[0]
       if (!record || !isServiceNowRecord(record)) {
         return null
       }

--- a/apps/sim/connectors/servicenow/servicenow.ts
+++ b/apps/sim/connectors/servicenow/servicenow.ts
@@ -42,6 +42,7 @@ interface ServiceNowRecord {
 interface KBArticle extends ServiceNowRecord {
   short_description?: string
   text?: string
+  wiki?: string
   workflow_state?: string
   kb_category?: string | { display_value?: string }
   kb_knowledge_base?: string | { display_value?: string }
@@ -269,7 +270,12 @@ function priorityLabel(priority: string | undefined): string {
  */
 function kbArticleToDocument(article: KBArticle, instanceUrl: string): ExternalDocument {
   const title = rawValue(article.short_description) || rawValue(article.number) || article.sys_id
-  const articleText = rawValue(article.text) || ''
+  /**
+   * Wiki-template KB articles populate `wiki` with the body and leave
+   * `text` empty; HTML-template articles do the opposite. Falling back
+   * to `wiki` keeps both layouts indexable.
+   */
+  const articleText = rawValue(article.text) || rawValue(article.wiki) || ''
   const content = htmlToPlainText(articleText)
   const sysId = rawValue(article.sys_id) || article.sys_id
   const updatedOn = rawValue(article.sys_updated_on) || ''
@@ -554,7 +560,7 @@ export const servicenowConnector: ConnectorConfig = {
     const query = isKB ? buildKBQuery(sourceConfig) : buildIncidentQuery(sourceConfig)
 
     const fields = isKB
-      ? 'sys_id,short_description,text,workflow_state,kb_category,kb_knowledge_base,number,author,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
+      ? 'sys_id,short_description,text,wiki,workflow_state,kb_category,kb_knowledge_base,number,author,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
       : 'sys_id,number,short_description,description,state,priority,category,assigned_to,opened_by,close_notes,resolution_notes,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
 
     const params: Record<string, string> = {
@@ -630,7 +636,7 @@ export const servicenowConnector: ConnectorConfig = {
     }
 
     const fields = isKB
-      ? 'sys_id,short_description,text,workflow_state,kb_category,kb_knowledge_base,number,author,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
+      ? 'sys_id,short_description,text,wiki,workflow_state,kb_category,kb_knowledge_base,number,author,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
       : 'sys_id,number,short_description,description,state,priority,category,assigned_to,opened_by,close_notes,resolution_notes,sys_created_by,sys_updated_by,sys_updated_on,sys_created_on'
 
     const instanceUrl = resolveServiceNowInstanceUrl(sourceConfig.instanceUrl as string)

--- a/apps/sim/connectors/slack/slack.ts
+++ b/apps/sim/connectors/slack/slack.ts
@@ -17,6 +17,9 @@ interface SlackMessage {
   text?: string
   ts: string
   subtype?: string
+  edited?: { ts: string; user?: string }
+  latest_reply?: string
+  reply_count?: number
 }
 
 interface SlackChannel {
@@ -301,7 +304,22 @@ async function buildSlackChannelDocument(
 
   const content = await formatMessages(accessToken, messages, syncContext)
   const messageCount = messages.length
-  const contentHash = `slack:${channel.id}:${oldestTs ?? 'empty'}:${lastActivityTs ?? 'empty'}:${messageCount}`
+
+  /**
+   * Edit/thread fingerprint: max(edited.ts) and max(latest_reply) across the
+   * window. `ts` is immutable for messages, so without these signals an
+   * in-place edit (chat.update) or a new threaded reply would not change the
+   * channel hash. Slack returns `edited.ts` only when a message was edited
+   * and `latest_reply` only when threaded replies exist.
+   */
+  let maxEditTs = ''
+  let maxReplyTs = ''
+  for (const m of messages) {
+    if (m.edited?.ts && m.edited.ts > maxEditTs) maxEditTs = m.edited.ts
+    if (m.latest_reply && m.latest_reply > maxReplyTs) maxReplyTs = m.latest_reply
+  }
+
+  const contentHash = `slack:${channel.id}:${oldestTs ?? 'empty'}:${lastActivityTs ?? 'empty'}:${messageCount}:${maxEditTs || 'noedit'}:${maxReplyTs || 'noreply'}`
 
   return { content, contentHash, messageCount, lastActivityTs }
 }

--- a/apps/sim/connectors/slack/slack.ts
+++ b/apps/sim/connectors/slack/slack.ts
@@ -11,6 +11,33 @@ const SLACK_API_BASE = 'https://slack.com/api'
 const DEFAULT_MAX_MESSAGES = 1000
 const MESSAGES_PER_PAGE = 200
 
+/**
+ * Message subtypes that carry no user-authored text (channel events, bot
+ * lifecycle, etc.). Per https://api.slack.com/events/message every other
+ * subtype — `bot_message`, `file_share`, `me_message`, `thread_broadcast`,
+ * `reminder_add`, `file_comment`, etc. — can carry meaningful content.
+ */
+const SLACK_NOISE_SUBTYPES = new Set([
+  'channel_join',
+  'channel_leave',
+  'channel_topic',
+  'channel_purpose',
+  'channel_name',
+  'channel_archive',
+  'channel_unarchive',
+  'group_join',
+  'group_leave',
+  'group_topic',
+  'group_purpose',
+  'group_name',
+  'group_archive',
+  'group_unarchive',
+  'pinned_item',
+  'unpinned_item',
+  'bot_add',
+  'bot_remove',
+])
+
 interface SlackMessage {
   type: string
   user?: string
@@ -187,7 +214,13 @@ async function formatMessages(
   for (const msg of chronological) {
     // Skip non-user messages (join/leave, bot messages without text, etc.)
     if (!msg.text) continue
-    if (msg.subtype && msg.subtype !== 'bot_message' && msg.subtype !== 'file_share') continue
+    /**
+     * Drop only known noise subtypes (channel join/leave/topic events,
+     * bot add/remove, etc.). Per https://api.slack.com/events/message any
+     * subtype with user-authored text — `thread_broadcast`, `me_message`,
+     * `bot_message`, `file_share`, `reminder_add`, etc. — should be kept.
+     */
+    if (msg.subtype && SLACK_NOISE_SUBTYPES.has(msg.subtype)) continue
 
     const timestamp = formatSlackTimestamp(msg.ts)
     const userName = msg.user
@@ -314,12 +347,19 @@ async function buildSlackChannelDocument(
    */
   let maxEditTs = ''
   let maxReplyTs = ''
+  let totalReplies = 0
   for (const m of messages) {
     if (m.edited?.ts && m.edited.ts > maxEditTs) maxEditTs = m.edited.ts
     if (m.latest_reply && m.latest_reply > maxReplyTs) maxReplyTs = m.latest_reply
+    if (typeof m.reply_count === 'number') totalReplies += m.reply_count
   }
 
-  const contentHash = `slack:${channel.id}:${oldestTs ?? 'empty'}:${lastActivityTs ?? 'empty'}:${messageCount}:${maxEditTs || 'noedit'}:${maxReplyTs || 'noreply'}`
+  /**
+   * `latest_reply` alone misses reply edits and deletes. Folding `reply_count`
+   * in catches deletes (count drops) but still cannot detect reply edits
+   * without fetching `conversations.replies` for each parent.
+   */
+  const contentHash = `slack:${channel.id}:${oldestTs ?? 'empty'}:${lastActivityTs ?? 'empty'}:${messageCount}:${maxEditTs || 'noedit'}:${maxReplyTs || 'noreply'}:${totalReplies}`
 
   return { content, contentHash, messageCount, lastActivityTs }
 }

--- a/apps/sim/connectors/slack/slack.ts
+++ b/apps/sim/connectors/slack/slack.ts
@@ -541,8 +541,9 @@ export const slackConnector: ConnectorConfig = {
     try {
       const trimmed = channelInput.trim().replace(/^#/, '')
 
-      // If it looks like a channel ID, verify directly
-      if (/^[CDG][A-Z0-9]+$/.test(trimmed)) {
+      // If it looks like a channel ID, verify directly. DMs (D...) are excluded
+      // because we don't request im:*/mpim:* scopes — see resolveChannel.
+      if (/^[CG][A-Z0-9]+$/.test(trimmed)) {
         await slackApiGet(
           'conversations.info',
           accessToken,

--- a/apps/sim/connectors/slack/slack.ts
+++ b/apps/sim/connectors/slack/slack.ts
@@ -3,7 +3,7 @@ import { toError } from '@sim/utils/errors'
 import { SlackIcon } from '@/components/icons'
 import { fetchWithRetry, VALIDATE_RETRY_OPTIONS } from '@/lib/knowledge/documents/utils'
 import type { ConnectorConfig, ExternalDocument, ExternalDocumentList } from '@/connectors/types'
-import { computeContentHash, parseTagDate } from '@/connectors/utils'
+import { parseTagDate } from '@/connectors/utils'
 
 const logger = createLogger('SlackConnector')
 
@@ -239,6 +239,71 @@ async function resolveChannel(
   return null
 }
 
+/**
+ * Resolves the Slack team ID for the current token, caching the result on
+ * `syncContext._slackTeamId` to avoid repeated `auth.test` calls. The team ID
+ * is stable per token, so caching for the lifetime of a sync is safe.
+ */
+async function resolveTeamId(
+  accessToken: string,
+  syncContext?: Record<string, unknown>
+): Promise<string | undefined> {
+  const cacheKey = '_slackTeamId'
+  if (syncContext && typeof syncContext[cacheKey] === 'string') {
+    return syncContext[cacheKey] as string
+  }
+
+  try {
+    const authData = await slackApiGet('auth.test', accessToken, {})
+    const teamId = authData.team_id as string | undefined
+    if (teamId && syncContext) {
+      syncContext[cacheKey] = teamId
+    }
+    return teamId
+  } catch (error) {
+    logger.warn('Failed to resolve Slack team ID', {
+      error: toError(error).message,
+    })
+    return undefined
+  }
+}
+
+/**
+ * Builds a channel document payload shared by `listDocuments` and `getDocument`.
+ *
+ * The `contentHash` is derived from stable Slack metadata — channel ID, the
+ * newest message `ts`, and the message count — rather than the formatted text.
+ * This keeps the hash deterministic across calls even though the formatted
+ * content depends on the user-name cache state and the sliding message window.
+ *
+ * Each Slack message has a unique, stable `ts` per channel
+ * (https://api.slack.com/methods/conversations.history), so `lastActivityTs`
+ * uniquely identifies the newest message included in the document.
+ */
+async function buildSlackChannelDocument(
+  accessToken: string,
+  channel: SlackChannel,
+  maxMessages: number,
+  syncContext?: Record<string, unknown>
+): Promise<{
+  content: string
+  contentHash: string
+  messageCount: number
+  lastActivityTs?: string
+}> {
+  const { messages, lastActivityTs } = await fetchChannelMessages(
+    accessToken,
+    channel.id,
+    maxMessages
+  )
+
+  const content = await formatMessages(accessToken, messages, syncContext)
+  const messageCount = messages.length
+  const contentHash = `slack:${channel.id}:${lastActivityTs ?? 'empty'}:${messageCount}`
+
+  return { content, contentHash, messageCount, lastActivityTs }
+}
+
 export const slackConnector: ConnectorConfig = {
   id: 'slack',
   name: 'Slack',
@@ -311,31 +376,21 @@ export const slackConnector: ConnectorConfig = {
       throw new Error(`Channel not found: ${channelInput}`)
     }
 
-    const { messages, lastActivityTs } = await fetchChannelMessages(
+    const { content, contentHash, messageCount, lastActivityTs } = await buildSlackChannelDocument(
       accessToken,
-      channel.id,
-      maxMessages
+      channel,
+      maxMessages,
+      syncContext
     )
-
-    const content = await formatMessages(accessToken, messages, syncContext)
     if (!content.trim()) {
       logger.info(`No messages found in channel: #${channel.name}`)
       return { documents: [], hasMore: false }
     }
 
-    const contentHash = await computeContentHash(content)
-
-    // Attempt to get team ID for the source URL
-    let sourceUrl = `https://app.slack.com/client/${channel.id}`
-    try {
-      const authData = await slackApiGet('auth.test', accessToken, {})
-      const teamId = authData.team_id as string | undefined
-      if (teamId) {
-        sourceUrl = `https://app.slack.com/client/${teamId}/${channel.id}`
-      }
-    } catch {
-      // Fall back to URL without team ID
-    }
+    const teamId = await resolveTeamId(accessToken, syncContext)
+    const sourceUrl = teamId
+      ? `https://app.slack.com/client/${teamId}/${channel.id}`
+      : `https://app.slack.com/client/${channel.id}`
 
     const document: ExternalDocument = {
       externalId: channel.id,
@@ -346,7 +401,7 @@ export const slackConnector: ConnectorConfig = {
       contentHash,
       metadata: {
         channelName: channel.name,
-        messageCount: messages.length,
+        messageCount,
         lastActivity: lastActivityTs ? formatSlackTimestamp(lastActivityTs) : undefined,
         topic: channel.topic?.value,
         purpose: channel.purpose?.value,
@@ -374,27 +429,14 @@ export const slackConnector: ConnectorConfig = {
       const data = await slackApiGet('conversations.info', accessToken, { channel: externalId })
       const channel = data.channel as SlackChannel
 
-      const { messages, lastActivityTs } = await fetchChannelMessages(
-        accessToken,
-        externalId,
-        maxMessages
-      )
-
-      const content = await formatMessages(accessToken, messages, syncContext)
+      const { content, contentHash, messageCount, lastActivityTs } =
+        await buildSlackChannelDocument(accessToken, channel, maxMessages, syncContext)
       if (!content.trim()) return null
 
-      const contentHash = await computeContentHash(content)
-
-      let sourceUrl = `https://app.slack.com/client/${channel.id}`
-      try {
-        const authData = await slackApiGet('auth.test', accessToken, {})
-        const teamId = authData.team_id as string | undefined
-        if (teamId) {
-          sourceUrl = `https://app.slack.com/client/${teamId}/${channel.id}`
-        }
-      } catch {
-        // Fall back to URL without team ID
-      }
+      const teamId = await resolveTeamId(accessToken, syncContext)
+      const sourceUrl = teamId
+        ? `https://app.slack.com/client/${teamId}/${channel.id}`
+        : `https://app.slack.com/client/${channel.id}`
 
       return {
         externalId: channel.id,
@@ -405,7 +447,7 @@ export const slackConnector: ConnectorConfig = {
         contentHash,
         metadata: {
           channelName: channel.name,
-          messageCount: messages.length,
+          messageCount,
           lastActivity: lastActivityTs ? formatSlackTimestamp(lastActivityTs) : undefined,
           topic: channel.topic?.value,
           purpose: channel.purpose?.value,

--- a/apps/sim/connectors/slack/slack.ts
+++ b/apps/sim/connectors/slack/slack.ts
@@ -242,8 +242,9 @@ async function resolveChannel(
 ): Promise<SlackChannel | null> {
   const trimmed = channelInput.trim().replace(/^#/, '')
 
-  // If it looks like a channel ID (starts with C, D, or G), try direct lookup
-  if (/^[CDG][A-Z0-9]+$/.test(trimmed)) {
+  // If it looks like a channel ID (public C / private G), try direct lookup.
+  // DMs (D...) and MPIMs require im:*/mpim:* scopes, which we do not request.
+  if (/^[CG][A-Z0-9]+$/.test(trimmed)) {
     try {
       const data = await slackApiGet('conversations.info', accessToken, { channel: trimmed })
       return data.channel as SlackChannel

--- a/apps/sim/connectors/slack/slack.ts
+++ b/apps/sim/connectors/slack/slack.ts
@@ -130,7 +130,7 @@ async function fetchChannelMessages(
   accessToken: string,
   channelId: string,
   maxMessages: number
-): Promise<{ messages: SlackMessage[]; lastActivityTs?: string }> {
+): Promise<{ messages: SlackMessage[]; lastActivityTs?: string; oldestTs?: string }> {
   const allMessages: SlackMessage[] = []
   let cursor: string | undefined
   let lastActivityTs: string | undefined
@@ -162,7 +162,9 @@ async function fetchChannelMessages(
     cursor = nextCursor
   }
 
-  return { messages: allMessages.slice(0, maxMessages), lastActivityTs }
+  const trimmed = allMessages.slice(0, maxMessages)
+  const oldestTs = trimmed.length > 0 ? trimmed[trimmed.length - 1].ts : undefined
+  return { messages: trimmed, lastActivityTs, oldestTs }
 }
 
 /**
@@ -291,7 +293,7 @@ async function buildSlackChannelDocument(
   messageCount: number
   lastActivityTs?: string
 }> {
-  const { messages, lastActivityTs } = await fetchChannelMessages(
+  const { messages, lastActivityTs, oldestTs } = await fetchChannelMessages(
     accessToken,
     channel.id,
     maxMessages
@@ -299,7 +301,7 @@ async function buildSlackChannelDocument(
 
   const content = await formatMessages(accessToken, messages, syncContext)
   const messageCount = messages.length
-  const contentHash = `slack:${channel.id}:${lastActivityTs ?? 'empty'}:${messageCount}`
+  const contentHash = `slack:${channel.id}:${oldestTs ?? 'empty'}:${lastActivityTs ?? 'empty'}:${messageCount}`
 
   return { content, contentHash, messageCount, lastActivityTs }
 }
@@ -520,7 +522,7 @@ export const slackConnector: ConnectorConfig = {
 
       return { valid: false, error: `Channel not found: ${channelInput}` }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to validate configuration'
+      const message = toError(error).message || 'Failed to validate configuration'
       return { valid: false, error: message }
     }
   },

--- a/apps/sim/connectors/zendesk/zendesk.ts
+++ b/apps/sim/connectors/zendesk/zendesk.ts
@@ -10,6 +10,7 @@ const logger = createLogger('ZendeskConnector')
 const ARTICLES_PER_PAGE = 30
 const TICKETS_PER_PAGE = 100
 const DEFAULT_MAX_TICKETS = 500
+const SEARCH_API_RESULT_CAP = 1000
 
 const VALID_TICKET_STATUSES = new Set(['new', 'open', 'pending', 'hold', 'solved', 'closed'])
 
@@ -134,6 +135,11 @@ async function fetchTickets(
   let url: string | null = `${baseUrl}/api/v2/tickets.json?per_page=${TICKETS_PER_PAGE}`
 
   if (statusFilter && statusFilter !== 'all' && VALID_TICKET_STATUSES.has(statusFilter)) {
+    if (limit > SEARCH_API_RESULT_CAP) {
+      logger.warn(
+        `Zendesk Search API caps at ${SEARCH_API_RESULT_CAP} results; requested limit ${limit} will be truncated. Remove status filter to use the unbounded tickets endpoint.`
+      )
+    }
     const params = new URLSearchParams({
       query: `type:ticket status:${statusFilter}`,
       per_page: String(TICKETS_PER_PAGE),
@@ -509,6 +515,7 @@ export const zendeskConnector: ConnectorConfig = {
   tagDefinitions: [
     { id: 'contentType', displayName: 'Content Type', fieldType: 'text' },
     { id: 'status', displayName: 'Status', fieldType: 'text' },
+    { id: 'priority', displayName: 'Priority', fieldType: 'text' },
     { id: 'labels', displayName: 'Labels', fieldType: 'text' },
     { id: 'tags', displayName: 'Tags', fieldType: 'text' },
     { id: 'updatedAt', displayName: 'Last Updated', fieldType: 'date' },
@@ -524,6 +531,10 @@ export const zendeskConnector: ConnectorConfig = {
 
     if (typeof metadata.status === 'string') {
       result.status = metadata.status
+    }
+
+    if (typeof metadata.priority === 'string') {
+      result.priority = metadata.priority
     }
 
     const labels = joinTagArray(metadata.labels)

--- a/apps/sim/connectors/zendesk/zendesk.ts
+++ b/apps/sim/connectors/zendesk/zendesk.ts
@@ -11,6 +11,8 @@ const ARTICLES_PER_PAGE = 30
 const TICKETS_PER_PAGE = 100
 const DEFAULT_MAX_TICKETS = 500
 
+const VALID_TICKET_STATUSES = new Set(['new', 'open', 'pending', 'hold', 'solved', 'closed'])
+
 interface ZendeskArticle {
   id: number
   title: string
@@ -97,7 +99,7 @@ async function fetchArticles(
 ): Promise<ZendeskArticle[]> {
   const allArticles: ZendeskArticle[] = []
   const baseUrl = buildBaseUrl(subdomain)
-  const localePath = locale ? `/${locale}` : ''
+  const localePath = locale ? `/${encodeURIComponent(locale)}` : ''
   let page = 1
 
   while (true) {
@@ -131,8 +133,12 @@ async function fetchTickets(
   const limit = maxTickets || DEFAULT_MAX_TICKETS
   let url: string | null = `${baseUrl}/api/v2/tickets.json?per_page=${TICKETS_PER_PAGE}`
 
-  if (statusFilter && statusFilter !== 'all') {
-    url = `${baseUrl}/api/v2/search.json?query=type:ticket status:${statusFilter}&per_page=${TICKETS_PER_PAGE}`
+  if (statusFilter && statusFilter !== 'all' && VALID_TICKET_STATUSES.has(statusFilter)) {
+    const params = new URLSearchParams({
+      query: `type:ticket status:${statusFilter}`,
+      per_page: String(TICKETS_PER_PAGE),
+    })
+    url = `${baseUrl}/api/v2/search.json?${params.toString()}`
   }
 
   while (url && allTickets.length < limit) {
@@ -496,8 +502,7 @@ export const zendeskConnector: ConnectorConfig = {
       await zendeskApiGet(url, accessToken, sourceConfig, VALIDATE_RETRY_OPTIONS)
       return { valid: true }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to validate configuration'
-      return { valid: false, error: message }
+      return { valid: false, error: toError(error).message }
     }
   },
 

--- a/apps/sim/connectors/zendesk/zendesk.ts
+++ b/apps/sim/connectors/zendesk/zendesk.ts
@@ -514,7 +514,7 @@ export const zendeskConnector: ConnectorConfig = {
       await zendeskApiGet(url, accessToken, sourceConfig, VALIDATE_RETRY_OPTIONS)
       return { valid: true }
     } catch (error) {
-      return { valid: false, error: toError(error).message }
+      return { valid: false, error: toError(error).message || 'Failed to validate configuration' }
     }
   },
 

--- a/apps/sim/connectors/zendesk/zendesk.ts
+++ b/apps/sim/connectors/zendesk/zendesk.ts
@@ -362,8 +362,10 @@ export const zendeskConnector: ConnectorConfig = {
       description: 'Filter tickets by status (applies only when syncing tickets)',
       options: [
         { label: 'All Statuses', id: 'all' },
+        { label: 'New', id: 'new' },
         { label: 'Open', id: 'open' },
         { label: 'Pending', id: 'pending' },
+        { label: 'On Hold', id: 'hold' },
         { label: 'Solved', id: 'solved' },
         { label: 'Closed', id: 'closed' },
       ],

--- a/apps/sim/connectors/zendesk/zendesk.ts
+++ b/apps/sim/connectors/zendesk/zendesk.ts
@@ -134,17 +134,23 @@ async function fetchTickets(
   const limit = maxTickets || DEFAULT_MAX_TICKETS
   let url: string | null = `${baseUrl}/api/v2/tickets.json?per_page=${TICKETS_PER_PAGE}`
 
-  if (statusFilter && statusFilter !== 'all' && VALID_TICKET_STATUSES.has(statusFilter)) {
-    if (limit > SEARCH_API_RESULT_CAP) {
+  if (statusFilter && statusFilter !== 'all') {
+    if (VALID_TICKET_STATUSES.has(statusFilter)) {
+      if (limit > SEARCH_API_RESULT_CAP) {
+        logger.warn(
+          `Zendesk Search API caps at ${SEARCH_API_RESULT_CAP} results; requested limit ${limit} will be truncated. Remove status filter to use the unbounded tickets endpoint.`
+        )
+      }
+      const params = new URLSearchParams({
+        query: `type:ticket status:${statusFilter}`,
+        per_page: String(TICKETS_PER_PAGE),
+      })
+      url = `${baseUrl}/api/v2/search.json?${params.toString()}`
+    } else {
       logger.warn(
-        `Zendesk Search API caps at ${SEARCH_API_RESULT_CAP} results; requested limit ${limit} will be truncated. Remove status filter to use the unbounded tickets endpoint.`
+        `Invalid Zendesk statusFilter "${statusFilter}"; falling back to all tickets. Valid values: ${[...VALID_TICKET_STATUSES].join(', ')}.`
       )
     }
-    const params = new URLSearchParams({
-      query: `type:ticket status:${statusFilter}`,
-      per_page: String(TICKETS_PER_PAGE),
-    })
-    url = `${baseUrl}/api/v2/search.json?${params.toString()}`
   }
 
   while (url && allTickets.length < limit) {

--- a/apps/sim/tools/jira/utils.ts
+++ b/apps/sim/tools/jira/utils.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@sim/logger'
+import type { RetryOptions } from '@/lib/knowledge/documents/utils'
 import { fetchWithRetry } from '@/lib/knowledge/documents/utils'
 
 const logger = createLogger('JiraUtils')
@@ -163,7 +164,11 @@ export function normalizeDomain(domain: string): string {
     .replace(/\/+$/, '')}`.toLowerCase()
 }
 
-export async function getJiraCloudId(domain: string, accessToken: string): Promise<string> {
+export async function getJiraCloudId(
+  domain: string,
+  accessToken: string,
+  retryOptions?: RetryOptions
+): Promise<string> {
   const response = await fetchWithRetry(
     'https://api.atlassian.com/oauth/token/accessible-resources',
     {
@@ -172,7 +177,8 @@ export async function getJiraCloudId(domain: string, accessToken: string): Promi
         Authorization: `Bearer ${accessToken}`,
         Accept: 'application/json',
       },
-    }
+    },
+    retryOptions
   )
 
   if (!response.ok) {

--- a/apps/sim/tools/jira/utils.ts
+++ b/apps/sim/tools/jira/utils.ts
@@ -62,6 +62,9 @@ export function extractAdfText(content: any): string | null {
     return content.map(extractAdfText).filter(Boolean).join(' ')
   }
   if (content.type === 'text') return content.text || ''
+  if (content.type === 'hardBreak') return '\n'
+  if (content.type === 'mention') return content.attrs?.text || ''
+  if (content.type === 'emoji') return content.attrs?.shortName || content.attrs?.text || ''
   if (content.content) return extractAdfText(content.content)
   return ''
 }


### PR DESCRIPTION
## Summary
- jira: migrate from deprecated `/rest/api/3/search` (Atlassian sunset May 2025) to `/rest/api/3/search/jql` with `nextPageToken` pagination
- confluence: unify stub hash across v1 CQL (`when`) and v2 (`createdAt`) paths via shared `pageToStub` helper using `version.number`
- salesforce: replace hardcoded `login.salesforce.com` userinfo with host fallback so sandbox-issued tokens (`test.salesforce.com`) work
- servicenow: validate `sys_id` against `/^[a-f0-9]{32}$/` and switch `getDocument` to path-based `/api/now/table/{table}/{sys_id}` to close encoded-query injection; reject `^` in `kbCategory`
- zendesk: URL-encode Search API query via `URLSearchParams`; whitelist ticket statuses; encode locale path segment
- github: add 10MB cap and `/git/blobs/{sha}` fallback for files >1MB that `/contents/` returns with `encoding:"none"`
- slack: replace SHA-256 over formatted-message window with metadata hash `slack:{channelId}:{oldestTs}:{latestTs}:{count}` so list and getDocument agree; cache `auth.test` `team_id` on `syncContext`
- obsidian: drop `syncRunId` from stub hash (Local REST API has no HEAD/Last-Modified per OpenAPI spec); fall back to path-only stub
- evernote: title fallback for attachments-only notes — breaks infinite hydration loop where empty plaintext returned null
- google-docs: drop residual `error instanceof Error` pattern

Each fix was validated against the provider API docs by an independent subagent before applying. Confluence and Slack hash format changes self-heal with a one-time re-sync; no data loss.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Lint and typecheck pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)