### PR TITLE
fix(ui): grey subagent tool calls and soften failure copy

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/agent-group.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/agent-group.tsx
@@ -42,6 +42,7 @@ export function AgentGroup({
 }: AgentGroupProps) {
   const AgentIcon = getAgentIcon(agentName)
   const hasItems = items.length > 0
+  const isSubagent = agentName !== 'mothership'
   const toolItems = items.filter(
     (item): item is Extract<AgentGroupItem, { type: 'tool' }> => item.type === 'tool'
   )
@@ -112,7 +113,7 @@ export function AgentGroup({
         <Expandable expanded={expanded}>
           <ExpandableContent>
             <BoundedViewport isStreaming={isStreaming}>
-              <div className='flex flex-col gap-1.5 py-0.5'>
+              <div className={cn('flex flex-col gap-1.5 py-0.5', isSubagent && 'opacity-60')}>
                 {items.map((item, idx) => {
                   if (item.type === 'tool') {
                     return (
@@ -128,7 +129,7 @@ export function AgentGroup({
                   return (
                     <span
                       key={`text-${idx}`}
-                      className='pl-6 font-base text-[13px] text-[var(--text-secondary)] leading-[18px] opacity-60'
+                      className='pl-6 font-base text-[13px] text-[var(--text-secondary)] leading-[18px]'
                     >
                       {item.content.trim()}
                     </span>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/tool-call-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/tool-call-item.tsx
@@ -94,7 +94,7 @@ export function ToolCallItem({ toolName, displayTitle, status, streamingArgs }: 
   }, [toolName, streamingArgs])
 
   return (
-    <div className='flex items-center gap-[8px] pl-[24px]'>
+    <div className='flex items-center gap-[8px] pl-[24px] opacity-60'>
       <div className='flex h-[16px] w-[16px] flex-shrink-0 items-center justify-center'>
         <StatusIcon status={status} toolName={toolName} />
       </div>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/tool-call-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/tool-call-item.tsx
@@ -94,7 +94,7 @@ export function ToolCallItem({ toolName, displayTitle, status, streamingArgs }: 
   }, [toolName, streamingArgs])
 
   return (
-    <div className='flex items-center gap-[8px] pl-[24px] opacity-60'>
+    <div className='flex items-center gap-[8px] pl-[24px]'>
       <div className='flex h-[16px] w-[16px] flex-shrink-0 items-center justify-center'>
         <StatusIcon status={status} toolName={toolName} />
       </div>

--- a/apps/sim/lib/copilot/tools/client/store-utils.ts
+++ b/apps/sim/lib/copilot/tools/client/store-utils.ts
@@ -127,14 +127,16 @@ function humanizedFallback(
   toolName: string,
   state: ClientToolCallState
 ): ClientToolDisplay | undefined {
-  const formattedName = toolName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+  const titleCaseName = toolName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+  if (state === ClientToolCallState.error) {
+    const lowerCaseName = toolName.replace(/_/g, ' ').toLowerCase()
+    return { text: `Attempted to ${lowerCaseName}`, icon: Loader }
+  }
   const stateVerb =
     state === ClientToolCallState.success
       ? 'Executed'
-      : state === ClientToolCallState.error
-        ? 'Attempted to'
-        : state === ClientToolCallState.rejected || state === ClientToolCallState.aborted
-          ? 'Skipped'
-          : 'Executing'
-  return { text: `${stateVerb} ${formattedName}`, icon: Loader }
+      : state === ClientToolCallState.rejected || state === ClientToolCallState.aborted
+        ? 'Skipped'
+        : 'Executing'
+  return { text: `${stateVerb} ${titleCaseName}`, icon: Loader }
 }

--- a/apps/sim/lib/copilot/tools/client/store-utils.ts
+++ b/apps/sim/lib/copilot/tools/client/store-utils.ts
@@ -71,7 +71,7 @@ function formatReadingLabel(target: string | undefined, state: ClientToolCallSta
     case ClientToolCallState.success:
       return `Read${suffix}`
     case ClientToolCallState.error:
-      return `Failed reading${suffix}`
+      return `Attempted to read${suffix}`
     case ClientToolCallState.rejected:
     case ClientToolCallState.aborted:
       return `Skipped reading${suffix}`
@@ -132,7 +132,7 @@ function humanizedFallback(
     state === ClientToolCallState.success
       ? 'Executed'
       : state === ClientToolCallState.error
-        ? 'Failed'
+        ? 'Attempted to'
         : state === ClientToolCallState.rejected || state === ClientToolCallState.aborted
           ? 'Skipped'
           : 'Executing'


### PR DESCRIPTION
## Summary
- Apply `opacity-60` to subagent tool-call rows so they fade to match the surrounding subagent text (previously text was greyed but tool calls stayed full-opacity).
- Replace user-facing "Failed" tool-result label with "Attempted to" — `Failed reading X` → `Attempted to read X`, and humanized fallback `Failed Foo Bar` → `Attempted to Foo Bar`.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run lint` and `bun run check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)