### PR TITLE
fix(knowledge): revert column width multipliers that misaligned Name header

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -84,11 +84,11 @@ const DOCUMENTS_PER_PAGE = 50
 
 const DOCUMENT_COLUMNS: ResourceColumn[] = [
   { id: 'name', header: 'Name' },
-  { id: 'size', header: 'Size', widthMultiplier: 0.625 },
-  { id: 'tokens', header: 'Tokens', widthMultiplier: 0.625 },
-  { id: 'chunks', header: 'Chunks', widthMultiplier: 0.5 },
-  { id: 'uploaded', header: 'Uploaded', widthMultiplier: 0.75 },
-  { id: 'status', header: 'Status', widthMultiplier: 0.875 },
+  { id: 'size', header: 'Size' },
+  { id: 'tokens', header: 'Tokens' },
+  { id: 'chunks', header: 'Chunks' },
+  { id: 'uploaded', header: 'Uploaded' },
+  { id: 'status', header: 'Status' },
   { id: 'tags', header: 'Tags' },
 ]
 


### PR DESCRIPTION
## Summary
- Revert `widthMultiplier` values on `DOCUMENT_COLUMNS` in the KB documents page
- The multipliers shrunk numeric/badge columns, but the slack flowed into the Name column (`table-fixed` + `w-full`), making the Name header appear visually offset from the data on KB while other resource pages stayed flush left
- Tighter numeric columns can come back later via a proper layout primitive (trailing spacer or fractional widths)

## Type of Change
- [x] Bug fix

## Testing
Tested manually on the KB documents page — Name column now matches Files / Tables / Scheduled Tasks layout.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)