### PR TITLE
improvement(next): bundle and CI cache config

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -44,13 +44,11 @@ jobs:
           key: ${{ github.repository }}-turbo-cache
           path: ./.turbo
 
-      - name: Restore Next.js build cache
-        uses: actions/cache@v5
+      - name: Mount Next.js build cache (Sticky Disk)
+        uses: useblacksmith/stickydisk@v1
         with:
+          key: ${{ github.repository }}-nextjs-cache
           path: ./apps/sim/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -10,6 +10,7 @@ import {
 
 const nextConfig: NextConfig = {
   devIndicators: false,
+  poweredByHeader: false,
   images: {
     formats: ['image/avif', 'image/webp'],
     remotePatterns: [
@@ -75,9 +76,6 @@ const nextConfig: NextConfig = {
     ignoreBuildErrors: isTruthy(env.DOCKER_BUILD),
   },
   output: isTruthy(env.DOCKER_BUILD) ? 'standalone' : undefined,
-  turbopack: {
-    resolveExtensions: ['.tsx', '.ts', '.jsx', '.js', '.mjs', '.json'],
-  },
   serverExternalPackages: [
     '@1password/sdk',
     'unpdf',
@@ -99,11 +97,9 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     optimizeCss: true,
-    turbopackSourceMaps: false,
-    turbopackFileSystemCacheForDev: true,
     preloadEntriesOnStart: false,
+    turbopackFileSystemCacheForBuild: true,
     optimizePackageImports: [
-      'lucide-react',
       'lodash',
       'framer-motion',
       'reactflow',
@@ -119,7 +115,6 @@ const nextConfig: NextConfig = {
       '@radix-ui/react-slider',
       'streamdown',
       'zod',
-      'date-fns',
     ],
   },
   ...(isDev && {


### PR DESCRIPTION
## Summary
- drop redundant turbopack config (Next 16 makes them defaults)
- remove `lucide-react`/`date-fns` from `optimizePackageImports` (Next 16 built-in defaults)
- enable `experimental.turbopackFileSystemCacheForBuild` for warm CI builds
- disable `poweredByHeader`
- swap `actions/cache` for Blacksmith sticky disk on `.next/cache` (~3s mount, survives lockfile changes)

## Type of Change
- [x] Improvement

## Testing
Tested manually — built locally with Turbopack, ran experimental bundle analyzer to confirm `lucide-react`/`date-fns` are tree-shaken by default in Next 16.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)