### PR TITLE
improvement(seo): restore explicit AI/search bot allow-list and add link-preview rules

### DIFF
--- a/apps/sim/app/robots.ts
+++ b/apps/sim/app/robots.ts
@@ -24,11 +24,14 @@ const DISALLOWED_PATHS = [
 /**
  * Tighter disallow list for link-preview bots. They fetch single URLs to
  * render Open Graph cards rather than crawl, so publicly-shareable surfaces
- * like /chat/, /form/, and /w/ must be reachable for previews to render.
+ * like /chat/ and /form/ must be reachable for previews to render. Other
+ * authenticated routes (/workspace/, /w/, /playground/) stay blocked.
  */
 const LINK_PREVIEW_DISALLOWED_PATHS = [
   '/api/',
   '/workspace/',
+  '/w/',
+  '/playground/',
   '/resume/',
   '/invite/',
   '/unsubscribe/',
@@ -49,7 +52,6 @@ const SEARCH_AND_AI_BOTS = [
   'Bingbot',
   'DuckDuckBot',
   'Kagibot',
-  'Bravebot',
   // Regional search engines
   'YandexBot',
   'Baiduspider',
@@ -82,7 +84,9 @@ const SEARCH_AND_AI_BOTS = [
   'CCBot',
   'cohere-ai',
   'cohere-training-data-crawler',
-  'Grok-web-crawl',
+  'GrokBot',
+  'xAI-Grok',
+  'Grok-DeepSearch',
   'MistralAI-User',
   'DeepSeek-AI',
   'YouBot',

--- a/apps/sim/app/robots.ts
+++ b/apps/sim/app/robots.ts
@@ -41,60 +41,6 @@ const LINK_PREVIEW_DISALLOWED_PATHS = [
 ]
 
 /**
- * Search engines and AI/answer-engine crawlers explicitly allow-listed for
- * SEO/AEO/GEO. Explicit Allow rules ensure these bots are not accidentally
- * suppressed by downstream filters and signal intent to operators that
- * publish allow-list audits (Profound, Scrunch, Otterly, etc.).
- */
-const SEARCH_AND_AI_BOTS = [
-  // Western search engines
-  'Googlebot',
-  'Bingbot',
-  'DuckDuckBot',
-  'Kagibot',
-  'Bravebot',
-  // Regional search engines
-  'YandexBot',
-  'Baiduspider',
-  'Sogou web spider',
-  'Yeti',
-  'SeznamBot',
-  'PetalBot',
-  // OpenAI
-  'GPTBot',
-  'OAI-SearchBot',
-  'ChatGPT-User',
-  // Anthropic
-  'ClaudeBot',
-  'Claude-SearchBot',
-  'Claude-User',
-  // Google AI
-  'Google-Extended',
-  // Perplexity
-  'PerplexityBot',
-  'Perplexity-User',
-  // Apple
-  'Applebot',
-  'Applebot-Extended',
-  // Meta
-  'Meta-ExternalAgent',
-  'Meta-ExternalFetcher',
-  'FacebookBot',
-  // Other major AI / answer engines
-  'Amazonbot',
-  'CCBot',
-  'cohere-ai',
-  'cohere-training-data-crawler',
-  'MistralAI-User',
-  'DeepSeekBot',
-  'YouBot',
-  'Diffbot',
-  'AI2Bot',
-  'Timpibot',
-  'ImagesiftBot',
-]
-
-/**
  * Social and messaging platforms that fetch URLs to render link previews
  * (Open Graph / Twitter Card images). These need access to publicly-shared
  * surfaces like /chat/ and /form/ that are otherwise blocked.
@@ -118,7 +64,6 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       { userAgent: '*', allow: '/', disallow: DISALLOWED_PATHS },
-      { userAgent: SEARCH_AND_AI_BOTS, allow: '/', disallow: DISALLOWED_PATHS },
       {
         userAgent: LINK_PREVIEW_BOTS,
         allow: '/',

--- a/apps/sim/app/robots.ts
+++ b/apps/sim/app/robots.ts
@@ -1,10 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { getBaseUrl } from '@/lib/core/utils/urls'
 
-/**
- * Default disallow list applied to crawlers and the wildcard rule. Blocks
- * authenticated surfaces, internal endpoints, and one-time-use links.
- */
 const DISALLOWED_PATHS = [
   '/api/',
   '/workspace/',
@@ -21,12 +17,7 @@ const DISALLOWED_PATHS = [
   '/blog*tag=',
 ]
 
-/**
- * Tighter disallow list for link-preview bots. They fetch single URLs to
- * render Open Graph cards rather than crawl, so publicly-shareable surfaces
- * like /chat/ and /form/ must be reachable for previews to render. Other
- * authenticated routes (/workspace/, /w/, /playground/) stay blocked.
- */
+/** Looser disallow than the wildcard so OG previews can fetch /chat/ and /form/. */
 const LINK_PREVIEW_DISALLOWED_PATHS = [
   '/api/',
   '/workspace/',
@@ -40,11 +31,6 @@ const LINK_PREVIEW_DISALLOWED_PATHS = [
   '/private/',
 ]
 
-/**
- * Social and messaging platforms that fetch URLs to render link previews
- * (Open Graph / Twitter Card images). These need access to publicly-shared
- * surfaces like /chat/ and /form/ that are otherwise blocked.
- */
 const LINK_PREVIEW_BOTS = [
   'Twitterbot',
   'LinkedInBot',

--- a/apps/sim/app/robots.ts
+++ b/apps/sim/app/robots.ts
@@ -1,29 +1,126 @@
 import type { MetadataRoute } from 'next'
 import { getBaseUrl } from '@/lib/core/utils/urls'
 
+/**
+ * Default disallow list applied to crawlers and the wildcard rule. Blocks
+ * authenticated surfaces, internal endpoints, and one-time-use links.
+ */
+const DISALLOWED_PATHS = [
+  '/api/',
+  '/workspace/',
+  '/chat/',
+  '/playground/',
+  '/resume/',
+  '/invite/',
+  '/unsubscribe/',
+  '/w/',
+  '/form/',
+  '/credential-account/',
+  '/_next/',
+  '/private/',
+  '/blog*tag=',
+]
+
+/**
+ * Tighter disallow list for link-preview bots. They fetch single URLs to
+ * render Open Graph cards rather than crawl, so publicly-shareable surfaces
+ * like /chat/, /form/, and /w/ must be reachable for previews to render.
+ */
+const LINK_PREVIEW_DISALLOWED_PATHS = [
+  '/api/',
+  '/workspace/',
+  '/resume/',
+  '/invite/',
+  '/unsubscribe/',
+  '/credential-account/',
+  '/_next/',
+  '/private/',
+]
+
+/**
+ * Search engines and AI/answer-engine crawlers explicitly allow-listed for
+ * SEO/AEO/GEO. Explicit Allow rules ensure these bots are not accidentally
+ * suppressed by downstream filters and signal intent to operators that
+ * publish allow-list audits (Profound, Scrunch, Otterly, etc.).
+ */
+const SEARCH_AND_AI_BOTS = [
+  // Western search engines
+  'Googlebot',
+  'Bingbot',
+  'DuckDuckBot',
+  'Kagibot',
+  'Bravebot',
+  // Regional search engines
+  'YandexBot',
+  'Baiduspider',
+  'Sogou web spider',
+  'Yeti',
+  'SeznamBot',
+  'PetalBot',
+  // OpenAI
+  'GPTBot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  // Anthropic
+  'ClaudeBot',
+  'Claude-SearchBot',
+  'Claude-User',
+  // Google AI
+  'Google-Extended',
+  // Perplexity
+  'PerplexityBot',
+  'Perplexity-User',
+  // Apple
+  'Applebot',
+  'Applebot-Extended',
+  // Meta
+  'Meta-ExternalAgent',
+  'Meta-ExternalFetcher',
+  'FacebookBot',
+  // Other major AI / answer engines
+  'Amazonbot',
+  'CCBot',
+  'cohere-ai',
+  'cohere-training-data-crawler',
+  'Grok-web-crawl',
+  'MistralAI-User',
+  'DeepSeek-AI',
+  'YouBot',
+  'Diffbot',
+  'AI2Bot',
+  'Timpibot',
+  'ImageSiftBot',
+]
+
+/**
+ * Social and messaging platforms that fetch URLs to render link previews
+ * (Open Graph / Twitter Card images). These need access to publicly-shared
+ * surfaces like /chat/ and /form/ that are otherwise blocked.
+ */
+const LINK_PREVIEW_BOTS = [
+  'Twitterbot',
+  'LinkedInBot',
+  'Slackbot',
+  'Slack-ImgProxy',
+  'Discordbot',
+  'TelegramBot',
+  'WhatsApp',
+  'facebookexternalhit',
+  'Pinterestbot',
+  'redditbot',
+]
+
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = getBaseUrl()
 
   return {
     rules: [
+      { userAgent: '*', allow: '/', disallow: DISALLOWED_PATHS },
+      { userAgent: SEARCH_AND_AI_BOTS, allow: '/', disallow: DISALLOWED_PATHS },
       {
-        userAgent: '*',
+        userAgent: LINK_PREVIEW_BOTS,
         allow: '/',
-        disallow: [
-          '/api/',
-          '/workspace/',
-          '/chat/',
-          '/playground/',
-          '/resume/',
-          '/invite/',
-          '/unsubscribe/',
-          '/w/',
-          '/form/',
-          '/credential-account/',
-          '/_next/',
-          '/private/',
-          '/blog*tag=',
-        ],
+        disallow: LINK_PREVIEW_DISALLOWED_PATHS,
       },
     ],
     sitemap: [`${baseUrl}/sitemap.xml`, `${baseUrl}/blog/sitemap-images.xml`],

--- a/apps/sim/app/robots.ts
+++ b/apps/sim/app/robots.ts
@@ -84,16 +84,13 @@ const SEARCH_AND_AI_BOTS = [
   'CCBot',
   'cohere-ai',
   'cohere-training-data-crawler',
-  'GrokBot',
-  'xAI-Grok',
-  'Grok-DeepSearch',
   'MistralAI-User',
-  'DeepSeek-AI',
+  'DeepSeekBot',
   'YouBot',
   'Diffbot',
   'AI2Bot',
   'Timpibot',
-  'ImageSiftBot',
+  'ImagesiftBot',
 ]
 
 /**

--- a/apps/sim/app/robots.ts
+++ b/apps/sim/app/robots.ts
@@ -52,6 +52,7 @@ const SEARCH_AND_AI_BOTS = [
   'Bingbot',
   'DuckDuckBot',
   'Kagibot',
+  'Bravebot',
   // Regional search engines
   'YandexBot',
   'Baiduspider',


### PR DESCRIPTION
## Summary
- Restore proper robots.txt structure that PR #4170 collapsed into a single wildcard rule (suspected culprit for the Profound metric drop on Apr 18).
- Wildcard rule (`User-agent: *`) allows crawling with a tight disallow list for authenticated surfaces and internal endpoints. Any new AI/search crawler is auto-allowed without code changes.
- Separate group for link-preview bots (Twitter/LinkedIn/Slack/Discord/etc.) with a looser disallow list so OG cards render for shared `/chat/` and `/form/` URLs.
- No named AI/search bot allow-list — it's functionally redundant against the wildcard and goes stale fast. Behavior is identical for any compliant crawler.

## Type of Change
- [x] Bug fix

## Testing
Tested manually — typecheck passes, `bun run lint` clean. Output verified to render the expected two rule groups per Next.js Metadata API.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)