### PR TITLE
fix(copilot): upload sandbox-rendered bytes for docx/pptx/pdf creation

### DIFF
--- a/apps/sim/lib/copilot/tools/server/files/edit-content.ts
+++ b/apps/sim/lib/copilot/tools/server/files/edit-content.ts
@@ -201,9 +201,10 @@ export const editContentServerTool: BaseServerTool<EditContentArgs, EditContentR
           return { success: false, message: `Unsupported operation in intent: ${operation}` }
       }
 
+      let fileBuffer: Buffer
       if (docInfo.isDoc) {
         try {
-          await runSandboxTask(
+          fileBuffer = await runSandboxTask(
             docInfo.taskId!,
             { code: finalContent, workspaceId },
             { ownerKey: `user:${context.userId}`, signal: context.abortSignal }
@@ -215,9 +216,9 @@ export const editContentServerTool: BaseServerTool<EditContentArgs, EditContentR
             message: `${docInfo.formatName} generation failed: ${msg}. Fix the content and retry.`,
           }
         }
+      } else {
+        fileBuffer = Buffer.from(finalContent, 'utf-8')
       }
-
-      const fileBuffer = Buffer.from(finalContent, 'utf-8')
       assertServerToolNotAborted(context)
       const mime = docInfo.sourceMime || inferContentType(fileRecord.name, intent.contentType)
       await updateWorkspaceFileContent(workspaceId, intent.fileId, context.userId, fileBuffer, mime)

--- a/apps/sim/lib/copilot/tools/server/files/workspace-file.ts
+++ b/apps/sim/lib/copilot/tools/server/files/workspace-file.ts
@@ -199,9 +199,10 @@ export const workspaceFileServerTool: BaseServerTool<WorkspaceFileArgs, Workspac
 
           const docInfo = getDocumentFormatInfo(fileName)
           let contentType = inferContentType(fileName, explicitType)
+          let fileBuffer: Buffer
           if (docInfo.isDoc) {
             try {
-              await runSandboxTask(
+              fileBuffer = await runSandboxTask(
                 docInfo.taskId!,
                 { code: content, workspaceId },
                 { ownerKey: `user:${context.userId}`, signal: context.abortSignal }
@@ -214,9 +215,9 @@ export const workspaceFileServerTool: BaseServerTool<WorkspaceFileArgs, Workspac
               }
             }
             contentType = docInfo.sourceMime!
+          } else {
+            fileBuffer = Buffer.from(content, 'utf-8')
           }
-
-          const fileBuffer = Buffer.from(content, 'utf-8')
           assertServerToolNotAborted(context)
           const result = await uploadWorkspaceFile(
             workspaceId,


### PR DESCRIPTION
## Summary
- `workspace_file:create` and `edit_content` called `runSandboxTask('docx-generate' | 'pptx-generate' | 'pdf-generate', ...)` but discarded the returned `Buffer` and uploaded `Buffer.from(content, 'utf-8')` instead — so `.docx`/`.pptx`/`.pdf` files contained the model's source code (or whatever string it emitted) labeled with the correct binary MIME, causing "Failed to load file content" in the viewer and rejection by Word
- Capture the sandbox-rendered `Buffer` and upload that; non-doc paths unchanged

## Type of Change
- [x] Bug fix

## Testing
Will test on staging. `bun run lint` and `bun run check:api-validation:strict` clean; `vitest run lib/copilot/tools/server/files/` passes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)