### PR TITLE
feat(files-in-agent): Add file attachments to agent blocks

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/file-upload/file-upload.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/file-upload/file-upload.tsx
@@ -26,21 +26,25 @@ const logger = createLogger('FileUpload')
 interface FileUploadProps {
   blockId: string
   subBlockId: string
+  value?: FileUploadValue | null
+  onValueChange?: (value: FileUploadValue | null) => void
   maxSize?: number // in MB
   acceptedTypes?: string // comma separated MIME types
   multiple?: boolean // whether to allow multiple file uploads
   isPreview?: boolean
-  previewValue?: any | null
+  previewValue?: FileUploadValue | null
   disabled?: boolean
 }
 
-interface UploadedFile {
+export interface UploadedFile {
   name: string
   path: string
   key?: string
   size: number
   type: string
 }
+
+export type FileUploadValue = UploadedFile | UploadedFile[]
 
 interface SingleFileSelectorProps {
   file: UploadedFile
@@ -143,6 +147,8 @@ interface UploadingFile {
 export function FileUpload({
   blockId,
   subBlockId,
+  value: controlledValue,
+  onValueChange,
   maxSize = 10, // Default 10MB
   acceptedTypes = '*',
   multiple = false, // Default to single file for backward compatibility
@@ -151,6 +157,7 @@ export function FileUpload({
   disabled = false,
 }: FileUploadProps) {
   const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlockId)
+  const isControlled = controlledValue !== undefined
   const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([])
   const [uploadProgress, setUploadProgress] = useState(0)
   const [uploadError, setUploadError] = useState<string | null>(null)
@@ -173,7 +180,21 @@ export function FileUpload({
   const uploadFileMutation = useUploadWorkspaceFile()
   const queryClient = useQueryClient()
 
-  const value = isPreview ? previewValue : storeValue
+  const value =
+    isPreview && previewValue !== undefined
+      ? previewValue
+      : isControlled
+        ? controlledValue
+        : storeValue
+
+  const setValue = (newValue: FileUploadValue | null) => {
+    if (isControlled) {
+      onValueChange?.(newValue)
+    } else {
+      setStoreValue(newValue)
+    }
+    useWorkflowStore.getState().triggerUpdate()
+  }
 
   /**
    * Checks if a file's MIME type matches the accepted types
@@ -390,11 +411,9 @@ export function FileUpload({
 
         const newFiles = Array.from(uniqueFiles.values())
 
-        setStoreValue(newFiles)
-        useWorkflowStore.getState().triggerUpdate()
+        setValue(newFiles)
       } else {
-        setStoreValue(uploadedFiles[0] || null)
-        useWorkflowStore.getState().triggerUpdate()
+        setValue(uploadedFiles[0] || null)
       }
     } catch (error) {
       logger.error(
@@ -439,12 +458,11 @@ export function FileUpload({
       uniqueFiles.set(uploadedFile.path, uploadedFile)
       const newFiles = Array.from(uniqueFiles.values())
 
-      setStoreValue(newFiles)
+      setValue(newFiles)
     } else {
-      setStoreValue(uploadedFile)
+      setValue(uploadedFile)
     }
 
-    useWorkflowStore.getState().triggerUpdate()
     logger.info(`Selected workspace file: ${selectedFile.name}`, activeWorkflowId)
   }
 
@@ -481,12 +499,10 @@ export function FileUpload({
       if (multiple) {
         const filesArray = Array.isArray(value) ? value : value ? [value] : []
         const updatedFiles = filesArray.filter((f) => f.path !== file.path)
-        setStoreValue(updatedFiles.length > 0 ? updatedFiles : null)
+        setValue(updatedFiles.length > 0 ? updatedFiles : null)
       } else {
-        setStoreValue(null)
+        setValue(null)
       }
-
-      useWorkflowStore.getState().triggerUpdate()
     } catch (error) {
       logger.error(
         error instanceof Error ? error.message : 'Failed to remove file',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/messages-input/messages-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/messages-input/messages-input.tsx
@@ -9,11 +9,22 @@ import {
 } from 'react'
 import { generateShortId } from '@sim/utils/id'
 import { isEqual } from 'es-toolkit'
-import { ChevronDown, ChevronsUpDown, ChevronUp, Plus } from 'lucide-react'
-import { Button, Popover, PopoverContent, PopoverItem, PopoverTrigger } from '@/components/emcn'
+import { AlertTriangle, ChevronDown, ChevronsUpDown, ChevronUp, Plus } from 'lucide-react'
+import {
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverItem,
+  PopoverTrigger,
+  Tooltip,
+} from '@/components/emcn'
 import { Trash } from '@/components/emcn/icons/trash'
 import { cn } from '@/lib/core/utils/cn'
 import { EnvVarDropdown } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/env-var-dropdown'
+import {
+  FileUpload,
+  type FileUploadValue,
+} from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/file-upload/file-upload'
 import { formatDisplayText } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/formatted-text'
 import { TagDropdown } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/tag-dropdown'
 import { useSubBlockInput } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-sub-block-input'
@@ -22,9 +33,36 @@ import type { WandControlHandlers } from '@/app/workspace/[workspaceId]/w/[workf
 import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import { useWand } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-wand'
 import type { SubBlockConfig } from '@/blocks/types'
+import { getProviderFromModel, supportsFileAttachments } from '@/providers/models'
 
 const MIN_TEXTAREA_HEIGHT_PX = 80
 const MAX_TEXTAREA_HEIGHT_PX = 320
+
+const ANTHROPIC_SUPPORTED_IMAGE_TYPES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+])
+
+const ANTHROPIC_SUPPORTED_DOCUMENT_TYPES = new Set([
+  'application/pdf',
+  'text/plain',
+  'text/csv',
+  'application/json',
+  'application/xml',
+  'text/xml',
+  'text/html',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/msword',
+  'application/vnd.ms-excel',
+  'application/vnd.ms-powerpoint',
+  'text/markdown',
+  'application/rtf',
+])
 
 /** Pattern to match complete message objects in JSON */
 const COMPLETE_MESSAGE_PATTERN =
@@ -42,13 +80,44 @@ const ROLE_BEFORE_CONTENT_PATTERN = /"role"\s*:\s*"(system|user|assistant)"[^{]*
 const unescapeContent = (str: string): string =>
   str.replace(/\\n/g, '\n').replace(/\\"/g, '"').replace(/\\\\/g, '\\')
 
+function isTextMessage(message: Message | undefined): message is TextMessage {
+  return (
+    !!message &&
+    (message.role === 'system' || message.role === 'user' || message.role === 'assistant')
+  )
+}
+
+function hasFilesValue(value: FileUploadValue | null | undefined): boolean {
+  return Array.isArray(value) ? value.length > 0 : Boolean(value)
+}
+
+function hasAnthropicUnsupportedFiles(value: FileUploadValue | null | undefined): boolean {
+  const files = Array.isArray(value) ? value : value ? [value] : []
+  return files.some((file) => {
+    const type = file.type.toLowerCase()
+    if (type === 'image/svg+xml') return false
+    return (
+      !ANTHROPIC_SUPPORTED_IMAGE_TYPES.has(type) && !ANTHROPIC_SUPPORTED_DOCUMENT_TYPES.has(type)
+    )
+  })
+}
+
 /**
  * Interface for individual message in the messages array
  */
-interface Message {
-  role: 'system' | 'user' | 'assistant'
+type TextMessageRole = 'system' | 'user' | 'assistant'
+
+interface TextMessage {
+  role: TextMessageRole
   content: string
 }
+
+interface FilesMessage {
+  role: 'files'
+  files?: FileUploadValue | null
+}
+
+type Message = TextMessage | FilesMessage
 
 /**
  * Props for the MessagesInput component
@@ -88,10 +157,13 @@ export function MessagesInput({
   wandControlRef,
 }: MessagesInputProps) {
   const [messages, setMessages] = useSubBlockValue<Message[]>(blockId, subBlockId, false)
+  const [selectedModel] = useSubBlockValue<string>(blockId, 'model', false)
   const [localMessages, setLocalMessages] = useState<Message[]>([{ role: 'user', content: '' }])
   const messageIdsRef = useRef<string[]>([generateShortId()])
   const accessiblePrefixes = useAccessibleReferencePrefixes(blockId)
   const [openPopoverIndex, setOpenPopoverIndex] = useState<number | null>(null)
+  const fileAttachmentsSupported = selectedModel ? supportsFileAttachments(selectedModel) : true
+  const selectedProvider = selectedModel ? getProviderFromModel(selectedModel) : null
   const subBlockInput = useSubBlockInput({
     blockId,
     subBlockId,
@@ -106,7 +178,9 @@ export function MessagesInput({
   const getMessagesJson = useCallback((): string => {
     if (localMessages.length === 0) return ''
     // Filter out empty messages for cleaner context
-    const nonEmptyMessages = localMessages.filter((m) => m.content.trim() !== '')
+    const nonEmptyMessages = localMessages.filter(
+      (m): m is TextMessage => isTextMessage(m) && m.content.trim() !== ''
+    )
     if (nonEmptyMessages.length === 0) return ''
     return JSON.stringify(nonEmptyMessages, null, 2)
   }, [localMessages])
@@ -119,11 +193,11 @@ export function MessagesInput({
   /**
    * Parses and validates messages from JSON content
    */
-  const parseMessages = useCallback((content: string): Message[] | null => {
+  const parseMessages = useCallback((content: string): TextMessage[] | null => {
     try {
       const parsed = JSON.parse(content)
       if (Array.isArray(parsed)) {
-        const validMessages: Message[] = parsed
+        const validMessages: TextMessage[] = parsed
           .filter(
             (m): m is { role: string; content: string } =>
               typeof m === 'object' &&
@@ -134,7 +208,7 @@ export function MessagesInput({
           .map((m) => ({
             role: (['system', 'user', 'assistant'].includes(m.role)
               ? m.role
-              : 'user') as Message['role'],
+              : 'user') as TextMessageRole,
             content: m.content,
           }))
         return validMessages.length > 0 ? validMessages : null
@@ -150,18 +224,18 @@ export function MessagesInput({
    * Uses simple pattern matching for efficiency
    */
   const extractStreamingMessages = useCallback(
-    (buffer: string): Message[] => {
+    (buffer: string): TextMessage[] => {
       // Try complete JSON parse first
       const complete = parseMessages(buffer)
       if (complete) return complete
 
-      const result: Message[] = []
+      const result: TextMessage[] = []
 
       // Reset regex lastIndex for global pattern
       COMPLETE_MESSAGE_PATTERN.lastIndex = 0
       let match
       while ((match = COMPLETE_MESSAGE_PATTERN.exec(buffer)) !== null) {
-        result.push({ role: match[1] as Message['role'], content: unescapeContent(match[2]) })
+        result.push({ role: match[1] as TextMessageRole, content: unescapeContent(match[2]) })
       }
 
       // Check for incomplete message at end (content still streaming)
@@ -176,7 +250,7 @@ export function MessagesInput({
             const content = unescapeContent(incomplete[1])
             // Only add if not duplicate of last complete message
             if (result.length === 0 || result[result.length - 1].content !== content) {
-              result.push({ role: roleMatch[1] as Message['role'], content })
+              result.push({ role: roleMatch[1] as TextMessageRole, content })
             }
           }
         }
@@ -288,6 +362,7 @@ export function MessagesInput({
       if (isPreview || disabled) return
 
       const updatedMessages = [...localMessages]
+      if (!isTextMessage(updatedMessages[index])) return
       updatedMessages[index] = {
         ...updatedMessages[index],
         content,
@@ -302,14 +377,27 @@ export function MessagesInput({
    * Updates a specific message's role
    */
   const updateMessageRole = useCallback(
-    (index: number, role: 'system' | 'user' | 'assistant') => {
+    (index: number, role: TextMessageRole | 'files') => {
       if (isPreview || disabled) return
 
       const updatedMessages = [...localMessages]
-      updatedMessages[index] = {
-        ...updatedMessages[index],
-        role,
-      }
+      const currentMessage = updatedMessages[index]
+      updatedMessages[index] =
+        role === 'files'
+          ? { role: 'files', files: isTextMessage(currentMessage) ? null : currentMessage.files }
+          : { role, content: isTextMessage(currentMessage) ? currentMessage.content : '' }
+      setLocalMessages(updatedMessages)
+      setMessages(updatedMessages)
+    },
+    [localMessages, setMessages, isPreview, disabled]
+  )
+
+  const updateMessageFiles = useCallback(
+    (index: number, files: FileUploadValue | null) => {
+      if (isPreview || disabled) return
+
+      const updatedMessages = [...localMessages]
+      updatedMessages[index] = { role: 'files', files }
       setLocalMessages(updatedMessages)
       setMessages(updatedMessages)
     },
@@ -553,10 +641,19 @@ export function MessagesInput({
         >
           {(() => {
             const fieldId = `message-${index}`
+            const textContent = isTextMessage(message) ? message.content : ''
+            const isFilesMessage = message.role === 'files'
+            const showFilesWarning =
+              isFilesMessage && hasFilesValue(message.files) && !fileAttachmentsSupported
+            const showUnsupportedFilesWarning =
+              isFilesMessage &&
+              fileAttachmentsSupported &&
+              (selectedProvider === 'anthropic' || selectedProvider === 'azure-anthropic') &&
+              hasAnthropicUnsupportedFiles(message.files)
             const fieldState = subBlockInput.fieldHelpers.getFieldState(fieldId)
             const fieldHandlers = subBlockInput.fieldHelpers.createFieldHandlers(
               fieldId,
-              message.content,
+              textContent,
               (newValue: string) => {
                 updateMessageContent(index, newValue)
               }
@@ -564,7 +661,7 @@ export function MessagesInput({
 
             const handleEnvSelect = subBlockInput.fieldHelpers.createEnvVarSelectHandler(
               fieldId,
-              message.content,
+              textContent,
               (newValue: string) => {
                 updateMessageContent(index, newValue)
               }
@@ -572,7 +669,7 @@ export function MessagesInput({
 
             const handleTagSelect = subBlockInput.fieldHelpers.createTagSelectHandler(
               fieldId,
-              message.content,
+              textContent,
               (newValue: string) => {
                 updateMessageContent(index, newValue)
               }
@@ -598,51 +695,80 @@ export function MessagesInput({
                     }
                   }}
                 >
-                  <Popover
-                    open={openPopoverIndex === index}
-                    onOpenChange={(open) => setOpenPopoverIndex(open ? index : null)}
-                    colorScheme='inverted'
-                  >
-                    <PopoverTrigger asChild>
-                      <button
-                        type='button'
-                        disabled={isPreview || disabled}
-                        className={cn(
-                          'group -ml-1.5 -my-1 flex items-center gap-1 rounded px-1.5 py-1 font-medium text-[var(--text-primary)] text-small leading-none transition-colors hover-hover:bg-[var(--surface-5)] hover-hover:text-[var(--text-secondary)]',
-                          (isPreview || disabled) &&
-                            'cursor-default hover-hover:bg-transparent hover-hover:text-[var(--text-primary)]'
-                        )}
-                        onClick={(e) => e.stopPropagation()}
-                        aria-label='Select message role'
-                      >
-                        {formatRole(message.role)}
-                        {!isPreview && !disabled && (
-                          <ChevronDown
-                            className={cn(
-                              'h-3 w-3 flex-shrink-0 transition-transform duration-100',
-                              openPopoverIndex === index && 'rotate-180'
-                            )}
-                          />
-                        )}
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent minWidth={140} align='start'>
-                      <div className='flex flex-col gap-0.5'>
-                        {(['system', 'user', 'assistant'] as const).map((role) => (
-                          <PopoverItem
-                            key={role}
-                            active={message.role === role}
-                            onClick={() => {
-                              updateMessageRole(index, role)
-                              setOpenPopoverIndex(null)
-                            }}
-                          >
-                            <span>{formatRole(role)}</span>
-                          </PopoverItem>
-                        ))}
-                      </div>
-                    </PopoverContent>
-                  </Popover>
+                  <div className='flex items-center gap-1'>
+                    <Popover
+                      open={openPopoverIndex === index}
+                      onOpenChange={(open) => setOpenPopoverIndex(open ? index : null)}
+                      colorScheme='inverted'
+                    >
+                      <PopoverTrigger asChild>
+                        <button
+                          type='button'
+                          disabled={isPreview || disabled}
+                          className={cn(
+                            'group -ml-1.5 -my-1 flex items-center gap-1 rounded px-1.5 py-1 font-medium text-[var(--text-primary)] text-small leading-none transition-colors hover-hover:bg-[var(--surface-5)] hover-hover:text-[var(--text-secondary)]',
+                            (isPreview || disabled) &&
+                              'cursor-default hover-hover:bg-transparent hover-hover:text-[var(--text-primary)]'
+                          )}
+                          onClick={(e) => e.stopPropagation()}
+                          aria-label='Select message role'
+                        >
+                          {formatRole(message.role)}
+                          {!isPreview && !disabled && (
+                            <ChevronDown
+                              className={cn(
+                                'size-3 flex-shrink-0 transition-transform duration-100',
+                                openPopoverIndex === index && 'rotate-180'
+                              )}
+                            />
+                          )}
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent minWidth={140} align='start'>
+                        <div className='flex flex-col gap-0.5'>
+                          {(['system', 'user', 'assistant', 'files'] as const).map((role) => (
+                            <PopoverItem
+                              key={role}
+                              active={message.role === role}
+                              onClick={() => {
+                                updateMessageRole(index, role)
+                                setOpenPopoverIndex(null)
+                              }}
+                            >
+                              <span>{formatRole(role)}</span>
+                            </PopoverItem>
+                          ))}
+                        </div>
+                      </PopoverContent>
+                    </Popover>
+
+                    {showFilesWarning && (
+                      <Tooltip.Root>
+                        <Tooltip.Trigger asChild>
+                          <span className='flex size-5 items-center justify-center text-[var(--warning)]'>
+                            <AlertTriangle className='size-3.5' />
+                          </span>
+                        </Tooltip.Trigger>
+                        <Tooltip.Content side='top'>
+                          The selected model does not accept files. These files will be ignored.
+                        </Tooltip.Content>
+                      </Tooltip.Root>
+                    )}
+
+                    {showUnsupportedFilesWarning && (
+                      <Tooltip.Root>
+                        <Tooltip.Trigger asChild>
+                          <span className='flex size-5 items-center justify-center text-[var(--warning)]'>
+                            <AlertTriangle className='size-3.5' />
+                          </span>
+                        </Tooltip.Trigger>
+                        <Tooltip.Content side='top'>
+                          The selected model does not accept one or more file types. Unsupported
+                          files will be ignored.
+                        </Tooltip.Content>
+                      </Tooltip.Root>
+                    )}
+                  </div>
 
                   {!isPreview && !disabled && (
                     <div className='flex items-center'>
@@ -703,100 +829,118 @@ export function MessagesInput({
                 </div>
 
                 {/* Content Input with overlay for variable highlighting */}
-                <div className='relative w-full overflow-hidden'>
-                  <textarea
-                    ref={(el) => {
-                      textareaRefs.current[fieldId] = el
-                    }}
-                    className='relative z-[2] m-0 box-border h-auto min-h-[80px] w-full resize-none overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words border-none bg-transparent p-2 font-medium font-sans text-sm text-transparent leading-[1.5] caret-[var(--text-primary)] outline-none [-ms-overflow-style:none] [scrollbar-width:none] placeholder:text-[var(--text-muted)] focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed [&::-webkit-scrollbar]:hidden'
-                    placeholder='Enter message content...'
-                    value={message.content}
-                    onChange={fieldHandlers.onChange}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Tab' && !isPreview && !disabled) {
-                        e.preventDefault()
-                        const direction = e.shiftKey ? -1 : 1
-                        const nextIndex = index + direction
+                <div
+                  className={cn('relative w-full overflow-hidden', isFilesMessage && 'p-2 pt-1')}
+                >
+                  {isFilesMessage ? (
+                    <FileUpload
+                      blockId={blockId}
+                      subBlockId={`${subBlockId}-${messageIdsRef.current[index] ?? index}-files`}
+                      value={message.files ?? null}
+                      onValueChange={(files) => updateMessageFiles(index, files)}
+                      acceptedTypes='*'
+                      multiple
+                      maxSize={10}
+                      isPreview={isPreview}
+                      disabled={disabled}
+                    />
+                  ) : (
+                    <>
+                      <textarea
+                        ref={(el) => {
+                          textareaRefs.current[fieldId] = el
+                        }}
+                        className='relative z-[2] m-0 box-border h-auto min-h-[80px] w-full resize-none overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words border-none bg-transparent p-2 font-medium font-sans text-sm text-transparent leading-[1.5] caret-[var(--text-primary)] outline-none [-ms-overflow-style:none] [scrollbar-width:none] placeholder:text-[var(--text-muted)] focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed [&::-webkit-scrollbar]:hidden'
+                        placeholder='Enter message content...'
+                        value={textContent}
+                        onChange={fieldHandlers.onChange}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Tab' && !isPreview && !disabled) {
+                            e.preventDefault()
+                            const direction = e.shiftKey ? -1 : 1
+                            const nextIndex = index + direction
 
-                        if (nextIndex >= 0 && nextIndex < currentMessages.length) {
-                          const nextFieldId = `message-${nextIndex}`
-                          const nextTextarea = textareaRefs.current[nextFieldId]
-                          if (nextTextarea) {
-                            nextTextarea.focus()
-                            nextTextarea.selectionStart = nextTextarea.value.length
-                            nextTextarea.selectionEnd = nextTextarea.value.length
+                            if (nextIndex >= 0 && nextIndex < currentMessages.length) {
+                              const nextFieldId = `message-${nextIndex}`
+                              const nextTextarea = textareaRefs.current[nextFieldId]
+                              if (nextTextarea) {
+                                nextTextarea.focus()
+                                nextTextarea.selectionStart = nextTextarea.value.length
+                                nextTextarea.selectionEnd = nextTextarea.value.length
+                              }
+                            }
+                            return
                           }
-                        }
-                        return
-                      }
 
-                      fieldHandlers.onKeyDown(e)
-                    }}
-                    onDrop={fieldHandlers.onDrop}
-                    onDragOver={fieldHandlers.onDragOver}
-                    onFocus={fieldHandlers.onFocus}
-                    onScroll={(e) => {
-                      const overlay = overlayRefs.current[fieldId]
-                      if (overlay) {
-                        overlay.scrollTop = e.currentTarget.scrollTop
-                        overlay.scrollLeft = e.currentTarget.scrollLeft
-                      }
-                    }}
-                    disabled={isPreview || disabled}
-                  />
-                  <div
-                    ref={(el) => {
-                      overlayRefs.current[fieldId] = el
-                    }}
-                    className={cn(
-                      'absolute top-0 left-0 z-[1] m-0 box-border w-full overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words border-none bg-transparent p-2 font-medium font-sans text-[var(--text-primary)] text-sm leading-[1.5] [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-                      !(isPreview || disabled) && 'pointer-events-none'
-                    )}
-                  >
-                    {formatDisplayText(message.content, {
-                      accessiblePrefixes,
-                      highlightAll: !accessiblePrefixes,
-                    })}
-                    {message.content.endsWith('\n') && '\u200B'}
-                  </div>
+                          fieldHandlers.onKeyDown(e)
+                        }}
+                        onDrop={fieldHandlers.onDrop}
+                        onDragOver={fieldHandlers.onDragOver}
+                        onFocus={fieldHandlers.onFocus}
+                        onScroll={(e) => {
+                          const overlay = overlayRefs.current[fieldId]
+                          if (overlay) {
+                            overlay.scrollTop = e.currentTarget.scrollTop
+                            overlay.scrollLeft = e.currentTarget.scrollLeft
+                          }
+                        }}
+                        disabled={isPreview || disabled}
+                      />
+                      <div
+                        ref={(el) => {
+                          overlayRefs.current[fieldId] = el
+                        }}
+                        className={cn(
+                          'absolute top-0 left-0 z-[1] m-0 box-border w-full overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words border-none bg-transparent p-2 font-medium font-sans text-[var(--text-primary)] text-sm leading-[1.5] [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+                          !(isPreview || disabled) && 'pointer-events-none'
+                        )}
+                      >
+                        {formatDisplayText(textContent, {
+                          accessiblePrefixes,
+                          highlightAll: !accessiblePrefixes,
+                        })}
+                        {textContent.endsWith('\n') && '\u200B'}
+                      </div>
 
-                  {/* Env var dropdown for this message */}
-                  <EnvVarDropdown
-                    visible={fieldState.showEnvVars && !isPreview && !disabled}
-                    onSelect={handleEnvSelect}
-                    searchTerm={fieldState.searchTerm}
-                    inputValue={message.content}
-                    cursorPosition={fieldState.cursorPosition}
-                    onClose={() => subBlockInput.fieldHelpers.hideFieldDropdowns(fieldId)}
-                    workspaceId={subBlockInput.workspaceId}
-                    maxHeight='192px'
-                    inputRef={textareaRefObject}
-                  />
+                      {/* Env var dropdown for this message */}
+                      <EnvVarDropdown
+                        visible={fieldState.showEnvVars && !isPreview && !disabled}
+                        onSelect={handleEnvSelect}
+                        searchTerm={fieldState.searchTerm}
+                        inputValue={textContent}
+                        cursorPosition={fieldState.cursorPosition}
+                        onClose={() => subBlockInput.fieldHelpers.hideFieldDropdowns(fieldId)}
+                        workspaceId={subBlockInput.workspaceId}
+                        maxHeight='192px'
+                        inputRef={textareaRefObject}
+                      />
 
-                  {/* Tag dropdown for this message */}
-                  <TagDropdown
-                    visible={fieldState.showTags && !isPreview && !disabled}
-                    onSelect={handleTagSelect}
-                    blockId={blockId}
-                    activeSourceBlockId={fieldState.activeSourceBlockId}
-                    inputValue={message.content}
-                    cursorPosition={fieldState.cursorPosition}
-                    onClose={() => subBlockInput.fieldHelpers.hideFieldDropdowns(fieldId)}
-                    inputRef={textareaRefObject}
-                  />
+                      {/* Tag dropdown for this message */}
+                      <TagDropdown
+                        visible={fieldState.showTags && !isPreview && !disabled}
+                        onSelect={handleTagSelect}
+                        blockId={blockId}
+                        activeSourceBlockId={fieldState.activeSourceBlockId}
+                        inputValue={textContent}
+                        cursorPosition={fieldState.cursorPosition}
+                        onClose={() => subBlockInput.fieldHelpers.hideFieldDropdowns(fieldId)}
+                        inputRef={textareaRefObject}
+                      />
 
-                  {!isPreview && !disabled && (
-                    <div
-                      role='separator'
-                      aria-orientation='horizontal'
-                      className='absolute right-1 bottom-1 z-[3] flex size-4 cursor-ns-resize items-center justify-center rounded-sm border border-[var(--border-1)] bg-[var(--surface-5)] dark:bg-[var(--surface-5)]'
-                      onMouseDown={(e) => handleResizeStart(fieldId, e)}
-                      onDragStart={(e) => {
-                        e.preventDefault()
-                      }}
-                    >
-                      <ChevronsUpDown className='size-3 text-[var(--text-muted)]' />
-                    </div>
+                      {!isPreview && !disabled && (
+                        <div
+                          role='separator'
+                          aria-orientation='horizontal'
+                          className='absolute right-1 bottom-1 z-[3] flex size-4 cursor-ns-resize items-center justify-center rounded-sm border border-[var(--border-1)] bg-[var(--surface-5)] dark:bg-[var(--surface-5)]'
+                          onMouseDown={(e) => handleResizeStart(fieldId, e)}
+                          onDragStart={(e) => {
+                            e.preventDefault()
+                          }}
+                        >
+                          <ChevronsUpDown className='size-3 text-[var(--text-muted)]' />
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
               </>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/messages-input/messages-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/messages-input/messages-input.tsx
@@ -20,6 +20,10 @@ import {
 } from '@/components/emcn'
 import { Trash } from '@/components/emcn/icons/trash'
 import { cn } from '@/lib/core/utils/cn'
+import {
+  CLAUDE_SUPPORTED_IMAGE_MIME_TYPES,
+  MIME_TYPE_MAPPING,
+} from '@/lib/uploads/utils/file-utils'
 import { EnvVarDropdown } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/env-var-dropdown'
 import {
   FileUpload,
@@ -38,7 +42,13 @@ import { getProviderFromModel, supportsFileAttachments } from '@/providers/model
 const MIN_TEXTAREA_HEIGHT_PX = 80
 const MAX_TEXTAREA_HEIGHT_PX = 320
 
-const ANTHROPIC_SUPPORTED_IMAGE_TYPES = new Set([
+const ANTHROPIC_SUPPORTED_DOCUMENT_TYPES = new Set(
+  Object.entries(MIME_TYPE_MAPPING)
+    .filter(([, contentType]) => contentType === 'document')
+    .map(([mimeType]) => mimeType)
+)
+
+const OPENAI_SUPPORTED_IMAGE_TYPES = new Set([
   'image/jpeg',
   'image/jpg',
   'image/png',
@@ -46,22 +56,29 @@ const ANTHROPIC_SUPPORTED_IMAGE_TYPES = new Set([
   'image/webp',
 ])
 
-const ANTHROPIC_SUPPORTED_DOCUMENT_TYPES = new Set([
-  'application/pdf',
-  'text/plain',
-  'text/csv',
-  'application/json',
-  'application/xml',
-  'text/xml',
-  'text/html',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+const OPENAI_SUPPORTED_FILE_TYPES = new Set([
+  'text/x-c',
+  'text/x-c++',
+  'text/x-csharp',
+  'text/css',
   'application/msword',
-  'application/vnd.ms-excel',
-  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'text/x-golang',
+  'text/html',
+  'text/x-java',
+  'text/javascript',
+  'application/json',
   'text/markdown',
-  'application/rtf',
+  'application/pdf',
+  'text/x-php',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'text/x-python',
+  'text/x-script.python',
+  'text/x-ruby',
+  'application/x-sh',
+  'text/x-tex',
+  'application/typescript',
+  'text/plain',
 ])
 
 /** Pattern to match complete message objects in JSON */
@@ -97,8 +114,16 @@ function hasAnthropicUnsupportedFiles(value: FileUploadValue | null | undefined)
     const type = file.type.toLowerCase()
     if (type === 'image/svg+xml') return false
     return (
-      !ANTHROPIC_SUPPORTED_IMAGE_TYPES.has(type) && !ANTHROPIC_SUPPORTED_DOCUMENT_TYPES.has(type)
+      !CLAUDE_SUPPORTED_IMAGE_MIME_TYPES.has(type) && !ANTHROPIC_SUPPORTED_DOCUMENT_TYPES.has(type)
     )
+  })
+}
+
+function hasOpenAIUnsupportedFiles(value: FileUploadValue | null | undefined): boolean {
+  const files = Array.isArray(value) ? value : value ? [value] : []
+  return files.some((file) => {
+    const type = file.type.toLowerCase()
+    return !OPENAI_SUPPORTED_IMAGE_TYPES.has(type) && !OPENAI_SUPPORTED_FILE_TYPES.has(type)
   })
 }
 
@@ -648,8 +673,10 @@ export function MessagesInput({
             const showUnsupportedFilesWarning =
               isFilesMessage &&
               fileAttachmentsSupported &&
-              (selectedProvider === 'anthropic' || selectedProvider === 'azure-anthropic') &&
-              hasAnthropicUnsupportedFiles(message.files)
+              (((selectedProvider === 'anthropic' || selectedProvider === 'azure-anthropic') &&
+                hasAnthropicUnsupportedFiles(message.files)) ||
+                ((selectedProvider === 'openai' || selectedProvider === 'azure-openai') &&
+                  hasOpenAIUnsupportedFiles(message.files)))
             const fieldState = subBlockInput.fieldHelpers.getFieldState(fieldId)
             const fieldHandlers = subBlockInput.fieldHelpers.createFieldHandlers(
               fieldId,

--- a/apps/sim/executor/handlers/agent/agent-handler.test.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.test.ts
@@ -5,11 +5,19 @@ import { BlockType, isMcpTool } from '@/executor/constants'
 import { AgentBlockHandler } from '@/executor/handlers/agent/agent-handler'
 import type { ExecutionContext, StreamingExecution } from '@/executor/types'
 import { executeProviderRequest } from '@/providers'
-import { getProviderFromModel, transformBlockTool } from '@/providers/utils'
+import {
+  getProviderFromModel,
+  supportsFileAttachments,
+  transformBlockTool,
+} from '@/providers/utils'
 import type { SerializedBlock, SerializedWorkflow } from '@/serializer/types'
 import { executeTool } from '@/tools'
 
 process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
+
+const { mockReadUserFileContent } = vi.hoisted(() => ({
+  mockReadUserFileContent: vi.fn(),
+}))
 
 vi.mock('@/lib/core/config/feature-flags', () => ({
   isHosted: false,
@@ -26,6 +34,7 @@ vi.mock('@/lib/core/config/feature-flags', () => ({
 
 vi.mock('@/providers/utils', () => ({
   getProviderFromModel: vi.fn().mockReturnValue('mock-provider'),
+  supportsFileAttachments: vi.fn().mockReturnValue(false),
   transformBlockTool: vi.fn(),
   getBaseModelProviders: vi.fn().mockReturnValue({ openai: {}, anthropic: {} }),
   getApiKey: vi.fn().mockReturnValue('mock-api-key'),
@@ -43,6 +52,10 @@ vi.mock('@/providers/utils', () => ({
       },
     },
   }),
+}))
+
+vi.mock('@/lib/execution/payloads/materialization.server', () => ({
+  readUserFileContent: mockReadUserFileContent,
 }))
 
 vi.mock('@/blocks', () => ({
@@ -113,6 +126,7 @@ setupGlobalFetchMock()
 const mockGetAllBlocks = getAllBlocks as Mock
 const mockExecuteTool = executeTool as Mock
 const mockGetProviderFromModel = getProviderFromModel as Mock
+const mockSupportsFileAttachments = supportsFileAttachments as Mock
 const mockTransformBlockTool = transformBlockTool as Mock
 const mockFetch = global.fetch as unknown as Mock
 const mockExecuteProviderRequest = executeProviderRequest as Mock
@@ -164,6 +178,8 @@ describe('AgentBlockHandler', () => {
       } as SerializedWorkflow,
     }
     mockGetProviderFromModel.mockReturnValue('mock-provider')
+    mockSupportsFileAttachments.mockReturnValue(false)
+    mockReadUserFileContent.mockResolvedValue('ZmlsZQ==')
 
     mockExecuteProviderRequest.mockResolvedValue({
       content: 'Mocked response content',
@@ -1119,6 +1135,113 @@ describe('AgentBlockHandler', () => {
       // Then user message from messages array
       expect(requestBody.messages[6].role).toBe('user')
       expect(requestBody.messages[6].content).toBe('Continue our conversation.')
+    })
+
+    it('should pass files messages as provider file attachments when the model supports files', async () => {
+      const inputs = {
+        model: 'gpt-4o',
+        messages: [
+          { role: 'user' as const, content: 'Summarize the attached file.' },
+          {
+            role: 'files' as const,
+            files: [
+              {
+                name: 'brief.pdf',
+                path: '/api/files/serve/test-workspace/brief.pdf',
+                key: 'workspace/test-workspace/brief.pdf',
+                size: 128,
+                type: 'application/pdf',
+              },
+            ],
+          },
+        ],
+        apiKey: 'test-api-key',
+      }
+
+      mockGetProviderFromModel.mockReturnValue('openai')
+      mockSupportsFileAttachments.mockReturnValue(true)
+      mockReadUserFileContent.mockResolvedValue('cGRm')
+
+      await handler.execute(
+        {
+          ...mockContext,
+          userId: 'test-user',
+          workspaceId: 'test-workspace',
+          executionId: 'test-execution',
+        },
+        mockBlock,
+        inputs
+      )
+
+      const requestBody = mockExecuteProviderRequest.mock.calls[0][1]
+
+      expect(requestBody.messages).toEqual([
+        { role: 'user', content: 'Summarize the attached file.' },
+      ])
+      expect(requestBody.fileAttachments).toEqual([
+        {
+          name: 'brief.pdf',
+          type: 'application/pdf',
+          base64: 'cGRm',
+        },
+      ])
+      expect(mockReadUserFileContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'brief.pdf',
+          key: 'workspace/test-workspace/brief.pdf',
+          type: 'application/pdf',
+        }),
+        expect.objectContaining({
+          userId: 'test-user',
+          workspaceId: 'test-workspace',
+          executionId: 'test-execution',
+          encoding: 'base64',
+        })
+      )
+    })
+
+    it('should ignore files messages when the selected model does not support files', async () => {
+      const inputs = {
+        model: 'deepseek-chat',
+        messages: [
+          { role: 'user' as const, content: 'Summarize the attached file.' },
+          {
+            role: 'files' as const,
+            files: [
+              {
+                name: 'brief.pdf',
+                path: '/api/files/serve/test-workspace/brief.pdf',
+                key: 'workspace/test-workspace/brief.pdf',
+                size: 128,
+                type: 'application/pdf',
+              },
+            ],
+          },
+        ],
+        apiKey: 'test-api-key',
+      }
+
+      mockGetProviderFromModel.mockReturnValue('deepseek')
+      mockSupportsFileAttachments.mockReturnValue(false)
+
+      await handler.execute(
+        {
+          ...mockContext,
+          userId: 'test-user',
+          workspaceId: 'test-workspace',
+          executionId: 'test-execution',
+        },
+        mockBlock,
+        inputs
+      )
+
+      const requestBody = mockExecuteProviderRequest.mock.calls[0][1]
+
+      expect(requestBody.messages).toEqual([
+        { role: 'user', content: 'Summarize the attached file.' },
+      ])
+      expect(requestBody.fileAttachments).toBeUndefined()
+      expect(mockReadUserFileContent).not.toHaveBeenCalled()
     })
 
     it('should preserve multiple system messages when no explicit systemPrompt is provided', async () => {

--- a/apps/sim/executor/handlers/agent/agent-handler.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.ts
@@ -3,12 +3,16 @@ import { mcpServers } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
 import { sleep } from '@sim/utils/helpers'
+import { generateId } from '@sim/utils/id'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { normalizeStringRecord, normalizeWorkflowVariables } from '@/lib/core/utils/records'
+import { readUserFileContent } from '@/lib/execution/payloads/materialization.server'
 import { createMcpToolId } from '@/lib/mcp/utils'
+import { processSingleFileToUserFile, type RawFileInput } from '@/lib/uploads/utils/file-utils'
 import { getCustomToolById } from '@/lib/workflows/custom-tools/operations'
 import { getAllBlocks } from '@/blocks'
 import type { BlockOutput } from '@/blocks/types'
+import { normalizeFileInput } from '@/blocks/utils'
 import {
   validateBlockType,
   validateCustomToolsAllowed,
@@ -27,6 +31,7 @@ import type {
   AgentInputs,
   Message,
   StreamingConfig,
+  TextMessage,
   ToolInput,
 } from '@/executor/handlers/agent/types'
 import { parseResponseFormat } from '@/executor/handlers/shared/response-format'
@@ -36,13 +41,19 @@ import { buildAPIUrl, buildAuthHeaders } from '@/executor/utils/http'
 import { stringifyJSON } from '@/executor/utils/json'
 import { resolveVertexCredential } from '@/executor/utils/vertex-credential'
 import { executeProviderRequest } from '@/providers'
-import { getProviderFromModel, transformBlockTool } from '@/providers/utils'
+import type { ProviderFileAttachment } from '@/providers/types'
+import {
+  getProviderFromModel,
+  supportsFileAttachments,
+  transformBlockTool,
+} from '@/providers/utils'
 import type { SerializedBlock } from '@/serializer/types'
 import { filterSchemaForLLM, type ToolSchema } from '@/tools/params'
 import { getTool } from '@/tools/utils'
 import { getToolAsync } from '@/tools/utils.server'
 
 const logger = createLogger('AgentBlockHandler')
+const MAX_AGENT_ATTACHMENT_BYTES = 10 * 1024 * 1024
 
 /**
  * Handler for Agent blocks that process LLM requests with optional tools.
@@ -87,6 +98,8 @@ export class AgentBlockHandler implements BlockHandler {
 
     const streamingConfig = this.getStreamingConfig(ctx, block)
     const messages = await this.buildMessages(ctx, filteredInputs, skillMetadata)
+    const requestId = generateId()
+    const fileAttachments = await this.buildFileAttachments(ctx, filteredInputs, model, requestId)
 
     const providerRequest = this.buildProviderRequest({
       ctx,
@@ -97,6 +110,7 @@ export class AgentBlockHandler implements BlockHandler {
       formattedTools,
       responseFormat,
       streaming: streamingConfig.shouldUseStreaming ?? false,
+      fileAttachments,
     })
 
     const result = await this.executeProviderRequest(ctx, providerRequest, block, responseFormat)
@@ -576,8 +590,8 @@ export class AgentBlockHandler implements BlockHandler {
     ctx: ExecutionContext,
     inputs: AgentInputs,
     skillMetadata: Array<{ name: string; description: string }> = []
-  ): Promise<Message[] | undefined> {
-    const messages: Message[] = []
+  ): Promise<TextMessage[] | undefined> {
+    const messages: TextMessage[] = []
     const memoryEnabled = inputs.memoryType && inputs.memoryType !== 'none'
 
     // 1. Extract and validate messages from messages-input subblock
@@ -672,11 +686,11 @@ export class AgentBlockHandler implements BlockHandler {
     return messages.length > 0 ? messages : undefined
   }
 
-  private extractValidMessages(messages?: Message[]): Message[] {
+  private extractValidMessages(messages?: Message[]): TextMessage[] {
     if (!messages || !Array.isArray(messages)) return []
 
     return messages.filter(
-      (msg): msg is Message =>
+      (msg): msg is TextMessage =>
         msg &&
         typeof msg === 'object' &&
         'role' in msg &&
@@ -685,7 +699,69 @@ export class AgentBlockHandler implements BlockHandler {
     )
   }
 
-  private processMemories(memories: any): Message[] {
+  private extractFileInputs(messages?: Message[]): object[] {
+    if (!messages || !Array.isArray(messages)) return []
+
+    const files: object[] = []
+    for (const message of messages) {
+      if (!message || typeof message !== 'object' || message.role !== 'files') continue
+      const normalizedFiles = normalizeFileInput(message.files)
+      if (normalizedFiles) {
+        files.push(...normalizedFiles)
+      }
+    }
+    return files
+  }
+
+  private async buildFileAttachments(
+    ctx: ExecutionContext,
+    inputs: AgentInputs,
+    model: string,
+    requestId: string
+  ): Promise<ProviderFileAttachment[] | undefined> {
+    const files = this.extractFileInputs(inputs.messages)
+    if (files.length === 0) return undefined
+
+    if (!supportsFileAttachments(model)) {
+      logger.warn(
+        'Ignoring agent file attachments because the selected model does not support them',
+        {
+          model,
+          fileCount: files.length,
+        }
+      )
+      return undefined
+    }
+
+    if (!ctx.userId) {
+      throw new Error('Agent file attachments require an authenticated user.')
+    }
+
+    const attachments: ProviderFileAttachment[] = []
+    for (const file of files) {
+      const userFile = processSingleFileToUserFile(file as RawFileInput, requestId, logger)
+      const base64 = await readUserFileContent(userFile, {
+        workflowId: ctx.workflowId,
+        workspaceId: ctx.workspaceId,
+        executionId: ctx.executionId,
+        userId: ctx.userId,
+        requestId,
+        logger,
+        encoding: 'base64',
+        maxBytes: MAX_AGENT_ATTACHMENT_BYTES,
+        maxSourceBytes: MAX_AGENT_ATTACHMENT_BYTES,
+      })
+      attachments.push({
+        name: userFile.name,
+        type: userFile.type,
+        base64,
+      })
+    }
+
+    return attachments.length > 0 ? attachments : undefined
+  }
+
+  private processMemories(memories: any): TextMessage[] {
     if (!memories) return []
 
     let memoryArray: any[] = []
@@ -695,7 +771,7 @@ export class AgentBlockHandler implements BlockHandler {
       memoryArray = memories
     }
 
-    const messages: Message[] = []
+    const messages: TextMessage[] = []
     memoryArray.forEach((memory: any) => {
       if (memory.data && Array.isArray(memory.data)) {
         memory.data.forEach((msg: any) => {
@@ -725,7 +801,7 @@ export class AgentBlockHandler implements BlockHandler {
    * Ensures system message is at position 0 (industry standard)
    * Preserves existing system message if already at position 0, otherwise adds/moves it
    */
-  private addSystemPrompt(messages: Message[], systemPrompt: any) {
+  private addSystemPrompt(messages: TextMessage[], systemPrompt: any) {
     let content: string
 
     if (typeof systemPrompt === 'string') {
@@ -759,7 +835,7 @@ export class AgentBlockHandler implements BlockHandler {
     }
   }
 
-  private addUserPrompt(messages: Message[], userPrompt: any) {
+  private addUserPrompt(messages: TextMessage[], userPrompt: any) {
     let content: string
     if (typeof userPrompt === 'object' && userPrompt.input) {
       content = String(userPrompt.input)
@@ -776,14 +852,24 @@ export class AgentBlockHandler implements BlockHandler {
     ctx: ExecutionContext
     providerId: string
     model: string
-    messages: Message[] | undefined
+    messages: TextMessage[] | undefined
     inputs: AgentInputs
     formattedTools: any[]
     responseFormat: any
     streaming: boolean
+    fileAttachments?: ProviderFileAttachment[]
   }) {
-    const { ctx, providerId, model, messages, inputs, formattedTools, responseFormat, streaming } =
-      config
+    const {
+      ctx,
+      providerId,
+      model,
+      messages,
+      inputs,
+      formattedTools,
+      responseFormat,
+      streaming,
+      fileAttachments,
+    } = config
 
     const validMessages = this.validateMessages(messages)
 
@@ -816,6 +902,7 @@ export class AgentBlockHandler implements BlockHandler {
       userId: ctx.userId,
       stream: streaming,
       messages: messages?.map(({ executionId, ...msg }) => msg),
+      fileAttachments,
       environmentVariables: normalizeStringRecord(ctx.environmentVariables),
       workflowVariables: normalizeWorkflowVariables(ctx.workflowVariables),
       blockData,
@@ -827,7 +914,7 @@ export class AgentBlockHandler implements BlockHandler {
     }
   }
 
-  private validateMessages(messages: Message[] | undefined): boolean {
+  private validateMessages(messages: TextMessage[] | undefined): boolean {
     return (
       Array.isArray(messages) &&
       messages.length > 0 &&
@@ -886,6 +973,7 @@ export class AgentBlockHandler implements BlockHandler {
         userId: ctx.userId,
         stream: providerRequest.stream,
         messages: 'messages' in providerRequest ? providerRequest.messages : undefined,
+        fileAttachments: providerRequest.fileAttachments,
         environmentVariables: normalizeStringRecord(ctx.environmentVariables),
         workflowVariables: normalizeWorkflowVariables(ctx.workflowVariables),
         blockData,

--- a/apps/sim/executor/handlers/agent/memory.ts
+++ b/apps/sim/executor/handlers/agent/memory.ts
@@ -5,14 +5,14 @@ import { generateId } from '@sim/utils/id'
 import { and, eq, sql } from 'drizzle-orm'
 import { getAccurateTokenCount } from '@/lib/tokenization/estimators'
 import { MEMORY } from '@/executor/constants'
-import type { AgentInputs, Message } from '@/executor/handlers/agent/types'
+import type { AgentInputs, TextMessage } from '@/executor/handlers/agent/types'
 import type { ExecutionContext } from '@/executor/types'
 import { PROVIDER_DEFINITIONS } from '@/providers/models'
 
 const logger = createLogger('Memory')
 
 export class Memory {
-  async fetchMemoryMessages(ctx: ExecutionContext, inputs: AgentInputs): Promise<Message[]> {
+  async fetchMemoryMessages(ctx: ExecutionContext, inputs: AgentInputs): Promise<TextMessage[]> {
     if (!inputs.memoryType || inputs.memoryType === 'none') {
       return []
     }
@@ -50,7 +50,7 @@ export class Memory {
   async appendToMemory(
     ctx: ExecutionContext,
     inputs: AgentInputs,
-    message: Message
+    message: TextMessage
   ): Promise<void> {
     if (!inputs.memoryType || inputs.memoryType === 'none') {
       return
@@ -71,7 +71,11 @@ export class Memory {
     })
   }
 
-  async seedMemory(ctx: ExecutionContext, inputs: AgentInputs, messages: Message[]): Promise<void> {
+  async seedMemory(
+    ctx: ExecutionContext,
+    inputs: AgentInputs,
+    messages: TextMessage[]
+  ): Promise<void> {
     if (!inputs.memoryType || inputs.memoryType === 'none') {
       return
     }
@@ -118,12 +122,16 @@ export class Memory {
     return ctx.workspaceId
   }
 
-  private applyWindow(messages: Message[], limit: number): Message[] {
+  private applyWindow(messages: TextMessage[], limit: number): TextMessage[] {
     return messages.slice(-limit)
   }
 
-  private applyTokenWindow(messages: Message[], maxTokens: number, model?: string): Message[] {
-    const result: Message[] = []
+  private applyTokenWindow(
+    messages: TextMessage[],
+    maxTokens: number,
+    model?: string
+  ): TextMessage[] {
+    const result: TextMessage[] = []
     let tokenCount = 0
 
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -144,7 +152,7 @@ export class Memory {
     return result
   }
 
-  private applyContextWindowLimit(messages: Message[], model?: string): Message[] {
+  private applyContextWindowLimit(messages: TextMessage[], model?: string): TextMessage[] {
     if (!model) return messages
 
     for (const provider of Object.values(PROVIDER_DEFINITIONS)) {
@@ -165,7 +173,7 @@ export class Memory {
     return messages
   }
 
-  private async fetchMemory(workspaceId: string, key: string): Promise<Message[]> {
+  private async fetchMemory(workspaceId: string, key: string): Promise<TextMessage[]> {
     const result = await db
       .select({ data: memory.data })
       .from(memory)
@@ -178,14 +186,19 @@ export class Memory {
     if (!Array.isArray(data)) return []
 
     return data.filter(
-      (msg): msg is Message => msg && typeof msg === 'object' && 'role' in msg && 'content' in msg
+      (msg): msg is TextMessage =>
+        msg &&
+        typeof msg === 'object' &&
+        'role' in msg &&
+        ['system', 'user', 'assistant'].includes(msg.role) &&
+        'content' in msg
     )
   }
 
   private async seedMemoryRecord(
     workspaceId: string,
     key: string,
-    messages: Message[]
+    messages: TextMessage[]
   ): Promise<void> {
     const now = new Date()
 
@@ -202,7 +215,11 @@ export class Memory {
       .onConflictDoNothing()
   }
 
-  private async appendMessage(workspaceId: string, key: string, message: Message): Promise<void> {
+  private async appendMessage(
+    workspaceId: string,
+    key: string,
+    message: TextMessage
+  ): Promise<void> {
     const now = new Date()
 
     await db

--- a/apps/sim/executor/handlers/agent/types.ts
+++ b/apps/sim/executor/handlers/agent/types.ts
@@ -1,3 +1,5 @@
+import type { FileUploadValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/file-upload/file-upload'
+
 export interface SkillInput {
   skillId: string
   name?: string
@@ -73,7 +75,7 @@ export interface TextMessage {
 
 export interface FilesMessage {
   role: 'files'
-  files?: unknown
+  files?: FileUploadValue | null
 }
 
 export type Message = TextMessage | FilesMessage

--- a/apps/sim/executor/handlers/agent/types.ts
+++ b/apps/sim/executor/handlers/agent/types.ts
@@ -63,13 +63,20 @@ export interface ToolInput {
   customToolId?: string
 }
 
-export interface Message {
+export interface TextMessage {
   role: 'system' | 'user' | 'assistant'
   content: string
   executionId?: string
   function_call?: any
   tool_calls?: any[]
 }
+
+export interface FilesMessage {
+  role: 'files'
+  files?: unknown
+}
+
+export type Message = TextMessage | FilesMessage
 
 export interface StreamingConfig {
   shouldUseStreaming: boolean

--- a/apps/sim/lib/uploads/utils/file-utils.ts
+++ b/apps/sim/lib/uploads/utils/file-utils.ts
@@ -153,7 +153,10 @@ export function createFileContent(fileBuffer: Buffer, mimeType: string): Message
 /**
  * Create message content from base64-encoded file data.
  */
-export function createFileContentFromBase64(base64: string, mimeType: string): MessageContent | null {
+export function createFileContentFromBase64(
+  base64: string,
+  mimeType: string
+): MessageContent | null {
   // SVG is XML text — Claude only supports raster image formats (JPEG, PNG, GIF, WebP),
   // so send SVGs as an XML document instead
   if (mimeType.toLowerCase() === 'image/svg+xml') {
@@ -186,7 +189,7 @@ export function createFileContentFromBase64(base64: string, mimeType: string): M
   }
 }
 
-const CLAUDE_SUPPORTED_IMAGE_MIME_TYPES = new Set([
+export const CLAUDE_SUPPORTED_IMAGE_MIME_TYPES = new Set([
   'image/jpeg',
   'image/jpg',
   'image/png',

--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -3,6 +3,7 @@ import { transformJSONSchema } from '@anthropic-ai/sdk/lib/transform-json-schema
 import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources/messages/messages'
 import type { Logger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
+import { createFileContentFromBase64 } from '@/lib/uploads/utils/file-utils'
 import type { BlockTokens, IterationToolCall, StreamingExecution } from '@/executor/types'
 import { MAX_TOOL_ITERATIONS } from '@/providers'
 import {
@@ -16,7 +17,12 @@ import {
   supportsTemperature,
 } from '@/providers/models'
 import { enrichLastModelSegment } from '@/providers/trace-enrichment'
-import type { ProviderRequest, ProviderResponse, TimeSegment } from '@/providers/types'
+import type {
+  ProviderFileAttachment,
+  ProviderRequest,
+  ProviderResponse,
+  TimeSegment,
+} from '@/providers/types'
 import { ProviderError } from '@/providers/types'
 import {
   calculateCost,
@@ -147,6 +153,57 @@ function buildThinkingConfig(
  */
 const ANTHROPIC_SDK_NON_STREAMING_MAX_TOKENS = 21333
 
+function buildAnthropicFileBlocks(
+  fileAttachments?: ProviderFileAttachment[]
+): Anthropic.Messages.ContentBlockParam[] {
+  if (!fileAttachments?.length) return []
+
+  const blocks: Anthropic.Messages.ContentBlockParam[] = []
+  for (const file of fileAttachments) {
+    const content = createFileContentFromBase64(file.base64, file.type)
+    if (!content?.source || (content.type !== 'image' && content.type !== 'document')) {
+      continue
+    }
+
+    if (content.type === 'image') {
+      blocks.push({
+        type: 'image',
+        source: content.source as Anthropic.Messages.ImageBlockParam['source'],
+      })
+      continue
+    }
+
+    blocks.push({
+      type: 'document',
+      source: content.source as Anthropic.Messages.DocumentBlockParam['source'],
+      title: file.name,
+    })
+  }
+
+  return blocks
+}
+
+function appendFileBlocksToMessages(
+  messages: Anthropic.Messages.MessageParam[],
+  fileAttachments?: ProviderFileAttachment[]
+) {
+  const fileBlocks = buildAnthropicFileBlocks(fileAttachments)
+  if (fileBlocks.length === 0) return
+
+  const lastUserMessage = [...messages].reverse().find((message) => message.role === 'user')
+  if (!lastUserMessage) {
+    messages.push({
+      role: 'user',
+      content: [{ type: 'text', text: 'Please use the attached files.' }, ...fileBlocks],
+    })
+    return
+  }
+
+  lastUserMessage.content = Array.isArray(lastUserMessage.content)
+    ? [...lastUserMessage.content, ...fileBlocks]
+    : [{ type: 'text', text: lastUserMessage.content }, ...fileBlocks]
+}
+
 /**
  * Creates an Anthropic message, automatically using streaming internally when max_tokens
  * exceeds the SDK's non-streaming threshold. Returns the same Message object either way.
@@ -244,6 +301,8 @@ export async function executeAnthropicProviderRequest(
     })
     systemPrompt = ''
   }
+
+  appendFileBlocksToMessages(messages, request.fileAttachments)
 
   let anthropicTools: Anthropic.Messages.Tool[] | undefined = request.tools?.length
     ? request.tools.map((tool) => ({

--- a/apps/sim/providers/azure-openai/index.ts
+++ b/apps/sim/providers/azure-openai/index.ts
@@ -15,6 +15,7 @@ import { validateUrlWithDNS } from '@/lib/core/security/input-validation.server'
 import type { StreamingExecution } from '@/executor/types'
 import { MAX_TOOL_ITERATIONS } from '@/providers'
 import {
+  appendFileAttachmentsToChatCompletionMessages,
   checkForForcedToolUsage,
   createReadableStreamFromAzureOpenAIStream,
   extractApiVersionFromUrl,
@@ -92,6 +93,8 @@ async function executeChatCompletionsRequest(
   if (request.messages) {
     allMessages.push(...(request.messages as ChatCompletionMessageParam[]))
   }
+
+  appendFileAttachmentsToChatCompletionMessages(allMessages, request.fileAttachments)
 
   const tools: ChatCompletionTool[] | undefined = request.tools?.length
     ? request.tools.map((tool) => ({

--- a/apps/sim/providers/azure-openai/utils.test.ts
+++ b/apps/sim/providers/azure-openai/utils.test.ts
@@ -1,0 +1,94 @@
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions'
+import { describe, expect, it } from 'vitest'
+import { appendFileAttachmentsToChatCompletionMessages } from '@/providers/azure-openai/utils'
+import type { ProviderFileAttachment } from '@/providers/types'
+
+describe('appendFileAttachmentsToChatCompletionMessages', () => {
+  it('adds supported file attachments to the latest user message', () => {
+    const messages: ChatCompletionMessageParam[] = [
+      { role: 'user', content: 'Earlier request' },
+      { role: 'assistant', content: 'Earlier response' },
+      { role: 'user', content: 'Use these attachments' },
+    ]
+    const fileAttachments: ProviderFileAttachment[] = [
+      {
+        name: 'brief.pdf',
+        type: 'application/pdf',
+        base64: 'cGRm',
+      },
+      {
+        name: 'photo.png',
+        type: 'image/png',
+        base64: 'cG5n',
+      },
+    ]
+
+    appendFileAttachmentsToChatCompletionMessages(messages, fileAttachments)
+
+    expect(messages[0]).toEqual({ role: 'user', content: 'Earlier request' })
+    expect(messages[1]).toEqual({ role: 'assistant', content: 'Earlier response' })
+    expect(messages[2]).toEqual({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Use these attachments' },
+        {
+          type: 'file',
+          file: {
+            file_data: 'cGRm',
+            filename: 'brief.pdf',
+          },
+        },
+        {
+          type: 'image_url',
+          image_url: {
+            url: 'data:image/png;base64,cG5n',
+            detail: 'auto',
+          },
+        },
+      ],
+    })
+  })
+
+  it('adds a user message when there is no existing user message', () => {
+    const messages: ChatCompletionMessageParam[] = [{ role: 'system', content: 'You are helpful' }]
+
+    appendFileAttachmentsToChatCompletionMessages(messages, [
+      {
+        name: 'brief.pdf',
+        type: 'application/pdf',
+        base64: 'cGRm',
+      },
+    ])
+
+    expect(messages).toEqual([
+      { role: 'system', content: 'You are helpful' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Please use the attached files.' },
+          {
+            type: 'file',
+            file: {
+              file_data: 'cGRm',
+              filename: 'brief.pdf',
+            },
+          },
+        ],
+      },
+    ])
+  })
+
+  it('leaves messages unchanged when attachments have unsupported MIME types', () => {
+    const messages: ChatCompletionMessageParam[] = [{ role: 'user', content: 'Text only' }]
+
+    appendFileAttachmentsToChatCompletionMessages(messages, [
+      {
+        name: 'spreadsheet.xlsx',
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        base64: 'eGxzeA==',
+      },
+    ])
+
+    expect(messages).toEqual([{ role: 'user', content: 'Text only' }])
+  })
+})

--- a/apps/sim/providers/azure-openai/utils.ts
+++ b/apps/sim/providers/azure-openai/utils.ts
@@ -1,8 +1,15 @@
 import type { Logger } from '@sim/logger'
 import type OpenAI from 'openai'
-import type { ChatCompletionChunk } from 'openai/resources/chat/completions'
+import type {
+  ChatCompletionChunk,
+  ChatCompletionContentPart,
+  ChatCompletionMessageParam,
+  ChatCompletionUserMessageParam,
+} from 'openai/resources/chat/completions'
 import type { CompletionUsage } from 'openai/resources/completions'
 import type { Stream } from 'openai/streaming'
+import { buildChatCompletionFileParts } from '@/providers/openai/utils'
+import type { ProviderFileAttachment } from '@/providers/types'
 import { checkForForcedToolUsageOpenAI, createOpenAICompatibleStream } from '@/providers/utils'
 
 /**
@@ -35,6 +42,43 @@ export function checkForForcedToolUsage(
     usedForcedTools,
     _logger
   )
+}
+
+function isUserMessage(
+  message: ChatCompletionMessageParam
+): message is ChatCompletionUserMessageParam {
+  return message.role === 'user'
+}
+
+function createTextPart(text: string): ChatCompletionContentPart {
+  return {
+    type: 'text',
+    text,
+  }
+}
+
+/**
+ * Adds supported file attachments to the latest user message for Azure Chat Completions.
+ */
+export function appendFileAttachmentsToChatCompletionMessages(
+  messages: ChatCompletionMessageParam[],
+  fileAttachments?: ProviderFileAttachment[]
+): void {
+  const fileParts = buildChatCompletionFileParts(fileAttachments)
+  if (fileParts.length === 0) return
+
+  const lastUserMessage = [...messages].reverse().find(isUserMessage)
+  if (!lastUserMessage) {
+    messages.push({
+      role: 'user',
+      content: [createTextPart('Please use the attached files.'), ...fileParts],
+    })
+    return
+  }
+
+  lastUserMessage.content = Array.isArray(lastUserMessage.content)
+    ? [...lastUserMessage.content, ...fileParts]
+    : [createTextPart(lastUserMessage.content || 'Please use the attached files.'), ...fileParts]
 }
 
 /**

--- a/apps/sim/providers/google/utils.ts
+++ b/apps/sim/providers/google/utils.ts
@@ -14,7 +14,7 @@ import {
 } from '@google/genai'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
-import type { ProviderRequest } from '@/providers/types'
+import type { ProviderFileAttachment, ProviderRequest } from '@/providers/types'
 import { trackForcedToolUsage } from '@/providers/utils'
 
 const logger = createLogger('GoogleUtils')
@@ -163,6 +163,36 @@ export interface GeminiToolDef {
   parameters: Schema
 }
 
+function buildGeminiFileParts(fileAttachments?: ProviderFileAttachment[]): Part[] {
+  if (!fileAttachments?.length) return []
+
+  return fileAttachments.map((file) => ({
+    inlineData: {
+      mimeType: file.type,
+      data: file.base64,
+    },
+  }))
+}
+
+function appendFilePartsToContents(
+  contents: Content[],
+  fileAttachments?: ProviderFileAttachment[]
+) {
+  const fileParts = buildGeminiFileParts(fileAttachments)
+  if (fileParts.length === 0) return
+
+  const lastUserContent = [...contents].reverse().find((content) => content.role === 'user')
+  if (lastUserContent) {
+    lastUserContent.parts = [...(lastUserContent.parts ?? []), ...fileParts]
+    return
+  }
+
+  contents.push({
+    role: 'user',
+    parts: [{ text: 'Please use the attached files.' }, ...fileParts],
+  })
+}
+
 /**
  * Converts OpenAI-style request format to Gemini format
  */
@@ -233,6 +263,8 @@ export function convertToGeminiFormat(request: ProviderRequest): {
       }
     }
   }
+
+  appendFilePartsToContents(contents, request.fileAttachments)
 
   const tools = request.tools?.map((tool): GeminiToolDef => {
     const toolParameters = { ...(tool.parameters || {}) }

--- a/apps/sim/providers/index.ts
+++ b/apps/sim/providers/index.ts
@@ -10,6 +10,7 @@ import {
   generateStructuredOutputInstructions,
   shouldBillModelUsage,
   sumToolCosts,
+  supportsFileAttachments,
   supportsReasoningEffort,
   supportsTemperature,
   supportsThinking,
@@ -42,6 +43,10 @@ function sanitizeRequest(request: ProviderRequest): ProviderRequest {
 
   if (model && !supportsThinking(model)) {
     sanitizedRequest.thinkingLevel = undefined
+  }
+
+  if (model && !supportsFileAttachments(model)) {
+    sanitizedRequest.fileAttachments = undefined
   }
 
   return sanitizedRequest

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -33,6 +33,7 @@ export interface ModelCapabilities {
     max: number
   }
   toolUsageControl?: boolean
+  fileAttachments?: boolean
   computerUse?: boolean
   nativeStructuredOutputs?: boolean
   /** Maximum supported output tokens for this model */
@@ -135,6 +136,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     color: '#E8E8E8',
     capabilities: {
       toolUsageControl: true,
+      fileAttachments: true,
     },
     models: [
       // GPT-4.1 family
@@ -565,6 +567,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     color: '#D97757',
     capabilities: {
       toolUsageControl: true,
+      fileAttachments: true,
     },
     models: [
       {
@@ -773,6 +776,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     modelPatterns: [/^azure\//],
     capabilities: {
       toolUsageControl: true,
+      fileAttachments: true,
     },
     icon: AzureIcon,
     isReseller: true,
@@ -1088,6 +1092,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     isReseller: true,
     capabilities: {
       toolUsageControl: true,
+      fileAttachments: true,
     },
     models: [
       {
@@ -1200,6 +1205,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     modelPatterns: [/^gemini/, /^deep-research/],
     capabilities: {
       toolUsageControl: true,
+      fileAttachments: true,
     },
     icon: GeminiIcon,
     color: '#4285F4',
@@ -1346,6 +1352,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           deepResearch: true,
+          fileAttachments: false,
           memory: false,
           maxOutputTokens: 65536,
         },
@@ -1364,6 +1371,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     isReseller: true,
     capabilities: {
       toolUsageControl: true,
+      fileAttachments: true,
     },
     models: [
       {
@@ -1516,6 +1524,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           deepResearch: true,
+          fileAttachments: false,
           memory: false,
         },
         contextWindow: 1000000,
@@ -2971,6 +2980,20 @@ export function getMaxTemperature(modelId: string): number | undefined {
 
 export function supportsToolUsageControl(providerId: string): boolean {
   return getProvidersWithToolUsageControl().includes(providerId)
+}
+
+export function supportsFileAttachments(modelId: string): boolean {
+  if (
+    modelId
+      .toLowerCase()
+      .replace(/^vertex\//, '')
+      .startsWith('deep-research')
+  ) {
+    return false
+  }
+
+  const capabilities = getModelCapabilities(modelId)
+  return capabilities?.fileAttachments === true
 }
 
 export function updateOllamaModels(models: string[]): void {

--- a/apps/sim/providers/openai/core.ts
+++ b/apps/sim/providers/openai/core.ts
@@ -133,7 +133,7 @@ export async function executeResponsesProviderRequest(
     allMessages.push(...request.messages)
   }
 
-  const initialInput = buildResponsesInputFromMessages(allMessages)
+  const initialInput = buildResponsesInputFromMessages(allMessages, request.fileAttachments)
 
   const basePayload: Record<string, unknown> = {
     model: config.modelName,

--- a/apps/sim/providers/openai/utils.test.ts
+++ b/apps/sim/providers/openai/utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { buildResponsesInputFromMessages } from '@/providers/openai/utils'
+import type { ProviderFileAttachment } from '@/providers/types'
+
+describe('buildResponsesInputFromMessages', () => {
+  it('attaches files to the latest user message', () => {
+    const fileAttachments: ProviderFileAttachment[] = [
+      {
+        name: 'brief.pdf',
+        type: 'application/pdf',
+        base64: 'cGRm',
+      },
+    ]
+
+    const input = buildResponsesInputFromMessages(
+      [
+        { role: 'user', content: 'Earlier request' },
+        { role: 'assistant', content: 'Earlier response' },
+        { role: 'user', content: 'Use this file now' },
+      ],
+      fileAttachments
+    )
+
+    expect(input[0]).toEqual({ role: 'user', content: 'Earlier request' })
+    expect(input[1]).toEqual({ role: 'assistant', content: 'Earlier response' })
+    expect(input[2]).toEqual({
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'Use this file now' },
+        {
+          type: 'input_file',
+          file_data: 'data:application/pdf;base64,cGRm',
+          filename: 'brief.pdf',
+        },
+      ],
+    })
+  })
+})

--- a/apps/sim/providers/openai/utils.test.ts
+++ b/apps/sim/providers/openai/utils.test.ts
@@ -35,4 +35,60 @@ describe('buildResponsesInputFromMessages', () => {
       ],
     })
   })
+
+  it('ignores files with unsupported MIME types', () => {
+    const fileAttachments: ProviderFileAttachment[] = [
+      {
+        name: 'brief.pdf',
+        type: 'application/pdf',
+        base64: 'cGRm',
+      },
+      {
+        name: 'archive.bin',
+        type: 'application/octet-stream',
+        base64: 'YmluYXJ5',
+      },
+      {
+        name: 'unknown',
+        type: '',
+        base64: 'dW5rbm93bg==',
+      },
+    ]
+
+    const input = buildResponsesInputFromMessages(
+      [{ role: 'user', content: 'Use the supported file only' }],
+      fileAttachments
+    )
+
+    expect(input).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'Use the supported file only' },
+          {
+            type: 'input_file',
+            file_data: 'data:application/pdf;base64,cGRm',
+            filename: 'brief.pdf',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('leaves messages unchanged when all file attachments are unsupported', () => {
+    const fileAttachments: ProviderFileAttachment[] = [
+      {
+        name: 'spreadsheet.xlsx',
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        base64: 'eGxzeA==',
+      },
+    ]
+
+    const input = buildResponsesInputFromMessages(
+      [{ role: 'user', content: 'This should stay text-only' }],
+      fileAttachments
+    )
+
+    expect(input).toEqual([{ role: 'user', content: 'This should stay text-only' }])
+  })
 })

--- a/apps/sim/providers/openai/utils.ts
+++ b/apps/sim/providers/openai/utils.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type OpenAI from 'openai'
-import type { Message } from '@/providers/types'
+import type { Message, ProviderFileAttachment } from '@/providers/types'
 
 const logger = createLogger('ResponsesUtils')
 
@@ -21,7 +21,13 @@ export interface ResponsesToolCall {
 export type ResponsesInputItem =
   | {
       role: 'system' | 'user' | 'assistant'
-      content: string
+      content:
+        | string
+        | Array<
+            | { type: 'input_text'; text: string }
+            | { type: 'input_image'; image_url: string; detail: 'auto' }
+            | { type: 'input_file'; file_data: string; filename?: string }
+          >
     }
   | {
       type: 'function_call'
@@ -42,13 +48,53 @@ export interface ResponsesToolDefinition {
   parameters?: Record<string, unknown>
 }
 
+function toDataUrl(file: ProviderFileAttachment): string {
+  return `data:${file.type};base64,${file.base64}`
+}
+
+function buildResponsesFileParts(fileAttachments?: ProviderFileAttachment[]) {
+  if (!fileAttachments?.length) return []
+
+  return fileAttachments.map((file) => {
+    const dataUrl = toDataUrl(file)
+    if (file.type.toLowerCase().startsWith('image/')) {
+      return {
+        type: 'input_image' as const,
+        image_url: dataUrl,
+        detail: 'auto' as const,
+      }
+    }
+
+    return {
+      type: 'input_file' as const,
+      file_data: dataUrl,
+      filename: file.name,
+    }
+  })
+}
+
 /**
  * Converts chat-style messages into Responses API input items.
  */
-export function buildResponsesInputFromMessages(messages: Message[]): ResponsesInputItem[] {
+export function buildResponsesInputFromMessages(
+  messages: Message[],
+  fileAttachments?: ProviderFileAttachment[]
+): ResponsesInputItem[] {
   const input: ResponsesInputItem[] = []
+  const fileParts = buildResponsesFileParts(fileAttachments)
+  let lastUserMessageIndex = -1
+  if (fileParts.length > 0) {
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const message = messages[index]
+      if (message.role === 'user' && !!message.content) {
+        lastUserMessageIndex = index
+        break
+      }
+    }
+  }
+  let attachmentsAdded = false
 
-  for (const message of messages) {
+  for (const [index, message] of messages.entries()) {
     if (message.role === 'tool' && message.tool_call_id) {
       input.push({
         type: 'function_call_output',
@@ -62,6 +108,15 @@ export function buildResponsesInputFromMessages(messages: Message[]): ResponsesI
       message.content &&
       (message.role === 'system' || message.role === 'user' || message.role === 'assistant')
     ) {
+      if (index === lastUserMessageIndex && fileParts.length > 0 && !attachmentsAdded) {
+        input.push({
+          role: message.role,
+          content: [{ type: 'input_text', text: message.content }, ...fileParts],
+        })
+        attachmentsAdded = true
+        continue
+      }
+
       input.push({
         role: message.role,
         content: message.content,
@@ -78,6 +133,13 @@ export function buildResponsesInputFromMessages(messages: Message[]): ResponsesI
         })
       }
     }
+  }
+
+  if (fileParts.length > 0 && !attachmentsAdded) {
+    input.push({
+      role: 'user',
+      content: [{ type: 'input_text', text: 'Please use the attached files.' }, ...fileParts],
+    })
   }
 
   return input

--- a/apps/sim/providers/openai/utils.ts
+++ b/apps/sim/providers/openai/utils.ts
@@ -18,16 +18,15 @@ export interface ResponsesToolCall {
   arguments: string
 }
 
+type ResponsesInputContentPart =
+  | { type: 'input_text'; text: string }
+  | { type: 'input_image'; image_url: string; detail: 'auto' }
+  | { type: 'input_file'; file_data: string; filename?: string }
+
 export type ResponsesInputItem =
   | {
       role: 'system' | 'user' | 'assistant'
-      content:
-        | string
-        | Array<
-            | { type: 'input_text'; text: string }
-            | { type: 'input_image'; image_url: string; detail: 'auto' }
-            | { type: 'input_file'; file_data: string; filename?: string }
-          >
+      content: string | ResponsesInputContentPart[]
     }
   | {
       type: 'function_call'
@@ -48,28 +47,72 @@ export interface ResponsesToolDefinition {
   parameters?: Record<string, unknown>
 }
 
+const OPENAI_SUPPORTED_FILE_MIME_TYPES = new Set([
+  'text/x-c',
+  'text/x-c++',
+  'text/x-csharp',
+  'text/css',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'text/x-golang',
+  'text/html',
+  'text/x-java',
+  'text/javascript',
+  'application/json',
+  'text/markdown',
+  'application/pdf',
+  'text/x-php',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'text/x-python',
+  'text/x-script.python',
+  'text/x-ruby',
+  'application/x-sh',
+  'text/x-tex',
+  'application/typescript',
+  'text/plain',
+])
+
+const OPENAI_SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+])
+
 function toDataUrl(file: ProviderFileAttachment): string {
   return `data:${file.type};base64,${file.base64}`
 }
 
-function buildResponsesFileParts(fileAttachments?: ProviderFileAttachment[]) {
+function buildResponsesFileParts(
+  fileAttachments?: ProviderFileAttachment[]
+): ResponsesInputContentPart[] {
   if (!fileAttachments?.length) return []
 
-  return fileAttachments.map((file) => {
+  return fileAttachments.flatMap<ResponsesInputContentPart>((file) => {
+    const type = file.type.toLowerCase()
     const dataUrl = toDataUrl(file)
-    if (file.type.toLowerCase().startsWith('image/')) {
-      return {
-        type: 'input_image' as const,
-        image_url: dataUrl,
-        detail: 'auto' as const,
-      }
+    if (OPENAI_SUPPORTED_IMAGE_MIME_TYPES.has(type)) {
+      return [
+        {
+          type: 'input_image' as const,
+          image_url: dataUrl,
+          detail: 'auto' as const,
+        },
+      ]
     }
 
-    return {
-      type: 'input_file' as const,
-      file_data: dataUrl,
-      filename: file.name,
+    if (!OPENAI_SUPPORTED_FILE_MIME_TYPES.has(type)) {
+      return []
     }
+
+    return [
+      {
+        type: 'input_file' as const,
+        file_data: dataUrl,
+        filename: file.name,
+      },
+    ]
   })
 }
 

--- a/apps/sim/providers/openai/utils.ts
+++ b/apps/sim/providers/openai/utils.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type OpenAI from 'openai'
+import type { ChatCompletionContentPart } from 'openai/resources/chat/completions'
 import type { Message, ProviderFileAttachment } from '@/providers/types'
 
 const logger = createLogger('ResponsesUtils')
@@ -111,6 +112,41 @@ function buildResponsesFileParts(
         type: 'input_file' as const,
         file_data: dataUrl,
         filename: file.name,
+      },
+    ]
+  })
+}
+
+export function buildChatCompletionFileParts(
+  fileAttachments?: ProviderFileAttachment[]
+): ChatCompletionContentPart[] {
+  if (!fileAttachments?.length) return []
+
+  return fileAttachments.flatMap<ChatCompletionContentPart>((file) => {
+    const type = file.type.toLowerCase()
+    if (OPENAI_SUPPORTED_IMAGE_MIME_TYPES.has(type)) {
+      return [
+        {
+          type: 'image_url',
+          image_url: {
+            url: toDataUrl(file),
+            detail: 'auto',
+          },
+        },
+      ]
+    }
+
+    if (!OPENAI_SUPPORTED_FILE_MIME_TYPES.has(type)) {
+      return []
+    }
+
+    return [
+      {
+        type: 'file',
+        file: {
+          file_data: file.base64,
+          filename: file.name,
+        },
       },
     ]
   })

--- a/apps/sim/providers/types.ts
+++ b/apps/sim/providers/types.ts
@@ -137,6 +137,12 @@ export interface Message {
   tool_call_id?: string
 }
 
+export interface ProviderFileAttachment {
+  name: string
+  type: string
+  base64: string
+}
+
 export interface ProviderRequest {
   model: string
   systemPrompt?: string
@@ -146,6 +152,7 @@ export interface ProviderRequest {
   maxTokens?: number
   apiKey?: string
   messages?: Message[]
+  fileAttachments?: ProviderFileAttachment[]
   responseFormat?: {
     name: string
     schema: any

--- a/apps/sim/providers/utils.ts
+++ b/apps/sim/providers/utils.ts
@@ -39,6 +39,7 @@ import {
   getThinkingLevelsForModel as getThinkingLevelsForModelFromDefinitions,
   getVerbosityValuesForModel as getVerbosityValuesForModelFromDefinitions,
   PROVIDER_DEFINITIONS,
+  supportsFileAttachments as supportsFileAttachmentsFromDefinitions,
   supportsTemperature as supportsTemperatureFromDefinitions,
   supportsToolUsageControl as supportsToolUsageControlFromDefinitions,
   updateOllamaModels as updateOllamaModelsInDefinitions,
@@ -1084,6 +1085,10 @@ export function getMaxTemperature(model: string): number | undefined {
 
 export function supportsToolUsageControl(provider: string): boolean {
   return supportsToolUsageControlFromDefinitions(provider)
+}
+
+export function supportsFileAttachments(model: string): boolean {
+  return supportsFileAttachmentsFromDefinitions(model)
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a `Files` message type to the Agent block so users can attach one or more files directly alongside system/user/assistant messages. The files are passed through to supported model providers, with warnings when the selected model or provider file type support would cause attachments to be ignored.

This is needed so Agent blocks can use file inputs without adding a separate block or changing the existing message workflow.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Tested with:
- `bun run type-check`
- `bun run test providers/google/utils.test.ts` (added some tests here)
- Pre-commit Biome hook ran successfully during commit
Reviewers should focus on:
- `messages-input.tsx`: Files row UX, warning behavior, and whether controlled FileUpload state is stored correctly inside the messages array.
- `agent-handler.ts`: file extraction/materialization from messages and unsupported-model ignore behavior.
- Provider mappings: OpenAI, Gemini/Vertex, and Anthropic attachment formatting.
- Model capability gating, especially unsupported models and deep research models.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<img width="500" height="546" alt="image" src="https://github.com/user-attachments/assets/de02999e-aa05-41b5-9ba2-03b618cfc5fe" />
<img width="579" height="684" alt="image" src="https://github.com/user-attachments/assets/f525409a-aa33-4c64-b309-86c0440605e7" />
<img width="585" height="700" alt="image" src="https://github.com/user-attachments/assets/a1caf6f3-b54c-408a-bd75-c53fbaa1c337" />
