### PR TITLE
fix(vfs): make copilot message ordering deterministic via WITH ORDINALITY

### DIFF
--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -1161,22 +1161,23 @@ export class WorkspaceVFS {
           messages: sql<unknown[]>`COALESCE((
             SELECT jsonb_agg(
               jsonb_build_object(
-                'role', m->>'role',
-                'content', m->'content',
+                'role', m.value->>'role',
+                'content', m.value->'content',
                 'contentBlocks', COALESCE((
-                  SELECT jsonb_agg(jsonb_build_object('type', 'text', 'content', b->'content'))
+                  SELECT jsonb_agg(jsonb_build_object('type', 'text', 'content', b.value->'content') ORDER BY b.ord)
                   FROM jsonb_array_elements(
-                    CASE WHEN jsonb_typeof(m->'contentBlocks') = 'array'
-                         THEN m->'contentBlocks'
+                    CASE WHEN jsonb_typeof(m.value->'contentBlocks') = 'array'
+                         THEN m.value->'contentBlocks'
                          ELSE '[]'::jsonb
                     END
-                  ) AS b
-                  WHERE b->>'type' = 'text'
+                  ) WITH ORDINALITY AS b(value, ord)
+                  WHERE b.value->>'type' = 'text'
                 ), '[]'::jsonb)
               )
+              ORDER BY m.ord
             )
-            FROM jsonb_array_elements(${copilotChats.messages}) AS m
-            WHERE m->>'role' IN ('user', 'assistant')
+            FROM jsonb_array_elements(${copilotChats.messages}) WITH ORDINALITY AS m(value, ord)
+            WHERE m.value->>'role' IN ('user', 'assistant')
           ), '[]'::jsonb)`,
           createdAt: copilotChats.createdAt,
           updatedAt: copilotChats.updatedAt,


### PR DESCRIPTION
## Summary
- Follow-up to #4594 addressing Greptile inline feedback
- `jsonb_agg` without explicit `ORDER BY` has implementation-defined input ordering per PostgreSQL docs — though in practice `jsonb_array_elements` + `jsonb_agg` preserves array order, the SQL standard doesn't guarantee it
- Switched to `WITH ORDINALITY` + `ORDER BY ord` on both the outer message aggregate and the inner `contentBlocks` text aggregate so message and block ordering is explicitly deterministic regardless of planner changes

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Negligible CPU cost (≤5 rows per query). Message ordering is critical for chat transcripts; this aligns with PostgreSQL's documented recommendation to use `ORDER BY` inside order-sensitive aggregates.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)