### PR TITLE
v0.6.80: security hardening, nextjs minor version bump, cloudwatch tools, seo fixes

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,7 +26,7 @@
     "fumadocs-openapi": "10.8.1",
     "fumadocs-ui": "16.8.5",
     "lucide-react": "^0.511.0",
-    "next": "16.2.4",
+    "next": "16.2.6",
     "next-themes": "^0.4.6",
     "postgres": "^3.4.5",
     "react": "19.2.4",

--- a/apps/sim/app/(landing)/seo.test.ts
+++ b/apps/sim/app/(landing)/seo.test.ts
@@ -26,7 +26,19 @@ const SEO_SCAN_DIRS = [
 
 const SEO_SCAN_INDIVIDUAL_FILES = [
   path.resolve(APP_DIR, 'page.tsx'),
+  path.resolve(APP_DIR, 'robots.ts'),
+  path.resolve(APP_DIR, 'sitemap.ts'),
   path.resolve(SIM_ROOT, 'ee', 'whitelabeling', 'metadata.ts'),
+]
+
+/**
+ * Files whose entire URL output is SEO-facing (robots.txt, sitemap.xml).
+ * Unlike metadata exports, these don't use `metadataBase`, so the existing
+ * `getBaseUrl()`-in-metadata check would miss a regression here.
+ */
+const SEO_DEFAULT_EXPORT_FILES = [
+  path.resolve(APP_DIR, 'robots.ts'),
+  path.resolve(APP_DIR, 'sitemap.ts'),
 ]
 
 function collectFiles(dir: string, exts: string[]): string[] {
@@ -94,6 +106,21 @@ describe('SEO canonical URLs', () => {
     expect(
       violations,
       `Found hardcoded https://sim.ai (without www):\n${violations.join('\n')}`
+    ).toHaveLength(0)
+  })
+
+  it('robots.ts and sitemap.ts do not import getBaseUrl', () => {
+    const violations: string[] = []
+    for (const file of SEO_DEFAULT_EXPORT_FILES) {
+      if (!fs.existsSync(file)) continue
+      const content = fs.readFileSync(file, 'utf-8')
+      if (content.includes('getBaseUrl')) {
+        violations.push(path.relative(SIM_ROOT, file))
+      }
+    }
+    expect(
+      violations,
+      `robots.ts/sitemap.ts must use SITE_URL, not getBaseUrl():\n${violations.join('\n')}`
     ).toHaveLength(0)
   })
 

--- a/apps/sim/app/api/files/authorization.ts
+++ b/apps/sim/app/api/files/authorization.ts
@@ -14,6 +14,14 @@ import { isUuid } from '@/executor/constants'
 
 const logger = createLogger('FileAuthorization')
 
+/** Thrown by utility functions when file access is denied, so route handlers can return 404. */
+export class FileAccessDeniedError extends Error {
+  constructor() {
+    super('File not found')
+    this.name = 'FileAccessDeniedError'
+  }
+}
+
 interface AuthorizationResult {
   granted: boolean
   reason: string
@@ -598,16 +606,12 @@ async function authorizeFileAccess(
  */
 export async function assertToolFileAccess(
   key: unknown,
-  userId: string | undefined,
+  userId: string,
   requestId: string,
   routeLogger: ReturnType<typeof createLogger>
 ): Promise<NextResponse | null> {
   if (typeof key !== 'string' || key.length === 0) {
     routeLogger.warn(`[${requestId}] File access check rejected: missing key`)
-    return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
-  }
-  if (!userId) {
-    routeLogger.warn(`[${requestId}] File access check requires userId but none available`)
     return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
   }
   const hasAccess = await verifyFileAccess(key, userId)

--- a/apps/sim/app/api/files/multipart/route.test.ts
+++ b/apps/sim/app/api/files/multipart/route.test.ts
@@ -53,6 +53,15 @@ vi.mock('@/lib/uploads/providers/blob/client', () => ({
 
 vi.mock('@/lib/workspaces/permissions/utils', () => permissionsMock)
 
+const { mockCheckStorageQuota, mockInitiateS3MultipartUpload } = vi.hoisted(() => ({
+  mockCheckStorageQuota: vi.fn(),
+  mockInitiateS3MultipartUpload: vi.fn(),
+}))
+
+vi.mock('@/lib/billing/storage', () => ({
+  checkStorageQuota: mockCheckStorageQuota,
+}))
+
 import { POST } from '@/app/api/files/multipart/route'
 
 const tokenPayload = {
@@ -198,5 +207,71 @@ describe('POST /api/files/multipart action=complete', () => {
     )
     expect(res.status).toBe(200)
     expect(mockCompleteS3MultipartUpload).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('POST /api/files/multipart action=initiate quota enforcement', () => {
+  const makeInitiateRequest = (body: unknown) =>
+    new NextRequest('http://localhost/api/files/multipart?action=initiate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authMockFns.mockGetSession.mockResolvedValue({ user: { id: 'user-1' } })
+    permissionsMockFns.mockGetUserEntityPermissions.mockResolvedValue('write')
+    mockIsUsingCloudStorage.mockReturnValue(true)
+    mockGetStorageProvider.mockReturnValue('s3')
+    mockGetStorageConfig.mockReturnValue({ bucket: 'b', region: 'r' })
+    mockSignUploadToken.mockReturnValue('signed-token')
+    mockCheckStorageQuota.mockResolvedValue({ allowed: true })
+    mockInitiateS3MultipartUpload.mockResolvedValue({ uploadId: 'up-1', key: 'k/file.bin' })
+  })
+
+  it('blocks upload when fileSize: 0 exceeds quota', async () => {
+    mockCheckStorageQuota.mockResolvedValue({ allowed: false, error: 'Storage limit exceeded' })
+
+    const res = await makeInitiateRequest({
+      fileName: 'file.bin',
+      contentType: 'application/octet-stream',
+      fileSize: 0,
+      workspaceId: 'ws-1',
+      context: 'knowledge-base',
+    })
+
+    const response = await POST(res)
+    expect(response.status).toBe(413)
+    const body = await response.json()
+    expect(body.error).toContain('Storage limit exceeded')
+  })
+
+  it('does not check quota for quota-exempt contexts (og-images)', async () => {
+    const res = await makeInitiateRequest({
+      fileName: 'img.png',
+      contentType: 'image/png',
+      fileSize: 99999,
+      workspaceId: 'ws-1',
+      context: 'og-images',
+    })
+
+    const response = await POST(res)
+    expect(mockCheckStorageQuota).not.toHaveBeenCalled()
+  })
+
+  it('rejects logs context — not allowed via the multipart endpoint', async () => {
+    const res = await makeInitiateRequest({
+      fileName: 'exec.log',
+      contentType: 'text/plain',
+      fileSize: 1000,
+      workspaceId: 'ws-1',
+      context: 'logs',
+    })
+
+    const response = await POST(res)
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toMatch(/invalid storage context/i)
   })
 })

--- a/apps/sim/app/api/files/multipart/route.ts
+++ b/apps/sim/app/api/files/multipart/route.ts
@@ -22,7 +22,7 @@ import {
   type UploadTokenPayload,
   verifyUploadToken,
 } from '@/lib/uploads/core/upload-token'
-import type { StorageConfig } from '@/lib/uploads/shared/types'
+import { QUOTA_EXEMPT_STORAGE_CONTEXTS, type StorageConfig } from '@/lib/uploads/shared/types'
 import { getUserEntityPermissions } from '@/lib/workspaces/permissions/utils'
 
 const logger = createLogger('MultipartUploadAPI')
@@ -36,7 +36,6 @@ const ALLOWED_UPLOAD_CONTEXTS = new Set<StorageContext>([
   'workspace',
   'profile-pictures',
   'og-images',
-  'logs',
   'workspace-logos',
 ])
 
@@ -135,6 +134,20 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
         const config = getStorageConfig(storageContext)
 
+        if (
+          !QUOTA_EXEMPT_STORAGE_CONTEXTS.has(context as StorageContext) &&
+          typeof fileSize === 'number'
+        ) {
+          const { checkStorageQuota } = await import('@/lib/billing/storage')
+          const quotaCheck = await checkStorageQuota(userId, fileSize)
+          if (!quotaCheck.allowed) {
+            return NextResponse.json(
+              { error: quotaCheck.error || 'Storage limit exceeded' },
+              { status: 413 }
+            )
+          }
+        }
+
         let customKey: string | undefined
         if (context === 'workspace' || context === 'mothership') {
           const { MAX_WORKSPACE_FILE_SIZE } = await import('@/lib/uploads/shared/types')
@@ -149,15 +162,6 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
             '@/lib/uploads/contexts/workspace/workspace-file-manager'
           )
           customKey = generateWorkspaceFileKey(workspaceId, fileName)
-
-          const { checkStorageQuota } = await import('@/lib/billing/storage')
-          const quotaCheck = await checkStorageQuota(userId, fileSize)
-          if (!quotaCheck.allowed) {
-            return NextResponse.json(
-              { error: quotaCheck.error || 'Storage limit exceeded' },
-              { status: 413 }
-            )
-          }
         } else if (context === 'execution') {
           const workflowId = (data as { workflowId?: unknown }).workflowId
           const executionId = (data as { executionId?: unknown }).executionId

--- a/apps/sim/app/api/files/multipart/route.ts
+++ b/apps/sim/app/api/files/multipart/route.ts
@@ -134,12 +134,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
         const config = getStorageConfig(storageContext)
 
-        if (
-          !QUOTA_EXEMPT_STORAGE_CONTEXTS.has(context as StorageContext) &&
-          typeof fileSize === 'number'
-        ) {
+        if (!QUOTA_EXEMPT_STORAGE_CONTEXTS.has(context as StorageContext)) {
           const { checkStorageQuota } = await import('@/lib/billing/storage')
-          const quotaCheck = await checkStorageQuota(userId, fileSize)
+          const quotaCheck = await checkStorageQuota(userId, fileSize ?? 0)
           if (!quotaCheck.allowed) {
             return NextResponse.json(
               { error: quotaCheck.error || 'Storage limit exceeded' },

--- a/apps/sim/app/api/schedules/execute/route.ts
+++ b/apps/sim/app/api/schedules/execute/route.ts
@@ -21,9 +21,9 @@ export const dynamic = 'force-dynamic'
 export const maxDuration = 3600
 
 const logger = createLogger('ScheduledExecuteAPI')
-const MAX_CRON_CLAIMS = 200
-const RESERVED_WORKFLOW_CLAIMS = 100
-const RESERVED_JOB_CLAIMS = MAX_CRON_CLAIMS - RESERVED_WORKFLOW_CLAIMS
+const WORKFLOW_CHUNK_SIZE = 100
+const JOB_CHUNK_SIZE = 100
+const MAX_TICK_DURATION_MS = 3 * 60 * 1000
 const STALE_SCHEDULE_CLAIM_MS = getMaxExecutionTimeout()
 
 const dueFilter = (queuedAt: Date) =>
@@ -143,8 +143,178 @@ async function claimJobSchedules(queuedAt: Date, limit: number) {
   })
 }
 
+type ClaimedSchedule = Awaited<ReturnType<typeof claimWorkflowSchedules>>[number]
+type ClaimedJob = Awaited<ReturnType<typeof claimJobSchedules>>[number]
+type WorkflowUtils = typeof import('@/lib/workflows/utils')
+type JobQueue = Awaited<ReturnType<typeof getJobQueue>>
+
+async function processScheduleItem(
+  schedule: ClaimedSchedule,
+  queuedAt: Date,
+  requestId: string,
+  jobQueue: JobQueue,
+  workflowUtils: WorkflowUtils
+) {
+  const queueTime = schedule.lastQueuedAt ?? queuedAt
+  const executionId = generateId()
+  const correlation = {
+    executionId,
+    requestId,
+    source: 'schedule' as const,
+    workflowId: schedule.workflowId!,
+    scheduleId: schedule.id,
+    triggerType: 'schedule',
+    scheduledFor: schedule.nextRunAt?.toISOString(),
+  }
+
+  const payload = {
+    scheduleId: schedule.id,
+    workflowId: schedule.workflowId!,
+    executionId,
+    requestId,
+    correlation,
+    blockId: schedule.blockId || undefined,
+    deploymentVersionId: schedule.deploymentVersionId || undefined,
+    cronExpression: schedule.cronExpression || undefined,
+    lastRanAt: schedule.lastRanAt?.toISOString(),
+    failedCount: schedule.failedCount || 0,
+    now: queueTime.toISOString(),
+    scheduledFor: schedule.nextRunAt?.toISOString(),
+  }
+
+  try {
+    const scheduleJobId = buildScheduleExecutionJobId(schedule)
+    const existingJob = await jobQueue.getJob(scheduleJobId)
+    if (existingJob && ['pending', 'processing'].includes(existingJob.status)) {
+      logger.info(`[${requestId}] Schedule execution job already exists`, {
+        scheduleId: schedule.id,
+        jobId: scheduleJobId,
+        status: existingJob.status,
+      })
+      return
+    }
+    if (existingJob) {
+      logger.info(`[${requestId}] Releasing stale schedule claim for finished job`, {
+        scheduleId: schedule.id,
+        jobId: scheduleJobId,
+        status: existingJob.status,
+      })
+      await releaseScheduleLock(
+        schedule.id,
+        requestId,
+        queuedAt,
+        `Released stale schedule ${schedule.id} for finished job ${scheduleJobId}`,
+        getNextRunFromCronExpression(schedule.cronExpression)
+      )
+      return
+    }
+
+    const resolvedWorkflow = schedule.workflowId
+      ? await workflowUtils.getWorkflowById(schedule.workflowId)
+      : null
+    const resolvedWorkspaceId = resolvedWorkflow?.workspaceId
+
+    const jobId = await jobQueue.enqueue('schedule-execution', payload, {
+      jobId: scheduleJobId,
+      concurrencyKey: scheduleJobId,
+      metadata: {
+        workflowId: schedule.workflowId ?? undefined,
+        workspaceId: resolvedWorkspaceId ?? undefined,
+        correlation,
+      },
+    })
+    logger.info(
+      `[${requestId}] Queued schedule execution task ${jobId} for workflow ${schedule.workflowId}`
+    )
+
+    const queuedJob = await jobQueue.getJob(jobId)
+    if (queuedJob && !['pending', 'processing'].includes(queuedJob.status)) {
+      logger.info(`[${requestId}] Schedule execution job already finished`, {
+        scheduleId: schedule.id,
+        jobId,
+        status: queuedJob.status,
+      })
+      await releaseScheduleLock(
+        schedule.id,
+        requestId,
+        queuedAt,
+        `Released stale schedule ${schedule.id} for finished job ${jobId}`,
+        getNextRunFromCronExpression(schedule.cronExpression)
+      )
+      return
+    }
+
+    if (shouldExecuteInline()) {
+      try {
+        await jobQueue.startJob(jobId)
+        const output = await executeScheduleJob(payload)
+        await jobQueue.completeJob(jobId, output)
+      } catch (error) {
+        const errorMessage = toError(error).message
+        logger.error(
+          `[${requestId}] Schedule execution failed for workflow ${schedule.workflowId}`,
+          {
+            jobId,
+            error: errorMessage,
+          }
+        )
+        try {
+          await jobQueue.markJobFailed(jobId, errorMessage)
+        } catch (markFailedError) {
+          logger.error(`[${requestId}] Failed to mark job as failed`, {
+            jobId,
+            error: toError(markFailedError).message,
+          })
+        }
+        await releaseScheduleLock(
+          schedule.id,
+          requestId,
+          queuedAt,
+          `Failed to release lock for schedule ${schedule.id} after inline execution failure`
+        )
+      }
+    }
+  } catch (error) {
+    logger.error(
+      `[${requestId}] Failed to queue schedule execution for workflow ${schedule.workflowId}`,
+      error
+    )
+    await releaseScheduleLock(
+      schedule.id,
+      requestId,
+      queuedAt,
+      `Failed to release lock for schedule ${schedule.id} after queue failure`
+    )
+  }
+}
+
+async function processJobItem(job: ClaimedJob, queuedAt: Date, requestId: string) {
+  const queueTime = job.lastQueuedAt ?? queuedAt
+  const payload = {
+    scheduleId: job.id,
+    cronExpression: job.cronExpression || undefined,
+    failedCount: job.failedCount || 0,
+    now: queueTime.toISOString(),
+  }
+
+  try {
+    await executeJobInline(payload)
+  } catch (error) {
+    logger.error(`[${requestId}] Job execution failed for ${job.id}`, {
+      error: toError(error).message,
+    })
+    await releaseScheduleLock(
+      job.id,
+      requestId,
+      queuedAt,
+      `Failed to release lock for job ${job.id}`
+    )
+  }
+}
+
 export const GET = withRouteHandler(async (request: NextRequest) => {
   const requestId = generateRequestId()
+  const tickStart = Date.now()
   logger.info(`[${requestId}] Scheduled execution triggered at ${new Date().toISOString()}`)
 
   const authError = verifyCronAuth(request, 'Schedule execution')
@@ -152,194 +322,61 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     return authError
   }
 
-  const queuedAt = new Date()
-
   try {
-    const dueSchedules = await claimWorkflowSchedules(queuedAt, RESERVED_WORKFLOW_CLAIMS)
-    const dueJobs = await claimJobSchedules(queuedAt, RESERVED_JOB_CLAIMS)
-    const remainingClaimBudget = Math.max(0, MAX_CRON_CLAIMS - dueSchedules.length - dueJobs.length)
+    const jobQueue = await getJobQueue()
+    let workflowUtils: WorkflowUtils | undefined
 
-    if (remainingClaimBudget > 0 && dueSchedules.length === RESERVED_WORKFLOW_CLAIMS) {
-      dueSchedules.push(...(await claimWorkflowSchedules(queuedAt, remainingClaimBudget)))
-    } else if (remainingClaimBudget > 0 && dueJobs.length === RESERVED_JOB_CLAIMS) {
-      dueJobs.push(...(await claimJobSchedules(queuedAt, remainingClaimBudget)))
+    let totalSchedules = 0
+    let totalJobs = 0
+    let iterations = 0
+    let schedulesExhausted = false
+    let jobsExhausted = false
+
+    while (Date.now() - tickStart < MAX_TICK_DURATION_MS) {
+      if (schedulesExhausted && jobsExhausted) break
+      const queuedAt = new Date()
+
+      const [dueSchedules, dueJobs] = await Promise.all([
+        schedulesExhausted ? [] : claimWorkflowSchedules(queuedAt, WORKFLOW_CHUNK_SIZE),
+        jobsExhausted ? [] : claimJobSchedules(queuedAt, JOB_CHUNK_SIZE),
+      ])
+
+      if (dueSchedules.length < WORKFLOW_CHUNK_SIZE) schedulesExhausted = true
+      if (dueJobs.length < JOB_CHUNK_SIZE) jobsExhausted = true
+
+      if (dueSchedules.length === 0 && dueJobs.length === 0) break
+
+      iterations += 1
+      totalSchedules += dueSchedules.length
+      totalJobs += dueJobs.length
+
+      logger.info(
+        `[${requestId}] Iteration ${iterations}: claimed ${dueSchedules.length} schedules, ${dueJobs.length} jobs`
+      )
+
+      if (dueSchedules.length > 0 && !workflowUtils) {
+        workflowUtils = await import('@/lib/workflows/utils')
+      }
+
+      const loadedWorkflowUtils = workflowUtils
+      const schedulePromises =
+        loadedWorkflowUtils && dueSchedules.length > 0
+          ? dueSchedules.map((schedule) =>
+              processScheduleItem(schedule, queuedAt, requestId, jobQueue, loadedWorkflowUtils)
+            )
+          : []
+
+      await Promise.allSettled([
+        ...schedulePromises,
+        ...dueJobs.map((job) => processJobItem(job, queuedAt, requestId)),
+      ])
     }
 
-    const totalCount = dueSchedules.length + dueJobs.length
+    const totalCount = totalSchedules + totalJobs
+    const durationMs = Date.now() - tickStart
     logger.info(
-      `[${requestId}] Processing ${totalCount} due items (${dueSchedules.length} schedules, ${dueJobs.length} jobs)`
+      `[${requestId}] Processed ${totalCount} items across ${iterations} iteration(s) in ${durationMs}ms (${totalSchedules} schedules, ${totalJobs} jobs)`
     )
-
-    const jobQueue = await getJobQueue()
-
-    const workflowUtils =
-      dueSchedules.length > 0 ? await import('@/lib/workflows/utils') : undefined
-
-    const schedulePromises = dueSchedules.map(async (schedule) => {
-      const queueTime = schedule.lastQueuedAt ?? queuedAt
-      const executionId = generateId()
-      const correlation = {
-        executionId,
-        requestId,
-        source: 'schedule' as const,
-        workflowId: schedule.workflowId!,
-        scheduleId: schedule.id,
-        triggerType: 'schedule',
-        scheduledFor: schedule.nextRunAt?.toISOString(),
-      }
-
-      const payload = {
-        scheduleId: schedule.id,
-        workflowId: schedule.workflowId!,
-        executionId,
-        requestId,
-        correlation,
-        blockId: schedule.blockId || undefined,
-        deploymentVersionId: schedule.deploymentVersionId || undefined,
-        cronExpression: schedule.cronExpression || undefined,
-        lastRanAt: schedule.lastRanAt?.toISOString(),
-        failedCount: schedule.failedCount || 0,
-        now: queueTime.toISOString(),
-        scheduledFor: schedule.nextRunAt?.toISOString(),
-      }
-
-      try {
-        const scheduleJobId = buildScheduleExecutionJobId(schedule)
-        const existingJob = await jobQueue.getJob(scheduleJobId)
-        if (existingJob && ['pending', 'processing'].includes(existingJob.status)) {
-          logger.info(`[${requestId}] Schedule execution job already exists`, {
-            scheduleId: schedule.id,
-            jobId: scheduleJobId,
-            status: existingJob.status,
-          })
-          return
-        }
-        if (existingJob) {
-          logger.info(`[${requestId}] Releasing stale schedule claim for finished job`, {
-            scheduleId: schedule.id,
-            jobId: scheduleJobId,
-            status: existingJob.status,
-          })
-          await releaseScheduleLock(
-            schedule.id,
-            requestId,
-            queuedAt,
-            `Released stale schedule ${schedule.id} for finished job ${scheduleJobId}`,
-            getNextRunFromCronExpression(schedule.cronExpression)
-          )
-          return
-        }
-
-        const resolvedWorkflow = schedule.workflowId
-          ? await workflowUtils?.getWorkflowById(schedule.workflowId)
-          : null
-        const resolvedWorkspaceId = resolvedWorkflow?.workspaceId
-
-        const jobId = await jobQueue.enqueue('schedule-execution', payload, {
-          jobId: scheduleJobId,
-          concurrencyKey: scheduleJobId,
-          metadata: {
-            workflowId: schedule.workflowId ?? undefined,
-            workspaceId: resolvedWorkspaceId ?? undefined,
-            correlation,
-          },
-        })
-        logger.info(
-          `[${requestId}] Queued schedule execution task ${jobId} for workflow ${schedule.workflowId}`
-        )
-
-        const queuedJob = await jobQueue.getJob(jobId)
-        if (queuedJob && !['pending', 'processing'].includes(queuedJob.status)) {
-          logger.info(`[${requestId}] Schedule execution job already finished`, {
-            scheduleId: schedule.id,
-            jobId,
-            status: queuedJob.status,
-          })
-          await releaseScheduleLock(
-            schedule.id,
-            requestId,
-            queuedAt,
-            `Released stale schedule ${schedule.id} for finished job ${jobId}`,
-            getNextRunFromCronExpression(schedule.cronExpression)
-          )
-          return
-        }
-
-        if (shouldExecuteInline()) {
-          try {
-            await jobQueue.startJob(jobId)
-            const output = await executeScheduleJob(payload)
-            await jobQueue.completeJob(jobId, output)
-          } catch (error) {
-            const errorMessage = toError(error).message
-            logger.error(
-              `[${requestId}] Schedule execution failed for workflow ${schedule.workflowId}`,
-              {
-                jobId,
-                error: errorMessage,
-              }
-            )
-            try {
-              await jobQueue.markJobFailed(jobId, errorMessage)
-            } catch (markFailedError) {
-              logger.error(`[${requestId}] Failed to mark job as failed`, {
-                jobId,
-                error:
-                  markFailedError instanceof Error
-                    ? markFailedError.message
-                    : String(markFailedError),
-              })
-            }
-            await releaseScheduleLock(
-              schedule.id,
-              requestId,
-              queuedAt,
-              `Failed to release lock for schedule ${schedule.id} after inline execution failure`
-            )
-          }
-        }
-      } catch (error) {
-        logger.error(
-          `[${requestId}] Failed to queue schedule execution for workflow ${schedule.workflowId}`,
-          error
-        )
-        await releaseScheduleLock(
-          schedule.id,
-          requestId,
-          queuedAt,
-          `Failed to release lock for schedule ${schedule.id} after queue failure`
-        )
-      }
-    })
-
-    // Mothership jobs are executed inline directly.
-    const jobPromises = dueJobs.map(async (job) => {
-      const queueTime = job.lastQueuedAt ?? queuedAt
-      const payload = {
-        scheduleId: job.id,
-        cronExpression: job.cronExpression || undefined,
-        failedCount: job.failedCount || 0,
-        now: queueTime.toISOString(),
-      }
-
-      try {
-        await executeJobInline(payload)
-      } catch (error) {
-        logger.error(`[${requestId}] Job execution failed for ${job.id}`, {
-          error: toError(error).message,
-        })
-        await releaseScheduleLock(
-          job.id,
-          requestId,
-          queuedAt,
-          `Failed to release lock for job ${job.id}`
-        )
-      }
-    })
-
-    await Promise.allSettled([...schedulePromises, ...jobPromises])
-
-    logger.info(`[${requestId}] Processed ${totalCount} items`)
 
     return NextResponse.json({
       message: 'Scheduled workflow executions processed',

--- a/apps/sim/app/api/tools/agiloft/attach/route.ts
+++ b/apps/sim/app/api/tools/agiloft/attach/route.ts
@@ -10,6 +10,7 @@ import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import type { RawFileInput } from '@/lib/uploads/utils/file-schemas'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import { agiloftLogin, agiloftLogout, buildAttachFileUrl } from '@/tools/agiloft/utils'
 
 export const dynamic = 'force-dynamic'
@@ -22,7 +23,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Agiloft attach attempt: ${authResult.error}`)
       return NextResponse.json(
         { success: false, error: authResult.error || 'Authentication required' },
@@ -66,6 +67,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       `[${requestId}] Downloading file for Agiloft attach: ${userFile.name} (${userFile.size} bytes)`
     )
 
+    const denied = await assertToolFileAccess(userFile.key, authResult.userId, requestId, logger)
+    if (denied) return denied
     const fileBuffer = await downloadFileFromStorage(userFile, requestId, logger)
     const resolvedFileName = data.fileName || userFile.name || 'attachment'
 

--- a/apps/sim/app/api/tools/box/upload/route.ts
+++ b/apps/sim/app/api/tools/box/upload/route.ts
@@ -7,6 +7,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles, type RawFileInput } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -18,7 +19,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Box upload attempt: ${authResult.error}`)
       return NextResponse.json(
         { success: false, error: authResult.error || 'Authentication required' },
@@ -49,6 +50,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       const userFile = userFiles[0]
       logger.info(`[${requestId}] Downloading file: ${userFile.name} (${userFile.size} bytes)`)
 
+      const denied = await assertToolFileAccess(userFile.key, authResult.userId, requestId, logger)
+      if (denied) return denied
       fileBuffer = await downloadFileFromStorage(userFile, requestId, logger)
       fileName = validatedData.fileName || userFile.name
     } else if (validatedData.fileContent) {

--- a/apps/sim/app/api/tools/cloudwatch/mute-alarm/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/mute-alarm/route.ts
@@ -1,0 +1,62 @@
+import { CloudWatchClient, DisableAlarmActionsCommand } from '@aws-sdk/client-cloudwatch'
+import { createLogger } from '@sim/logger'
+import { toError } from '@sim/utils/errors'
+import { type NextRequest, NextResponse } from 'next/server'
+import { awsCloudwatchMuteAlarmContract } from '@/lib/api/contracts/tools/aws/cloudwatch-mute-alarm'
+import { parseToolRequest } from '@/lib/api/server'
+import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+
+const logger = createLogger('CloudWatchMuteAlarm')
+
+export const POST = withRouteHandler(async (request: NextRequest) => {
+  try {
+    const auth = await checkInternalAuth(request)
+    if (!auth.success || !auth.userId) {
+      return NextResponse.json({ error: auth.error || 'Unauthorized' }, { status: 401 })
+    }
+
+    const parsed = await parseToolRequest(awsCloudwatchMuteAlarmContract, request, {
+      errorFormat: 'details',
+      logger,
+    })
+    if (!parsed.success) return parsed.response
+    const validatedData = parsed.data.body
+
+    logger.info(`Muting ${validatedData.alarmNames.length} CloudWatch alarm(s)`)
+
+    const client = new CloudWatchClient({
+      region: validatedData.region,
+      credentials: {
+        accessKeyId: validatedData.accessKeyId,
+        secretAccessKey: validatedData.secretAccessKey,
+      },
+    })
+
+    try {
+      const command = new DisableAlarmActionsCommand({
+        AlarmNames: validatedData.alarmNames,
+      })
+
+      await client.send(command)
+
+      logger.info(`Successfully muted ${validatedData.alarmNames.length} alarm(s)`)
+
+      return NextResponse.json({
+        success: true,
+        output: {
+          success: true,
+          alarmNames: validatedData.alarmNames,
+        },
+      })
+    } finally {
+      client.destroy()
+    }
+  } catch (error) {
+    logger.error('MuteAlarm failed', { error: toError(error).message })
+    return NextResponse.json(
+      { error: `Failed to mute CloudWatch alarm: ${toError(error).message}` },
+      { status: 500 }
+    )
+  }
+})

--- a/apps/sim/app/api/tools/cloudwatch/unmute-alarm/route.ts
+++ b/apps/sim/app/api/tools/cloudwatch/unmute-alarm/route.ts
@@ -1,0 +1,62 @@
+import { CloudWatchClient, EnableAlarmActionsCommand } from '@aws-sdk/client-cloudwatch'
+import { createLogger } from '@sim/logger'
+import { toError } from '@sim/utils/errors'
+import { type NextRequest, NextResponse } from 'next/server'
+import { awsCloudwatchUnmuteAlarmContract } from '@/lib/api/contracts/tools/aws/cloudwatch-unmute-alarm'
+import { parseToolRequest } from '@/lib/api/server'
+import { checkInternalAuth } from '@/lib/auth/hybrid'
+import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+
+const logger = createLogger('CloudWatchUnmuteAlarm')
+
+export const POST = withRouteHandler(async (request: NextRequest) => {
+  try {
+    const auth = await checkInternalAuth(request)
+    if (!auth.success || !auth.userId) {
+      return NextResponse.json({ error: auth.error || 'Unauthorized' }, { status: 401 })
+    }
+
+    const parsed = await parseToolRequest(awsCloudwatchUnmuteAlarmContract, request, {
+      errorFormat: 'details',
+      logger,
+    })
+    if (!parsed.success) return parsed.response
+    const validatedData = parsed.data.body
+
+    logger.info(`Unmuting ${validatedData.alarmNames.length} CloudWatch alarm(s)`)
+
+    const client = new CloudWatchClient({
+      region: validatedData.region,
+      credentials: {
+        accessKeyId: validatedData.accessKeyId,
+        secretAccessKey: validatedData.secretAccessKey,
+      },
+    })
+
+    try {
+      const command = new EnableAlarmActionsCommand({
+        AlarmNames: validatedData.alarmNames,
+      })
+
+      await client.send(command)
+
+      logger.info(`Successfully unmuted ${validatedData.alarmNames.length} alarm(s)`)
+
+      return NextResponse.json({
+        success: true,
+        output: {
+          success: true,
+          alarmNames: validatedData.alarmNames,
+        },
+      })
+    } finally {
+      client.destroy()
+    }
+  } catch (error) {
+    logger.error('UnmuteAlarm failed', { error: toError(error).message })
+    return NextResponse.json(
+      { error: `Failed to unmute CloudWatch alarm: ${toError(error).message}` },
+      { status: 500 }
+    )
+  }
+})

--- a/apps/sim/app/api/tools/confluence/upload-attachment/route.ts
+++ b/apps/sim/app/api/tools/confluence/upload-attachment/route.ts
@@ -7,6 +7,7 @@ import { validateAlphanumericId, validateJiraCloudId } from '@/lib/core/security
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processSingleFileToUserFile, type RawFileInput } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import { getConfluenceCloudId } from '@/tools/confluence/utils'
 import { parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
@@ -79,6 +80,14 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         { status: 400 }
       )
     }
+
+    const denied = await assertToolFileAccess(
+      userFile.key,
+      auth.userId,
+      'confluence-upload',
+      logger
+    )
+    if (denied) return denied
 
     let fileBuffer: Buffer
     try {

--- a/apps/sim/app/api/tools/discord/send-message/route.ts
+++ b/apps/sim/app/api/tools/discord/send-message/route.ts
@@ -8,6 +8,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,7 +20,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Discord send attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -30,8 +31,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(`[${requestId}] Authenticated Discord send request via ${authResult.authType}`, {
-      userId: authResult.userId,
+      userId,
     })
 
     const parsed = await parseRequest(discordSendMessageContract, request, {})
@@ -134,17 +136,30 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     }
     formData.append('payload_json', JSON.stringify(payload))
 
-    const downloadedFiles = await Promise.all(
-      userFiles.map(async (userFile, i) => {
-        logger.info(`[${requestId}] Downloading file ${i}: ${userFile.name}`)
-        const buffer = await downloadFileFromStorage(userFile, requestId, logger)
-        logger.info(`[${requestId}] Added file ${i}: ${userFile.name} (${buffer.length} bytes)`)
-        return { userFile, buffer }
+    const accessResults = await Promise.all(
+      userFiles.map((file) => assertToolFileAccess(file.key, userId, requestId, logger))
+    )
+    const denied = accessResults.find((r) => r !== null)
+    if (denied) return denied
+
+    const buffers = await Promise.all(
+      userFiles.map(async (file, i) => {
+        try {
+          logger.info(`[${requestId}] Downloading file ${i}: ${file.name}`)
+          return await downloadFileFromStorage(file, requestId, logger)
+        } catch (error) {
+          logger.error(`[${requestId}] Failed to download attachment ${file.name}:`, error)
+          throw new Error(
+            `Failed to download attachment "${file.name}": ${error instanceof Error ? error.message : 'Unknown error'}`
+          )
+        }
       })
     )
 
-    for (let i = 0; i < downloadedFiles.length; i++) {
-      const { userFile, buffer } = downloadedFiles[i]
+    for (let i = 0; i < userFiles.length; i++) {
+      const userFile = userFiles[i]
+      const buffer = buffers[i]
+      logger.info(`[${requestId}] Added file ${i}: ${userFile.name} (${buffer.length} bytes)`)
       filesOutput.push({
         name: userFile.name,
         mimeType: userFile.type || 'application/octet-stream',

--- a/apps/sim/app/api/tools/docusign/route.ts
+++ b/apps/sim/app/api/tools/docusign/route.ts
@@ -7,6 +7,7 @@ import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { FileInputSchema } from '@/lib/uploads/utils/file-schemas'
 import { processFilesToUserFiles, type RawFileInput } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 const logger = createLogger('DocuSignAPI')
 
@@ -54,7 +55,7 @@ async function resolveAccount(accessToken: string): Promise<DocuSignAccountInfo>
 
 export const POST = withRouteHandler(async (request: NextRequest) => {
   const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
-  if (!authResult.success) {
+  if (!authResult.success || !authResult.userId) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -84,7 +85,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
     switch (operation) {
       case 'send_envelope':
-        return await handleSendEnvelope(apiBase, headers, params)
+        return await handleSendEnvelope(apiBase, headers, params, authResult.userId)
       case 'create_from_template':
         return await handleCreateFromTemplate(apiBase, headers, params)
       case 'get_envelope':
@@ -115,7 +116,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 async function handleSendEnvelope(
   apiBase: string,
   headers: Record<string, string>,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  userId: string
 ) {
   const { signerEmail, signerName, emailSubject, emailBody, ccEmail, ccName, file, status } = params
 
@@ -135,6 +137,8 @@ async function handleSendEnvelope(
       const userFiles = processFilesToUserFiles([parsed as RawFileInput], 'docusign-send', logger)
       if (userFiles.length > 0) {
         const userFile = userFiles[0]
+        const denied = await assertToolFileAccess(userFile.key, userId, 'docusign-send', logger)
+        if (denied) return denied
         const buffer = await downloadFileFromStorage(userFile, 'docusign-send', logger)
         documentBase64 = buffer.toString('base64')
         documentName = userFile.name

--- a/apps/sim/app/api/tools/dropbox/upload/route.ts
+++ b/apps/sim/app/api/tools/dropbox/upload/route.ts
@@ -8,6 +8,7 @@ import { httpHeaderSafeJson } from '@/lib/core/utils/validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles, type RawFileInput } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,7 +20,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Dropbox upload attempt: ${authResult.error}`)
       return NextResponse.json(
         { success: false, error: authResult.error || 'Authentication required' },
@@ -52,6 +53,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       const userFile = userFiles[0]
       logger.info(`[${requestId}] Downloading file: ${userFile.name} (${userFile.size} bytes)`)
 
+      const denied = await assertToolFileAccess(userFile.key, authResult.userId, requestId, logger)
+      if (denied) return denied
       fileBuffer = await downloadFileFromStorage(userFile, requestId, logger)
       fileName = userFile.name
     } else if (validatedData.fileContent) {

--- a/apps/sim/app/api/tools/firecrawl/parse/route.ts
+++ b/apps/sim/app/api/tools/firecrawl/parse/route.ts
@@ -8,6 +8,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -42,6 +43,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       fileName: userFile.name,
       size: userFile.size,
     })
+
+    const denied = await assertToolFileAccess(userFile.key, authResult.userId, requestId, logger)
+    if (denied) return denied
 
     const buffer = await downloadFileFromStorage(userFile, requestId, logger)
 

--- a/apps/sim/app/api/tools/gmail/draft/route.ts
+++ b/apps/sim/app/api/tools/gmail/draft/route.ts
@@ -7,6 +7,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import {
   base64UrlEncode,
   buildMimeMessage,
@@ -26,7 +27,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Gmail draft attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -37,8 +38,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(`[${requestId}] Authenticated Gmail draft request via ${authResult.authType}`, {
-      userId: authResult.userId,
+      userId,
     })
 
     const parsed = await parseRequest(gmailDraftContract, request, {})
@@ -85,20 +87,19 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           )
         }
 
-        const attachmentBuffers = await Promise.all(
+        const accessResults = await Promise.all(
+          attachments.map((file) => assertToolFileAccess(file.key, userId, requestId, logger))
+        )
+        const denied = accessResults.find((r) => r !== null)
+        if (denied) return denied
+
+        const buffers = await Promise.all(
           attachments.map(async (file) => {
             try {
               logger.info(
                 `[${requestId}] Downloading attachment: ${file.name} (${file.size} bytes)`
               )
-
-              const buffer = await downloadFileFromStorage(file, requestId, logger)
-
-              return {
-                filename: file.name,
-                mimeType: file.type || 'application/octet-stream',
-                content: buffer,
-              }
+              return await downloadFileFromStorage(file, requestId, logger)
             } catch (error) {
               logger.error(`[${requestId}] Failed to download attachment ${file.name}:`, error)
               throw new Error(
@@ -107,6 +108,12 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
             }
           })
         )
+
+        const attachmentBuffers = attachments.map((file, i) => ({
+          filename: file.name,
+          mimeType: file.type || 'application/octet-stream',
+          content: buffers[i],
+        }))
 
         const mimeMessage = buildMimeMessage({
           to: validatedData.to,

--- a/apps/sim/app/api/tools/gmail/edit-draft/route.ts
+++ b/apps/sim/app/api/tools/gmail/edit-draft/route.ts
@@ -7,6 +7,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import {
   base64UrlEncode,
   buildMimeMessage,
@@ -25,7 +26,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Gmail edit draft attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -36,9 +37,10 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(
       `[${requestId}] Authenticated Gmail edit draft request via ${authResult.authType}`,
-      { userId: authResult.userId }
+      { userId }
     )
 
     const parsed = await parseRequest(gmailEditDraftContract, request, {})
@@ -81,16 +83,33 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           )
         }
 
-        const attachmentBuffers = await Promise.all(
+        const accessResults = await Promise.all(
+          attachments.map((file) => assertToolFileAccess(file.key, userId, requestId, logger))
+        )
+        const denied = accessResults.find((r) => r !== null)
+        if (denied) return denied
+
+        const buffers = await Promise.all(
           attachments.map(async (file) => {
-            const buffer = await downloadFileFromStorage(file, requestId, logger)
-            return {
-              filename: file.name,
-              mimeType: file.type || 'application/octet-stream',
-              content: buffer,
+            try {
+              logger.info(
+                `[${requestId}] Downloading attachment: ${file.name} (${file.size} bytes)`
+              )
+              return await downloadFileFromStorage(file, requestId, logger)
+            } catch (error) {
+              logger.error(`[${requestId}] Failed to download attachment ${file.name}:`, error)
+              throw new Error(
+                `Failed to download attachment "${file.name}": ${error instanceof Error ? error.message : 'Unknown error'}`
+              )
             }
           })
         )
+
+        const attachmentBuffers = attachments.map((file, i) => ({
+          filename: file.name,
+          mimeType: file.type || 'application/octet-stream',
+          content: buffers[i],
+        }))
 
         const mimeMessage = buildMimeMessage({
           to: validatedData.to,

--- a/apps/sim/app/api/tools/gmail/send/route.ts
+++ b/apps/sim/app/api/tools/gmail/send/route.ts
@@ -7,6 +7,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import {
   base64UrlEncode,
   buildMimeMessage,
@@ -26,7 +27,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Gmail send attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -37,8 +38,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(`[${requestId}] Authenticated Gmail send request via ${authResult.authType}`, {
-      userId: authResult.userId,
+      userId,
     })
 
     const parsed = await parseRequest(gmailSendContract, request, {})
@@ -85,20 +87,19 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           )
         }
 
-        const attachmentBuffers = await Promise.all(
+        const accessResults = await Promise.all(
+          attachments.map((file) => assertToolFileAccess(file.key, userId, requestId, logger))
+        )
+        const denied = accessResults.find((r) => r !== null)
+        if (denied) return denied
+
+        const buffers = await Promise.all(
           attachments.map(async (file) => {
             try {
               logger.info(
                 `[${requestId}] Downloading attachment: ${file.name} (${file.size} bytes)`
               )
-
-              const buffer = await downloadFileFromStorage(file, requestId, logger)
-
-              return {
-                filename: file.name,
-                mimeType: file.type || 'application/octet-stream',
-                content: buffer,
-              }
+              return await downloadFileFromStorage(file, requestId, logger)
             } catch (error) {
               logger.error(`[${requestId}] Failed to download attachment ${file.name}:`, error)
               throw new Error(
@@ -107,6 +108,12 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
             }
           })
         )
+
+        const attachmentBuffers = attachments.map((file, i) => ({
+          filename: file.name,
+          mimeType: file.type || 'application/octet-stream',
+          content: buffers[i],
+        }))
 
         const mimeMessage = buildMimeMessage({
           to: validatedData.to,

--- a/apps/sim/app/api/tools/google_drive/upload/route.ts
+++ b/apps/sim/app/api/tools/google_drive/upload/route.ts
@@ -7,6 +7,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processSingleFileToUserFile } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import {
   GOOGLE_WORKSPACE_MIME_TYPES,
   handleSheetsFormat,
@@ -52,7 +53,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Google Drive upload attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -112,6 +113,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       key: userFile.key,
       size: userFile.size,
     })
+
+    const denied = await assertToolFileAccess(userFile.key, authResult.userId, requestId, logger)
+    if (denied) return denied
 
     let fileBuffer: Buffer
 

--- a/apps/sim/app/api/tools/jira/add-attachment/route.ts
+++ b/apps/sim/app/api/tools/jira/add-attachment/route.ts
@@ -6,6 +6,7 @@ import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import { getJiraCloudId, parseAtlassianErrorMessage } from '@/tools/jira/utils'
 
 const logger = createLogger('JiraAddAttachmentAPI')
@@ -17,7 +18,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       return NextResponse.json(
         { success: false, error: authResult.error || 'Unauthorized' },
         { status: 401 }
@@ -43,6 +44,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     const formData = new FormData()
 
     for (const file of userFiles) {
+      const denied = await assertToolFileAccess(file.key, authResult.userId, requestId, logger)
+      if (denied) return denied
       const buffer = await downloadFileFromStorage(file, requestId, logger)
       const blob = new Blob([new Uint8Array(buffer)], {
         type: file.type || 'application/octet-stream',

--- a/apps/sim/app/api/tools/microsoft-dataverse/upload-file/route.ts
+++ b/apps/sim/app/api/tools/microsoft-dataverse/upload-file/route.ts
@@ -8,6 +8,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processSingleFileToUserFile } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,7 +20,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Dataverse upload attempt: ${authResult.error}`)
       return NextResponse.json(
         { success: false, error: authResult.error || 'Authentication required' },
@@ -65,6 +66,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           { status: 400 }
         )
       }
+
+      const denied = await assertToolFileAccess(userFile.key, authResult.userId, requestId, logger)
+      if (denied) return denied
 
       fileBuffer = await downloadFileFromStorage(userFile, requestId, logger)
     } else if (validatedData.fileContent) {

--- a/apps/sim/app/api/tools/microsoft_teams/write_channel/route.ts
+++ b/apps/sim/app/api/tools/microsoft_teams/write_channel/route.ts
@@ -6,6 +6,7 @@ import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { secureFetchWithValidation } from '@/lib/core/security/input-validation.server'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { FileAccessDeniedError } from '@/app/api/files/authorization'
 import { uploadFilesForTeamsMessage } from '@/tools/microsoft_teams/server-utils'
 import type { GraphApiErrorResponse, GraphChatMessage } from '@/tools/microsoft_teams/types'
 import { resolveMentionsForChannel, type TeamsMention } from '@/tools/microsoft_teams/utils'
@@ -20,7 +21,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Teams channel write attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -31,10 +32,11 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(
       `[${requestId}] Authenticated Teams channel write request via ${authResult.authType}`,
       {
-        userId: authResult.userId,
+        userId,
       }
     )
 
@@ -54,6 +56,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       accessToken: validatedData.accessToken,
       requestId,
       logger,
+      userId,
     })
 
     let messageContent = validatedData.content
@@ -160,6 +163,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       },
     })
   } catch (error) {
+    if (error instanceof FileAccessDeniedError) {
+      return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
+    }
     logger.error(`[${requestId}] Error sending Teams channel message:`, error)
     return NextResponse.json(
       {

--- a/apps/sim/app/api/tools/microsoft_teams/write_chat/route.ts
+++ b/apps/sim/app/api/tools/microsoft_teams/write_chat/route.ts
@@ -6,6 +6,7 @@ import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { secureFetchWithValidation } from '@/lib/core/security/input-validation.server'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { FileAccessDeniedError } from '@/app/api/files/authorization'
 import { uploadFilesForTeamsMessage } from '@/tools/microsoft_teams/server-utils'
 import type { GraphApiErrorResponse, GraphChatMessage } from '@/tools/microsoft_teams/types'
 import { resolveMentionsForChat, type TeamsMention } from '@/tools/microsoft_teams/utils'
@@ -20,7 +21,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Teams chat write attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -31,10 +32,11 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(
       `[${requestId}] Authenticated Teams chat write request via ${authResult.authType}`,
       {
-        userId: authResult.userId,
+        userId,
       }
     )
 
@@ -53,6 +55,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       accessToken: validatedData.accessToken,
       requestId,
       logger,
+      userId,
     })
 
     let messageContent = validatedData.content
@@ -157,6 +160,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       },
     })
   } catch (error) {
+    if (error instanceof FileAccessDeniedError) {
+      return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
+    }
     logger.error(`[${requestId}] Error sending Teams chat message:`, error)
     return NextResponse.json(
       {

--- a/apps/sim/app/api/tools/mistral/parse/route.ts
+++ b/apps/sim/app/api/tools/mistral/parse/route.ts
@@ -14,6 +14,7 @@ import {
   downloadFileFromStorage,
   resolveInternalFileUrl,
 } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -120,6 +121,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       }
       let base64 = userFile.base64
       if (!base64) {
+        const denied = await assertToolFileAccess(userFile.key, userId, requestId, logger)
+        if (denied) return denied
         const buffer = await downloadFileFromStorage(userFile, requestId, logger)
         base64 = buffer.toString('base64')
       }

--- a/apps/sim/app/api/tools/onedrive/upload/route.ts
+++ b/apps/sim/app/api/tools/onedrive/upload/route.ts
@@ -13,6 +13,7 @@ import {
   processSingleFileToUserFile,
 } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import { normalizeExcelValues } from '@/tools/onedrive/utils'
 
 export const dynamic = 'force-dynamic'
@@ -47,7 +48,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized OneDrive upload attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -107,6 +108,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           { status: 400 }
         )
       }
+
+      const denied = await assertToolFileAccess(userFile.key, authResult.userId, requestId, logger)
+      if (denied) return denied
 
       try {
         fileBuffer = await downloadFileFromStorage(userFile, requestId, logger)

--- a/apps/sim/app/api/tools/outlook/draft/route.ts
+++ b/apps/sim/app/api/tools/outlook/draft/route.ts
@@ -7,6 +7,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -18,7 +19,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Outlook draft attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -29,8 +30,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(`[${requestId}] Authenticated Outlook draft request via ${authResult.authType}`, {
-      userId: authResult.userId,
+      userId,
     })
 
     const parsed = await parseRequest(outlookDraftContract, request, {})
@@ -98,23 +100,19 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           )
         }
 
-        const attachmentObjects = await Promise.all(
+        const accessResults = await Promise.all(
+          attachments.map((file) => assertToolFileAccess(file.key, userId, requestId, logger))
+        )
+        const denied = accessResults.find((r) => r !== null)
+        if (denied) return denied
+
+        const buffers = await Promise.all(
           attachments.map(async (file) => {
             try {
               logger.info(
                 `[${requestId}] Downloading attachment: ${file.name} (${file.size} bytes)`
               )
-
-              const buffer = await downloadFileFromStorage(file, requestId, logger)
-
-              const base64Content = buffer.toString('base64')
-
-              return {
-                '@odata.type': '#microsoft.graph.fileAttachment',
-                name: file.name,
-                contentType: file.type || 'application/octet-stream',
-                contentBytes: base64Content,
-              }
+              return await downloadFileFromStorage(file, requestId, logger)
             } catch (error) {
               logger.error(`[${requestId}] Failed to download attachment ${file.name}:`, error)
               throw new Error(
@@ -123,6 +121,13 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
             }
           })
         )
+
+        const attachmentObjects = attachments.map((file, i) => ({
+          '@odata.type': '#microsoft.graph.fileAttachment',
+          name: file.name,
+          contentType: file.type || 'application/octet-stream',
+          contentBytes: buffers[i].toString('base64'),
+        }))
 
         logger.info(`[${requestId}] Converted ${attachmentObjects.length} attachments to base64`)
         message.attachments = attachmentObjects

--- a/apps/sim/app/api/tools/outlook/send/route.ts
+++ b/apps/sim/app/api/tools/outlook/send/route.ts
@@ -7,6 +7,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -18,7 +19,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Outlook send attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -29,8 +30,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(`[${requestId}] Authenticated Outlook send request via ${authResult.authType}`, {
-      userId: authResult.userId,
+      userId,
     })
 
     const parsed = await parseRequest(outlookSendContract, request, {})
@@ -98,23 +100,19 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           )
         }
 
-        const attachmentObjects = await Promise.all(
+        const accessResults = await Promise.all(
+          attachments.map((file) => assertToolFileAccess(file.key, userId, requestId, logger))
+        )
+        const denied = accessResults.find((r) => r !== null)
+        if (denied) return denied
+
+        const buffers = await Promise.all(
           attachments.map(async (file) => {
             try {
               logger.info(
                 `[${requestId}] Downloading attachment: ${file.name} (${file.size} bytes)`
               )
-
-              const buffer = await downloadFileFromStorage(file, requestId, logger)
-
-              const base64Content = buffer.toString('base64')
-
-              return {
-                '@odata.type': '#microsoft.graph.fileAttachment',
-                name: file.name,
-                contentType: file.type || 'application/octet-stream',
-                contentBytes: base64Content,
-              }
+              return await downloadFileFromStorage(file, requestId, logger)
             } catch (error) {
               logger.error(`[${requestId}] Failed to download attachment ${file.name}:`, error)
               throw new Error(
@@ -123,6 +121,13 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
             }
           })
         )
+
+        const attachmentObjects = attachments.map((file, i) => ({
+          '@odata.type': '#microsoft.graph.fileAttachment',
+          name: file.name,
+          contentType: file.type || 'application/octet-stream',
+          contentBytes: buffers[i].toString('base64'),
+        }))
 
         logger.info(`[${requestId}] Converted ${attachmentObjects.length} attachments to base64`)
         message.attachments = attachmentObjects

--- a/apps/sim/app/api/tools/quiver/image-to-svg/route.ts
+++ b/apps/sim/app/api/tools/quiver/image-to-svg/route.ts
@@ -8,6 +8,7 @@ import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import type { RawFileInput } from '@/lib/uploads/utils/file-schemas'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 const logger = createLogger('QuiverImageToSvgAPI')
 
@@ -15,7 +16,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   const requestId = generateRequestId()
 
   const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
-  if (!authResult.success) {
+  if (!authResult.success || !authResult.userId) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -47,6 +48,13 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         if (parsed && typeof parsed === 'object') {
           const userFiles = processFilesToUserFiles([parsed as RawFileInput], requestId, logger)
           if (userFiles.length > 0) {
+            const denied = await assertToolFileAccess(
+              userFiles[0].key,
+              authResult.userId,
+              requestId,
+              logger
+            )
+            if (denied) return denied
             const buffer = await downloadFileFromStorage(userFiles[0], requestId, logger)
             apiImage = { base64: buffer.toString('base64') }
           } else {
@@ -64,6 +72,13 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     } else if (typeof data.image === 'object' && data.image !== null) {
       const userFiles = processFilesToUserFiles([data.image as RawFileInput], requestId, logger)
       if (userFiles.length > 0) {
+        const denied = await assertToolFileAccess(
+          userFiles[0].key,
+          authResult.userId,
+          requestId,
+          logger
+        )
+        if (denied) return denied
         const buffer = await downloadFileFromStorage(userFiles[0], requestId, logger)
         apiImage = { base64: buffer.toString('base64') }
       } else {

--- a/apps/sim/app/api/tools/quiver/text-to-svg/route.ts
+++ b/apps/sim/app/api/tools/quiver/text-to-svg/route.ts
@@ -8,6 +8,7 @@ import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import type { RawFileInput } from '@/lib/uploads/utils/file-schemas'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 const logger = createLogger('QuiverTextToSvgAPI')
 
@@ -15,9 +16,10 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   const requestId = generateRequestId()
 
   const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
-  if (!authResult.success) {
+  if (!authResult.success || !authResult.userId) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
   }
+  const userId = authResult.userId
 
   try {
     const parsed = await parseRequest(
@@ -51,6 +53,13 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
             if (parsed && typeof parsed === 'object') {
               const userFiles = processFilesToUserFiles([parsed as RawFileInput], requestId, logger)
               if (userFiles.length > 0) {
+                const denied = await assertToolFileAccess(
+                  userFiles[0].key,
+                  userId,
+                  requestId,
+                  logger
+                )
+                if (denied) return denied
                 const buffer = await downloadFileFromStorage(userFiles[0], requestId, logger)
                 apiReferences.push({ base64: buffer.toString('base64') })
               }
@@ -61,6 +70,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         } else if (typeof ref === 'object' && ref !== null) {
           const userFiles = processFilesToUserFiles([ref as RawFileInput], requestId, logger)
           if (userFiles.length > 0) {
+            const denied = await assertToolFileAccess(userFiles[0].key, userId, requestId, logger)
+            if (denied) return denied
             const buffer = await downloadFileFromStorage(userFiles[0], requestId, logger)
             apiReferences.push({ base64: buffer.toString('base64') })
           }

--- a/apps/sim/app/api/tools/s3/put-object/route.ts
+++ b/apps/sim/app/api/tools/s3/put-object/route.ts
@@ -8,6 +8,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processSingleFileToUserFile } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,7 +20,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized S3 put object attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -75,6 +76,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           { status: 400 }
         )
       }
+
+      const denied = await assertToolFileAccess(userFile.key, authResult.userId, requestId, logger)
+      if (denied) return denied
 
       const buffer = await downloadFileFromStorage(userFile, requestId, logger)
 

--- a/apps/sim/app/api/tools/sap_concur/upload/route.ts
+++ b/apps/sim/app/api/tools/sap_concur/upload/route.ts
@@ -8,6 +8,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles, type RawFileInput } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import {
   assertSafeExternalUrl,
   extractSapConcurError,
@@ -180,13 +181,14 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Concur upload request: ${authResult.error}`)
       return NextResponse.json(
         { success: false, error: authResult.error || 'Authentication required' },
         { status: 401 }
       )
     }
+    const userId = authResult.userId
 
     // boundary-raw-json: internal upload envelope validated by SapConcurUploadRequestSchema below; not a public boundary
     const json = await request.json()
@@ -204,6 +206,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
     const userFile = userFiles[0]
+    const denied = await assertToolFileAccess(userFile.key, userId, requestId, logger)
+    if (denied) return denied
     const fileBuffer = await downloadFileFromStorage(userFile, requestId, logger)
     const fileName = userFile.name
     const mimeType = inferMimeType(fileName, userFile.type)

--- a/apps/sim/app/api/tools/sendgrid/send-mail/route.ts
+++ b/apps/sim/app/api/tools/sendgrid/send-mail/route.ts
@@ -7,6 +7,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -18,7 +19,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized SendGrid send attempt: ${authResult.error}`)
       return NextResponse.json(
         { success: false, error: authResult.error || 'Authentication required' },
@@ -26,6 +27,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(`[${requestId}] Authenticated SendGrid send request via ${authResult.authType}`)
 
     const parsed = await parseRequest(sendGridSendMailContract, request, {})
@@ -97,20 +99,19 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       const userFiles = processFilesToUserFiles(rawAttachments, requestId, logger)
 
       if (userFiles.length > 0) {
-        const sendGridAttachments = await Promise.all(
+        const accessResults = await Promise.all(
+          userFiles.map((file) => assertToolFileAccess(file.key, userId, requestId, logger))
+        )
+        const denied = accessResults.find((r) => r !== null)
+        if (denied) return denied
+
+        const buffers = await Promise.all(
           userFiles.map(async (file) => {
             try {
               logger.info(
                 `[${requestId}] Downloading attachment: ${file.name} (${file.size} bytes)`
               )
-              const buffer = await downloadFileFromStorage(file, requestId, logger)
-
-              return {
-                content: buffer.toString('base64'),
-                filename: file.name,
-                type: file.type || 'application/octet-stream',
-                disposition: 'attachment',
-              }
+              return await downloadFileFromStorage(file, requestId, logger)
             } catch (error) {
               logger.error(`[${requestId}] Failed to download attachment ${file.name}:`, error)
               throw new Error(
@@ -119,6 +120,13 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
             }
           })
         )
+
+        const sendGridAttachments = userFiles.map((file, i) => ({
+          content: buffers[i].toString('base64'),
+          filename: file.name,
+          type: file.type || 'application/octet-stream',
+          disposition: 'attachment',
+        }))
 
         mailBody.attachments = sendGridAttachments
       }

--- a/apps/sim/app/api/tools/sftp/upload/route.ts
+++ b/apps/sim/app/api/tools/sftp/upload/route.ts
@@ -27,7 +27,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized SFTP upload attempt: ${authResult.error}`)
       return NextResponse.json(
         { success: false, error: authResult.error || 'Authentication required' },

--- a/apps/sim/app/api/tools/sharepoint/site/route.ts
+++ b/apps/sim/app/api/tools/sharepoint/site/route.ts
@@ -1,15 +1,12 @@
-import { db } from '@sim/db'
-import { account } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
-import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { sharepointSiteQuerySchema } from '@/lib/api/contracts/selectors/sharepoint'
 import { getValidationErrorMessage } from '@/lib/api/server'
-import { getSession } from '@/lib/auth'
+import { authorizeCredentialUse } from '@/lib/auth/credential-access'
 import { validateMicrosoftGraphId } from '@/lib/core/security/input-validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { refreshAccessTokenIfNeeded, resolveOAuthAccountId } from '@/app/api/auth/oauth/utils'
+import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,11 +16,6 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const requestId = generateId().slice(0, 8)
 
   try {
-    const session = await getSession()
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
-    }
-
     const { searchParams } = new URL(request.url)
     const validation = sharepointSiteQuerySchema.safeParse({
       credentialId: searchParams.get('credentialId') ?? '',
@@ -42,37 +34,14 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       return NextResponse.json({ error: siteIdValidation.error }, { status: 400 })
     }
 
-    const resolved = await resolveOAuthAccountId(credentialId)
-    if (!resolved) {
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
+    const authz = await authorizeCredentialUse(request, { credentialId })
+    if (!authz.ok || !authz.credentialOwnerUserId || !authz.resolvedCredentialId) {
+      return NextResponse.json({ error: authz.error || 'Unauthorized' }, { status: 403 })
     }
-
-    if (resolved.workspaceId) {
-      const { getUserEntityPermissions } = await import('@/lib/workspaces/permissions/utils')
-      const perm = await getUserEntityPermissions(
-        session.user.id,
-        'workspace',
-        resolved.workspaceId
-      )
-      if (perm === null) {
-        return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-      }
-    }
-
-    const credentials = await db
-      .select()
-      .from(account)
-      .where(eq(account.id, resolved.accountId))
-      .limit(1)
-    if (!credentials.length) {
-      return NextResponse.json({ error: 'Credential not found' }, { status: 404 })
-    }
-
-    const accountRow = credentials[0]
 
     const accessToken = await refreshAccessTokenIfNeeded(
-      resolved.accountId,
-      accountRow.userId,
+      authz.resolvedCredentialId,
+      authz.credentialOwnerUserId,
       requestId
     )
     if (!accessToken) {

--- a/apps/sim/app/api/tools/sharepoint/upload/route.ts
+++ b/apps/sim/app/api/tools/sharepoint/upload/route.ts
@@ -24,7 +24,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized SharePoint upload attempt: ${authResult.error}`)
       return NextResponse.json(
         {

--- a/apps/sim/app/api/tools/slack/send-message/route.ts
+++ b/apps/sim/app/api/tools/slack/send-message/route.ts
@@ -5,7 +5,8 @@ import { parseRequest } from '@/lib/api/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { sendSlackMessage } from '../utils'
+import { FileAccessDeniedError } from '@/app/api/files/authorization'
+import { sendSlackMessage } from '@/app/api/tools/slack/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,7 +18,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Slack send attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -28,8 +29,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(`[${requestId}] Authenticated Slack send request via ${authResult.authType}`, {
-      userId: authResult.userId,
+      userId,
     })
 
     const parsed = await parseRequest(slackSendMessageContract, request, {})
@@ -50,6 +52,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         accessToken: validatedData.accessToken,
         channel: validatedData.channel ?? undefined,
         userId: validatedData.userId ?? undefined,
+        ownerUserId: userId,
         text: validatedData.text,
         threadTs: validatedData.thread_ts ?? undefined,
         blocks: validatedData.blocks ?? undefined,
@@ -65,6 +68,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
     return NextResponse.json({ success: true, output: result.output })
   } catch (error) {
+    if (error instanceof FileAccessDeniedError) {
+      return NextResponse.json({ success: false, error: 'File not found' }, { status: 404 })
+    }
     logger.error(`[${requestId}] Error sending Slack message:`, error)
     return NextResponse.json(
       {

--- a/apps/sim/app/api/tools/slack/utils.ts
+++ b/apps/sim/app/api/tools/slack/utils.ts
@@ -2,6 +2,7 @@ import type { Logger } from '@sim/logger'
 import { secureFetchWithValidation } from '@/lib/core/security/input-validation.server'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { FileAccessDeniedError, verifyFileAccess } from '@/app/api/files/authorization'
 import type { ToolFileData } from '@/tools/types'
 
 /**
@@ -73,7 +74,8 @@ async function uploadFilesToSlack(
   files: any[],
   accessToken: string,
   requestId: string,
-  logger: Logger
+  logger: Logger,
+  ownerUserId: string
 ): Promise<{ fileIds: string[]; files: ToolFileData[] }> {
   const userFiles = processFilesToUserFiles(files, requestId, logger)
   const uploadedFileIds: string[] = []
@@ -81,6 +83,11 @@ async function uploadFilesToSlack(
 
   for (const userFile of userFiles) {
     logger.info(`[${requestId}] Uploading file: ${userFile.name}`)
+
+    const hasAccess = await verifyFileAccess(userFile.key, ownerUserId)
+    if (!hasAccess) {
+      throw new FileAccessDeniedError()
+    }
 
     const buffer = await downloadFileFromStorage(userFile, requestId, logger)
 
@@ -224,6 +231,7 @@ export interface SlackMessageParams {
   accessToken: string
   channel?: string
   userId?: string
+  ownerUserId: string
   text: string
   threadTs?: string | null
   blocks?: unknown[] | null
@@ -249,7 +257,7 @@ export async function sendSlackMessage(
   }
   error?: string
 }> {
-  const { accessToken, text, threadTs, blocks, files } = params
+  const { accessToken, text, threadTs, blocks, files, ownerUserId } = params
   let { channel } = params
 
   if (!channel && params.userId) {
@@ -282,7 +290,8 @@ export async function sendSlackMessage(
     files,
     accessToken,
     requestId,
-    logger
+    logger,
+    ownerUserId
   )
 
   // No valid files uploaded - send text-only

--- a/apps/sim/app/api/tools/slack/utils.ts
+++ b/apps/sim/app/api/tools/slack/utils.ts
@@ -141,7 +141,8 @@ async function completeSlackFileUpload(
   channel: string,
   text: string,
   accessToken: string,
-  threadTs?: string | null
+  threadTs?: string | null,
+  blocks?: unknown[] | null
 ): Promise<{ ok: boolean; files?: any[]; error?: string }> {
   const response = await fetch('https://slack.com/api/files.completeUploadExternal', {
     method: 'POST',
@@ -152,7 +153,10 @@ async function completeSlackFileUpload(
     body: JSON.stringify({
       files: uploadedFileIds.map((id) => ({ id })),
       channel_id: channel,
-      initial_comment: text,
+      // Per Slack docs for files.completeUploadExternal: if `initial_comment`
+      // is provided, `blocks` is silently ignored. So when blocks are present
+      // we omit initial_comment and let blocks render instead.
+      ...(blocks && blocks.length > 0 ? { blocks } : { initial_comment: text }),
       ...(threadTs && { thread_ts: threadTs }),
     }),
   })
@@ -295,7 +299,14 @@ export async function sendSlackMessage(
   }
 
   // Complete file upload with thread support
-  const completeData = await completeSlackFileUpload(fileIds, channel, text, accessToken, threadTs)
+  const completeData = await completeSlackFileUpload(
+    fileIds,
+    channel,
+    text,
+    accessToken,
+    threadTs,
+    blocks
+  )
 
   if (!completeData.ok) {
     logger.error(`[${requestId}] Failed to complete upload:`, completeData.error)

--- a/apps/sim/app/api/tools/smtp/send/route.ts
+++ b/apps/sim/app/api/tools/smtp/send/route.ts
@@ -22,7 +22,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized SMTP send attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -33,8 +33,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
+    const userId = authResult.userId
     logger.info(`[${requestId}] Authenticated SMTP request via ${authResult.authType}`, {
-      userId: authResult.userId,
+      userId,
     })
 
     const parsed = await parseRequest(smtpSendContract, request, {})
@@ -120,25 +121,33 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           )
         }
 
-        const attachmentBuffers: { filename: string; content: Buffer; contentType: string }[] = []
-        for (const file of attachments) {
-          const denied = await assertToolFileAccess(file.key, authResult.userId, requestId, logger)
-          if (denied) return denied
-          try {
-            logger.info(`[${requestId}] Downloading attachment: ${file.name} (${file.size} bytes)`)
-            const buffer = await downloadFileFromStorage(file, requestId, logger)
-            attachmentBuffers.push({
-              filename: file.name,
-              content: buffer,
-              contentType: file.type || 'application/octet-stream',
-            })
-          } catch (error) {
-            logger.error(`[${requestId}] Failed to download attachment ${file.name}:`, error)
-            throw new Error(
-              `Failed to download attachment "${file.name}": ${error instanceof Error ? error.message : 'Unknown error'}`
-            )
-          }
-        }
+        const accessResults = await Promise.all(
+          attachments.map((file) => assertToolFileAccess(file.key, userId, requestId, logger))
+        )
+        const denied = accessResults.find((r) => r !== null)
+        if (denied) return denied
+
+        const buffers = await Promise.all(
+          attachments.map(async (file) => {
+            try {
+              logger.info(
+                `[${requestId}] Downloading attachment: ${file.name} (${file.size} bytes)`
+              )
+              return await downloadFileFromStorage(file, requestId, logger)
+            } catch (error) {
+              logger.error(`[${requestId}] Failed to download attachment ${file.name}:`, error)
+              throw new Error(
+                `Failed to download attachment "${file.name}": ${error instanceof Error ? error.message : 'Unknown error'}`
+              )
+            }
+          })
+        )
+
+        const attachmentBuffers = attachments.map((file, i) => ({
+          filename: file.name,
+          content: buffers[i],
+          contentType: file.type || 'application/octet-stream',
+        }))
 
         logger.info(`[${requestId}] Processed ${attachmentBuffers.length} attachment(s)`)
         mailOptions.attachments = attachmentBuffers

--- a/apps/sim/app/api/tools/ssh/read-file-content/route.ts
+++ b/apps/sim/app/api/tools/ssh/read-file-content/route.ts
@@ -73,9 +73,16 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
       const content = await new Promise<string>((resolve, reject) => {
         const chunks: Buffer[] = []
+        let totalBytes = 0
         const readStream = sftp.createReadStream(filePath)
 
         readStream.on('data', (chunk: Buffer) => {
+          totalBytes += chunk.length
+          if (totalBytes > maxBytes) {
+            readStream.destroy()
+            reject(new Error(`File exceeds maximum allowed size of ${params.maxSize}MB`))
+            return
+          }
           chunks.push(chunk)
         })
 

--- a/apps/sim/app/api/tools/stt/route.ts
+++ b/apps/sim/app/api/tools/stt/route.ts
@@ -17,6 +17,7 @@ import {
   downloadFileFromStorage,
   resolveInternalFileUrl,
 } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import type { TranscriptSegment } from '@/tools/stt/types'
 
 const logger = createLogger('SttProxyAPI')
@@ -31,7 +32,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
@@ -79,6 +80,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       const file = Array.isArray(body.audioFile) ? body.audioFile[0] : body.audioFile
       logger.info(`[${requestId}] Processing uploaded file: ${file.name}`)
 
+      const deniedAudio = await assertToolFileAccess(file.key, userId, requestId, logger)
+      if (deniedAudio) return deniedAudio
       audioBuffer = await downloadFileFromStorage(file, requestId, logger)
       audioFileName = file.name
       // file.type may be missing if the file came from a block that doesn't preserve it
@@ -97,6 +100,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         : body.audioFileReference
       logger.info(`[${requestId}] Processing referenced file: ${file.name}`)
 
+      const deniedRef = await assertToolFileAccess(file.key, userId, requestId, logger)
+      if (deniedRef) return deniedRef
       audioBuffer = await downloadFileFromStorage(file, requestId, logger)
       audioFileName = file.name
 

--- a/apps/sim/app/api/tools/supabase/storage-upload/route.ts
+++ b/apps/sim/app/api/tools/supabase/storage-upload/route.ts
@@ -8,6 +8,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processSingleFileToUserFile } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,7 +20,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(
         `[${requestId}] Unauthorized Supabase storage upload attempt: ${authResult.error}`
       )
@@ -143,6 +144,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         )
       }
 
+      const denied = await assertToolFileAccess(userFile.key, authResult.userId, requestId, logger)
+      if (denied) return denied
       const buffer = await downloadFileFromStorage(userFile, requestId, logger)
 
       uploadBody = buffer

--- a/apps/sim/app/api/tools/telegram/send-document/route.ts
+++ b/apps/sim/app/api/tools/telegram/send-document/route.ts
@@ -7,6 +7,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processFilesToUserFiles } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import { convertMarkdownToHTML } from '@/tools/telegram/utils'
 
 export const dynamic = 'force-dynamic'
@@ -21,7 +22,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       requireWorkflowId: false,
     })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Telegram send attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -87,6 +88,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
     const userFile = userFiles[0]
     logger.info(`[${requestId}] Uploading document: ${userFile.name}`)
+
+    const denied = await assertToolFileAccess(userFile.key, authResult.userId, requestId, logger)
+    if (denied) return denied
 
     const buffer = await downloadFileFromStorage(userFile, requestId, logger)
     const filesOutput = [

--- a/apps/sim/app/api/tools/textract/parse/route.ts
+++ b/apps/sim/app/api/tools/textract/parse/route.ts
@@ -18,6 +18,7 @@ import {
   downloadFileFromStorage,
   resolveInternalFileUrl,
 } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300 // 5 minutes for large multi-page PDF processing
@@ -428,6 +429,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         )
       }
 
+      const denied = await assertToolFileAccess(userFile.key, userId, requestId, logger)
+      if (denied) return denied
       const buffer = await downloadFileFromStorage(userFile, requestId, logger)
       bytes = buffer.toString('base64')
       contentType = userFile.type || 'application/octet-stream'

--- a/apps/sim/app/api/tools/video/route.ts
+++ b/apps/sim/app/api/tools/video/route.ts
@@ -8,6 +8,7 @@ import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { getMaxExecutionTimeout } from '@/lib/core/execution-limits'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import type { UserFile } from '@/executor/types'
 
 const logger = createLogger('VideoProxyAPI')
@@ -21,7 +22,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
@@ -99,6 +100,16 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     let height: number | undefined
     let jobId: string | undefined
     let actualDuration: number | undefined
+
+    if (body.visualReference) {
+      const denied = await assertToolFileAccess(
+        body.visualReference.key,
+        authResult.userId,
+        requestId,
+        logger
+      )
+      if (denied) return denied
+    }
 
     try {
       if (provider === 'runway') {

--- a/apps/sim/app/api/tools/vision/analyze/route.ts
+++ b/apps/sim/app/api/tools/vision/analyze/route.ts
@@ -15,6 +15,7 @@ import {
   downloadFileFromStorage,
   resolveInternalFileUrl,
 } from '@/lib/uploads/utils/file-utils.server'
+import { assertToolFileAccess } from '@/app/api/files/authorization'
 import { convertUsageMetadata, extractTextContent } from '@/providers/google/utils'
 
 export const dynamic = 'force-dynamic'
@@ -27,7 +28,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized Vision analyze attempt: ${authResult.error}`)
       return NextResponse.json(
         {
@@ -87,6 +88,13 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       let base64 = userFile.base64
       let bufferLength = 0
       if (!base64) {
+        const denied = await assertToolFileAccess(
+          userFile.key,
+          authResult.userId,
+          requestId,
+          logger
+        )
+        if (denied) return denied
         const buffer = await downloadFileFromStorage(userFile, requestId, logger)
         base64 = buffer.toString('base64')
         bufferLength = buffer.length

--- a/apps/sim/app/api/tools/wordpress/upload/route.ts
+++ b/apps/sim/app/api/tools/wordpress/upload/route.ts
@@ -25,7 +25,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   try {
     const authResult = await checkInternalAuth(request, { requireWorkflowId: false })
 
-    if (!authResult.success) {
+    if (!authResult.success || !authResult.userId) {
       logger.warn(`[${requestId}] Unauthorized WordPress upload attempt: ${authResult.error}`)
       return NextResponse.json(
         {

--- a/apps/sim/app/api/workflows/[id]/log/route.test.ts
+++ b/apps/sim/app/api/workflows/[id]/log/route.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment node
+ */
+import { authMockFns, dbChainMock, dbChainMockFns, resetDbChainMock } from '@sim/testing'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Override global db mock with the configurable chain mock
+vi.mock('@sim/db', () => dbChainMock)
+
+const { mockValidateWorkflowAccess, mockGetWorkspaceBilledAccountUserId } = vi.hoisted(() => ({
+  mockValidateWorkflowAccess: vi.fn(),
+  mockGetWorkspaceBilledAccountUserId: vi.fn(),
+}))
+
+vi.mock('@/app/api/workflows/middleware', () => ({
+  validateWorkflowAccess: mockValidateWorkflowAccess,
+}))
+
+vi.mock('@/lib/workspaces/utils', () => ({
+  getWorkspaceBilledAccountUserId: mockGetWorkspaceBilledAccountUserId,
+}))
+
+vi.mock('@/lib/logs/execution/logging-session', () => ({
+  LoggingSession: vi.fn().mockImplementation(() => ({
+    start: vi.fn().mockResolvedValue(undefined),
+    markAsFailed: vi.fn().mockResolvedValue(undefined),
+    safeCompleteWithError: vi.fn().mockResolvedValue(undefined),
+    safeComplete: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+vi.mock('@/lib/logs/execution/trace-spans/trace-spans', () => ({
+  buildTraceSpans: vi.fn().mockReturnValue([]),
+}))
+
+import { POST } from './route'
+
+const makeRequest = (workflowId: string, body: unknown) =>
+  new NextRequest(`http://localhost/api/workflows/${workflowId}/log`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+const validResult = { success: true, output: { value: 42 } }
+
+describe('POST /api/workflows/[id]/log cross-tenant guard', () => {
+  const OWNER_WORKFLOW_ID = 'wf-owner'
+  const ATTACKER_WORKFLOW_ID = 'wf-attacker'
+  const VICTIM_EXECUTION_ID = 'exec-victim-uuid'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDbChainMock()
+    authMockFns.mockGetSession.mockResolvedValue({ user: { id: 'user-1' } })
+    mockValidateWorkflowAccess.mockResolvedValue({ error: null })
+    mockGetWorkspaceBilledAccountUserId.mockResolvedValue('user-1')
+    // Default: no existing log (fresh execution)
+    dbChainMockFns.limit.mockResolvedValue([])
+  })
+
+  it('returns 404 when executionId belongs to a different workflow', async () => {
+    dbChainMockFns.limit.mockResolvedValueOnce([{ workflowId: OWNER_WORKFLOW_ID }])
+
+    const res = await POST(
+      makeRequest(ATTACKER_WORKFLOW_ID, {
+        executionId: VICTIM_EXECUTION_ID,
+        result: validResult,
+      }),
+      { params: Promise.resolve({ id: ATTACKER_WORKFLOW_ID }) }
+    )
+
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.error).toBe('Execution not found')
+  })
+
+  it('proceeds when executionId belongs to the same workflow', async () => {
+    dbChainMockFns.limit.mockResolvedValueOnce([{ workflowId: OWNER_WORKFLOW_ID }])
+
+    const res = await POST(
+      makeRequest(OWNER_WORKFLOW_ID, {
+        executionId: VICTIM_EXECUTION_ID,
+        result: validResult,
+      }),
+      { params: Promise.resolve({ id: OWNER_WORKFLOW_ID }) }
+    )
+
+    expect(res.status).not.toBe(404)
+    expect(res.status).not.toBe(403)
+  })
+
+  it('proceeds when executionId has no existing log row (fresh execution)', async () => {
+    dbChainMockFns.limit.mockResolvedValueOnce([])
+
+    const res = await POST(
+      makeRequest(OWNER_WORKFLOW_ID, {
+        executionId: 'brand-new-execution-id',
+        result: validResult,
+      }),
+      { params: Promise.resolve({ id: OWNER_WORKFLOW_ID }) }
+    )
+
+    expect(res.status).not.toBe(404)
+    expect(res.status).not.toBe(403)
+  })
+})

--- a/apps/sim/app/api/workflows/[id]/log/route.ts
+++ b/apps/sim/app/api/workflows/[id]/log/route.ts
@@ -1,4 +1,7 @@
+import { db } from '@sim/db'
+import { workflowExecutionLogs } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
+import { eq } from 'drizzle-orm'
 import type { NextRequest } from 'next/server'
 import { workflowLogContract } from '@/lib/api/contracts/workflows'
 import { parseRequest } from '@/lib/api/server'
@@ -38,6 +41,19 @@ export const POST = withRouteHandler(
         if (!executionId) {
           logger.warn(`[${requestId}] Missing executionId for result logging`)
           return createErrorResponse('executionId is required when logging results', 400)
+        }
+
+        const [existingLog] = await db
+          .select({ workflowId: workflowExecutionLogs.workflowId })
+          .from(workflowExecutionLogs)
+          .where(eq(workflowExecutionLogs.executionId, executionId))
+          .limit(1)
+
+        if (existingLog && existingLog.workflowId !== id) {
+          logger.warn(
+            `[${requestId}] executionId ${executionId} belongs to workflow ${existingLog.workflowId}, not ${id}`
+          )
+          return createErrorResponse('Execution not found', 404)
         }
 
         logger.info(`[${requestId}] Persisting execution result for workflow: ${id}`, {

--- a/apps/sim/app/robots.ts
+++ b/apps/sim/app/robots.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from 'next'
-import { getBaseUrl } from '@/lib/core/utils/urls'
+import { SITE_URL } from '@/lib/core/utils/urls'
 
 const DISALLOWED_PATHS = [
   '/api/',
@@ -45,8 +45,6 @@ const LINK_PREVIEW_BOTS = [
 ]
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = getBaseUrl()
-
   return {
     rules: [
       { userAgent: '*', allow: '/', disallow: DISALLOWED_PATHS },
@@ -56,6 +54,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: LINK_PREVIEW_DISALLOWED_PATHS,
       },
     ],
-    sitemap: [`${baseUrl}/sitemap.xml`, `${baseUrl}/blog/sitemap-images.xml`],
+    sitemap: [`${SITE_URL}/sitemap.xml`, `${SITE_URL}/blog/sitemap-images.xml`],
   }
 }

--- a/apps/sim/app/sitemap.ts
+++ b/apps/sim/app/sitemap.ts
@@ -1,12 +1,12 @@
 import type { MetadataRoute } from 'next'
 import { COURSES } from '@/lib/academy/content'
 import { getAllPostMeta } from '@/lib/blog/registry'
-import { getBaseUrl } from '@/lib/core/utils/urls'
+import { SITE_URL } from '@/lib/core/utils/urls'
 import integrations from '@/app/(landing)/integrations/data/integrations.json'
 import { ALL_CATALOG_MODELS, MODEL_PROVIDERS_WITH_CATALOGS } from '@/app/(landing)/models/utils'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = getBaseUrl()
+  const baseUrl = SITE_URL
   const posts = await getAllPostMeta()
 
   const latestPostDate =
@@ -45,6 +45,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
     {
       url: `${baseUrl}/partners`,
+    },
+    {
+      url: `${baseUrl}/contact`,
     },
     {
       url: `${baseUrl}/terms`,

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options-bar/resource-options-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options-bar/resource-options-bar.tsx
@@ -98,7 +98,7 @@ export const ResourceOptionsBar = memo(function ResourceOptionsBar({
             <Button
               key={tag.label}
               variant='subtle'
-              className='max-w-[200px] px-2 py-1 text-caption'
+              className='max-w-[280px] px-2 py-1 text-caption'
               onClick={tag.onRemove}
             >
               <span className='truncate'>{tag.label}</span>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-tabs/resource-tabs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-tabs/resource-tabs.tsx
@@ -178,64 +178,57 @@ const ResourceTabItem = memo(function ResourceTabItem({
       {showGapBefore && (
         <div className='-translate-x-1/2 -translate-y-1/2 pointer-events-none absolute top-1/2 left-0 z-10 h-[16px] w-[2px] rounded-full bg-[var(--text-subtle)]' />
       )}
-      <Tooltip.Root>
-        <Tooltip.Trigger asChild>
-          <Button
-            variant='subtle'
-            draggable
-            data-resource-tab-id={resource.id}
-            onDragStart={(e) => onDragStart(e, idx)}
-            onDragOver={(e) => onDragOver(e, idx)}
-            onDragLeave={onDragLeave}
-            onDragEnd={onDragEnd}
-            onMouseDown={(e) => {
-              if (e.button === 1) {
-                e.preventDefault()
-                if (chatId) onRemove(e, resource)
-              }
+      <Button
+        variant='subtle'
+        draggable
+        data-resource-tab-id={resource.id}
+        onDragStart={(e) => onDragStart(e, idx)}
+        onDragOver={(e) => onDragOver(e, idx)}
+        onDragLeave={onDragLeave}
+        onDragEnd={onDragEnd}
+        onMouseDown={(e) => {
+          if (e.button === 1) {
+            e.preventDefault()
+            if (chatId) onRemove(e, resource)
+          }
+        }}
+        onClick={(e) => onTabClick(e, idx)}
+        onMouseEnter={() => setHoveredTabId(resource.id)}
+        onMouseLeave={() => setHoveredTabId(null)}
+        className={cn(
+          'group relative shrink-0 bg-transparent px-2 py-[3px] pr-[22px] text-caption transition-colors duration-150',
+          isActive && 'bg-[var(--surface-4)]',
+          isSelected && !isActive && 'bg-[var(--surface-3)]',
+          isDragging && 'opacity-30'
+        )}
+      >
+        {config.renderTabIcon(resource, 'mr-1.5 h-[14px] w-[14px]')}
+        {displayName}
+        {(isHovered || isActive) && chatId && (
+          <span
+            role='button'
+            tabIndex={-1}
+            onClick={(e) => onRemove(e, resource)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') onRemove(e, resource)
             }}
-            onClick={(e) => onTabClick(e, idx)}
-            onMouseEnter={() => setHoveredTabId(resource.id)}
-            onMouseLeave={() => setHoveredTabId(null)}
-            className={cn(
-              'group relative shrink-0 bg-transparent px-2 py-1 pr-[22px] text-caption transition-opacity duration-150',
-              isActive && 'bg-[var(--surface-4)]',
-              isSelected && !isActive && 'bg-[var(--surface-3)]',
-              isDragging && 'opacity-30'
-            )}
+            className='-translate-y-1/2 absolute top-1/2 right-[4px] flex items-center justify-center rounded-sm p-[1px] hover-hover:bg-[var(--surface-5)]'
+            aria-label={`Close ${displayName}`}
           >
-            {config.renderTabIcon(resource, 'mr-1.5 h-[14px] w-[14px]')}
-            {displayName}
-            {(isHovered || isActive) && chatId && (
-              <span
-                role='button'
-                tabIndex={-1}
-                onClick={(e) => onRemove(e, resource)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') onRemove(e, resource)
-                }}
-                className='-translate-y-1/2 absolute top-1/2 right-[4px] flex items-center justify-center rounded-sm p-[1px] hover-hover:bg-[var(--surface-5)]'
-                aria-label={`Close ${displayName}`}
-              >
-                <svg
-                  className='size-[10px] text-[var(--text-icon)]'
-                  viewBox='0 0 24 24'
-                  fill='none'
-                  stroke='currentColor'
-                  strokeWidth='2.5'
-                  strokeLinecap='round'
-                  strokeLinejoin='round'
-                >
-                  <path d='M18 6 6 18M6 6l12 12' />
-                </svg>
-              </span>
-            )}
-          </Button>
-        </Tooltip.Trigger>
-        <Tooltip.Content side='bottom'>
-          <p>{displayName}</p>
-        </Tooltip.Content>
-      </Tooltip.Root>
+            <svg
+              className='size-[10px] text-[var(--text-icon)]'
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+              strokeWidth='2.5'
+              strokeLinecap='round'
+              strokeLinejoin='round'
+            >
+              <path d='M18 6 6 18M6 6l12 12' />
+            </svg>
+          </span>
+        )}
+      </Button>
       {showGapAfter && (
         <div className='-translate-y-1/2 pointer-events-none absolute top-1/2 right-0 z-10 h-[16px] w-[2px] translate-x-1/2 rounded-full bg-[var(--text-subtle)]' />
       )}

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/logs-toolbar/logs-toolbar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/logs-toolbar/logs-toolbar.tsx
@@ -21,7 +21,11 @@ import { hasActiveFilters } from '@/lib/logs/filters'
 import { getTriggerOptions } from '@/lib/logs/get-trigger-options'
 import { captureEvent } from '@/lib/posthog/client'
 import { workflowBorderColor } from '@/lib/workspaces/colors'
-import { type LogStatus, STATUS_CONFIG } from '@/app/workspace/[workspaceId]/logs/utils'
+import {
+  formatDateShort,
+  type LogStatus,
+  STATUS_CONFIG,
+} from '@/app/workspace/[workspaceId]/logs/utils'
 import { getBlock } from '@/blocks/registry'
 import { useFolderMap } from '@/hooks/queries/folders'
 import { useWorkflows } from '@/hooks/queries/workflows'
@@ -42,28 +46,6 @@ const TIME_RANGE_OPTIONS: ComboboxOption[] = [
   { value: 'Past 30 days', label: 'Past 30 days' },
   { value: 'Custom range', label: 'Custom range' },
 ] as const
-
-/**
- * Formats a date string (YYYY-MM-DD) for display.
- */
-function formatDateShort(dateStr: string): string {
-  const date = new Date(dateStr)
-  const months = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
-  ]
-  return `${months[date.getMonth()]} ${date.getDate()}`
-}
 
 type ViewMode = 'logs' | 'dashboard'
 
@@ -794,11 +776,13 @@ export const LogsToolbar = memo(function LogsToolbar({
                 }
                 size='sm'
                 align='end'
-                className='h-[32px] w-[120px] rounded-md'
+                className='h-[32px] w-[160px] rounded-md'
+                maxHeight={320}
               />
               <DatePicker
                 mode='range'
                 showTrigger={false}
+                showTime
                 open={datePickerOpen}
                 onOpenChange={(isOpen) => {
                   if (!isOpen) {

--- a/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
@@ -91,6 +91,7 @@ import {
   DELETED_WORKFLOW_LABEL,
   extractRetryInput,
   formatDate,
+  formatDateShort,
   getDisplayStatus,
   type LogStatus,
   parseDuration,
@@ -203,25 +204,6 @@ function getTriggerIcon(
 
 function SpinningRefreshCw(props: React.SVGProps<SVGSVGElement>) {
   return <RefreshCw {...props} animate />
-}
-
-function formatDateShort(dateStr: string): string {
-  const date = new Date(dateStr)
-  const months = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
-  ]
-  return `${months[date.getMonth()]} ${date.getDate()}`
 }
 
 /**
@@ -866,7 +848,7 @@ export default function Logs() {
       tags.push({
         label:
           timeRange === 'Custom range' && startDate && endDate
-            ? `${startDate} – ${endDate}`
+            ? `${formatDateShort(startDate)} – ${formatDateShort(endDate)}`
             : timeRange,
         onRemove: () => {
           clearDateRange()
@@ -1519,10 +1501,12 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
             }
             size='sm'
             className='h-[32px] w-full rounded-md'
+            maxHeight={320}
           />
           <DatePicker
             mode='range'
             showTrigger={false}
+            showTime
             open={datePickerOpen}
             onOpenChange={(isOpen) => {
               if (!isOpen) {

--- a/apps/sim/app/workspace/[workspaceId]/logs/utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/logs/utils.ts
@@ -179,6 +179,31 @@ export function formatLatency(ms: number): string {
   return formatDuration(ms, { precision: 2 }) ?? '—'
 }
 
+export function formatDateShort(dateStr: string): string {
+  const hasTime = dateStr.includes('T')
+  const [datePart, timePart] = dateStr.split('T')
+  const [, month, day] = datePart.split('-').map(Number)
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ]
+  const dateLabel = `${months[month - 1]} ${day}`
+  if (hasTime && timePart) {
+    return `${dateLabel} ${timePart.slice(0, 5)}`
+  }
+  return dateLabel
+}
+
 export const formatDate = (dateString: string) => {
   const date = new Date(dateString)
   return {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -416,6 +416,18 @@ function createToolIcon(
  * - Allows drag-and-drop reordering of selected tools
  * - Supports tool usage control (auto/force/none) for compatible LLM providers
  */
+
+function IconComponent({
+  icon: Icon,
+  className,
+}: {
+  icon?: React.ComponentType<{ className?: string }>
+  className?: string
+}) {
+  if (!Icon) return null
+  return <Icon className={className} />
+}
+
 export const ToolInput = memo(function ToolInput({
   blockId,
   subBlockId,
@@ -1069,17 +1081,6 @@ export const ToolInput = memo(function ToolInput({
     setStoreValue(newTools)
     setDraggedIndex(null)
     setDragOverIndex(null)
-  }
-
-  const IconComponent = ({
-    icon: Icon,
-    className,
-  }: {
-    icon?: React.ComponentType<{ className?: string }>
-    className?: string
-  }) => {
-    if (!Icon) return null
-    return <Icon className={className} />
   }
 
   const evaluateParameterCondition = (param: ToolParameterConfig, tool: StoredTool): boolean => {

--- a/apps/sim/blocks/blocks/cloudwatch.ts
+++ b/apps/sim/blocks/blocks/cloudwatch.ts
@@ -8,8 +8,10 @@ import type {
   CloudWatchGetLogEventsResponse,
   CloudWatchGetMetricStatisticsResponse,
   CloudWatchListMetricsResponse,
+  CloudWatchMuteAlarmResponse,
   CloudWatchPutMetricDataResponse,
   CloudWatchQueryLogsResponse,
+  CloudWatchUnmuteAlarmResponse,
 } from '@/tools/cloudwatch/types'
 
 export const CloudWatchBlock: BlockConfig<
@@ -21,6 +23,8 @@ export const CloudWatchBlock: BlockConfig<
   | CloudWatchListMetricsResponse
   | CloudWatchGetMetricStatisticsResponse
   | CloudWatchPutMetricDataResponse
+  | CloudWatchMuteAlarmResponse
+  | CloudWatchUnmuteAlarmResponse
 > = {
   type: 'cloudwatch',
   name: 'CloudWatch',
@@ -47,6 +51,8 @@ export const CloudWatchBlock: BlockConfig<
         { label: 'Get Metric Statistics', id: 'get_metric_statistics' },
         { label: 'Publish Metric', id: 'put_metric_data' },
         { label: 'Describe Alarms', id: 'describe_alarms' },
+        { label: 'Mute Alarm', id: 'mute_alarm' },
+        { label: 'Unmute Alarm', id: 'unmute_alarm' },
       ],
       value: () => 'query_logs',
     },
@@ -361,6 +367,14 @@ Return ONLY the numeric timestamp - no explanations, no quotes, no extra text.`,
       condition: { field: 'operation', value: 'describe_alarms' },
     },
     {
+      id: 'alarmNames',
+      title: 'Alarm Names',
+      type: 'short-input',
+      placeholder: 'my-alarm-1, my-alarm-2',
+      condition: { field: 'operation', value: ['mute_alarm', 'unmute_alarm'] },
+      required: { field: 'operation', value: ['mute_alarm', 'unmute_alarm'] },
+    },
+    {
       id: 'limit',
       title: 'Limit',
       type: 'short-input',
@@ -389,6 +403,8 @@ Return ONLY the numeric timestamp - no explanations, no quotes, no extra text.`,
       'cloudwatch_get_metric_statistics',
       'cloudwatch_put_metric_data',
       'cloudwatch_describe_alarms',
+      'cloudwatch_mute_alarm',
+      'cloudwatch_unmute_alarm',
     ],
     config: {
       tool: (params) => {
@@ -409,6 +425,10 @@ Return ONLY the numeric timestamp - no explanations, no quotes, no extra text.`,
             return 'cloudwatch_put_metric_data'
           case 'describe_alarms':
             return 'cloudwatch_describe_alarms'
+          case 'mute_alarm':
+            return 'cloudwatch_mute_alarm'
+          case 'unmute_alarm':
+            return 'cloudwatch_unmute_alarm'
           default:
             throw new Error(`Invalid CloudWatch operation: ${params.operation}`)
         }
@@ -613,6 +633,33 @@ Return ONLY the numeric timestamp - no explanations, no quotes, no extra text.`,
               ...(parsedLimit !== undefined && { limit: parsedLimit }),
             }
 
+          case 'mute_alarm':
+          case 'unmute_alarm': {
+            const alarmNames = rest.alarmNames
+            if (!alarmNames) {
+              throw new Error('Alarm names are required')
+            }
+
+            const names =
+              typeof alarmNames === 'string'
+                ? alarmNames
+                    .split(',')
+                    .map((n: string) => n.trim())
+                    .filter(Boolean)
+                : alarmNames
+
+            if (!Array.isArray(names) || names.length === 0) {
+              throw new Error('At least one alarm name is required')
+            }
+
+            return {
+              awsRegion,
+              awsAccessKeyId,
+              awsSecretAccessKey,
+              alarmNames: names,
+            }
+          }
+
           default:
             throw new Error(`Invalid CloudWatch operation: ${operation}`)
         }
@@ -653,6 +700,7 @@ Return ONLY the numeric timestamp - no explanations, no quotes, no extra text.`,
       description: 'Alarm state filter (OK, ALARM, INSUFFICIENT_DATA)',
     },
     alarmType: { type: 'string', description: 'Alarm type filter (MetricAlarm, CompositeAlarm)' },
+    alarmNames: { type: 'string', description: 'Comma-separated alarm names to mute or unmute' },
     limit: { type: 'number', description: 'Maximum number of results' },
   },
   outputs: {
@@ -696,9 +744,13 @@ Return ONLY the numeric timestamp - no explanations, no quotes, no extra text.`,
       type: 'array',
       description: 'CloudWatch alarms with state and configuration',
     },
+    alarmNames: {
+      type: 'array',
+      description: 'Names of the alarms that were muted or unmuted',
+    },
     success: {
       type: 'boolean',
-      description: 'Whether the published metric was successful',
+      description: 'Whether the operation completed successfully',
     },
     namespace: {
       type: 'string',

--- a/apps/sim/components/emcn/components/date-picker/date-picker.tsx
+++ b/apps/sim/components/emcn/components/date-picker/date-picker.tsx
@@ -33,6 +33,7 @@ import {
   PopoverAnchor,
   PopoverContent,
 } from '@/components/emcn/components/popover/popover'
+import { TimePicker } from '@/components/emcn/components/time-picker/time-picker'
 import { cn } from '@/lib/core/utils/cn'
 
 /**
@@ -96,22 +97,26 @@ interface DatePickerSingleProps extends DatePickerBaseProps {
   onCancel?: never
   /** Not used in single mode */
   onClear?: never
+  /** Not used in single mode */
+  showTime?: never
 }
 
 /** Props for range date mode */
 interface DatePickerRangeProps extends DatePickerBaseProps {
   /** Selection mode */
   mode: 'range'
-  /** Start date for range mode (YYYY-MM-DD string or Date) */
+  /** Start date for range mode (YYYY-MM-DD or YYYY-MM-DDTHH:mm string or Date) */
   startDate?: string | Date
-  /** End date for range mode (YYYY-MM-DD string or Date) */
+  /** End date for range mode (YYYY-MM-DD or YYYY-MM-DDTHH:mm string or Date) */
   endDate?: string | Date
-  /** Callback when date range is applied */
+  /** Callback when date range is applied — returns YYYY-MM-DD or YYYY-MM-DDTHH:mm depending on showTime */
   onRangeChange?: (startDate: string, endDate: string) => void
   /** Callback when range selection is cancelled */
   onCancel?: () => void
   /** Callback when range is cleared */
   onClear?: () => void
+  /** Whether to show time inputs for precise range selection */
+  showTime?: boolean
   /** Not used in range mode */
   value?: never
   /** Not used in range mode */
@@ -503,6 +508,7 @@ const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>((props, ref
     onRangeChange: _onRangeChange,
     onCancel: _onCancel,
     onClear: _onClear,
+    showTime = false,
     ...htmlProps
   } = rest as any
 
@@ -530,6 +536,8 @@ const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>((props, ref
   const [rangeEnd, setRangeEnd] = React.useState<Date | null>(initialEnd)
   const [hoverDate, setHoverDate] = React.useState<Date | null>(null)
   const [selectingEnd, setSelectingEnd] = React.useState(false)
+  const [startTime, setStartTime] = React.useState('00:00')
+  const [endTime, setEndTime] = React.useState('23:59')
 
   const [viewMonth, setViewMonth] = React.useState(() => {
     const d = selectedDate || initialStart || new Date()
@@ -548,6 +556,12 @@ const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>((props, ref
       setRangeStart(initialStart)
       setRangeEnd(initialEnd)
       setSelectingEnd(false)
+      if (showTime) {
+        const sd = isRangeMode ? props.startDate : undefined
+        const ed = isRangeMode ? props.endDate : undefined
+        setStartTime(typeof sd === 'string' && sd.includes('T') ? sd.slice(11, 16) : '00:00')
+        setEndTime(typeof ed === 'string' && ed.includes('T') ? ed.slice(11, 16) : '23:59')
+      }
       if (initialStart) {
         setViewMonth(initialStart.getMonth())
         setViewYear(initialStart.getFullYear())
@@ -557,7 +571,7 @@ const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>((props, ref
         setViewYear(now.getFullYear())
       }
     }
-  }, [open, isRangeMode, initialStart, initialEnd])
+  }, [open, isRangeMode, initialStart, initialEnd, showTime, props.startDate, props.endDate])
 
   const singleValueKey = !isRangeMode && selectedDate ? selectedDate.getTime() : undefined
   const [prevSingleValueKey, setPrevSingleValueKey] = React.useState(singleValueKey)
@@ -661,13 +675,32 @@ const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>((props, ref
     if (isRangeMode && props.onRangeChange && rangeStart) {
       const start = rangeEnd && rangeEnd < rangeStart ? rangeEnd : rangeStart
       const end = rangeEnd && rangeEnd < rangeStart ? rangeStart : rangeEnd || rangeStart
+      const startStr = formatDateAsString(start.getFullYear(), start.getMonth(), start.getDate())
+      const endStr = formatDateAsString(end.getFullYear(), end.getMonth(), end.getDate())
+
+      let effectiveStartTime = startTime
+      let effectiveEndTime = endTime
+      if (showTime && startStr === endStr && startTime > endTime) {
+        effectiveStartTime = endTime
+        effectiveEndTime = startTime
+      }
+
       props.onRangeChange(
-        formatDateAsString(start.getFullYear(), start.getMonth(), start.getDate()),
-        formatDateAsString(end.getFullYear(), end.getMonth(), end.getDate())
+        showTime ? `${startStr}T${effectiveStartTime}` : startStr,
+        showTime ? `${endStr}T${effectiveEndTime}:59` : endStr
       )
       setOpen(false)
     }
-  }, [isRangeMode, props.onRangeChange, rangeStart, rangeEnd, setOpen])
+  }, [
+    isRangeMode,
+    props.onRangeChange,
+    rangeStart,
+    rangeEnd,
+    showTime,
+    startTime,
+    endTime,
+    setOpen,
+  ])
 
   /**
    * Cancels range selection.
@@ -753,6 +786,21 @@ const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>((props, ref
           showNavigation='right'
         />
       </div>
+
+      {/* Time inputs */}
+      {showTime && (
+        <div className='flex border-[var(--border-1)] border-t'>
+          <div className='flex flex-1 items-center justify-between gap-2 px-3 py-2'>
+            <span className='shrink-0 text-[12px] text-[var(--text-muted)]'>Start</span>
+            <TimePicker size='sm' value={startTime} onChange={setStartTime} />
+          </div>
+          <div className='w-[1px] bg-[var(--border-1)]' />
+          <div className='flex flex-1 items-center justify-between gap-2 px-3 py-2'>
+            <span className='shrink-0 text-[12px] text-[var(--text-muted)]'>End</span>
+            <TimePicker size='sm' value={endTime} onChange={setEndTime} />
+          </div>
+        </div>
+      )}
 
       {/* Actions */}
       <div className='flex items-center justify-between border-[var(--border-1)] border-t px-3 py-2'>

--- a/apps/sim/components/emcn/components/date-picker/date-picker.tsx
+++ b/apps/sim/components/emcn/components/date-picker/date-picker.tsx
@@ -126,8 +126,22 @@ interface DatePickerRangeProps extends DatePickerBaseProps {
 export type DatePickerProps = DatePickerSingleProps | DatePickerRangeProps
 
 /**
- * Month names for calendar display.
+ * Flattened props type for safe destructuring.
+ * The discriminated union prevents direct destructuring of mode-specific props,
+ * so we cast to this merged shape after the forwardRef boundary.
  */
+type FlatDatePickerProps = DatePickerBaseProps & {
+  mode?: 'single' | 'range'
+  value?: string | Date
+  onChange?: (value: string) => void
+  startDate?: string | Date
+  endDate?: string | Date
+  onRangeChange?: (startDate: string, endDate: string) => void
+  onCancel?: () => void
+  onClear?: () => void
+  showTime?: boolean
+}
+
 const MONTHS = [
   'January',
   'February',
@@ -143,28 +157,8 @@ const MONTHS = [
   'December',
 ]
 
-/**
- * Day abbreviations for calendar header.
- */
 const DAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
 
-/**
- * Gets the number of days in a given month.
- */
-function getDaysInMonth(year: number, month: number): number {
-  return new Date(year, month + 1, 0).getDate()
-}
-
-/**
- * Gets the day of the week (0-6) for the first day of the month.
- */
-function getFirstDayOfMonth(year: number, month: number): number {
-  return new Date(year, month, 1).getDay()
-}
-
-/**
- * Short month names for display.
- */
 const MONTHS_SHORT = [
   'Jan',
   'Feb',
@@ -180,9 +174,14 @@ const MONTHS_SHORT = [
   'Dec',
 ]
 
-/**
- * Formats a date for display in the trigger button.
- */
+function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate()
+}
+
+function getFirstDayOfMonth(year: number, month: number): number {
+  return new Date(year, month, 1).getDay()
+}
+
 function formatDateForDisplay(date: Date | null): string {
   if (!date) return ''
   return date.toLocaleDateString('en-US', {
@@ -192,9 +191,6 @@ function formatDateForDisplay(date: Date | null): string {
   })
 }
 
-/**
- * Formats a date range for display.
- */
 function formatDateRangeForDisplay(start: Date | null, end: Date | null): string {
   if (!start && !end) return ''
   if (start && !end) return formatDateForDisplay(start)
@@ -210,9 +206,6 @@ function formatDateRangeForDisplay(start: Date | null, end: Date | null): string
   return ''
 }
 
-/**
- * Checks if a date is between two dates (inclusive).
- */
 function isDateInRange(date: Date, start: Date | null, end: Date | null): boolean {
   if (!start || !end) return false
   const time = date.getTime()
@@ -221,9 +214,6 @@ function isDateInRange(date: Date, start: Date | null, end: Date | null): boolea
   return time >= startTime && time <= endTime
 }
 
-/**
- * Checks if two dates are the same day.
- */
 function isSameDay(date1: Date, date2: Date): boolean {
   return (
     date1.getFullYear() === date2.getFullYear() &&
@@ -232,9 +222,6 @@ function isSameDay(date1: Date, date2: Date): boolean {
   )
 }
 
-/**
- * Formats a date as YYYY-MM-DD string.
- */
 function formatDateAsString(year: number, month: number, day: number): string {
   const m = (month + 1).toString().padStart(2, '0')
   const d = day.toString().padStart(2, '0')
@@ -243,7 +230,7 @@ function formatDateAsString(year: number, month: number, day: number): string {
 
 /**
  * Parses a string or Date value into a Date object.
- * Handles various date formats including YYYY-MM-DD and ISO strings.
+ * YYYY-MM-DD strings are parsed as local time to avoid UTC offset shifts.
  */
 function parseDate(value: string | Date | undefined): Date | null {
   if (!value) return null
@@ -272,9 +259,6 @@ function parseDate(value: string | Date | undefined): Date | null {
   }
 }
 
-/**
- * Calendar component for rendering a single month.
- */
 interface CalendarMonthProps {
   viewMonth: number
   viewYear: number
@@ -296,7 +280,7 @@ function CalendarMonth({
   selectedDate,
   rangeStart,
   rangeEnd,
-  hoverDate,
+  hoverDate: _hoverDate,
   isRangeMode,
   onSelectDate,
   onHoverDate,
@@ -368,17 +352,13 @@ function CalendarMonth({
 
   const isInRange = React.useCallback(
     (day: number) => {
-      if (!isRangeMode) return false
+      if (!isRangeMode || !rangeStart || !rangeEnd) return false
       const date = new Date(viewYear, viewMonth, day)
-      // Only show range highlight when both start and end are selected
-      if (rangeStart && rangeEnd) {
-        return (
-          isDateInRange(date, rangeStart, rangeEnd) &&
-          !isSameDay(date, rangeStart) &&
-          !isSameDay(date, rangeEnd)
-        )
-      }
-      return false
+      return (
+        isDateInRange(date, rangeStart, rangeEnd) &&
+        !isSameDay(date, rangeStart) &&
+        !isSameDay(date, rangeEnd)
+      )
     },
     [isRangeMode, rangeStart, rangeEnd, viewMonth, viewYear]
   )
@@ -490,89 +470,99 @@ const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>((props, ref
     className,
     variant,
     size,
-    placeholder = props.mode === 'range' ? 'Select date range' : 'Select date',
+    placeholder: placeholderProp,
     disabled,
     showTrigger = true,
     open: controlledOpen,
     onOpenChange,
     inline = false,
-    mode: _mode,
-    ...rest
-  } = props
-
-  const {
-    value: _value,
-    onChange: _onChange,
-    startDate: _startDate,
-    endDate: _endDate,
-    onRangeChange: _onRangeChange,
-    onCancel: _onCancel,
-    onClear: _onClear,
+    mode,
+    value,
+    onChange,
+    startDate,
+    endDate,
+    onRangeChange,
+    onCancel,
+    onClear,
     showTime = false,
     ...htmlProps
-  } = rest as any
+  } = props as FlatDatePickerProps
 
-  const isRangeMode = props.mode === 'range'
+  const isRangeMode = mode === 'range'
+  const placeholder = placeholderProp ?? (isRangeMode ? 'Select date range' : 'Select date')
 
   const isControlled = controlledOpen !== undefined
   const [internalOpen, setInternalOpen] = React.useState(false)
   const open = isControlled ? controlledOpen : internalOpen
 
   const setOpen = React.useCallback(
-    (value: boolean) => {
-      if (!isControlled) {
-        setInternalOpen(value)
-      }
-      onOpenChange?.(value)
+    (next: boolean) => {
+      if (!isControlled) setInternalOpen(next)
+      onOpenChange?.(next)
     },
     [isControlled, onOpenChange]
   )
 
-  const selectedDate = !isRangeMode ? parseDate(props.value) : null
+  const selectedDate = !isRangeMode ? parseDate(value) : null
 
-  const initialStart = isRangeMode ? parseDate(props.startDate) : null
-  const initialEnd = isRangeMode ? parseDate(props.endDate) : null
-  const [rangeStart, setRangeStart] = React.useState<Date | null>(initialStart)
-  const [rangeEnd, setRangeEnd] = React.useState<Date | null>(initialEnd)
+  const [rangeStart, setRangeStart] = React.useState<Date | null>(() =>
+    isRangeMode ? parseDate(startDate) : null
+  )
+  const [rangeEnd, setRangeEnd] = React.useState<Date | null>(() =>
+    isRangeMode ? parseDate(endDate) : null
+  )
   const [hoverDate, setHoverDate] = React.useState<Date | null>(null)
   const [selectingEnd, setSelectingEnd] = React.useState(false)
   const [startTime, setStartTime] = React.useState('00:00')
   const [endTime, setEndTime] = React.useState('23:59')
 
   const [viewMonth, setViewMonth] = React.useState(() => {
-    const d = selectedDate || initialStart || new Date()
+    const d = selectedDate ?? (isRangeMode ? parseDate(startDate) : null) ?? new Date()
     return d.getMonth()
   })
   const [viewYear, setViewYear] = React.useState(() => {
-    const d = selectedDate || initialStart || new Date()
+    const d = selectedDate ?? (isRangeMode ? parseDate(startDate) : null) ?? new Date()
     return d.getFullYear()
   })
 
   const rightViewMonth = viewMonth === 11 ? 0 : viewMonth + 1
   const rightViewYear = viewMonth === 11 ? viewYear + 1 : viewYear
 
+  // Sync range state when the popover opens with the current prop values.
+  // Deps are the raw string/Date props — NOT derived Date objects — to avoid
+  // an infinite re-render loop: Object.is(new Date(), new Date()) === false,
+  // so derived Date objects in deps cause the effect to fire every render.
   React.useEffect(() => {
-    if (open && isRangeMode) {
-      setRangeStart(initialStart)
-      setRangeEnd(initialEnd)
-      setSelectingEnd(false)
-      if (showTime) {
-        const sd = isRangeMode ? props.startDate : undefined
-        const ed = isRangeMode ? props.endDate : undefined
-        setStartTime(typeof sd === 'string' && sd.includes('T') ? sd.slice(11, 16) : '00:00')
-        setEndTime(typeof ed === 'string' && ed.includes('T') ? ed.slice(11, 16) : '23:59')
-      }
-      if (initialStart) {
-        setViewMonth(initialStart.getMonth())
-        setViewYear(initialStart.getFullYear())
-      } else {
-        const now = new Date()
-        setViewMonth(now.getMonth())
-        setViewYear(now.getFullYear())
-      }
-    }
-  }, [open, isRangeMode, initialStart, initialEnd, showTime, props.startDate, props.endDate])
+    if (!open || !isRangeMode) return
 
+    const start = parseDate(startDate)
+    const end = parseDate(endDate)
+    setRangeStart(start)
+    setRangeEnd(end)
+    setSelectingEnd(false)
+
+    if (showTime) {
+      setStartTime(
+        typeof startDate === 'string' && startDate.includes('T') ? startDate.slice(11, 16) : '00:00'
+      )
+      setEndTime(
+        typeof endDate === 'string' && endDate.includes('T') ? endDate.slice(11, 16) : '23:59'
+      )
+    }
+
+    if (start) {
+      setViewMonth(start.getMonth())
+      setViewYear(start.getFullYear())
+    } else {
+      const now = new Date()
+      setViewMonth(now.getMonth())
+      setViewYear(now.getFullYear())
+    }
+  }, [open, isRangeMode, startDate, endDate, showTime])
+
+  // Sync the calendar view when the external single-date value changes.
+  // This is a render-phase state update (derived state pattern): safe because
+  // it only triggers when singleValueKey — a primitive timestamp — actually changes.
   const singleValueKey = !isRangeMode && selectedDate ? selectedDate.getTime() : undefined
   const [prevSingleValueKey, setPrevSingleValueKey] = React.useState(singleValueKey)
   if (singleValueKey !== prevSingleValueKey) {
@@ -583,26 +573,19 @@ const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>((props, ref
     }
   }
 
-  /**
-   * Handles selection of a specific day in single mode.
-   */
   const handleSelectDateSingle = React.useCallback(
     (day: number) => {
-      if (!isRangeMode && props.onChange) {
-        props.onChange(formatDateAsString(viewYear, viewMonth, day))
+      if (!isRangeMode) {
+        onChange?.(formatDateAsString(viewYear, viewMonth, day))
         setOpen(false)
       }
     },
-    [isRangeMode, viewYear, viewMonth, props.onChange, setOpen]
+    [isRangeMode, onChange, viewYear, viewMonth, setOpen]
   )
 
-  /**
-   * Handles selection of a day in range mode.
-   */
   const handleSelectDateRange = React.useCallback(
     (year: number, month: number, day: number) => {
       const date = new Date(year, month, day)
-
       if (!selectingEnd || !rangeStart) {
         setRangeStart(date)
         setRangeEnd(null)
@@ -620,113 +603,72 @@ const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>((props, ref
     [selectingEnd, rangeStart]
   )
 
-  /**
-   * Handles hover for range preview.
-   */
   const handleHoverDate = React.useCallback((year: number, month: number, day: number | null) => {
-    if (day === null) {
-      setHoverDate(null)
-    } else {
-      setHoverDate(new Date(year, month, day))
-    }
+    setHoverDate(day === null ? null : new Date(year, month, day))
   }, [])
 
-  /**
-   * Navigates to the previous month.
-   */
   const goToPrevMonth = React.useCallback(() => {
     if (viewMonth === 0) {
       setViewMonth(11)
-      setViewYear((prev) => prev - 1)
+      setViewYear((y) => y - 1)
     } else {
-      setViewMonth((prev) => prev - 1)
+      setViewMonth((m) => m - 1)
     }
   }, [viewMonth])
 
-  /**
-   * Navigates to the next month.
-   */
   const goToNextMonth = React.useCallback(() => {
     if (viewMonth === 11) {
       setViewMonth(0)
-      setViewYear((prev) => prev + 1)
+      setViewYear((y) => y + 1)
     } else {
-      setViewMonth((prev) => prev + 1)
+      setViewMonth((m) => m + 1)
     }
   }, [viewMonth])
 
-  /**
-   * Selects today's date (single mode only).
-   */
   const handleSelectToday = React.useCallback(() => {
-    if (!isRangeMode && props.onChange) {
+    if (!isRangeMode) {
       const now = new Date()
       setViewMonth(now.getMonth())
       setViewYear(now.getFullYear())
-      props.onChange(formatDateAsString(now.getFullYear(), now.getMonth(), now.getDate()))
+      onChange?.(formatDateAsString(now.getFullYear(), now.getMonth(), now.getDate()))
       setOpen(false)
     }
-  }, [isRangeMode, props.onChange, setOpen])
+  }, [isRangeMode, onChange, setOpen])
 
-  /**
-   * Applies the selected range (range mode only).
-   */
   const handleApplyRange = React.useCallback(() => {
-    if (isRangeMode && props.onRangeChange && rangeStart) {
-      const start = rangeEnd && rangeEnd < rangeStart ? rangeEnd : rangeStart
-      const end = rangeEnd && rangeEnd < rangeStart ? rangeStart : rangeEnd || rangeStart
-      const startStr = formatDateAsString(start.getFullYear(), start.getMonth(), start.getDate())
-      const endStr = formatDateAsString(end.getFullYear(), end.getMonth(), end.getDate())
+    if (!isRangeMode || !onRangeChange || !rangeStart) return
 
-      let effectiveStartTime = startTime
-      let effectiveEndTime = endTime
-      if (showTime && startStr === endStr && startTime > endTime) {
-        effectiveStartTime = endTime
-        effectiveEndTime = startTime
-      }
+    const start = rangeEnd && rangeEnd < rangeStart ? rangeEnd : rangeStart
+    const end = rangeEnd && rangeEnd < rangeStart ? rangeStart : (rangeEnd ?? rangeStart)
+    const startStr = formatDateAsString(start.getFullYear(), start.getMonth(), start.getDate())
+    const endStr = formatDateAsString(end.getFullYear(), end.getMonth(), end.getDate())
 
-      props.onRangeChange(
-        showTime ? `${startStr}T${effectiveStartTime}` : startStr,
-        showTime ? `${endStr}T${effectiveEndTime}:59` : endStr
-      )
-      setOpen(false)
+    let effectiveStartTime = startTime
+    let effectiveEndTime = endTime
+    if (showTime && startStr === endStr && startTime > endTime) {
+      effectiveStartTime = endTime
+      effectiveEndTime = startTime
     }
-  }, [
-    isRangeMode,
-    props.onRangeChange,
-    rangeStart,
-    rangeEnd,
-    showTime,
-    startTime,
-    endTime,
-    setOpen,
-  ])
 
-  /**
-   * Cancels range selection.
-   */
-  const handleCancelRange = React.useCallback(() => {
-    if (isRangeMode && props.onCancel) {
-      props.onCancel()
-    }
+    onRangeChange(
+      showTime ? `${startStr}T${effectiveStartTime}` : startStr,
+      showTime ? `${endStr}T${effectiveEndTime}:59` : endStr
+    )
     setOpen(false)
-  }, [isRangeMode, props.onCancel, setOpen])
+  }, [isRangeMode, onRangeChange, rangeStart, rangeEnd, showTime, startTime, endTime, setOpen])
 
-  /**
-   * Clears the selected range.
-   */
+  const handleCancelRange = React.useCallback(() => {
+    if (isRangeMode) onCancel?.()
+    setOpen(false)
+  }, [isRangeMode, onCancel, setOpen])
+
   const handleClearRange = React.useCallback(() => {
     setRangeStart(null)
     setRangeEnd(null)
     setSelectingEnd(false)
-    if (isRangeMode && props.onClear) {
-      props.onClear()
-    }
-  }, [isRangeMode, props.onClear])
+    if (isRangeMode) onClear?.()
+  }, [isRangeMode, onClear])
 
-  /**
-   * Handles keyboard events on the trigger.
-   */
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
       if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
@@ -737,17 +679,12 @@ const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>((props, ref
     [disabled, open, setOpen]
   )
 
-  /**
-   * Handles click on the trigger.
-   */
   const handleTriggerClick = React.useCallback(() => {
-    if (!disabled) {
-      setOpen(!open)
-    }
+    if (!disabled) setOpen(!open)
   }, [disabled, open, setOpen])
 
   const displayValue = isRangeMode
-    ? formatDateRangeForDisplay(initialStart, initialEnd)
+    ? formatDateRangeForDisplay(parseDate(startDate), parseDate(endDate))
     : formatDateForDisplay(selectedDate)
 
   const calendarContent = isRangeMode ? (

--- a/apps/sim/lib/api/contracts/storage-transfer.ts
+++ b/apps/sim/lib/api/contracts/storage-transfer.ts
@@ -243,7 +243,7 @@ export const sshReadFileContentBodySchema = requirePasswordOrPrivateKey(
     ...connectionFields,
     path: z.string().min(1, 'Path is required'),
     encoding: z.string().default('utf-8'),
-    maxSize: z.coerce.number().default(10),
+    maxSize: z.coerce.number().min(0.01).max(50).default(10),
   })
 )
 

--- a/apps/sim/lib/api/contracts/tools/aws/cloudwatch-mute-alarm.ts
+++ b/apps/sim/lib/api/contracts/tools/aws/cloudwatch-mute-alarm.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod'
+import type {
+  ContractBody,
+  ContractBodyInput,
+  ContractJsonResponse,
+} from '@/lib/api/contracts/types'
+import { defineRouteContract } from '@/lib/api/contracts/types'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
+
+const MuteAlarmSchema = z.object({
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
+  accessKeyId: z.string().min(1, 'AWS access key ID is required'),
+  secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
+  alarmNames: z
+    .array(z.string().min(1, 'Alarm name cannot be empty'))
+    .min(1, 'At least one alarm name is required')
+    .max(100, 'At most 100 alarm names are allowed per request'),
+})
+
+const MuteAlarmResponseSchema = z.object({
+  success: z.literal(true),
+  output: z.object({
+    success: z.literal(true),
+    alarmNames: z.array(z.string()),
+  }),
+})
+
+export const awsCloudwatchMuteAlarmContract = defineRouteContract({
+  method: 'POST',
+  path: '/api/tools/cloudwatch/mute-alarm',
+  body: MuteAlarmSchema,
+  response: { mode: 'json', schema: MuteAlarmResponseSchema },
+})
+export type AwsCloudwatchMuteAlarmRequest = ContractBodyInput<typeof awsCloudwatchMuteAlarmContract>
+export type AwsCloudwatchMuteAlarmBody = ContractBody<typeof awsCloudwatchMuteAlarmContract>
+export type AwsCloudwatchMuteAlarmResponse = ContractJsonResponse<
+  typeof awsCloudwatchMuteAlarmContract
+>

--- a/apps/sim/lib/api/contracts/tools/aws/cloudwatch-unmute-alarm.ts
+++ b/apps/sim/lib/api/contracts/tools/aws/cloudwatch-unmute-alarm.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod'
+import type {
+  ContractBody,
+  ContractBodyInput,
+  ContractJsonResponse,
+} from '@/lib/api/contracts/types'
+import { defineRouteContract } from '@/lib/api/contracts/types'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
+
+const UnmuteAlarmSchema = z.object({
+  region: z
+    .string()
+    .min(1, 'AWS region is required')
+    .refine((v) => validateAwsRegion(v).isValid, {
+      message: 'Invalid AWS region format (e.g., us-east-1, eu-west-2)',
+    }),
+  accessKeyId: z.string().min(1, 'AWS access key ID is required'),
+  secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
+  alarmNames: z
+    .array(z.string().min(1, 'Alarm name cannot be empty'))
+    .min(1, 'At least one alarm name is required')
+    .max(100, 'At most 100 alarm names are allowed per request'),
+})
+
+const UnmuteAlarmResponseSchema = z.object({
+  success: z.literal(true),
+  output: z.object({
+    success: z.literal(true),
+    alarmNames: z.array(z.string()),
+  }),
+})
+
+export const awsCloudwatchUnmuteAlarmContract = defineRouteContract({
+  method: 'POST',
+  path: '/api/tools/cloudwatch/unmute-alarm',
+  body: UnmuteAlarmSchema,
+  response: { mode: 'json', schema: UnmuteAlarmResponseSchema },
+})
+export type AwsCloudwatchUnmuteAlarmRequest = ContractBodyInput<
+  typeof awsCloudwatchUnmuteAlarmContract
+>
+export type AwsCloudwatchUnmuteAlarmBody = ContractBody<typeof awsCloudwatchUnmuteAlarmContract>
+export type AwsCloudwatchUnmuteAlarmResponse = ContractJsonResponse<
+  typeof awsCloudwatchUnmuteAlarmContract
+>

--- a/apps/sim/lib/environment/utils.ts
+++ b/apps/sim/lib/environment/utils.ts
@@ -9,6 +9,7 @@ import {
   getAccessibleEnvCredentials,
   syncPersonalEnvCredentialsForUser,
 } from '@/lib/credentials/environment'
+import { checkWorkspaceAccess } from '@/lib/workspaces/permissions/utils'
 
 const logger = createLogger('EnvironmentUtils')
 const EFFECTIVE_ENV_CACHE_TTL_MS = 15_000
@@ -72,6 +73,13 @@ export async function getPersonalAndWorkspaceEnv(
   conflicts: string[]
   decryptionFailures: string[]
 }> {
+  if (workspaceId) {
+    const access = await checkWorkspaceAccess(workspaceId, userId)
+    if (!access.hasAccess) {
+      throw new Error(`Access denied to workspace ${workspaceId}`)
+    }
+  }
+
   const [personalRows, workspaceRows, accessibleEnvCredentials] = await Promise.all([
     db.select().from(environment).where(eq(environment.userId, userId)).limit(1),
     workspaceId

--- a/apps/sim/lib/knowledge/documents/service.ts
+++ b/apps/sim/lib/knowledge/documents/service.ts
@@ -748,6 +748,126 @@ async function processDocumentsWithTrigger(
   }
 }
 
+interface NewDocumentRow {
+  id: string
+  knowledgeBaseId: string
+  filename: string
+  fileUrl: string
+  fileSize: number
+  mimeType: string
+  chunkCount: number
+  tokenCount: number
+  characterCount: number
+  processingStatus: 'pending'
+  enabled: boolean
+  uploadedAt: Date
+  tag1: string | null
+  tag2: string | null
+  tag3: string | null
+  tag4: string | null
+  tag5: string | null
+  tag6: string | null
+  tag7: string | null
+  number1: number | null
+  number2: number | null
+  number3: number | null
+  number4: number | null
+  number5: number | null
+  date1: Date | null
+  date2: Date | null
+  boolean1: boolean | null
+  boolean2: boolean | null
+  boolean3: boolean | null
+}
+
+/**
+ * Insert N document rows IF the parent knowledge base is still alive
+ * (`deleted_at IS NULL`) at the statement's MVCC snapshot. Returns the
+ * number of rows actually inserted.
+ *
+ * Knowledge bases are soft-deleted, so a normal FK can't catch a concurrent
+ * delete — the KB row physically remains. We do the existence check and the
+ * insert in a single statement via INSERT...SELECT...WHERE EXISTS, which
+ * Postgres evaluates atomically. No transaction or row lock required, no
+ * race window between check and insert.
+ *
+ * Returns 0 if the KB was soft-deleted; caller throws.
+ */
+async function insertDocumentsIfKbAlive(
+  rows: NewDocumentRow[],
+  knowledgeBaseId: string
+): Promise<number> {
+  if (rows.length === 0) return 0
+
+  // jsonb_to_recordset declares the column types once, so we don't need to
+  // cast every parameter individually to keep Postgres' type inference happy
+  // when nullable columns end up all-NULL across the batch.
+  const jsonRows = rows.map((d) => ({
+    id: d.id,
+    knowledge_base_id: d.knowledgeBaseId,
+    filename: d.filename,
+    file_url: d.fileUrl,
+    file_size: d.fileSize,
+    mime_type: d.mimeType,
+    chunk_count: d.chunkCount,
+    token_count: d.tokenCount,
+    character_count: d.characterCount,
+    processing_status: d.processingStatus,
+    enabled: d.enabled,
+    uploaded_at: d.uploadedAt.toISOString(),
+    tag1: d.tag1,
+    tag2: d.tag2,
+    tag3: d.tag3,
+    tag4: d.tag4,
+    tag5: d.tag5,
+    tag6: d.tag6,
+    tag7: d.tag7,
+    number1: d.number1,
+    number2: d.number2,
+    number3: d.number3,
+    number4: d.number4,
+    number5: d.number5,
+    date1: d.date1?.toISOString() ?? null,
+    date2: d.date2?.toISOString() ?? null,
+    boolean1: d.boolean1,
+    boolean2: d.boolean2,
+    boolean3: d.boolean3,
+  }))
+
+  const result = await db.execute(sql`
+    INSERT INTO document (
+      id, knowledge_base_id, filename, file_url, file_size, mime_type,
+      chunk_count, token_count, character_count, processing_status, enabled, uploaded_at,
+      tag1, tag2, tag3, tag4, tag5, tag6, tag7,
+      number1, number2, number3, number4, number5,
+      date1, date2,
+      boolean1, boolean2, boolean3
+    )
+    SELECT
+      id, knowledge_base_id, filename, file_url, file_size, mime_type,
+      chunk_count, token_count, character_count, processing_status, enabled, uploaded_at,
+      tag1, tag2, tag3, tag4, tag5, tag6, tag7,
+      number1, number2, number3, number4, number5,
+      date1, date2,
+      boolean1, boolean2, boolean3
+    FROM jsonb_to_recordset(${JSON.stringify(jsonRows)}::jsonb) AS x(
+      id text, knowledge_base_id text, filename text, file_url text, file_size integer, mime_type text,
+      chunk_count integer, token_count integer, character_count integer, processing_status text, enabled boolean, uploaded_at timestamp,
+      tag1 text, tag2 text, tag3 text, tag4 text, tag5 text, tag6 text, tag7 text,
+      number1 double precision, number2 double precision, number3 double precision, number4 double precision, number5 double precision,
+      date1 timestamp, date2 timestamp,
+      boolean1 boolean, boolean2 boolean, boolean3 boolean
+    )
+    WHERE EXISTS (
+      SELECT 1 FROM knowledge_base
+      WHERE id = ${knowledgeBaseId} AND deleted_at IS NULL
+    )
+    RETURNING id
+  `)
+
+  return Array.from(result).length
+}
+
 export async function createDocumentRecords(
   documents: Array<{
     filename: string
@@ -766,99 +886,102 @@ export async function createDocumentRecords(
   knowledgeBaseId: string,
   requestId: string
 ): Promise<DocumentData[]> {
-  return await db.transaction(async (tx) => {
-    await tx.execute(sql`SELECT 1 FROM knowledge_base WHERE id = ${knowledgeBaseId} FOR UPDATE`)
+  // Cheap upfront existence check so the common KB-not-found path fails fast
+  // before we burn CPU on tag processing. The atomic insert below is the
+  // race-safe guard against a concurrent KB soft-delete in the small window
+  // between this check and the insert.
+  const kb = await db
+    .select({ id: knowledgeBase.id })
+    .from(knowledgeBase)
+    .where(and(eq(knowledgeBase.id, knowledgeBaseId), isNull(knowledgeBase.deletedAt)))
+    .limit(1)
 
-    const kb = await tx
-      .select({ id: knowledgeBase.id })
-      .from(knowledgeBase)
-      .where(and(eq(knowledgeBase.id, knowledgeBaseId), isNull(knowledgeBase.deletedAt)))
-      .limit(1)
+  if (kb.length === 0) {
+    throw new Error('Knowledge base not found')
+  }
 
-    if (kb.length === 0) {
-      throw new Error('Knowledge base not found')
-    }
+  const now = new Date()
+  const documentRecords: NewDocumentRow[] = []
+  const returnData: DocumentData[] = []
 
-    const now = new Date()
-    const documentRecords = []
-    const returnData: DocumentData[] = []
+  for (const docData of documents) {
+    const documentId = generateId()
 
-    for (const docData of documents) {
-      const documentId = generateId()
+    let processedTags: Partial<ProcessedDocumentTags> = {}
 
-      let processedTags: Partial<ProcessedDocumentTags> = {}
-
-      if (docData.documentTagsData) {
-        try {
-          const tagData = JSON.parse(docData.documentTagsData)
-          if (Array.isArray(tagData)) {
-            processedTags = await processDocumentTags(knowledgeBaseId, tagData, requestId)
-          }
-        } catch (error) {
-          if (error instanceof SyntaxError) {
-            logger.warn(`[${requestId}] Failed to parse documentTagsData for bulk document:`, error)
-          } else {
-            throw error
-          }
+    if (docData.documentTagsData) {
+      try {
+        const tagData = JSON.parse(docData.documentTagsData)
+        if (Array.isArray(tagData)) {
+          processedTags = await processDocumentTags(knowledgeBaseId, tagData, requestId)
+        }
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          logger.warn(`[${requestId}] Failed to parse documentTagsData for bulk document:`, error)
+        } else {
+          throw error
         }
       }
-
-      const newDocument = {
-        id: documentId,
-        knowledgeBaseId,
-        filename: docData.filename,
-        fileUrl: docData.fileUrl,
-        fileSize: docData.fileSize,
-        mimeType: docData.mimeType,
-        chunkCount: 0,
-        tokenCount: 0,
-        characterCount: 0,
-        processingStatus: 'pending' as const,
-        enabled: true,
-        uploadedAt: now,
-        tag1: processedTags.tag1 ?? docData.tag1 ?? null,
-        tag2: processedTags.tag2 ?? docData.tag2 ?? null,
-        tag3: processedTags.tag3 ?? docData.tag3 ?? null,
-        tag4: processedTags.tag4 ?? docData.tag4 ?? null,
-        tag5: processedTags.tag5 ?? docData.tag5 ?? null,
-        tag6: processedTags.tag6 ?? docData.tag6 ?? null,
-        tag7: processedTags.tag7 ?? docData.tag7 ?? null,
-        number1: processedTags.number1 ?? null,
-        number2: processedTags.number2 ?? null,
-        number3: processedTags.number3 ?? null,
-        number4: processedTags.number4 ?? null,
-        number5: processedTags.number5 ?? null,
-        date1: processedTags.date1 ?? null,
-        date2: processedTags.date2 ?? null,
-        boolean1: processedTags.boolean1 ?? null,
-        boolean2: processedTags.boolean2 ?? null,
-        boolean3: processedTags.boolean3 ?? null,
-      }
-
-      documentRecords.push(newDocument)
-      returnData.push({
-        documentId,
-        filename: docData.filename,
-        fileUrl: docData.fileUrl,
-        fileSize: docData.fileSize,
-        mimeType: docData.mimeType,
-      })
     }
 
-    if (documentRecords.length > 0) {
-      await tx.insert(document).values(documentRecords)
-      logger.info(
-        `[${requestId}] Bulk created ${documentRecords.length} document records in knowledge base ${knowledgeBaseId}`
-      )
-
-      await tx
-        .update(knowledgeBase)
-        .set({ updatedAt: now })
-        .where(eq(knowledgeBase.id, knowledgeBaseId))
+    const newDocument = {
+      id: documentId,
+      knowledgeBaseId,
+      filename: docData.filename,
+      fileUrl: docData.fileUrl,
+      fileSize: docData.fileSize,
+      mimeType: docData.mimeType,
+      chunkCount: 0,
+      tokenCount: 0,
+      characterCount: 0,
+      processingStatus: 'pending' as const,
+      enabled: true,
+      uploadedAt: now,
+      tag1: processedTags.tag1 ?? docData.tag1 ?? null,
+      tag2: processedTags.tag2 ?? docData.tag2 ?? null,
+      tag3: processedTags.tag3 ?? docData.tag3 ?? null,
+      tag4: processedTags.tag4 ?? docData.tag4 ?? null,
+      tag5: processedTags.tag5 ?? docData.tag5 ?? null,
+      tag6: processedTags.tag6 ?? docData.tag6 ?? null,
+      tag7: processedTags.tag7 ?? docData.tag7 ?? null,
+      number1: processedTags.number1 ?? null,
+      number2: processedTags.number2 ?? null,
+      number3: processedTags.number3 ?? null,
+      number4: processedTags.number4 ?? null,
+      number5: processedTags.number5 ?? null,
+      date1: processedTags.date1 ?? null,
+      date2: processedTags.date2 ?? null,
+      boolean1: processedTags.boolean1 ?? null,
+      boolean2: processedTags.boolean2 ?? null,
+      boolean3: processedTags.boolean3 ?? null,
     }
 
-    return returnData
-  })
+    documentRecords.push(newDocument)
+    returnData.push({
+      documentId,
+      filename: docData.filename,
+      fileUrl: docData.fileUrl,
+      fileSize: docData.fileSize,
+      mimeType: docData.mimeType,
+    })
+  }
+
+  if (documentRecords.length > 0) {
+    const insertedCount = await insertDocumentsIfKbAlive(documentRecords, knowledgeBaseId)
+    if (insertedCount === 0) {
+      throw new Error('Knowledge base not found')
+    }
+    logger.info(
+      `[${requestId}] Bulk created ${insertedCount} document records in knowledge base ${knowledgeBaseId}`
+    )
+
+    await db
+      .update(knowledgeBase)
+      .set({ updatedAt: now })
+      .where(eq(knowledgeBase.id, knowledgeBaseId))
+  }
+
+  return returnData
 }
 
 export interface TagFilterCondition {
@@ -1297,7 +1420,7 @@ export async function createSingleDocument(
     }
   }
 
-  const newDocument = {
+  const newDocument: NewDocumentRow = {
     id: documentId,
     knowledgeBaseId,
     filename: documentData.filename,
@@ -1307,31 +1430,21 @@ export async function createSingleDocument(
     chunkCount: 0,
     tokenCount: 0,
     characterCount: 0,
+    processingStatus: 'pending',
     enabled: true,
     uploadedAt: now,
     ...processedTags,
   }
 
-  await db.transaction(async (tx) => {
-    await tx.execute(sql`SELECT 1 FROM knowledge_base WHERE id = ${knowledgeBaseId} FOR UPDATE`)
+  const insertedCount = await insertDocumentsIfKbAlive([newDocument], knowledgeBaseId)
+  if (insertedCount === 0) {
+    throw new Error('Knowledge base not found')
+  }
 
-    const kb = await tx
-      .select({ id: knowledgeBase.id })
-      .from(knowledgeBase)
-      .where(and(eq(knowledgeBase.id, knowledgeBaseId), isNull(knowledgeBase.deletedAt)))
-      .limit(1)
-
-    if (kb.length === 0) {
-      throw new Error('Knowledge base not found')
-    }
-
-    await tx.insert(document).values(newDocument)
-
-    await tx
-      .update(knowledgeBase)
-      .set({ updatedAt: now })
-      .where(eq(knowledgeBase.id, knowledgeBaseId))
-  })
+  await db
+    .update(knowledgeBase)
+    .set({ updatedAt: now })
+    .where(eq(knowledgeBase.id, knowledgeBaseId))
   logger.info(`[${requestId}] Document created: ${documentId} in knowledge base ${knowledgeBaseId}`)
 
   return newDocument as {

--- a/apps/sim/lib/knowledge/documents/service.ts
+++ b/apps/sim/lib/knowledge/documents/service.ts
@@ -748,126 +748,6 @@ async function processDocumentsWithTrigger(
   }
 }
 
-interface NewDocumentRow {
-  id: string
-  knowledgeBaseId: string
-  filename: string
-  fileUrl: string
-  fileSize: number
-  mimeType: string
-  chunkCount: number
-  tokenCount: number
-  characterCount: number
-  processingStatus: 'pending'
-  enabled: boolean
-  uploadedAt: Date
-  tag1: string | null
-  tag2: string | null
-  tag3: string | null
-  tag4: string | null
-  tag5: string | null
-  tag6: string | null
-  tag7: string | null
-  number1: number | null
-  number2: number | null
-  number3: number | null
-  number4: number | null
-  number5: number | null
-  date1: Date | null
-  date2: Date | null
-  boolean1: boolean | null
-  boolean2: boolean | null
-  boolean3: boolean | null
-}
-
-/**
- * Insert N document rows IF the parent knowledge base is still alive
- * (`deleted_at IS NULL`) at the statement's MVCC snapshot. Returns the
- * number of rows actually inserted.
- *
- * Knowledge bases are soft-deleted, so a normal FK can't catch a concurrent
- * delete — the KB row physically remains. We do the existence check and the
- * insert in a single statement via INSERT...SELECT...WHERE EXISTS, which
- * Postgres evaluates atomically. No transaction or row lock required, no
- * race window between check and insert.
- *
- * Returns 0 if the KB was soft-deleted; caller throws.
- */
-async function insertDocumentsIfKbAlive(
-  rows: NewDocumentRow[],
-  knowledgeBaseId: string
-): Promise<number> {
-  if (rows.length === 0) return 0
-
-  // jsonb_to_recordset declares the column types once, so we don't need to
-  // cast every parameter individually to keep Postgres' type inference happy
-  // when nullable columns end up all-NULL across the batch.
-  const jsonRows = rows.map((d) => ({
-    id: d.id,
-    knowledge_base_id: d.knowledgeBaseId,
-    filename: d.filename,
-    file_url: d.fileUrl,
-    file_size: d.fileSize,
-    mime_type: d.mimeType,
-    chunk_count: d.chunkCount,
-    token_count: d.tokenCount,
-    character_count: d.characterCount,
-    processing_status: d.processingStatus,
-    enabled: d.enabled,
-    uploaded_at: d.uploadedAt.toISOString(),
-    tag1: d.tag1,
-    tag2: d.tag2,
-    tag3: d.tag3,
-    tag4: d.tag4,
-    tag5: d.tag5,
-    tag6: d.tag6,
-    tag7: d.tag7,
-    number1: d.number1,
-    number2: d.number2,
-    number3: d.number3,
-    number4: d.number4,
-    number5: d.number5,
-    date1: d.date1?.toISOString() ?? null,
-    date2: d.date2?.toISOString() ?? null,
-    boolean1: d.boolean1,
-    boolean2: d.boolean2,
-    boolean3: d.boolean3,
-  }))
-
-  const result = await db.execute(sql`
-    INSERT INTO document (
-      id, knowledge_base_id, filename, file_url, file_size, mime_type,
-      chunk_count, token_count, character_count, processing_status, enabled, uploaded_at,
-      tag1, tag2, tag3, tag4, tag5, tag6, tag7,
-      number1, number2, number3, number4, number5,
-      date1, date2,
-      boolean1, boolean2, boolean3
-    )
-    SELECT
-      id, knowledge_base_id, filename, file_url, file_size, mime_type,
-      chunk_count, token_count, character_count, processing_status, enabled, uploaded_at,
-      tag1, tag2, tag3, tag4, tag5, tag6, tag7,
-      number1, number2, number3, number4, number5,
-      date1, date2,
-      boolean1, boolean2, boolean3
-    FROM jsonb_to_recordset(${JSON.stringify(jsonRows)}::jsonb) AS x(
-      id text, knowledge_base_id text, filename text, file_url text, file_size integer, mime_type text,
-      chunk_count integer, token_count integer, character_count integer, processing_status text, enabled boolean, uploaded_at timestamp,
-      tag1 text, tag2 text, tag3 text, tag4 text, tag5 text, tag6 text, tag7 text,
-      number1 double precision, number2 double precision, number3 double precision, number4 double precision, number5 double precision,
-      date1 timestamp, date2 timestamp,
-      boolean1 boolean, boolean2 boolean, boolean3 boolean
-    )
-    WHERE EXISTS (
-      SELECT 1 FROM knowledge_base
-      WHERE id = ${knowledgeBaseId} AND deleted_at IS NULL
-    )
-    RETURNING id
-  `)
-
-  return Array.from(result).length
-}
-
 export async function createDocumentRecords(
   documents: Array<{
     filename: string
@@ -886,102 +766,99 @@ export async function createDocumentRecords(
   knowledgeBaseId: string,
   requestId: string
 ): Promise<DocumentData[]> {
-  // Cheap upfront existence check so the common KB-not-found path fails fast
-  // before we burn CPU on tag processing. The atomic insert below is the
-  // race-safe guard against a concurrent KB soft-delete in the small window
-  // between this check and the insert.
-  const kb = await db
-    .select({ id: knowledgeBase.id })
-    .from(knowledgeBase)
-    .where(and(eq(knowledgeBase.id, knowledgeBaseId), isNull(knowledgeBase.deletedAt)))
-    .limit(1)
+  return await db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT 1 FROM knowledge_base WHERE id = ${knowledgeBaseId} FOR UPDATE`)
 
-  if (kb.length === 0) {
-    throw new Error('Knowledge base not found')
-  }
+    const kb = await tx
+      .select({ id: knowledgeBase.id })
+      .from(knowledgeBase)
+      .where(and(eq(knowledgeBase.id, knowledgeBaseId), isNull(knowledgeBase.deletedAt)))
+      .limit(1)
 
-  const now = new Date()
-  const documentRecords: NewDocumentRow[] = []
-  const returnData: DocumentData[] = []
-
-  for (const docData of documents) {
-    const documentId = generateId()
-
-    let processedTags: Partial<ProcessedDocumentTags> = {}
-
-    if (docData.documentTagsData) {
-      try {
-        const tagData = JSON.parse(docData.documentTagsData)
-        if (Array.isArray(tagData)) {
-          processedTags = await processDocumentTags(knowledgeBaseId, tagData, requestId)
-        }
-      } catch (error) {
-        if (error instanceof SyntaxError) {
-          logger.warn(`[${requestId}] Failed to parse documentTagsData for bulk document:`, error)
-        } else {
-          throw error
-        }
-      }
-    }
-
-    const newDocument = {
-      id: documentId,
-      knowledgeBaseId,
-      filename: docData.filename,
-      fileUrl: docData.fileUrl,
-      fileSize: docData.fileSize,
-      mimeType: docData.mimeType,
-      chunkCount: 0,
-      tokenCount: 0,
-      characterCount: 0,
-      processingStatus: 'pending' as const,
-      enabled: true,
-      uploadedAt: now,
-      tag1: processedTags.tag1 ?? docData.tag1 ?? null,
-      tag2: processedTags.tag2 ?? docData.tag2 ?? null,
-      tag3: processedTags.tag3 ?? docData.tag3 ?? null,
-      tag4: processedTags.tag4 ?? docData.tag4 ?? null,
-      tag5: processedTags.tag5 ?? docData.tag5 ?? null,
-      tag6: processedTags.tag6 ?? docData.tag6 ?? null,
-      tag7: processedTags.tag7 ?? docData.tag7 ?? null,
-      number1: processedTags.number1 ?? null,
-      number2: processedTags.number2 ?? null,
-      number3: processedTags.number3 ?? null,
-      number4: processedTags.number4 ?? null,
-      number5: processedTags.number5 ?? null,
-      date1: processedTags.date1 ?? null,
-      date2: processedTags.date2 ?? null,
-      boolean1: processedTags.boolean1 ?? null,
-      boolean2: processedTags.boolean2 ?? null,
-      boolean3: processedTags.boolean3 ?? null,
-    }
-
-    documentRecords.push(newDocument)
-    returnData.push({
-      documentId,
-      filename: docData.filename,
-      fileUrl: docData.fileUrl,
-      fileSize: docData.fileSize,
-      mimeType: docData.mimeType,
-    })
-  }
-
-  if (documentRecords.length > 0) {
-    const insertedCount = await insertDocumentsIfKbAlive(documentRecords, knowledgeBaseId)
-    if (insertedCount === 0) {
+    if (kb.length === 0) {
       throw new Error('Knowledge base not found')
     }
-    logger.info(
-      `[${requestId}] Bulk created ${insertedCount} document records in knowledge base ${knowledgeBaseId}`
-    )
 
-    await db
-      .update(knowledgeBase)
-      .set({ updatedAt: now })
-      .where(eq(knowledgeBase.id, knowledgeBaseId))
-  }
+    const now = new Date()
+    const documentRecords = []
+    const returnData: DocumentData[] = []
 
-  return returnData
+    for (const docData of documents) {
+      const documentId = generateId()
+
+      let processedTags: Partial<ProcessedDocumentTags> = {}
+
+      if (docData.documentTagsData) {
+        try {
+          const tagData = JSON.parse(docData.documentTagsData)
+          if (Array.isArray(tagData)) {
+            processedTags = await processDocumentTags(knowledgeBaseId, tagData, requestId)
+          }
+        } catch (error) {
+          if (error instanceof SyntaxError) {
+            logger.warn(`[${requestId}] Failed to parse documentTagsData for bulk document:`, error)
+          } else {
+            throw error
+          }
+        }
+      }
+
+      const newDocument = {
+        id: documentId,
+        knowledgeBaseId,
+        filename: docData.filename,
+        fileUrl: docData.fileUrl,
+        fileSize: docData.fileSize,
+        mimeType: docData.mimeType,
+        chunkCount: 0,
+        tokenCount: 0,
+        characterCount: 0,
+        processingStatus: 'pending' as const,
+        enabled: true,
+        uploadedAt: now,
+        tag1: processedTags.tag1 ?? docData.tag1 ?? null,
+        tag2: processedTags.tag2 ?? docData.tag2 ?? null,
+        tag3: processedTags.tag3 ?? docData.tag3 ?? null,
+        tag4: processedTags.tag4 ?? docData.tag4 ?? null,
+        tag5: processedTags.tag5 ?? docData.tag5 ?? null,
+        tag6: processedTags.tag6 ?? docData.tag6 ?? null,
+        tag7: processedTags.tag7 ?? docData.tag7 ?? null,
+        number1: processedTags.number1 ?? null,
+        number2: processedTags.number2 ?? null,
+        number3: processedTags.number3 ?? null,
+        number4: processedTags.number4 ?? null,
+        number5: processedTags.number5 ?? null,
+        date1: processedTags.date1 ?? null,
+        date2: processedTags.date2 ?? null,
+        boolean1: processedTags.boolean1 ?? null,
+        boolean2: processedTags.boolean2 ?? null,
+        boolean3: processedTags.boolean3 ?? null,
+      }
+
+      documentRecords.push(newDocument)
+      returnData.push({
+        documentId,
+        filename: docData.filename,
+        fileUrl: docData.fileUrl,
+        fileSize: docData.fileSize,
+        mimeType: docData.mimeType,
+      })
+    }
+
+    if (documentRecords.length > 0) {
+      await tx.insert(document).values(documentRecords)
+      logger.info(
+        `[${requestId}] Bulk created ${documentRecords.length} document records in knowledge base ${knowledgeBaseId}`
+      )
+
+      await tx
+        .update(knowledgeBase)
+        .set({ updatedAt: now })
+        .where(eq(knowledgeBase.id, knowledgeBaseId))
+    }
+
+    return returnData
+  })
 }
 
 export interface TagFilterCondition {
@@ -1420,7 +1297,7 @@ export async function createSingleDocument(
     }
   }
 
-  const newDocument: NewDocumentRow = {
+  const newDocument = {
     id: documentId,
     knowledgeBaseId,
     filename: documentData.filename,
@@ -1430,21 +1307,31 @@ export async function createSingleDocument(
     chunkCount: 0,
     tokenCount: 0,
     characterCount: 0,
-    processingStatus: 'pending',
     enabled: true,
     uploadedAt: now,
     ...processedTags,
   }
 
-  const insertedCount = await insertDocumentsIfKbAlive([newDocument], knowledgeBaseId)
-  if (insertedCount === 0) {
-    throw new Error('Knowledge base not found')
-  }
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT 1 FROM knowledge_base WHERE id = ${knowledgeBaseId} FOR UPDATE`)
 
-  await db
-    .update(knowledgeBase)
-    .set({ updatedAt: now })
-    .where(eq(knowledgeBase.id, knowledgeBaseId))
+    const kb = await tx
+      .select({ id: knowledgeBase.id })
+      .from(knowledgeBase)
+      .where(and(eq(knowledgeBase.id, knowledgeBaseId), isNull(knowledgeBase.deletedAt)))
+      .limit(1)
+
+    if (kb.length === 0) {
+      throw new Error('Knowledge base not found')
+    }
+
+    await tx.insert(document).values(newDocument)
+
+    await tx
+      .update(knowledgeBase)
+      .set({ updatedAt: now })
+      .where(eq(knowledgeBase.id, knowledgeBaseId))
+  })
   logger.info(`[${requestId}] Document created: ${documentId} in knowledge base ${knowledgeBaseId}`)
 
   return newDocument as {

--- a/apps/sim/lib/logs/execution/logging-session.test.ts
+++ b/apps/sim/lib/logs/execution/logging-session.test.ts
@@ -10,6 +10,7 @@ const dbMocks = vi.hoisted(() => {
   const update = vi.fn()
   const execute = vi.fn()
   const eq = vi.fn()
+  const and = vi.fn((...args: unknown[]) => ({ type: 'and', args }))
   const sql = vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }))
 
   select.mockReturnValue({ from: selectFrom })
@@ -29,6 +30,7 @@ const dbMocks = vi.hoisted(() => {
     updateWhere,
     execute,
     eq,
+    and,
     sql,
   }
 })
@@ -47,6 +49,7 @@ vi.mock('@sim/db', () => ({
 
 vi.mock('drizzle-orm', () => ({
   eq: dbMocks.eq,
+  and: dbMocks.and,
   sql: dbMocks.sql,
 }))
 
@@ -447,5 +450,44 @@ describe('LoggingSession completion retries', () => {
     expect(session.completeExecutionWithFinalization).toHaveBeenCalledTimes(1)
     expect(session.completed).toBe(true)
     expect(session.completing).toBe(true)
+  })
+})
+
+describe('LoggingSession.markExecutionAsFailed workflowId scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dbMocks.updateWhere.mockResolvedValue(undefined)
+  })
+
+  it('scopes UPDATE by both executionId and workflowId', async () => {
+    await LoggingSession.markExecutionAsFailed('exec-1', undefined, undefined, 'wf-1')
+
+    expect(dbMocks.update).toHaveBeenCalledTimes(1)
+    expect(dbMocks.updateSet).toHaveBeenCalledTimes(1)
+    expect(dbMocks.updateWhere).toHaveBeenCalledTimes(1)
+
+    const whereArgs = dbMocks.updateWhere.mock.calls[0]
+    expect(whereArgs).toBeDefined()
+  })
+
+  it('instance markAsFailed forwards workflowId to the static method', async () => {
+    const updateWhereSpy = dbMocks.updateWhere
+    dbMocks.selectLimit.mockResolvedValue([{ executionData: {} }])
+
+    const session = new LoggingSession('wf-42', 'exec-42', 'api', 'req-1')
+    await session.markAsFailed('something went wrong')
+
+    expect(updateWhereSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the provided errorMessage in the SQL set', async () => {
+    const sqlMock = dbMocks.sql
+    await LoggingSession.markExecutionAsFailed('exec-2', 'custom error', undefined, 'wf-2')
+
+    expect(sqlMock).toHaveBeenCalled()
+    const lastCall = sqlMock.mock.calls.at(-1)!
+    const [strings, ...values] = lastCall
+    const combined = String(Array.from(strings)).toLowerCase() + values.join(' ').toLowerCase()
+    expect(combined).toContain('force_failed')
   })
 })

--- a/apps/sim/lib/logs/execution/logging-session.ts
+++ b/apps/sim/lib/logs/execution/logging-session.ts
@@ -2,7 +2,7 @@ import { db } from '@sim/db'
 import { workflowExecutionLogs } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
-import { eq, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { BASE_EXECUTION_CHARGE } from '@/lib/billing/constants'
 import { executionLogger } from '@/lib/logs/execution/logger'
 import {
@@ -29,6 +29,7 @@ type TriggerData = Record<string, unknown> & {
 
 function buildStartedMarkerPersistenceQuery(params: {
   executionId: string
+  workflowId: string
   marker: ExecutionLastStartedBlock
 }) {
   const markerJson = JSON.stringify(params.marker)
@@ -41,6 +42,7 @@ function buildStartedMarkerPersistenceQuery(params: {
       true
     )
     WHERE execution_id = ${params.executionId}
+      AND workflow_id = ${params.workflowId}
       AND COALESCE(
         jsonb_extract_path_text(COALESCE(execution_data, '{}'::jsonb), 'lastStartedBlock', 'startedAt'),
         ''
@@ -49,6 +51,7 @@ function buildStartedMarkerPersistenceQuery(params: {
 
 function buildCompletedMarkerPersistenceQuery(params: {
   executionId: string
+  workflowId: string
   marker: ExecutionLastCompletedBlock
 }) {
   const markerJson = JSON.stringify(params.marker)
@@ -61,6 +64,7 @@ function buildCompletedMarkerPersistenceQuery(params: {
       true
     )
     WHERE execution_id = ${params.executionId}
+      AND workflow_id = ${params.workflowId}
       AND COALESCE(
         jsonb_extract_path_text(COALESCE(execution_data, '{}'::jsonb), 'lastCompletedBlock', 'endedAt'),
         ''
@@ -190,6 +194,7 @@ export class LoggingSession {
       await db.execute(
         buildStartedMarkerPersistenceQuery({
           executionId: this.executionId,
+          workflowId: this.workflowId,
           marker,
         })
       )
@@ -205,6 +210,7 @@ export class LoggingSession {
       await db.execute(
         buildCompletedMarkerPersistenceQuery({
           executionId: this.executionId,
+          workflowId: this.workflowId,
           marker,
         })
       )
@@ -357,7 +363,12 @@ export class LoggingSession {
             models: this.accumulatedCost.models,
           },
         })
-        .where(eq(workflowExecutionLogs.executionId, this.executionId))
+        .where(
+          and(
+            eq(workflowExecutionLogs.workflowId, this.workflowId),
+            eq(workflowExecutionLogs.executionId, this.executionId)
+          )
+        )
 
       this.costFlushed = true
     } catch (error) {
@@ -372,7 +383,12 @@ export class LoggingSession {
       const [existing] = await db
         .select({ cost: workflowExecutionLogs.cost })
         .from(workflowExecutionLogs)
-        .where(eq(workflowExecutionLogs.executionId, this.executionId))
+        .where(
+          and(
+            eq(workflowExecutionLogs.workflowId, this.workflowId),
+            eq(workflowExecutionLogs.executionId, this.executionId)
+          )
+        )
         .limit(1)
 
       if (existing?.cost) {
@@ -655,7 +671,12 @@ export class LoggingSession {
       const currentLog = await db
         .select({ status: workflowExecutionLogs.status })
         .from(workflowExecutionLogs)
-        .where(eq(workflowExecutionLogs.executionId, this.executionId))
+        .where(
+          and(
+            eq(workflowExecutionLogs.workflowId, this.workflowId),
+            eq(workflowExecutionLogs.executionId, this.executionId)
+          )
+        )
         .limit(1)
         .then((rows) => rows[0])
 
@@ -754,7 +775,12 @@ export class LoggingSession {
       const currentLog = await db
         .select({ status: workflowExecutionLogs.status })
         .from(workflowExecutionLogs)
-        .where(eq(workflowExecutionLogs.executionId, this.executionId))
+        .where(
+          and(
+            eq(workflowExecutionLogs.workflowId, this.workflowId),
+            eq(workflowExecutionLogs.executionId, this.executionId)
+          )
+        )
         .limit(1)
         .then((rows) => rows[0])
 
@@ -1064,13 +1090,19 @@ export class LoggingSession {
 
   async markAsFailed(errorMessage?: string): Promise<void> {
     await this.waitForCompletion()
-    await LoggingSession.markExecutionAsFailed(this.executionId, errorMessage, this.requestId)
+    await LoggingSession.markExecutionAsFailed(
+      this.executionId,
+      errorMessage,
+      this.requestId,
+      this.workflowId
+    )
   }
 
   static async markExecutionAsFailed(
     executionId: string,
-    errorMessage?: string,
-    requestId?: string
+    errorMessage: string | undefined,
+    requestId: string | undefined,
+    workflowId: string
   ): Promise<void> {
     try {
       const message = errorMessage || 'Run failed'
@@ -1093,7 +1125,12 @@ export class LoggingSession {
             to_jsonb('force_failed'::text)
           )`,
         })
-        .where(eq(workflowExecutionLogs.executionId, executionId))
+        .where(
+          and(
+            eq(workflowExecutionLogs.executionId, executionId),
+            eq(workflowExecutionLogs.workflowId, workflowId)
+          )
+        )
 
       logger.info(`[${requestId || 'unknown'}] Marked execution ${executionId} as failed`)
     } catch (error) {

--- a/apps/sim/lib/logs/filters.ts
+++ b/apps/sim/lib/logs/filters.ts
@@ -66,7 +66,7 @@ export function getStartDateFromTimeRange(timeRange: TimeRange, startDate?: stri
   if (timeRange === 'Custom range') {
     if (startDate) {
       const date = new Date(startDate)
-      date.setHours(0, 0, 0, 0)
+      if (!startDate.includes('T')) date.setHours(0, 0, 0, 0)
       return date
     }
     return null
@@ -111,7 +111,11 @@ export function getEndDateFromTimeRange(timeRange: TimeRange, endDate?: string):
 
   if (endDate) {
     const date = new Date(endDate)
-    date.setHours(23, 59, 59, 999)
+    if (!endDate.includes('T')) {
+      date.setHours(23, 59, 59, 999)
+    } else {
+      date.setMilliseconds(999)
+    }
     return date
   }
 

--- a/apps/sim/lib/uploads/shared/types.ts
+++ b/apps/sim/lib/uploads/shared/types.ts
@@ -24,9 +24,14 @@ export type StorageContext =
   | 'workspace-logos'
 
 /**
- * Contexts exempt from storage quota checks — small metadata assets not managed
- * by the user (profile pictures, logos, OG images). All other contexts represent
- * user-driven uploads and must pass quota validation before upload is initiated.
+ * Contexts exempt from storage quota checks. Includes system-internal contexts
+ * (`logs` — written by the execution pipeline, not user-initiated) and small
+ * metadata assets (`profile-pictures`, `workspace-logos`, `og-images`). All
+ * other contexts are user-driven uploads and must pass quota validation.
+ *
+ * Note: `logs` is excluded from `ALLOWED_UPLOAD_CONTEXTS` in the multipart
+ * endpoint, so it is unreachable there. The exemption applies to non-multipart
+ * (single-part) upload paths used by the execution logging pipeline.
  */
 export const QUOTA_EXEMPT_STORAGE_CONTEXTS = new Set<StorageContext>([
   'profile-pictures',

--- a/apps/sim/lib/uploads/shared/types.ts
+++ b/apps/sim/lib/uploads/shared/types.ts
@@ -23,6 +23,18 @@ export type StorageContext =
   | 'logs'
   | 'workspace-logos'
 
+/**
+ * Contexts exempt from storage quota checks — small metadata assets not managed
+ * by the user (profile pictures, logos, OG images). All other contexts represent
+ * user-driven uploads and must pass quota validation before upload is initiated.
+ */
+export const QUOTA_EXEMPT_STORAGE_CONTEXTS = new Set<StorageContext>([
+  'profile-pictures',
+  'workspace-logos',
+  'og-images',
+  'logs',
+])
+
 export interface FileInfo {
   path: string
   key: string

--- a/apps/sim/lib/webhooks/providers/attio.ts
+++ b/apps/sim/lib/webhooks/providers/attio.ts
@@ -30,13 +30,6 @@ function validateAttioSignature(secret: string, signature: string, body: string)
       return false
     }
     const computedHash = hmacSha256Hex(body, secret)
-    logger.debug('Attio signature comparison', {
-      computedSignature: `${computedHash.substring(0, 10)}...`,
-      providedSignature: `${signature.substring(0, 10)}...`,
-      computedLength: computedHash.length,
-      providedLength: signature.length,
-      match: computedHash === signature,
-    })
     return safeCompare(computedHash, signature)
   } catch (error) {
     logger.error('Error validating Attio signature:', error)
@@ -65,10 +58,7 @@ export const attioHandler: WebhookProviderHandler = {
       const isValidSignature = validateAttioSignature(secret, signature, rawBody)
 
       if (!isValidSignature) {
-        logger.warn(`[${requestId}] Attio signature verification failed`, {
-          signatureLength: signature.length,
-          secretLength: secret.length,
-        })
+        logger.warn(`[${requestId}] Attio signature verification failed`)
         return new NextResponse('Unauthorized - Invalid Attio signature', {
           status: 401,
         })

--- a/apps/sim/lib/webhooks/providers/github.ts
+++ b/apps/sim/lib/webhooks/providers/github.ts
@@ -37,14 +37,6 @@ function validateGitHubSignature(secret: string, signature: string, body: string
       return false
     }
     const computedHash = crypto.createHmac(algorithm, secret).update(body, 'utf8').digest('hex')
-    logger.debug('GitHub signature comparison', {
-      algorithm,
-      computedSignature: `${computedHash.substring(0, 10)}...`,
-      providedSignature: `${providedSignature.substring(0, 10)}...`,
-      computedLength: computedHash.length,
-      providedLength: providedSignature.length,
-      match: computedHash === providedSignature,
-    })
     return safeCompare(computedHash, providedSignature)
   } catch (error) {
     logger.error('Error validating GitHub signature:', error)
@@ -68,8 +60,6 @@ export const githubHandler: WebhookProviderHandler = {
 
     if (!validateGitHubSignature(secret, signature, rawBody)) {
       logger.warn(`[${requestId}] GitHub signature verification failed`, {
-        signatureLength: signature.length,
-        secretLength: secret.length,
         usingSha256: !!request.headers.get('X-Hub-Signature-256'),
       })
       return new NextResponse('Unauthorized - Invalid GitHub signature', { status: 401 })

--- a/apps/sim/lib/webhooks/providers/intercom.ts
+++ b/apps/sim/lib/webhooks/providers/intercom.ts
@@ -59,10 +59,7 @@ export const intercomHandler: WebhookProviderHandler = {
     }
 
     if (!validateIntercomSignature(secret, signature, rawBody)) {
-      logger.warn(`[${requestId}] Intercom signature verification failed`, {
-        signatureLength: signature.length,
-        secretLength: secret.length,
-      })
+      logger.warn(`[${requestId}] Intercom signature verification failed`)
       return new NextResponse('Unauthorized - Invalid Intercom signature', { status: 401 })
     }
 

--- a/apps/sim/lib/webhooks/providers/whatsapp.ts
+++ b/apps/sim/lib/webhooks/providers/whatsapp.ts
@@ -179,7 +179,7 @@ async function handleWhatsAppVerification(
         continue
       }
 
-      if (token === verificationToken) {
+      if (safeCompare(token, verificationToken as string)) {
         logger.info(`[${requestId}] WhatsApp verification successful for webhook ${wh.id}`)
         return new NextResponse(challenge, {
           status: 200,

--- a/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
+++ b/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
@@ -444,7 +444,9 @@ export class PauseResumeManager {
           })
           await LoggingSession.markExecutionAsFailed(
             effectiveExecutionId,
-            'Missing snapshot seed for paused execution'
+            'Missing snapshot seed for paused execution',
+            undefined,
+            pausedExecution.workflowId
           )
         } else {
           try {
@@ -462,7 +464,9 @@ export class PauseResumeManager {
             })
             await LoggingSession.markExecutionAsFailed(
               effectiveExecutionId,
-              `Failed to persist pause state: ${toError(pauseError).message}`
+              `Failed to persist pause state: ${toError(pauseError).message}`,
+              undefined,
+              pausedExecution.workflowId
             )
           }
         }

--- a/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
+++ b/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
@@ -1390,7 +1390,7 @@ export class PauseResumeManager {
       await tx
         .update(pausedExecutions)
         .set({
-          pausePoints: sql`jsonb_set(jsonb_set(pause_points, ARRAY[${contextId}, 'resumeStatus'], '"resumed"'::jsonb), ARRAY[${contextId}, 'resumedAt'], '"${sql.raw(now.toISOString())}"'::jsonb)`,
+          pausePoints: sql`jsonb_set(jsonb_set(pause_points, ARRAY[${contextId}, 'resumeStatus'], '"resumed"'::jsonb), ARRAY[${contextId}, 'resumedAt'], ${JSON.stringify(now.toISOString())}::jsonb)`,
           resumedCount: sql`resumed_count + 1`,
           status: sql`CASE WHEN status = 'cancelling' THEN 'cancelling' WHEN resumed_count + 1 >= total_pause_count THEN 'fully_resumed' ELSE 'partially_resumed' END`,
           updatedAt: now,

--- a/apps/sim/lib/workspaces/lifecycle.test.ts
+++ b/apps/sim/lib/workspaces/lifecycle.test.ts
@@ -55,6 +55,7 @@ describe('workspace lifecycle', () => {
     })
 
     const tx = {
+      execute: vi.fn().mockResolvedValue([]),
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([{ id: 'kb-1' }]),

--- a/apps/sim/lib/workspaces/lifecycle.test.ts
+++ b/apps/sim/lib/workspaces/lifecycle.test.ts
@@ -55,7 +55,6 @@ describe('workspace lifecycle', () => {
     })
 
     const tx = {
-      execute: vi.fn().mockResolvedValue([]),
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([{ id: 'kb-1' }]),

--- a/apps/sim/lib/workspaces/lifecycle.ts
+++ b/apps/sim/lib/workspaces/lifecycle.ts
@@ -49,13 +49,6 @@ export async function archiveWorkspace(
     .where(eq(workflowMcpServer.workspaceId, workspaceId))
 
   await db.transaction(async (tx) => {
-    // Workspace archival is a rare admin/cleanup operation that touches every
-    // child table; on large workspaces it can exceed the 30s session default.
-    // Override per-tx with a generous ceiling — if it ever runs longer than
-    // this something is genuinely wrong.
-    await tx.execute(sql`SET LOCAL statement_timeout = '5min'`)
-    await tx.execute(sql`SET LOCAL lock_timeout = '30s'`)
-
     await tx
       .update(knowledgeBase)
       .set({

--- a/apps/sim/lib/workspaces/lifecycle.ts
+++ b/apps/sim/lib/workspaces/lifecycle.ts
@@ -49,6 +49,13 @@ export async function archiveWorkspace(
     .where(eq(workflowMcpServer.workspaceId, workspaceId))
 
   await db.transaction(async (tx) => {
+    // Workspace archival is a rare admin/cleanup operation that touches every
+    // child table; on large workspaces it can exceed the 30s session default.
+    // Override per-tx with a generous ceiling — if it ever runs longer than
+    // this something is genuinely wrong.
+    await tx.execute(sql`SET LOCAL statement_timeout = '5min'`)
+    await tx.execute(sql`SET LOCAL lock_timeout = '30s'`)
+
     await tx
       .update(knowledgeBase)
       .set({

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -155,7 +155,7 @@
     "mongodb": "6.19.0",
     "mysql2": "3.14.3",
     "neo4j-driver": "6.0.1",
-    "next": "16.2.4",
+    "next": "16.2.6",
     "next-mdx-remote": "^6.0.0",
     "next-runtime-env": "3.3.0",
     "next-themes": "^0.4.6",
@@ -241,8 +241,8 @@
     "sharp"
   ],
   "overrides": {
-    "next": "16.2.4",
-    "@next/env": "16.2.4",
+    "next": "16.2.6",
+    "@next/env": "16.2.6",
     "react-floater": {
       "react": "$react",
       "react-dom": "$react-dom"

--- a/apps/sim/tools/cloudwatch/index.ts
+++ b/apps/sim/tools/cloudwatch/index.ts
@@ -4,8 +4,10 @@ import { describeLogStreamsTool } from '@/tools/cloudwatch/describe_log_streams'
 import { getLogEventsTool } from '@/tools/cloudwatch/get_log_events'
 import { getMetricStatisticsTool } from '@/tools/cloudwatch/get_metric_statistics'
 import { listMetricsTool } from '@/tools/cloudwatch/list_metrics'
+import { muteAlarmTool } from '@/tools/cloudwatch/mute_alarm'
 import { putMetricDataTool } from '@/tools/cloudwatch/put_metric_data'
 import { queryLogsTool } from '@/tools/cloudwatch/query_logs'
+import { unmuteAlarmTool } from '@/tools/cloudwatch/unmute_alarm'
 
 export * from './types'
 
@@ -15,5 +17,7 @@ export const cloudwatchDescribeLogStreamsTool = describeLogStreamsTool
 export const cloudwatchGetLogEventsTool = getLogEventsTool
 export const cloudwatchGetMetricStatisticsTool = getMetricStatisticsTool
 export const cloudwatchListMetricsTool = listMetricsTool
+export const cloudwatchMuteAlarmTool = muteAlarmTool
 export const cloudwatchPutMetricDataTool = putMetricDataTool
 export const cloudwatchQueryLogsTool = queryLogsTool
+export const cloudwatchUnmuteAlarmTool = unmuteAlarmTool

--- a/apps/sim/tools/cloudwatch/mute_alarm.ts
+++ b/apps/sim/tools/cloudwatch/mute_alarm.ts
@@ -1,0 +1,75 @@
+import type {
+  CloudWatchMuteAlarmParams,
+  CloudWatchMuteAlarmResponse,
+} from '@/tools/cloudwatch/types'
+import type { ToolConfig } from '@/tools/types'
+
+export const muteAlarmTool: ToolConfig<CloudWatchMuteAlarmParams, CloudWatchMuteAlarmResponse> = {
+  id: 'cloudwatch_mute_alarm',
+  name: 'CloudWatch Mute Alarm',
+  description: 'Disable notification actions on one or more CloudWatch alarms',
+  version: '1.0.0',
+
+  params: {
+    awsRegion: {
+      type: 'string',
+      required: true,
+      visibility: 'user-only',
+      description: 'AWS region (e.g., us-east-1)',
+    },
+    awsAccessKeyId: {
+      type: 'string',
+      required: true,
+      visibility: 'user-only',
+      description: 'AWS access key ID',
+    },
+    awsSecretAccessKey: {
+      type: 'string',
+      required: true,
+      visibility: 'user-only',
+      description: 'AWS secret access key',
+    },
+    alarmNames: {
+      type: 'array',
+      required: true,
+      visibility: 'user-or-llm',
+      description: 'Names of the CloudWatch alarms to mute',
+    },
+  },
+
+  request: {
+    url: '/api/tools/cloudwatch/mute-alarm',
+    method: 'POST',
+    headers: () => ({
+      'Content-Type': 'application/json',
+    }),
+    body: (params) => ({
+      region: params.awsRegion,
+      accessKeyId: params.awsAccessKeyId,
+      secretAccessKey: params.awsSecretAccessKey,
+      alarmNames: params.alarmNames,
+    }),
+  },
+
+  transformResponse: async (response: Response) => {
+    const data = await response.json()
+
+    if (!response.ok) {
+      throw new Error(data.error || 'Failed to mute CloudWatch alarm')
+    }
+
+    return {
+      success: true,
+      output: data.output,
+    }
+  },
+
+  outputs: {
+    success: { type: 'boolean', description: 'Whether the alarms were muted successfully' },
+    alarmNames: {
+      type: 'array',
+      description: 'Names of the alarms that were muted',
+      items: { type: 'string' },
+    },
+  },
+}

--- a/apps/sim/tools/cloudwatch/types.ts
+++ b/apps/sim/tools/cloudwatch/types.ts
@@ -163,3 +163,25 @@ export interface CloudWatchPutMetricDataResponse extends ToolResponse {
     timestamp: string
   }
 }
+
+export interface CloudWatchMuteAlarmParams extends CloudWatchConnectionConfig {
+  alarmNames: string[]
+}
+
+export interface CloudWatchMuteAlarmResponse extends ToolResponse {
+  output: {
+    success: boolean
+    alarmNames: string[]
+  }
+}
+
+export interface CloudWatchUnmuteAlarmParams extends CloudWatchConnectionConfig {
+  alarmNames: string[]
+}
+
+export interface CloudWatchUnmuteAlarmResponse extends ToolResponse {
+  output: {
+    success: boolean
+    alarmNames: string[]
+  }
+}

--- a/apps/sim/tools/cloudwatch/unmute_alarm.ts
+++ b/apps/sim/tools/cloudwatch/unmute_alarm.ts
@@ -1,0 +1,78 @@
+import type {
+  CloudWatchUnmuteAlarmParams,
+  CloudWatchUnmuteAlarmResponse,
+} from '@/tools/cloudwatch/types'
+import type { ToolConfig } from '@/tools/types'
+
+export const unmuteAlarmTool: ToolConfig<
+  CloudWatchUnmuteAlarmParams,
+  CloudWatchUnmuteAlarmResponse
+> = {
+  id: 'cloudwatch_unmute_alarm',
+  name: 'CloudWatch Unmute Alarm',
+  description: 'Re-enable notification actions on one or more CloudWatch alarms',
+  version: '1.0.0',
+
+  params: {
+    awsRegion: {
+      type: 'string',
+      required: true,
+      visibility: 'user-only',
+      description: 'AWS region (e.g., us-east-1)',
+    },
+    awsAccessKeyId: {
+      type: 'string',
+      required: true,
+      visibility: 'user-only',
+      description: 'AWS access key ID',
+    },
+    awsSecretAccessKey: {
+      type: 'string',
+      required: true,
+      visibility: 'user-only',
+      description: 'AWS secret access key',
+    },
+    alarmNames: {
+      type: 'array',
+      required: true,
+      visibility: 'user-or-llm',
+      description: 'Names of the CloudWatch alarms to unmute',
+    },
+  },
+
+  request: {
+    url: '/api/tools/cloudwatch/unmute-alarm',
+    method: 'POST',
+    headers: () => ({
+      'Content-Type': 'application/json',
+    }),
+    body: (params) => ({
+      region: params.awsRegion,
+      accessKeyId: params.awsAccessKeyId,
+      secretAccessKey: params.awsSecretAccessKey,
+      alarmNames: params.alarmNames,
+    }),
+  },
+
+  transformResponse: async (response: Response) => {
+    const data = await response.json()
+
+    if (!response.ok) {
+      throw new Error(data.error || 'Failed to unmute CloudWatch alarm')
+    }
+
+    return {
+      success: true,
+      output: data.output,
+    }
+  },
+
+  outputs: {
+    success: { type: 'boolean', description: 'Whether the alarms were unmuted successfully' },
+    alarmNames: {
+      type: 'array',
+      description: 'Names of the alarms that were unmuted',
+      items: { type: 'string' },
+    },
+  },
+}

--- a/apps/sim/tools/gmail/utils.test.ts
+++ b/apps/sim/tools/gmail/utils.test.ts
@@ -81,9 +81,9 @@ describe('plainTextToHtml', () => {
 })
 
 describe('htmlToPlainText', () => {
-  it('strips tags, decodes entities, and collapses whitespace', () => {
+  it('strips tags and decodes entities', () => {
     const result = htmlToPlainText('<p>Hi &amp; bye</p><p>Line<br>break</p>')
-    expect(result).toBe('Hi & bye\nLine\nbreak')
+    expect(result).toBe('Hi & bye\n\nLine\nbreak')
   })
 
   it('drops <style> and <script> contents', () => {
@@ -97,9 +97,20 @@ describe('htmlToPlainText', () => {
   })
 
   it('decodes decimal and hexadecimal numeric entities', () => {
-    expect(htmlToPlainText('<p>&#8220;hi&#8221; &#160;and&#x2019;s</p>')).toBe(
-      '\u201chi\u201d \u00a0and\u2019s'
+    expect(htmlToPlainText('<p>&#8220;hi&#8221; and&#x2019;s</p>')).toBe(
+      '\u201chi\u201d and\u2019s'
     )
+  })
+
+  it('preserves &#160; (non-breaking space) as U+00A0 for fidelity in plain-text output', () => {
+    expect(htmlToPlainText('<p>a&#160;b</p>')).toBe('a\u00a0b')
+  })
+
+  it('elides anchor URLs that exactly match link text, and drops bare # anchors', () => {
+    expect(
+      htmlToPlainText('<p>Visit <a href="https://example.com">https://example.com</a></p>')
+    ).toBe('Visit https://example.com')
+    expect(htmlToPlainText('<p><a href="#section">Anchor</a></p>')).toBe('Anchor')
   })
 })
 

--- a/apps/sim/tools/gmail/utils.test.ts
+++ b/apps/sim/tools/gmail/utils.test.ts
@@ -2,7 +2,32 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from 'vitest'
-import { encodeRfc2047 } from './utils'
+import {
+  buildMimeMessage,
+  buildSimpleEmailMessage,
+  encodeRfc2047,
+  escapeHtml,
+  htmlToPlainText,
+  plainTextToHtml,
+} from './utils'
+
+function decodeSimpleMessage(encoded: string): string {
+  return Buffer.from(encoded, 'base64url').toString('utf-8')
+}
+
+/**
+ * Extract and base64-decode the body of a specific MIME part identified by its
+ * Content-Type prefix (e.g. `text/plain`, `text/html`). Returns the decoded
+ * UTF-8 string.
+ */
+function decodePart(mime: string, contentTypePrefix: string): string {
+  const partRegex = new RegExp(
+    `Content-Type: ${contentTypePrefix}[^\\n]*\\nContent-Transfer-Encoding: base64\\n\\n([\\s\\S]*?)\\n\\n--`
+  )
+  const match = mime.match(partRegex)
+  if (!match) throw new Error(`No ${contentTypePrefix} part found`)
+  return Buffer.from(match[1].replace(/\n/g, ''), 'base64').toString('utf-8')
+}
 
 describe('encodeRfc2047', () => {
   it('returns ASCII text unchanged', () => {
@@ -32,5 +57,135 @@ describe('encodeRfc2047', () => {
   it('does not double-encode already-encoded subjects', () => {
     const alreadyEncoded = '=?UTF-8?B?VGltZSB0byBTdHJldGNoISDwn6eY?='
     expect(encodeRfc2047(alreadyEncoded)).toBe(alreadyEncoded)
+  })
+})
+
+describe('escapeHtml', () => {
+  it('escapes the five HTML special characters', () => {
+    expect(escapeHtml(`<script>alert("x & y's")</script>`)).toBe(
+      '&lt;script&gt;alert(&quot;x &amp; y&#39;s&quot;)&lt;/script&gt;'
+    )
+  })
+})
+
+describe('plainTextToHtml', () => {
+  it('renders blank lines as paragraph breaks and single newlines as <br>', () => {
+    const html = plainTextToHtml('Hi Janice,\n\nHope you are well.\nSecond line.')
+    expect(html).toContain('<p>Hi Janice,</p>')
+    expect(html).toContain('<p>Hope you are well.<br>Second line.</p>')
+  })
+
+  it('escapes HTML in the source text', () => {
+    expect(plainTextToHtml('<b>bold</b>')).toContain('&lt;b&gt;bold&lt;/b&gt;')
+  })
+})
+
+describe('htmlToPlainText', () => {
+  it('strips tags, decodes entities, and collapses whitespace', () => {
+    const result = htmlToPlainText('<p>Hi &amp; bye</p><p>Line<br>break</p>')
+    expect(result).toBe('Hi & bye\nLine\nbreak')
+  })
+
+  it('drops <style> and <script> contents', () => {
+    expect(htmlToPlainText('<style>p{}</style><p>Hi</p>')).toBe('Hi')
+  })
+
+  it('does not double-decode compound entities like &amp;lt;', () => {
+    expect(htmlToPlainText('<p>&amp;lt; is the literal &lt; entity</p>')).toBe(
+      '&lt; is the literal < entity'
+    )
+  })
+
+  it('decodes decimal and hexadecimal numeric entities', () => {
+    expect(htmlToPlainText('<p>&#8220;hi&#8221; &#160;and&#x2019;s</p>')).toBe(
+      '\u201chi\u201d \u00a0and\u2019s'
+    )
+  })
+})
+
+describe('buildSimpleEmailMessage', () => {
+  it('emits multipart/alternative with text/plain then text/html for plain-text input', () => {
+    const encoded = buildSimpleEmailMessage({
+      to: 'a@example.com',
+      subject: 'Hi',
+      body: 'Hi Janice,\n\nQuick question.',
+    })
+    const decoded = decodeSimpleMessage(encoded)
+    expect(decoded).toMatch(/Content-Type: multipart\/alternative; boundary="([^"]+)"/)
+    const plainIdx = decoded.indexOf('text/plain')
+    const htmlIdx = decoded.indexOf('text/html')
+    expect(plainIdx).toBeGreaterThan(-1)
+    expect(htmlIdx).toBeGreaterThan(plainIdx)
+    expect(decodePart(decoded, 'text/plain')).toBe('Hi Janice,\n\nQuick question.')
+    expect(decodePart(decoded, 'text/html')).toContain('<p>Hi Janice,</p>')
+  })
+
+  it('encodes bodies as base64 so UTF-8 (emoji, accents) round-trips cleanly', () => {
+    const body = 'Café 🎉 — résumé'
+    const encoded = buildSimpleEmailMessage({
+      to: 'a@example.com',
+      subject: 'Hi',
+      body,
+    })
+    const decoded = decodeSimpleMessage(encoded)
+    expect(decoded).toContain('Content-Transfer-Encoding: base64')
+    expect(decodePart(decoded, 'text/plain')).toBe(body)
+    expect(decodePart(decoded, 'text/html')).toContain('Café 🎉 — résumé')
+  })
+
+  it('uses the supplied HTML body and derives a plain-text fallback when contentType is html', () => {
+    const encoded = buildSimpleEmailMessage({
+      to: 'a@example.com',
+      subject: 'Hi',
+      body: '<p>Hello <b>there</b></p>',
+      contentType: 'html',
+    })
+    const decoded = decodeSimpleMessage(encoded)
+    expect(decodePart(decoded, 'text/html')).toBe('<p>Hello <b>there</b></p>')
+    expect(decodePart(decoded, 'text/plain')).toBe('Hello there')
+  })
+
+  it('includes threading headers when replying', () => {
+    const encoded = buildSimpleEmailMessage({
+      to: 'a@example.com',
+      body: 'reply',
+      inReplyTo: '<msg-1@example.com>',
+      references: '<root@example.com>',
+    })
+    const decoded = decodeSimpleMessage(encoded)
+    expect(decoded).toContain('In-Reply-To: <msg-1@example.com>')
+    expect(decoded).toContain('References: <root@example.com> <msg-1@example.com>')
+  })
+})
+
+describe('buildMimeMessage', () => {
+  it('nests multipart/alternative inside multipart/mixed when attachments are present', () => {
+    const message = buildMimeMessage({
+      to: 'a@example.com',
+      subject: 'Hi',
+      body: 'Hello',
+      attachments: [
+        {
+          filename: 'note.txt',
+          mimeType: 'text/plain',
+          content: Buffer.from('hi'),
+        },
+      ],
+    })
+    expect(message).toMatch(/Content-Type: multipart\/mixed; boundary="([^"]+)"/)
+    expect(message).toMatch(/Content-Type: multipart\/alternative; boundary="([^"]+)"/)
+    expect(message).toContain('Content-Disposition: attachment; filename="note.txt"')
+    expect(decodePart(message, 'text/plain')).toBe('Hello')
+    expect(decodePart(message, 'text/html')).toContain('<p>Hello</p>')
+  })
+
+  it('emits multipart/alternative without multipart/mixed when no attachments', () => {
+    const message = buildMimeMessage({
+      to: 'a@example.com',
+      subject: 'Hi',
+      body: 'Hello',
+    })
+    expect(message).toMatch(/Content-Type: multipart\/alternative; boundary="([^"]+)"/)
+    expect(message).not.toContain('multipart/mixed')
   })
 })

--- a/apps/sim/tools/gmail/utils.ts
+++ b/apps/sim/tools/gmail/utils.ts
@@ -317,8 +317,108 @@ export function base64UrlEncode(data: string | Buffer): string {
 }
 
 /**
- * Build a simple text email message (without attachments)
- * @param params Email parameters including recipients, subject, body, and threading info
+ * Escape HTML special characters so user-supplied text renders safely inside an HTML body.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * Convert a plain-text body to an HTML body that flows naturally in Gmail.
+ * Blank lines become paragraph breaks; single newlines become `<br>`.
+ * This avoids the narrow hard-wrapped rendering Gmail uses for `text/plain`.
+ */
+export function plainTextToHtml(body: string): string {
+  const normalized = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+  const paragraphs = normalized.split(/\n{2,}/)
+  const htmlParagraphs = paragraphs.map((paragraph) => {
+    const escaped = escapeHtml(paragraph).replace(/\n/g, '<br>')
+    return `<p>${escaped}</p>`
+  })
+  return `<!DOCTYPE html><html><body>${htmlParagraphs.join('')}</body></html>`
+}
+
+/**
+ * Best-effort conversion of an HTML body to a plain-text fallback. Strips tags
+ * and decodes the common entities. Used so we always include a plain-text part
+ * alongside HTML for clients that don't render HTML.
+ */
+export function htmlToPlainText(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|h[1-6]|li|tr)>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number.parseInt(dec, 10)))
+    .replace(/&amp;/g, '&')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+/**
+ * Produce the plain-text and HTML representations of a body so we can emit a
+ * `multipart/alternative` section. Gmail renders the HTML version full-width
+ * (matching how a manually-composed email looks); the plain-text part is the
+ * fallback for clients that don't render HTML.
+ */
+export function buildBodyAlternatives(
+  body: string,
+  contentType: 'text' | 'html' | undefined
+): { plain: string; html: string } {
+  if (contentType === 'html') {
+    return { plain: htmlToPlainText(body) || body, html: body }
+  }
+  return { plain: body, html: plainTextToHtml(body) }
+}
+
+/**
+ * Encode a text body as base64 with RFC 2045 line wrapping (max 76 chars).
+ * Using base64 lets us safely transport arbitrary UTF-8 (emoji, accented
+ * characters, etc.) — `7bit` is only valid for strict 7-bit ASCII.
+ */
+function encodeBodyBase64(content: string): string[] {
+  const base64 = Buffer.from(content, 'utf-8').toString('base64')
+  return base64.match(/.{1,76}/g) || ['']
+}
+
+/**
+ * Render the inner part of a `multipart/alternative` section (text/plain
+ * followed by text/html, per RFC 2046 — clients pick the last format they
+ * understand).
+ */
+function renderAlternativeParts(plain: string, html: string, boundary: string): string[] {
+  return [
+    `--${boundary}`,
+    'Content-Type: text/plain; charset="UTF-8"',
+    'Content-Transfer-Encoding: base64',
+    '',
+    ...encodeBodyBase64(plain),
+    '',
+    `--${boundary}`,
+    'Content-Type: text/html; charset="UTF-8"',
+    'Content-Transfer-Encoding: base64',
+    '',
+    ...encodeBodyBase64(html),
+    '',
+    `--${boundary}--`,
+  ]
+}
+
+/**
+ * Build a `multipart/alternative` email (without attachments). Always emits
+ * both text/plain and text/html parts so Gmail renders messages full-width
+ * like a hand-composed email.
  * @returns Base64url encoded raw message
  */
 export function buildSimpleEmailMessage(params: {
@@ -332,12 +432,10 @@ export function buildSimpleEmailMessage(params: {
   references?: string
 }): string {
   const { to, cc, bcc, subject, body, contentType, inReplyTo, references } = params
-  const mimeContentType = contentType === 'html' ? 'text/html' : 'text/plain'
-  const emailHeaders = [
-    `Content-Type: ${mimeContentType}; charset="UTF-8"`,
-    'MIME-Version: 1.0',
-    `To: ${to}`,
-  ]
+  const boundary = generateBoundary()
+  const { plain, html } = buildBodyAlternatives(body, contentType)
+
+  const emailHeaders = ['MIME-Version: 1.0', `To: ${to}`]
 
   if (cc) {
     emailHeaders.push(`Cc: ${cc}`)
@@ -354,7 +452,10 @@ export function buildSimpleEmailMessage(params: {
     emailHeaders.push(`References: ${referencesChain}`)
   }
 
-  emailHeaders.push('', body)
+  emailHeaders.push(`Content-Type: multipart/alternative; boundary="${boundary}"`)
+  emailHeaders.push('')
+  emailHeaders.push(...renderAlternativeParts(plain, html, boundary))
+
   const email = emailHeaders.join('\n')
   return Buffer.from(email).toString('base64url')
 }
@@ -382,9 +483,8 @@ export interface BuildMimeMessageParams {
 
 export function buildMimeMessage(params: BuildMimeMessageParams): string {
   const { to, cc, bcc, subject, body, contentType, inReplyTo, references, attachments } = params
-  const boundary = generateBoundary()
   const messageParts: string[] = []
-  const mimeContentType = contentType === 'html' ? 'text/html' : 'text/plain'
+  const { plain, html } = buildBodyAlternatives(body, contentType)
 
   messageParts.push(`To: ${to}`)
   if (cc) {
@@ -408,17 +508,19 @@ export function buildMimeMessage(params: BuildMimeMessageParams): string {
   messageParts.push('MIME-Version: 1.0')
 
   if (attachments && attachments.length > 0) {
-    messageParts.push(`Content-Type: multipart/mixed; boundary="${boundary}"`)
+    const mixedBoundary = generateBoundary()
+    const altBoundary = generateBoundary()
+
+    messageParts.push(`Content-Type: multipart/mixed; boundary="${mixedBoundary}"`)
     messageParts.push('')
-    messageParts.push(`--${boundary}`)
-    messageParts.push(`Content-Type: ${mimeContentType}; charset="UTF-8"`)
-    messageParts.push('Content-Transfer-Encoding: 7bit')
+    messageParts.push(`--${mixedBoundary}`)
+    messageParts.push(`Content-Type: multipart/alternative; boundary="${altBoundary}"`)
     messageParts.push('')
-    messageParts.push(body)
+    messageParts.push(...renderAlternativeParts(plain, html, altBoundary))
     messageParts.push('')
 
     for (const attachment of attachments) {
-      messageParts.push(`--${boundary}`)
+      messageParts.push(`--${mixedBoundary}`)
       messageParts.push(`Content-Type: ${attachment.mimeType}`)
       messageParts.push(`Content-Disposition: attachment; filename="${attachment.filename}"`)
       messageParts.push('Content-Transfer-Encoding: base64')
@@ -430,12 +532,12 @@ export function buildMimeMessage(params: BuildMimeMessageParams): string {
       messageParts.push('')
     }
 
-    messageParts.push(`--${boundary}--`)
+    messageParts.push(`--${mixedBoundary}--`)
   } else {
-    messageParts.push(`Content-Type: ${mimeContentType}; charset="UTF-8"`)
-    messageParts.push('MIME-Version: 1.0')
+    const altBoundary = generateBoundary()
+    messageParts.push(`Content-Type: multipart/alternative; boundary="${altBoundary}"`)
     messageParts.push('')
-    messageParts.push(body)
+    messageParts.push(...renderAlternativeParts(plain, html, altBoundary))
   }
 
   return messageParts.join('\n')

--- a/apps/sim/tools/gmail/utils.ts
+++ b/apps/sim/tools/gmail/utils.ts
@@ -1,3 +1,4 @@
+import { convert } from 'html-to-text'
 import type {
   GmailAttachment,
   GmailMessage,
@@ -344,26 +345,21 @@ export function plainTextToHtml(body: string): string {
 }
 
 /**
- * Best-effort conversion of an HTML body to a plain-text fallback. Strips tags
- * and decodes the common entities. Used so we always include a plain-text part
- * alongside HTML for clients that don't render HTML.
+ * Best-effort conversion of an HTML body to a plain-text fallback. Used so we
+ * always include a plain-text part alongside HTML for clients that don't render
+ * HTML. Delegates to the `html-to-text` library for robust tag stripping and
+ * entity decoding (also used elsewhere in the repo for the same purpose).
  */
 export function htmlToPlainText(html: string): string {
-  return html
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/(p|div|h[1-6]|li|tr)>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number.parseInt(dec, 10)))
-    .replace(/&amp;/g, '&')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim()
+  return convert(html, {
+    wordwrap: false,
+    selectors: [
+      { selector: 'a', options: { hideLinkHrefIfSameAsText: true, noAnchorUrl: true } },
+      { selector: 'img', format: 'skip' },
+      { selector: 'script', format: 'skip' },
+      { selector: 'style', format: 'skip' },
+    ],
+  })
 }
 
 /**

--- a/apps/sim/tools/google_drive/list.ts
+++ b/apps/sim/tools/google_drive/list.ts
@@ -66,8 +66,11 @@ export const listTool: ToolConfig<GoogleDriveToolParams, GoogleDriveListResponse
       const escapeQueryValue = (value: string): string =>
         value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
 
-      // Build the query conditions
-      const conditions = ['trashed = false'] // Always exclude trashed files
+      // Build the query conditions. `params.query` here is a plain-text name
+      // search term (wrapped in `name contains '...'` below), not Google Drive
+      // query syntax — so there's no caller-supplied `trashed` predicate to
+      // honour. Always exclude trashed files.
+      const conditions: string[] = ['trashed = false']
       const folderId = (params.folderId || params.folderSelector)?.trim()
       if (folderId) {
         const escapedFolderId = escapeQueryValue(folderId)

--- a/apps/sim/tools/google_drive/search.ts
+++ b/apps/sim/tools/google_drive/search.ts
@@ -64,9 +64,14 @@ export const searchTool: ToolConfig<GoogleDriveSearchParams, GoogleDriveSearchRe
       url.searchParams.append('includeItemsFromAllDrives', 'true')
 
       // The query is passed directly as Google Drive query syntax
-      const conditions = ['trashed = false']
-      if (params.query?.trim()) {
-        conditions.push(params.query.trim())
+      const userQuery = params.query?.trim()
+      const userSpecifiesTrashed = userQuery ? /\btrashed\s*=/.test(userQuery) : false
+      const conditions: string[] = []
+      if (!userSpecifiesTrashed) {
+        conditions.push('trashed = false')
+      }
+      if (userQuery) {
+        conditions.push(userQuery)
       }
       url.searchParams.append('q', conditions.join(' and '))
 

--- a/apps/sim/tools/microsoft_teams/server-utils.ts
+++ b/apps/sim/tools/microsoft_teams/server-utils.ts
@@ -7,6 +7,7 @@ import type { Logger } from '@sim/logger'
 import { secureFetchWithValidation } from '@/lib/core/security/input-validation.server'
 import { processFilesToUserFiles, type RawFileInput } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { FileAccessDeniedError, verifyFileAccess } from '@/app/api/files/authorization'
 import type { UserFile } from '@/executor/types'
 import type { GraphApiErrorResponse, GraphDriveItem } from '@/tools/microsoft_teams/types'
 
@@ -45,8 +46,9 @@ export async function uploadFilesForTeamsMessage(params: {
   accessToken: string
   requestId: string
   logger: Logger
+  userId: string
 }): Promise<TeamsFileUploadResult> {
-  const { rawFiles, accessToken, requestId, logger: log } = params
+  const { rawFiles, accessToken, requestId, logger: log, userId } = params
   const attachments: TeamsAttachmentRef[] = []
   const filesOutput: TeamsFileOutput[] = []
 
@@ -71,6 +73,11 @@ export async function uploadFilesForTeamsMessage(params: {
     }
 
     log.info(`[${requestId}] Uploading file to Teams: ${file.name} (${file.size} bytes)`)
+
+    const hasAccess = await verifyFileAccess(file.key, userId)
+    if (!hasAccess) {
+      throw new FileAccessDeniedError()
+    }
 
     // Download file from storage
     const buffer = await downloadFileFromStorage(file, requestId, log)

--- a/apps/sim/tools/microsoft_teams/utils.ts
+++ b/apps/sim/tools/microsoft_teams/utils.ts
@@ -368,7 +368,7 @@ export async function resolveMentionsForChat(
         })
       }
       resolvedTags.add(mention.fullTag)
-      updatedContent = updatedContent.replace(
+      updatedContent = updatedContent.replaceAll(
         mention.fullTag,
         `<at id="${mention.mentionId}">${mention.name}</at>`
       )
@@ -435,7 +435,7 @@ export async function resolveMentionsForChannel(
         })
       }
       resolvedTags.add(mention.fullTag)
-      updatedContent = updatedContent.replace(
+      updatedContent = updatedContent.replaceAll(
         mention.fullTag,
         `<at id="${mention.mentionId}">${mention.name}</at>`
       )

--- a/apps/sim/tools/registry.ts
+++ b/apps/sim/tools/registry.ts
@@ -350,8 +350,10 @@ import {
   cloudwatchGetLogEventsTool,
   cloudwatchGetMetricStatisticsTool,
   cloudwatchListMetricsTool,
+  cloudwatchMuteAlarmTool,
   cloudwatchPutMetricDataTool,
   cloudwatchQueryLogsTool,
+  cloudwatchUnmuteAlarmTool,
 } from '@/tools/cloudwatch'
 import {
   confluenceAddLabelTool,
@@ -3813,8 +3815,10 @@ export const tools: Record<string, ToolConfig> = {
   cloudwatch_get_log_events: cloudwatchGetLogEventsTool,
   cloudwatch_get_metric_statistics: cloudwatchGetMetricStatisticsTool,
   cloudwatch_list_metrics: cloudwatchListMetricsTool,
+  cloudwatch_mute_alarm: cloudwatchMuteAlarmTool,
   cloudwatch_put_metric_data: cloudwatchPutMetricDataTool,
   cloudwatch_query_logs: cloudwatchQueryLogsTool,
+  cloudwatch_unmute_alarm: cloudwatchUnmuteAlarmTool,
   crowdstrike_get_sensor_aggregates: crowdstrikeGetSensorAggregatesTool,
   crowdstrike_get_sensor_details: crowdstrikeGetSensorDetailsTool,
   crowdstrike_query_sensors: crowdstrikeQuerySensorsTool,

--- a/apps/sim/tools/slack/get_message.ts
+++ b/apps/sim/tools/slack/get_message.ts
@@ -1,6 +1,9 @@
+import { createLogger } from '@sim/logger'
 import type { SlackGetMessageParams, SlackGetMessageResponse } from '@/tools/slack/types'
 import { MESSAGE_OUTPUT_PROPERTIES } from '@/tools/slack/types'
 import type { ToolConfig } from '@/tools/types'
+
+const logger = createLogger('SlackGetMessageTool')
 
 export const slackGetMessageTool: ToolConfig<SlackGetMessageParams, SlackGetMessageResponse> = {
   id: 'slack_get_message',
@@ -49,11 +52,10 @@ export const slackGetMessageTool: ToolConfig<SlackGetMessageParams, SlackGetMess
 
   request: {
     url: (params: SlackGetMessageParams) => {
-      const url = new URL('https://slack.com/api/conversations.history')
+      const url = new URL('https://slack.com/api/conversations.replies')
       url.searchParams.append('channel', params.channel?.trim() ?? '')
-      url.searchParams.append('oldest', params.timestamp?.trim() ?? '')
+      url.searchParams.append('ts', params.timestamp?.trim() ?? '')
       url.searchParams.append('limit', '1')
-      url.searchParams.append('inclusive', 'true')
       return url.toString()
     },
     method: 'GET',
@@ -63,8 +65,9 @@ export const slackGetMessageTool: ToolConfig<SlackGetMessageParams, SlackGetMess
     }),
   },
 
-  transformResponse: async (response: Response) => {
+  transformResponse: async (response: Response, params?: SlackGetMessageParams) => {
     const data = await response.json()
+    const requestedTs = params?.timestamp?.trim() ?? ''
 
     if (!data.ok) {
       if (data.error === 'missing_scope') {
@@ -78,15 +81,25 @@ export const slackGetMessageTool: ToolConfig<SlackGetMessageParams, SlackGetMess
       if (data.error === 'channel_not_found') {
         throw new Error('Channel not found. Please check the channel ID.')
       }
+      if (data.error === 'message_not_found' || data.error === 'thread_not_found') {
+        throw new Error(`Message not found at timestamp ${requestedTs}`)
+      }
       throw new Error(data.error || 'Failed to get message from Slack')
     }
 
     const messages = data.messages || []
     if (messages.length === 0) {
-      throw new Error('Message not found')
+      throw new Error(`Message not found at timestamp ${requestedTs}`)
     }
 
     const msg = messages[0]
+    if (requestedTs && msg.ts !== requestedTs) {
+      logger.warn('Slack returned a message with a different timestamp than requested', {
+        requestedTs,
+        returnedTs: msg.ts,
+      })
+      throw new Error(`Message not found at timestamp ${requestedTs}`)
+    }
     const message = {
       type: msg.type ?? 'message',
       ts: msg.ts,

--- a/apps/sim/tools/supabase/vector_search.ts
+++ b/apps/sim/tools/supabase/vector_search.ts
@@ -1,3 +1,4 @@
+import { validateDatabaseIdentifier } from '@/lib/core/security/input-validation'
 import type {
   SupabaseVectorSearchParams,
   SupabaseVectorSearchResponse,
@@ -56,8 +57,9 @@ export const vectorSearchTool: ToolConfig<
 
   request: {
     url: (params) => {
-      // Use RPC endpoint for calling PostgreSQL functions
-      return `${supabaseBaseUrl(params.projectId)}/rest/v1/rpc/${params.functionName}`
+      const fnValidation = validateDatabaseIdentifier(params.functionName, 'functionName')
+      if (!fnValidation.isValid) throw new Error(fnValidation.error)
+      return `${supabaseBaseUrl(params.projectId)}/rest/v1/rpc/${encodeURIComponent(params.functionName)}`
     },
     method: 'POST',
     headers: (params) => ({

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,7 @@
     "includes": [
       "**",
       "!**/.next",
-      "!**/.next/**",
+      "!**/.next",
       "!**/next-env.d.ts",
       "!**/out",
       "!**/dist",
@@ -69,8 +69,7 @@
     "rules": {
       "recommended": true,
       "nursery": {
-        "useSortedClasses": "warn",
-        "noNestedComponentDefinitions": "off"
+        "useSortedClasses": "warn"
       },
       "a11y": {
         "noSvgWithoutTitle": "off",

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "fumadocs-openapi": "10.8.1",
         "fumadocs-ui": "16.8.5",
         "lucide-react": "^0.511.0",
-        "next": "16.2.4",
+        "next": "16.2.6",
         "next-themes": "^0.4.6",
         "postgres": "^3.4.5",
         "react": "19.2.4",
@@ -210,7 +210,7 @@
         "mongodb": "6.19.0",
         "mysql2": "3.14.3",
         "neo4j-driver": "6.0.1",
-        "next": "16.2.4",
+        "next": "16.2.6",
         "next-mdx-remote": "^6.0.0",
         "next-runtime-env": "3.3.0",
         "next-themes": "^0.4.6",
@@ -475,10 +475,10 @@
     "sharp",
   ],
   "overrides": {
-    "@next/env": "16.2.4",
+    "@next/env": "16.2.6",
     "drizzle-orm": "^0.45.2",
     "minimatch": "^10.2.5",
-    "next": "16.2.4",
+    "next": "16.2.6",
     "postgres": "^3.4.5",
     "react": "19.2.4",
     "react-dom": "19.2.4",
@@ -1042,23 +1042,23 @@
 
     "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
 
-    "@next/env": ["@next/env@16.2.4", "", {}, "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw=="],
+    "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
@@ -3160,7 +3160,7 @@
 
     "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
 
-    "next": ["next@16.2.4", "", { "dependencies": { "@next/env": "16.2.4", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.4", "@next/swc-darwin-x64": "16.2.4", "@next/swc-linux-arm64-gnu": "16.2.4", "@next/swc-linux-arm64-musl": "16.2.4", "@next/swc-linux-x64-gnu": "16.2.4", "@next/swc-linux-x64-musl": "16.2.4", "@next/swc-win32-arm64-msvc": "16.2.4", "@next/swc-win32-x64-msvc": "16.2.4", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q=="],
+    "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
 
     "next-mdx-remote": ["next-mdx-remote@6.0.0", "", { "dependencies": { "@babel/code-frame": "^7.23.5", "@mdx-js/mdx": "^3.0.1", "@mdx-js/react": "^3.0.1", "unist-util-remove": "^4.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.1", "vfile-matter": "^5.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ=="],
 

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   "overrides": {
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "next": "16.2.4",
-    "@next/env": "16.2.4",
+    "next": "16.2.6",
+    "@next/env": "16.2.6",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.5",
     "minimatch": "^10.2.5"

--- a/packages/db/db.ts
+++ b/packages/db/db.ts
@@ -13,14 +13,6 @@ const postgresClient = postgres(connectionString, {
   connect_timeout: 30,
   max: 15,
   onnotice: () => {},
-  // Server-side guards. lock_timeout cancels a query waiting on a row lock for
-  // >5s (e.g. another tx holding `SELECT ... FOR UPDATE`). statement_timeout
-  // cancels any query running >30s. Heavy paths that legitimately need longer
-  // (table service bulk JSONB rewrites) override per-tx with `SET LOCAL`.
-  connection: {
-    lock_timeout: 5_000,
-    statement_timeout: 30_000,
-  },
 })
 
 export const db = drizzle(postgresClient, { schema })

--- a/packages/db/db.ts
+++ b/packages/db/db.ts
@@ -13,6 +13,14 @@ const postgresClient = postgres(connectionString, {
   connect_timeout: 30,
   max: 15,
   onnotice: () => {},
+  // Server-side guards. lock_timeout cancels a query waiting on a row lock for
+  // >5s (e.g. another tx holding `SELECT ... FOR UPDATE`). statement_timeout
+  // cancels any query running >30s. Heavy paths that legitimately need longer
+  // (table service bulk JSONB rewrites) override per-tx with `SET LOCAL`.
+  connection: {
+    lock_timeout: 5_000,
+    statement_timeout: 30_000,
+  },
 })
 
 export const db = drizzle(postgresClient, { schema })

--- a/scripts/check-api-validation-contracts.ts
+++ b/scripts/check-api-validation-contracts.ts
@@ -9,8 +9,8 @@ const QUERY_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/queries')
 const SELECTOR_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/selectors')
 
 const BASELINE = {
-  totalRoutes: 736,
-  zodRoutes: 736,
+  totalRoutes: 738,
+  zodRoutes: 738,
   nonZodRoutes: 0,
 } as const
 


### PR DESCRIPTION
- **improvement(db): add session statement/lock timeouts; simplify KB doc tx (#4593)**
- **fix(seo): use canonical SITE_URL for robots and sitemap (#4598)**
- **Revert "improvement(db): add session statement/lock timeouts; simplify KB doc tx (#4593)" (#4599)**
- **improvement(scheduler): drain due schedules in chunks (#4578)**
- **fix(integrations): gdrive trashed search, slack blocks-with-file, slack get_message ts (#4600)**
- **feat(cloudwatch): add mute and unmute alarm operations (#4602)**
- **fix(security): harden file access controls, webhook auth, and input bounds (#4601)**
- **chore(deps): bump next to 16.2.5 for CVE-2026-44578 SSRF fix (#4606)**
- **fix(security): supabase rpc path validation, ssh stream byte cap, storage quota coverage (#4605)**
- **fix(date-picker): eliminate infinite re-render crash on re-open with existing selection (#4609)**
- **fix(gmail): send emails as multipart/alternative so they render full-width (#4611)**