### PR TITLE
improvement(peopledatalabs): add titlecase, placeholders, and 404 handling on search

### DIFF
--- a/apps/sim/blocks/blocks/peopledatalabs.ts
+++ b/apps/sim/blocks/blocks/peopledatalabs.ts
@@ -64,6 +64,7 @@ export const PeopleDataLabsBlock: BlockConfig<PdlPersonEnrichResponse> = {
       id: 'first_name',
       title: 'First Name',
       type: 'short-input',
+      placeholder: 'Jane',
       condition: { field: 'operation', value: ['pdl_person_enrich', 'pdl_person_identify'] },
       mode: 'advanced',
     },
@@ -71,6 +72,7 @@ export const PeopleDataLabsBlock: BlockConfig<PdlPersonEnrichResponse> = {
       id: 'last_name',
       title: 'Last Name',
       type: 'short-input',
+      placeholder: 'Doe',
       condition: { field: 'operation', value: ['pdl_person_enrich', 'pdl_person_identify'] },
       mode: 'advanced',
     },
@@ -185,6 +187,7 @@ export const PeopleDataLabsBlock: BlockConfig<PdlPersonEnrichResponse> = {
       id: 'pdl_id',
       title: 'PDL Company ID',
       type: 'short-input',
+      placeholder: 'people-data-labs',
       condition: { field: 'operation', value: 'pdl_company_enrich' },
       mode: 'advanced',
     },
@@ -268,6 +271,7 @@ export const PeopleDataLabsBlock: BlockConfig<PdlPersonEnrichResponse> = {
       id: 'identify_postal_code',
       title: 'Postal Code',
       type: 'short-input',
+      placeholder: '94103',
       condition: { field: 'operation', value: 'pdl_person_identify' },
       mode: 'advanced',
     },
@@ -363,6 +367,25 @@ export const PeopleDataLabsBlock: BlockConfig<PdlPersonEnrichResponse> = {
       type: 'short-input',
       placeholder: 'https://linkedin.com/school/stanford-university',
       condition: { field: 'operation', value: 'pdl_clean_school' },
+      mode: 'advanced',
+    },
+
+    // Title case (shared by Person Enrich/Identify/Search, Company Enrich, Autocomplete)
+    {
+      id: 'titlecase',
+      title: 'Title Case Names',
+      type: 'switch',
+      condition: {
+        field: 'operation',
+        value: [
+          'pdl_person_enrich',
+          'pdl_person_identify',
+          'pdl_person_search',
+          'pdl_company_enrich',
+          'pdl_company_search',
+          'pdl_autocomplete',
+        ],
+      },
       mode: 'advanced',
     },
 
@@ -488,6 +511,18 @@ export const PeopleDataLabsBlock: BlockConfig<PdlPersonEnrichResponse> = {
           result.min_likelihood = undefined
         }
 
+        // titlecase is honored by enrich/identify/search/autocomplete; clear it for others
+        if (
+          op !== 'pdl_person_enrich' &&
+          op !== 'pdl_person_identify' &&
+          op !== 'pdl_person_search' &&
+          op !== 'pdl_company_enrich' &&
+          op !== 'pdl_company_search' &&
+          op !== 'pdl_autocomplete'
+        ) {
+          result.titlecase = undefined
+        }
+
         if (op === 'pdl_person_identify') {
           if (params.identify_locality !== undefined) result.locality = params.identify_locality
           if (params.identify_region !== undefined) result.region = params.identify_region
@@ -575,6 +610,8 @@ export const PeopleDataLabsBlock: BlockConfig<PdlPersonEnrichResponse> = {
     // Bulk
     requests: { type: 'string', description: 'JSON array of bulk request objects' },
     required: { type: 'string', description: 'Required-fields expression for bulk' },
+    // Shared
+    titlecase: { type: 'boolean', description: 'Return name fields in title case' },
   },
 
   outputs: {

--- a/apps/sim/tools/peopledatalabs/autocomplete.ts
+++ b/apps/sim/tools/peopledatalabs/autocomplete.ts
@@ -45,6 +45,12 @@ export const autocompleteTool: ToolConfig<PdlAutocompleteParams, PdlAutocomplete
       visibility: 'user-or-llm',
       description: 'Number of suggestions to return (1-100, default 10)',
     },
+    titlecase: {
+      type: 'boolean',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Return name fields in title case',
+    },
   },
 
   request: {
@@ -53,6 +59,7 @@ export const autocompleteTool: ToolConfig<PdlAutocompleteParams, PdlAutocomplete
         field: params.field,
         text: params.text,
         size: params.size,
+        titlecase: params.titlecase,
       })
       return `https://api.peopledatalabs.com/v5/autocomplete${qs}`
     },

--- a/apps/sim/tools/peopledatalabs/company_enrich.ts
+++ b/apps/sim/tools/peopledatalabs/company_enrich.ts
@@ -83,6 +83,12 @@ export const companyEnrichTool: ToolConfig<PdlCompanyEnrichParams, PdlCompanyEnr
       visibility: 'user-or-llm',
       description: 'Required-fields expression',
     },
+    titlecase: {
+      type: 'boolean',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Return name fields in title case',
+    },
   },
 
   request: {
@@ -99,6 +105,7 @@ export const companyEnrichTool: ToolConfig<PdlCompanyEnrichParams, PdlCompanyEnr
         country: params.country,
         min_likelihood: params.min_likelihood,
         required: params.required,
+        titlecase: params.titlecase,
       })
       return `https://api.peopledatalabs.com/v5/company/enrich${qs}`
     },

--- a/apps/sim/tools/peopledatalabs/company_search.ts
+++ b/apps/sim/tools/peopledatalabs/company_search.ts
@@ -42,6 +42,12 @@ export const companySearchTool: ToolConfig<PdlCompanySearchParams, PdlCompanySea
       visibility: 'user-or-llm',
       description: 'Pagination token returned from a prior response',
     },
+    titlecase: {
+      type: 'boolean',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Return name fields in title case',
+    },
   },
 
   request: {
@@ -64,12 +70,18 @@ export const companySearchTool: ToolConfig<PdlCompanySearchParams, PdlCompanySea
       }
       if (params.size !== undefined) body.size = Number(params.size)
       if (params.scroll_token) body.scroll_token = params.scroll_token
+      if (params.titlecase !== undefined) body.titlecase = params.titlecase
       return body
     },
   },
 
   transformResponse: async (response: Response) => {
     const data = (await response.json()) as Record<string, unknown>
+    const status = (data.status as number) ?? response.status
+
+    if (status === 404) {
+      return { success: true, output: { total: 0, scroll_token: null, results: [] } }
+    }
 
     if (!response.ok) {
       const error = (data.error as { message?: string })?.message

--- a/apps/sim/tools/peopledatalabs/person_enrich.ts
+++ b/apps/sim/tools/peopledatalabs/person_enrich.ts
@@ -89,6 +89,12 @@ export const personEnrichTool: ToolConfig<PdlPersonEnrichParams, PdlPersonEnrich
       visibility: 'user-or-llm',
       description: 'Required-fields expression (e.g., "emails AND job_title")',
     },
+    titlecase: {
+      type: 'boolean',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Return name fields in title case',
+    },
   },
 
   request: {
@@ -106,6 +112,7 @@ export const personEnrichTool: ToolConfig<PdlPersonEnrichParams, PdlPersonEnrich
         location: params.location,
         min_likelihood: params.min_likelihood,
         required: params.required,
+        titlecase: params.titlecase,
       })
       return `https://api.peopledatalabs.com/v5/person/enrich${qs}`
     },

--- a/apps/sim/tools/peopledatalabs/person_identify.ts
+++ b/apps/sim/tools/peopledatalabs/person_identify.ts
@@ -145,6 +145,12 @@ export const personIdentifyTool: ToolConfig<PdlPersonIdentifyParams, PdlPersonId
       visibility: 'user-or-llm',
       description: 'Include `matched_on` for each match',
     },
+    titlecase: {
+      type: 'boolean',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Return name fields in title case',
+    },
   },
 
   request: {
@@ -170,6 +176,7 @@ export const personIdentifyTool: ToolConfig<PdlPersonIdentifyParams, PdlPersonId
         birth_date: params.birth_date,
         data_include: params.data_include,
         include_if_matched: params.include_if_matched,
+        titlecase: params.titlecase,
       })
       return `https://api.peopledatalabs.com/v5/person/identify${qs}`
     },

--- a/apps/sim/tools/peopledatalabs/person_search.ts
+++ b/apps/sim/tools/peopledatalabs/person_search.ts
@@ -49,6 +49,12 @@ export const personSearchTool: ToolConfig<PdlPersonSearchParams, PdlPersonSearch
       description:
         'Dataset filter: all, resume, email, phone, mobile_phone, street_address, consumer_social, developer (combinable with commas, exclude with `-` prefix)',
     },
+    titlecase: {
+      type: 'boolean',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Return name fields in title case',
+    },
   },
 
   request: {
@@ -72,12 +78,18 @@ export const personSearchTool: ToolConfig<PdlPersonSearchParams, PdlPersonSearch
       if (params.size !== undefined) body.size = Number(params.size)
       if (params.scroll_token) body.scroll_token = params.scroll_token
       if (params.dataset) body.dataset = params.dataset
+      if (params.titlecase !== undefined) body.titlecase = params.titlecase
       return body
     },
   },
 
   transformResponse: async (response: Response) => {
     const data = (await response.json()) as Record<string, unknown>
+    const status = (data.status as number) ?? response.status
+
+    if (status === 404) {
+      return { success: true, output: { total: 0, scroll_token: null, results: [] } }
+    }
 
     if (!response.ok) {
       const error = (data.error as { message?: string })?.message

--- a/apps/sim/tools/peopledatalabs/types.ts
+++ b/apps/sim/tools/peopledatalabs/types.ts
@@ -217,6 +217,7 @@ export interface PdlPersonEnrichParams {
   location?: string
   min_likelihood?: number
   required?: string
+  titlecase?: boolean
 }
 
 export interface PdlPersonEnrichResponse extends ToolResponse {
@@ -234,6 +235,7 @@ export interface PdlPersonSearchParams {
   size?: number
   scroll_token?: string
   dataset?: string
+  titlecase?: boolean
 }
 
 export interface PdlPersonSearchResponse extends ToolResponse {
@@ -257,6 +259,7 @@ export interface PdlCompanyEnrichParams {
   country?: string
   min_likelihood?: number
   required?: string
+  titlecase?: boolean
 }
 
 export interface PdlCompanyEnrichResponse extends ToolResponse {
@@ -273,6 +276,7 @@ export interface PdlCompanySearchParams {
   query?: string
   size?: number
   scroll_token?: string
+  titlecase?: boolean
 }
 
 export interface PdlCompanySearchResponse extends ToolResponse {
@@ -288,6 +292,7 @@ export interface PdlAutocompleteParams {
   field: string
   text?: string
   size?: number
+  titlecase?: boolean
 }
 
 export interface PdlAutocompleteSuggestion {
@@ -364,6 +369,7 @@ export interface PdlPersonIdentifyParams {
   birth_date?: string
   data_include?: string
   include_if_matched?: boolean
+  titlecase?: boolean
 }
 
 export interface PdlPersonIdentifyMatch {


### PR DESCRIPTION
## Summary
- Add `titlecase` boolean param across the 6 PDL endpoints that document it: Person Enrich/Identify/Search, Company Enrich/Search, Autocomplete
- Add example placeholders to First Name, Last Name, PDL Company ID, and Postal Code subBlocks for clearer UI hints
- Return empty results on 404 from Person Search and Company Search instead of throwing — matches the pattern used by every other PDL tool

## Type of Change
- [x] Improvement

## Testing
Tested manually. `bun run check:api-validation` and typecheck pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)