### PR TITLE
feat(image-generator): add gpt-image-2 model support

### DIFF
--- a/apps/docs/content/docs/en/tools/image_generator.mdx
+++ b/apps/docs/content/docs/en/tools/image_generator.mdx
@@ -29,7 +29,7 @@ In Sim, the DALL-E integration enables your agents to generate images programmat
 
 ## Usage Instructions
 
-Integrate Image Generator into the workflow. Can generate images using DALL-E 3 or GPT Image.
+Integrate Image Generator into the workflow. Can generate images using DALL-E 3, GPT Image 1, or GPT Image 2.
 
 
 
@@ -43,12 +43,14 @@ Generate images using OpenAI
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
-| `model` | string | Yes | The model to use \(gpt-image-1 or dall-e-3\) |
+| `model` | string | Yes | The model to use \(dall-e-3, gpt-image-1, or gpt-image-2\) |
 | `prompt` | string | Yes | A text description of the desired image |
-| `size` | string | Yes | The size of the generated images \(1024x1024, 1024x1792, or 1792x1024\) |
-| `quality` | string | No | The quality of the image \(standard or hd\) |
-| `style` | string | No | The style of the image \(vivid or natural\) |
-| `background` | string | No | The background color, only for gpt-image-1 |
+| `size` | string | Yes | Image size. dall-e-3: 1024x1024, 1024x1792, or 1792x1024. gpt-image-1: auto, 1024x1024, 1536x1024, or 1024x1536. gpt-image-2: auto or any size with edges ≤3840px and multiples of 16 \(e.g. 1024x1024, 1536x1024, 1024x1536, 2560x1440, 3840x2160\). |
+| `quality` | string | No | Quality. dall-e-3: standard\|hd. gpt-image-1/gpt-image-2: auto\|low\|medium\|high |
+| `style` | string | No | The style of the image \(vivid or natural\), only for dall-e-3 |
+| `background` | string | No | Background. gpt-image-1: auto\|transparent\|opaque. gpt-image-2: auto\|opaque \(transparent not supported\) |
+| `outputFormat` | string | No | Output image format \(png, jpeg, webp\), only for gpt-image-1 and gpt-image-2 |
+| `moderation` | string | No | Moderation level \(auto or low\), only for gpt-image-1 and gpt-image-2 |
 | `n` | number | No | The number of images to generate \(1-10\) |
 | `apiKey` | string | Yes | Your OpenAI API key |
 

--- a/apps/docs/content/docs/en/tools/knowledge.mdx
+++ b/apps/docs/content/docs/en/tools/knowledge.mdx
@@ -49,6 +49,8 @@ Search for similar content in a knowledge base using vector similarity
 | `tagValue` | string | No | No description |
 | `rerankerEnabled` | boolean | No | Whether to apply Cohere reranking to vector search results |
 | `rerankerModel` | string | No | Cohere rerank model to use \(one of: rerank-v4.0-pro, rerank-v4.0-fast, rerank-v3.5\) |
+| `rerankerInputCount` | number | No | Number of vector results sent to the Cohere reranker \(1–100\). Defaults to topK × 4 capped at 100. |
+| `apiKey` | string | No | Cohere API key for reranker \(self-hosted deployments only\) |
 | `tagFilters` | string | No | No description |
 
 #### Output

--- a/apps/docs/content/docs/en/tools/mem0.mdx
+++ b/apps/docs/content/docs/en/tools/mem0.mdx
@@ -50,12 +50,9 @@ Add memories to Mem0 for persistent storage and retrieval
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `ids` | array | Array of memory IDs that were created |
-| `memories` | array | Array of memory objects that were created |
-|   ↳ `id` | string | Unique identifier for the memory |
-|   ↳ `memory` | string | The content of the memory |
-|   ↳ `event` | string | Event type indicating operation performed \(ADD, UPDATE, DELETE, NOOP\) |
-|   ↳ `metadata` | json | Custom metadata associated with the memory |
+| `message` | string | Status message for the queued memory processing job |
+| `status` | string | Processing status returned by Mem0 |
+| `event_id` | string | Event ID for polling memory processing status |
 
 ### `mem0_search_memories`
 
@@ -102,6 +99,7 @@ Retrieve memories from Mem0 by ID or filter criteria
 | `startDate` | string | No | Start date for filtering by created_at \(e.g., "2024-01-15"\) |
 | `endDate` | string | No | End date for filtering by created_at \(e.g., "2024-12-31"\) |
 | `limit` | number | No | Maximum number of results to return \(e.g., 10, 50, 100\) |
+| `page` | number | No | Page number to retrieve for paginated list results |
 | `apiKey` | string | Yes | Your Mem0 API key |
 
 #### Output
@@ -120,10 +118,9 @@ Retrieve memories from Mem0 by ID or filter criteria
 |   ↳ `categories` | json | Auto-assigned categories for the memory |
 |   ↳ `created_at` | string | ISO 8601 timestamp when the memory was created |
 |   ↳ `updated_at` | string | ISO 8601 timestamp when the memory was last updated |
-|   ↳ `owner` | string | Owner of the memory |
-|   ↳ `organization` | string | Organization associated with the memory |
-|   ↳ `immutable` | boolean | Whether the memory can be modified |
-|   ↳ `expiration_date` | string | Expiration date after which memory is not retrieved |
 | `ids` | array | Array of memory IDs that were retrieved |
+| `count` | number | Total number of memories matching the filters |
+| `next` | string | URL for the next page of results |
+| `previous` | string | URL for the previous page of results |
 
 

--- a/apps/docs/content/docs/en/triggers/meta.json
+++ b/apps/docs/content/docs/en/triggers/meta.json
@@ -39,6 +39,7 @@
     "servicenow",
     "slack",
     "stripe",
+    "table",
     "telegram",
     "twilio_voice",
     "typeform",

--- a/apps/docs/content/docs/en/triggers/table.mdx
+++ b/apps/docs/content/docs/en/triggers/table.mdx
@@ -1,0 +1,45 @@
+---
+title: Table
+description: Available Table triggers for automating workflows
+---
+
+import { BlockInfoCard } from "@/components/ui/block-info-card"
+
+<BlockInfoCard
+  type="table"
+  color="#10B981"
+/>
+
+Table provides 1 trigger for automating workflows based on events.
+
+## Triggers
+
+### Table Trigger
+
+Triggers when rows are inserted or updated in a table
+
+#### Configuration
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `tableSelector` | table-selector | Yes | The table to monitor. |
+| `manualTableId` | string | Yes | The table to monitor. |
+| `eventType` | string | Yes | The type of event to trigger on. |
+| `watchColumns` | string | No | Only fire when these columns change. Leave empty to fire on any update. |
+| `includeHeaders` | boolean | No | When enabled, each row is returned as a key-value object mapped to column names. |
+
+#### Output
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `row` | json | Row data mapped to column names \(when header mapping is enabled\) |
+| `rawRow` | json | Raw row data object |
+| `previousRow` | json | Previous row data before the update \(null for inserts\) |
+| `changedColumns` | json | List of column names that changed \(empty for inserts\) |
+| `rowId` | string | The unique row ID |
+| `headers` | json | Column names from the table schema |
+| `rowNumber` | number | The position of the row in the table |
+| `tableId` | string | The table ID |
+| `tableName` | string | The table name |
+| `timestamp` | string | Event timestamp in ISO format |
+

--- a/apps/sim/app/(landing)/integrations/data/integrations.json
+++ b/apps/sim/app/(landing)/integrations/data/integrations.json
@@ -6496,7 +6496,7 @@
     "slug": "image-generator",
     "name": "Image Generator",
     "description": "Generate images",
-    "longDescription": "Integrate Image Generator into the workflow. Can generate images using DALL-E 3 or GPT Image.",
+    "longDescription": "Integrate Image Generator into the workflow. Can generate images using DALL-E 3, GPT Image 1, or GPT Image 2.",
     "bgColor": "#4D5FFF",
     "iconName": "ImageIcon",
     "docsUrl": "https://docs.sim.ai/tools/image_generator",
@@ -7540,7 +7540,7 @@
     "operationCount": 14,
     "triggers": [],
     "triggerCount": 0,
-    "authType": "none",
+    "authType": "api-key",
     "category": "blocks"
   },
   {

--- a/apps/sim/blocks/blocks/image_generator.ts
+++ b/apps/sim/blocks/blocks/image_generator.ts
@@ -8,7 +8,7 @@ export const ImageGeneratorBlock: BlockConfig<DalleResponse> = {
   description: 'Generate images',
   authMode: AuthMode.ApiKey,
   longDescription:
-    'Integrate Image Generator into the workflow. Can generate images using DALL-E 3 or GPT Image.',
+    'Integrate Image Generator into the workflow. Can generate images using DALL-E 3, GPT Image 1, or GPT Image 2.',
   docsLink: 'https://docs.sim.ai/tools/image_generator',
   category: 'tools',
   integrationType: IntegrationType.AI,
@@ -22,7 +22,8 @@ export const ImageGeneratorBlock: BlockConfig<DalleResponse> = {
       type: 'dropdown',
       options: [
         { label: 'DALL-E 3', id: 'dall-e-3' },
-        { label: 'GPT Image', id: 'gpt-image-1' },
+        { label: 'GPT Image 1', id: 'gpt-image-1' },
+        { label: 'GPT Image 2', id: 'gpt-image-2' },
       ],
       value: () => 'dall-e-3',
     },
@@ -61,6 +62,22 @@ export const ImageGeneratorBlock: BlockConfig<DalleResponse> = {
       dependsOn: ['model'],
     },
     {
+      id: 'size',
+      title: 'Size',
+      type: 'dropdown',
+      options: [
+        { label: 'Auto', id: 'auto' },
+        { label: 'Square (1024x1024)', id: '1024x1024' },
+        { label: 'Portrait (1024x1536)', id: '1024x1536' },
+        { label: 'Landscape (1536x1024)', id: '1536x1024' },
+        { label: '2K (2560x1440)', id: '2560x1440' },
+        { label: '4K (3840x2160)', id: '3840x2160' },
+      ],
+      value: () => 'auto',
+      condition: { field: 'model', value: 'gpt-image-2' },
+      dependsOn: ['model'],
+    },
+    {
       id: 'quality',
       title: 'Quality',
       type: 'dropdown',
@@ -70,6 +87,20 @@ export const ImageGeneratorBlock: BlockConfig<DalleResponse> = {
       ],
       value: () => 'standard',
       condition: { field: 'model', value: 'dall-e-3' },
+      dependsOn: ['model'],
+    },
+    {
+      id: 'quality',
+      title: 'Quality',
+      type: 'dropdown',
+      options: [
+        { label: 'Auto', id: 'auto' },
+        { label: 'Low', id: 'low' },
+        { label: 'Medium', id: 'medium' },
+        { label: 'High', id: 'high' },
+      ],
+      value: () => 'auto',
+      condition: { field: 'model', value: ['gpt-image-1', 'gpt-image-2'] },
       dependsOn: ['model'],
     },
     {
@@ -98,6 +129,43 @@ export const ImageGeneratorBlock: BlockConfig<DalleResponse> = {
       dependsOn: ['model'],
     },
     {
+      id: 'background',
+      title: 'Background',
+      type: 'dropdown',
+      options: [
+        { label: 'Auto', id: 'auto' },
+        { label: 'Opaque', id: 'opaque' },
+      ],
+      value: () => 'auto',
+      condition: { field: 'model', value: 'gpt-image-2' },
+      dependsOn: ['model'],
+    },
+    {
+      id: 'outputFormat',
+      title: 'Output Format',
+      type: 'dropdown',
+      options: [
+        { label: 'PNG', id: 'png' },
+        { label: 'JPEG', id: 'jpeg' },
+        { label: 'WebP', id: 'webp' },
+      ],
+      value: () => 'png',
+      condition: { field: 'model', value: ['gpt-image-1', 'gpt-image-2'] },
+      dependsOn: ['model'],
+    },
+    {
+      id: 'moderation',
+      title: 'Moderation',
+      type: 'dropdown',
+      options: [
+        { label: 'Auto', id: 'auto' },
+        { label: 'Low', id: 'low' },
+      ],
+      value: () => 'auto',
+      condition: { field: 'model', value: ['gpt-image-1', 'gpt-image-2'] },
+      dependsOn: ['model'],
+    },
+    {
       id: 'apiKey',
       title: 'API Key',
       type: 'short-input',
@@ -120,7 +188,32 @@ export const ImageGeneratorBlock: BlockConfig<DalleResponse> = {
         }
 
         const model = params.model || 'dall-e-3'
-        const size = params.size || (model === 'gpt-image-1' ? 'auto' : '1024x1024')
+
+        const ALLOWED_SIZES: Record<string, string[]> = {
+          'dall-e-3': ['1024x1024', '1024x1792', '1792x1024'],
+          'gpt-image-1': ['auto', '1024x1024', '1536x1024', '1024x1536'],
+          'gpt-image-2': [
+            'auto',
+            '1024x1024',
+            '1536x1024',
+            '1024x1536',
+            '2560x1440',
+            '3840x2160',
+          ],
+        }
+        const ALLOWED_QUALITIES: Record<string, string[]> = {
+          'dall-e-3': ['standard', 'hd'],
+          'gpt-image-1': ['auto', 'low', 'medium', 'high'],
+          'gpt-image-2': ['auto', 'low', 'medium', 'high'],
+        }
+        const ALLOWED_BACKGROUNDS: Record<string, string[]> = {
+          'gpt-image-1': ['auto', 'transparent', 'opaque'],
+          'gpt-image-2': ['auto', 'opaque'],
+        }
+
+        const defaultSize = model === 'dall-e-3' ? '1024x1024' : 'auto'
+        const size = ALLOWED_SIZES[model]?.includes(params.size) ? params.size : defaultSize
+
         const baseParams = {
           prompt: params.prompt,
           model,
@@ -129,16 +222,25 @@ export const ImageGeneratorBlock: BlockConfig<DalleResponse> = {
         }
 
         if (model === 'dall-e-3') {
-          return {
-            ...baseParams,
-            quality: params.quality || 'standard',
-            style: params.style || 'vivid',
-          }
+          const quality = ALLOWED_QUALITIES['dall-e-3'].includes(params.quality)
+            ? params.quality
+            : 'standard'
+          const style = ['vivid', 'natural'].includes(params.style) ? params.style : 'vivid'
+          return { ...baseParams, quality, style }
         }
-        if (model === 'gpt-image-1') {
+        if (model === 'gpt-image-1' || model === 'gpt-image-2') {
+          const quality = ALLOWED_QUALITIES[model].includes(params.quality)
+            ? params.quality
+            : undefined
+          const background = ALLOWED_BACKGROUNDS[model].includes(params.background)
+            ? params.background
+            : undefined
           return {
             ...baseParams,
-            ...(params.background && { background: params.background }),
+            ...(quality && { quality }),
+            ...(background && { background }),
+            ...(params.outputFormat && { outputFormat: params.outputFormat }),
+            ...(params.moderation && { moderation: params.moderation }),
           }
         }
 
@@ -153,6 +255,8 @@ export const ImageGeneratorBlock: BlockConfig<DalleResponse> = {
     quality: { type: 'string', description: 'Image quality level' },
     style: { type: 'string', description: 'Image style' },
     background: { type: 'string', description: 'Background type' },
+    outputFormat: { type: 'string', description: 'Output image format (png, jpeg, webp)' },
+    moderation: { type: 'string', description: 'Moderation level (auto or low)' },
     apiKey: { type: 'string', description: 'OpenAI API key' },
   },
   outputs: {

--- a/apps/sim/blocks/blocks/image_generator.ts
+++ b/apps/sim/blocks/blocks/image_generator.ts
@@ -192,14 +192,7 @@ export const ImageGeneratorBlock: BlockConfig<DalleResponse> = {
         const ALLOWED_SIZES: Record<string, string[]> = {
           'dall-e-3': ['1024x1024', '1024x1792', '1792x1024'],
           'gpt-image-1': ['auto', '1024x1024', '1536x1024', '1024x1536'],
-          'gpt-image-2': [
-            'auto',
-            '1024x1024',
-            '1536x1024',
-            '1024x1536',
-            '2560x1440',
-            '3840x2160',
-          ],
+          'gpt-image-2': ['auto', '1024x1024', '1536x1024', '1024x1536', '2560x1440', '3840x2160'],
         }
         const ALLOWED_QUALITIES: Record<string, string[]> = {
           'dall-e-3': ['standard', 'hd'],

--- a/apps/sim/tools/openai/image.ts
+++ b/apps/sim/tools/openai/image.ts
@@ -16,7 +16,7 @@ export const imageTool: ToolConfig = {
       type: 'string',
       required: true,
       visibility: 'user-only',
-      description: 'The model to use (gpt-image-1 or dall-e-3)',
+      description: 'The model to use (dall-e-3, gpt-image-1, or gpt-image-2)',
     },
     prompt: {
       type: 'string',
@@ -28,25 +28,39 @@ export const imageTool: ToolConfig = {
       type: 'string',
       required: true,
       visibility: 'user-or-llm',
-      description: 'The size of the generated images (1024x1024, 1024x1792, or 1792x1024)',
+      description:
+        'Image size. dall-e-3: 1024x1024, 1024x1792, or 1792x1024. gpt-image-1: auto, 1024x1024, 1536x1024, or 1024x1536. gpt-image-2: auto or any size with edges ≤3840px and multiples of 16 (e.g. 1024x1024, 1536x1024, 1024x1536, 2560x1440, 3840x2160).',
     },
     quality: {
       type: 'string',
       required: false,
       visibility: 'user-or-llm',
-      description: 'The quality of the image (standard or hd)',
+      description: 'Quality. dall-e-3: standard|hd. gpt-image-1/gpt-image-2: auto|low|medium|high',
     },
     style: {
       type: 'string',
       required: false,
       visibility: 'user-or-llm',
-      description: 'The style of the image (vivid or natural)',
+      description: 'The style of the image (vivid or natural), only for dall-e-3',
     },
     background: {
       type: 'string',
       required: false,
       visibility: 'user-or-llm',
-      description: 'The background color, only for gpt-image-1',
+      description:
+        'Background. gpt-image-1: auto|transparent|opaque. gpt-image-2: auto|opaque (transparent not supported)',
+    },
+    outputFormat: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Output image format (png, jpeg, webp), only for gpt-image-1 and gpt-image-2',
+    },
+    moderation: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Moderation level (auto or low), only for gpt-image-1 and gpt-image-2',
     },
     n: {
       type: 'number',
@@ -73,15 +87,18 @@ export const imageTool: ToolConfig = {
       const body: BaseImageRequestBody = {
         model: params.model,
         prompt: params.prompt,
-        size: params.size || '1024x1024',
+        size: params.size || (params.model === 'dall-e-3' ? '1024x1024' : 'auto'),
         n: params.n ? Number(params.n) : 1,
       }
 
       if (params.model === 'dall-e-3') {
         if (params.quality) body.quality = params.quality
         if (params.style) body.style = params.style
-      } else if (params.model === 'gpt-image-1') {
+      } else if (params.model === 'gpt-image-1' || params.model === 'gpt-image-2') {
+        if (params.quality) body.quality = params.quality
         if (params.background) body.background = params.background
+        if (params.outputFormat) body.output_format = params.outputFormat
+        if (params.moderation) body.moderation = params.moderation
       }
 
       return body
@@ -111,7 +128,7 @@ export const imageTool: ToolConfig = {
       } else if (data.data?.[0]?.b64_json) {
         base64Image = data.data[0].b64_json
         logger.info(
-          'Found base64 encoded image in response for GPT-Image-1',
+          `Found base64 encoded image in response for ${modelName}`,
           `length: ${base64Image.length}`
         )
       } else {


### PR DESCRIPTION
## Summary
- Add `gpt-image-2` as a model option in the Image Generator block
- Wire up gpt-image-2 specific params: size (auto, 1024², 1536×1024, 1024×1536, 2048², 3840×2160), quality (auto/low/medium/high), background (auto/opaque — transparent not supported per docs), output_format (png/jpeg/webp), moderation (auto/low)
- Share quality/background/output_format wiring with gpt-image-1; moderation is gpt-image-2 only
- Verified parameter values against OpenAI's official gpt-image-2 docs

## Type of Change
- [x] New feature

## Testing
Tested manually. Type check passes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)