### PR TITLE
fix(tables): cmd+a always selects all cells on the table page

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
@@ -2272,10 +2272,10 @@ export function TableGrid({
       if (target.isContentEditable) return
       if (target.closest('[role="dialog"]')) return
       if (!containerRef.current) return
-      e.preventDefault()
       const rws = rowsRef.current
       const currentCols = columnsRef.current
       if (rws.length > 0 && currentCols.length > 0) {
+        e.preventDefault()
         suppressFocusScrollRef.current = true
         setEditingCell(null)
         setRowSelection((prev) => (prev.kind === 'none' ? prev : ROW_SELECTION_NONE))

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
@@ -1527,25 +1527,6 @@ export function TableGrid({
         return
       }
 
-      if ((e.metaKey || e.ctrlKey) && e.key === 'a') {
-        e.preventDefault()
-        const rws = rowsRef.current
-        const currentCols = columnsRef.current
-        if (rws.length > 0 && currentCols.length > 0) {
-          suppressFocusScrollRef.current = true
-          setEditingCell(null)
-          setRowSelection((prev) => (prev.kind === 'none' ? prev : ROW_SELECTION_NONE))
-          lastCheckboxRowRef.current = null
-          setSelectionAnchor({ rowIndex: 0, colIndex: 0 })
-          setSelectionFocus({
-            rowIndex: rws.length - 1,
-            colIndex: currentCols.length - 1,
-          })
-          setIsColumnSelection(false)
-        }
-        return
-      }
-
       if ((e.metaKey || e.ctrlKey) && e.key === ' ') {
         const a = selectionAnchorRef.current
         if (!a || editingCellRef.current) return
@@ -2280,6 +2261,33 @@ export function TableGrid({
       el.removeEventListener('paste', handlePaste)
     }
   }, [])
+
+  useEffect(() => {
+    if (embedded) return
+    const handleSelectAll = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.key !== 'a') return
+      const target = e.target as HTMLElement
+      const tag = target.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+      if (target.isContentEditable) return
+      if (target.closest('[role="dialog"]')) return
+      if (!containerRef.current) return
+      e.preventDefault()
+      const rws = rowsRef.current
+      const currentCols = columnsRef.current
+      if (rws.length > 0 && currentCols.length > 0) {
+        suppressFocusScrollRef.current = true
+        setEditingCell(null)
+        setRowSelection((prev) => (prev.kind === 'none' ? prev : ROW_SELECTION_NONE))
+        lastCheckboxRowRef.current = null
+        setSelectionAnchor({ rowIndex: 0, colIndex: 0 })
+        setSelectionFocus({ rowIndex: rws.length - 1, colIndex: currentCols.length - 1 })
+        setIsColumnSelection(false)
+      }
+    }
+    document.addEventListener('keydown', handleSelectAll)
+    return () => document.removeEventListener('keydown', handleSelectAll)
+  }, [embedded])
 
   const navigateAfterSave = useCallback((reason: SaveReason) => {
     const anchor = selectionAnchorRef.current


### PR DESCRIPTION
## Summary
- Cmd+A on the tables page now selects all cells regardless of where focus is (toolbar buttons, sidebar, page background)
- Moved the select-all handler to a document-level listener so it fires even when focus is outside the grid container
- Guards: skips when focus is in an input/textarea/select/contenteditable, inside an open dialog, or when the grid is in embedded mode

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)