### PR TITLE
improvement(sidebar): overlay lock indicator on leading icon

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -523,12 +523,17 @@ export function FolderItem({
           {folder.locked && (
             <Tooltip.Root>
               <Tooltip.Trigger asChild>
-                <span className='-right-[4px] -bottom-[4px] absolute flex h-[12px] w-[12px] items-center justify-center rounded-full bg-[var(--surface-1)]'>
+                <button
+                  type='button'
+                  aria-label='Folder is locked'
+                  className='-right-[4px] -bottom-[4px] absolute flex h-[12px] w-[12px] items-center justify-center rounded-full bg-[var(--surface-1)] outline-none focus-visible:ring-1 focus-visible:ring-[var(--text-icon)]'
+                  onClick={(e) => e.preventDefault()}
+                >
                   <Lock
                     className='pointer-events-none h-[10px] w-[10px] text-[var(--text-icon)]'
                     aria-hidden='true'
                   />
-                </span>
+                </button>
               </Tooltip.Trigger>
               <Tooltip.Content side='bottom'>
                 <span>Locked</span>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -514,33 +514,17 @@ export function FolderItem({
           )}
           aria-hidden='true'
         />
-        <span className='relative flex-shrink-0'>
-          {isExpanded ? (
-            <FolderOpen className='h-[16px] w-[16px] text-[var(--text-icon)]' aria-hidden='true' />
-          ) : (
-            <Folder className='h-[16px] w-[16px] text-[var(--text-icon)]' aria-hidden='true' />
-          )}
-          {folder.locked && (
-            <Tooltip.Root>
-              <Tooltip.Trigger asChild>
-                <button
-                  type='button'
-                  aria-label='Folder is locked'
-                  className='-right-[4px] -bottom-[4px] absolute flex h-[12px] w-[12px] items-center justify-center rounded-full bg-[var(--surface-1)] outline-none focus-visible:ring-1 focus-visible:ring-[var(--text-icon)]'
-                  onClick={(e) => e.preventDefault()}
-                >
-                  <Lock
-                    className='pointer-events-none h-[10px] w-[10px] text-[var(--text-icon)]'
-                    aria-hidden='true'
-                  />
-                </button>
-              </Tooltip.Trigger>
-              <Tooltip.Content side='bottom'>
-                <span>Locked</span>
-              </Tooltip.Content>
-            </Tooltip.Root>
-          )}
-        </span>
+        {isExpanded ? (
+          <FolderOpen
+            className='h-[16px] w-[16px] flex-shrink-0 text-[var(--text-icon)]'
+            aria-hidden='true'
+          />
+        ) : (
+          <Folder
+            className='h-[16px] w-[16px] flex-shrink-0 text-[var(--text-icon)]'
+            aria-hidden='true'
+          />
+        )}
         {isEditing ? (
           <input
             ref={inputRef}
@@ -570,19 +554,43 @@ export function FolderItem({
                 {folder.name}
               </span>
             </div>
-            <button
-              type='button'
-              aria-label='Folder options'
-              onPointerDown={handleMorePointerDown}
-              onClick={handleMoreClick}
-              className={clsx(
-                'flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity',
-                !isAnyDragActive && 'group-hover:opacity-100',
-                isContextMenuOpen && 'opacity-100'
+            <div className='relative h-[18px] w-[18px] flex-shrink-0'>
+              {folder.locked && (
+                <Tooltip.Root>
+                  <Tooltip.Trigger asChild>
+                    <span
+                      aria-label='Folder is locked'
+                      className={clsx(
+                        'absolute inset-0 flex items-center justify-center transition-opacity',
+                        !isAnyDragActive && 'group-hover:opacity-0',
+                        isContextMenuOpen && 'opacity-0'
+                      )}
+                    >
+                      <Lock
+                        className='h-[14px] w-[14px] text-[var(--text-icon)]'
+                        aria-hidden='true'
+                      />
+                    </span>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content side='bottom'>
+                    <span>Locked</span>
+                  </Tooltip.Content>
+                </Tooltip.Root>
               )}
-            >
-              <MoreHorizontal className='h-[16px] w-[16px] text-[var(--text-icon)]' />
-            </button>
+              <button
+                type='button'
+                aria-label='Folder options'
+                onPointerDown={handleMorePointerDown}
+                onClick={handleMoreClick}
+                className={clsx(
+                  'absolute inset-0 flex items-center justify-center rounded-sm opacity-0 transition-opacity',
+                  !isAnyDragActive && 'group-hover:opacity-100',
+                  isContextMenuOpen && 'opacity-100'
+                )}
+              >
+                <MoreHorizontal className='h-[16px] w-[16px] text-[var(--text-icon)]' />
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -556,6 +556,7 @@ export function FolderItem({
             <div className='relative h-[18px] w-[18px] flex-shrink-0'>
               {folder.locked && (
                 <span
+                  role='img'
                   aria-label='Folder is locked'
                   className={clsx(
                     'pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity',

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -6,7 +6,6 @@ import { generateId } from '@sim/utils/id'
 import clsx from 'clsx'
 import { ChevronRight, Folder, FolderOpen, MoreHorizontal } from 'lucide-react'
 import { useParams, useRouter } from 'next/navigation'
-import { Tooltip } from '@/components/emcn'
 import { Lock } from '@/components/emcn/icons'
 import { SIM_RESOURCES_DRAG_TYPE } from '@/lib/copilot/resource-types'
 import { getNextWorkflowColor } from '@/lib/workflows/colors'
@@ -556,26 +555,16 @@ export function FolderItem({
             </div>
             <div className='relative h-[18px] w-[18px] flex-shrink-0'>
               {folder.locked && (
-                <Tooltip.Root>
-                  <Tooltip.Trigger asChild>
-                    <span
-                      aria-label='Folder is locked'
-                      className={clsx(
-                        'absolute inset-0 flex items-center justify-center transition-opacity',
-                        !isAnyDragActive && 'group-hover:opacity-0',
-                        isContextMenuOpen && 'opacity-0'
-                      )}
-                    >
-                      <Lock
-                        className='h-[14px] w-[14px] text-[var(--text-icon)]'
-                        aria-hidden='true'
-                      />
-                    </span>
-                  </Tooltip.Trigger>
-                  <Tooltip.Content side='bottom'>
-                    <span>Locked</span>
-                  </Tooltip.Content>
-                </Tooltip.Root>
+                <span
+                  aria-label='Folder is locked'
+                  className={clsx(
+                    'pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity',
+                    !isAnyDragActive && 'group-hover:opacity-0',
+                    isContextMenuOpen && 'opacity-0'
+                  )}
+                >
+                  <Lock className='h-[14px] w-[14px] text-[var(--text-icon)]' aria-hidden='true' />
+                </span>
               )}
               <button
                 type='button'
@@ -583,9 +572,9 @@ export function FolderItem({
                 onPointerDown={handleMorePointerDown}
                 onClick={handleMoreClick}
                 className={clsx(
-                  'absolute inset-0 flex items-center justify-center rounded-sm opacity-0 transition-opacity',
-                  !isAnyDragActive && 'group-hover:opacity-100',
-                  isContextMenuOpen && 'opacity-100'
+                  'pointer-events-none absolute inset-0 flex items-center justify-center rounded-sm opacity-0 transition-opacity',
+                  !isAnyDragActive && 'group-hover:pointer-events-auto group-hover:opacity-100',
+                  isContextMenuOpen && 'pointer-events-auto opacity-100'
                 )}
               >
                 <MoreHorizontal className='h-[16px] w-[16px] text-[var(--text-icon)]' />

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -6,6 +6,7 @@ import { generateId } from '@sim/utils/id'
 import clsx from 'clsx'
 import { ChevronRight, Folder, FolderOpen, MoreHorizontal } from 'lucide-react'
 import { useParams, useRouter } from 'next/navigation'
+import { Tooltip } from '@/components/emcn'
 import { Lock } from '@/components/emcn/icons'
 import { SIM_RESOURCES_DRAG_TYPE } from '@/lib/copilot/resource-types'
 import { getNextWorkflowColor } from '@/lib/workflows/colors'
@@ -513,17 +514,28 @@ export function FolderItem({
           )}
           aria-hidden='true'
         />
-        {isExpanded ? (
-          <FolderOpen
-            className='h-[16px] w-[16px] flex-shrink-0 text-[var(--text-icon)]'
-            aria-hidden='true'
-          />
-        ) : (
-          <Folder
-            className='h-[16px] w-[16px] flex-shrink-0 text-[var(--text-icon)]'
-            aria-hidden='true'
-          />
-        )}
+        <span className='relative flex-shrink-0'>
+          {isExpanded ? (
+            <FolderOpen className='h-[16px] w-[16px] text-[var(--text-icon)]' aria-hidden='true' />
+          ) : (
+            <Folder className='h-[16px] w-[16px] text-[var(--text-icon)]' aria-hidden='true' />
+          )}
+          {folder.locked && (
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                <span className='-right-[4px] -bottom-[4px] absolute flex h-[12px] w-[12px] items-center justify-center rounded-full bg-[var(--surface-1)]'>
+                  <Lock
+                    className='pointer-events-none h-[10px] w-[10px] text-[var(--text-icon)]'
+                    aria-hidden='true'
+                  />
+                </span>
+              </Tooltip.Trigger>
+              <Tooltip.Content side='bottom'>
+                <span>Locked</span>
+              </Tooltip.Content>
+            </Tooltip.Root>
+          )}
+        </span>
         {isEditing ? (
           <input
             ref={inputRef}
@@ -552,12 +564,6 @@ export function FolderItem({
               >
                 {folder.name}
               </span>
-              {folder.locked && (
-                <Lock
-                  className='pointer-events-none h-[12px] w-[12px] flex-shrink-0 text-[var(--text-icon)]'
-                  aria-label='Folder is locked'
-                />
-              )}
             </div>
             <button
               type='button'

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -475,6 +475,7 @@ export function WorkflowItem({
           <div className='relative h-[18px] w-[18px] flex-shrink-0'>
             {workflow.locked && (
               <span
+                role='img'
                 aria-label='Workflow is locked'
                 className={clsx(
                   'pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity',

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx'
 import { MoreHorizontal } from 'lucide-react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { Tooltip } from '@/components/emcn'
 import { Lock } from '@/components/emcn/icons'
 import { SIM_RESOURCES_DRAG_TYPE } from '@/lib/copilot/resource-types'
 import { workflowBorderColor } from '@/lib/workspaces/colors'
@@ -475,26 +474,16 @@ export function WorkflowItem({
         {!isEditing && (
           <div className='relative h-[18px] w-[18px] flex-shrink-0'>
             {workflow.locked && (
-              <Tooltip.Root>
-                <Tooltip.Trigger asChild>
-                  <span
-                    aria-label='Workflow is locked'
-                    className={clsx(
-                      'absolute inset-0 flex items-center justify-center transition-opacity',
-                      !isAnyDragActive && 'group-hover:opacity-0',
-                      isContextMenuOpen && 'opacity-0'
-                    )}
-                  >
-                    <Lock
-                      className='h-[14px] w-[14px] text-[var(--text-icon)]'
-                      aria-hidden='true'
-                    />
-                  </span>
-                </Tooltip.Trigger>
-                <Tooltip.Content side='bottom'>
-                  <span>Locked</span>
-                </Tooltip.Content>
-              </Tooltip.Root>
+              <span
+                aria-label='Workflow is locked'
+                className={clsx(
+                  'pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity',
+                  !isAnyDragActive && 'group-hover:opacity-0',
+                  isContextMenuOpen && 'opacity-0'
+                )}
+              >
+                <Lock className='h-[14px] w-[14px] text-[var(--text-icon)]' aria-hidden='true' />
+              </span>
             )}
             <button
               type='button'
@@ -502,9 +491,9 @@ export function WorkflowItem({
               onPointerDown={handleMorePointerDown}
               onClick={handleMoreClick}
               className={clsx(
-                'absolute inset-0 flex items-center justify-center rounded-sm opacity-0 transition-opacity',
-                !isAnyDragActive && 'group-hover:opacity-100',
-                isContextMenuOpen && 'opacity-100'
+                'pointer-events-none absolute inset-0 flex items-center justify-center rounded-sm opacity-0 transition-opacity',
+                !isAnyDragActive && 'group-hover:pointer-events-auto group-hover:opacity-100',
+                isContextMenuOpen && 'pointer-events-auto opacity-100'
               )}
             >
               <MoreHorizontal className='h-[16px] w-[16px] text-[var(--text-icon)]' />

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -432,36 +432,14 @@ export function WorkflowItem({
         onClick={handleClick}
         onContextMenu={handleContextMenu}
       >
-        <div className='relative flex-shrink-0'>
-          <div
-            className='h-[16px] w-[16px] rounded-sm border-[2.5px]'
-            style={{
-              backgroundColor: workflow.color,
-              borderColor: workflowBorderColor(workflow.color),
-              backgroundClip: 'padding-box',
-            }}
-          />
-          {workflow.locked && (
-            <Tooltip.Root>
-              <Tooltip.Trigger asChild>
-                <button
-                  type='button'
-                  aria-label='Workflow is locked'
-                  className='-right-[4px] -bottom-[4px] absolute flex h-[12px] w-[12px] items-center justify-center rounded-full bg-[var(--surface-1)] outline-none focus-visible:ring-1 focus-visible:ring-[var(--text-icon)]'
-                  onClick={(e) => e.preventDefault()}
-                >
-                  <Lock
-                    className='pointer-events-none h-[10px] w-[10px] text-[var(--text-icon)]'
-                    aria-hidden='true'
-                  />
-                </button>
-              </Tooltip.Trigger>
-              <Tooltip.Content side='bottom'>
-                <span>Locked</span>
-              </Tooltip.Content>
-            </Tooltip.Root>
-          )}
-        </div>
+        <div
+          className='h-[16px] w-[16px] flex-shrink-0 rounded-sm border-[2.5px]'
+          style={{
+            backgroundColor: workflow.color,
+            borderColor: workflowBorderColor(workflow.color),
+            backgroundClip: 'padding-box',
+          }}
+        />
         <div className='min-w-0 flex-1'>
           <div className='flex min-w-0 items-center gap-2'>
             {isEditing ? (
@@ -495,21 +473,43 @@ export function WorkflowItem({
           </div>
         </div>
         {!isEditing && (
-          <>
+          <div className='relative h-[18px] w-[18px] flex-shrink-0'>
+            {workflow.locked && (
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <span
+                    aria-label='Workflow is locked'
+                    className={clsx(
+                      'absolute inset-0 flex items-center justify-center transition-opacity',
+                      !isAnyDragActive && 'group-hover:opacity-0',
+                      isContextMenuOpen && 'opacity-0'
+                    )}
+                  >
+                    <Lock
+                      className='h-[14px] w-[14px] text-[var(--text-icon)]'
+                      aria-hidden='true'
+                    />
+                  </span>
+                </Tooltip.Trigger>
+                <Tooltip.Content side='bottom'>
+                  <span>Locked</span>
+                </Tooltip.Content>
+              </Tooltip.Root>
+            )}
             <button
               type='button'
               aria-label='Workflow options'
               onPointerDown={handleMorePointerDown}
               onClick={handleMoreClick}
               className={clsx(
-                'flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity',
+                'absolute inset-0 flex items-center justify-center rounded-sm opacity-0 transition-opacity',
                 !isAnyDragActive && 'group-hover:opacity-100',
                 isContextMenuOpen && 'opacity-100'
               )}
             >
               <MoreHorizontal className='h-[16px] w-[16px] text-[var(--text-icon)]' />
             </button>
-          </>
+          </div>
         )}
       </Link>
 

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -432,7 +432,7 @@ export function WorkflowItem({
         onClick={handleClick}
         onContextMenu={handleContextMenu}
       >
-        <span className='relative flex-shrink-0'>
+        <div className='relative flex-shrink-0'>
           <div
             className='h-[16px] w-[16px] rounded-sm border-[2.5px]'
             style={{
@@ -444,19 +444,24 @@ export function WorkflowItem({
           {workflow.locked && (
             <Tooltip.Root>
               <Tooltip.Trigger asChild>
-                <span className='-right-[4px] -bottom-[4px] absolute flex h-[12px] w-[12px] items-center justify-center rounded-full bg-[var(--surface-1)]'>
+                <button
+                  type='button'
+                  aria-label='Workflow is locked'
+                  className='-right-[4px] -bottom-[4px] absolute flex h-[12px] w-[12px] items-center justify-center rounded-full bg-[var(--surface-1)] outline-none focus-visible:ring-1 focus-visible:ring-[var(--text-icon)]'
+                  onClick={(e) => e.preventDefault()}
+                >
                   <Lock
                     className='pointer-events-none h-[10px] w-[10px] text-[var(--text-icon)]'
                     aria-hidden='true'
                   />
-                </span>
+                </button>
               </Tooltip.Trigger>
               <Tooltip.Content side='bottom'>
                 <span>Locked</span>
               </Tooltip.Content>
             </Tooltip.Root>
           )}
-        </span>
+        </div>
         <div className='min-w-0 flex-1'>
           <div className='flex min-w-0 items-center gap-2'>
             {isEditing ? (

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx'
 import { MoreHorizontal } from 'lucide-react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
+import { Tooltip } from '@/components/emcn'
 import { Lock } from '@/components/emcn/icons'
 import { SIM_RESOURCES_DRAG_TYPE } from '@/lib/copilot/resource-types'
 import { workflowBorderColor } from '@/lib/workspaces/colors'
@@ -431,14 +432,31 @@ export function WorkflowItem({
         onClick={handleClick}
         onContextMenu={handleContextMenu}
       >
-        <div
-          className='h-[16px] w-[16px] flex-shrink-0 rounded-sm border-[2.5px]'
-          style={{
-            backgroundColor: workflow.color,
-            borderColor: workflowBorderColor(workflow.color),
-            backgroundClip: 'padding-box',
-          }}
-        />
+        <span className='relative flex-shrink-0'>
+          <div
+            className='h-[16px] w-[16px] rounded-sm border-[2.5px]'
+            style={{
+              backgroundColor: workflow.color,
+              borderColor: workflowBorderColor(workflow.color),
+              backgroundClip: 'padding-box',
+            }}
+          />
+          {workflow.locked && (
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                <span className='-right-[4px] -bottom-[4px] absolute flex h-[12px] w-[12px] items-center justify-center rounded-full bg-[var(--surface-1)]'>
+                  <Lock
+                    className='pointer-events-none h-[10px] w-[10px] text-[var(--text-icon)]'
+                    aria-hidden='true'
+                  />
+                </span>
+              </Tooltip.Trigger>
+              <Tooltip.Content side='bottom'>
+                <span>Locked</span>
+              </Tooltip.Content>
+            </Tooltip.Root>
+          )}
+        </span>
         <div className='min-w-0 flex-1'>
           <div className='flex min-w-0 items-center gap-2'>
             {isEditing ? (
@@ -467,12 +485,6 @@ export function WorkflowItem({
               >
                 {workflow.name}
               </div>
-            )}
-            {!isEditing && workflow.locked && (
-              <Lock
-                className='pointer-events-none h-[12px] w-[12px] flex-shrink-0 text-[var(--text-icon)]'
-                aria-label='Workflow is locked'
-              />
             )}
             {!isEditing && <Avatars workflowId={workflow.id} />}
           </div>


### PR DESCRIPTION
## Summary
- Move the lock icon on workflow and folder sidebar items from inline (next to the name) to a small overlay on the leading icon (color swatch / folder icon), matching the read/unread indicator pattern used in the conversation list
- Wrap the indicator in an emcn `Tooltip` with a "Locked" label and use design tokens (`--surface-1` knockout, `--text-icon`)

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)