### PR TITLE
fix(files): skip zip and return plain .md when no embedded images

### DIFF
--- a/apps/sim/app/api/files/export/[id]/route.ts
+++ b/apps/sim/app/api/files/export/[id]/route.ts
@@ -86,7 +86,7 @@ export const GET = withRouteHandler(
       MAX_EMBEDDED_IMAGES
     )
 
-    logger.info('Exporting markdown with embedded images', { id, imageCount: imageIds.length })
+    logger.info('Exporting markdown', { id, imageCount: imageIds.length })
 
     const fetchResults = await Promise.allSettled(
       imageIds.map(async (imageId) => {
@@ -120,6 +120,19 @@ export const GET = withRouteHandler(
       const filename = deduplicatedFilename(preferred, usedFilenames, imageId)
       usedFilenames.add(filename)
       assetMap.set(imageId, { filename, buffer })
+    }
+
+    if (assetMap.size === 0) {
+      const mdName = safeFilename(record.originalName)
+      const mdBytes = Buffer.from(mdContent, 'utf-8')
+      return new NextResponse(new Uint8Array(mdBytes), {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/markdown; charset=utf-8',
+          'Content-Disposition': `attachment; filename="${mdName}"`,
+          'Content-Length': String(mdBytes.length),
+        },
+      })
     }
 
     for (const [imageId, asset] of assetMap) {

--- a/apps/sim/app/api/files/export/[id]/route.ts
+++ b/apps/sim/app/api/files/export/[id]/route.ts
@@ -122,7 +122,7 @@ export const GET = withRouteHandler(
       assetMap.set(imageId, { filename, buffer })
     }
 
-    if (assetMap.size === 0) {
+    if (imageIds.length === 0) {
       const mdName = safeFilename(record.originalName)
       const mdBytes = Buffer.from(mdContent, 'utf-8')
       return new NextResponse(new Uint8Array(mdBytes), {

--- a/apps/sim/app/api/files/export/[id]/route.ts
+++ b/apps/sim/app/api/files/export/[id]/route.ts
@@ -88,6 +88,19 @@ export const GET = withRouteHandler(
 
     logger.info('Exporting markdown', { id, imageCount: imageIds.length })
 
+    if (imageIds.length === 0) {
+      const mdName = safeFilename(record.originalName)
+      const mdBytes = Buffer.from(mdContent, 'utf-8')
+      return new NextResponse(new Uint8Array(mdBytes), {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/markdown; charset=utf-8',
+          'Content-Disposition': `attachment; filename="${mdName}"`,
+          'Content-Length': String(mdBytes.length),
+        },
+      })
+    }
+
     const fetchResults = await Promise.allSettled(
       imageIds.map(async (imageId) => {
         const imgRecord = await getFileMetadataById(imageId)
@@ -120,19 +133,6 @@ export const GET = withRouteHandler(
       const filename = deduplicatedFilename(preferred, usedFilenames, imageId)
       usedFilenames.add(filename)
       assetMap.set(imageId, { filename, buffer })
-    }
-
-    if (imageIds.length === 0) {
-      const mdName = safeFilename(record.originalName)
-      const mdBytes = Buffer.from(mdContent, 'utf-8')
-      return new NextResponse(new Uint8Array(mdBytes), {
-        status: 200,
-        headers: {
-          'Content-Type': 'text/markdown; charset=utf-8',
-          'Content-Disposition': `attachment; filename="${mdName}"`,
-          'Content-Length': String(mdBytes.length),
-        },
-      })
     }
 
     for (const [imageId, asset] of assetMap) {


### PR DESCRIPTION
## Summary
- MD files with no embedded image references now download as plain `.md` instead of a `.zip`
- ZIP is only produced when the file contains resolved `/api/files/view/` image assets

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)