### PR TITLE
fix(security): close cross-tenant IDOR gaps in OAuth credential and execution auth

### DIFF
--- a/apps/sim/app/api/auth/oauth/wealthbox/item/route.ts
+++ b/apps/sim/app/api/auth/oauth/wealthbox/item/route.ts
@@ -1,15 +1,12 @@
-import { db } from '@sim/db'
-import { account } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
-import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { wealthboxOAuthItemContract } from '@/lib/api/contracts/selectors/wealthbox'
 import { parseRequest } from '@/lib/api/server'
-import { getSession } from '@/lib/auth'
+import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validateEnum, validatePathSegment } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { refreshAccessTokenIfNeeded, resolveOAuthAccountId } from '@/app/api/auth/oauth/utils'
+import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -31,13 +28,6 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const requestId = generateRequestId()
 
   try {
-    const session = await getSession()
-
-    if (!session?.user?.id) {
-      logger.warn(`[${requestId}] Unauthenticated request rejected`)
-      return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
-    }
-
     const parsed = await parseRequest(wealthboxOAuthItemContract, request, {})
     if (!parsed.success) return parsed.response
     const { credentialId, itemId, type } = parsed.data.query
@@ -60,39 +50,18 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       return NextResponse.json({ error: itemIdValidation.error }, { status: 400 })
     }
 
-    const resolved = await resolveOAuthAccountId(credentialId)
-    if (!resolved) {
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
+    const credAccess = await authorizeCredentialUse(request, {
+      credentialId,
+      requireWorkflowIdForInternal: false,
+    })
+    if (!credAccess.ok || !credAccess.credentialOwnerUserId) {
+      logger.warn(`[${requestId}] Credential access denied`, { error: credAccess.error })
+      return NextResponse.json({ error: credAccess.error || 'Unauthorized' }, { status: 401 })
     }
-
-    if (resolved.workspaceId) {
-      const { getUserEntityPermissions } = await import('@/lib/workspaces/permissions/utils')
-      const perm = await getUserEntityPermissions(
-        session.user.id,
-        'workspace',
-        resolved.workspaceId
-      )
-      if (perm === null) {
-        return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-      }
-    }
-
-    const credentials = await db
-      .select()
-      .from(account)
-      .where(eq(account.id, resolved.accountId))
-      .limit(1)
-
-    if (!credentials.length) {
-      logger.warn(`[${requestId}] Credential not found`, { credentialId })
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
-    }
-
-    const accountRow = credentials[0]
 
     const accessToken = await refreshAccessTokenIfNeeded(
-      resolved.accountId,
-      accountRow.userId,
+      credentialId,
+      credAccess.credentialOwnerUserId,
       requestId
     )
 

--- a/apps/sim/app/api/providers/route.ts
+++ b/apps/sim/app/api/providers/route.ts
@@ -6,6 +6,7 @@ import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { executeProviderContract } from '@/lib/api/contracts/providers'
 import { parseRequest } from '@/lib/api/server'
+import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
@@ -141,6 +142,21 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     let finalApiKey: string | undefined = apiKey
     try {
       if (provider === 'vertex' && vertexCredential) {
+        const vertexCredAccess = await authorizeCredentialUse(request, {
+          credentialId: vertexCredential,
+          workflowId: workflowId || undefined,
+          requireWorkflowIdForInternal: false,
+        })
+        if (!vertexCredAccess.ok) {
+          logger.warn(`[${requestId}] Vertex credential access denied`, {
+            error: vertexCredAccess.error,
+            credentialId: vertexCredential,
+          })
+          return NextResponse.json(
+            { error: vertexCredAccess.error || 'Unauthorized' },
+            { status: 401 }
+          )
+        }
         finalApiKey = await resolveVertexCredential(requestId, vertexCredential)
       }
     } catch (error) {

--- a/apps/sim/app/api/resume/[workflowId]/[executionId]/[contextId]/route.ts
+++ b/apps/sim/app/api/resume/[workflowId]/[executionId]/[contextId]/route.ts
@@ -284,7 +284,7 @@ export const POST = withRouteHandler(
         executionId: enqueueResult.resumeExecutionId,
         message: 'Resume execution started.',
       })
-    } catch (error: any) {
+    } catch (error) {
       logger.error('Resume request failed', {
         workflowId,
         executionId,
@@ -292,7 +292,7 @@ export const POST = withRouteHandler(
         error,
       })
       return NextResponse.json(
-        { error: error.message || 'Failed to queue resume request' },
+        { error: toError(error).message || 'Failed to queue resume request' },
         { status: 400 }
       )
     }

--- a/apps/sim/app/api/resume/[workflowId]/[executionId]/[contextId]/route.ts
+++ b/apps/sim/app/api/resume/[workflowId]/[executionId]/[contextId]/route.ts
@@ -141,6 +141,7 @@ export const POST = withRouteHandler(
     try {
       const enqueueResult = await PauseResumeManager.enqueueOrStartResume({
         executionId,
+        workflowId,
         contextId,
         resumeInput,
         userId,

--- a/apps/sim/app/api/resume/[workflowId]/[executionId]/[contextId]/route.ts
+++ b/apps/sim/app/api/resume/[workflowId]/[executionId]/[contextId]/route.ts
@@ -250,7 +250,7 @@ export const POST = withRouteHandler(
             contextId: enqueueResult.contextId,
             failureReason: 'Failed to queue async resume execution',
           })
-          await PauseResumeManager.processQueuedResumes(executionId)
+          await PauseResumeManager.processQueuedResumes(executionId, workflowId)
           return NextResponse.json(
             { error: 'Failed to queue resume execution. Please try again.' },
             { status: 503 }

--- a/apps/sim/app/api/resume/poll/route.ts
+++ b/apps/sim/app/api/resume/poll/route.ts
@@ -128,6 +128,7 @@ async function dispatchRow(row: DueRow, now: Date): Promise<RowResult> {
     try {
       const enqueueResult = await PauseResumeManager.enqueueOrStartResume({
         executionId: row.executionId,
+        workflowId: row.workflowId,
         contextId: point.contextId,
         resumeInput: {},
         userId,

--- a/apps/sim/app/api/tools/gmail/label/route.ts
+++ b/apps/sim/app/api/tools/gmail/label/route.ts
@@ -1,21 +1,13 @@
-import { db } from '@sim/db'
-import { account } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
-import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { gmailLabelSelectorContract } from '@/lib/api/contracts/selectors/google'
 import { parseRequest } from '@/lib/api/server'
-import { getSession } from '@/lib/auth'
+import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validateAlphanumericId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { getScopesForService } from '@/lib/oauth/utils'
-import {
-  getServiceAccountToken,
-  refreshAccessTokenIfNeeded,
-  resolveOAuthAccountId,
-  ServiceAccountTokenError,
-} from '@/app/api/auth/oauth/utils'
+import { refreshAccessTokenIfNeeded, ServiceAccountTokenError } from '@/app/api/auth/oauth/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -25,13 +17,6 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const requestId = generateRequestId()
 
   try {
-    const session = await getSession()
-
-    if (!session?.user?.id) {
-      logger.warn(`[${requestId}] Unauthenticated label request rejected`)
-      return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
-    }
-
     const parsed = await parseRequest(gmailLabelSelectorContract, request, {})
     if (!parsed.success) return parsed.response
     const { credentialId, labelId } = parsed.data.query
@@ -43,56 +28,22 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       return NextResponse.json({ error: labelIdValidation.error }, { status: 400 })
     }
 
-    const resolved = await resolveOAuthAccountId(credentialId)
-    if (!resolved) {
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
+    const credAccess = await authorizeCredentialUse(request, {
+      credentialId,
+      requireWorkflowIdForInternal: false,
+    })
+    if (!credAccess.ok || !credAccess.credentialOwnerUserId) {
+      logger.warn(`[${requestId}] Credential access denied`, { error: credAccess.error })
+      return NextResponse.json({ error: credAccess.error || 'Unauthorized' }, { status: 401 })
     }
 
-    if (resolved.workspaceId) {
-      const { getUserEntityPermissions } = await import('@/lib/workspaces/permissions/utils')
-      const perm = await getUserEntityPermissions(
-        session.user.id,
-        'workspace',
-        resolved.workspaceId
-      )
-      if (perm === null) {
-        return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-      }
-    }
-
-    let accessToken: string | null = null
-
-    if (resolved.credentialType === 'service_account' && resolved.credentialId) {
-      accessToken = await getServiceAccountToken(
-        resolved.credentialId,
-        getScopesForService('gmail'),
-        impersonateEmail
-      )
-    } else {
-      const credentials = await db
-        .select()
-        .from(account)
-        .where(eq(account.id, resolved.accountId))
-        .limit(1)
-
-      if (!credentials.length) {
-        logger.warn(`[${requestId}] Credential not found`)
-        return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
-      }
-
-      const accountRow = credentials[0]
-
-      logger.info(
-        `[${requestId}] Using credential: ${accountRow.id}, provider: ${accountRow.providerId}`
-      )
-
-      accessToken = await refreshAccessTokenIfNeeded(
-        resolved.accountId,
-        accountRow.userId,
-        requestId,
-        getScopesForService('gmail')
-      )
-    }
+    const accessToken = await refreshAccessTokenIfNeeded(
+      credentialId,
+      credAccess.credentialOwnerUserId,
+      requestId,
+      getScopesForService('gmail'),
+      impersonateEmail
+    )
 
     if (!accessToken) {
       return NextResponse.json({ error: 'Failed to obtain valid access token' }, { status: 401 })

--- a/apps/sim/app/api/tools/onedrive/files/route.ts
+++ b/apps/sim/app/api/tools/onedrive/files/route.ts
@@ -1,15 +1,12 @@
-import { db } from '@sim/db'
-import { account } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
-import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { onedriveFilesQuerySchema } from '@/lib/api/contracts/selectors/microsoft'
 import { getValidationErrorMessage } from '@/lib/api/server'
-import { getSession } from '@/lib/auth'
+import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validateMicrosoftGraphId } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { refreshAccessTokenIfNeeded, resolveOAuthAccountId } from '@/app/api/auth/oauth/utils'
+import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 import type { MicrosoftGraphDriveItem } from '@/tools/onedrive/types'
 
 export const dynamic = 'force-dynamic'
@@ -24,12 +21,6 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   logger.info(`[${requestId}] OneDrive files request received`)
 
   try {
-    const session = await getSession()
-    if (!session?.user?.id) {
-      logger.warn(`[${requestId}] Unauthenticated request rejected`)
-      return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
-    }
-
     const { searchParams } = new URL(request.url)
     const validation = onedriveFilesQuerySchema.safeParse({
       credentialId: searchParams.get('credentialId') ?? '',
@@ -53,38 +44,18 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
 
     logger.info(`[${requestId}] Fetching credential`, { credentialId })
 
-    const resolved = await resolveOAuthAccountId(credentialId)
-    if (!resolved) {
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
+    const credAccess = await authorizeCredentialUse(request, {
+      credentialId,
+      requireWorkflowIdForInternal: false,
+    })
+    if (!credAccess.ok || !credAccess.credentialOwnerUserId) {
+      logger.warn(`[${requestId}] Credential access denied`, { error: credAccess.error })
+      return NextResponse.json({ error: credAccess.error || 'Unauthorized' }, { status: 401 })
     }
-
-    if (resolved.workspaceId) {
-      const { getUserEntityPermissions } = await import('@/lib/workspaces/permissions/utils')
-      const perm = await getUserEntityPermissions(
-        session.user.id,
-        'workspace',
-        resolved.workspaceId
-      )
-      if (perm === null) {
-        return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-      }
-    }
-
-    const credentials = await db
-      .select()
-      .from(account)
-      .where(eq(account.id, resolved.accountId))
-      .limit(1)
-    if (!credentials.length) {
-      logger.warn(`[${requestId}] Credential not found`, { credentialId })
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
-    }
-
-    const accountRow = credentials[0]
 
     const accessToken = await refreshAccessTokenIfNeeded(
-      resolved.accountId,
-      accountRow.userId,
+      credentialId,
+      credAccess.credentialOwnerUserId,
       requestId
     )
     if (!accessToken) {

--- a/apps/sim/app/api/tools/onedrive/files/route.ts
+++ b/apps/sim/app/api/tools/onedrive/files/route.ts
@@ -63,11 +63,9 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       return NextResponse.json({ error: 'Failed to obtain valid access token' }, { status: 401 })
     }
 
-    // Use search endpoint if query provided, otherwise list root children
-    // Microsoft Graph API doesn't support $filter on file/folder properties for /children endpoint
+    // $filter is unsupported on the /children endpoint; use search when a query is present
     let url: string
     if (query) {
-      // Use search endpoint with query
       const searchParams_new = new URLSearchParams()
       searchParams_new.append(
         '$select',
@@ -76,7 +74,6 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       searchParams_new.append('$top', '50')
       url = `https://graph.microsoft.com/v1.0/me/drive/root/search(q='${encodeURIComponent(query)}')?${searchParams_new.toString()}`
     } else {
-      // List all children (files and folders) from root
       const searchParams_new = new URLSearchParams()
       searchParams_new.append(
         '$select',
@@ -109,27 +106,8 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     const data = await response.json()
     logger.info(`[${requestId}] Received ${data.value?.length || 0} items from Microsoft Graph`)
 
-    // Log what we received to debug filtering
-    const itemBreakdown = (data.value || []).reduce(
-      (acc: any, item: MicrosoftGraphDriveItem) => {
-        if (item.file) acc.files++
-        if (item.folder) acc.folders++
-        return acc
-      },
-      { files: 0, folders: 0 }
-    )
-    logger.info(`[${requestId}] Item breakdown`, itemBreakdown)
-
     const files = (data.value || [])
-      .filter((item: MicrosoftGraphDriveItem) => {
-        const isFile = !!item.file && !item.folder
-        if (!isFile) {
-          logger.debug(
-            `[${requestId}] Filtering out item: ${item.name} (isFolder: ${!!item.folder})`
-          )
-        }
-        return isFile
-      })
+      .filter((item: MicrosoftGraphDriveItem) => !!item.file && !item.folder)
       .map((file: MicrosoftGraphDriveItem) => ({
         id: file.id,
         name: file.name,
@@ -150,16 +128,9 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
           : [],
       }))
 
-    logger.info(
-      `[${requestId}] Returning ${files.length} files (filtered from ${data.value?.length || 0} items)`
-    )
-
-    // Log the file IDs we're returning
-    if (files.length > 0) {
-      logger.info(`[${requestId}] File IDs being returned:`, {
-        fileIds: files.slice(0, 5).map((f: any) => ({ id: f.id, name: f.name })),
-      })
-    }
+    logger.info(`[${requestId}] Returning ${files.length} files`, {
+      totalItems: data.value?.length || 0,
+    })
 
     return NextResponse.json({ files }, { status: 200 })
   } catch (error) {

--- a/apps/sim/app/api/tools/onedrive/folder/route.ts
+++ b/apps/sim/app/api/tools/onedrive/folder/route.ts
@@ -39,7 +39,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       requireWorkflowIdForInternal: false,
     })
     if (!credAccess.ok || !credAccess.credentialOwnerUserId) {
-      logger.error(`[${requestId}] Credential access denied`, { error: credAccess.error })
+      logger.warn(`[${requestId}] Credential access denied`, { error: credAccess.error })
       return NextResponse.json({ error: credAccess.error || 'Unauthorized' }, { status: 401 })
     }
 

--- a/apps/sim/app/api/tools/onedrive/folder/route.ts
+++ b/apps/sim/app/api/tools/onedrive/folder/route.ts
@@ -1,15 +1,12 @@
-import { db } from '@sim/db'
-import { account } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
-import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { onedriveFolderQuerySchema } from '@/lib/api/contracts/selectors/microsoft'
 import { getValidationErrorMessage } from '@/lib/api/server'
-import { getSession } from '@/lib/auth'
+import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validateMicrosoftGraphId } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { refreshAccessTokenIfNeeded, resolveOAuthAccountId } from '@/app/api/auth/oauth/utils'
+import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,11 +16,6 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const requestId = generateId().slice(0, 8)
 
   try {
-    const session = await getSession()
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
-    }
-
     const { searchParams } = new URL(request.url)
     const validation = onedriveFolderQuerySchema.safeParse({
       credentialId: searchParams.get('credentialId') ?? '',
@@ -42,37 +34,18 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       return NextResponse.json({ error: fileIdValidation.error }, { status: 400 })
     }
 
-    const resolved = await resolveOAuthAccountId(credentialId)
-    if (!resolved) {
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
+    const credAccess = await authorizeCredentialUse(request, {
+      credentialId,
+      requireWorkflowIdForInternal: false,
+    })
+    if (!credAccess.ok || !credAccess.credentialOwnerUserId) {
+      logger.error(`[${requestId}] Credential access denied`, { error: credAccess.error })
+      return NextResponse.json({ error: credAccess.error || 'Unauthorized' }, { status: 401 })
     }
-
-    if (resolved.workspaceId) {
-      const { getUserEntityPermissions } = await import('@/lib/workspaces/permissions/utils')
-      const perm = await getUserEntityPermissions(
-        session.user.id,
-        'workspace',
-        resolved.workspaceId
-      )
-      if (perm === null) {
-        return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-      }
-    }
-
-    const credentials = await db
-      .select()
-      .from(account)
-      .where(eq(account.id, resolved.accountId))
-      .limit(1)
-    if (!credentials.length) {
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
-    }
-
-    const accountRow = credentials[0]
 
     const accessToken = await refreshAccessTokenIfNeeded(
-      resolved.accountId,
-      accountRow.userId,
+      credentialId,
+      credAccess.credentialOwnerUserId,
       requestId
     )
     if (!accessToken) {

--- a/apps/sim/app/api/tools/outlook/folders/route.ts
+++ b/apps/sim/app/api/tools/outlook/folders/route.ts
@@ -1,16 +1,13 @@
-import { db } from '@sim/db'
-import { account } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
-import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { outlookFoldersSelectorContract } from '@/lib/api/contracts/selectors/microsoft'
 import { parseRequest } from '@/lib/api/server'
-import { getSession } from '@/lib/auth'
+import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validateAlphanumericId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { refreshAccessTokenIfNeeded, resolveOAuthAccountId } from '@/app/api/auth/oauth/utils'
+import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -25,7 +22,6 @@ interface OutlookFolder {
 
 export const GET = withRouteHandler(async (request: NextRequest) => {
   try {
-    const session = await getSession()
     const parsed = await parseRequest(outlookFoldersSelectorContract, request, {})
     if (!parsed.success) return parsed.response
     const { credentialId } = parsed.data.query
@@ -37,49 +33,29 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     }
 
     try {
-      const sessionUserId = session?.user?.id || ''
-
-      if (!sessionUserId) {
-        logger.error('No user ID found in session')
-        return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
-      }
-
-      const resolved = await resolveOAuthAccountId(credentialId)
-      if (!resolved) {
-        return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
-      }
-
-      if (resolved.workspaceId) {
-        const { getUserEntityPermissions } = await import('@/lib/workspaces/permissions/utils')
-        const perm = await getUserEntityPermissions(
-          session!.user!.id,
-          'workspace',
-          resolved.workspaceId
+      const credAccess = await authorizeCredentialUse(request, {
+        credentialId,
+        requireWorkflowIdForInternal: false,
+      })
+      if (!credAccess.ok || !credAccess.credentialOwnerUserId) {
+        logger.error('Credential access denied', { error: credAccess.error })
+        return NextResponse.json(
+          { error: credAccess.error || 'Authentication required' },
+          { status: 401 }
         )
-        if (perm === null) {
-          return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-        }
       }
-
-      const creds = await db
-        .select()
-        .from(account)
-        .where(eq(account.id, resolved.accountId))
-        .limit(1)
-      if (!creds.length) {
-        logger.warn('Credential not found', { credentialId })
-        return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
-      }
-      const credentialOwnerUserId = creds[0].userId
 
       const accessToken = await refreshAccessTokenIfNeeded(
-        resolved.accountId,
-        credentialOwnerUserId,
+        credentialId,
+        credAccess.credentialOwnerUserId,
         generateRequestId()
       )
 
       if (!accessToken) {
-        logger.error('Failed to get access token', { credentialId, userId: credentialOwnerUserId })
+        logger.error('Failed to get access token', {
+          credentialId,
+          userId: credAccess.credentialOwnerUserId,
+        })
         return NextResponse.json(
           {
             error: 'Could not retrieve access token',

--- a/apps/sim/app/api/tools/outlook/folders/route.ts
+++ b/apps/sim/app/api/tools/outlook/folders/route.ts
@@ -38,7 +38,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
         requireWorkflowIdForInternal: false,
       })
       if (!credAccess.ok || !credAccess.credentialOwnerUserId) {
-        logger.error('Credential access denied', { error: credAccess.error })
+        logger.warn('Credential access denied', { error: credAccess.error })
         return NextResponse.json(
           { error: credAccess.error || 'Authentication required' },
           { status: 401 }

--- a/apps/sim/app/api/tools/wealthbox/item/route.ts
+++ b/apps/sim/app/api/tools/wealthbox/item/route.ts
@@ -1,15 +1,12 @@
-import { db } from '@sim/db'
-import { account } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
-import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { wealthboxItemContract } from '@/lib/api/contracts/selectors/wealthbox'
 import { parseRequest } from '@/lib/api/server'
-import { getSession } from '@/lib/auth'
+import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validatePathSegment } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { refreshAccessTokenIfNeeded, resolveOAuthAccountId } from '@/app/api/auth/oauth/utils'
+import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,13 +16,6 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const requestId = generateRequestId()
 
   try {
-    const session = await getSession()
-
-    if (!session?.user?.id) {
-      logger.warn(`[${requestId}] Unauthenticated request rejected`)
-      return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
-    }
-
     const parsed = await parseRequest(wealthboxItemContract, request, {})
     if (!parsed.success) return parsed.response
     const { credentialId, itemId, type } = parsed.data.query
@@ -54,39 +44,18 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       return NextResponse.json({ error: credentialIdValidation.error }, { status: 400 })
     }
 
-    const resolved = await resolveOAuthAccountId(credentialId)
-    if (!resolved) {
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
+    const credAccess = await authorizeCredentialUse(request, {
+      credentialId,
+      requireWorkflowIdForInternal: false,
+    })
+    if (!credAccess.ok || !credAccess.credentialOwnerUserId) {
+      logger.warn(`[${requestId}] Credential access denied`, { error: credAccess.error })
+      return NextResponse.json({ error: credAccess.error || 'Unauthorized' }, { status: 401 })
     }
-
-    if (resolved.workspaceId) {
-      const { getUserEntityPermissions } = await import('@/lib/workspaces/permissions/utils')
-      const perm = await getUserEntityPermissions(
-        session.user.id,
-        'workspace',
-        resolved.workspaceId
-      )
-      if (perm === null) {
-        return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-      }
-    }
-
-    const credentials = await db
-      .select()
-      .from(account)
-      .where(eq(account.id, resolved.accountId))
-      .limit(1)
-
-    if (!credentials.length) {
-      logger.warn(`[${requestId}] Credential not found`, { credentialId })
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
-    }
-
-    const accountRow = credentials[0]
 
     const accessToken = await refreshAccessTokenIfNeeded(
-      resolved.accountId,
-      accountRow.userId,
+      credentialId,
+      credAccess.credentialOwnerUserId,
       requestId
     )
 

--- a/apps/sim/app/api/tools/wordpress/upload/route.ts
+++ b/apps/sim/app/api/tools/wordpress/upload/route.ts
@@ -11,6 +11,7 @@ import {
   processSingleFileToUserFile,
 } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { verifyFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -76,6 +77,23 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         },
         { status: 400 }
       )
+    }
+
+    if (userFile.key && authResult.userId) {
+      const hasAccess = await verifyFileAccess(userFile.key, authResult.userId)
+      if (!hasAccess) {
+        logger.warn(`[${requestId}] File access denied for user`, {
+          userId: authResult.userId,
+          key: userFile.key,
+        })
+        return NextResponse.json(
+          {
+            success: false,
+            error: 'File not found',
+          },
+          { status: 404 }
+        )
+      }
     }
 
     logger.info(`[${requestId}] Downloading file from storage`, {

--- a/apps/sim/app/api/tools/wordpress/upload/route.ts
+++ b/apps/sim/app/api/tools/wordpress/upload/route.ts
@@ -63,7 +63,6 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
-    // Process file - convert to UserFile format if needed
     const fileData = validatedData.file
 
     let userFile
@@ -115,7 +114,6 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
-    // Use provided filename or fall back to the original file name
     const filename = validatedData.filename || userFile.name
     const mimeType = userFile.type || getMimeTypeFromExtension(getFileExtension(filename))
 
@@ -126,14 +124,11 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       size: fileBuffer.length,
     })
 
-    // Upload to WordPress using multipart form data
     const formData = new FormData()
-    // Convert Buffer to Uint8Array for Blob compatibility
     const uint8Array = new Uint8Array(fileBuffer)
     const blob = new Blob([uint8Array], { type: mimeType })
     formData.append('file', blob, filename)
 
-    // Add optional metadata
     if (validatedData.title) {
       formData.append('title', validatedData.title)
     }

--- a/apps/sim/app/api/tools/wordpress/upload/route.ts
+++ b/apps/sim/app/api/tools/wordpress/upload/route.ts
@@ -78,19 +78,21 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
-    if (userFile.key) {
-      if (!authResult.userId) {
-        logger.warn(`[${requestId}] File access check requires userId but none available`)
-        return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
-      }
-      const hasAccess = await verifyFileAccess(userFile.key, authResult.userId)
-      if (!hasAccess) {
-        logger.warn(`[${requestId}] File access denied for user`, {
-          userId: authResult.userId,
-          key: userFile.key,
-        })
-        return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
-      }
+    if (typeof userFile.key !== 'string' || userFile.key.length === 0) {
+      logger.warn(`[${requestId}] File access check rejected: missing key`)
+      return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
+    }
+    if (!authResult.userId) {
+      logger.warn(`[${requestId}] File access check requires userId but none available`)
+      return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
+    }
+    const hasAccess = await verifyFileAccess(userFile.key, authResult.userId)
+    if (!hasAccess) {
+      logger.warn(`[${requestId}] File access denied for user`, {
+        userId: authResult.userId,
+        key: userFile.key,
+      })
+      return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
     }
 
     logger.info(`[${requestId}] Downloading file from storage`, {

--- a/apps/sim/app/api/tools/wordpress/upload/route.ts
+++ b/apps/sim/app/api/tools/wordpress/upload/route.ts
@@ -79,20 +79,18 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
-    if (userFile.key && authResult.userId) {
+    if (userFile.key) {
+      if (!authResult.userId) {
+        logger.warn(`[${requestId}] File access check requires userId but none available`)
+        return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
+      }
       const hasAccess = await verifyFileAccess(userFile.key, authResult.userId)
       if (!hasAccess) {
         logger.warn(`[${requestId}] File access denied for user`, {
           userId: authResult.userId,
           key: userFile.key,
         })
-        return NextResponse.json(
-          {
-            success: false,
-            error: 'File not found',
-          },
-          { status: 404 }
-        )
+        return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
       }
     }
 

--- a/apps/sim/app/api/workflows/[id]/executions/[executionId]/cancel/route.ts
+++ b/apps/sim/app/api/workflows/[id]/executions/[executionId]/cancel/route.ts
@@ -22,10 +22,13 @@ const logger = createLogger('CancelExecutionAPI')
 const PAUSED_CANCELLATION_DB_ATTEMPTS = 3
 const PAUSED_CANCELLATION_DB_RETRY_MS = 200
 
-async function completePausedCancellationWithRetry(executionId: string): Promise<boolean> {
+async function completePausedCancellationWithRetry(
+  executionId: string,
+  workflowId: string
+): Promise<boolean> {
   for (let attempt = 1; attempt <= PAUSED_CANCELLATION_DB_ATTEMPTS; attempt++) {
     try {
-      const cancelled = await PauseResumeManager.completePausedCancellation(executionId)
+      const cancelled = await PauseResumeManager.completePausedCancellation(executionId, workflowId)
       if (cancelled) {
         logger.info('Paused execution cancelled in database', { executionId, attempt })
         return true
@@ -129,7 +132,10 @@ export const POST = withRouteHandler(
       let pausedCancellationStarted = false
       let pausedCancelled = false
       try {
-        pausedCancellationStarted = await PauseResumeManager.beginPausedCancellation(executionId)
+        pausedCancellationStarted = await PauseResumeManager.beginPausedCancellation(
+          executionId,
+          workflowId
+        )
       } catch (error) {
         logger.warn('Failed to begin paused execution cancellation in database', {
           executionId,
@@ -138,7 +144,7 @@ export const POST = withRouteHandler(
       }
       const pendingPausedCancellation = pausedCancellationStarted
         ? null
-        : await PauseResumeManager.getPausedCancellationStatus(executionId)
+        : await PauseResumeManager.getPausedCancellationStatus(executionId, workflowId)
       const isPausedCancellationPath =
         pausedCancellationStarted || pendingPausedCancellation !== null
 
@@ -161,22 +167,26 @@ export const POST = withRouteHandler(
       }
 
       if (!isPausedCancellationPath && (cancellation.durablyRecorded || locallyAborted)) {
-        await PauseResumeManager.blockQueuedResumesForCancellation(executionId).catch((error) => {
-          logger.warn('Failed to block queued paused resumes after cancellation', {
-            executionId,
-            error,
-          })
-        })
-      } else if (!isPausedCancellationPath) {
-        await PauseResumeManager.clearPausedCancellationIntent(executionId).catch((error) => {
-          logger.warn(
-            'Failed to clear paused cancellation intent after unsuccessful cancellation',
-            {
+        await PauseResumeManager.blockQueuedResumesForCancellation(executionId, workflowId).catch(
+          (error) => {
+            logger.warn('Failed to block queued paused resumes after cancellation', {
               executionId,
               error,
-            }
-          )
-        })
+            })
+          }
+        )
+      } else if (!isPausedCancellationPath) {
+        await PauseResumeManager.clearPausedCancellationIntent(executionId, workflowId).catch(
+          (error) => {
+            logger.warn(
+              'Failed to clear paused cancellation intent after unsuccessful cancellation',
+              {
+                executionId,
+                error,
+              }
+            )
+          }
+        )
       }
 
       let pausedCancellationPublished = false
@@ -188,7 +198,7 @@ export const POST = withRouteHandler(
         )
         pausedCancellationPublishFailed = !pausedCancellationPublished
         if (pausedCancellationPublished) {
-          pausedCancelled = await completePausedCancellationWithRetry(executionId)
+          pausedCancelled = await completePausedCancellationWithRetry(executionId, workflowId)
         }
       } else {
         if (pendingPausedCancellation === 'cancelled') {
@@ -205,7 +215,7 @@ export const POST = withRouteHandler(
           )
           pausedCancellationPublishFailed = !pausedCancellationPublished
           if (pausedCancellationPublished) {
-            pausedCancelled = await completePausedCancellationWithRetry(executionId)
+            pausedCancelled = await completePausedCancellationWithRetry(executionId, workflowId)
           }
         }
       }
@@ -214,12 +224,14 @@ export const POST = withRouteHandler(
         pausedCancellationPublishFailed &&
         (pausedCancellationStarted || pendingPausedCancellation === 'cancelling')
       ) {
-        await PauseResumeManager.clearPausedCancellationIntent(executionId).catch((error) => {
-          logger.warn('Failed to clear paused cancellation intent after publish failure', {
-            executionId,
-            error,
-          })
-        })
+        await PauseResumeManager.clearPausedCancellationIntent(executionId, workflowId).catch(
+          (error) => {
+            logger.warn('Failed to clear paused cancellation intent after publish failure', {
+              executionId,
+              error,
+            })
+          }
+        )
       }
 
       if ((cancellation.durablyRecorded || locallyAborted) && !pausedCancelled) {

--- a/apps/sim/app/api/workflows/[id]/executions/[executionId]/cancel/route.ts
+++ b/apps/sim/app/api/workflows/[id]/executions/[executionId]/cancel/route.ts
@@ -1,6 +1,7 @@
 import { db } from '@sim/db'
 import { workflowExecutionLogs } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
+import { toError } from '@sim/utils/errors'
 import { sleep } from '@sim/utils/helpers'
 import { authorizeWorkflowByWorkspacePermission } from '@sim/workflow-authz'
 import { and, eq } from 'drizzle-orm'
@@ -293,10 +294,14 @@ export const POST = withRouteHandler(
         pausedCancelled,
         reason,
       })
-    } catch (error: any) {
-      logger.error('Failed to cancel execution', { workflowId, executionId, error: error.message })
+    } catch (error) {
+      logger.error('Failed to cancel execution', {
+        workflowId,
+        executionId,
+        error: toError(error).message,
+      })
       return NextResponse.json(
-        { error: error.message || 'Failed to cancel execution' },
+        { error: toError(error).message || 'Failed to cancel execution' },
         { status: 500 }
       )
     }

--- a/apps/sim/lib/auth/credential-access.ts
+++ b/apps/sim/lib/auth/credential-access.ts
@@ -78,44 +78,40 @@ export async function authorizeCredentialUse(
         return { ok: false, error: 'Credential is not accessible from this workflow workspace' }
       }
 
-      if (actingUserId) {
-        const requesterPerm = await getUserEntityPermissions(
-          actingUserId,
-          'workspace',
-          platformCredential.workspaceId
-        )
+      const requesterPerm = await getUserEntityPermissions(
+        actingUserId,
+        'workspace',
+        platformCredential.workspaceId
+      )
 
-        const [membership] = await db
-          .select({ id: credentialMember.id })
-          .from(credentialMember)
-          .where(
-            and(
-              eq(credentialMember.credentialId, platformCredential.id),
-              eq(credentialMember.userId, actingUserId),
-              eq(credentialMember.status, 'active')
-            )
+      const [membership] = await db
+        .select({ id: credentialMember.id })
+        .from(credentialMember)
+        .where(
+          and(
+            eq(credentialMember.credentialId, platformCredential.id),
+            eq(credentialMember.userId, actingUserId),
+            eq(credentialMember.status, 'active')
           )
-          .limit(1)
+        )
+        .limit(1)
 
-        if (!membership) {
-          return {
-            ok: false,
-            error:
-              'You do not have access to this credential. Ask the credential admin to add you as a member.',
-          }
+      if (!membership) {
+        return {
+          ok: false,
+          error:
+            'You do not have access to this credential. Ask the credential admin to add you as a member.',
         }
-        if (requesterPerm === null) {
-          return { ok: false, error: 'You do not have access to this workspace.' }
-        }
-      } else if (!workflowContext) {
-        return { ok: false, error: 'workflowId is required' }
+      }
+      if (requesterPerm === null) {
+        return { ok: false, error: 'You do not have access to this workspace.' }
       }
 
       return {
         ok: true,
         authType: auth.authType as CredentialAccessResult['authType'],
         requesterUserId: auth.userId,
-        credentialOwnerUserId: actingUserId || auth.userId,
+        credentialOwnerUserId: actingUserId,
         workspaceId: platformCredential.workspaceId,
         resolvedCredentialId: platformCredential.id,
       }
@@ -139,36 +135,34 @@ export async function authorizeCredentialUse(
       return { ok: false, error: 'Credential account not found' }
     }
 
-    if (actingUserId) {
-      const requesterPerm = await getUserEntityPermissions(
-        actingUserId,
-        'workspace',
-        platformCredential.workspaceId
-      )
+    const requesterPerm = await getUserEntityPermissions(
+      actingUserId,
+      'workspace',
+      platformCredential.workspaceId
+    )
 
-      const [membership] = await db
-        .select({ id: credentialMember.id })
-        .from(credentialMember)
-        .where(
-          and(
-            eq(credentialMember.credentialId, platformCredential.id),
-            eq(credentialMember.userId, actingUserId),
-            eq(credentialMember.status, 'active')
-          )
+    const [membership] = await db
+      .select({ id: credentialMember.id })
+      .from(credentialMember)
+      .where(
+        and(
+          eq(credentialMember.credentialId, platformCredential.id),
+          eq(credentialMember.userId, actingUserId),
+          eq(credentialMember.status, 'active')
         )
-        .limit(1)
+      )
+      .limit(1)
 
-      if (!membership) {
-        return {
-          ok: false,
-          error: `You do not have access to this credential. Ask the credential admin to add you as a member.`,
-        }
+    if (!membership) {
+      return {
+        ok: false,
+        error: `You do not have access to this credential. Ask the credential admin to add you as a member.`,
       }
-      if (requesterPerm === null) {
-        return {
-          ok: false,
-          error: 'You do not have access to this workspace.',
-        }
+    }
+    if (requesterPerm === null) {
+      return {
+        ok: false,
+        error: 'You do not have access to this workspace.',
       }
     }
 
@@ -222,25 +216,23 @@ export async function authorizeCredentialUse(
       return { ok: false, error: 'Credential account not found' }
     }
 
-    if (actingUserId) {
-      const [membership] = await db
-        .select({ id: credentialMember.id })
-        .from(credentialMember)
-        .where(
-          and(
-            eq(credentialMember.credentialId, workspaceCredential.id),
-            eq(credentialMember.userId, actingUserId),
-            eq(credentialMember.status, 'active')
-          )
+    const [membership] = await db
+      .select({ id: credentialMember.id })
+      .from(credentialMember)
+      .where(
+        and(
+          eq(credentialMember.credentialId, workspaceCredential.id),
+          eq(credentialMember.userId, actingUserId),
+          eq(credentialMember.status, 'active')
         )
-        .limit(1)
+      )
+      .limit(1)
 
-      if (!membership) {
-        return {
-          ok: false,
-          error:
-            'You do not have access to this credential. Ask the credential admin to add you as a member.',
-        }
+    if (!membership) {
+      return {
+        ok: false,
+        error:
+          'You do not have access to this credential. Ask the credential admin to add you as a member.',
       }
     }
 

--- a/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
@@ -10,7 +10,7 @@ interface ToolRuntimeSchemaEntry {
 }
 
 export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
-  ['agent']: {
+  agent: {
     parameters: {
       properties: {
         request: {
@@ -23,7 +23,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['auth']: {
+  auth: {
     parameters: {
       properties: {
         request: {
@@ -36,7 +36,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['check_deployment_status']: {
+  check_deployment_status: {
     parameters: {
       type: 'object',
       properties: {
@@ -48,7 +48,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['complete_job']: {
+  complete_job: {
     parameters: {
       type: 'object',
       properties: {
@@ -61,7 +61,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['context_write']: {
+  context_write: {
     parameters: {
       type: 'object',
       properties: {
@@ -78,7 +78,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['crawl_website']: {
+  crawl_website: {
     parameters: {
       type: 'object',
       properties: {
@@ -113,7 +113,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_file']: {
+  create_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -149,7 +149,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['create_folder']: {
+  create_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -170,7 +170,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_job']: {
+  create_job: {
     parameters: {
       type: 'object',
       properties: {
@@ -220,7 +220,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_workflow']: {
+  create_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -245,7 +245,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_workspace_mcp_server']: {
+  create_workspace_mcp_server: {
     parameters: {
       type: 'object',
       properties: {
@@ -266,7 +266,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['debug']: {
+  debug: {
     parameters: {
       properties: {
         context: {
@@ -285,7 +285,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['delete_file']: {
+  delete_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -314,7 +314,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['delete_folder']: {
+  delete_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -330,7 +330,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['delete_workflow']: {
+  delete_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -346,7 +346,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['delete_workspace_mcp_server']: {
+  delete_workspace_mcp_server: {
     parameters: {
       type: 'object',
       properties: {
@@ -359,7 +359,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['deploy']: {
+  deploy: {
     parameters: {
       properties: {
         request: {
@@ -373,7 +373,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['deploy_api']: {
+  deploy_api: {
     parameters: {
       type: 'object',
       properties: {
@@ -447,7 +447,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       ],
     },
   },
-  ['deploy_chat']: {
+  deploy_chat: {
     parameters: {
       type: 'object',
       properties: {
@@ -595,7 +595,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       ],
     },
   },
-  ['deploy_mcp']: {
+  deploy_mcp: {
     parameters: {
       type: 'object',
       properties: {
@@ -711,7 +711,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['deploymentType', 'deploymentStatus'],
     },
   },
-  ['download_to_workspace_file']: {
+  download_to_workspace_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -730,7 +730,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['edit_content']: {
+  edit_content: {
     parameters: {
       type: 'object',
       properties: {
@@ -762,7 +762,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['edit_workflow']: {
+  edit_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -801,13 +801,13 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['file']: {
+  file: {
     parameters: {
       type: 'object',
     },
     resultSchema: undefined,
   },
-  ['function_execute']: {
+  function_execute: {
     parameters: {
       type: 'object',
       properties: {
@@ -868,7 +868,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_api_key']: {
+  generate_api_key: {
     parameters: {
       type: 'object',
       properties: {
@@ -886,7 +886,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_image']: {
+  generate_image: {
     parameters: {
       type: 'object',
       properties: {
@@ -923,7 +923,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_visualization']: {
+  generate_visualization: {
     parameters: {
       type: 'object',
       properties: {
@@ -963,7 +963,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_block_outputs']: {
+  get_block_outputs: {
     parameters: {
       type: 'object',
       properties: {
@@ -984,7 +984,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_block_upstream_references']: {
+  get_block_upstream_references: {
     parameters: {
       type: 'object',
       properties: {
@@ -1006,7 +1006,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_deployed_workflow_state']: {
+  get_deployed_workflow_state: {
     parameters: {
       type: 'object',
       properties: {
@@ -1019,7 +1019,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_deployment_version']: {
+  get_deployment_version: {
     parameters: {
       type: 'object',
       properties: {
@@ -1036,7 +1036,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_execution_summary']: {
+  get_execution_summary: {
     parameters: {
       type: 'object',
       properties: {
@@ -1063,7 +1063,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_job_logs']: {
+  get_job_logs: {
     parameters: {
       type: 'object',
       properties: {
@@ -1088,7 +1088,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_page_contents']: {
+  get_page_contents: {
     parameters: {
       type: 'object',
       properties: {
@@ -1116,14 +1116,14 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_platform_actions']: {
+  get_platform_actions: {
     parameters: {
       type: 'object',
       properties: {},
     },
     resultSchema: undefined,
   },
-  ['get_workflow_data']: {
+  get_workflow_data: {
     parameters: {
       type: 'object',
       properties: {
@@ -1142,7 +1142,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_workflow_logs']: {
+  get_workflow_logs: {
     parameters: {
       type: 'object',
       properties: {
@@ -1168,7 +1168,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['glob']: {
+  glob: {
     parameters: {
       type: 'object',
       properties: {
@@ -1187,7 +1187,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['grep']: {
+  grep: {
     parameters: {
       type: 'object',
       properties: {
@@ -1234,7 +1234,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['job']: {
+  job: {
     parameters: {
       properties: {
         request: {
@@ -1247,7 +1247,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['knowledge']: {
+  knowledge: {
     parameters: {
       properties: {
         request: {
@@ -1260,7 +1260,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['knowledge_base']: {
+  knowledge_base: {
     parameters: {
       type: 'object',
       properties: {
@@ -1452,7 +1452,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['list_folders']: {
+  list_folders: {
     parameters: {
       type: 'object',
       properties: {
@@ -1464,14 +1464,14 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['list_user_workspaces']: {
+  list_user_workspaces: {
     parameters: {
       type: 'object',
       properties: {},
     },
     resultSchema: undefined,
   },
-  ['list_workspace_mcp_servers']: {
+  list_workspace_mcp_servers: {
     parameters: {
       type: 'object',
       properties: {
@@ -1483,7 +1483,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_credential']: {
+  manage_credential: {
     parameters: {
       type: 'object',
       properties: {
@@ -1512,7 +1512,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_custom_tool']: {
+  manage_custom_tool: {
     parameters: {
       type: 'object',
       properties: {
@@ -1591,7 +1591,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_job']: {
+  manage_job: {
     parameters: {
       type: 'object',
       properties: {
@@ -1661,7 +1661,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_mcp_tool']: {
+  manage_mcp_tool: {
     parameters: {
       type: 'object',
       properties: {
@@ -1712,7 +1712,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_skill']: {
+  manage_skill: {
     parameters: {
       type: 'object',
       properties: {
@@ -1744,7 +1744,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['materialize_file']: {
+  materialize_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -1778,7 +1778,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['move_folder']: {
+  move_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -1796,7 +1796,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['move_workflow']: {
+  move_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -1816,7 +1816,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['oauth_get_auth_link']: {
+  oauth_get_auth_link: {
     parameters: {
       type: 'object',
       properties: {
@@ -1830,7 +1830,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['oauth_request_access']: {
+  oauth_request_access: {
     parameters: {
       type: 'object',
       properties: {
@@ -1844,7 +1844,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['open_resource']: {
+  open_resource: {
     parameters: {
       type: 'object',
       properties: {
@@ -1872,7 +1872,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['read']: {
+  read: {
     parameters: {
       type: 'object',
       properties: {
@@ -1899,7 +1899,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['redeploy']: {
+  redeploy: {
     parameters: {
       type: 'object',
       properties: {
@@ -1967,7 +1967,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       ],
     },
   },
-  ['rename_file']: {
+  rename_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -2002,7 +2002,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['rename_workflow']: {
+  rename_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -2019,7 +2019,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['research']: {
+  research: {
     parameters: {
       properties: {
         topic: {
@@ -2032,7 +2032,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['respond']: {
+  respond: {
     parameters: {
       additionalProperties: true,
       properties: {
@@ -2055,7 +2055,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['restore_resource']: {
+  restore_resource: {
     parameters: {
       type: 'object',
       properties: {
@@ -2073,7 +2073,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['revert_to_version']: {
+  revert_to_version: {
     parameters: {
       type: 'object',
       properties: {
@@ -2090,7 +2090,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run']: {
+  run: {
     parameters: {
       properties: {
         context: {
@@ -2107,7 +2107,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_block']: {
+  run_block: {
     parameters: {
       type: 'object',
       properties: {
@@ -2139,7 +2139,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_from_block']: {
+  run_from_block: {
     parameters: {
       type: 'object',
       properties: {
@@ -2171,7 +2171,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_workflow']: {
+  run_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -2199,7 +2199,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_workflow_until_block']: {
+  run_workflow_until_block: {
     parameters: {
       type: 'object',
       properties: {
@@ -2231,7 +2231,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['scrape_page']: {
+  scrape_page: {
     parameters: {
       type: 'object',
       properties: {
@@ -2252,7 +2252,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_documentation']: {
+  search_documentation: {
     parameters: {
       type: 'object',
       properties: {
@@ -2269,7 +2269,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_library_docs']: {
+  search_library_docs: {
     parameters: {
       type: 'object',
       properties: {
@@ -2290,7 +2290,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_online']: {
+  search_online: {
     parameters: {
       type: 'object',
       properties: {
@@ -2331,7 +2331,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_patterns']: {
+  search_patterns: {
     parameters: {
       type: 'object',
       properties: {
@@ -2353,7 +2353,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['set_block_enabled']: {
+  set_block_enabled: {
     parameters: {
       type: 'object',
       properties: {
@@ -2375,7 +2375,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['set_environment_variables']: {
+  set_environment_variables: {
     parameters: {
       type: 'object',
       properties: {
@@ -2409,7 +2409,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['set_global_workflow_variables']: {
+  set_global_workflow_variables: {
     parameters: {
       type: 'object',
       properties: {
@@ -2447,7 +2447,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['superagent']: {
+  superagent: {
     parameters: {
       properties: {
         task: {
@@ -2461,7 +2461,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['table']: {
+  table: {
     parameters: {
       properties: {
         request: {
@@ -2474,7 +2474,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['tool_search_tool_regex']: {
+  tool_search_tool_regex: {
     parameters: {
       properties: {
         case_insensitive: {
@@ -2495,7 +2495,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['update_job_history']: {
+  update_job_history: {
     parameters: {
       type: 'object',
       properties: {
@@ -2513,7 +2513,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['update_workspace_mcp_server']: {
+  update_workspace_mcp_server: {
     parameters: {
       type: 'object',
       properties: {
@@ -2538,7 +2538,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['user_memory']: {
+  user_memory: {
     parameters: {
       type: 'object',
       properties: {
@@ -2586,7 +2586,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['user_table']: {
+  user_table: {
     parameters: {
       type: 'object',
       properties: {
@@ -2915,13 +2915,13 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['workflow']: {
+  workflow: {
     parameters: {
       type: 'object',
     },
     resultSchema: undefined,
   },
-  ['workspace_file']: {
+  workspace_file: {
     parameters: {
       type: 'object',
       properties: {

--- a/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
+++ b/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
@@ -264,7 +264,7 @@ export class PauseResumeManager {
         .where(eq(pausedExecutions.id, existing.id))
     })
 
-    await PauseResumeManager.processQueuedResumes(executionId)
+    await PauseResumeManager.processQueuedResumes(executionId, workflowId)
   }
 
   static async enqueueOrStartResume(args: EnqueueResumeArgs): Promise<EnqueueResumeResult> {
@@ -504,7 +504,10 @@ export class PauseResumeManager {
         })
       }
 
-      await PauseResumeManager.processQueuedResumes(pausedExecution.executionId)
+      await PauseResumeManager.processQueuedResumes(
+        pausedExecution.executionId,
+        pausedExecution.workflowId
+      )
 
       return result
     } catch (error) {
@@ -532,7 +535,10 @@ export class PauseResumeManager {
         contextId,
         error,
       })
-      await PauseResumeManager.processQueuedResumes(pausedExecution.executionId)
+      await PauseResumeManager.processQueuedResumes(
+        pausedExecution.executionId,
+        pausedExecution.workflowId
+      )
       throw error
     }
   }
@@ -1689,7 +1695,7 @@ export class PauseResumeManager {
           eq(pausedExecutions.status, 'cancelling')
         )
       )
-    await PauseResumeManager.processQueuedResumes(executionId)
+    await PauseResumeManager.processQueuedResumes(executionId, workflowId)
   }
 
   static async getPausedCancellationStatus(

--- a/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
+++ b/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
@@ -1482,10 +1482,7 @@ export class PauseResumeManager {
       snapshotData.state = executionState
     }
 
-    // Update the DAG incoming edges in the snapshot
-    // Remove the edge from the resumed pause block
     if (snapshotData.state) {
-      // Track completed pause contexts so future resumes remove their edges
       const completedPauseContexts = new Set<string>(
         (snapshotData.state.completedPauseContexts ?? []).map((id: string) =>
           PauseResumeManager.normalizePauseBlockId(id)
@@ -1497,7 +1494,6 @@ export class PauseResumeManager {
       const dagIncomingEdges = snapshotData.state.dagIncomingEdges
 
       if (dagIncomingEdges) {
-        // Find all edges from the resumed pause block and remove them from targets
         const workflowData = snapshotData.workflow
         const connections = workflowData.connections || []
 
@@ -1505,7 +1501,6 @@ export class PauseResumeManager {
           if (conn.source === pauseBlockId) {
             const targetId = conn.target
             if (dagIncomingEdges[targetId]) {
-              // Remove this source from the target's incoming edges
               dagIncomingEdges[targetId] = dagIncomingEdges[targetId].filter(
                 (sourceId: string) => sourceId !== pauseBlockId
               )
@@ -1521,7 +1516,6 @@ export class PauseResumeManager {
       }
     }
 
-    // Update the snapshot in the database
     const updatedSnapshot: SerializedSnapshot = {
       snapshot: JSON.stringify(snapshotData),
       triggerIds: currentSnapshot.triggerIds,

--- a/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
+++ b/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
@@ -274,12 +274,10 @@ export class PauseResumeManager {
         .select()
         .from(pausedExecutions)
         .where(
-          workflowId
-            ? and(
-                eq(pausedExecutions.executionId, executionId),
-                eq(pausedExecutions.workflowId, workflowId)
-              )
-            : eq(pausedExecutions.executionId, executionId)
+          and(
+            eq(pausedExecutions.executionId, executionId),
+            eq(pausedExecutions.workflowId, workflowId)
+          )
         )
         .for('update')
         .limit(1)
@@ -1548,7 +1546,7 @@ export class PauseResumeManager {
         .where(
           and(
             eq(pausedExecutions.executionId, executionId),
-            ...(workflowId ? [eq(pausedExecutions.workflowId, workflowId)] : []),
+            eq(pausedExecutions.workflowId, workflowId),
             inArray(pausedExecutions.status, [...CANCELLABLE_PAUSED_STATUSES, 'cancelling'])
           )
         )
@@ -1597,12 +1595,10 @@ export class PauseResumeManager {
         .select({ id: pausedExecutions.id, status: pausedExecutions.status })
         .from(pausedExecutions)
         .where(
-          workflowId
-            ? and(
-                eq(pausedExecutions.executionId, executionId),
-                eq(pausedExecutions.workflowId, workflowId)
-              )
-            : eq(pausedExecutions.executionId, executionId)
+          and(
+            eq(pausedExecutions.executionId, executionId),
+            eq(pausedExecutions.workflowId, workflowId)
+          )
         )
         .for('update')
         .limit(1)
@@ -1642,7 +1638,7 @@ export class PauseResumeManager {
         .where(
           and(
             eq(pausedExecutions.executionId, executionId),
-            ...(workflowId ? [eq(pausedExecutions.workflowId, workflowId)] : []),
+            eq(pausedExecutions.workflowId, workflowId),
             inArray(pausedExecutions.status, [...CANCELLABLE_PAUSED_STATUSES, 'cancelling'])
           )
         )
@@ -1688,7 +1684,7 @@ export class PauseResumeManager {
       .where(
         and(
           eq(pausedExecutions.executionId, executionId),
-          ...(workflowId ? [eq(pausedExecutions.workflowId, workflowId)] : []),
+          eq(pausedExecutions.workflowId, workflowId),
           eq(pausedExecutions.status, 'cancelling')
         )
       )
@@ -1714,12 +1710,10 @@ export class PauseResumeManager {
       .select({ status: pausedExecutions.status })
       .from(pausedExecutions)
       .where(
-        workflowId
-          ? and(
-              eq(pausedExecutions.executionId, executionId),
-              eq(pausedExecutions.workflowId, workflowId)
-            )
-          : eq(pausedExecutions.executionId, executionId)
+        and(
+          eq(pausedExecutions.executionId, executionId),
+          eq(pausedExecutions.workflowId, workflowId)
+        )
       )
       .limit(1)
       .then((rows) => rows[0])
@@ -1889,12 +1883,10 @@ export class PauseResumeManager {
           .select()
           .from(pausedExecutions)
           .where(
-            workflowId
-              ? and(
-                  eq(pausedExecutions.executionId, parentExecutionId),
-                  eq(pausedExecutions.workflowId, workflowId)
-                )
-              : eq(pausedExecutions.executionId, parentExecutionId)
+            and(
+              eq(pausedExecutions.executionId, parentExecutionId),
+              eq(pausedExecutions.workflowId, workflowId)
+            )
           )
           .for('update')
           .limit(1)

--- a/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
+++ b/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
@@ -105,8 +105,7 @@ interface PersistPauseResultArgs {
 
 interface EnqueueResumeArgs {
   executionId: string
-  /** workflowId is used to scope the lookup to the correct tenant. Required unless the caller is a trusted internal cron. */
-  workflowId?: string
+  workflowId: string
   contextId: string
   resumeInput: unknown
   userId: string
@@ -1535,7 +1534,7 @@ export class PauseResumeManager {
     })
   }
 
-  static async beginPausedCancellation(executionId: string, workflowId?: string): Promise<boolean> {
+  static async beginPausedCancellation(executionId: string, workflowId: string): Promise<boolean> {
     const now = new Date()
 
     return await db.transaction(async (tx) => {
@@ -1585,7 +1584,7 @@ export class PauseResumeManager {
 
   static async completePausedCancellation(
     executionId: string,
-    workflowId?: string
+    workflowId: string
   ): Promise<boolean> {
     const now = new Date()
 
@@ -1628,7 +1627,7 @@ export class PauseResumeManager {
 
   static async blockQueuedResumesForCancellation(
     executionId: string,
-    workflowId?: string
+    workflowId: string
   ): Promise<boolean> {
     const now = new Date()
 
@@ -1673,7 +1672,7 @@ export class PauseResumeManager {
 
   static async clearPausedCancellationIntent(
     executionId: string,
-    workflowId?: string
+    workflowId: string
   ): Promise<void> {
     const now = new Date()
     await db
@@ -1694,7 +1693,7 @@ export class PauseResumeManager {
 
   static async getPausedCancellationStatus(
     executionId: string,
-    workflowId?: string
+    workflowId: string
   ): Promise<'cancelling' | 'cancelled' | null> {
     const activeResume = await db
       .select({ id: resumeQueue.id })
@@ -1874,7 +1873,7 @@ export class PauseResumeManager {
     }
   }
 
-  static async processQueuedResumes(parentExecutionId: string, workflowId?: string): Promise<void> {
+  static async processQueuedResumes(parentExecutionId: string, workflowId: string): Promise<void> {
     let pendingEntry: {
       entry: typeof resumeQueue.$inferSelect
       pausedExecution: typeof pausedExecutions.$inferSelect

--- a/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
+++ b/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
@@ -105,6 +105,8 @@ interface PersistPauseResultArgs {
 
 interface EnqueueResumeArgs {
   executionId: string
+  /** workflowId is used to scope the lookup to the correct tenant. Required unless the caller is a trusted internal cron. */
+  workflowId?: string
   contextId: string
   resumeInput: unknown
   userId: string
@@ -266,13 +268,20 @@ export class PauseResumeManager {
   }
 
   static async enqueueOrStartResume(args: EnqueueResumeArgs): Promise<EnqueueResumeResult> {
-    const { executionId, contextId, resumeInput, userId, allowedPauseKinds } = args
+    const { executionId, workflowId, contextId, resumeInput, userId, allowedPauseKinds } = args
 
     return await db.transaction(async (tx) => {
       const pausedExecution = await tx
         .select()
         .from(pausedExecutions)
-        .where(eq(pausedExecutions.executionId, executionId))
+        .where(
+          workflowId
+            ? and(
+                eq(pausedExecutions.executionId, executionId),
+                eq(pausedExecutions.workflowId, workflowId)
+              )
+            : eq(pausedExecutions.executionId, executionId)
+        )
         .for('update')
         .limit(1)
         .then((rows) => rows[0])
@@ -1526,7 +1535,7 @@ export class PauseResumeManager {
     })
   }
 
-  static async beginPausedCancellation(executionId: string): Promise<boolean> {
+  static async beginPausedCancellation(executionId: string, workflowId?: string): Promise<boolean> {
     const now = new Date()
 
     return await db.transaction(async (tx) => {
@@ -1536,6 +1545,7 @@ export class PauseResumeManager {
         .where(
           and(
             eq(pausedExecutions.executionId, executionId),
+            ...(workflowId ? [eq(pausedExecutions.workflowId, workflowId)] : []),
             inArray(pausedExecutions.status, [...CANCELLABLE_PAUSED_STATUSES, 'cancelling'])
           )
         )
@@ -1573,14 +1583,24 @@ export class PauseResumeManager {
     })
   }
 
-  static async completePausedCancellation(executionId: string): Promise<boolean> {
+  static async completePausedCancellation(
+    executionId: string,
+    workflowId?: string
+  ): Promise<boolean> {
     const now = new Date()
 
     return await db.transaction(async (tx) => {
       const pausedExecution = await tx
         .select({ id: pausedExecutions.id, status: pausedExecutions.status })
         .from(pausedExecutions)
-        .where(eq(pausedExecutions.executionId, executionId))
+        .where(
+          workflowId
+            ? and(
+                eq(pausedExecutions.executionId, executionId),
+                eq(pausedExecutions.workflowId, workflowId)
+              )
+            : eq(pausedExecutions.executionId, executionId)
+        )
         .for('update')
         .limit(1)
         .then((rows) => rows[0])
@@ -1606,7 +1626,10 @@ export class PauseResumeManager {
     })
   }
 
-  static async blockQueuedResumesForCancellation(executionId: string): Promise<boolean> {
+  static async blockQueuedResumesForCancellation(
+    executionId: string,
+    workflowId?: string
+  ): Promise<boolean> {
     const now = new Date()
 
     return await db.transaction(async (tx) => {
@@ -1616,6 +1639,7 @@ export class PauseResumeManager {
         .where(
           and(
             eq(pausedExecutions.executionId, executionId),
+            ...(workflowId ? [eq(pausedExecutions.workflowId, workflowId)] : []),
             inArray(pausedExecutions.status, [...CANCELLABLE_PAUSED_STATUSES, 'cancelling'])
           )
         )
@@ -1647,7 +1671,10 @@ export class PauseResumeManager {
     })
   }
 
-  static async clearPausedCancellationIntent(executionId: string): Promise<void> {
+  static async clearPausedCancellationIntent(
+    executionId: string,
+    workflowId?: string
+  ): Promise<void> {
     const now = new Date()
     await db
       .update(pausedExecutions)
@@ -1658,6 +1685,7 @@ export class PauseResumeManager {
       .where(
         and(
           eq(pausedExecutions.executionId, executionId),
+          ...(workflowId ? [eq(pausedExecutions.workflowId, workflowId)] : []),
           eq(pausedExecutions.status, 'cancelling')
         )
       )
@@ -1665,7 +1693,8 @@ export class PauseResumeManager {
   }
 
   static async getPausedCancellationStatus(
-    executionId: string
+    executionId: string,
+    workflowId?: string
   ): Promise<'cancelling' | 'cancelled' | null> {
     const activeResume = await db
       .select({ id: resumeQueue.id })
@@ -1681,7 +1710,14 @@ export class PauseResumeManager {
     const pausedExecution = await db
       .select({ status: pausedExecutions.status })
       .from(pausedExecutions)
-      .where(eq(pausedExecutions.executionId, executionId))
+      .where(
+        workflowId
+          ? and(
+              eq(pausedExecutions.executionId, executionId),
+              eq(pausedExecutions.workflowId, workflowId)
+            )
+          : eq(pausedExecutions.executionId, executionId)
+      )
       .limit(1)
       .then((rows) => rows[0])
 
@@ -1838,7 +1874,7 @@ export class PauseResumeManager {
     }
   }
 
-  static async processQueuedResumes(parentExecutionId: string): Promise<void> {
+  static async processQueuedResumes(parentExecutionId: string, workflowId?: string): Promise<void> {
     let pendingEntry: {
       entry: typeof resumeQueue.$inferSelect
       pausedExecution: typeof pausedExecutions.$inferSelect
@@ -1849,7 +1885,14 @@ export class PauseResumeManager {
         const pausedExecution = await tx
           .select()
           .from(pausedExecutions)
-          .where(eq(pausedExecutions.executionId, parentExecutionId))
+          .where(
+            workflowId
+              ? and(
+                  eq(pausedExecutions.executionId, parentExecutionId),
+                  eq(pausedExecutions.workflowId, workflowId)
+                )
+              : eq(pausedExecutions.executionId, parentExecutionId)
+          )
           .for('update')
           .limit(1)
           .then((rows) => rows[0])

--- a/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
+++ b/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
@@ -476,10 +476,14 @@ export class PauseResumeManager {
             failureReason: 'Resume execution cancelled',
           })
           const pausedCancellationStatus = await PauseResumeManager.getPausedCancellationStatus(
-            pausedExecution.executionId
+            pausedExecution.executionId,
+            pausedExecution.workflowId
           )
           if (pausedCancellationStatus === 'cancelling') {
-            await PauseResumeManager.completePausedCancellation(pausedExecution.executionId)
+            await PauseResumeManager.completePausedCancellation(
+              pausedExecution.executionId,
+              pausedExecution.workflowId
+            )
           }
         } else {
           await PauseResumeManager.updateSnapshotAfterResume({

--- a/apps/sim/lib/workflows/executor/pause-persistence.ts
+++ b/apps/sim/lib/workflows/executor/pause-persistence.ts
@@ -54,7 +54,7 @@ export async function handlePostExecutionPauseState({
     }
   } else {
     try {
-      await PauseResumeManager.processQueuedResumes(executionId)
+      await PauseResumeManager.processQueuedResumes(executionId, workflowId)
     } catch (resumeError) {
       logger.error('Failed to process queued resumes', {
         executionId,


### PR DESCRIPTION
## Summary
- Several tool routes (`gmail/label`, `onedrive/files`, `onedrive/folder`, `outlook/folders`, `wealthbox/item`, `auth/oauth/wealthbox/item`) called `resolveOAuthAccountId` then only checked workspace permissions when `workspaceId` was set — the legacy account-ID fallback path returned no `workspaceId`, silently skipping all ownership validation. Any authenticated user could supply a raw `account.id` to access another tenant's OAuth credentials
- Replace all instances with `authorizeCredentialUse`, which enforces ownership on every credential type including the legacy fallback path
- Add `authorizeCredentialUse` ownership gate before `resolveVertexCredential` in `providers/route.ts` (Vertex AI credential path had the same gap)
- Add `verifyFileAccess` check in `wordpress/upload` before `downloadFileFromStorage` — file key was user-supplied with no ownership verification
- Add optional `workflowId` filter to all `PauseResumeManager` methods (`enqueueOrStartResume`, `beginPausedCancellation`, etc.) — previously looked up paused executions by `executionId` only, allowing any authenticated user to cancel or resume another tenant's paused workflow execution; update all call sites (cancel, resume, poll routes)

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `authorizeCredentialUse` backwards-compatibility verified: legacy account-ID callers who own their credentials still work (ownership enforced); HITL manager `workflowId` param is optional so internal self-calls without it are unaffected; `verifyFileAccess` confirmed to exist and match usage.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)