### PR TITLE
fix(oauth): persist rotated Microsoft refresh tokens

### DIFF
--- a/apps/sim/lib/oauth/oauth.test.ts
+++ b/apps/sim/lib/oauth/oauth.test.ts
@@ -392,7 +392,17 @@ describe('OAuth Token Refresh', () => {
     it.concurrent(
       'should rotate refresh token for Microsoft providers (microsoft, outlook, onedrive, sharepoint)',
       async () => {
-        const microsoftProviders = ['microsoft', 'outlook', 'onedrive', 'sharepoint']
+        const microsoftProviders = [
+          'microsoft',
+          'outlook',
+          'onedrive',
+          'sharepoint',
+          'microsoft-excel',
+          'microsoft-teams',
+          'microsoft-planner',
+          'microsoft-ad',
+          'microsoft-dataverse',
+        ]
         const oldRefreshToken = 'old_microsoft_refresh_token'
         const rotatedRefreshToken = 'rotated_microsoft_refresh_token'
 

--- a/apps/sim/lib/oauth/oauth.test.ts
+++ b/apps/sim/lib/oauth/oauth.test.ts
@@ -389,6 +389,36 @@ describe('OAuth Token Refresh', () => {
       })
     })
 
+    it.concurrent(
+      'should rotate refresh token for Microsoft providers (microsoft, outlook, onedrive, sharepoint)',
+      async () => {
+        const microsoftProviders = ['microsoft', 'outlook', 'onedrive', 'sharepoint']
+        const oldRefreshToken = 'old_microsoft_refresh_token'
+        const rotatedRefreshToken = 'rotated_microsoft_refresh_token'
+
+        for (const providerId of microsoftProviders) {
+          const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+              access_token: 'new_access_token',
+              expires_in: 3600,
+              refresh_token: rotatedRefreshToken,
+            }),
+          })
+
+          const result = await withMockFetch(mockFetch, () =>
+            refreshOAuthToken(providerId, oldRefreshToken)
+          )
+
+          expect(result).toEqual({
+            accessToken: 'new_access_token',
+            expiresIn: 3600,
+            refreshToken: rotatedRefreshToken,
+          })
+        }
+      }
+    )
+
     it.concurrent('should use original refresh token when new one is not provided', async () => {
       const refreshToken = 'original_refresh_token'
 

--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -1163,6 +1163,7 @@ function getProviderAuthConfig(provider: string): ProviderAuthConfig {
         clientId,
         clientSecret,
         useBasicAuth: false,
+        supportsRefreshTokenRotation: true,
       }
     }
     case 'linear': {


### PR DESCRIPTION
## Summary
- Microsoft Entra rotates refresh tokens on every refresh and expects the client to replace the stored token with the new one (see [Microsoft docs](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens)).
- The Microsoft provider config in `apps/sim/lib/oauth/oauth.ts` was missing `supportsRefreshTokenRotation`, so the rotated `refresh_token` from Azure AD was silently discarded and the original token from initial OAuth connect was reused indefinitely.
- This caused periodic `Failed to refresh access token` failures (~monthly) for Excel, Teams, Outlook, OneDrive, SharePoint, Planner, AD, and Dataverse integrations even on daily-running workflows.
- Fix: set `supportsRefreshTokenRotation: true` on the Microsoft branch. Persistence in `apps/sim/app/api/auth/oauth/utils.ts` already writes the new token back when returned.

## Type of Change
- [x] Bug fix

## Testing
- Added unit test asserting all four Microsoft provider IDs (`microsoft`, `outlook`, `onedrive`, `sharepoint`) capture the rotated `refresh_token` from the token response.
- Existing 31 oauth tests still pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)