### PR TITLE
improvement(db): reduce connection saturation and egress hotspots

### DIFF
--- a/apps/realtime/src/database/operations.ts
+++ b/apps/realtime/src/database/operations.ts
@@ -30,7 +30,7 @@ const socketDb = drizzle(
     prepare: false,
     idle_timeout: 10,
     connect_timeout: 20,
-    max: 30,
+    max: 15,
     onnotice: () => {},
   }),
   { schema }

--- a/apps/sim/app/api/mcp/servers/[id]/refresh/route.ts
+++ b/apps/sim/app/api/mcp/servers/[id]/refresh/route.ts
@@ -2,7 +2,7 @@ import { db } from '@sim/db'
 import { mcpServers, workflow, workflowBlocks } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
-import { and, eq, isNull } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import type { NextRequest } from 'next/server'
 import { mcpServerIdParamsSchema } from '@/lib/api/contracts/mcp'
 import { validationErrorResponse } from '@/lib/api/server'
@@ -77,13 +77,11 @@ async function syncToolSchemasToWorkflows(
       subBlocks: workflowBlocks.subBlocks,
     })
     .from(workflowBlocks)
-    .where(eq(workflowBlocks.type, 'agent'))
+    .where(and(eq(workflowBlocks.type, 'agent'), inArray(workflowBlocks.workflowId, workflowIds)))
 
   const updatedWorkflowIds = new Set<string>()
 
   for (const block of agentBlocks) {
-    if (!workflowIds.includes(block.workflowId)) continue
-
     const subBlocks = block.subBlocks as Record<string, unknown> | null
     if (!subBlocks) continue
 

--- a/apps/sim/app/api/mcp/tools/stored/route.ts
+++ b/apps/sim/app/api/mcp/tools/stored/route.ts
@@ -2,7 +2,7 @@ import { db } from '@sim/db'
 import { workflow, workflowBlocks } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
-import { eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import type { NextRequest } from 'next/server'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { withMcpAuth } from '@/lib/mcp/middleware'
@@ -33,13 +33,13 @@ export const GET = withRouteHandler(
       const agentBlocks = await db
         .select({ workflowId: workflowBlocks.workflowId, subBlocks: workflowBlocks.subBlocks })
         .from(workflowBlocks)
-        .where(eq(workflowBlocks.type, 'agent'))
+        .where(
+          and(eq(workflowBlocks.type, 'agent'), inArray(workflowBlocks.workflowId, workflowIds))
+        )
 
       const storedTools: StoredMcpTool[] = []
 
       for (const block of agentBlocks) {
-        if (!workflowMap.has(block.workflowId)) continue
-
         const subBlocks = block.subBlocks as Record<string, unknown> | null
         if (!subBlocks) continue
 

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -1162,9 +1162,9 @@ export class WorkspaceVFS {
             SELECT jsonb_agg(
               jsonb_build_object(
                 'role', m->>'role',
-                'content', m->>'content',
+                'content', m->'content',
                 'contentBlocks', COALESCE((
-                  SELECT jsonb_agg(jsonb_build_object('type', 'text', 'content', b->>'content'))
+                  SELECT jsonb_agg(jsonb_build_object('type', 'text', 'content', b->'content'))
                   FROM jsonb_array_elements(COALESCE(m->'contentBlocks', '[]'::jsonb)) AS b
                   WHERE b->>'type' = 'text'
                 ), '[]'::jsonb)

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -17,7 +17,7 @@ import {
 } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
-import { and, desc, eq, isNotNull, isNull, ne } from 'drizzle-orm'
+import { and, desc, eq, isNotNull, isNull, ne, sql } from 'drizzle-orm'
 import { listApiKeys } from '@/lib/api-key/service'
 import { buildWorkspaceMd, type WorkspaceMdData } from '@/lib/copilot/chat/workspace-context'
 import { extractDocumentStyle } from '@/lib/copilot/vfs/document-style'
@@ -1157,7 +1157,22 @@ export class WorkspaceVFS {
         .select({
           id: copilotChats.id,
           title: copilotChats.title,
-          messages: copilotChats.messages,
+          messageCount: sql<number>`COALESCE(jsonb_array_length(${copilotChats.messages}), 0)`,
+          messages: sql<unknown[]>`COALESCE((
+            SELECT jsonb_agg(
+              jsonb_build_object(
+                'role', m->>'role',
+                'content', m->>'content',
+                'contentBlocks', COALESCE((
+                  SELECT jsonb_agg(jsonb_build_object('type', 'text', 'content', b->>'content'))
+                  FROM jsonb_array_elements(COALESCE(m->'contentBlocks', '[]'::jsonb)) AS b
+                  WHERE b->>'type' = 'text'
+                ), '[]'::jsonb)
+              )
+            )
+            FROM jsonb_array_elements(${copilotChats.messages}) AS m
+            WHERE m->>'role' IN ('user', 'assistant')
+          ), '[]'::jsonb)`,
           createdAt: copilotChats.createdAt,
           updatedAt: copilotChats.updatedAt,
         })
@@ -1177,13 +1192,14 @@ export class WorkspaceVFS {
         const safeName = sanitizeName(title)
         const prefix = `tasks/${safeName}/`
         const messages = Array.isArray(task.messages) ? task.messages : []
+        const messageCount = Number(task.messageCount) || 0
 
         this.files.set(
           `${prefix}session.md`,
           serializeTaskSession({
             id: task.id,
             title,
-            messageCount: messages.length,
+            messageCount,
             createdAt: task.createdAt,
             updatedAt: task.updatedAt,
           })

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -1165,7 +1165,12 @@ export class WorkspaceVFS {
                 'content', m->'content',
                 'contentBlocks', COALESCE((
                   SELECT jsonb_agg(jsonb_build_object('type', 'text', 'content', b->'content'))
-                  FROM jsonb_array_elements(COALESCE(m->'contentBlocks', '[]'::jsonb)) AS b
+                  FROM jsonb_array_elements(
+                    CASE WHEN jsonb_typeof(m->'contentBlocks') = 'array'
+                         THEN m->'contentBlocks'
+                         ELSE '[]'::jsonb
+                    END
+                  ) AS b
                   WHERE b->>'type' = 'text'
                 ), '[]'::jsonb)
               )

--- a/packages/db/db.ts
+++ b/packages/db/db.ts
@@ -11,7 +11,7 @@ const postgresClient = postgres(connectionString, {
   prepare: false,
   idle_timeout: 20,
   connect_timeout: 30,
-  max: 30,
+  max: 15,
   onnotice: () => {},
 })
 


### PR DESCRIPTION
## Summary
- Reduce postgres-js pool `max` from 30 → 15 in `@sim/db` and realtime app (validated against 24h PlanetScale Insights: 3.5 avg fleet concurrency, 25× headroom on steady state, 2.5× under 10× burst)
- Scope `workflow_blocks` agent query to workspace in MCP refresh + stored routes (eliminates ~88 GB/day egress from cross-tenant scan)
- Project `copilot_chats.messages` SQL-side in workspace VFS materializer (eliminates ~58 GB/day egress; semantically identical to prior JS-side filter)

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Validated:
- `bun run check:api-validation` passes
- `bun run type-check` passes (no errors)
- SQL projection produces exactly the shape `serializeTaskChat` consumes
- MCP route filter migrated from JS to SQL is logically equivalent; `inArray` guarded by existing `workflowIds.length === 0` early return

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)