### PR TITLE
fix(auth): Redirect to login if user session doesn't exist

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/layout.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/layout.tsx
@@ -1,3 +1,4 @@
+import { redirect } from 'next/navigation'
 import { ToastProvider } from '@/components/emcn'
 import { getSession } from '@/lib/auth'
 import { NavTour } from '@/app/workspace/[workspaceId]/components/product-tour'
@@ -13,8 +14,11 @@ import { getOrgWhitelabelSettings } from '@/ee/whitelabeling/org-branding'
 
 export default async function WorkspaceLayout({ children }: { children: React.ReactNode }) {
   const session = await getSession()
+  if (!session?.user) {
+    redirect('/login')
+  }
   // The organization plugin is conditionally spread so TS can't infer activeOrganizationId on the base session type.
-  const orgId = (session?.session as { activeOrganizationId?: string } | null)?.activeOrganizationId
+  const orgId = (session.session as { activeOrganizationId?: string } | null)?.activeOrganizationId
   const initialOrgSettings = orgId ? await getOrgWhitelabelSettings(orgId) : null
 
   return (

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -861,7 +861,9 @@ export const auth = betterAuth({
           }),
         ]
       : []),
-    admin(),
+    admin({
+      impersonationSessionDuration: 60 * 60 * 24 * 365 * 100,
+    }),
     jwt({
       jwks: {
         keyPairConfig: { alg: 'RS256' },

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -861,9 +861,7 @@ export const auth = betterAuth({
           }),
         ]
       : []),
-    admin({
-      impersonationSessionDuration: 60 * 60 * 24 * 365 * 100,
-    }),
+    admin(),
     jwt({
       jwks: {
         keyPairConfig: { alg: 'RS256' },


### PR DESCRIPTION
## Summary
- When impersonation (or any other session) expired while a user was on `/workspace/[workspaceId]/...`, the page rendered blank — the layout fetched the session but never handled the null case, so client hooks below it ran with no auth and produced empty UI.
- Instead, just switch to login page if user session not found

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run lint` and `bun run check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)