### PR TITLE
fix(table): return 400 instead of 500 for malformed sort/filter input

### DIFF
--- a/apps/sim/app/api/table/[tableId]/rows/route.ts
+++ b/apps/sim/app/api/table/[tableId]/rows/route.ts
@@ -30,7 +30,7 @@ import {
   validateRowData,
   validateRowSize,
 } from '@/lib/table'
-import { buildFilterClause, buildSortClause } from '@/lib/table/sql'
+import { buildFilterClause, buildSortClause, TableQueryValidationError } from '@/lib/table/sql'
 import { accessError, checkAccess } from '@/app/api/table/utils'
 
 const logger = createLogger('TableRowsAPI')
@@ -336,6 +336,10 @@ export const GET = withRouteHandler(
         return validationErrorResponse(error)
       }
 
+      if (error instanceof TableQueryValidationError) {
+        return NextResponse.json({ error: error.message }, { status: 400 })
+      }
+
       logger.error(`[${requestId}] Error querying rows:`, error)
       return NextResponse.json({ error: 'Failed to query rows' }, { status: 500 })
     }
@@ -419,6 +423,10 @@ export const PUT = withRouteHandler(
     } catch (error) {
       if (isZodError(error)) {
         return validationErrorResponse(error)
+      }
+
+      if (error instanceof TableQueryValidationError) {
+        return NextResponse.json({ error: error.message }, { status: 400 })
       }
 
       const errorMessage = toError(error).message
@@ -518,6 +526,10 @@ export const DELETE = withRouteHandler(
     } catch (error) {
       if (isZodError(error)) {
         return validationErrorResponse(error)
+      }
+
+      if (error instanceof TableQueryValidationError) {
+        return NextResponse.json({ error: error.message }, { status: 400 })
       }
 
       const errorMessage = toError(error).message

--- a/apps/sim/app/api/v1/tables/[tableId]/rows/route.ts
+++ b/apps/sim/app/api/v1/tables/[tableId]/rows/route.ts
@@ -30,7 +30,7 @@ import {
   validateRowData,
   validateRowSize,
 } from '@/lib/table'
-import { buildFilterClause, buildSortClause } from '@/lib/table/sql'
+import { buildFilterClause, buildSortClause, TableQueryValidationError } from '@/lib/table/sql'
 import { accessError, checkAccess } from '@/app/api/table/utils'
 import {
   checkRateLimit,
@@ -240,6 +240,10 @@ export const GET = withRouteHandler(async (request: NextRequest, context: TableR
     const validationResponse = validationErrorResponseFromError(error)
     if (validationResponse) return validationResponse
 
+    if (error instanceof TableQueryValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+
     logger.error(`[${requestId}] Error querying rows:`, error)
     return NextResponse.json({ error: 'Failed to query rows' }, { status: 500 })
   }
@@ -407,6 +411,10 @@ export const PUT = withRouteHandler(async (request: NextRequest, context: TableR
     const validationResponse = validationErrorResponseFromError(error)
     if (validationResponse) return validationResponse
 
+    if (error instanceof TableQueryValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+
     const errorMessage = toError(error).message
 
     if (
@@ -499,6 +507,10 @@ export const DELETE = withRouteHandler(
     } catch (error) {
       const validationResponse = validationErrorResponseFromError(error)
       if (validationResponse) return validationResponse
+
+      if (error instanceof TableQueryValidationError) {
+        return NextResponse.json({ error: error.message }, { status: 400 })
+      }
 
       const errorMessage = toError(error).message
 

--- a/apps/sim/lib/table/sql.ts
+++ b/apps/sim/lib/table/sql.ts
@@ -11,6 +11,17 @@ import { NAME_PATTERN } from './constants'
 import type { ColumnDefinition, ConditionOperators, Filter, JsonValue, Sort } from './types'
 
 /**
+ * Error thrown when caller-supplied filter or sort input is malformed.
+ * Routes should map this to HTTP 400 with the message preserved.
+ */
+export class TableQueryValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'TableQueryValidationError'
+  }
+}
+
+/**
  * Whitelist of allowed operators for query filtering.
  * Only these operators can be used in filter conditions.
  */
@@ -133,7 +144,9 @@ export function buildSortClause(
     validateFieldName(field)
 
     if (direction !== 'asc' && direction !== 'desc') {
-      throw new Error(`Invalid sort direction "${direction}". Must be "asc" or "desc".`)
+      throw new TableQueryValidationError(
+        `Invalid sort direction "${direction}". Must be "asc" or "desc".`
+      )
     }
 
     const columnType = columnTypeMap.get(field)
@@ -152,11 +165,11 @@ export function buildSortClause(
  */
 function validateFieldName(field: string): void {
   if (!field || typeof field !== 'string') {
-    throw new Error('Field name must be a non-empty string')
+    throw new TableQueryValidationError('Field name must be a non-empty string')
   }
 
   if (!NAME_PATTERN.test(field)) {
-    throw new Error(
+    throw new TableQueryValidationError(
       `Invalid field name "${field}". Field names must start with a letter or underscore, followed by alphanumeric characters or underscores.`
     )
   }
@@ -170,7 +183,7 @@ function validateFieldName(field: string): void {
  */
 function validateOperator(operator: string): void {
   if (!ALLOWED_OPERATORS.has(operator)) {
-    throw new Error(
+    throw new TableQueryValidationError(
       `Invalid operator "${operator}". Allowed operators: ${Array.from(ALLOWED_OPERATORS).join(', ')}`
     )
   }
@@ -261,7 +274,7 @@ function buildFieldCondition(
 
         default:
           // This should never happen due to validateOperator, but added for completeness
-          throw new Error(`Unsupported operator: ${op}`)
+          throw new TableQueryValidationError(`Unsupported operator: ${op}`)
       }
     }
   } else {

--- a/apps/sim/lib/table/sql.ts
+++ b/apps/sim/lib/table/sql.ts
@@ -52,7 +52,7 @@ const ALLOWED_OPERATORS = new Set([
  * @param filter - Filter object with field conditions and logical operators
  * @param tableName - Table name for the query (e.g., 'user_table_rows')
  * @returns SQL WHERE clause or undefined if no filter specified
- * @throws Error if field name is invalid or operator is not allowed
+ * @throws {TableQueryValidationError} if field name is invalid or operator is not allowed
  *
  * @example
  * // Simple equality
@@ -121,7 +121,7 @@ export function buildFilterClause(filter: Filter, tableName: string): SQL | unde
  * @param tableName - Table name for the query (e.g., 'user_table_rows')
  * @param columns - Optional column definitions for type-aware sorting
  * @returns SQL ORDER BY clause or undefined if no sort specified
- * @throws Error if field name is invalid
+ * @throws {TableQueryValidationError} if field name or sort direction is invalid
  *
  * @example
  * buildSortClause({ name: 'asc', age: 'desc' }, 'user_table_rows')
@@ -161,7 +161,7 @@ export function buildSortClause(
  * Field names must match the NAME_PATTERN (alphanumeric + underscore, starting with letter/underscore).
  *
  * @param field - The field name to validate
- * @throws Error if field name is invalid
+ * @throws {TableQueryValidationError} if field name is invalid
  */
 function validateFieldName(field: string): void {
   if (!field || typeof field !== 'string') {
@@ -179,7 +179,7 @@ function validateFieldName(field: string): void {
  * Validates an operator to ensure it's in the allowed list.
  *
  * @param operator - The operator to validate
- * @throws Error if operator is not allowed
+ * @throws {TableQueryValidationError} if operator is not allowed
  */
 function validateOperator(operator: string): void {
   if (!ALLOWED_OPERATORS.has(operator)) {
@@ -203,7 +203,7 @@ function validateOperator(operator: string): void {
  *                    object with operators like $eq, $gt, $in, etc.
  * @returns Array of SQL condition fragments. Multiple conditions are returned
  *          when the condition object contains multiple operators.
- * @throws Error if field name is invalid or operator is not allowed
+ * @throws {TableQueryValidationError} if field name is invalid or operator is not allowed
  */
 function buildFieldCondition(
   tableName: string,
@@ -273,8 +273,10 @@ function buildFieldCondition(
           break
 
         default:
-          // This should never happen due to validateOperator, but added for completeness
-          throw new TableQueryValidationError(`Unsupported operator: ${op}`)
+          // This should never happen due to validateOperator, but added for completeness.
+          // Throw a plain Error (→ 500) since reaching this default means the switch
+          // and ALLOWED_OPERATORS have drifted — that's a programmer error, not a caller error.
+          throw new Error(`Unsupported operator: ${op}`)
       }
     }
   } else {


### PR DESCRIPTION
## Summary
- Introduce `TableQueryValidationError` in `lib/table/sql.ts` and throw it from `buildSortClause`/`buildFilterClause` for caller-supplied bad input (invalid sort direction, invalid field name, invalid operator).
- Catch it in v0 and v1 `/tables/[id]/rows` GET/PUT/DELETE handlers and return 400 with the original message instead of the generic 500.
- Fixes case where `?sort={"column":"date","direction":"desc"}` (wrong shape) silently 500'd; now returns a clear 400 the caller can react to.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. All 38 existing `lib/table/__tests__/sql.test.ts` tests pass (error messages preserved). `bun run check:api-validation` passes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)