### PR TITLE
improvement(workflow-panel): header tooltips, search shortcut hint, URL-driven active tab

### DIFF
--- a/apps/sim/app/layout.tsx
+++ b/apps/sim/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next'
 import Script from 'next/script'
 import { PublicEnvScript } from 'next-runtime-env'
+import { NuqsAdapter } from 'nuqs/adapters/next/app'
 import { BrandedLayout } from '@/components/branded-layout'
 import { PostHogProvider } from '@/app/_shell/providers/posthog-provider'
 import { generateBrandedMetadata, generateThemeCSS } from '@/ee/whitelabeling'
@@ -104,7 +105,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   document.documentElement.style.setProperty('--sidebar-width', defaultSidebarWidth);
                 }
 
-                // Panel width and active tab
+                // Panel width
                 try {
                   var panelStored = localStorage.getItem('panel-state');
                   if (panelStored) {
@@ -118,14 +119,22 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     } else if (panelWidth > maxPanelWidth) {
                       document.documentElement.style.setProperty('--panel-width', maxPanelWidth + 'px');
                     }
-
-                    var activeTab = panelState && panelState.activeTab;
-                    if (activeTab) {
-                      document.documentElement.setAttribute('data-panel-active-tab', activeTab);
-                    }
                   }
                 } catch (e) {
                   // Fallback handled by CSS defaults
+                }
+
+                // Panel active tab — sourced from the URL so a hard refresh paints
+                // the correct tab before React hydrates (no copilot → editor flash).
+                try {
+                  var panelTab = new URLSearchParams(window.location.search).get('panel');
+                  if (panelTab === 'copilot' || panelTab === 'toolbar' || panelTab === 'editor') {
+                    document.documentElement.setAttribute('data-panel-active-tab', panelTab);
+                  } else {
+                    document.documentElement.setAttribute('data-panel-active-tab', 'copilot');
+                  }
+                } catch (e) {
+                  document.documentElement.setAttribute('data-panel-active-tab', 'copilot');
                 }
 
                 // Toolbar triggers height
@@ -258,11 +267,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <PostHogProvider>
           <ThemeProvider>
             <QueryProvider>
-              <SessionProvider>
-                <TooltipProvider>
-                  <BrandedLayout>{children}</BrandedLayout>
-                </TooltipProvider>
-              </SessionProvider>
+              <NuqsAdapter>
+                <SessionProvider>
+                  <TooltipProvider>
+                    <BrandedLayout>{children}</BrandedLayout>
+                  </TooltipProvider>
+                </SessionProvider>
+              </NuqsAdapter>
             </QueryProvider>
           </ThemeProvider>
         </PostHogProvider>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/toolbar/toolbar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/toolbar/toolbar.tsx
@@ -11,9 +11,10 @@ import {
   useState,
 } from 'react'
 import clsx from 'clsx'
-import { Search } from 'lucide-react'
+import { Command, Info, Option, Search } from 'lucide-react'
 import { usePostHog } from 'posthog-js/react'
-import { Button } from '@/components/emcn'
+import { Button, Tooltip } from '@/components/emcn'
+import { isMacPlatform } from '@/lib/core/utils/platform'
 import { captureEvent } from '@/lib/posthog/client'
 import {
   getBlocksForSidebar,
@@ -313,6 +314,10 @@ export const Toolbar = memo(
     // Search state
     const [isSearchActive, setIsSearchActive] = useState(false)
     const [searchQuery, setSearchQuery] = useState('')
+    const [isMac, setIsMac] = useState<boolean | null>(null)
+    useEffect(() => {
+      setIsMac(isMacPlatform())
+    }, [])
     const [prevIsActive, setPrevIsActive] = useState(isActive)
     if (isActive !== prevIsActive) {
       setPrevIsActive(isActive)
@@ -729,14 +734,31 @@ export const Toolbar = memo(
           <h2 className='font-medium text-[var(--text-primary)] text-sm'>Toolbar</h2>
           <div className='flex shrink-0 items-center gap-2'>
             {!isSearchActive ? (
-              <Button
-                variant='ghost'
-                className='p-0'
-                aria-label='Search toolbar'
-                onClick={handleSearchClick}
-              >
-                <Search className='h-[14px] w-[14px]' />
-              </Button>
+              <>
+                {isMac !== null && (
+                  <kbd className='inline-flex items-center gap-0.5 rounded-[4px] border border-[var(--border)] bg-[var(--surface-3)] px-1 py-0.5 font-mono font-normal text-[11px] text-[var(--text-muted)] leading-none'>
+                    {isMac ? (
+                      <>
+                        <span className='flex items-center gap-0.5'>
+                          <Option className='h-[10px] w-[10px]' strokeWidth={2.5} />
+                          <Command className='h-[10px] w-[10px]' strokeWidth={2.5} />
+                        </span>
+                        <span>F</span>
+                      </>
+                    ) : (
+                      <span>Ctrl+Alt+F</span>
+                    )}
+                  </kbd>
+                )}
+                <Button
+                  variant='ghost'
+                  className='p-0'
+                  aria-label='Search toolbar'
+                  onClick={handleSearchClick}
+                >
+                  <Search className='h-[14px] w-[14px]' />
+                </Button>
+              </>
             ) : (
               <input
                 ref={searchInputRef}
@@ -762,9 +784,17 @@ export const Toolbar = memo(
           >
             <div
               ref={triggersHeaderRef}
-              className='px-2.5 pt-1.5 pb-1.5 font-medium text-[var(--text-primary)] text-small'
+              className='flex items-center gap-1.5 px-2.5 pt-1.5 pb-1.5 font-medium text-[var(--text-primary)] text-small'
             >
-              Triggers
+              <span>Triggers</span>
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <Info className='h-[14px] w-[14px] cursor-default text-[var(--text-muted)]' />
+                </Tooltip.Trigger>
+                <Tooltip.Content side='top' align='start'>
+                  <p>Events that start a workflow.</p>
+                </Tooltip.Content>
+              </Tooltip.Root>
             </div>
             <div className='flex-1 overflow-y-auto overflow-x-hidden px-1.5'>
               <div ref={triggersContentRef} className='space-y-1 pb-2'>
@@ -796,9 +826,20 @@ export const Toolbar = memo(
             <div
               ref={blocksHeaderRef}
               onClick={handleBlocksHeaderClick}
-              className='cursor-pointer px-2.5 pt-1.5 pb-1.5 font-medium text-[var(--text-primary)] text-small'
+              className='flex cursor-pointer items-center gap-1.5 px-2.5 pt-1.5 pb-1.5 font-medium text-[var(--text-primary)] text-small'
             >
-              Blocks
+              <span>Blocks</span>
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <Info
+                    className='h-[14px] w-[14px] cursor-default text-[var(--text-muted)]'
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </Tooltip.Trigger>
+                <Tooltip.Content side='top' align='start'>
+                  <p>Actions that make up the steps of a workflow.</p>
+                </Tooltip.Content>
+              </Tooltip.Root>
             </div>
             <div className='flex-1 overflow-y-auto overflow-x-hidden px-1.5'>
               <div className='space-y-1 pb-2'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -140,10 +140,6 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
   const setActiveTab = useCallback(
     (tab: PanelTab) => {
       void setActiveTabRaw(tab)
-      // Drop the pre-hydration data attribute once React owns visibility.
-      if (typeof document !== 'undefined') {
-        document.documentElement.removeAttribute('data-panel-active-tab')
-      }
     },
     [setActiveTabRaw]
   )
@@ -455,6 +451,12 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
    */
   useEffect(() => {
     setHasHydrated(true)
+    // The blocking script in layout.tsx pins this attribute pre-hydration to
+    // hide inactive tabs via CSS. Once React owns visibility, drop it so the
+    // CSS `!important` rules don't fight React's className-based toggling.
+    if (typeof document !== 'undefined') {
+      document.documentElement.removeAttribute('data-panel-active-tab')
+    }
   }, [setHasHydrated])
 
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -6,6 +6,7 @@ import { toError } from '@sim/utils/errors'
 import { useQueryClient } from '@tanstack/react-query'
 import { History, Plus } from 'lucide-react'
 import { useParams, useRouter } from 'next/navigation'
+import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { usePostHog } from 'posthog-js/react'
 import { useShallow } from 'zustand/react/shallow'
 import {
@@ -94,22 +95,20 @@ import type { WorkflowState } from '@/stores/workflows/workflow/types'
 const logger = createLogger('Panel')
 const EMPTY_COPILOT_CHATS: readonly CopilotChatListItem[] = []
 /**
- * Panel component with resizable width and tab navigation that persists across page refreshes.
+ * Panel component with resizable width and tab navigation.
  *
- * Uses a CSS-based approach to prevent hydration mismatches and flash on load:
- * 1. Width is controlled by CSS variable (--panel-width)
- * 2. Blocking script in layout.tsx sets CSS variable and data-panel-active-tab before React hydrates
- * 3. CSS rules control initial visibility based on data-panel-active-tab attribute
- * 4. React takes over visibility control after hydration completes
- * 5. Store updates CSS variable when width changes
+ * The active tab is stored in the URL (`?panel=...`) via nuqs so a hard refresh
+ * paints the correct tab before React hydrates — no copilot-then-editor flash.
+ * The blocking script in layout.tsx reads the same query param and sets
+ * `data-panel-active-tab` on `<html>`, which CSS uses to hide the inactive tabs
+ * before paint.
  *
- * This ensures server and client render identical HTML, preventing hydration errors and visual flash.
- *
- * Note: All tabs are kept mounted but hidden to preserve component state during tab switches.
- * This prevents unnecessary remounting which would trigger data reloads and reset state.
+ * All tabs stay mounted but hidden to preserve component state across switches.
  *
  * @returns Panel on the right side of the workflow
  */
+const PANEL_TABS = ['copilot', 'toolbar', 'editor'] as const
+
 interface PanelProps {
   /** Override workspaceId when rendered outside a workspace route (e.g. sandbox mode) */
   workspaceId?: string
@@ -125,14 +124,28 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
 
   const panelRef = useRef<HTMLElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const { activeTab, setActiveTab, panelWidth, _hasHydrated, setHasHydrated } = usePanelStore(
+  const { panelWidth, _hasHydrated, setHasHydrated } = usePanelStore(
     useShallow((state) => ({
-      activeTab: state.activeTab,
-      setActiveTab: state.setActiveTab,
       panelWidth: state.panelWidth,
       _hasHydrated: state._hasHydrated,
       setHasHydrated: state.setHasHydrated,
     }))
+  )
+  const [activeTab, setActiveTabRaw] = useQueryState(
+    'panel',
+    parseAsStringLiteral(PANEL_TABS)
+      .withDefault('copilot')
+      .withOptions({ history: 'replace', clearOnDefault: true })
+  )
+  const setActiveTab = useCallback(
+    (tab: PanelTab) => {
+      void setActiveTabRaw(tab)
+      // Drop the pre-hydration data attribute once React owns visibility.
+      if (typeof document !== 'undefined') {
+        document.documentElement.removeAttribute('data-panel-active-tab')
+      }
+    },
+    [setActiveTabRaw]
   )
   const toolbarRef = useRef<{
     focusSearch: () => void
@@ -454,6 +467,17 @@ export const Panel = memo(function Panel({ workspaceId: propWorkspaceId }: Panel
     window.addEventListener('mothership-send-message', handler)
     return () => window.removeEventListener('mothership-send-message', handler)
   }, [setActiveTab, copilotSendMessage])
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const tab = (e as CustomEvent<PanelTab>).detail
+      if (tab === 'copilot' || tab === 'toolbar' || tab === 'editor') {
+        setActiveTab(tab)
+      }
+    }
+    window.addEventListener('panel:set-tab', handler)
+    return () => window.removeEventListener('panel:set-tab', handler)
+  }, [setActiveTab])
 
   useEffect(() => {
     if (activeTab !== 'copilot') return

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-block-visual.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-block-visual.ts
@@ -1,11 +1,14 @@
 import { useCallback, useMemo } from 'react'
+import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useBlockState } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/hooks'
 import type { WorkflowBlockProps } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/types'
 import { useCurrentWorkflow } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-current-workflow'
 import { getBlockRingStyles } from '@/app/workspace/[workspaceId]/w/[workflowId]/utils/block-ring-utils'
 import { useLastRunPath } from '@/stores/execution'
-import { usePanelEditorStore, usePanelStore } from '@/stores/panel'
+import { usePanelEditorStore } from '@/stores/panel'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
+
+const PANEL_TABS = ['copilot', 'toolbar', 'editor'] as const
 
 /**
  * Props for the useBlockVisual hook.
@@ -54,16 +57,8 @@ export function useBlockVisual({
   const currentBlockId = usePanelEditorStore((state) => state.currentBlockId)
 
   const isThisBlockInEditor = currentBlockId === blockId
-  const activeTabIsEditor = usePanelStore(
-    useCallback(
-      (state) => {
-        if (isPreview || isEmbedded || !isThisBlockInEditor) return false
-        return state.activeTab === 'editor'
-      },
-      [isPreview, isEmbedded, isThisBlockInEditor]
-    )
-  )
-  const isEditorOpen = !isPreview && !isEmbedded && isThisBlockInEditor && activeTabIsEditor
+  const [panelTab] = useQueryState('panel', parseAsStringLiteral(PANEL_TABS).withDefault('copilot'))
+  const isEditorOpen = !isPreview && !isEmbedded && isThisBlockInEditor && panelTab === 'editor'
 
   const lastRunPath = useLastRunPath()
   const runPathStatus = isPreview ? undefined : lastRunPath.get(blockId)

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -165,6 +165,7 @@
     "next-runtime-env": "3.3.0",
     "next-themes": "^0.4.6",
     "nodemailer": "8.0.7",
+    "nuqs": "2.8.9",
     "officeparser": "^5.2.0",
     "openai": "^4.91.1",
     "papaparse": "5.5.3",

--- a/apps/sim/stores/panel/editor/store.ts
+++ b/apps/sim/stores/panel/editor/store.ts
@@ -3,9 +3,18 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { EDITOR_CONNECTIONS_HEIGHT } from '@/stores/constants'
-import { usePanelStore } from '../store'
 
 let renameCallback: (() => void) | null = null
+
+/**
+ * Asks the workflow panel to switch to the editor tab. The active tab lives
+ * in the URL via nuqs, which is React-only, so we hop through a window event
+ * that the panel component listens for.
+ */
+function requestEditorTab() {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent('panel:set-tab', { detail: 'editor' }))
+}
 
 export interface ActiveSearchTarget {
   matchId: string
@@ -63,13 +72,13 @@ export const usePanelEditorStore = create<PanelEditorState>()(
       setCurrentBlockId: (blockId) => {
         set({ currentBlockId: blockId })
         if (blockId !== null) {
-          usePanelStore.getState().setActiveTab('editor')
+          requestEditorTab()
         }
       },
       setActiveSearchTarget: (target) => {
         set({ activeSearchTarget: target })
         if (target) {
-          usePanelStore.getState().setActiveTab('editor')
+          requestEditorTab()
         }
       },
       clearCurrentBlock: () => {

--- a/apps/sim/stores/panel/store.ts
+++ b/apps/sim/stores/panel/store.ts
@@ -1,12 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { PANEL_WIDTH } from '@/stores/constants'
-import type { PanelState, PanelTab } from '@/stores/panel/types'
-
-/**
- * Default panel tab
- */
-const DEFAULT_TAB: PanelTab = 'copilot'
+import type { PanelState } from '@/stores/panel/types'
 
 export const usePanelStore = create<PanelState>()(
   persist(
@@ -21,14 +16,6 @@ export const usePanelStore = create<PanelState>()(
           document.documentElement.style.setProperty('--panel-width', `${clampedWidth}px`)
         }
       },
-      activeTab: DEFAULT_TAB,
-      setActiveTab: (tab) => {
-        set({ activeTab: tab })
-        // Remove data attribute once React takes control
-        if (typeof document !== 'undefined') {
-          document.documentElement.removeAttribute('data-panel-active-tab')
-        }
-      },
       isResizing: false,
       setIsResizing: (isResizing) => {
         set({ isResizing })
@@ -40,12 +27,10 @@ export const usePanelStore = create<PanelState>()(
     }),
     {
       name: 'panel-state',
+      partialize: (state) => ({ panelWidth: state.panelWidth }),
       onRehydrateStorage: () => (state) => {
-        // Sync CSS variables with stored state after rehydration
         if (state && typeof window !== 'undefined') {
           document.documentElement.style.setProperty('--panel-width', `${state.panelWidth}px`)
-          // Remove the data attribute so CSS rules stop interfering
-          document.documentElement.removeAttribute('data-panel-active-tab')
         }
       },
     }

--- a/apps/sim/stores/panel/types.ts
+++ b/apps/sim/stores/panel/types.ts
@@ -4,13 +4,16 @@
 export type PanelTab = 'copilot' | 'editor' | 'toolbar'
 
 /**
- * Panel state interface
+ * Panel state interface.
+ *
+ * @remarks
+ * The active tab is intentionally not stored here — it lives in the URL
+ * (`?panel=...`) via nuqs so a hard refresh can paint the correct tab
+ * before React hydrates.
  */
 export interface PanelState {
   panelWidth: number
   setPanelWidth: (width: number) => void
-  activeTab: PanelTab
-  setActiveTab: (tab: PanelTab) => void
   /** Whether the panel is currently being resized */
   isResizing: boolean
   /** Updates the panel resize state */

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "simstudio",
@@ -220,6 +219,7 @@
         "next-runtime-env": "3.3.0",
         "next-themes": "^0.4.6",
         "nodemailer": "8.0.7",
+        "nuqs": "2.8.9",
         "officeparser": "^5.2.0",
         "openai": "^4.91.1",
         "papaparse": "5.5.3",
@@ -3241,6 +3241,8 @@
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
+    "nuqs": ["nuqs@2.8.9", "", { "dependencies": { "@standard-schema/spec": "1.0.0" }, "peerDependencies": { "@remix-run/react": ">=2", "@tanstack/react-router": "^1", "next": ">=14.2.0", "react": ">=18.2.0 || ^19.0.0-0", "react-router": "^5 || ^6 || ^7", "react-router-dom": "^5 || ^6 || ^7" }, "optionalPeers": ["@remix-run/react", "@tanstack/react-router", "next", "react-router", "react-router-dom"] }, "sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ=="],
+
     "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
 
     "nypm": ["nypm@0.6.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "pathe": "^2.0.3", "pkg-types": "^2.0.0", "tinyexec": "^0.3.2" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-mn8wBFV9G9+UFHIrq+pZ2r2zL4aPau/by3kJb3cM7+5tQHMt6HGQB8FDIeKFYp8o0D2pnH6nVsO88N4AmUxIWg=="],
@@ -4792,6 +4794,8 @@
     "next/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "nuqs/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "nypm/pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
 


### PR DESCRIPTION
## Summary

A handful of polish changes on the workflow page's right-side panel:

- **Toolbar header tooltips** — added `Info` icons next to the **Triggers** and **Blocks** labels with concise definitions ("Events that start a workflow." / "Actions that make up the steps of a workflow."). The Blocks icon stops click propagation so the section's collapse toggle isn't triggered when hovering the icon.
- **Search shortcut badge** — rendered a `kbd`-style badge next to the toolbar search icon showing the existing `Mod+Alt+F` shortcut. Uses lucide `Option` and `Command` icons on Mac, falls back to `Ctrl+Alt+F` text on Windows/Linux. The badge waits for client mount before rendering so the wrong platform doesn't flash.
- **Active panel tab → URL** — moved the panel's `activeTab` from the persisted Zustand store into the URL via `nuqs` (`?panel=copilot|toolbar|editor`). The blocking script in `app/layout.tsx` now reads `?panel=` instead of `localStorage`, so a hard refresh paints the correct tab before React hydrates — fixes the flash where Copilot rendered briefly before swapping to the previously-selected tab.

`nuqs` is added to `apps/sim` at `2.8.9` to match the install in #4522, and `NuqsAdapter` is wired in `app/layout.tsx` in the same position (inside `QueryProvider`, outside `SessionProvider`) so the two PRs don't conflict.

The editor store's old `usePanelStore.getState().setActiveTab('editor')` call (fired from outside React when a block is selected) goes through a new `panel:set-tab` `CustomEvent` that the panel component listens for, since nuqs state can only be updated from inside React.

## Test plan

- [ ] Hard refresh the workflow page with the toolbar or editor tab previously active → no Copilot flash; the correct tab paints immediately.
- [ ] Switch tabs → URL updates with `?panel=...` (or clears when on the default Copilot tab).
- [ ] Click a block on the canvas → editor tab opens (event-driven path).
- [ ] Press `⌘⌥F` / `Ctrl+Alt+F` → toolbar tab focuses and the search input opens.
- [ ] Hover the `Info` icons in the toolbar → tooltips appear with the right copy.
- [ ] Confirm the `kbd` badge next to the search icon does not flash with the wrong platform variant on first load.