### PR TITLE
fix(mothership): catch draft restore errors instead of crashing /home

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -11,6 +11,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import { createLogger } from '@sim/logger'
 import { Paperclip } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { Button, Tooltip } from '@/components/emcn'
@@ -57,6 +58,8 @@ import { useMothershipDraftsStore } from '@/stores/mothership-drafts/store'
 import type { ChatContext } from '@/stores/panel'
 
 export type { FileAttachmentForApi } from '@/app/workspace/[workspaceId]/home/types'
+
+const logger = createLogger('UserInput')
 
 function getCaretAnchor(
   textarea: HTMLTextAreaElement,
@@ -190,34 +193,42 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
   useEffect(() => {
     if (hasRestoredDraftRef.current || !draftScopeKey) return
     hasRestoredDraftRef.current = true
+    let restoredContexts: ChatContext[] | null = null
+    let restoredFiles: AttachedFile[] | null = null
+    let caretText: string | null = null
     try {
       const draft = useMothershipDraftsStore.getState().drafts[draftScopeKey]
       if (!draft) return
       if (draft.contexts?.length) {
-        contextManagement.setSelectedContexts(draft.contexts)
+        restoredContexts = draft.contexts
       }
       if (draft.fileAttachments?.length) {
-        files.restoreAttachedFiles(
-          draft.fileAttachments.map((a) => ({
-            id: a.id,
-            name: a.filename,
-            size: a.size,
-            type: a.media_type,
-            path: a.path ?? '',
-            key: a.key,
-            uploading: false,
-          }))
-        )
+        restoredFiles = draft.fileAttachments.map((a) => ({
+          id: a.id,
+          name: a.filename,
+          size: a.size,
+          type: a.media_type,
+          path: a.path ?? '',
+          key: a.key,
+          uploading: false,
+        }))
       }
       if (typeof draft.text === 'string' && draft.text.length > 0) {
-        const textarea = textareaRef.current
-        if (textarea) {
-          textarea.focus()
-          textarea.setSelectionRange(draft.text.length, draft.text.length)
-        }
+        caretText = draft.text
       }
-    } catch {
+    } catch (err) {
+      logger.error('Failed to read draft, clearing', { err })
       useMothershipDraftsStore.getState().clearDraft(draftScopeKey)
+      return
+    }
+    if (restoredContexts) contextManagement.setSelectedContexts(restoredContexts)
+    if (restoredFiles) files.restoreAttachedFiles(restoredFiles)
+    if (caretText !== null) {
+      const textarea = textareaRef.current
+      if (textarea) {
+        textarea.focus()
+        textarea.setSelectionRange(caretText.length, caretText.length)
+      }
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps -- intentional mount-only restore
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -148,7 +148,8 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
   const [value, setValue] = useState(() => {
     if (defaultValue) return defaultValue
     if (!draftScopeKey) return ''
-    return useMothershipDraftsStore.getState().drafts[draftScopeKey]?.text ?? ''
+    const text = useMothershipDraftsStore.getState().drafts[draftScopeKey]?.text
+    return typeof text === 'string' ? text : ''
   })
   const overlayRef = useRef<HTMLDivElement>(null)
   const plusMenuRef = useRef<PlusMenuHandle>(null)
@@ -189,30 +190,34 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
   useEffect(() => {
     if (hasRestoredDraftRef.current || !draftScopeKey) return
     hasRestoredDraftRef.current = true
-    const draft = useMothershipDraftsStore.getState().drafts[draftScopeKey]
-    if (!draft) return
-    if (draft.contexts?.length) {
-      contextManagement.setSelectedContexts(draft.contexts)
-    }
-    if (draft.fileAttachments?.length) {
-      files.restoreAttachedFiles(
-        draft.fileAttachments.map((a) => ({
-          id: a.id,
-          name: a.filename,
-          size: a.size,
-          type: a.media_type,
-          path: a.path ?? '',
-          key: a.key,
-          uploading: false,
-        }))
-      )
-    }
-    if (draft.text) {
-      const textarea = textareaRef.current
-      if (textarea) {
-        textarea.focus()
-        textarea.setSelectionRange(draft.text.length, draft.text.length)
+    try {
+      const draft = useMothershipDraftsStore.getState().drafts[draftScopeKey]
+      if (!draft) return
+      if (draft.contexts?.length) {
+        contextManagement.setSelectedContexts(draft.contexts)
       }
+      if (draft.fileAttachments?.length) {
+        files.restoreAttachedFiles(
+          draft.fileAttachments.map((a) => ({
+            id: a.id,
+            name: a.filename,
+            size: a.size,
+            type: a.media_type,
+            path: a.path ?? '',
+            key: a.key,
+            uploading: false,
+          }))
+        )
+      }
+      if (typeof draft.text === 'string' && draft.text.length > 0) {
+        const textarea = textareaRef.current
+        if (textarea) {
+          textarea.focus()
+          textarea.setSelectionRange(draft.text.length, draft.text.length)
+        }
+      }
+    } catch {
+      useMothershipDraftsStore.getState().clearDraft(draftScopeKey)
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps -- intentional mount-only restore
 


### PR DESCRIPTION
## Summary
- Wrap the mount-time draft restore effect in try/catch and call `clearDraft` on throw, so a corrupt `mothership-drafts:v1` localStorage entry no longer takes down the entire workspace via the error boundary
- Coerce `text` to a string in the `useState` initializer so a non-string truthy value doesn't crash render before the effect runs

## Type of Change
- [x] Bug fix

## Testing
Tested manually — set `mothership-drafts:v1` to malformed values in DevTools, page renders and the bad draft is silently dropped on next interaction.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)