### PR TITLE
fix(billing): drop transaction wrapper in recordUsage to relieve pool contention

### DIFF
--- a/apps/sim/lib/billing/core/usage-log.ts
+++ b/apps/sim/lib/billing/core/usage-log.ts
@@ -71,15 +71,13 @@ export interface RecordUsageParams {
 }
 
 /**
- * Records usage in a single atomic transaction.
+ * Records usage by inserting into usage_log and incrementing userStats counters.
  *
- * Inserts all entries into usage_log and updates userStats counters
- * (totalCost, currentPeriodCost, lastActive) within one Postgres transaction.
- * The total cost added to userStats is derived from summing entry costs,
- * ensuring usage_log and currentPeriodCost can never drift apart.
- *
- * If billing is disabled, total cost is zero, or no entries have positive cost,
- * this function returns early without writing anything.
+ * The two writes are intentionally not wrapped in a transaction: under high
+ * concurrency for the same userId, holding BEGIN/COMMIT across the user_stats
+ * row-lock wait pins pgbouncer connections and exhausts the pool. usage_log
+ * is the source of truth; if the userStats UPDATE fails the counter drifts
+ * and must be reconciled from usage_log out-of-band.
  */
 export async function recordUsage(params: RecordUsageParams): Promise<void> {
   if (!isBillingEnabled) {
@@ -103,47 +101,52 @@ export async function recordUsage(params: RecordUsageParams): Promise<void> {
     ? Object.fromEntries(Object.entries(additionalStats).filter(([k]) => !RESERVED_KEYS.has(k)))
     : undefined
 
-  await db.transaction(async (tx) => {
-    if (validEntries.length > 0) {
-      await tx.insert(usageLog).values(
-        validEntries.map((entry) => ({
-          id: generateId(),
-          userId,
-          category: entry.category,
-          source: entry.source,
-          description: entry.description,
-          metadata: entry.metadata ?? null,
-          cost: entry.cost.toString(),
-          workspaceId: workspaceId ?? null,
-          workflowId: workflowId ?? null,
-          executionId: executionId ?? null,
-        }))
-      )
-    }
+  if (validEntries.length > 0) {
+    await db.insert(usageLog).values(
+      validEntries.map((entry) => ({
+        id: generateId(),
+        userId,
+        category: entry.category,
+        source: entry.source,
+        description: entry.description,
+        metadata: entry.metadata ?? null,
+        cost: entry.cost.toString(),
+        workspaceId: workspaceId ?? null,
+        workflowId: workflowId ?? null,
+        executionId: executionId ?? null,
+      }))
+    )
+  }
 
-    const updateFields: Record<string, SQL | Date> = {
-      lastActive: new Date(),
-      ...(totalCost > 0 && {
-        totalCost: sql`total_cost + ${totalCost}`,
-        currentPeriodCost: sql`current_period_cost + ${totalCost}`,
-      }),
-      ...safeStats,
-    }
+  const updateFields: Record<string, SQL | Date> = {
+    lastActive: new Date(),
+    ...(totalCost > 0 && {
+      totalCost: sql`total_cost + ${totalCost}`,
+      currentPeriodCost: sql`current_period_cost + ${totalCost}`,
+    }),
+    ...safeStats,
+  }
 
-    const result = await tx
+  try {
+    const result = await db
       .update(userStats)
       .set(updateFields)
       .where(eq(userStats.userId, userId))
       .returning({ userId: userStats.userId })
 
     if (result.length === 0) {
-      logger.warn('recordUsage: userStats row not found, transaction will roll back', {
+      logger.warn('recordUsage: userStats row not found; counter will drift from usage_log', {
         userId,
         totalCost,
       })
-      throw new Error(`userStats row not found for userId: ${userId}`)
     }
-  })
+  } catch (error) {
+    logger.error('recordUsage: userStats update failed; counter will drift from usage_log', {
+      error: toError(error).message,
+      userId,
+      totalCost,
+    })
+  }
 
   logger.debug('Recorded usage', {
     userId,

--- a/apps/sim/lib/billing/core/usage-log.ts
+++ b/apps/sim/lib/billing/core/usage-log.ts
@@ -75,9 +75,13 @@ export interface RecordUsageParams {
  *
  * The two writes are intentionally not wrapped in a transaction: under high
  * concurrency for the same userId, holding BEGIN/COMMIT across the user_stats
- * row-lock wait pins pgbouncer connections and exhausts the pool. usage_log
- * is the source of truth; if the userStats UPDATE fails the counter drifts
- * and must be reconciled from usage_log out-of-band.
+ * row-lock wait pins pgbouncer connections and exhausts the pool.
+ *
+ * usage_log is the source of truth and the INSERT propagates errors to the
+ * caller. The userStats UPDATE is best-effort: failures (and missing-row
+ * cases) are logged as warnings and swallowed. Counter drift is acceptable
+ * here — the long-term plan is to derive counters from usage_log directly.
+ * Any drift warning in logs is a signal that needs investigation.
  */
 export async function recordUsage(params: RecordUsageParams): Promise<void> {
   if (!isBillingEnabled) {
@@ -135,16 +139,20 @@ export async function recordUsage(params: RecordUsageParams): Promise<void> {
       .returning({ userId: userStats.userId })
 
     if (result.length === 0) {
-      logger.warn('recordUsage: userStats row not found; counter will drift from usage_log', {
+      logger.warn('recordUsage: userStats row not found; counter increment dropped', {
         userId,
         totalCost,
+        hadEntries: validEntries.length > 0,
+        additionalStatsKeys: safeStats ? Object.keys(safeStats) : [],
       })
     }
   } catch (error) {
-    logger.error('recordUsage: userStats update failed; counter will drift from usage_log', {
+    logger.warn('recordUsage: userStats update failed; counter increment dropped', {
       error: toError(error).message,
       userId,
       totalCost,
+      hadEntries: validEntries.length > 0,
+      additionalStatsKeys: safeStats ? Object.keys(safeStats) : [],
     })
   }
 


### PR DESCRIPTION
## Summary
- Split `recordUsage()` in `apps/sim/lib/billing/core/usage-log.ts` into two independent statements (INSERT into `usage_log`, UPDATE on `user_stats`) instead of one wrapped transaction
- Under high concurrency for a single user (~90 workflow finishes in seconds), the transaction wrapper pinned pgbouncer connections through the entire `user_stats` row-lock wait, exhausting the pool and failing unrelated requests with `query_wait_timeout` and connection-terminated errors
- Without the transaction, each statement only holds its connection while executing, so contention stays inside Postgres's row-lock queue and does not bleed into the pool
- `usage_log` is the source of truth (immutable ledger); if the `user_stats` UPDATE fails after a successful INSERT the counter drifts and must be reconciled from `usage_log` out-of-band. The "row not found" case now logs a warning instead of throwing (no transaction to roll back)

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run lint` clean, `bun run check:api-validation:strict` passes, `tsc --noEmit` clean for the touched file. No tests directly cover `recordUsage`. Followup: add a periodic reconciler that SUMs `usage_log` per period and corrects `user_stats.currentPeriodCost` to recover from any UPDATE failures.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)