### PR TITLE
improvement(redis): strip idempotency body and cap mothership stream zsets

### DIFF
--- a/apps/sim/lib/copilot/request/session/buffer.test.ts
+++ b/apps/sim/lib/copilot/request/session/buffer.test.ts
@@ -166,7 +166,7 @@ describe('mothership-stream-outbox', () => {
     expect(mockRedis.zremrangebyrank).toHaveBeenCalledWith(
       'mothership_stream:stream-1:events',
       0,
-      expect.any(Number)
+      -5_001
     )
   })
 

--- a/apps/sim/lib/copilot/request/session/buffer.test.ts
+++ b/apps/sim/lib/copilot/request/session/buffer.test.ts
@@ -149,7 +149,7 @@ describe('mothership-stream-outbox', () => {
     expect(replayed.map((entry) => entry.payload.text)).toEqual(['world'])
   })
 
-  it('does not trim active stream history while appending events', async () => {
+  it('trims active stream history to eventLimit on every append', async () => {
     const cursor = await allocateCursor('stream-1')
 
     await appendEvent(
@@ -163,7 +163,11 @@ describe('mothership-stream-outbox', () => {
       })
     )
 
-    expect(mockRedis.zremrangebyrank).not.toHaveBeenCalled()
+    expect(mockRedis.zremrangebyrank).toHaveBeenCalledWith(
+      'mothership_stream:stream-1:events',
+      0,
+      expect.any(Number)
+    )
   })
 
   it('clears persisted stream state during teardown cleanup', async () => {

--- a/apps/sim/lib/copilot/request/session/buffer.ts
+++ b/apps/sim/lib/copilot/request/session/buffer.ts
@@ -144,6 +144,7 @@ export async function appendEvents(
       zaddArgs.push(envelope.seq, JSON.stringify(envelope))
     }
     pipeline.zadd(key, ...(zaddArgs as [number, string, ...Array<number | string>]))
+    pipeline.zremrangebyrank(key, 0, -config.eventLimit - 1)
     pipeline.expire(key, config.ttlSeconds)
     pipeline.set(seqKey, String(envelopes[envelopes.length - 1].seq), 'EX', config.ttlSeconds)
     await pipeline.exec()

--- a/apps/sim/lib/core/idempotency/service.ts
+++ b/apps/sim/lib/core/idempotency/service.ts
@@ -17,6 +17,16 @@ export interface IdempotencyConfig {
   /** When true, failed keys are deleted rather than stored so the operation is retried on the next attempt. */
   retryFailures?: boolean
   /**
+   * When false, the operation's return value is not persisted alongside
+   * the dedupe marker — only `{ success, status, error? }` is stored.
+   * Duplicate calls still short-circuit, but `executeWithIdempotency`
+   * resolves to `undefined` on the dedupe path. Use for webhook/polling
+   * flows where the cached body is large (multi-KB execution results)
+   * and callers don't consume the value of a duplicated delivery.
+   * Defaults to true.
+   */
+  storeResultBody?: boolean
+  /**
    * Force a specific storage backend regardless of the environment's
    * auto-detection. Use `'database'` for correctness-critical flows
    * (money, billing, compliance) where the claim + operation should
@@ -77,6 +87,7 @@ export class IdempotencyService {
       ttlSeconds: config.ttlSeconds ?? DEFAULT_TTL,
       namespace: config.namespace ?? 'default',
       retryFailures: config.retryFailures ?? false,
+      storeResultBody: config.storeResultBody ?? true,
     }
     this.storageMethod = config.forceStorage ?? getStorageMethod()
     logger.info(`IdempotencyService using ${this.storageMethod} storage`, {
@@ -441,7 +452,9 @@ export class IdempotencyService {
 
       await this.storeResult(
         claimResult.normalizedKey,
-        { success: true, result, status: 'completed' },
+        this.config.storeResultBody
+          ? { success: true, result, status: 'completed' }
+          : { success: true, status: 'completed' },
         claimResult.storageMethod
       )
 
@@ -510,15 +523,29 @@ export class IdempotencyService {
   }
 }
 
+/**
+ * Webhook idempotency. We're the receiver of provider-initiated webhooks,
+ * not the originator — duplicate deliveries from the provider's retry
+ * machinery just need a "we saw this" marker, not a replayable response
+ * body. `storeResultBody: false` drops the cached workflow result from
+ * each key, eliminating the long tail of large gmail/outlook payloads
+ * that pushed Redis Cloud into OOM on 2026-05-15.
+ *
+ * TTL stays at 7 days because that's the longest provider retry window
+ * we care about (Gmail / Pub/Sub). With body-stripping the per-key cost
+ * is ~150 bytes, so the long TTL is essentially free.
+ */
 export const webhookIdempotency = new IdempotencyService({
   namespace: 'webhook',
-  ttlSeconds: 60 * 60 * 24 * 7, // 7 days
+  ttlSeconds: 60 * 60 * 24 * 7, // 7 days — must exceed Gmail/Pub-Sub retry window
+  storeResultBody: false,
 })
 
 export const pollingIdempotency = new IdempotencyService({
   namespace: 'polling',
   ttlSeconds: 60 * 60 * 24 * 3, // 3 days
   retryFailures: true,
+  storeResultBody: false,
 })
 
 /**

--- a/apps/sim/lib/core/idempotency/service.ts
+++ b/apps/sim/lib/core/idempotency/service.ts
@@ -17,12 +17,10 @@ export interface IdempotencyConfig {
   /** When true, failed keys are deleted rather than stored so the operation is retried on the next attempt. */
   retryFailures?: boolean
   /**
-   * When false, the operation's return value is not persisted alongside
-   * the dedupe marker — only `{ success, status, error? }` is stored.
-   * Duplicate calls still short-circuit, but `executeWithIdempotency`
-   * resolves to `undefined` on the dedupe path. Use for webhook/polling
-   * flows where the cached body is large (multi-KB execution results)
-   * and callers don't consume the value of a duplicated delivery.
+   * When false, only `{ success, status, error? }` is persisted — not the
+   * operation's return value. Duplicate calls still short-circuit but
+   * resolve to `undefined`. Use when callers don't consume the cached
+   * body (e.g. webhook receivers, where the provider just wants a 2xx).
    * Defaults to true.
    */
   storeResultBody?: boolean
@@ -524,20 +522,13 @@ export class IdempotencyService {
 }
 
 /**
- * Webhook idempotency. We're the receiver of provider-initiated webhooks,
- * not the originator — duplicate deliveries from the provider's retry
- * machinery just need a "we saw this" marker, not a replayable response
- * body. `storeResultBody: false` drops the cached workflow result from
- * each key, eliminating the long tail of large gmail/outlook payloads
- * that pushed Redis Cloud into OOM on 2026-05-15.
- *
- * TTL stays at 7 days because that's the longest provider retry window
- * we care about (Gmail / Pub/Sub). With body-stripping the per-key cost
- * is ~150 bytes, so the long TTL is essentially free.
+ * As a webhook receiver we only need a "we saw this delivery" marker —
+ * the provider's retry just needs a 2xx, not our cached response body.
+ * TTL must exceed the longest provider retry window (Gmail / Pub-Sub: 7d).
  */
 export const webhookIdempotency = new IdempotencyService({
   namespace: 'webhook',
-  ttlSeconds: 60 * 60 * 24 * 7, // 7 days — must exceed Gmail/Pub-Sub retry window
+  ttlSeconds: 60 * 60 * 24 * 7, // 7 days
   storeResultBody: false,
 })
 


### PR DESCRIPTION
## Summary

Two targeted fixes that reduce Redis memory pressure following the 2026-05-15 OOM incident:

- **Idempotency body stripping** (`apps/sim/lib/core/idempotency/service.ts`): webhook + polling idempotency now store only a `{ success, status }` marker instead of the full response body. As a webhook *receiver*, the provider's retry only needs a 2xx — not our cached response. TTLs unchanged (webhook 7d to cover Gmail/Pub-Sub retry window, polling 3d).
- **Mothership stream ZSET cap** (`apps/sim/lib/copilot/request/session/buffer.ts`): `appendEvents` now calls `ZREMRANGEBYRANK` to enforce `eventLimit` (default 5,000) on every append. Previously the limit was dead code — streams grew unbounded until the 1h TTL fired.

Both are additive and backward-compatible. New `storeResultBody` config flag defaults to `true` so callers (Stripe-style idempotency) that need the cached body are unaffected.

## Test plan

- [x] `bun run lint` clean
- [x] Inverted buffer test asserts `zremrangebyrank` is called on every append
- [ ] Verify in staging that webhook idempotency keys are ~50 bytes vs ~500-1700 bytes
- [ ] Verify mothership stream ZSETs cap at eventLimit under load