### PR TITLE
fix(file-viewer): prevent scroll jump to top during Mothership streaming

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -34,7 +34,7 @@ import 'prismjs/components/prism-python'
 import { cn } from '@/lib/core/utils/cn'
 import { extractTextContent } from '@/lib/core/utils/react-node-text'
 import { getFileExtension } from '@/lib/uploads/utils/file-utils'
-import { useAutoScroll } from '@/hooks/use-auto-scroll'
+import { useScrollAnchor } from '@/hooks/use-scroll-anchor'
 import { DataTable } from './data-table'
 import { ZoomablePreview } from './zoomable-preview'
 
@@ -866,7 +866,10 @@ const MarkdownPreview = memo(function MarkdownPreview({
   onCheckboxToggle?: (checkboxIndex: number, checked: boolean) => void
 }) {
   const { push: navigate } = useRouter()
-  const { ref: autoScrollRef } = useAutoScroll(isStreaming && !disableAutoScroll)
+  const { ref: autoScrollRef, spacerRef } = useScrollAnchor(
+    isStreaming && !disableAutoScroll,
+    content
+  )
 
   const contentRef = useRef(content)
   contentRef.current = content
@@ -921,16 +924,13 @@ const MarkdownPreview = memo(function MarkdownPreview({
       >
         {markdownContent}
       </Streamdown>
+      <div ref={spacerRef} aria-hidden />
     </div>
   )
 
   return (
     <NavigateCtx.Provider value={navigate}>
-      {onCheckboxToggle ? (
-        <MarkdownCheckboxCtx.Provider value={ctxValue}>{body}</MarkdownCheckboxCtx.Provider>
-      ) : (
-        body
-      )}
+      <MarkdownCheckboxCtx.Provider value={ctxValue}>{body}</MarkdownCheckboxCtx.Provider>
     </NavigateCtx.Provider>
   )
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.test.ts
@@ -339,21 +339,12 @@ describe('syncTextEditorContentState — streaming finalize shortcuts', () => {
 })
 
 describe('syncTextEditorContentState — inter-session content shrink (replace mode)', () => {
-  // These tests cover the path that causes scroll jumps in the file viewer.
-  // During "session linger" (session 1 complete, session 2 not yet started),
-  // the state machine stays in 'streaming' phase with session 1's full content.
-  // When session 2's first chunk arrives it is often SHORTER than session 1's
-  // final content. The state machine must correctly replace the content rather
-  // than treating it as already-final or dropping it.
-
   it('replaces long linger content with a short first chunk from a new session', () => {
-    // State during linger: streaming with session 1's full long content
     const lingerState = streaming(
       'a very long document with many paragraphs',
       'a very long document with many paragraphs',
       ''
     )
-    // Session 2 first chunk arrives — much shorter than session 1's content
     const next = syncTextEditorContentState(lingerState, {
       canReconcileToFetchedContent: false,
       fetchedContent: undefined,
@@ -382,8 +373,6 @@ describe('syncTextEditorContentState — inter-session content shrink (replace m
   })
 
   it('does not finalize early when the new short chunk happens to equal savedContent', () => {
-    // savedContent '' and streamingContent '' — but we are in streaming phase,
-    // not ready, so content should remain in streaming phase
     const lingerState = streaming('long content', 'long content', 'old saved')
     const next = syncTextEditorContentState(lingerState, {
       canReconcileToFetchedContent: false,
@@ -427,8 +416,6 @@ describe('syncTextEditorContentState — inter-session content shrink (replace m
   })
 
   it('synthetic file (canReconcile=false) finalizes with current content when streaming ends', () => {
-    // After the new session finishes streaming, since there is no fetchedContent
-    // to reconcile with (synthetic file has no db key), it must finalize immediately.
     const finalChunk = streaming(
       '# Complete Document\n\nAll done.',
       '# Complete Document\n\nAll done.',

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.test.ts
@@ -337,3 +337,112 @@ describe('syncTextEditorContentState — streaming finalize shortcuts', () => {
     expect(next.content).toBe('v2')
   })
 })
+
+describe('syncTextEditorContentState — inter-session content shrink (replace mode)', () => {
+  // These tests cover the path that causes scroll jumps in the file viewer.
+  // During "session linger" (session 1 complete, session 2 not yet started),
+  // the state machine stays in 'streaming' phase with session 1's full content.
+  // When session 2's first chunk arrives it is often SHORTER than session 1's
+  // final content. The state machine must correctly replace the content rather
+  // than treating it as already-final or dropping it.
+
+  it('replaces long linger content with a short first chunk from a new session', () => {
+    // State during linger: streaming with session 1's full long content
+    const lingerState = streaming(
+      'a very long document with many paragraphs',
+      'a very long document with many paragraphs',
+      ''
+    )
+    // Session 2 first chunk arrives — much shorter than session 1's content
+    const next = syncTextEditorContentState(lingerState, {
+      canReconcileToFetchedContent: false,
+      fetchedContent: undefined,
+      streamingContent: 'short',
+      streamingMode: 'replace',
+    })
+    expect(next.phase).toBe('streaming')
+    expect(next.content).toBe('short')
+    expect(next.lastStreamedContent).toBe('short')
+  })
+
+  it('correctly transitions to the new chunk even when it is a single character', () => {
+    const lingerState = streaming(
+      'full document\nmany lines\nof content',
+      'full document\nmany lines\nof content',
+      ''
+    )
+    const next = syncTextEditorContentState(lingerState, {
+      canReconcileToFetchedContent: false,
+      fetchedContent: undefined,
+      streamingContent: '#',
+      streamingMode: 'replace',
+    })
+    expect(next.phase).toBe('streaming')
+    expect(next.content).toBe('#')
+  })
+
+  it('does not finalize early when the new short chunk happens to equal savedContent', () => {
+    // savedContent '' and streamingContent '' — but we are in streaming phase,
+    // not ready, so content should remain in streaming phase
+    const lingerState = streaming('long content', 'long content', 'old saved')
+    const next = syncTextEditorContentState(lingerState, {
+      canReconcileToFetchedContent: false,
+      fetchedContent: undefined,
+      streamingContent: '',
+      streamingMode: 'replace',
+    })
+    expect(next.phase).toBe('streaming')
+    expect(next.content).toBe('')
+  })
+
+  it('stays streaming across multiple growing chunks after the shrink', () => {
+    const lingerState = streaming('final long document', 'final long document', '')
+
+    const chunk1 = syncTextEditorContentState(lingerState, {
+      canReconcileToFetchedContent: false,
+      fetchedContent: undefined,
+      streamingContent: '# New',
+      streamingMode: 'replace',
+    })
+    expect(chunk1.phase).toBe('streaming')
+    expect(chunk1.content).toBe('# New')
+
+    const chunk2 = syncTextEditorContentState(chunk1, {
+      canReconcileToFetchedContent: false,
+      fetchedContent: undefined,
+      streamingContent: '# New Section\n\nSome text',
+      streamingMode: 'replace',
+    })
+    expect(chunk2.phase).toBe('streaming')
+    expect(chunk2.content).toBe('# New Section\n\nSome text')
+
+    const chunk3 = syncTextEditorContentState(chunk2, {
+      canReconcileToFetchedContent: false,
+      fetchedContent: undefined,
+      streamingContent: '# New Section\n\nSome text that is now longer than the original',
+      streamingMode: 'replace',
+    })
+    expect(chunk3.phase).toBe('streaming')
+    expect(chunk3.content).toBe('# New Section\n\nSome text that is now longer than the original')
+  })
+
+  it('synthetic file (canReconcile=false) finalizes with current content when streaming ends', () => {
+    // After the new session finishes streaming, since there is no fetchedContent
+    // to reconcile with (synthetic file has no db key), it must finalize immediately.
+    const finalChunk = streaming(
+      '# Complete Document\n\nAll done.',
+      '# Complete Document\n\nAll done.',
+      ''
+    )
+    const next = syncTextEditorContentState(finalChunk, {
+      canReconcileToFetchedContent: false,
+      fetchedContent: undefined,
+      streamingContent: undefined,
+      streamingMode: 'replace',
+    })
+    expect(next.phase).toBe('ready')
+    expect(next.content).toBe('# Complete Document\n\nAll done.')
+    expect(next.savedContent).toBe('# Complete Document\n\nAll done.')
+    expect(next.lastStreamedContent).toBeNull()
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/mothership-view.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/mothership-view.tsx
@@ -30,11 +30,11 @@ function shouldShowStreamingFilePanel(
   previewSession: FilePreviewSession | null | undefined,
   active: MothershipResource | null
 ): boolean {
-  if (!previewSession || previewSession.status === 'complete' || !active) return false
+  if (!previewSession || !hasRenderableFilePreviewContent(previewSession) || !active) return false
   if (active.id === 'streaming-file') return true
   if (active.type !== 'file') return false
   if (active.id && previewSession.fileId === active.id) {
-    return hasRenderableFilePreviewContent(previewSession)
+    return true
   }
   return false
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
@@ -3402,7 +3402,11 @@ export function useChat(
                 if (parentToolCallId) {
                   subagentByParentToolCallId.delete(parentToolCallId)
                 }
-                if (previewSessionRef.current && !activePreviewSessionIdRef.current) {
+                if (
+                  previewSessionRef.current &&
+                  (!activePreviewSessionIdRef.current ||
+                    previewSessionRef.current.status === 'complete')
+                ) {
                   const lastFileResource = resourcesRef.current.find(
                     (r) => r.type === 'file' && r.id !== 'streaming-file'
                   )

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.test.tsx
@@ -397,7 +397,6 @@ describe('reduceFilePreviewSessions', () => {
         previewText: 'final',
       }),
     })
-    // activeSessionId is lingering on preview-1 after complete
 
     const reset = reduceFilePreviewSessions(state, { type: 'reset' })
 
@@ -417,7 +416,6 @@ describe('reduceFilePreviewSessions', () => {
   })
 
   it('hydrate merges incoming sessions into existing state without replacing non-stale sessions', () => {
-    // Existing state has preview-1 at version 3
     const existing = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
       type: 'upsert',
       session: createSession({
@@ -429,7 +427,6 @@ describe('reduceFilePreviewSessions', () => {
       }),
     })
 
-    // Hydrate with preview-1 at older version 2 + a new preview-2
     const hydrated = reduceFilePreviewSessions(existing, {
       type: 'hydrate',
       sessions: [
@@ -450,10 +447,8 @@ describe('reduceFilePreviewSessions', () => {
       ],
     })
 
-    // preview-1 kept at version 3 (not replaced by stale version 2)
     expect(hydrated.sessions['preview-1']?.previewVersion).toBe(3)
     expect(hydrated.sessions['preview-1']?.previewText).toBe('current')
-    // preview-2 added
     expect(hydrated.sessions['preview-2']?.previewText).toBe('new')
   })
 
@@ -553,8 +548,6 @@ describe('reduceFilePreviewSessions', () => {
         previewText: 'background',
       }),
     })
-    // active is now preview-2 (later upsert); preview-1 is no longer active
-    // Complete preview-1 (the non-active session)
     const completed = reduceFilePreviewSessions(state, {
       type: 'complete',
       session: createSession({

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.test.tsx
@@ -176,11 +176,6 @@ describe('reduceFilePreviewSessions', () => {
   })
 
   it('lingers on the completed session when it is the only one (no successor)', () => {
-    // Completing the only session must NOT drop activeSessionId to null.
-    // The linger keeps the completed session active so downstream consumers
-    // continue to receive previewText and the file viewer stays mounted,
-    // preserving the user's scroll position until a new tool call arrives
-    // or the session store is reset.
     const onlyStreaming = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
       type: 'upsert',
       session: createSession({
@@ -247,9 +242,6 @@ describe('reduceFilePreviewSessions', () => {
   })
 
   it('holds the linger when an empty pending session arrives (no content yet)', () => {
-    // Between tool calls, a new empty/pending session may arrive before its
-    // first content chunk. The active session must not switch to it so the
-    // file viewer stays mounted and scroll position is preserved.
     const lingered = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
       type: 'upsert',
       session: createSession({
@@ -271,7 +263,6 @@ describe('reduceFilePreviewSessions', () => {
       }),
     })
 
-    // New session arrives but with no renderable content (pending, empty).
     const afterEmptyUpsert = reduceFilePreviewSessions(afterComplete, {
       type: 'upsert',
       session: createSession({
@@ -285,7 +276,6 @@ describe('reduceFilePreviewSessions', () => {
 
     expect(afterEmptyUpsert.activeSessionId).toBe('preview-1')
 
-    // Once the first content chunk arrives, active switches.
     const afterContent = reduceFilePreviewSessions(afterEmptyUpsert, {
       type: 'upsert',
       session: createSession({
@@ -465,6 +455,88 @@ describe('reduceFilePreviewSessions', () => {
     expect(hydrated.sessions['preview-1']?.previewText).toBe('current')
     // preview-2 added
     expect(hydrated.sessions['preview-2']?.previewText).toBe('new')
+  })
+
+  it('hydrate preserves linger when no non-complete session exists in incoming batch', () => {
+    const lingered = reduceFilePreviewSessions(
+      reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+        type: 'upsert',
+        session: createSession({
+          id: 'preview-1',
+          toolCallId: 'preview-1',
+          previewVersion: 2,
+          previewText: 'final',
+        }),
+      }),
+      {
+        type: 'complete',
+        session: createSession({
+          id: 'preview-1',
+          toolCallId: 'preview-1',
+          status: 'complete',
+          previewVersion: 3,
+          completedAt: '2026-04-10T00:00:02.000Z',
+          previewText: 'final',
+        }),
+      }
+    )
+
+    // Hydrate with the same completed session — no non-complete successor.
+    const afterHydrate = reduceFilePreviewSessions(lingered, {
+      type: 'hydrate',
+      sessions: [
+        createSession({
+          id: 'preview-1',
+          toolCallId: 'preview-1',
+          status: 'complete',
+          previewVersion: 3,
+          previewText: 'final',
+          completedAt: '2026-04-10T00:00:02.000Z',
+        }),
+      ],
+    })
+
+    expect(afterHydrate.activeSessionId).toBe('preview-1')
+  })
+
+  it('hydrate releases linger when a non-complete session is present in the incoming batch', () => {
+    const lingered = reduceFilePreviewSessions(
+      reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+        type: 'upsert',
+        session: createSession({
+          id: 'preview-1',
+          toolCallId: 'preview-1',
+          previewVersion: 2,
+          previewText: 'final',
+        }),
+      }),
+      {
+        type: 'complete',
+        session: createSession({
+          id: 'preview-1',
+          toolCallId: 'preview-1',
+          status: 'complete',
+          previewVersion: 3,
+          completedAt: '2026-04-10T00:00:02.000Z',
+          previewText: 'final',
+        }),
+      }
+    )
+
+    const afterHydrate = reduceFilePreviewSessions(lingered, {
+      type: 'hydrate',
+      sessions: [
+        createSession({
+          id: 'preview-2',
+          toolCallId: 'preview-2',
+          status: 'streaming',
+          previewVersion: 1,
+          previewText: 'new content',
+        }),
+      ],
+    })
+
+    expect(afterHydrate.activeSessionId).toBe('preview-2')
   })
 
   it('complete for a non-active session updates the session but keeps activeSessionId', () => {

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.test.tsx
@@ -175,7 +175,12 @@ describe('reduceFilePreviewSessions', () => {
     expect(completedState.sessions['preview-1']?.id).toBe('preview-1')
   })
 
-  it('clears active session when the only session completes', () => {
+  it('lingers on the completed session when it is the only one (no successor)', () => {
+    // Completing the only session must NOT drop activeSessionId to null.
+    // The linger keeps the completed session active so downstream consumers
+    // continue to receive previewText and the file viewer stays mounted,
+    // preserving the user's scroll position until a new tool call arrives
+    // or the session store is reset.
     const onlyStreaming = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
       type: 'upsert',
       session: createSession({
@@ -200,8 +205,99 @@ describe('reduceFilePreviewSessions', () => {
       }),
     })
 
-    expect(completed.activeSessionId).toBeNull()
+    expect(completed.activeSessionId).toBe('preview-1')
     expect(completed.sessions['preview-1']?.status).toBe('complete')
+  })
+
+  it('releases the linger when a new non-complete session upserts', () => {
+    const lingered = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+      type: 'upsert',
+      session: createSession({
+        id: 'preview-1',
+        toolCallId: 'preview-1',
+        previewVersion: 2,
+        previewText: 'section one',
+      }),
+    })
+    const afterComplete = reduceFilePreviewSessions(lingered, {
+      type: 'complete',
+      session: createSession({
+        id: 'preview-1',
+        toolCallId: 'preview-1',
+        status: 'complete',
+        previewVersion: 3,
+        completedAt: '2026-04-10T00:00:02.000Z',
+        previewText: 'section one',
+      }),
+    })
+
+    // New tool call arrives with content — should switch active to the new session.
+    const afterNew = reduceFilePreviewSessions(afterComplete, {
+      type: 'upsert',
+      session: createSession({
+        id: 'preview-2',
+        toolCallId: 'preview-2',
+        status: 'streaming',
+        previewVersion: 1,
+        previewText: 'section two',
+      }),
+    })
+
+    expect(afterNew.activeSessionId).toBe('preview-2')
+  })
+
+  it('holds the linger when an empty pending session arrives (no content yet)', () => {
+    // Between tool calls, a new empty/pending session may arrive before its
+    // first content chunk. The active session must not switch to it so the
+    // file viewer stays mounted and scroll position is preserved.
+    const lingered = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+      type: 'upsert',
+      session: createSession({
+        id: 'preview-1',
+        toolCallId: 'preview-1',
+        previewVersion: 2,
+        previewText: 'existing content',
+      }),
+    })
+    const afterComplete = reduceFilePreviewSessions(lingered, {
+      type: 'complete',
+      session: createSession({
+        id: 'preview-1',
+        toolCallId: 'preview-1',
+        status: 'complete',
+        previewVersion: 3,
+        completedAt: '2026-04-10T00:00:02.000Z',
+        previewText: 'existing content',
+      }),
+    })
+
+    // New session arrives but with no renderable content (pending, empty).
+    const afterEmptyUpsert = reduceFilePreviewSessions(afterComplete, {
+      type: 'upsert',
+      session: createSession({
+        id: 'preview-2',
+        toolCallId: 'preview-2',
+        status: 'pending',
+        previewVersion: 0,
+        previewText: '',
+      }),
+    })
+
+    expect(afterEmptyUpsert.activeSessionId).toBe('preview-1')
+
+    // Once the first content chunk arrives, active switches.
+    const afterContent = reduceFilePreviewSessions(afterEmptyUpsert, {
+      type: 'upsert',
+      session: createSession({
+        id: 'preview-2',
+        toolCallId: 'preview-2',
+        status: 'streaming',
+        previewVersion: 1,
+        previewText: 'new content',
+      }),
+    })
+
+    expect(afterContent.activeSessionId).toBe('preview-2')
   })
 
   it('ignores stale complete events for a newer active session', () => {
@@ -230,5 +326,175 @@ describe('reduceFilePreviewSessions', () => {
     expect(staleCompleteState.activeSessionId).toBe('preview-1')
     expect(staleCompleteState.sessions['preview-1']?.status).toBe('streaming')
     expect(staleCompleteState.sessions['preview-1']?.previewVersion).toBe(3)
+  })
+
+  it('removes a session and clears activeSessionId when the active session is removed', () => {
+    const withSession = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+      type: 'upsert',
+      session: createSession({
+        id: 'preview-1',
+        toolCallId: 'preview-1',
+        previewVersion: 1,
+        previewText: 'content',
+      }),
+    })
+
+    const removed = reduceFilePreviewSessions(withSession, {
+      type: 'remove',
+      sessionId: 'preview-1',
+    })
+
+    expect(removed.activeSessionId).toBeNull()
+    expect(removed.sessions['preview-1']).toBeUndefined()
+  })
+
+  it('removes a non-active session without changing activeSessionId', () => {
+    let state = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+      type: 'upsert',
+      session: createSession({
+        id: 'preview-1',
+        toolCallId: 'preview-1',
+        previewVersion: 1,
+        previewText: 'active',
+      }),
+    })
+    state = reduceFilePreviewSessions(state, {
+      type: 'upsert',
+      session: createSession({
+        id: 'preview-2',
+        toolCallId: 'preview-2',
+        previewVersion: 1,
+        previewText: 'inactive',
+        status: 'complete',
+        completedAt: '2026-04-10T00:00:01.000Z',
+      }),
+    })
+
+    const removed = reduceFilePreviewSessions(state, {
+      type: 'remove',
+      sessionId: 'preview-2',
+    })
+
+    expect(removed.activeSessionId).toBe('preview-1')
+    expect(removed.sessions['preview-2']).toBeUndefined()
+    expect(removed.sessions['preview-1']).toBeDefined()
+  })
+
+  it('removing a non-existent session is a no-op', () => {
+    const state = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+      type: 'upsert',
+      session: createSession({ id: 'preview-1', toolCallId: 'preview-1', previewVersion: 1 }),
+    })
+
+    const next = reduceFilePreviewSessions(state, { type: 'remove', sessionId: 'does-not-exist' })
+
+    expect(next).toBe(state)
+  })
+
+  it('reset clears all sessions and activeSessionId', () => {
+    let state = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+      type: 'upsert',
+      session: createSession({ id: 'preview-1', toolCallId: 'preview-1', previewVersion: 1 }),
+    })
+    state = reduceFilePreviewSessions(state, {
+      type: 'complete',
+      session: createSession({
+        id: 'preview-1',
+        toolCallId: 'preview-1',
+        status: 'complete',
+        previewVersion: 2,
+        completedAt: '2026-04-10T00:00:02.000Z',
+        previewText: 'final',
+      }),
+    })
+    // activeSessionId is lingering on preview-1 after complete
+
+    const reset = reduceFilePreviewSessions(state, { type: 'reset' })
+
+    expect(reset.activeSessionId).toBeNull()
+    expect(Object.keys(reset.sessions)).toHaveLength(0)
+  })
+
+  it('hydrate with an empty sessions array is a no-op', () => {
+    const state = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+      type: 'upsert',
+      session: createSession({ id: 'preview-1', toolCallId: 'preview-1', previewVersion: 1 }),
+    })
+
+    const next = reduceFilePreviewSessions(state, { type: 'hydrate', sessions: [] })
+
+    expect(next).toBe(state)
+  })
+
+  it('hydrate merges incoming sessions into existing state without replacing non-stale sessions', () => {
+    // Existing state has preview-1 at version 3
+    const existing = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+      type: 'upsert',
+      session: createSession({
+        id: 'preview-1',
+        toolCallId: 'preview-1',
+        previewVersion: 3,
+        updatedAt: '2026-04-10T00:00:03.000Z',
+        previewText: 'current',
+      }),
+    })
+
+    // Hydrate with preview-1 at older version 2 + a new preview-2
+    const hydrated = reduceFilePreviewSessions(existing, {
+      type: 'hydrate',
+      sessions: [
+        createSession({
+          id: 'preview-1',
+          toolCallId: 'preview-1',
+          previewVersion: 2,
+          updatedAt: '2026-04-10T00:00:02.000Z',
+          previewText: 'stale',
+        }),
+        createSession({
+          id: 'preview-2',
+          toolCallId: 'preview-2',
+          previewVersion: 1,
+          updatedAt: '2026-04-10T00:00:04.000Z',
+          previewText: 'new',
+        }),
+      ],
+    })
+
+    // preview-1 kept at version 3 (not replaced by stale version 2)
+    expect(hydrated.sessions['preview-1']?.previewVersion).toBe(3)
+    expect(hydrated.sessions['preview-1']?.previewText).toBe('current')
+    // preview-2 added
+    expect(hydrated.sessions['preview-2']?.previewText).toBe('new')
+  })
+
+  it('complete for a non-active session updates the session but keeps activeSessionId', () => {
+    let state = reduceFilePreviewSessions(INITIAL_FILE_PREVIEW_SESSIONS_STATE, {
+      type: 'upsert',
+      session: createSession({ id: 'preview-1', toolCallId: 'preview-1', previewVersion: 1 }),
+    })
+    state = reduceFilePreviewSessions(state, {
+      type: 'upsert',
+      session: createSession({
+        id: 'preview-2',
+        toolCallId: 'preview-2',
+        previewVersion: 1,
+        previewText: 'background',
+      }),
+    })
+    // active is now preview-2 (later upsert); preview-1 is no longer active
+    // Complete preview-1 (the non-active session)
+    const completed = reduceFilePreviewSessions(state, {
+      type: 'complete',
+      session: createSession({
+        id: 'preview-1',
+        toolCallId: 'preview-1',
+        status: 'complete',
+        previewVersion: 2,
+        completedAt: '2026-04-10T00:00:02.000Z',
+      }),
+    })
+
+    expect(completed.activeSessionId).toBe('preview-2')
+    expect(completed.sessions['preview-1']?.status).toBe('complete')
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.ts
@@ -106,15 +106,24 @@ export function reduceFilePreviewSessions(
         [action.session.id]: action.session,
       }
 
-      return {
-        sessions: nextSessions,
-        activeSessionId:
-          action.activate === false
-            ? pickActiveSessionId(nextSessions, state.activeSessionId)
-            : action.session.status === 'complete'
-              ? pickActiveSessionId(nextSessions, state.activeSessionId)
-              : action.session.id,
+      let nextActiveSessionId: string | null
+      if (action.activate === false || action.session.status === 'complete') {
+        nextActiveSessionId = pickActiveSessionId(nextSessions, state.activeSessionId)
+      } else {
+        // Don't steal active from a session that already has renderable content
+        // just because a new empty/pending session arrived. Wait until the new
+        // session has actual content before switching, so the file viewer stays
+        // mounted and the user's scroll position is preserved between tool calls.
+        const currentActive = state.activeSessionId ? nextSessions[state.activeSessionId] : null
+        const currentHasContent = currentActive
+          ? hasRenderableFilePreviewContent(currentActive)
+          : false
+        const incomingHasContent = hasRenderableFilePreviewContent(action.session)
+        nextActiveSessionId =
+          currentHasContent && !incomingHasContent ? state.activeSessionId : action.session.id
       }
+
+      return { sessions: nextSessions, activeSessionId: nextActiveSessionId }
     }
 
     case 'complete': {
@@ -127,12 +136,19 @@ export function reduceFilePreviewSessions(
         [action.session.id]: action.session,
       }
 
+      if (state.activeSessionId !== action.session.id) {
+        return { sessions: nextSessions, activeSessionId: state.activeSessionId }
+      }
+
+      const successor = pickActiveSessionId(nextSessions, null)
       return {
         sessions: nextSessions,
-        activeSessionId:
-          state.activeSessionId === action.session.id
-            ? pickActiveSessionId(nextSessions, null)
-            : state.activeSessionId,
+        // Linger on the completed session when no non-complete successor exists.
+        // This prevents a streamingContent → undefined flicker that would collapse
+        // the file viewer to shorter fetched content, clip scrollTop, and jump the
+        // user's reading position. The linger ends when a new non-complete session
+        // upserts (switching activeSessionId) or reset fires.
+        activeSessionId: successor ?? action.session.id,
       }
     }
 

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.ts
@@ -93,8 +93,6 @@ export function reduceFilePreviewSessions(
       const successor = pickActiveSessionId(nextSessions, state.activeSessionId)
       return {
         sessions: nextSessions,
-        // Preserve linger: if the active session is a completed (lingered) one
-        // and no non-complete successor exists, keep it rather than going null.
         activeSessionId: successor ?? state.activeSessionId,
       }
     }
@@ -114,10 +112,7 @@ export function reduceFilePreviewSessions(
         const successor = pickActiveSessionId(nextSessions, state.activeSessionId)
         nextActiveSessionId = successor ?? state.activeSessionId
       } else {
-        // Don't steal active from a session that already has renderable content
-        // just because a new empty/pending session arrived. Wait until the new
-        // session has actual content before switching, so the file viewer stays
-        // mounted and the user's scroll position is preserved between tool calls.
+        // Don't switch to a new session until it has renderable content — keeps the viewer mounted.
         const currentActive = state.activeSessionId ? nextSessions[state.activeSessionId] : null
         const currentHasContent = currentActive
           ? hasRenderableFilePreviewContent(currentActive)
@@ -147,11 +142,8 @@ export function reduceFilePreviewSessions(
       const successor = pickActiveSessionId(nextSessions, null)
       return {
         sessions: nextSessions,
-        // Linger on the completed session when no non-complete successor exists.
-        // This prevents a streamingContent → undefined flicker that would collapse
-        // the file viewer to shorter fetched content, clip scrollTop, and jump the
-        // user's reading position. The linger ends when a new non-complete session
-        // upserts (switching activeSessionId) or reset fires.
+        // Linger on this session until a successor upserts. Without it, streamingContent
+        // becomes undefined between tool calls, collapsing the viewer and clipping scrollTop.
         activeSessionId: successor ?? action.session.id,
       }
     }

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-file-preview-sessions.ts
@@ -90,9 +90,12 @@ export function reduceFilePreviewSessions(
         }
       }
 
+      const successor = pickActiveSessionId(nextSessions, state.activeSessionId)
       return {
         sessions: nextSessions,
-        activeSessionId: pickActiveSessionId(nextSessions, state.activeSessionId),
+        // Preserve linger: if the active session is a completed (lingered) one
+        // and no non-complete successor exists, keep it rather than going null.
+        activeSessionId: successor ?? state.activeSessionId,
       }
     }
 
@@ -108,7 +111,8 @@ export function reduceFilePreviewSessions(
 
       let nextActiveSessionId: string | null
       if (action.activate === false || action.session.status === 'complete') {
-        nextActiveSessionId = pickActiveSessionId(nextSessions, state.activeSessionId)
+        const successor = pickActiveSessionId(nextSessions, state.activeSessionId)
+        nextActiveSessionId = successor ?? state.activeSessionId
       } else {
         // Don't steal active from a session that already has renderable content
         // just because a new empty/pending session arrived. Wait until the new

--- a/apps/sim/hooks/use-auto-scroll.ts
+++ b/apps/sim/hooks/use-auto-scroll.ts
@@ -49,9 +49,7 @@ export function useAutoScroll(
     const el = containerRef.current
     if (!el) return
 
-    // Only pin to bottom if the user is already near the bottom (or the
-    // container has no scrollable content yet). If they've scrolled up to
-    // read, keep their position — they can scroll down to re-engage.
+    // Don't jump if the user scrolled up — keep their position.
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
     const isNearBottom = distanceFromBottom <= STICK_THRESHOLD
     stickyRef.current = isNearBottom

--- a/apps/sim/hooks/use-auto-scroll.ts
+++ b/apps/sim/hooks/use-auto-scroll.ts
@@ -49,11 +49,16 @@ export function useAutoScroll(
     const el = containerRef.current
     if (!el) return
 
-    stickyRef.current = true
-    userDetachedRef.current = false
+    // Only pin to bottom if the user is already near the bottom (or the
+    // container has no scrollable content yet). If they've scrolled up to
+    // read, keep their position — they can scroll down to re-engage.
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    const isNearBottom = distanceFromBottom <= STICK_THRESHOLD
+    stickyRef.current = isNearBottom
+    userDetachedRef.current = !isNearBottom
     prevScrollTopRef.current = el.scrollTop
     prevScrollHeightRef.current = el.scrollHeight
-    scrollToBottom()
+    if (isNearBottom) scrollToBottom()
 
     const detach = () => {
       stickyRef.current = false

--- a/apps/sim/hooks/use-scroll-anchor.test.ts
+++ b/apps/sim/hooks/use-scroll-anchor.test.ts
@@ -10,8 +10,6 @@ import { describe, expect, it } from 'vitest'
 import { computeSpacerShortage } from '@/hooks/use-scroll-anchor'
 
 describe('computeSpacerShortage', () => {
-  // ── no shortage needed ────────────────────────────────────────────────────
-
   it('returns 0 when content is exactly tall enough', () => {
     // user at 500, viewport 600 → needs 1100; content is exactly 1100
     expect(computeSpacerShortage(500, 600, 1100, 0)).toBe(0)
@@ -31,8 +29,6 @@ describe('computeSpacerShortage', () => {
     expect(computeSpacerShortage(0, 600, 1000, 0)).toBe(0)
   })
 
-  // ── shortage cases ───────────────────────────────────────────────────────
-
   it('returns positive shortage when content shrank to almost nothing', () => {
     // user at 500, viewport 600 → needs 1100; content shrank to 100
     expect(computeSpacerShortage(500, 600, 100, 0)).toBe(1000)
@@ -46,8 +42,6 @@ describe('computeSpacerShortage', () => {
   it('returns the exact gap when content is one pixel short', () => {
     expect(computeSpacerShortage(500, 600, 1099, 0)).toBe(1)
   })
-
-  // ── spacer already inflated from a previous update ───────────────────────
 
   it('subtracts existing spacer height before recomputing shortage', () => {
     // spacer was 900 from last update; content grew to 1000 natural height
@@ -76,8 +70,6 @@ describe('computeSpacerShortage', () => {
     expect(computeSpacerShortage(500, 600, 2000, 1200)).toBe(300)
   })
 
-  // ── user scrolled deep into a long document ──────────────────────────────
-
   it('handles large scroll positions correctly', () => {
     // user at 5000, viewport 600 → needs 5600; content shrank to 200
     expect(computeSpacerShortage(5000, 600, 200, 0)).toBe(5400)
@@ -88,8 +80,6 @@ describe('computeSpacerShortage', () => {
     // content shrinks to 100; needed = 1400 + 600 = 2000; shortage = 2000 - 100 = 1900
     expect(computeSpacerShortage(1400, 600, 100, 0)).toBe(1900)
   })
-
-  // ── edge: zero-height content (first chunk of a fresh write) ─────────────
 
   it('handles zero-height content', () => {
     // first streaming chunk is empty; user was at 500

--- a/apps/sim/hooks/use-scroll-anchor.test.ts
+++ b/apps/sim/hooks/use-scroll-anchor.test.ts
@@ -1,13 +1,14 @@
 /**
  * @vitest-environment node
  *
- * Tests for the pure `computeSpacerShortage` function extracted from
- * `useScrollAnchor`. The hook's DOM-interaction behaviour (event listeners,
- * MutationObserver, and the forced-reflow / scroll-event race condition fix)
- * requires a real browser layout engine and is covered by manual QA.
+ * Tests for the pure functions extracted from `useScrollAnchor`:
+ * `computeSpacerShortage` and `shouldReengage`. The hook's DOM-interaction
+ * behaviour (event listeners, MutationObserver, and the forced-reflow /
+ * scroll-event race condition fix) requires a real browser layout engine
+ * and is covered by manual QA.
  */
 import { describe, expect, it } from 'vitest'
-import { computeSpacerShortage } from '@/hooks/use-scroll-anchor'
+import { computeSpacerShortage, shouldReengage } from '@/hooks/use-scroll-anchor'
 
 describe('computeSpacerShortage', () => {
   it('returns 0 when content is exactly tall enough', () => {
@@ -89,5 +90,44 @@ describe('computeSpacerShortage', () => {
   it('never returns a negative value', () => {
     expect(computeSpacerShortage(0, 600, 10000, 0)).toBe(0)
     expect(computeSpacerShortage(0, 600, 0, 0)).toBe(600)
+  })
+})
+
+describe('shouldReengage', () => {
+  it('returns false when the spacer is active, even at distanceFromBottom = 0', () => {
+    // The spacer inflates scrollHeight to exactly targetScrollTop + clientHeight,
+    // so programmatic scroll restoration always produces distanceFromBottom = 0.
+    // Without this guard, onScroll would falsely re-engage auto-follow, clear the
+    // spacer on the next content update, and jump the user to the top.
+    expect(shouldReengage(0, 1000)).toBe(false)
+  })
+
+  it('returns false when spacer is active and distance is within threshold', () => {
+    expect(shouldReengage(15, 500)).toBe(false)
+  })
+
+  it('returns false when spacer is even slightly active', () => {
+    expect(shouldReengage(0, 1)).toBe(false)
+  })
+
+  it('returns true when the user genuinely reaches the document bottom (no spacer)', () => {
+    expect(shouldReengage(0, 0)).toBe(true)
+  })
+
+  it('returns true when within threshold and spacer is cleared', () => {
+    expect(shouldReengage(30, 0)).toBe(true)
+  })
+
+  it('returns true when one pixel within threshold', () => {
+    expect(shouldReengage(29, 0)).toBe(true)
+  })
+
+  it('returns false when beyond threshold regardless of spacer', () => {
+    expect(shouldReengage(31, 0)).toBe(false)
+    expect(shouldReengage(31, 1000)).toBe(false)
+  })
+
+  it('returns false when exactly at threshold + 1', () => {
+    expect(shouldReengage(31, 0)).toBe(false)
   })
 })

--- a/apps/sim/hooks/use-scroll-anchor.test.ts
+++ b/apps/sim/hooks/use-scroll-anchor.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the pure `computeSpacerShortage` function extracted from
+ * `useScrollAnchor`. The hook's DOM-interaction behaviour (event listeners,
+ * MutationObserver, and the forced-reflow / scroll-event race condition fix)
+ * requires a real browser layout engine and is covered by manual QA.
+ */
+import { describe, expect, it } from 'vitest'
+import { computeSpacerShortage } from '@/hooks/use-scroll-anchor'
+
+describe('computeSpacerShortage', () => {
+  // ── no shortage needed ────────────────────────────────────────────────────
+
+  it('returns 0 when content is exactly tall enough', () => {
+    // user at 500, viewport 600 → needs 1100; content is exactly 1100
+    expect(computeSpacerShortage(500, 600, 1100, 0)).toBe(0)
+  })
+
+  it('returns 0 when content is taller than needed', () => {
+    // user at 500, viewport 600 → needs 1100; content is 2000
+    expect(computeSpacerShortage(500, 600, 2000, 0)).toBe(0)
+  })
+
+  it('returns 0 when user is at the very top (targetScrollTop = 0) and content fills viewport', () => {
+    // no scroll required; all content visible
+    expect(computeSpacerShortage(0, 600, 600, 0)).toBe(0)
+  })
+
+  it('returns 0 when user is at the very top and content exceeds viewport', () => {
+    expect(computeSpacerShortage(0, 600, 1000, 0)).toBe(0)
+  })
+
+  // ── shortage cases ───────────────────────────────────────────────────────
+
+  it('returns positive shortage when content shrank to almost nothing', () => {
+    // user at 500, viewport 600 → needs 1100; content shrank to 100
+    expect(computeSpacerShortage(500, 600, 100, 0)).toBe(1000)
+  })
+
+  it('returns positive shortage when content is shorter than viewport', () => {
+    // user at 200, viewport 600 → needs 800; content is 300
+    expect(computeSpacerShortage(200, 600, 300, 0)).toBe(500)
+  })
+
+  it('returns the exact gap when content is one pixel short', () => {
+    expect(computeSpacerShortage(500, 600, 1099, 0)).toBe(1)
+  })
+
+  // ── spacer already inflated from a previous update ───────────────────────
+
+  it('subtracts existing spacer height before recomputing shortage', () => {
+    // spacer was 900 from last update; content grew to 1000 natural height
+    // scrollHeight = 1000 + 900 = 1900; needed = 500 + 600 = 1100
+    // naturalScrollHeight = 1900 - 900 = 1000; shortage = 1100 - 1000 = 100
+    expect(computeSpacerShortage(500, 600, 1900, 900)).toBe(100)
+  })
+
+  it('returns 0 and spacer should be cleared when content has grown past needed', () => {
+    // spacer was 500; content has now grown enough that no spacer is needed
+    // naturalScrollHeight = 2000 - 500 = 1500 > 1100 needed
+    expect(computeSpacerShortage(500, 600, 2000, 500)).toBe(0)
+  })
+
+  it('returns required spacer height even when scroll height already equals needed', () => {
+    // spacer was 900; natural content is 200; scrollHeight = 1100; needed = 1100
+    // naturalScrollHeight = 1100 - 900 = 200; shortage = 1100 - 200 = 900
+    // The function returns the new target minHeight (900), not the change delta (0)
+    expect(computeSpacerShortage(500, 600, 1100, 900)).toBe(900)
+  })
+
+  it('correctly recomputes when spacer is larger than needed', () => {
+    // spacer was over-inflated at 1200; content grew to 800 naturally
+    // scrollHeight = 2000; naturalScrollHeight = 2000 - 1200 = 800; needed = 1100
+    // shortage = 1100 - 800 = 300 (spacer should shrink from 1200 to 300)
+    expect(computeSpacerShortage(500, 600, 2000, 1200)).toBe(300)
+  })
+
+  // ── user scrolled deep into a long document ──────────────────────────────
+
+  it('handles large scroll positions correctly', () => {
+    // user at 5000, viewport 600 → needs 5600; content shrank to 200
+    expect(computeSpacerShortage(5000, 600, 200, 0)).toBe(5400)
+  })
+
+  it('handles user scrolled to the absolute bottom', () => {
+    // user at bottom: scrollTop = scrollHeight - clientHeight = 2000 - 600 = 1400
+    // content shrinks to 100; needed = 1400 + 600 = 2000; shortage = 2000 - 100 = 1900
+    expect(computeSpacerShortage(1400, 600, 100, 0)).toBe(1900)
+  })
+
+  // ── edge: zero-height content (first chunk of a fresh write) ─────────────
+
+  it('handles zero-height content', () => {
+    // first streaming chunk is empty; user was at 500
+    expect(computeSpacerShortage(500, 600, 0, 0)).toBe(1100)
+  })
+
+  it('never returns a negative value', () => {
+    expect(computeSpacerShortage(0, 600, 10000, 0)).toBe(0)
+    expect(computeSpacerShortage(0, 600, 0, 0)).toBe(600)
+  })
+})

--- a/apps/sim/hooks/use-scroll-anchor.ts
+++ b/apps/sim/hooks/use-scroll-anchor.ts
@@ -57,6 +57,11 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
 
     if (hasUserScrolledRef.current) {
       intendedScrollTopRef.current = el.scrollTop
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+      if (distanceFromBottom <= NEAR_BOTTOM_THRESHOLD) {
+        hasUserScrolledRef.current = false
+        stickyRef.current = true
+      }
       return
     }
 

--- a/apps/sim/hooks/use-scroll-anchor.ts
+++ b/apps/sim/hooks/use-scroll-anchor.ts
@@ -36,6 +36,11 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
   const stickyRef = useRef(false)
   // Tracks the user's last intentional position; updated only on genuine user events, never programmatic ones.
   const intendedScrollTopRef = useRef(0)
+  // Mirrors the spacer's current minHeight so onScroll can check it without a layout read.
+  // Re-engagement is blocked while the spacer is active: the spacer inflates scrollHeight to
+  // exactly targetScrollTop + clientHeight, so distanceFromBottom = 0 after restoration —
+  // which would otherwise falsely trigger the re-engage branch and clear the spacer.
+  const spacerHeightRef = useRef(0)
 
   const scrollToBottom = useCallback(() => {
     const el = containerRef.current
@@ -59,7 +64,10 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
     if (hasUserScrolledRef.current) {
       intendedScrollTopRef.current = el.scrollTop
       const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-      if (distanceFromBottom <= NEAR_BOTTOM_THRESHOLD) {
+      // Only re-engage when the spacer is not active. While the spacer is inflated,
+      // distanceFromBottom reads 0 after programmatic scroll restoration — that is
+      // artificial proximity, not the user genuinely reaching the document bottom.
+      if (distanceFromBottom <= NEAR_BOTTOM_THRESHOLD && spacerHeightRef.current === 0) {
         hasUserScrolledRef.current = false
         stickyRef.current = true
       }
@@ -132,6 +140,7 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
     if (!el) return
 
     if (!hasUserScrolledRef.current || !isStreaming) {
+      spacerHeightRef.current = 0
       if (spacer) spacer.style.minHeight = '0'
       return
     }
@@ -148,6 +157,7 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
       prevSpacerHeight
     )
 
+    spacerHeightRef.current = shortage
     if (spacer) spacer.style.minHeight = `${shortage}px`
     if (el.scrollTop < targetScrollTop) el.scrollTop = targetScrollTop
   }, [content, isStreaming])

--- a/apps/sim/hooks/use-scroll-anchor.ts
+++ b/apps/sim/hooks/use-scroll-anchor.ts
@@ -21,9 +21,10 @@ export function computeSpacerShortage(
  * Manages scroll for a streaming file-preview container.
  *
  * Never-scrolled: auto-follows new content to the bottom (MutationObserver
- * keeps it pinned). Has-scrolled: position is locked via a spacer element
- * that inflates `scrollHeight` to prevent the browser from clamping `scrollTop`
- * when replace-mode streaming temporarily produces a shorter chunk.
+ * keeps it pinned). Scrolled-up: position is locked via a spacer element that
+ * inflates `scrollHeight` to prevent the browser from clamping `scrollTop` when
+ * replace-mode streaming temporarily produces a shorter chunk. Scrolled back to
+ * the bottom: auto-follow re-engages.
  *
  * @param isStreaming - whether the container is currently receiving streaming content
  * @param content - drives spacer recalculation; pass the current text value

--- a/apps/sim/hooks/use-scroll-anchor.ts
+++ b/apps/sim/hooks/use-scroll-anchor.ts
@@ -3,15 +3,8 @@ import { useCallback, useLayoutEffect, useRef } from 'react'
 const NEAR_BOTTOM_THRESHOLD = 30
 
 /**
- * Computes how much extra height the scroll-anchor spacer needs to maintain
- * the user's intended scroll position when replace-mode streaming temporarily
- * produces content shorter than that position.
- *
- * @param targetScrollTop - the scroll position the user intends to hold
- * @param clientHeight - visible height of the scroll container
- * @param scrollHeight - total scrollable height (including current spacer)
- * @param prevSpacerHeight - current spacer height (subtracted to get natural content height)
- * @returns the new `minHeight` value to apply to the spacer element, or 0 if none needed
+ * Returns the `minHeight` the spacer needs so `scrollTop` can safely reach
+ * `targetScrollTop` when replace-mode streaming produces temporarily shorter content.
  */
 export function computeSpacerShortage(
   targetScrollTop: number,
@@ -25,35 +18,22 @@ export function computeSpacerShortage(
 }
 
 /**
- * Manages scroll for a streaming content container.
+ * Manages scroll for a streaming file-preview container.
  *
- * Two modes based on whether the user has ever manually scrolled:
- *
- * **Never scrolled** — auto-follows new content to the bottom while
- * streaming (MutationObserver keeps it pinned). The user can scroll up to
- * detach; scrolling back to the bottom re-engages.
- *
- * **Has scrolled** — position is locked. The hook injects a spacer element
- * at the end of the container's content that inflates `scrollHeight` to at
- * least `intendedScrollTop + clientHeight` on every content update. This
- * prevents the browser from clamping `scrollTop` when replace-mode streaming
- * temporarily produces a chunk shorter than the previous content (which would
- * otherwise jump the viewport to the top before the content regrows).
- *
- * The "has scrolled" flag resets on unmount so each new chat / file gets a
- * clean slate (parent remounts on key change).
+ * Never-scrolled: auto-follows new content to the bottom (MutationObserver
+ * keeps it pinned). Has-scrolled: position is locked via a spacer element
+ * that inflates `scrollHeight` to prevent the browser from clamping `scrollTop`
+ * when replace-mode streaming temporarily produces a shorter chunk.
  *
  * @param isStreaming - whether the container is currently receiving streaming content
- * @param content - the current text content; drives the spacer recalculation
+ * @param content - drives spacer recalculation; pass the current text value
  */
 export function useScrollAnchor(isStreaming: boolean, content?: string) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const spacerRef = useRef<HTMLDivElement | null>(null)
   const hasUserScrolledRef = useRef(false)
   const stickyRef = useRef(false)
-
-  // The scroll position the user most recently settled on — updated only from
-  // genuine user scroll events, never from programmatic ones.
+  // Tracks the user's last intentional position; updated only on genuine user events, never programmatic ones.
   const intendedScrollTopRef = useRef(0)
 
   const scrollToBottom = useCallback(() => {
@@ -62,11 +42,9 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
     el.scrollTop = el.scrollHeight
   }, [])
 
-  // ── event listeners ─────────────────────────────────────────────────────
-
   const onWheel = useCallback((e: WheelEvent) => {
     if (e.deltaY >= 0 || hasUserScrolledRef.current) return
-    // User scrolled up before any scroll event fired — detach immediately.
+    // Upward wheel before any scroll event fires — mark detached immediately.
     hasUserScrolledRef.current = true
     stickyRef.current = false
     const el = containerRef.current
@@ -78,24 +56,19 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
     if (!el) return
 
     if (hasUserScrolledRef.current) {
-      // Track their position so we can restore it after a content-shrink event.
       intendedScrollTopRef.current = el.scrollTop
       return
     }
 
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
     if (distanceFromBottom > NEAR_BOTTOM_THRESHOLD) {
-      // User scrolled away from the bottom.
       hasUserScrolledRef.current = true
       stickyRef.current = false
       intendedScrollTopRef.current = el.scrollTop
     } else {
-      // Re-engaged (scrolled back to bottom).
       stickyRef.current = true
     }
   }, [])
-
-  // ── container ref callback ───────────────────────────────────────────────
 
   const callbackRef = useCallback(
     (el: HTMLDivElement | null) => {
@@ -113,25 +86,15 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
     [onScroll, onWheel]
   )
 
-  // ── stream-start: decide initial pin state ───────────────────────────────
-
   useLayoutEffect(() => {
     if (!isStreaming) return
     const el = containerRef.current
     if (!el) return
-
-    if (hasUserScrolledRef.current) {
-      // User has already scrolled — never override their position.
-      return
-    }
-
-    // Fresh stream or user is at the bottom — engage sticky follow.
+    if (hasUserScrolledRef.current) return
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
     stickyRef.current = distanceFromBottom <= NEAR_BOTTOM_THRESHOLD
     if (stickyRef.current) scrollToBottom()
   }, [isStreaming, scrollToBottom])
-
-  // ── sticky follow: MutationObserver while streaming ──────────────────────
 
   useLayoutEffect(() => {
     if (!isStreaming) return
@@ -157,39 +120,20 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
     }
   }, [isStreaming, scrollToBottom])
 
-  // ── scroll-clip prevention via spacer ───────────────────────────────────
-  //
-  // On every content update, if the user has scrolled:
-  //   1. Compute naturalScrollHeight (container height minus spacer contribution).
-  //   2. Compute the minimum scrollHeight needed to keep intendedScrollTop valid.
-  //   3. Set spacer.minHeight to fill any gap — this inflates scrollHeight before
-  //      we read scrollTop, so the browser never clamps it to 0.
-  //   4. Restore scrollTop if it was already clipped (e.g. by prior content).
-  //
-  // When the user has NOT scrolled: clear the spacer so it doesn't interfere
-  // with auto-scroll bottom detection.
-
   useLayoutEffect(() => {
     const el = containerRef.current
     const spacer = spacerRef.current
     if (!el) return
 
-    // Clear the spacer when the user hasn't scrolled (auto-follow mode) or when
-    // streaming has ended (content is stable; no more clip-prevention needed).
     if (!hasUserScrolledRef.current || !isStreaming) {
       if (spacer) spacer.style.minHeight = '0'
       return
     }
 
-    // Capture the target BEFORE any layout read. Reading layout properties
-    // (clientHeight, scrollHeight, offsetHeight) forces a browser reflow. If
-    // scrollHeight is already smaller than scrollTop + clientHeight, the browser
-    // clamps scrollTop to 0 during that reflow and dispatches a 'scroll' event
-    // synchronously. Our onScroll handler would then overwrite intendedScrollTopRef
-    // with 0, corrupting the restore. Saving to a local variable here avoids that.
+    // Capture before any layout read: reading scrollHeight forces a reflow which can
+    // synchronously fire 'scroll' and overwrite intendedScrollTopRef with the clamped value.
     const targetScrollTop = intendedScrollTopRef.current
 
-    // Read spacer and scroll heights BEFORE mutating the spacer.
     const prevSpacerHeight = spacer ? spacer.offsetHeight : 0
     const shortage = computeSpacerShortage(
       targetScrollTop,
@@ -198,13 +142,8 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
       prevSpacerHeight
     )
 
-    // Inflate spacer so scrollHeight >= needed, preventing scrollTop clamping.
     if (spacer) spacer.style.minHeight = `${shortage}px`
-
-    // Restore scroll position (now valid because spacer ensures enough height).
-    if (el.scrollTop < targetScrollTop) {
-      el.scrollTop = targetScrollTop
-    }
+    if (el.scrollTop < targetScrollTop) el.scrollTop = targetScrollTop
   }, [content, isStreaming])
 
   return {

--- a/apps/sim/hooks/use-scroll-anchor.ts
+++ b/apps/sim/hooks/use-scroll-anchor.ts
@@ -46,9 +46,8 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
   const spacerRef = useRef<HTMLDivElement | null>(null)
   const hasUserScrolledRef = useRef(false)
   const stickyRef = useRef(false)
-  // Tracks the user's last intentional position; updated only on genuine user events, never programmatic ones.
   const intendedScrollTopRef = useRef(0)
-  // Mirrors the spacer's current minHeight so onScroll can check it without a layout read.
+  // Avoids a layout read inside onScroll.
   const spacerHeightRef = useRef(0)
 
   const scrollToBottom = useCallback(() => {
@@ -59,7 +58,6 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
 
   const onWheel = useCallback((e: WheelEvent) => {
     if (e.deltaY >= 0 || hasUserScrolledRef.current) return
-    // Upward wheel before any scroll event fires — mark detached immediately.
     hasUserScrolledRef.current = true
     stickyRef.current = false
     const el = containerRef.current
@@ -151,8 +149,7 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
       return
     }
 
-    // Capture before any layout read: reading scrollHeight forces a reflow which can
-    // synchronously fire 'scroll' and overwrite intendedScrollTopRef with the clamped value.
+    // Must read before scrollHeight: that forced reflow can synchronously fire 'scroll' and clamp the value.
     const targetScrollTop = intendedScrollTopRef.current
 
     const prevSpacerHeight = spacer ? spacer.offsetHeight : 0

--- a/apps/sim/hooks/use-scroll-anchor.ts
+++ b/apps/sim/hooks/use-scroll-anchor.ts
@@ -1,0 +1,212 @@
+import { useCallback, useLayoutEffect, useRef } from 'react'
+
+const NEAR_BOTTOM_THRESHOLD = 30
+
+/**
+ * Computes how much extra height the scroll-anchor spacer needs to maintain
+ * the user's intended scroll position when replace-mode streaming temporarily
+ * produces content shorter than that position.
+ *
+ * @param targetScrollTop - the scroll position the user intends to hold
+ * @param clientHeight - visible height of the scroll container
+ * @param scrollHeight - total scrollable height (including current spacer)
+ * @param prevSpacerHeight - current spacer height (subtracted to get natural content height)
+ * @returns the new `minHeight` value to apply to the spacer element, or 0 if none needed
+ */
+export function computeSpacerShortage(
+  targetScrollTop: number,
+  clientHeight: number,
+  scrollHeight: number,
+  prevSpacerHeight: number
+): number {
+  const needed = targetScrollTop + clientHeight
+  const naturalScrollHeight = scrollHeight - prevSpacerHeight
+  return Math.max(0, needed - naturalScrollHeight)
+}
+
+/**
+ * Manages scroll for a streaming content container.
+ *
+ * Two modes based on whether the user has ever manually scrolled:
+ *
+ * **Never scrolled** — auto-follows new content to the bottom while
+ * streaming (MutationObserver keeps it pinned). The user can scroll up to
+ * detach; scrolling back to the bottom re-engages.
+ *
+ * **Has scrolled** — position is locked. The hook injects a spacer element
+ * at the end of the container's content that inflates `scrollHeight` to at
+ * least `intendedScrollTop + clientHeight` on every content update. This
+ * prevents the browser from clamping `scrollTop` when replace-mode streaming
+ * temporarily produces a chunk shorter than the previous content (which would
+ * otherwise jump the viewport to the top before the content regrows).
+ *
+ * The "has scrolled" flag resets on unmount so each new chat / file gets a
+ * clean slate (parent remounts on key change).
+ *
+ * @param isStreaming - whether the container is currently receiving streaming content
+ * @param content - the current text content; drives the spacer recalculation
+ */
+export function useScrollAnchor(isStreaming: boolean, content?: string) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const spacerRef = useRef<HTMLDivElement | null>(null)
+  const hasUserScrolledRef = useRef(false)
+  const stickyRef = useRef(false)
+
+  // The scroll position the user most recently settled on — updated only from
+  // genuine user scroll events, never from programmatic ones.
+  const intendedScrollTopRef = useRef(0)
+
+  const scrollToBottom = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [])
+
+  // ── event listeners ─────────────────────────────────────────────────────
+
+  const onWheel = useCallback((e: WheelEvent) => {
+    if (e.deltaY >= 0 || hasUserScrolledRef.current) return
+    // User scrolled up before any scroll event fired — detach immediately.
+    hasUserScrolledRef.current = true
+    stickyRef.current = false
+    const el = containerRef.current
+    if (el) intendedScrollTopRef.current = el.scrollTop
+  }, [])
+
+  const onScroll = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    if (hasUserScrolledRef.current) {
+      // Track their position so we can restore it after a content-shrink event.
+      intendedScrollTopRef.current = el.scrollTop
+      return
+    }
+
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    if (distanceFromBottom > NEAR_BOTTOM_THRESHOLD) {
+      // User scrolled away from the bottom.
+      hasUserScrolledRef.current = true
+      stickyRef.current = false
+      intendedScrollTopRef.current = el.scrollTop
+    } else {
+      // Re-engaged (scrolled back to bottom).
+      stickyRef.current = true
+    }
+  }, [])
+
+  // ── container ref callback ───────────────────────────────────────────────
+
+  const callbackRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      const prev = containerRef.current
+      if (prev) {
+        prev.removeEventListener('scroll', onScroll)
+        prev.removeEventListener('wheel', onWheel as EventListener)
+      }
+      containerRef.current = el
+      if (el) {
+        el.addEventListener('scroll', onScroll, { passive: true })
+        el.addEventListener('wheel', onWheel as EventListener, { passive: true })
+      }
+    },
+    [onScroll, onWheel]
+  )
+
+  // ── stream-start: decide initial pin state ───────────────────────────────
+
+  useLayoutEffect(() => {
+    if (!isStreaming) return
+    const el = containerRef.current
+    if (!el) return
+
+    if (hasUserScrolledRef.current) {
+      // User has already scrolled — never override their position.
+      return
+    }
+
+    // Fresh stream or user is at the bottom — engage sticky follow.
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    stickyRef.current = distanceFromBottom <= NEAR_BOTTOM_THRESHOLD
+    if (stickyRef.current) scrollToBottom()
+  }, [isStreaming, scrollToBottom])
+
+  // ── sticky follow: MutationObserver while streaming ──────────────────────
+
+  useLayoutEffect(() => {
+    if (!isStreaming) return
+    const el = containerRef.current
+    if (!el) return
+
+    let rafId = 0
+    const guardedScroll = () => {
+      if (stickyRef.current) scrollToBottom()
+    }
+    const onMutation = () => {
+      if (!stickyRef.current) return
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(guardedScroll)
+    }
+
+    const observer = new MutationObserver(onMutation)
+    observer.observe(el, { childList: true, subtree: true, characterData: true })
+
+    return () => {
+      observer.disconnect()
+      cancelAnimationFrame(rafId)
+    }
+  }, [isStreaming, scrollToBottom])
+
+  // ── scroll-clip prevention via spacer ───────────────────────────────────
+  //
+  // On every content update, if the user has scrolled:
+  //   1. Compute naturalScrollHeight (container height minus spacer contribution).
+  //   2. Compute the minimum scrollHeight needed to keep intendedScrollTop valid.
+  //   3. Set spacer.minHeight to fill any gap — this inflates scrollHeight before
+  //      we read scrollTop, so the browser never clamps it to 0.
+  //   4. Restore scrollTop if it was already clipped (e.g. by prior content).
+  //
+  // When the user has NOT scrolled: clear the spacer so it doesn't interfere
+  // with auto-scroll bottom detection.
+
+  useLayoutEffect(() => {
+    const el = containerRef.current
+    const spacer = spacerRef.current
+    if (!el) return
+
+    if (!hasUserScrolledRef.current) {
+      if (spacer) spacer.style.minHeight = '0'
+      return
+    }
+
+    // Capture the target BEFORE any layout read. Reading layout properties
+    // (clientHeight, scrollHeight, offsetHeight) forces a browser reflow. If
+    // scrollHeight is already smaller than scrollTop + clientHeight, the browser
+    // clamps scrollTop to 0 during that reflow and dispatches a 'scroll' event
+    // synchronously. Our onScroll handler would then overwrite intendedScrollTopRef
+    // with 0, corrupting the restore. Saving to a local variable here avoids that.
+    const targetScrollTop = intendedScrollTopRef.current
+
+    // Read spacer and scroll heights BEFORE mutating the spacer.
+    const prevSpacerHeight = spacer ? spacer.offsetHeight : 0
+    const shortage = computeSpacerShortage(
+      targetScrollTop,
+      el.clientHeight,
+      el.scrollHeight,
+      prevSpacerHeight
+    )
+
+    // Inflate spacer so scrollHeight >= needed, preventing scrollTop clamping.
+    if (spacer) spacer.style.minHeight = `${shortage}px`
+
+    // Restore scroll position (now valid because spacer ensures enough height).
+    if (el.scrollTop < targetScrollTop) {
+      el.scrollTop = targetScrollTop
+    }
+  }, [content])
+
+  return {
+    ref: callbackRef,
+    spacerRef,
+  }
+}

--- a/apps/sim/hooks/use-scroll-anchor.ts
+++ b/apps/sim/hooks/use-scroll-anchor.ts
@@ -18,6 +18,18 @@ export function computeSpacerShortage(
 }
 
 /**
+ * Returns whether the scroll container should re-engage auto-follow.
+ *
+ * Re-engagement is blocked while the spacer is active. The spacer inflates
+ * `scrollHeight` to exactly `targetScrollTop + clientHeight`, so programmatic
+ * scroll restoration produces `distanceFromBottom = 0` — which is artificial
+ * proximity, not the user genuinely reaching the document bottom.
+ */
+export function shouldReengage(distanceFromBottom: number, spacerHeight: number): boolean {
+  return distanceFromBottom <= NEAR_BOTTOM_THRESHOLD && spacerHeight === 0
+}
+
+/**
  * Manages scroll for a streaming file-preview container.
  *
  * Never-scrolled: auto-follows new content to the bottom (MutationObserver
@@ -37,9 +49,6 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
   // Tracks the user's last intentional position; updated only on genuine user events, never programmatic ones.
   const intendedScrollTopRef = useRef(0)
   // Mirrors the spacer's current minHeight so onScroll can check it without a layout read.
-  // Re-engagement is blocked while the spacer is active: the spacer inflates scrollHeight to
-  // exactly targetScrollTop + clientHeight, so distanceFromBottom = 0 after restoration —
-  // which would otherwise falsely trigger the re-engage branch and clear the spacer.
   const spacerHeightRef = useRef(0)
 
   const scrollToBottom = useCallback(() => {
@@ -64,10 +73,7 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
     if (hasUserScrolledRef.current) {
       intendedScrollTopRef.current = el.scrollTop
       const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-      // Only re-engage when the spacer is not active. While the spacer is inflated,
-      // distanceFromBottom reads 0 after programmatic scroll restoration — that is
-      // artificial proximity, not the user genuinely reaching the document bottom.
-      if (distanceFromBottom <= NEAR_BOTTOM_THRESHOLD && spacerHeightRef.current === 0) {
+      if (shouldReengage(distanceFromBottom, spacerHeightRef.current)) {
         hasUserScrolledRef.current = false
         stickyRef.current = true
       }

--- a/apps/sim/hooks/use-scroll-anchor.ts
+++ b/apps/sim/hooks/use-scroll-anchor.ts
@@ -174,7 +174,9 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
     const spacer = spacerRef.current
     if (!el) return
 
-    if (!hasUserScrolledRef.current) {
+    // Clear the spacer when the user hasn't scrolled (auto-follow mode) or when
+    // streaming has ended (content is stable; no more clip-prevention needed).
+    if (!hasUserScrolledRef.current || !isStreaming) {
       if (spacer) spacer.style.minHeight = '0'
       return
     }
@@ -203,7 +205,7 @@ export function useScrollAnchor(isStreaming: boolean, content?: string) {
     if (el.scrollTop < targetScrollTop) {
       el.scrollTop = targetScrollTop
     }
-  }, [content])
+  }, [content, isStreaming])
 
   return {
     ref: callbackRef,


### PR DESCRIPTION
## Summary
- Fix root cause of scroll jump: `MarkdownCheckboxCtx.Provider` was conditionally rendered around the scroll container, causing it to unmount/remount (and reset `scrollTop` to 0) every time streaming started
- Add `useScrollAnchor` hook with a spacer element that inflates `scrollHeight` to prevent the browser from clamping `scrollTop` when streamed content temporarily shrinks
- Linger `activeSessionId` on `complete` so `streamingContent` never becomes `undefined` between two consecutive Mothership tool calls on the same file
- Gate session activation in `upsert` on the incoming session having renderable content, preventing a blank flash when a new session starts before its first chunk arrives
- Fix `shouldShowStreamingFilePanel` to keep the panel mounted while the lingered session is active
- Fix `use-chat` post-write navigation condition to work with lingered completed sessions
- Fix `useAutoScroll` to check proximity before pinning to bottom on stream start (prevents unwanted jump-to-bottom in the chat panel)

## Type of Change
- [x] Bug fix

## Testing
Tested manually — scrolled to middle of a file, asked Mothership to make multi-step edits. Scroll position preserved across tool call boundaries. Also verified single `patch`, fresh `write`, and cross-file edits all behave correctly.

Unit tests added:
- `use-scroll-anchor.test.ts`: 15 tests for `computeSpacerShortage` pure function
- `use-file-preview-sessions.test.tsx`: 7 new tests for linger, content-gate, and edge cases
- `text-editor-state.test.ts`: 5 new tests for inter-session content shrink scenario

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)