### PR TITLE
revert(ci): drop turbopackFileSystemCacheForBuild and restore actions/cache

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -44,11 +44,13 @@ jobs:
           key: ${{ github.repository }}-turbo-cache
           path: ./.turbo
 
-      - name: Mount Next.js build cache (Sticky Disk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Restore Next.js build cache
+        uses: actions/cache@v5
         with:
-          key: ${{ github.repository }}-nextjs-cache
           path: ./apps/sim/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -98,7 +98,6 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizeCss: true,
     preloadEntriesOnStart: false,
-    turbopackFileSystemCacheForBuild: true,
     optimizePackageImports: [
       'lodash',
       'framer-motion',


### PR DESCRIPTION
## Summary
- Removes `experimental.turbopackFileSystemCacheForBuild: true` from `apps/sim/next.config.ts`
- Restores `actions/cache@v5` for `.next/cache` (replaces sticky-disk mount)
- Keeps the zero-risk wins from #4478 (`poweredByHeader: false`, `optimizePackageImports` trim)

## Why
After #4478 merged, CI build times grew monotonically:

| Run | Duration |
|---|---|
| pre-merge baseline (5 runs) | 153–241s |
| post-merge run 1 | 249s |
| post-merge run 13 | 1305s (~22min) |

The Turbopack FS build cache flag is the necessary condition — without it, Turbopack doesn't write FS cache during `next build`, so persistence is moot. Combined with sticky-disk's lack of key-based eviction (7-day idle only), the cache grew unbounded across runs and dominated mount/restore time. Reverting both restores the previous behavior.

## Type of Change
- [x] Bug fix (CI regression)

## Testing
Will verify build duration on this PR returns to the ~200s baseline.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)