### PR TITLE
fix(executor): strip childTraceSpans from block state before LLM tool calls

### DIFF
--- a/apps/sim/executor/execution/block-executor.ts
+++ b/apps/sim/executor/execution/block-executor.ts
@@ -187,7 +187,8 @@ export class BlockExecutor {
         }
       }
 
-      this.state.setBlockOutput(node.id, normalizedOutput, duration)
+      const { childTraceSpans: _traces, ...outputForState } = normalizedOutput
+      this.state.setBlockOutput(node.id, outputForState as NormalizedBlockOutput, duration)
 
       if (!isSentinel && blockLog) {
         const childWorkflowInstanceId =
@@ -270,7 +271,6 @@ export class BlockExecutor {
     }
 
     if (ChildWorkflowError.isChildWorkflowError(error)) {
-      errorOutput.childTraceSpans = error.childTraceSpans
       errorOutput.childWorkflowName = error.childWorkflowName
       if (error.childWorkflowSnapshotId) {
         errorOutput.childWorkflowSnapshotId = error.childWorkflowSnapshotId
@@ -287,8 +287,8 @@ export class BlockExecutor {
       blockLog.input = this.sanitizeInputsForLog(input)
       blockLog.output = filterOutputForLog(block.metadata?.id || '', errorOutput, { block })
 
-      if (errorOutput.childTraceSpans && Array.isArray(errorOutput.childTraceSpans)) {
-        blockLog.childTraceSpans = errorOutput.childTraceSpans
+      if (ChildWorkflowError.isChildWorkflowError(error) && error.childTraceSpans.length > 0) {
+        blockLog.childTraceSpans = error.childTraceSpans
       }
     }
 

--- a/apps/sim/executor/execution/block-executor.ts
+++ b/apps/sim/executor/execution/block-executor.ts
@@ -212,7 +212,7 @@ export class BlockExecutor {
         )
       }
 
-      return normalizedOutput
+      return outputForState as NormalizedBlockOutput
     } catch (error) {
       return await this.handleBlockError(
         error,


### PR DESCRIPTION
## Summary
- When a workflow block runs a child workflow inline, the execution trace (`childTraceSpans`) was being stored in execution state alongside the actual output
- Downstream Agent blocks reading that state sent the full trace to the LLM as tool result context — up to 148k tokens for workflows processing ~50 records, and over the 200k context limit at larger scale
- Strip `childTraceSpans` from the output before `setBlockOutput` on the success path; never put it in `errorOutput` on the failure path — it stays in `blockLog` only, which is where the Logs UI reads it from

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)