### PR TITLE
fix(redis): drop cached client and restart PING loop after forced reconnect

### DIFF
--- a/apps/sim/lib/core/config/redis.test.ts
+++ b/apps/sim/lib/core/config/redis.test.ts
@@ -90,6 +90,37 @@ describe('redis config', () => {
       expect(mockRedisInstance.disconnect).toHaveBeenCalledWith(true)
     })
 
+    it('should drop the cached client so the next getRedisClient() builds a fresh one', async () => {
+      getRedisClient()
+      const callsBefore = MockRedisConstructor.mock.calls.length
+
+      mockRedisInstance.ping.mockRejectedValue(new Error('ETIMEDOUT'))
+      await vi.advanceTimersByTimeAsync(15_000)
+      await vi.advanceTimersByTimeAsync(15_000)
+
+      expect(mockRedisInstance.disconnect).toHaveBeenCalledWith(true)
+
+      getRedisClient()
+      expect(MockRedisConstructor.mock.calls.length).toBe(callsBefore + 1)
+    })
+
+    it('should restart the PING health check against the new client', async () => {
+      getRedisClient()
+
+      mockRedisInstance.ping.mockRejectedValue(new Error('ETIMEDOUT'))
+      await vi.advanceTimersByTimeAsync(15_000)
+      await vi.advanceTimersByTimeAsync(15_000)
+
+      expect(mockRedisInstance.disconnect).toHaveBeenCalledTimes(1)
+
+      getRedisClient()
+
+      await vi.advanceTimersByTimeAsync(15_000)
+      await vi.advanceTimersByTimeAsync(15_000)
+
+      expect(mockRedisInstance.disconnect).toHaveBeenCalledTimes(2)
+    })
+
     it('should handle listener errors gracefully without breaking health check', async () => {
       const badListener = vi.fn(() => {
         throw new Error('listener crashed')

--- a/apps/sim/lib/core/config/redis.ts
+++ b/apps/sim/lib/core/config/redis.ts
@@ -47,6 +47,14 @@ function startPingHealthCheck(redis: Redis): void {
           consecutiveFailures: pingFailures,
         })
         pingFailures = 0
+        // Drop the cached client and stop this health check before disconnecting,
+        // so the next getRedisClient() builds a fresh client and a fresh PING loop.
+        // Listeners may call getRedisClient() and must observe the cleared global.
+        globalRedisClient = null
+        if (pingInterval) {
+          clearInterval(pingInterval)
+          pingInterval = null
+        }
         for (const cb of reconnectListeners) {
           try {
             cb()

--- a/apps/sim/lib/execution/isolated-vm.ts
+++ b/apps/sim/lib/execution/isolated-vm.ts
@@ -425,10 +425,20 @@ async function releaseDistributedLease(ownerKey: string, leaseId: string): Promi
     return 1
   `
 
+  let deadlineTimer: NodeJS.Timeout | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    deadlineTimer = setTimeout(
+      () => reject(new Error(`Redis lease release timed out after ${LEASE_REDIS_DEADLINE_MS}ms`)),
+      LEASE_REDIS_DEADLINE_MS
+    )
+  })
+
   try {
-    await redis.eval(script, 1, key, leaseId)
+    await Promise.race([redis.eval(script, 1, key, leaseId), deadline])
   } catch (error) {
     logger.error('Failed to release distributed owner lease', { ownerKey, error })
+  } finally {
+    clearTimeout(deadlineTimer)
   }
 }
 


### PR DESCRIPTION
## Summary
- After 2 consecutive PING failures, `startPingHealthCheck` was disconnecting the dead client but leaving `globalRedisClient` cached, so the next `getRedisClient()` returned the dead reference and every command sat in its offline queue until the 5s `commandTimeout`. Now the global is cleared and the PING interval is reset before disconnect, so the next call builds a fresh client with a fresh health check.
- Added a 200ms deadline race to `releaseDistributedLease` in `isolated-vm.ts` (matching `tryAcquireDistributedLease`) so a hung Redis client doesn't make releases wait the full 5s.
- Added two tests covering the cache-drop and PING-restart behavior.

## Type of Change
- [x] Bug fix

## Testing
- `bun run test lib/core/config/redis.test.ts` (13/13)
- `bun run test lib/execution/isolated-vm.test.ts` (9/9)
- `bunx tsc --noEmit -p tsconfig.json` clean
- `bun run lint` clean
- `bun run check:api-validation:strict` passed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)