### PR TITLE
fix(workday): correct SOAP service routing and reference types

### DIFF
--- a/apps/sim/app/api/tools/workday/assign-onboarding/route.ts
+++ b/apps/sim/app/api/tools/workday/assign-onboarding/route.ts
@@ -36,7 +36,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       Onboarding_Plan_Assignment_Data: {
         Onboarding_Plan_Reference: wdRef('Onboarding_Plan_ID', data.onboardingPlanId),
         Person_Reference: wdRef('WID', data.workerId),
-        Action_Event_Reference: wdRef('Background_Check_ID', data.actionEventId),
+        Action_Event_Reference: wdRef('WID', data.actionEventId),
         Assignment_Effective_Moment: new Date().toISOString(),
         Active: true,
       },

--- a/apps/sim/app/api/tools/workday/create-prehire/route.ts
+++ b/apps/sim/app/api/tools/workday/create-prehire/route.ts
@@ -48,7 +48,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     const client = await createWorkdaySoapClient(
       data.tenantUrl,
       data.tenant,
-      'staffing',
+      'recruiting',
       data.username,
       data.password
     )

--- a/apps/sim/blocks/blocks/workday.ts
+++ b/apps/sim/blocks/blocks/workday.ts
@@ -243,7 +243,7 @@ export const WorkdayBlock: BlockConfig = {
         prompt: `Generate a Workday Personal_Information_Data payload as JSON for the Change_Personal_Information SOAP operation.
 
 ### SUPPORTED FIELDS (demographics only)
-- Date_Of_Birth: ISO date string (YYYY-MM-DD)
+- Date_of_Birth: ISO date string (YYYY-MM-DD)
 - Gender_Reference: { ID: { attributes: { "wd:type": "Gender_Code" }, $value: "Male" | "Female" | ... } }
 - Marital_Status_Reference: { ID: { attributes: { "wd:type": "Marital_Status_ID" }, $value: "Married" | "Single" | ... } }
 - Ethnicity_Reference: { ID: { attributes: { "wd:type": "Ethnicity_ID" }, $value: "..." } }

--- a/apps/sim/blocks/blocks/workday.ts
+++ b/apps/sim/blocks/blocks/workday.ts
@@ -24,7 +24,7 @@ export const WorkdayBlock: BlockConfig = {
         { label: 'List Workers', id: 'list_workers' },
         { label: 'Create Pre-Hire', id: 'create_prehire' },
         { label: 'Hire Employee', id: 'hire_employee' },
-        { label: 'Update Worker', id: 'update_worker' },
+        { label: 'Update Personal Information', id: 'update_worker' },
         { label: 'Assign Onboarding Plan', id: 'assign_onboarding' },
         { label: 'Get Organizations', id: 'get_organizations' },
         { label: 'Change Job', id: 'change_job' },
@@ -228,31 +228,38 @@ export const WorkdayBlock: BlockConfig = {
     // Update Worker
     {
       id: 'fields',
-      title: 'Fields (JSON)',
+      title: 'Personal Information (JSON)',
       type: 'code',
       language: 'json',
       placeholder:
-        '{\n  "businessTitle": "Senior Engineer",\n  "primaryWorkEmail": "new@company.com"\n}',
+        '{\n  "Marital_Status_Reference": {\n    "ID": { "attributes": { "wd:type": "Marital_Status_ID" }, "$value": "Married" }\n  }\n}',
+      description:
+        'Demographic fields supported by Workday Change_Personal_Information (e.g. Date_of_Birth, Gender_Reference, Marital_Status_Reference, Ethnicity_Reference, Citizenship_Status_Reference). Does not update business title or work contact info.',
       condition: { field: 'operation', value: 'update_worker' },
       required: { field: 'operation', value: 'update_worker' },
       wandConfig: {
         enabled: true,
         maintainHistory: true,
-        prompt: `Generate a Workday worker update payload as JSON.
+        prompt: `Generate a Workday Personal_Information_Data payload as JSON for the Change_Personal_Information SOAP operation.
 
-### COMMON FIELDS
-- businessTitle: Job title string
-- primaryWorkEmail: Work email address
-- primaryWorkPhone: Work phone number
-- managerReference: Manager worker ID
+### SUPPORTED FIELDS (demographics only)
+- Date_Of_Birth: ISO date string (YYYY-MM-DD)
+- Gender_Reference: { ID: { attributes: { "wd:type": "Gender_Code" }, $value: "Male" | "Female" | ... } }
+- Marital_Status_Reference: { ID: { attributes: { "wd:type": "Marital_Status_ID" }, $value: "Married" | "Single" | ... } }
+- Ethnicity_Reference: { ID: { attributes: { "wd:type": "Ethnicity_ID" }, $value: "..." } }
+- Citizenship_Status_Reference: same shape
+
+### NOT SUPPORTED BY THIS OPERATION
+- Business title (use Change_Job)
+- Work email / phone / manager (different SOAP ops)
 
 ### RULES
 - Output ONLY valid JSON starting with { and ending with }
 - Include only fields that need updating
 
 ### EXAMPLE
-User: "Update title to Senior Engineer"
-Output: {"businessTitle": "Senior Engineer"}`,
+User: "Mark marital status as Married"
+Output: {"Marital_Status_Reference":{"ID":{"attributes":{"wd:type":"Marital_Status_ID"},"$value":"Married"}}}`,
         generationType: 'json-object',
       },
     },
@@ -424,8 +431,16 @@ Output: {"businessTitle": "Senior Engineer"}`,
     lastDayOfWork: { type: 'string', description: 'Last day of work' },
   },
   outputs: {
-    worker: { type: 'json', description: 'Worker profile data' },
-    workers: { type: 'json', description: 'Array of worker profiles' },
+    worker: {
+      type: 'json',
+      description:
+        'Worker profile (id, descriptor, primaryWorkEmail, primaryWorkPhone, businessTitle, supervisoryOrganization, hireDate, workerType, isActive)',
+    },
+    workers: {
+      type: 'json',
+      description:
+        'Array of worker profiles (id, descriptor, primaryWorkEmail, businessTitle, supervisoryOrganization, hireDate, workerType, isActive)',
+    },
     total: { type: 'number', description: 'Total count of results' },
     preHireId: { type: 'string', description: 'Created pre-hire ID' },
     descriptor: { type: 'string', description: 'Display name of pre-hire' },
@@ -434,10 +449,16 @@ Output: {"businessTitle": "Senior Engineer"}`,
     hireDate: { type: 'string', description: 'Hire date' },
     assignmentId: { type: 'string', description: 'Onboarding assignment ID' },
     planId: { type: 'string', description: 'Onboarding plan ID' },
-    organizations: { type: 'json', description: 'Array of organizations' },
+    organizations: {
+      type: 'json',
+      description: 'Array of organizations (id, descriptor, type, subtype, isActive)',
+    },
     eventId: { type: 'string', description: 'Event ID for staffing changes' },
     effectiveDate: { type: 'string', description: 'Effective date of change' },
-    compensationPlans: { type: 'json', description: 'Compensation plan details' },
+    compensationPlans: {
+      type: 'json',
+      description: 'Compensation plans (id, planName, amount, currency, frequency)',
+    },
     terminationDate: { type: 'string', description: 'Termination date' },
   },
 }


### PR DESCRIPTION
## Summary
- Route Put_Applicant to Recruiting service (was Staffing, where the op does not exist — every Create Pre-Hire call would 500)
- Use WID for assign-onboarding Action_Event_Reference (was Background_Check_ID, wrong ID domain for hire events)
- Rewrite Update Worker block labels + wand prompt to match Change_Personal_Information's demographic-only scope (prior prompt asked the LLM to emit businessTitle/primaryWorkEmail, which this SOAP op rejects)
- Enrich opaque JSON output descriptions on worker/workers/organizations/compensationPlans so downstream blocks can reference inner fields

## Type of Change
- [x] Bug fix

## Testing
Validated each route against Workday Web Services v45 docs (Recruiting/Put_Applicant, HR/Put_Onboarding_Plan_Assignment, HR/Change_Personal_Information, Staffing/Hire_Employee, Staffing/Terminate_Employee). TypeScript compiles clean; lint passes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)