### PR TITLE
fix(mcp): map validation and conflict orchestration errors to 400/409

### DIFF
--- a/apps/sim/app/api/mcp/workflow-servers/[id]/route.ts
+++ b/apps/sim/app/api/mcp/workflow-servers/[id]/route.ts
@@ -14,7 +14,11 @@ import {
   performDeleteWorkflowMcpServer,
   performUpdateWorkflowMcpServer,
 } from '@/lib/mcp/orchestration'
-import { createMcpErrorResponse, createMcpSuccessResponse } from '@/lib/mcp/utils'
+import {
+  createMcpErrorResponse,
+  createMcpSuccessResponse,
+  mcpOrchestrationStatus,
+} from '@/lib/mcp/utils'
 
 const logger = createLogger('WorkflowMcpServerAPI')
 
@@ -112,8 +116,7 @@ export const PATCH = withRouteHandler(
           isPublic: body.isPublic,
         })
         if (!result.success || !result.server) {
-          const status =
-            result.errorCode === 'not_found' ? 404 : result.errorCode === 'validation' ? 400 : 500
+          const status = mcpOrchestrationStatus(result.errorCode)
           return createMcpErrorResponse(
             new Error(result.error || 'Failed to update workflow MCP server'),
             result.error || 'Failed to update workflow MCP server',
@@ -160,7 +163,7 @@ export const DELETE = withRouteHandler(
           return createMcpErrorResponse(
             new Error(result.error || 'Server not found'),
             result.error || 'Server not found',
-            result.errorCode === 'not_found' ? 404 : 500
+            mcpOrchestrationStatus(result.errorCode)
           )
         }
         const deletedServer = result.server

--- a/apps/sim/app/api/mcp/workflow-servers/[id]/tools/route.ts
+++ b/apps/sim/app/api/mcp/workflow-servers/[id]/tools/route.ts
@@ -11,7 +11,11 @@ import {
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { getParsedBody, withMcpAuth } from '@/lib/mcp/middleware'
 import { performCreateWorkflowMcpTool } from '@/lib/mcp/orchestration'
-import { createMcpErrorResponse, createMcpSuccessResponse } from '@/lib/mcp/utils'
+import {
+  createMcpErrorResponse,
+  createMcpSuccessResponse,
+  mcpOrchestrationStatus,
+} from '@/lib/mcp/utils'
 
 const logger = createLogger('WorkflowMcpToolsAPI')
 
@@ -117,12 +121,10 @@ export const POST = withRouteHandler(
           parameterSchema: body.parameterSchema,
         })
         if (!result.success || !result.tool) {
-          const status =
-            result.errorCode === 'not_found' ? 404 : result.errorCode === 'conflict' ? 409 : 400
           return createMcpErrorResponse(
             new Error(result.error || 'Failed to add tool'),
             result.error || 'Failed to add tool',
-            result.errorCode === 'internal' ? 500 : status
+            mcpOrchestrationStatus(result.errorCode)
           )
         }
 

--- a/apps/sim/app/api/mcp/workflow-servers/route.ts
+++ b/apps/sim/app/api/mcp/workflow-servers/route.ts
@@ -8,7 +8,11 @@ import { createWorkflowMcpServerBodySchema } from '@/lib/api/contracts/workflow-
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { getParsedBody, withMcpAuth } from '@/lib/mcp/middleware'
 import { performCreateWorkflowMcpServer } from '@/lib/mcp/orchestration'
-import { createMcpErrorResponse, createMcpSuccessResponse } from '@/lib/mcp/utils'
+import {
+  createMcpErrorResponse,
+  createMcpSuccessResponse,
+  mcpOrchestrationStatus,
+} from '@/lib/mcp/utils'
 
 const logger = createLogger('WorkflowMcpServersAPI')
 
@@ -121,7 +125,7 @@ export const POST = withRouteHandler(
           return createMcpErrorResponse(
             new Error(result.error || 'Failed to create workflow MCP server'),
             result.error || 'Failed to create workflow MCP server',
-            result.errorCode === 'validation' ? 400 : 500
+            mcpOrchestrationStatus(result.errorCode)
           )
         }
 

--- a/apps/sim/lib/mcp/utils.ts
+++ b/apps/sim/lib/mcp/utils.ts
@@ -82,9 +82,11 @@ export function createMcpSuccessResponse<T>(data: T, status = 200): NextResponse
  * Maps MCP orchestration error codes to safe HTTP statuses.
  */
 export function mcpOrchestrationStatus(errorCode: string | undefined): number {
+  if (errorCode === 'validation') return 400
   if (errorCode === 'forbidden') return 403
-  if (errorCode === 'bad_gateway') return 502
   if (errorCode === 'not_found') return 404
+  if (errorCode === 'conflict') return 409
+  if (errorCode === 'bad_gateway') return 502
   return 500
 }
 


### PR DESCRIPTION
## Summary
- `mcpOrchestrationStatus` was missing `validation` and `conflict` error codes, defaulting both to 500
- `validation` now maps to 400, `conflict` to 409 — matching how workflow MCP server routes handle these codes

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)