### PR TITLE
fix(md-render): inline code inherits heading size in mothership/templates/changelog

### DIFF
--- a/apps/sim/app/changelog/components/timeline-list.tsx
+++ b/apps/sim/app/changelog/components/timeline-list.tsx
@@ -195,7 +195,7 @@ export default function ChangelogList({ initialEntries }: Props) {
                   </strong>
                 ),
                 inlineCode: ({ children }) => (
-                  <code className='rounded bg-[var(--landing-bg-elevated)] px-1 py-0.5 font-mono text-[var(--landing-text)] text-xs'>
+                  <code className='whitespace-normal rounded bg-[var(--landing-bg-elevated)] px-1 py-0.5 font-mono text-[var(--landing-text)] not-italic'>
                     {children}
                   </code>
                 ),

--- a/apps/sim/app/templates/[id]/template.tsx
+++ b/apps/sim/app/templates/[id]/template.tsx
@@ -887,7 +887,7 @@ export default function TemplateDetails({ isWorkspaceContext = false }: Template
                     ),
                     li: ({ children }) => <li className='leading-[1.4rem]'>{children}</li>,
                     inlineCode: ({ children }) => (
-                      <code className='rounded bg-muted px-1.5 py-0.5 font-mono text-[var(--caution)] text-xs'>
+                      <code className='whitespace-normal rounded bg-muted px-1.5 py-0.5 font-mono text-[var(--caution)] not-italic'>
                         {children}
                       </code>
                     ),

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -217,7 +217,7 @@ const MARKDOWN_COMPONENTS = {
   },
   inlineCode({ children }: { children?: React.ReactNode }) {
     return (
-      <code className='rounded bg-[var(--surface-5)] px-1.5 py-0.5 font-[400] font-mono text-[var(--text-primary)] text-small before:content-none after:content-none'>
+      <code className='whitespace-normal rounded bg-[var(--surface-5)] px-1.5 py-0.5 font-[400] font-mono text-[var(--text-primary)] not-italic before:content-none after:content-none'>
         {children}
       </code>
     )


### PR DESCRIPTION
## Summary
- Drop hardcoded `text-small`/`text-xs` on `inlineCode` in mothership chat (also covers copilot side panel), template detail page, and changelog renderer so inline code inherits the surrounding heading size
- Add `whitespace-normal` and `not-italic` to mirror the file-viewer fix from #4458

## Type of Change
- [x] Bug fix

## Testing
Tested manually — `setstate` in mothership chat headings now matches header size

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)