### PR TITLE
feat(files): zoom controls for inline mermaid and images in markdown

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -495,7 +495,14 @@ const STATIC_MARKDOWN_COMPONENTS = {
   ),
   'mermaid-diagram': ({ definition }: { definition?: string }) => {
     const isStreaming = useContext(MermaidStreamingCtx)
-    return <MermaidDiagram definition={definition ?? ''} isStreaming={isStreaming} />
+    return (
+      <MermaidDiagram
+        definition={definition ?? ''}
+        isStreaming={isStreaming}
+        zoomable
+        zoomClassName='my-4 h-[420px] rounded-lg'
+      />
+    )
   },
   p: ({ children }: { children?: React.ReactNode }) => (
     <p className='mb-3 break-words text-[14px] text-[var(--text-primary)] leading-[1.6] last:mb-0'>
@@ -619,12 +626,15 @@ const STATIC_MARKDOWN_COMPONENTS = {
   img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => {
     const resolvedSrc = resolveSimFileUrl(typeof src === 'string' ? src : undefined)
     return (
-      <img
-        src={resolvedSrc}
-        alt={alt ?? ''}
-        className='my-3 max-w-full rounded-md'
-        loading='lazy'
-      />
+      <ZoomablePreview className='my-3 h-[360px] rounded-md' initialScale='actual'>
+        <img
+          src={resolvedSrc}
+          alt={alt ?? ''}
+          className='max-h-full max-w-full select-none object-contain'
+          draggable={false}
+          loading='lazy'
+        />
+      </ZoomablePreview>
     )
   },
   table: ({ children }: { children?: React.ReactNode }) => (

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -462,9 +462,15 @@ function resolveSimFileUrl(src: string | undefined): string | undefined {
   try {
     const parsed = new URL(src, 'http://placeholder')
     if (parsed.origin !== 'http://placeholder') return src
-    const [, seg1, , seg3, fileId] = parsed.pathname.split('/')
+    const parts = parsed.pathname.split('/')
+    const [, seg1, , seg3, fileId] = parts
     if (seg1 === 'workspace' && seg3 === 'files' && fileId) {
       return `/api/files/view/${fileId}`
+    }
+    // files/by-id/{uuid}/content — canonical VFS path used by Mothership skills; treat as embed URL
+    const [, s1, s2, byIdFileId, s4] = parts
+    if (s1 === 'files' && s2 === 'by-id' && byIdFileId && s4 === 'content') {
+      return `/api/files/view/${byIdFileId}`
     }
   } catch {
     // not a parseable URL
@@ -476,7 +482,14 @@ const STATIC_MARKDOWN_COMPONENTS = {
   pre: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   'mermaid-diagram': ({ definition }: { definition?: string }) => {
     const isStreaming = useContext(MermaidStreamingCtx)
-    return <MermaidDiagram definition={definition ?? ''} isStreaming={isStreaming} />
+    return (
+      <MermaidDiagram
+        definition={definition ?? ''}
+        isStreaming={isStreaming}
+        zoomable
+        zoomClassName='h-[420px] rounded-lg'
+      />
+    )
   },
   p: ({ children }: { children?: React.ReactNode }) => (
     <p className='mb-3 break-words text-[14px] text-[var(--text-primary)] leading-[1.6] last:mb-0'>
@@ -613,12 +626,15 @@ const STATIC_MARKDOWN_COMPONENTS = {
   img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => {
     const resolvedSrc = resolveSimFileUrl(typeof src === 'string' ? src : undefined)
     return (
-      <img
-        src={resolvedSrc}
-        alt={alt ?? ''}
-        className='my-3 max-w-full rounded-md'
-        loading='lazy'
-      />
+      <ZoomablePreview className='my-3 h-[360px] rounded-md' initialScale='fit'>
+        <img
+          src={resolvedSrc}
+          alt={alt ?? ''}
+          className='max-h-full max-w-full select-none object-contain'
+          draggable={false}
+          loading='lazy'
+        />
+      </ZoomablePreview>
     )
   },
   table: ({ children }: { children?: React.ReactNode }) => (

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -462,15 +462,9 @@ function resolveSimFileUrl(src: string | undefined): string | undefined {
   try {
     const parsed = new URL(src, 'http://placeholder')
     if (parsed.origin !== 'http://placeholder') return src
-    const parts = parsed.pathname.split('/')
-    const [, seg1, , seg3, fileId] = parts
+    const [, seg1, , seg3, fileId] = parsed.pathname.split('/')
     if (seg1 === 'workspace' && seg3 === 'files' && fileId) {
       return `/api/files/view/${fileId}`
-    }
-    // files/by-id/{uuid}/content — canonical VFS path used by Mothership skills; treat as embed URL
-    const [, s1, s2, byIdFileId, s4] = parts
-    if (s1 === 'files' && s2 === 'by-id' && byIdFileId && s4 === 'content') {
-      return `/api/files/view/${byIdFileId}`
     }
   } catch {
     // not a parseable URL

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -481,7 +481,7 @@ const STATIC_MARKDOWN_COMPONENTS = {
         definition={definition ?? ''}
         isStreaming={isStreaming}
         zoomable
-        zoomClassName='h-[420px] rounded-lg'
+        zoomClassName='my-4 h-[420px] rounded-lg'
       />
     )
   },
@@ -620,7 +620,7 @@ const STATIC_MARKDOWN_COMPONENTS = {
   img: ({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) => {
     const resolvedSrc = resolveSimFileUrl(typeof src === 'string' ? src : undefined)
     return (
-      <ZoomablePreview className='my-3 h-[360px] rounded-md' initialScale='fit'>
+      <ZoomablePreview className='my-3 h-[360px] rounded-md' initialScale='actual'>
         <img
           src={resolvedSrc}
           alt={alt ?? ''}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/zoomable-preview.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/zoomable-preview.tsx
@@ -47,7 +47,7 @@ function getFitZoom(container: Size, content: Size): number {
 
   const availableWidth = Math.max(1, container.width - FIT_PADDING)
   const availableHeight = Math.max(1, container.height - FIT_PADDING)
-  return clampZoom(Math.min(1, availableWidth / content.width, availableHeight / content.height))
+  return clampZoom(Math.min(availableWidth / content.width, availableHeight / content.height))
 }
 
 function clampOffset(container: Size, content: Size, offset: Offset, zoom: number): Offset {


### PR DESCRIPTION
## Summary
- Add zoom controls (pan/zoom/fit) to mermaid diagrams rendered inline in markdown files — same experience as the full .mmd file viewer
- Add zoom controls to images embedded in markdown — wraps in ZoomablePreview with fit-to-container initial scale
- Fix fit zoom to allow upscaling small diagrams to fill the view (previously capped at 100%, leaving small SVGs tiny)

## Type of Change
- [x] New feature
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)