### PR TITLE
improvement(logs): increase log details panel max width from 40vw to 60vw

### DIFF
--- a/apps/sim/stores/logs/utils.ts
+++ b/apps/sim/stores/logs/utils.ts
@@ -12,7 +12,7 @@ export const DEFAULT_LOG_DETAILS_WIDTH = 520
 export const MAX_LOG_DETAILS_WIDTH_RATIO = 0.6
 
 /**
- * Returns the maximum log details panel width (65% of viewport width).
+ * Returns the maximum log details panel width (60% of viewport width).
  * Falls back to a reasonable default for SSR.
  */
 export const getMaxLogDetailsWidth = () =>
@@ -21,7 +21,7 @@ export const getMaxLogDetailsWidth = () =>
 /**
  * Clamps a width value to the valid panel range for the current viewport.
  * The floor (`MIN_LOG_DETAILS_WIDTH`) is itself capped by the viewport ratio
- * so a small viewport never produces a panel that covers more than 65vw.
+ * so a small viewport never produces a panel that covers more than 60vw.
  */
 export const clampPanelWidth = (width: number) => {
   const max = getMaxLogDetailsWidth()

--- a/apps/sim/stores/logs/utils.ts
+++ b/apps/sim/stores/logs/utils.ts
@@ -9,10 +9,10 @@
  */
 export const MIN_LOG_DETAILS_WIDTH = 320
 export const DEFAULT_LOG_DETAILS_WIDTH = 520
-export const MAX_LOG_DETAILS_WIDTH_RATIO = 0.4
+export const MAX_LOG_DETAILS_WIDTH_RATIO = 0.6
 
 /**
- * Returns the maximum log details panel width (65vw).
+ * Returns the maximum log details panel width (65% of viewport width).
  * Falls back to a reasonable default for SSR.
  */
 export const getMaxLogDetailsWidth = () =>


### PR DESCRIPTION
## Summary
- Increased the max draggable width of the log details side panel from 40vw to 60vw

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)