### PR TITLE
feat(observability): export Trigger.dev telemetry to Grafana Cloud OTLP

### DIFF
--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -157,6 +157,9 @@ export const env = createEnv({
     LOG_LEVEL:                             z.enum(['DEBUG', 'INFO', 'WARN', 'ERROR']).optional(), // Minimum log level to display (defaults to ERROR in production, DEBUG in development)
     PROFOUND_API_KEY:                      z.string().min(1).optional(),           // Profound analytics API key
     PROFOUND_ENDPOINT:                     z.string().url().optional(),            // Profound analytics endpoint
+    GRAFANA_OTLP_ENDPOINT:                 z.string().url().optional(),            // Grafana Cloud OTLP HTTP gateway base URL (e.g., https://otlp-gateway-prod-us-east-0.grafana.net/otlp). Trigger.dev exporters append /v1/traces, /v1/logs, /v1/metrics.
+    GRAFANA_INSTANCE_ID:                   z.string().min(1).optional(),           // Grafana Cloud instance ID (Basic auth username for OTLP)
+    GRAFANA_API_TOKEN:                     z.string().min(1).optional(),           // Grafana Cloud API token (Basic auth password for OTLP)
 
     // External Services
     BROWSERBASE_API_KEY:                   z.string().min(1).optional(),           // Browserbase API key for browser automation

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -160,6 +160,7 @@ export const env = createEnv({
     GRAFANA_OTLP_ENDPOINT:                 z.string().url().optional(),            // Grafana Cloud OTLP HTTP gateway base URL (e.g., https://otlp-gateway-prod-us-east-0.grafana.net/otlp). Trigger.dev exporters append /v1/traces, /v1/logs, /v1/metrics.
     GRAFANA_INSTANCE_ID:                   z.string().min(1).optional(),           // Grafana Cloud instance ID (Basic auth username for OTLP)
     GRAFANA_API_TOKEN:                     z.string().min(1).optional(),           // Grafana Cloud API token (Basic auth password for OTLP)
+    SIM_DEPLOYMENT_ENVIRONMENT:            z.string().min(1).optional(),           // Deployment tier label (e.g., "production", "staging", "development"). Emitted as the stable `deployment.environment.name` resource attribute on Trigger.dev telemetry to match the rest of the Sim OTEL stack.
 
     // External Services
     BROWSERBASE_API_KEY:                   z.string().min(1).optional(),           // Browserbase API key for browser automation

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -158,9 +158,8 @@ export const env = createEnv({
     PROFOUND_API_KEY:                      z.string().min(1).optional(),           // Profound analytics API key
     PROFOUND_ENDPOINT:                     z.string().url().optional(),            // Profound analytics endpoint
     GRAFANA_OTLP_ENDPOINT:                 z.string().url().optional(),            // Grafana Cloud OTLP HTTP gateway base URL (e.g., https://otlp-gateway-prod-us-east-0.grafana.net/otlp). Trigger.dev exporters append /v1/traces, /v1/logs, /v1/metrics.
-    GRAFANA_INSTANCE_ID:                   z.string().min(1).optional(),           // Grafana Cloud instance ID (Basic auth username for OTLP)
-    GRAFANA_API_TOKEN:                     z.string().min(1).optional(),           // Grafana Cloud API token (Basic auth password for OTLP)
-    SIM_DEPLOYMENT_ENVIRONMENT:            z.string().min(1).optional(),           // Deployment tier label (e.g., "production", "staging", "development"). Emitted as the stable `deployment.environment.name` resource attribute on Trigger.dev telemetry to match the rest of the Sim OTEL stack.
+    GRAFANA_OTLP_HEADERS:                  z.string().min(1).optional(),           // Comma-separated key=value headers for OTLP requests (e.g., "Authorization=Basic <base64(instanceId:token)>"). Same format as the OTEL_EXPORTER_OTLP_HEADERS spec.
+    GRAFANA_DEPLOYMENT_ENVIRONMENT:        z.string().min(1).optional(),           // Deployment tier label (e.g., "production", "staging", "development"). Emitted as the stable `deployment.environment.name` resource attribute on Trigger.dev telemetry to match the rest of the Sim OTEL stack.
 
     // External Services
     BROWSERBASE_API_KEY:                   z.string().min(1).optional(),           // Browserbase API key for browser automation

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -65,6 +65,8 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@monaco-editor/react": "4.7.0",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.217.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.217.0",
     "@opentelemetry/resources": "^2.7.0",
     "@opentelemetry/sdk-node": "^0.217.0",

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -66,7 +66,7 @@
     "@monaco-editor/react": "4.7.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "^0.217.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.217.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.217.0",
     "@opentelemetry/resources": "^2.7.0",
     "@opentelemetry/sdk-node": "^0.217.0",

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -1,5 +1,5 @@
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
-import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto'
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { additionalFiles, additionalPackages } from '@trigger.dev/build/extensions/core'
 import { defineConfig } from '@trigger.dev/sdk'

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -1,6 +1,35 @@
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { additionalFiles, additionalPackages } from '@trigger.dev/build/extensions/core'
 import { defineConfig } from '@trigger.dev/sdk'
 import { env } from './lib/core/config/env'
+
+const grafanaEndpoint = env.GRAFANA_OTLP_ENDPOINT
+const grafanaInstanceId = env.GRAFANA_INSTANCE_ID
+const grafanaToken = env.GRAFANA_API_TOKEN
+const grafanaConfigured = Boolean(grafanaEndpoint || grafanaInstanceId || grafanaToken)
+const grafanaFullyConfigured = Boolean(grafanaEndpoint && grafanaInstanceId && grafanaToken)
+
+if (grafanaConfigured && !grafanaFullyConfigured) {
+  throw new Error(
+    'Grafana OTLP telemetry is partially configured. Set GRAFANA_OTLP_ENDPOINT, GRAFANA_INSTANCE_ID, and GRAFANA_API_TOKEN together, or leave all three unset.'
+  )
+}
+
+const grafanaTelemetry = grafanaFullyConfigured
+  ? (() => {
+      const baseUrl = grafanaEndpoint!.replace(/\/+$/, '')
+      const headers = {
+        Authorization: `Basic ${Buffer.from(`${grafanaInstanceId}:${grafanaToken}`).toString('base64')}`,
+      }
+      return {
+        exporters: [new OTLPTraceExporter({ url: `${baseUrl}/v1/traces`, headers })],
+        logExporters: [new OTLPLogExporter({ url: `${baseUrl}/v1/logs`, headers })],
+        metricExporters: [new OTLPMetricExporter({ url: `${baseUrl}/v1/metrics`, headers })],
+      }
+    })()
+  : undefined
 
 export default defineConfig({
   project: env.TRIGGER_PROJECT_ID!,
@@ -14,6 +43,7 @@ export default defineConfig({
     },
   },
   dirs: ['./background'],
+  ...(grafanaTelemetry ? { telemetry: grafanaTelemetry } : {}),
   build: {
     external: ['isolated-vm'],
     extensions: [

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -7,32 +7,54 @@ import { defineConfig } from '@trigger.dev/sdk'
 import { env } from './lib/core/config/env'
 
 const grafanaEndpoint = env.GRAFANA_OTLP_ENDPOINT
-const grafanaInstanceId = env.GRAFANA_INSTANCE_ID
-const grafanaToken = env.GRAFANA_API_TOKEN
-const grafanaConfigured = Boolean(grafanaEndpoint || grafanaInstanceId || grafanaToken)
-const grafanaFullyConfigured = Boolean(grafanaEndpoint && grafanaInstanceId && grafanaToken)
+const grafanaHeaders = env.GRAFANA_OTLP_HEADERS
+const grafanaDeploymentEnvironment = env.GRAFANA_DEPLOYMENT_ENVIRONMENT
+const grafanaConfigured = Boolean(grafanaEndpoint || grafanaHeaders || grafanaDeploymentEnvironment)
+const grafanaFullyConfigured = Boolean(
+  grafanaEndpoint && grafanaHeaders && grafanaDeploymentEnvironment
+)
 
 if (grafanaConfigured && !grafanaFullyConfigured) {
   throw new Error(
-    'Grafana OTLP telemetry is partially configured. Set GRAFANA_OTLP_ENDPOINT, GRAFANA_INSTANCE_ID, and GRAFANA_API_TOKEN together, or leave all three unset.'
+    'Grafana OTLP telemetry is partially configured. Set GRAFANA_OTLP_ENDPOINT, GRAFANA_OTLP_HEADERS, and GRAFANA_DEPLOYMENT_ENVIRONMENT together, or leave all three unset.'
   )
+}
+
+/**
+ * Parse OTLP headers per the OTEL spec format `key1=value1,key2=value2`.
+ * Values are URL-decoded; keys/values are trimmed; empty entries are skipped.
+ * @see https://opentelemetry.io/docs/specs/otel/protocol/exporter/
+ */
+function parseOtlpHeaders(raw: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const pair of raw.split(',')) {
+    const eq = pair.indexOf('=')
+    if (eq === -1) continue
+    const key = pair.slice(0, eq).trim()
+    const value = pair.slice(eq + 1).trim()
+    if (!key) continue
+    out[key] = decodeURIComponent(value)
+  }
+  return out
 }
 
 const grafanaTelemetry = grafanaFullyConfigured
   ? (() => {
       const baseUrl = grafanaEndpoint!.replace(/\/+$/, '')
-      const headers = {
-        Authorization: `Basic ${Buffer.from(`${grafanaInstanceId}:${grafanaToken}`).toString('base64')}`,
+      const headers = parseOtlpHeaders(grafanaHeaders!)
+      if (Object.keys(headers).length === 0) {
+        throw new Error(
+          'GRAFANA_OTLP_HEADERS is set but yielded no valid key=value pairs. Expected format: "key1=value1,key2=value2".'
+        )
       }
-      const deploymentEnvironment = env.SIM_DEPLOYMENT_ENVIRONMENT
-      const resource = deploymentEnvironment
-        ? resourceFromAttributes({ 'deployment.environment.name': deploymentEnvironment })
-        : undefined
+      const resource = resourceFromAttributes({
+        'deployment.environment.name': grafanaDeploymentEnvironment!,
+      })
       return {
         exporters: [new OTLPTraceExporter({ url: `${baseUrl}/v1/traces`, headers })],
         logExporters: [new OTLPLogExporter({ url: `${baseUrl}/v1/logs`, headers })],
         metricExporters: [new OTLPMetricExporter({ url: `${baseUrl}/v1/metrics`, headers })],
-        ...(resource ? { resource } : {}),
+        resource,
       }
     })()
   : undefined

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -1,6 +1,7 @@
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { resourceFromAttributes } from '@opentelemetry/resources'
 import { additionalFiles, additionalPackages } from '@trigger.dev/build/extensions/core'
 import { defineConfig } from '@trigger.dev/sdk'
 import { env } from './lib/core/config/env'
@@ -23,10 +24,15 @@ const grafanaTelemetry = grafanaFullyConfigured
       const headers = {
         Authorization: `Basic ${Buffer.from(`${grafanaInstanceId}:${grafanaToken}`).toString('base64')}`,
       }
+      const deploymentEnvironment = env.SIM_DEPLOYMENT_ENVIRONMENT
+      const resource = deploymentEnvironment
+        ? resourceFromAttributes({ 'deployment.environment.name': deploymentEnvironment })
+        : undefined
       return {
         exporters: [new OTLPTraceExporter({ url: `${baseUrl}/v1/traces`, headers })],
         logExporters: [new OTLPLogExporter({ url: `${baseUrl}/v1/logs`, headers })],
         metricExporters: [new OTLPMetricExporter({ url: `${baseUrl}/v1/metrics`, headers })],
+        ...(resource ? { resource } : {}),
       }
     })()
   : undefined

--- a/bun.lock
+++ b/bun.lock
@@ -121,7 +121,7 @@
         "@monaco-editor/react": "4.7.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.217.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.217.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.217.0",
         "@opentelemetry/resources": "^2.7.0",
         "@opentelemetry/sdk-node": "^0.217.0",

--- a/bun.lock
+++ b/bun.lock
@@ -120,6 +120,8 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@monaco-editor/react": "4.7.0",
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.217.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.217.0",
         "@opentelemetry/resources": "^2.7.0",
         "@opentelemetry/sdk-node": "^0.217.0",


### PR DESCRIPTION
## Summary
- Wire OTLP HTTP exporters for traces, logs, and metrics from the Trigger.dev runtime to Grafana Cloud
- Auth uses Basic with Grafana Cloud instance ID + API token, computed once and reused across the three exporters
- Gated behind `GRAFANA_OTLP_ENDPOINT`, `GRAFANA_INSTANCE_ID`, `GRAFANA_API_TOKEN`; all three must be set together or all unset (partial config throws at startup, fail-fast)
- Env-splitting handled by Trigger's built-in `ctx.environment.type` resource attribute — no extra env var needed

## Type of Change
- [x] New feature

## Testing
- Tested manually: `bun run type-check` clean, `bun run lint` clean
- No new tests — config glue
- After merge: set the three env vars in Trigger.dev dashboard per environment, then verify signals land in Tempo/Loki/Mimir filtered by `ctx.environment.type`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)