### PR TITLE
fix(posthog): align tool params with subBlock canonical to fix missing-field error

### DIFF
--- a/apps/sim/scripts/check-block-registry.ts
+++ b/apps/sim/scripts/check-block-registry.ts
@@ -196,11 +196,18 @@ function checkCanonicalIdContract(): CheckResult {
     const access: string[] = block.tools?.access ?? []
     if (access.length === 0) continue
 
+    // A subBlock with `canonicalParamId` has its raw `id` deleted from `params` during
+    // canonical-group resolution in `extractParams` (serializer/index.ts), so the raw id is
+    // NOT a valid lookup key at execution time — only the canonical is. Tool params must
+    // align with the canonical, not the raw id.
     const subBlockKeys = new Set<string>()
     for (const sb of block.subBlocks ?? []) {
-      if (sb.id) subBlockKeys.add(sb.id)
       const canonical = (sb as { canonicalParamId?: string }).canonicalParamId
-      if (canonical) subBlockKeys.add(canonical)
+      if (canonical) {
+        subBlockKeys.add(canonical)
+      } else if (sb.id) {
+        subBlockKeys.add(sb.id)
+      }
     }
 
     for (const toolId of access) {

--- a/apps/sim/tools/posthog/delete_person.ts
+++ b/apps/sim/tools/posthog/delete_person.ts
@@ -1,7 +1,7 @@
 import type { ToolConfig } from '@/tools/types'
 
 export interface PostHogDeletePersonParams {
-  personalApiKey: string
+  apiKey: string
   region?: 'us' | 'eu'
   projectId: string
   personId: string
@@ -23,7 +23,7 @@ export const deletePersonTool: ToolConfig<PostHogDeletePersonParams, PostHogDele
     version: '1.0.0',
 
     params: {
-      personalApiKey: {
+      apiKey: {
         type: 'string',
         required: true,
         visibility: 'user-only',
@@ -57,7 +57,7 @@ export const deletePersonTool: ToolConfig<PostHogDeletePersonParams, PostHogDele
       },
       method: 'DELETE',
       headers: (params) => ({
-        Authorization: `Bearer ${params.personalApiKey}`,
+        Authorization: `Bearer ${params.apiKey}`,
         'Content-Type': 'application/json',
       }),
     },

--- a/apps/sim/tools/posthog/get_person.ts
+++ b/apps/sim/tools/posthog/get_person.ts
@@ -1,7 +1,7 @@
 import type { ToolConfig } from '@/tools/types'
 
 export interface PostHogGetPersonParams {
-  personalApiKey: string
+  apiKey: string
   region?: 'us' | 'eu'
   projectId: string
   personId: string
@@ -28,7 +28,7 @@ export const getPersonTool: ToolConfig<PostHogGetPersonParams, PostHogGetPersonR
   version: '1.0.0',
 
   params: {
-    personalApiKey: {
+    apiKey: {
       type: 'string',
       required: true,
       visibility: 'user-only',
@@ -62,7 +62,7 @@ export const getPersonTool: ToolConfig<PostHogGetPersonParams, PostHogGetPersonR
     },
     method: 'GET',
     headers: (params) => ({
-      Authorization: `Bearer ${params.personalApiKey}`,
+      Authorization: `Bearer ${params.apiKey}`,
       'Content-Type': 'application/json',
     }),
   },

--- a/apps/sim/tools/posthog/list_persons.ts
+++ b/apps/sim/tools/posthog/list_persons.ts
@@ -1,7 +1,7 @@
 import type { ToolConfig } from '@/tools/types'
 
 export interface PostHogListPersonsParams {
-  personalApiKey: string
+  apiKey: string
   region?: 'us' | 'eu'
   projectId: string
   limit?: number
@@ -35,7 +35,7 @@ export const listPersonsTool: ToolConfig<PostHogListPersonsParams, PostHogListPe
   version: '1.0.0',
 
   params: {
-    personalApiKey: {
+    apiKey: {
       type: 'string',
       required: true,
       visibility: 'user-only',
@@ -95,7 +95,7 @@ export const listPersonsTool: ToolConfig<PostHogListPersonsParams, PostHogListPe
     },
     method: 'GET',
     headers: (params) => ({
-      Authorization: `Bearer ${params.personalApiKey}`,
+      Authorization: `Bearer ${params.apiKey}`,
       'Content-Type': 'application/json',
     }),
   },

--- a/apps/sim/tools/posthog/query.ts
+++ b/apps/sim/tools/posthog/query.ts
@@ -1,7 +1,7 @@
 import type { ToolConfig } from '@/tools/types'
 
 export interface PostHogQueryParams {
-  personalApiKey: string
+  apiKey: string
   region?: 'us' | 'eu'
   projectId: string
   query: string
@@ -27,7 +27,7 @@ export const queryTool: ToolConfig<PostHogQueryParams, PostHogQueryResponse> = {
   version: '1.0.0',
 
   params: {
-    personalApiKey: {
+    apiKey: {
       type: 'string',
       required: true,
       visibility: 'user-only',
@@ -69,7 +69,7 @@ export const queryTool: ToolConfig<PostHogQueryParams, PostHogQueryResponse> = {
     },
     method: 'POST',
     headers: (params) => ({
-      Authorization: `Bearer ${params.personalApiKey}`,
+      Authorization: `Bearer ${params.apiKey}`,
       'Content-Type': 'application/json',
     }),
     body: (params) => {

--- a/apps/sim/tools/posthog/types.ts
+++ b/apps/sim/tools/posthog/types.ts
@@ -11,7 +11,7 @@ export interface PostHogPublicParams extends PostHogBaseParams {
 }
 
 export interface PostHogPrivateParams extends PostHogBaseParams {
-  personalApiKey: string
+  apiKey: string
   projectId: string
 }
 


### PR DESCRIPTION
## Summary
- Tool params were named `personalApiKey` while the subBlock resolves to canonical `apiKey`, so canonical-group resolution wrote the value to `params.apiKey` while the validator looked up `params.personalApiKey` and reported it as missing
- Renames `personalApiKey` → `apiKey` in `get_person`, `query`, `list_persons`, `delete_person`, and `types.ts`
- Tightens `check-block-registry.ts` so a subBlock with `canonicalParamId` no longer satisfies a tool param lookup by its raw id (the raw id is deleted during extraction)
- SubBlock id `personalApiKey` is unchanged, so persisted user workflows are unaffected

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Serializer suite + canonical-id audit pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)