### PR TITLE
fix(logs): include subfolders when filtering logs by folder

### DIFF
--- a/apps/sim/app/api/logs/export/route.ts
+++ b/apps/sim/app/api/logs/export/route.ts
@@ -5,7 +5,11 @@ import { and, desc, eq, sql } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { buildFilterConditions, LogFilterParamsSchema } from '@/lib/logs/filters'
+import {
+  buildFilterConditions,
+  expandFolderIdsWithDescendants,
+  LogFilterParamsSchema,
+} from '@/lib/logs/filters'
 
 const logger = createLogger('LogsExportAPI')
 
@@ -43,6 +47,10 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       cost: workflowExecutionLogs.cost,
       executionData: workflowExecutionLogs.executionData,
       workflowName: sql<string>`COALESCE(${workflow.name}, 'Deleted Workflow')`,
+    }
+
+    if (params.folderIds) {
+      params.folderIds = await expandFolderIdsWithDescendants(params.workspaceId, params.folderIds)
     }
 
     const workspaceCondition = eq(workflowExecutionLogs.workspaceId, params.workspaceId)

--- a/apps/sim/app/api/logs/export/route.ts
+++ b/apps/sim/app/api/logs/export/route.ts
@@ -5,11 +5,8 @@ import { and, desc, eq, sql } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import {
-  buildFilterConditions,
-  expandFolderIdsWithDescendants,
-  LogFilterParamsSchema,
-} from '@/lib/logs/filters'
+import { buildFilterConditions, LogFilterParamsSchema } from '@/lib/logs/filters'
+import { expandFolderIdsWithDescendants } from '@/lib/logs/folder-expansion'
 
 const logger = createLogger('LogsExportAPI')
 

--- a/apps/sim/app/api/logs/route.ts
+++ b/apps/sim/app/api/logs/route.ts
@@ -31,7 +31,8 @@ import { listLogsContract, type WorkflowLogSummary } from '@/lib/api/contracts/l
 import { parseRequest } from '@/lib/api/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { buildFilterConditions, expandFolderIdsWithDescendants } from '@/lib/logs/filters'
+import { buildFilterConditions } from '@/lib/logs/filters'
+import { expandFolderIdsWithDescendants } from '@/lib/logs/folder-expansion'
 
 const logger = createLogger('LogsAPI')
 

--- a/apps/sim/app/api/logs/route.ts
+++ b/apps/sim/app/api/logs/route.ts
@@ -31,7 +31,7 @@ import { listLogsContract, type WorkflowLogSummary } from '@/lib/api/contracts/l
 import { parseRequest } from '@/lib/api/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { buildFilterConditions } from '@/lib/logs/filters'
+import { buildFilterConditions, expandFolderIdsWithDescendants } from '@/lib/logs/filters'
 
 const logger = createLogger('LogsAPI')
 
@@ -160,6 +160,10 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
         levelConditions.length === 1 ? levelConditions[0] : or(...levelConditions)!
       )
     }
+  }
+
+  if (params.folderIds) {
+    params.folderIds = await expandFolderIdsWithDescendants(params.workspaceId, params.folderIds)
   }
 
   const commonFilters = buildFilterConditions(params, { useSimpleLevelFilter: false })

--- a/apps/sim/app/api/logs/stats/route.ts
+++ b/apps/sim/app/api/logs/stats/route.ts
@@ -13,7 +13,8 @@ import { isZodError } from '@/lib/api/server'
 import { getSession } from '@/lib/auth'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { buildFilterConditions, expandFolderIdsWithDescendants } from '@/lib/logs/filters'
+import { buildFilterConditions } from '@/lib/logs/filters'
+import { expandFolderIdsWithDescendants } from '@/lib/logs/folder-expansion'
 
 const logger = createLogger('LogsStatsAPI')
 

--- a/apps/sim/app/api/logs/stats/route.ts
+++ b/apps/sim/app/api/logs/stats/route.ts
@@ -13,7 +13,7 @@ import { isZodError } from '@/lib/api/server'
 import { getSession } from '@/lib/auth'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { buildFilterConditions } from '@/lib/logs/filters'
+import { buildFilterConditions, expandFolderIdsWithDescendants } from '@/lib/logs/filters'
 
 const logger = createLogger('LogsStatsAPI')
 
@@ -36,6 +36,13 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       const params = statsQueryParamsSchema.parse(Object.fromEntries(searchParams.entries()))
 
       const workspaceFilter = eq(workflowExecutionLogs.workspaceId, params.workspaceId)
+
+      if (params.folderIds) {
+        params.folderIds = await expandFolderIdsWithDescendants(
+          params.workspaceId,
+          params.folderIds
+        )
+      }
 
       const commonFilters = buildFilterConditions(params, { useSimpleLevelFilter: true })
       const whereCondition = commonFilters ? and(workspaceFilter, commonFilters) : workspaceFilter

--- a/apps/sim/lib/logs/filters.ts
+++ b/apps/sim/lib/logs/filters.ts
@@ -1,5 +1,6 @@
-import { workflow, workflowExecutionLogs } from '@sim/db/schema'
-import { and, eq, gt, gte, inArray, lt, lte, ne, type SQL, sql } from 'drizzle-orm'
+import { db } from '@sim/db'
+import { workflow, workflowExecutionLogs, workflowFolder } from '@sim/db/schema'
+import { and, eq, gt, gte, inArray, isNull, lt, lte, ne, type SQL, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import type { TimeRange } from '@/stores/logs/filters/types'
 
@@ -126,6 +127,53 @@ function buildWorkflowIdsCondition(workflowIds: string): SQL | undefined {
     return inArray(workflow.id, ids)
   }
   return undefined
+}
+
+/**
+ * Expands a CSV of selected folder IDs to include every descendant folder in the
+ * workspace, so that filtering by a parent folder also matches workflows that
+ * live in nested subfolders.
+ *
+ * Returns the original CSV when there are no descendants (or when the input is
+ * empty / undefined). Unknown IDs are preserved so the caller's `inArray` check
+ * behaves the same as today (matches nothing).
+ */
+export async function expandFolderIdsWithDescendants(
+  workspaceId: string,
+  folderIdsCsv: string | undefined
+): Promise<string | undefined> {
+  if (!folderIdsCsv) return folderIdsCsv
+  const seedIds = folderIdsCsv.split(',').filter(Boolean)
+  if (seedIds.length === 0) return folderIdsCsv
+
+  const rows = await db
+    .select({ id: workflowFolder.id, parentId: workflowFolder.parentId })
+    .from(workflowFolder)
+    .where(and(eq(workflowFolder.workspaceId, workspaceId), isNull(workflowFolder.archivedAt)))
+
+  const childrenByParent = new Map<string, string[]>()
+  for (const row of rows) {
+    if (!row.parentId) continue
+    const list = childrenByParent.get(row.parentId)
+    if (list) list.push(row.id)
+    else childrenByParent.set(row.parentId, [row.id])
+  }
+
+  const expanded = new Set<string>(seedIds)
+  const queue = [...seedIds]
+  while (queue.length > 0) {
+    const current = queue.shift() as string
+    const children = childrenByParent.get(current)
+    if (!children) continue
+    for (const childId of children) {
+      if (!expanded.has(childId)) {
+        expanded.add(childId)
+        queue.push(childId)
+      }
+    }
+  }
+
+  return Array.from(expanded).join(',')
 }
 
 function buildFolderIdsCondition(folderIds: string): SQL | undefined {

--- a/apps/sim/lib/logs/filters.ts
+++ b/apps/sim/lib/logs/filters.ts
@@ -1,6 +1,5 @@
-import { db } from '@sim/db'
-import { workflow, workflowExecutionLogs, workflowFolder } from '@sim/db/schema'
-import { and, eq, gt, gte, inArray, isNull, lt, lte, ne, type SQL, sql } from 'drizzle-orm'
+import { workflow, workflowExecutionLogs } from '@sim/db/schema'
+import { and, eq, gt, gte, inArray, lt, lte, ne, type SQL, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import type { TimeRange } from '@/stores/logs/filters/types'
 
@@ -127,53 +126,6 @@ function buildWorkflowIdsCondition(workflowIds: string): SQL | undefined {
     return inArray(workflow.id, ids)
   }
   return undefined
-}
-
-/**
- * Expands a CSV of selected folder IDs to include every descendant folder in the
- * workspace, so that filtering by a parent folder also matches workflows that
- * live in nested subfolders.
- *
- * Returns the original CSV when there are no descendants (or when the input is
- * empty / undefined). Unknown IDs are preserved so the caller's `inArray` check
- * behaves the same as today (matches nothing).
- */
-export async function expandFolderIdsWithDescendants(
-  workspaceId: string,
-  folderIdsCsv: string | undefined
-): Promise<string | undefined> {
-  if (!folderIdsCsv) return folderIdsCsv
-  const seedIds = folderIdsCsv.split(',').filter(Boolean)
-  if (seedIds.length === 0) return folderIdsCsv
-
-  const rows = await db
-    .select({ id: workflowFolder.id, parentId: workflowFolder.parentId })
-    .from(workflowFolder)
-    .where(and(eq(workflowFolder.workspaceId, workspaceId), isNull(workflowFolder.archivedAt)))
-
-  const childrenByParent = new Map<string, string[]>()
-  for (const row of rows) {
-    if (!row.parentId) continue
-    const list = childrenByParent.get(row.parentId)
-    if (list) list.push(row.id)
-    else childrenByParent.set(row.parentId, [row.id])
-  }
-
-  const expanded = new Set<string>(seedIds)
-  const queue = [...seedIds]
-  while (queue.length > 0) {
-    const current = queue.pop() as string
-    const children = childrenByParent.get(current)
-    if (!children) continue
-    for (const childId of children) {
-      if (!expanded.has(childId)) {
-        expanded.add(childId)
-        queue.push(childId)
-      }
-    }
-  }
-
-  return Array.from(expanded).join(',')
 }
 
 function buildFolderIdsCondition(folderIds: string): SQL | undefined {

--- a/apps/sim/lib/logs/filters.ts
+++ b/apps/sim/lib/logs/filters.ts
@@ -162,7 +162,7 @@ export async function expandFolderIdsWithDescendants(
   const expanded = new Set<string>(seedIds)
   const queue = [...seedIds]
   while (queue.length > 0) {
-    const current = queue.shift() as string
+    const current = queue.pop() as string
     const children = childrenByParent.get(current)
     if (!children) continue
     for (const childId of children) {

--- a/apps/sim/lib/logs/folder-expansion.ts
+++ b/apps/sim/lib/logs/folder-expansion.ts
@@ -1,0 +1,53 @@
+import { db } from '@sim/db'
+import { workflowFolder } from '@sim/db/schema'
+import { and, eq, isNull } from 'drizzle-orm'
+
+/**
+ * Expands a CSV of selected folder IDs to include every descendant folder in the
+ * workspace, so that filtering by a parent folder also matches workflows that
+ * live in nested subfolders.
+ *
+ * Returns the original CSV when there are no descendants (or when the input is
+ * empty / undefined). Unknown IDs are preserved so the caller's `inArray` check
+ * behaves the same as today (matches nothing).
+ *
+ * Server-only: pulls in the database client. Keep separate from `filters.ts`
+ * (imported by client hooks) to avoid leaking postgres into the browser bundle.
+ */
+export async function expandFolderIdsWithDescendants(
+  workspaceId: string,
+  folderIdsCsv: string | undefined
+): Promise<string | undefined> {
+  if (!folderIdsCsv) return folderIdsCsv
+  const seedIds = folderIdsCsv.split(',').filter(Boolean)
+  if (seedIds.length === 0) return folderIdsCsv
+
+  const rows = await db
+    .select({ id: workflowFolder.id, parentId: workflowFolder.parentId })
+    .from(workflowFolder)
+    .where(and(eq(workflowFolder.workspaceId, workspaceId), isNull(workflowFolder.archivedAt)))
+
+  const childrenByParent = new Map<string, string[]>()
+  for (const row of rows) {
+    if (!row.parentId) continue
+    const list = childrenByParent.get(row.parentId)
+    if (list) list.push(row.id)
+    else childrenByParent.set(row.parentId, [row.id])
+  }
+
+  const expanded = new Set<string>(seedIds)
+  const queue = [...seedIds]
+  while (queue.length > 0) {
+    const current = queue.pop() as string
+    const children = childrenByParent.get(current)
+    if (!children) continue
+    for (const childId of children) {
+      if (!expanded.has(childId)) {
+        expanded.add(childId)
+        queue.push(childId)
+      }
+    }
+  }
+
+  return Array.from(expanded).join(',')
+}


### PR DESCRIPTION
## Summary
- Folder filter on Logs page returned no results when a parent folder was selected because the SQL only matched workflows whose direct `folderId` was in the selected set
- Added `expandFolderIdsWithDescendants` helper that expands selected folder IDs to include all descendant folders in the workspace, then wired it into the list, stats, and export endpoints before `buildFilterConditions`
- Reported by Brandon Tarr — selecting `ITSM_PUX` showed an empty list even though logs existed in nested subfolders

## Type of Change
- [x] Bug fix

## Testing
Tested manually — selecting a parent folder now returns logs from the parent and every descendant; leaf folders behave the same as before. `bun run check:api-validation` passes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)