### PR TITLE
fix(agent): drop temperature param for claude-opus-4-7

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -576,7 +576,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
           updatedAt: '2026-04-16',
         },
         capabilities: {
-          temperature: { min: 0, max: 1 },
           nativeStructuredOutputs: true,
           maxOutputTokens: 128000,
           thinking: {


### PR DESCRIPTION
## Summary
- Remove `temperature` capability from `claude-opus-4-7` in `providers/models.ts` since Anthropic deprecated the parameter for this model
- `supportsTemperature('claude-opus-4-7')` now returns false, so the Anthropic provider skips sending `temperature` in the payload and the agent block hides the temperature slider for this model

## Type of Change
- [x] Bug fix

## Testing
- Ran `bun run lint` — clean
- Ran `bun run check:api-validation:strict` — passed
- Ran `bunx vitest run providers/utils.test.ts blocks/blocks/agent.test.ts` — 139 tests passing
- Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)