### PR TITLE
feat(copilot): preserve mothership chat when opening workflow

### DIFF
--- a/apps/sim/app/api/copilot/chats/route.ts
+++ b/apps/sim/app/api/copilot/chats/route.ts
@@ -36,6 +36,7 @@ export const GET = withRouteHandler(async (_request: NextRequest) => {
         workspaceId: copilotChats.workspaceId,
         activeStreamId: copilotChats.conversationId,
         updatedAt: copilotChats.updatedAt,
+        type: copilotChats.type,
         resources: copilotChats.resources,
       })
       .from(copilotChats)

--- a/apps/sim/app/api/copilot/chats/route.ts
+++ b/apps/sim/app/api/copilot/chats/route.ts
@@ -36,6 +36,7 @@ export const GET = withRouteHandler(async (_request: NextRequest) => {
         workspaceId: copilotChats.workspaceId,
         activeStreamId: copilotChats.conversationId,
         updatedAt: copilotChats.updatedAt,
+        resources: copilotChats.resources,
       })
       .from(copilotChats)
       .leftJoin(workflow, eq(copilotChats.workflowId, workflow.id))

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
@@ -52,6 +52,13 @@ interface MothershipChatProps {
   animateInput?: boolean
   onInputAnimationEnd?: () => void
   className?: string
+  /**
+   * When true, hides the input footer so the conversation is shown as
+   * read-only history. Used when a chat is surfaced outside the context
+   * where it can be safely continued (e.g. a Mothership chat opened from
+   * a workflow page).
+   */
+  readOnly?: boolean
 }
 
 const LAYOUT_STYLES = {
@@ -100,6 +107,7 @@ export function MothershipChat({
   animateInput = false,
   onInputAnimationEnd,
   className,
+  readOnly = false,
 }: MothershipChatProps) {
   const styles = LAYOUT_STYLES[layout]
   const isStreamActive = isSending || isReconnecting
@@ -227,32 +235,34 @@ export function MothershipChat({
         )}
       </div>
 
-      <div
-        className={cn(styles.footer, animateInput && 'animate-slide-in-bottom')}
-        onAnimationEnd={animateInput ? onInputAnimationEnd : undefined}
-      >
-        <div className={styles.footerInner}>
-          <QueuedMessages
-            messageQueue={messageQueue}
-            onRemove={onRemoveQueuedMessage}
-            onSendNow={onSendQueuedMessage}
-            onEdit={handleEditQueued}
-          />
-          <UserInput
-            ref={userInputRef}
-            onSubmit={onSubmit}
-            isSending={isStreamActive}
-            onStopGeneration={onStopGeneration}
-            isInitialView={false}
-            userId={userId}
-            onContextAdd={onContextAdd}
-            onContextRemove={onContextRemove}
-            onSendQueuedHead={handleSendQueuedHead}
-            onEditQueuedTail={handleEditQueuedTail}
-            draftScopeKey={draftScopeKey}
-          />
+      {!readOnly && (
+        <div
+          className={cn(styles.footer, animateInput && 'animate-slide-in-bottom')}
+          onAnimationEnd={animateInput ? onInputAnimationEnd : undefined}
+        >
+          <div className={styles.footerInner}>
+            <QueuedMessages
+              messageQueue={messageQueue}
+              onRemove={onRemoveQueuedMessage}
+              onSendNow={onSendQueuedMessage}
+              onEdit={handleEditQueued}
+            />
+            <UserInput
+              ref={userInputRef}
+              onSubmit={onSubmit}
+              isSending={isStreamActive}
+              onStopGeneration={onStopGeneration}
+              isInitialView={false}
+              userId={userId}
+              onContextAdd={onContextAdd}
+              onContextRemove={onContextRemove}
+              onSendQueuedHead={handleSendQueuedHead}
+              onEditQueuedTail={handleEditQueuedTail}
+              draftScopeKey={draftScopeKey}
+            />
+          </div>
         </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
@@ -52,13 +52,6 @@ interface MothershipChatProps {
   animateInput?: boolean
   onInputAnimationEnd?: () => void
   className?: string
-  /**
-   * When true, hides the input footer so the conversation is shown as
-   * read-only history. Used when a chat is surfaced outside the context
-   * where it can be safely continued (e.g. a Mothership chat opened from
-   * a workflow page).
-   */
-  readOnly?: boolean
 }
 
 const LAYOUT_STYLES = {
@@ -107,7 +100,6 @@ export function MothershipChat({
   animateInput = false,
   onInputAnimationEnd,
   className,
-  readOnly = false,
 }: MothershipChatProps) {
   const styles = LAYOUT_STYLES[layout]
   const isStreamActive = isSending || isReconnecting
@@ -235,34 +227,32 @@ export function MothershipChat({
         )}
       </div>
 
-      {!readOnly && (
-        <div
-          className={cn(styles.footer, animateInput && 'animate-slide-in-bottom')}
-          onAnimationEnd={animateInput ? onInputAnimationEnd : undefined}
-        >
-          <div className={styles.footerInner}>
-            <QueuedMessages
-              messageQueue={messageQueue}
-              onRemove={onRemoveQueuedMessage}
-              onSendNow={onSendQueuedMessage}
-              onEdit={handleEditQueued}
-            />
-            <UserInput
-              ref={userInputRef}
-              onSubmit={onSubmit}
-              isSending={isStreamActive}
-              onStopGeneration={onStopGeneration}
-              isInitialView={false}
-              userId={userId}
-              onContextAdd={onContextAdd}
-              onContextRemove={onContextRemove}
-              onSendQueuedHead={handleSendQueuedHead}
-              onEditQueuedTail={handleEditQueuedTail}
-              draftScopeKey={draftScopeKey}
-            />
-          </div>
+      <div
+        className={cn(styles.footer, animateInput && 'animate-slide-in-bottom')}
+        onAnimationEnd={animateInput ? onInputAnimationEnd : undefined}
+      >
+        <div className={styles.footerInner}>
+          <QueuedMessages
+            messageQueue={messageQueue}
+            onRemove={onRemoveQueuedMessage}
+            onSendNow={onSendQueuedMessage}
+            onEdit={handleEditQueued}
+          />
+          <UserInput
+            ref={userInputRef}
+            onSubmit={onSubmit}
+            isSending={isStreamActive}
+            onStopGeneration={onStopGeneration}
+            isInitialView={false}
+            userId={userId}
+            onContextAdd={onContextAdd}
+            onContextRemove={onContextRemove}
+            onSendQueuedHead={handleSendQueuedHead}
+            onEditQueuedTail={handleEditQueuedTail}
+            draftScopeKey={draftScopeKey}
+          />
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
@@ -211,12 +211,19 @@ export const ResourceContent = memo(function ResourceContent({
 interface ResourceActionsProps {
   workspaceId: string
   resource: MothershipResource
+  chatId?: string
 }
 
-export function ResourceActions({ workspaceId, resource }: ResourceActionsProps) {
+export function ResourceActions({ workspaceId, resource, chatId }: ResourceActionsProps) {
   switch (resource.type) {
     case 'workflow':
-      return <EmbeddedWorkflowActions workspaceId={workspaceId} workflowId={resource.id} />
+      return (
+        <EmbeddedWorkflowActions
+          workspaceId={workspaceId}
+          workflowId={resource.id}
+          chatId={chatId}
+        />
+      )
     case 'file':
       return <EmbeddedFileActions workspaceId={workspaceId} fileId={resource.id} />
     case 'knowledgebase':
@@ -244,9 +251,14 @@ export function ResourceActions({ workspaceId, resource }: ResourceActionsProps)
 interface EmbeddedWorkflowActionsProps {
   workspaceId: string
   workflowId: string
+  chatId?: string
 }
 
-export function EmbeddedWorkflowActions({ workspaceId, workflowId }: EmbeddedWorkflowActionsProps) {
+export function EmbeddedWorkflowActions({
+  workspaceId,
+  workflowId,
+  chatId,
+}: EmbeddedWorkflowActionsProps) {
   const router = useRouter()
   const { navigateToSettings } = useSettingsNavigation()
   const { userPermissions: effectivePermissions } = useWorkspacePermissionsContext()
@@ -284,7 +296,10 @@ export function EmbeddedWorkflowActions({ workspaceId, workflowId }: EmbeddedWor
   }
 
   const handleOpenWorkflow = () => {
-    window.open(`/workspace/${workspaceId}/w/${workflowId}`, '_blank')
+    const url = chatId
+      ? `/workspace/${workspaceId}/w/${workflowId}?chatId=${encodeURIComponent(chatId)}`
+      : `/workspace/${workspaceId}/w/${workflowId}`
+    window.open(url, '_blank')
   }
 
   return (

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
@@ -299,7 +299,7 @@ export function EmbeddedWorkflowActions({
     const url = chatId
       ? `/workspace/${workspaceId}/w/${workflowId}?chatId=${encodeURIComponent(chatId)}`
       : `/workspace/${workspaceId}/w/${workflowId}`
-    window.open(url, '_blank')
+    router.push(url)
   }
 
   return (

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/mothership-view.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/mothership-view.tsx
@@ -117,7 +117,9 @@ export const MothershipView = memo(
             onReorderResources={onReorderResources}
             onCollapse={onCollapse}
             actions={
-              active ? <ResourceActions workspaceId={workspaceId} resource={active} /> : null
+              active ? (
+                <ResourceActions workspaceId={workspaceId} resource={active} chatId={chatId} />
+              ) : null
             }
             previewMode={isActivePreviewable ? previewMode : undefined}
             onCyclePreviewMode={isActivePreviewable ? handleCyclePreview : undefined}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -5,7 +5,7 @@ import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
 import { useQueryClient } from '@tanstack/react-query'
 import { History, Plus } from 'lucide-react'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { usePostHog } from 'posthog-js/react'
 import { useShallow } from 'zustand/react/shallow'
 import {
@@ -118,7 +118,9 @@ interface PanelProps {
 export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: PanelProps = {}) {
   const router = useRouter()
   const params = useParams()
+  const searchParams = useSearchParams()
   const workspaceId = propWorkspaceId ?? (params.workspaceId as string)
+  const urlChatIdParam = searchParams?.get('chatId') ?? null
 
   const posthog = usePostHog()
   const posthogRef = useRef(posthog)
@@ -256,6 +258,21 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
     [copilotChatId, copilotChatList]
   )
 
+  /**
+   * A chat is read-only on this workflow page when it doesn't natively
+   * belong to the active workflow — currently the case for Mothership
+   * chats whose `workflowId` is null but whose `resources` reference this
+   * workflow. Continuing the conversation would route through the
+   * workflow copilot agent rather than the original Mothership context,
+   * so we surface the history without the input.
+   */
+  const isCopilotChatReadOnly = useMemo(() => {
+    if (!copilotChatId || !activeWorkflowId) return false
+    const chat = copilotChatList.find((c) => c.id === copilotChatId)
+    if (!chat) return false
+    return chat.workflowId !== activeWorkflowId
+  }, [copilotChatId, copilotChatList, activeWorkflowId])
+
   const queryClient = useQueryClient()
   const loadCopilotChats = useCallback(() => {
     if (!activeWorkflowId) return
@@ -264,7 +281,10 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
 
   // Auto-select most recent on first list arrival per workflow, and drop a
   // selection that no longer matches anything in the current list (e.g. the
-  // chat was deleted in another tab).
+  // chat was deleted in another tab). When a `?chatId=` param is present in
+  // the URL (e.g. after clicking "Open Workflow" from a Mothership task),
+  // prefer that chat over the most recent so the original conversation is
+  // shown right away.
   const autoSelectAttemptedForRef = useRef<Set<string>>(new Set())
   useEffect(() => {
     if (!activeWorkflowId) return
@@ -278,8 +298,12 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
     if (autoSelectAttemptedForRef.current.has(activeWorkflowId)) return
     if (copilotChatList.length === 0) return
     autoSelectAttemptedForRef.current.add(activeWorkflowId)
-    setCopilotChatId(copilotChatList[0].id)
-  }, [copilotChatList, copilotChatId, activeWorkflowId, setCopilotChatId])
+    const preferred =
+      urlChatIdParam && copilotChatList.find((c) => c.id === urlChatIdParam)
+        ? urlChatIdParam
+        : copilotChatList[0].id
+    setCopilotChatId(preferred)
+  }, [copilotChatList, copilotChatId, activeWorkflowId, setCopilotChatId, urlChatIdParam])
 
   useEffect(() => {
     posthogRef.current = posthog
@@ -443,6 +467,17 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
   useEffect(() => {
     setHasHydrated(true)
   }, [setHasHydrated])
+
+  /**
+   * If the workflow page was opened with `?chatId=`, surface the copilot
+   * tab so the linked conversation is visible without an extra click.
+   */
+  const chatIdParamHandledRef = useRef(false)
+  useEffect(() => {
+    if (chatIdParamHandledRef.current || !urlChatIdParam) return
+    chatIdParamHandledRef.current = true
+    setActiveTab('copilot')
+  }, [urlChatIdParam, setActiveTab])
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -890,6 +925,7 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
                   userId={session?.user?.id}
                   chatId={copilotResolvedChatId}
                   layout='copilot-view'
+                  readOnly={isCopilotChatReadOnly}
                 />
               </div>
             )}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -285,8 +285,11 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
   // chat was deleted in another tab). When a `?chatId=` param is present in
   // the URL (e.g. after clicking "Open Workflow" from a Mothership task),
   // prefer that chat over the most recent so the original conversation is
-  // shown right away.
+  // shown right away. The URL param is honored once per distinct value so
+  // returning to a workflow with a fresh `?chatId=` re-applies it instead of
+  // being shadowed by the once-per-workflow auto-select guard.
   const autoSelectAttemptedForRef = useRef<Set<string>>(new Set())
+  const consumedUrlChatIdRef = useRef<string | null>(null)
   useEffect(() => {
     if (!activeWorkflowId) return
 
@@ -295,15 +298,22 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
       return
     }
 
+    if (
+      urlChatIdParam &&
+      consumedUrlChatIdRef.current !== urlChatIdParam &&
+      copilotChatList.find((c) => c.id === urlChatIdParam)
+    ) {
+      consumedUrlChatIdRef.current = urlChatIdParam
+      autoSelectAttemptedForRef.current.add(activeWorkflowId)
+      setCopilotChatId(urlChatIdParam)
+      return
+    }
+
     if (copilotChatId) return
     if (autoSelectAttemptedForRef.current.has(activeWorkflowId)) return
     if (copilotChatList.length === 0) return
     autoSelectAttemptedForRef.current.add(activeWorkflowId)
-    const preferred =
-      urlChatIdParam && copilotChatList.find((c) => c.id === urlChatIdParam)
-        ? urlChatIdParam
-        : copilotChatList[0].id
-    setCopilotChatId(preferred)
+    setCopilotChatId(copilotChatList[0].id)
   }, [copilotChatList, copilotChatId, activeWorkflowId, setCopilotChatId, urlChatIdParam])
 
   useEffect(() => {
@@ -490,11 +500,14 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
   /**
    * If the workflow page was opened with `?chatId=`, surface the copilot
    * tab so the linked conversation is visible without an extra click.
+   * Re-applies whenever the param changes so returning to a workflow with
+   * a fresh `?chatId=` switches the tab again.
    */
-  const chatIdParamHandledRef = useRef(false)
+  const handledTabSwitchForChatIdRef = useRef<string | null>(null)
   useEffect(() => {
-    if (chatIdParamHandledRef.current || !urlChatIdParam) return
-    chatIdParamHandledRef.current = true
+    if (!urlChatIdParam) return
+    if (handledTabSwitchForChatIdRef.current === urlChatIdParam) return
+    handledTabSwitchForChatIdRef.current = urlChatIdParam
     setActiveTab('copilot')
   }, [urlChatIdParam, setActiveTab])
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -46,7 +46,11 @@ import { captureEvent } from '@/lib/posthog/client'
 import { generateWorkflowJson } from '@/lib/workflows/operations/import-export'
 import { ConversationListItem } from '@/app/workspace/[workspaceId]/components'
 import { MothershipChat } from '@/app/workspace/[workspaceId]/home/components'
-import { getWorkflowCopilotUseChatOptions, useChat } from '@/app/workspace/[workspaceId]/home/hooks'
+import {
+  getMothershipUseChatOptions,
+  getWorkflowCopilotUseChatOptions,
+  useChat,
+} from '@/app/workspace/[workspaceId]/home/hooks'
 import type { FileAttachmentForApi } from '@/app/workspace/[workspaceId]/home/types'
 import { useRegisterGlobalCommands } from '@/app/workspace/[workspaceId]/providers/global-commands-provider'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
@@ -252,26 +256,23 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
   )
   const [isCopilotHistoryOpen, setIsCopilotHistoryOpen] = useState(false)
 
-  const copilotChatTitle = useMemo(
-    () =>
-      copilotChatId ? (copilotChatList.find((c) => c.id === copilotChatId)?.title ?? null) : null,
+  const selectedCopilotChat = useMemo(
+    () => (copilotChatId ? (copilotChatList.find((c) => c.id === copilotChatId) ?? null) : null),
     [copilotChatId, copilotChatList]
   )
+  const copilotChatTitle = selectedCopilotChat?.title ?? null
 
   /**
-   * A chat is read-only on this workflow page when it doesn't natively
-   * belong to the active workflow — currently the case for Mothership
-   * chats whose `workflowId` is null but whose `resources` reference this
-   * workflow. Continuing the conversation would route through the
-   * workflow copilot agent rather than the original Mothership context,
-   * so we surface the history without the input.
+   * A selected chat is "foreign" to this workflow when it was started in
+   * Mothership (`type === 'mothership'`) but ended up referencing this
+   * workflow via `resources`. We keep the conversation continuable by
+   * routing sends through the Mothership branch — i.e. the request goes
+   * out without `workflowId`, so the server uses the broader Mothership
+   * agent surface that originally produced the chat. The trade-off is
+   * that resources spawned during continuation only show up in the
+   * Mothership view; this panel shows the conversation only.
    */
-  const isCopilotChatReadOnly = useMemo(() => {
-    if (!copilotChatId || !activeWorkflowId) return false
-    const chat = copilotChatList.find((c) => c.id === copilotChatId)
-    if (!chat) return false
-    return chat.workflowId !== activeWorkflowId
-  }, [copilotChatId, copilotChatList, activeWorkflowId])
+  const isMothershipChat = selectedCopilotChat?.type === 'mothership'
 
   const queryClient = useQueryClient()
   const loadCopilotChats = useCallback(() => {
@@ -359,6 +360,40 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
     [activeWorkflowId]
   )
 
+  const handleCopilotRequestStarted = useCallback(
+    ({ requestId, userMessageId }: { requestId: string; userMessageId: string }) => {
+      captureEvent(posthogRef.current, 'task_request_started', {
+        workspace_id: workspaceId,
+        view: 'copilot',
+        request_id: requestId,
+        user_message_id: userMessageId,
+      })
+    },
+    [workspaceId]
+  )
+
+  const copilotChatOptions = useMemo(
+    () =>
+      isMothershipChat
+        ? getMothershipUseChatOptions({
+            onStreamEnd: loadCopilotChats,
+            onRequestStarted: handleCopilotRequestStarted,
+          })
+        : getWorkflowCopilotUseChatOptions({
+            workflowId: activeWorkflowId || undefined,
+            onTitleUpdate: loadCopilotChats,
+            onToolResult: handleCopilotToolResult,
+            onRequestStarted: handleCopilotRequestStarted,
+          }),
+    [
+      isMothershipChat,
+      activeWorkflowId,
+      loadCopilotChats,
+      handleCopilotToolResult,
+      handleCopilotRequestStarted,
+    ]
+  )
+
   const {
     messages: copilotMessages,
     isSending: copilotIsSending,
@@ -371,23 +406,7 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
     sendNow: copilotSendNow,
     editQueuedMessage: copilotEditQueuedMessage,
     getCurrentRequestId: getCopilotCurrentRequestId,
-  } = useChat(
-    workspaceId,
-    copilotChatId,
-    getWorkflowCopilotUseChatOptions({
-      workflowId: activeWorkflowId || undefined,
-      onTitleUpdate: loadCopilotChats,
-      onToolResult: handleCopilotToolResult,
-      onRequestStarted: ({ requestId, userMessageId }) => {
-        captureEvent(posthogRef.current, 'task_request_started', {
-          workspace_id: workspaceId,
-          view: 'copilot',
-          request_id: requestId,
-          user_message_id: userMessageId,
-        })
-      },
-    })
-  )
+  } = useChat(workspaceId, copilotChatId, copilotChatOptions)
 
   const handleCopilotNewChat = useCallback(() => {
     if (!activeWorkflowId || !workspaceId) return
@@ -925,7 +944,6 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
                   userId={session?.user?.id}
                   chatId={copilotResolvedChatId}
                   layout='copilot-view'
-                  readOnly={isCopilotChatReadOnly}
                 />
               </div>
             )}

--- a/apps/sim/hooks/queries/copilot-chats.ts
+++ b/apps/sim/hooks/queries/copilot-chats.ts
@@ -17,7 +17,11 @@ async function fetchCopilotChats(
 ): Promise<CopilotChatListItem[]> {
   try {
     const data = await requestJson(listCopilotChatsContract, { signal })
-    return data.chats.filter((c) => c.workflowId === workflowId)
+    return data.chats.filter(
+      (c) =>
+        c.workflowId === workflowId ||
+        c.resources?.some((r) => r.type === 'workflow' && r.id === workflowId)
+    )
   } catch (error) {
     if (error instanceof ApiClientError) return []
     throw error

--- a/apps/sim/lib/api/contracts/copilot.ts
+++ b/apps/sim/lib/api/contracts/copilot.ts
@@ -307,6 +307,7 @@ export const copilotChatListItemSchema = z.object({
   workspaceId: z.string().nullable().optional(),
   activeStreamId: z.string().nullable(),
   updatedAt: z.string().nullable(),
+  type: z.enum(['mothership', 'copilot']).optional(),
   resources: z.array(copilotChatResourceSchema).optional(),
 })
 export type CopilotChatListItem = z.output<typeof copilotChatListItemSchema>

--- a/apps/sim/lib/api/contracts/copilot.ts
+++ b/apps/sim/lib/api/contracts/copilot.ts
@@ -307,8 +307,8 @@ export const copilotChatListItemSchema = z.object({
   workspaceId: z.string().nullable().optional(),
   activeStreamId: z.string().nullable(),
   updatedAt: z.string().nullable(),
-  type: z.enum(['mothership', 'copilot']).optional(),
-  resources: z.array(copilotChatResourceSchema).optional(),
+  type: z.enum(['mothership', 'copilot']).nullable().optional(),
+  resources: z.array(copilotChatResourceSchema).nullable().optional(),
 })
 export type CopilotChatListItem = z.output<typeof copilotChatListItemSchema>
 

--- a/apps/sim/lib/api/contracts/copilot.ts
+++ b/apps/sim/lib/api/contracts/copilot.ts
@@ -112,6 +112,12 @@ const copilotResourceTypeSchema = z.enum([
   'log',
 ])
 
+const copilotChatResourceSchema = z.object({
+  type: copilotResourceTypeSchema,
+  id: z.string(),
+  title: z.string(),
+})
+
 export const addCopilotChatResourceBodySchema = z.object({
   chatId: z.string(),
   resource: z.object({
@@ -301,6 +307,7 @@ export const copilotChatListItemSchema = z.object({
   workspaceId: z.string().nullable().optional(),
   activeStreamId: z.string().nullable(),
   updatedAt: z.string().nullable(),
+  resources: z.array(copilotChatResourceSchema).optional(),
 })
 export type CopilotChatListItem = z.output<typeof copilotChatListItemSchema>
 
@@ -376,12 +383,6 @@ const copilotCheckpointSchema = z.object({
   messageId: z.string().nullable().optional(),
   createdAt: z.string().nullable(),
   updatedAt: z.string().nullable(),
-})
-
-const copilotChatResourceSchema = z.object({
-  type: copilotResourceTypeSchema,
-  id: z.string(),
-  title: z.string(),
 })
 
 const copilotAvailableModelSchema = z.object({


### PR DESCRIPTION
## Summary

Clicking **Open Workflow** from a Mothership task now deep-links the
originating chat into the workflow page's copilot panel, so the
conversation that produced the workflow stays visible — and is fully
continuable.

When the selected chat has `type: 'mothership'`, the workflow panel
swaps its `useChat` options to the Mothership branch (no `workflowId`
in the request), so sends route to the broader Mothership agent that
originally produced the chat instead of the workflow-scoped copilot.
Resources created during continuation still only render in Mothership;
the workflow panel shows the conversation only.

### Changes

- **Contract** (`lib/api/contracts/copilot.ts`): `copilotChatListItemSchema`
  now exposes optional `type` (`'mothership' | 'copilot'`) and
  `resources` so the client can identify mothership chats and chats
  that *reference* a workflow via `resources` even when
  `chat.workflowId` is null.
- **Route** (`/api/copilot/chats`): selects `type` and `resources` from
  the existing columns.
- **Client filter** (`hooks/queries/copilot-chats.ts`):
  `useCopilotChats(workflowId)` now also includes chats whose
  `resources` contain a `{ type: 'workflow', id }` matching the
  workflow.
- **Open Workflow button** (`resource-content.tsx`): appends
  `?chatId=<currentChat>` to the URL. `chatId` is threaded through
  `MothershipView` → `ResourceActions` → `EmbeddedWorkflowActions`.
- **Workflow panel** (`panel.tsx`):
  - Reads `?chatId=` from the URL, prefers it over the most-recent
    auto-select on first list arrival, and switches the panel to the
    copilot tab on first mount when the param is present.
  - Computes `isMothershipChat` from `selectedChat.type` and swaps the
    `useChat` options between `getMothershipUseChatOptions` and
    `getWorkflowCopilotUseChatOptions` accordingly.

## Known limitation

Resources (workflows, files, tables) spawned by the agent during
continuation from the workflow panel are persisted on the chat row but
not rendered in the workflow panel — that side panel only exists in
the Mothership view. Users see the conversation; to inspect or
interact with new resources, they go back to Mothership.

## Test plan

- [ ] In Mothership, ask the copilot to create a workflow and wait for
      the `Open Workflow` button to appear in the resource panel.
- [ ] Click **Open Workflow**. Verify a new tab opens with
      `?chatId=<id>` in the URL and the copilot panel is open with the
      original conversation visible.
- [ ] Type a follow-up like "rename this workflow to X". Verify the
      response uses the Mothership agent (broader tools, can still
      create new resources) — and that a network request to
      `/api/mothership/chat` goes out **without** `workflowId` in the
      body.
- [ ] Click **+ New chat** in the copilot panel. The new chat is a
      regular workflow-copilot chat — sends include `workflowId`.
- [ ] Switch back to the original mothership chat via the chat history
      dropdown — sends drop `workflowId` again.
- [ ] On a workflow page with no `?chatId=` param, behavior is
      unchanged: most recent workflow chat auto-selects.
- [ ] Refresh on `?chatId=<unknown>`: falls through to the most-recent
      auto-select gracefully.