### PR TITLE
fix(uploads): write workspaceFiles row when issuing presigned URL

### DIFF
--- a/apps/sim/app/api/files/presigned/route.test.ts
+++ b/apps/sim/app/api/files/presigned/route.test.ts
@@ -25,6 +25,7 @@ const {
   mockGetUserEntityPermissions,
   mockGenerateWorkspaceFileKey,
   mockGenerateExecutionFileKey,
+  mockInsertFileMetadata,
 } = vi.hoisted(() => ({
   mockVerifyFileAccess: vi.fn().mockResolvedValue(true),
   mockVerifyWorkspaceFileAccess: vi.fn().mockResolvedValue(true),
@@ -50,6 +51,7 @@ const {
     (ctx: { workspaceId: string; workflowId: string; executionId: string }, fileName: string) =>
       `execution/${ctx.workspaceId}/${ctx.workflowId}/${ctx.executionId}/${fileName}`
   ),
+  mockInsertFileMetadata: vi.fn().mockResolvedValue({ id: 'wf_test' }),
 }))
 
 vi.mock('@/app/api/files/authorization', () => ({
@@ -87,6 +89,10 @@ vi.mock('@/lib/uploads/contexts/workspace/workspace-file-manager', () => ({
 
 vi.mock('@/lib/uploads/contexts/execution/utils', () => ({
   generateExecutionFileKey: mockGenerateExecutionFileKey,
+}))
+
+vi.mock('@/lib/uploads/server/metadata', () => ({
+  insertFileMetadata: mockInsertFileMetadata,
 }))
 
 vi.mock('@/lib/uploads/utils/file-utils', () => ({
@@ -614,6 +620,37 @@ describe('/api/files/presigned', () => {
       const response = await POST(request)
       expect(response.status).toBe(403)
     })
+
+    it('inserts a workspaceFiles row with context=mothership so previews authorize', async () => {
+      setupFileApiMocks({ cloudEnabled: true, storageProvider: 's3' })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/files/presigned?type=mothership&workspaceId=ws-1',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            fileName: 'screenshot.png',
+            contentType: 'image/png',
+            fileSize: 4096,
+          }),
+        }
+      )
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(mockInsertFileMetadata).toHaveBeenCalledTimes(1)
+      expect(mockInsertFileMetadata).toHaveBeenCalledWith({
+        key: data.fileInfo.key,
+        userId: 'test-user-id',
+        workspaceId: 'ws-1',
+        context: 'mothership',
+        originalName: 'screenshot.png',
+        contentType: 'image/png',
+        size: 4096,
+      })
+    })
   })
 
   describe('execution uploads', () => {
@@ -681,6 +718,70 @@ describe('/api/files/presigned', () => {
 
       const response = await POST(request)
       expect(response.status).toBe(400)
+    })
+
+    it('inserts a workspaceFiles row with context=execution so previews authorize', async () => {
+      setupFileApiMocks({ cloudEnabled: true, storageProvider: 's3' })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/files/presigned?type=execution&workspaceId=ws-1&workflowId=wf-1&executionId=exec-1',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            fileName: 'output.mp4',
+            contentType: 'video/mp4',
+            fileSize: 4096,
+          }),
+        }
+      )
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(mockInsertFileMetadata).toHaveBeenCalledTimes(1)
+      expect(mockInsertFileMetadata).toHaveBeenCalledWith({
+        key: data.fileInfo.key,
+        userId: 'test-user-id',
+        workspaceId: 'ws-1',
+        context: 'execution',
+        originalName: 'output.mp4',
+        contentType: 'video/mp4',
+        size: 4096,
+      })
+    })
+  })
+
+  describe('workspace-logos uploads', () => {
+    it('inserts a workspaceFiles row with context=workspace-logos so logos authorize', async () => {
+      setupFileApiMocks({ cloudEnabled: true, storageProvider: 's3' })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/files/presigned?type=workspace-logos&workspaceId=ws-1',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            fileName: 'logo.png',
+            contentType: 'image/png',
+            fileSize: 4096,
+          }),
+        }
+      )
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(mockInsertFileMetadata).toHaveBeenCalledTimes(1)
+      expect(mockInsertFileMetadata).toHaveBeenCalledWith({
+        key: data.fileInfo.key,
+        userId: 'test-user-id',
+        workspaceId: 'ws-1',
+        context: 'workspace-logos',
+        originalName: 'logo.png',
+        contentType: 'image/png',
+        size: 4096,
+      })
     })
   })
 

--- a/apps/sim/app/api/files/presigned/route.test.ts
+++ b/apps/sim/app/api/files/presigned/route.test.ts
@@ -651,6 +651,26 @@ describe('/api/files/presigned', () => {
         size: 4096,
       })
     })
+
+    it('returns 500 when insertFileMetadata fails so callers do not get an unauthorizable URL', async () => {
+      setupFileApiMocks({ cloudEnabled: true, storageProvider: 's3' })
+      mockInsertFileMetadata.mockRejectedValueOnce(new Error('DB connection lost'))
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/files/presigned?type=mothership&workspaceId=ws-1',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            fileName: 'screenshot.png',
+            contentType: 'image/png',
+            fileSize: 4096,
+          }),
+        }
+      )
+
+      const response = await POST(request)
+      expect(response.status).toBe(500)
+    })
   })
 
   describe('execution uploads', () => {

--- a/apps/sim/app/api/files/presigned/route.ts
+++ b/apps/sim/app/api/files/presigned/route.ts
@@ -10,6 +10,7 @@ import { USE_BLOB_STORAGE } from '@/lib/uploads/config'
 import { generateExecutionFileKey } from '@/lib/uploads/contexts/execution/utils'
 import { generateWorkspaceFileKey } from '@/lib/uploads/contexts/workspace/workspace-file-manager'
 import { generatePresignedUploadUrl, hasCloudStorage } from '@/lib/uploads/core/storage-service'
+import { insertFileMetadata } from '@/lib/uploads/server/metadata'
 import { isImageFileType } from '@/lib/uploads/utils/file-utils'
 import { validateAttachmentFileType, validateFileType } from '@/lib/uploads/utils/validation'
 import { getUserEntityPermissions } from '@/lib/workspaces/permissions/utils'
@@ -157,6 +158,16 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         expirationSeconds: 3600,
         metadata: { workspaceId },
       })
+
+      await insertFileMetadata({
+        key: presignedUrlResponse.key,
+        userId: sessionUserId,
+        workspaceId,
+        context: 'mothership',
+        originalName: fileName,
+        contentType,
+        size: fileSize,
+      })
     } else if (uploadType === 'execution') {
       const workflowId = request.nextUrl.searchParams.get('workflowId')
       const executionId = request.nextUrl.searchParams.get('executionId')
@@ -191,6 +202,16 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         expirationSeconds: 3600,
         metadata: { workspaceId, workflowId, executionId },
       })
+
+      await insertFileMetadata({
+        key: presignedUrlResponse.key,
+        userId: sessionUserId,
+        workspaceId,
+        context: 'execution',
+        originalName: fileName,
+        contentType,
+        size: fileSize,
+      })
     } else if (uploadType === 'workspace-logos') {
       const workspaceId = request.nextUrl.searchParams.get('workspaceId')
       if (!workspaceId?.trim()) {
@@ -221,6 +242,16 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         userId: sessionUserId,
         expirationSeconds: 3600,
         metadata: { workspaceId },
+      })
+
+      await insertFileMetadata({
+        key: presignedUrlResponse.key,
+        userId: sessionUserId,
+        workspaceId,
+        context: 'workspace-logos',
+        originalName: fileName,
+        contentType,
+        size: fileSize,
       })
     } else {
       if (uploadType === 'profile-pictures') {


### PR DESCRIPTION
## Summary
- Mothership/execution/workspace-logos presigned uploads no longer leave previews unauthorized — the route now writes the `workspaceFiles` row at presign time, matching what `storageService.uploadFile` does on main
- Without this, clicking an in-chat image preview before sending the message threw `FileNotFoundError` from `/api/files/serve` because no DB row existed and S3 `HeadObject` returned lowercased metadata keys
- Added test coverage asserting the row is inserted with the expected context for each branch

## Type of Change
- [x] Bug fix

## Testing
Tested manually on staging — dropped image into Mothership chat, clicked preview, image renders. `bun run check:api-validation` passes; new and existing tests pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)