### PR TITLE
fix(logs): relax fileSchema so execution logs with files render again

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/file-download/file-download.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/file-download/file-download.tsx
@@ -5,6 +5,7 @@ import { createLogger } from '@sim/logger'
 import { ArrowDown } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { Button, Loader } from '@/components/emcn'
+import { cn } from '@/lib/core/utils/cn'
 import { extractWorkspaceIdFromExecutionKey, getViewerUrl } from '@/lib/uploads/utils/file-utils'
 
 const logger = createLogger('FileCards')
@@ -16,8 +17,8 @@ interface FileData {
   type: string
   key: string
   url: string
-  uploadedAt: string
-  expiresAt: string
+  uploadedAt?: string
+  expiresAt?: string
   storageProvider?: 's3' | 'blob' | 'local'
   bucketName?: string
 }
@@ -220,7 +221,7 @@ export function FileDownload({
   return (
     <Button
       variant='ghost'
-      className={`h-7 px-2 text-xs ${className}`}
+      className={cn('h-7 px-2 text-xs', className)}
       onClick={handleDownload}
       disabled={isDownloading}
     >

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/file-download/file-download.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/file-download/file-download.tsx
@@ -7,30 +7,18 @@ import { useRouter } from 'next/navigation'
 import { Button, Loader } from '@/components/emcn'
 import { cn } from '@/lib/core/utils/cn'
 import { extractWorkspaceIdFromExecutionKey, getViewerUrl } from '@/lib/uploads/utils/file-utils'
+import type { UserFile } from '@/executor/types'
 
 const logger = createLogger('FileCards')
 
-interface FileData {
-  id?: string
-  name: string
-  size: number
-  type: string
-  key: string
-  url: string
-  uploadedAt?: string
-  expiresAt?: string
-  storageProvider?: 's3' | 'blob' | 'local'
-  bucketName?: string
-}
-
 interface FileCardsProps {
-  files: FileData[]
+  files: UserFile[]
   isExecutionFile?: boolean
   workspaceId?: string
 }
 
 interface FileCardProps {
-  file: FileData
+  file: UserFile
   isExecutionFile?: boolean
   workspaceId?: string
 }
@@ -158,7 +146,7 @@ export function FileDownload({
   className,
   workspaceId,
 }: {
-  file: FileData
+  file: UserFile
   isExecutionFile?: boolean
   className?: string
   workspaceId?: string

--- a/apps/sim/lib/api/contracts/logs.ts
+++ b/apps/sim/lib/api/contracts/logs.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { mediaUserFileSchema } from '@/lib/api/contracts/tools/media/shared'
+import { userFileSchema } from '@/lib/api/contracts/primitives'
 import { defineRouteContract } from '@/lib/api/contracts/types'
 
 const comparisonOperatorSchema = z.enum(['=', '>', '<', '>=', '<=', '!='])
@@ -225,7 +225,7 @@ export const workflowLogSummarySchema = z.object({
 
 export const workflowLogDetailSchema = workflowLogSummarySchema.extend({
   executionData: executionDataDetailSchema,
-  files: z.array(mediaUserFileSchema).nullable(),
+  files: z.array(userFileSchema).nullable(),
 })
 
 export type WorkflowLogSummary = z.output<typeof workflowLogSummarySchema>

--- a/apps/sim/lib/api/contracts/logs.ts
+++ b/apps/sim/lib/api/contracts/logs.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { mediaUserFileSchema } from '@/lib/api/contracts/tools/media/shared'
 import { defineRouteContract } from '@/lib/api/contracts/types'
 
 const comparisonOperatorSchema = z.enum(['=', '>', '<', '>=', '<=', '!='])
@@ -65,19 +66,6 @@ const workflowSummarySchema = z
     updatedAt: z.string().nullable(),
   })
   .partial()
-
-const fileSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  size: z.number(),
-  type: z.string(),
-  url: z.string(),
-  key: z.string(),
-  uploadedAt: z.string().optional(),
-  expiresAt: z.string().optional(),
-  storageProvider: z.enum(['s3', 'blob', 'local']).optional(),
-  bucketName: z.string().optional(),
-})
 
 const tokenBreakdownSchema = z
   .object({
@@ -237,7 +225,7 @@ export const workflowLogSummarySchema = z.object({
 
 export const workflowLogDetailSchema = workflowLogSummarySchema.extend({
   executionData: executionDataDetailSchema,
-  files: z.array(fileSchema).nullable(),
+  files: z.array(mediaUserFileSchema).nullable(),
 })
 
 export type WorkflowLogSummary = z.output<typeof workflowLogSummarySchema>

--- a/apps/sim/lib/api/contracts/logs.ts
+++ b/apps/sim/lib/api/contracts/logs.ts
@@ -73,8 +73,8 @@ const fileSchema = z.object({
   type: z.string(),
   url: z.string(),
   key: z.string(),
-  uploadedAt: z.string(),
-  expiresAt: z.string(),
+  uploadedAt: z.string().optional(),
+  expiresAt: z.string().optional(),
   storageProvider: z.enum(['s3', 'blob', 'local']).optional(),
   bucketName: z.string().optional(),
 })

--- a/apps/sim/lib/api/contracts/primitives.ts
+++ b/apps/sim/lib/api/contracts/primitives.ts
@@ -59,6 +59,26 @@ export const workflowIdSchema = z.string().min(1, 'Workflow ID is required')
  * Use `.optional()` / `.default(...)` at the call site, not here, so each
  * query field controls its own omission/default semantics.
  */
+/**
+ * Canonical boundary schema for `UserFile` (`apps/sim/executor/types.ts`) — the
+ * shape produced by the executor and persisted in `workflowExecutionLogs.files`,
+ * forwarded through tool inputs, and rendered in the logs UI. `.passthrough()`
+ * tolerates legacy/extra fields on stored rows (e.g. `uploadedAt`, `expiresAt`,
+ * `storageProvider`) without rejecting the whole payload.
+ */
+export const userFileSchema = z
+  .object({
+    id: z.string().optional().default(''),
+    name: z.string().min(1),
+    url: z.string().optional().default(''),
+    size: z.coerce.number().nonnegative(),
+    type: z.string().optional().default('application/octet-stream'),
+    key: z.string().min(1),
+    context: z.string().optional(),
+    base64: z.string().optional(),
+  })
+  .passthrough()
+
 export const booleanQueryFlagSchema = z.preprocess(
   (value) => {
     if (typeof value === 'boolean') return value

--- a/apps/sim/lib/api/contracts/tools/media/shared.ts
+++ b/apps/sim/lib/api/contracts/tools/media/shared.ts
@@ -3,19 +3,6 @@ import { z } from 'zod'
 export const AWS_REGION_PATTERN =
   /^(eu-isoe|us-isob|us-iso|us-gov|af|ap|ca|cn|eu|il|me|mx|sa|us)-(central|north|northeast|northwest|south|southeast|southwest|east|west)-\d{1,2}$/
 
-export const mediaUserFileSchema = z
-  .object({
-    id: z.string().optional().default(''),
-    name: z.string().min(1),
-    url: z.string().optional().default(''),
-    size: z.coerce.number().nonnegative(),
-    type: z.string().optional().default('application/octet-stream'),
-    key: z.string().min(1),
-    context: z.string().optional(),
-    base64: z.string().optional(),
-  })
-  .passthrough()
-
 export const toolJsonResponseSchema = z
   .object({
     success: z.boolean().optional(),

--- a/apps/sim/lib/api/contracts/tools/media/stt.ts
+++ b/apps/sim/lib/api/contracts/tools/media/stt.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod'
-import { mediaUserFileSchema, toolJsonResponseSchema } from '@/lib/api/contracts/tools/media/shared'
+import { userFileSchema } from '@/lib/api/contracts/primitives'
+import { toolJsonResponseSchema } from '@/lib/api/contracts/tools/media/shared'
 import { defineRouteContract } from '@/lib/api/contracts/types'
 
 export const sttProviders = ['whisper', 'deepgram', 'elevenlabs', 'assemblyai', 'gemini'] as const
 const MISSING_STT_FIELDS_ERROR = 'Missing required fields: provider and apiKey'
 
-export const sttUserFileSchema = mediaUserFileSchema.extend({
+export const sttUserFileSchema = userFileSchema.extend({
   type: z.string().optional().default(''),
 })
 

--- a/apps/sim/lib/api/contracts/tools/media/video.ts
+++ b/apps/sim/lib/api/contracts/tools/media/video.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
-import { mediaUserFileSchema, toolJsonResponseSchema } from '@/lib/api/contracts/tools/media/shared'
+import { userFileSchema } from '@/lib/api/contracts/primitives'
+import { toolJsonResponseSchema } from '@/lib/api/contracts/tools/media/shared'
 import { defineRouteContract } from '@/lib/api/contracts/types'
 
 export const videoProviders = ['runway', 'veo', 'luma', 'minimax', 'falai'] as const
@@ -19,7 +20,7 @@ export const videoToolBodySchema = z
     duration: z.coerce.number().optional(),
     aspectRatio: z.string().optional(),
     resolution: z.string().optional(),
-    visualReference: mediaUserFileSchema.optional(),
+    visualReference: userFileSchema.optional(),
     cameraControl: z.unknown().optional(),
     endpoint: z.string().optional(),
     promptOptimizer: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- Make `uploadedAt` and `expiresAt` optional in `fileSchema` so contract validation passes for execution log rows whose files (written by `extractFilesFromExecution` and `execution-file-manager`) don't include those fields
- Mirror in the local `FileData` type in `file-download.tsx`; switch its template literal className to `cn()`

Before this fix, `useLogDetail` was throwing `ApiClientError("Response failed contract validation")` on any workflow log with files, the query fell back to the list row (no `files`), and `<FileCards>` never rendered.

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)