### PR TITLE
fix(memory): return 200 with null data when memory key not found on GET

### DIFF
--- a/apps/sim/app/api/memory/[id]/route.ts
+++ b/apps/sim/app/api/memory/[id]/route.ts
@@ -86,7 +86,7 @@ export const GET = withRouteHandler(async (request: NextRequest, context: Memory
       .limit(1)
 
     if (memories.length === 0) {
-      return memoryEnvelopeError('Memory not found', 404)
+      return NextResponse.json({ success: true, data: null }, { status: 200 })
     }
 
     const mem = memories[0]

--- a/apps/sim/tools/memory/get.test.ts
+++ b/apps/sim/tools/memory/get.test.ts
@@ -36,6 +36,20 @@ describe('memoryGetTool', () => {
     expect(url).toBe('/api/memory/team%2Fuser%20123?workspaceId=workspace-1')
   })
 
+  it('returns empty memories when key is not found (null data)', async () => {
+    const result = await transformResponse(
+      new Response(JSON.stringify({ success: true, data: null }))
+    )
+
+    expect(result).toEqual({
+      success: true,
+      output: {
+        memories: [],
+        message: 'No memories found',
+      },
+    })
+  })
+
   it('wraps the exact memory response as a single result', async () => {
     const result = await transformResponse(
       new Response(


### PR DESCRIPTION
## Summary
- The \`memory_get\` tool was changed in #4415 to call \`GET /api/memory/{id}\` instead of the list endpoint
- When a memory key doesn't exist yet, the \`[id]\` route returned 404 — but the executor throws on any non-2xx response before \`transformResponse\` is ever called
- This broke workflows using Memory blocks with \`get\` on first run (key doesn't exist yet), causing a \"Memory not found\" error instead of returning an empty memories array
- Fix: return \`200\` with \`{ success: true, data: null }\` when the key isn't found, so \`transformResponse\` can handle it gracefully and return \`{ memories: [], message: 'No memories found' }\`
- DELETE and PUT handlers correctly keep their 404 behavior — only GET needed this change

## Type of Change
- [x] Bug fix

## Testing
Tested by tracing executor flow through \`executeToolRequest\` — non-2xx responses throw before \`transformResponse\`, 200+null flows through correctly.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)