### PR TITLE
fix(redis): apply TLS SNI override to pub/sub clients

### DIFF
--- a/apps/sim/lib/core/config/redis.ts
+++ b/apps/sim/lib/core/config/redis.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
 import { randomFloat } from '@sim/utils/random'
-import Redis from 'ioredis'
+import Redis, { type RedisOptions } from 'ioredis'
 import { env } from '@/lib/core/config/env'
 
 const logger = createLogger('Redis')
@@ -16,9 +16,7 @@ const redisUrl = env.REDIS_URL
  *
  * For DNS hosts: no override needed, default verification works.
  */
-export function resolveRedisTlsOptions(
-  url: string | undefined
-): { servername: string } | undefined {
+function resolveRedisTlsOptions(url: string | undefined): { servername: string } | undefined {
   if (!url) return undefined
   let parsed: URL
   try {
@@ -37,6 +35,23 @@ export function resolveRedisTlsOptions(
     )
   }
   return { servername: env.REDIS_TLS_SERVERNAME }
+}
+
+/**
+ * Shared connection defaults — keepAlive, connectTimeout, enableOfflineQueue,
+ * and TLS SNI when REDIS_URL targets an IP. Every Redis client we open should
+ * spread this; callers add their own retry / timeout policy on top.
+ */
+export function getRedisConnectionDefaults(
+  url: string | undefined
+): Pick<RedisOptions, 'keepAlive' | 'connectTimeout' | 'enableOfflineQueue' | 'tls'> {
+  const tls = resolveRedisTlsOptions(url)
+  return {
+    keepAlive: 1000,
+    connectTimeout: 10000,
+    enableOfflineQueue: true,
+    ...(tls ? { tls } : {}),
+  }
 }
 
 let globalRedisClient: Redis | null = null
@@ -119,18 +134,15 @@ export function getRedisClient(): Redis | null {
   if (globalRedisClient) return globalRedisClient
 
   // Outside the try/catch so config errors aren't silently swallowed.
-  const tls = resolveRedisTlsOptions(redisUrl)
+  const defaults = getRedisConnectionDefaults(redisUrl)
 
   try {
     logger.info('Initializing Redis client')
 
     globalRedisClient = new Redis(redisUrl, {
-      keepAlive: 1000,
-      connectTimeout: 10000,
+      ...defaults,
       commandTimeout: 5000,
       maxRetriesPerRequest: 5,
-      enableOfflineQueue: true,
-      ...(tls ? { tls } : {}),
 
       retryStrategy: (times) => {
         if (times > 10) {

--- a/apps/sim/lib/core/config/redis.ts
+++ b/apps/sim/lib/core/config/redis.ts
@@ -16,7 +16,9 @@ const redisUrl = env.REDIS_URL
  *
  * For DNS hosts: no override needed, default verification works.
  */
-function resolveTlsOptions(url: string | undefined): { servername: string } | undefined {
+export function resolveRedisTlsOptions(
+  url: string | undefined
+): { servername: string } | undefined {
   if (!url) return undefined
   let parsed: URL
   try {
@@ -117,7 +119,7 @@ export function getRedisClient(): Redis | null {
   if (globalRedisClient) return globalRedisClient
 
   // Outside the try/catch so config errors aren't silently swallowed.
-  const tls = resolveTlsOptions(redisUrl)
+  const tls = resolveRedisTlsOptions(redisUrl)
 
   try {
     logger.info('Initializing Redis client')

--- a/apps/sim/lib/events/pubsub.ts
+++ b/apps/sim/lib/events/pubsub.ts
@@ -32,10 +32,11 @@ class RedisPubSubChannel<T> implements PubSubChannel<T> {
 
   constructor(
     redisUrl: string,
+    connectionDefaults: ReturnType<typeof getRedisConnectionDefaults>,
     private config: PubSubChannelConfig
   ) {
     const commonOpts = {
-      ...getRedisConnectionDefaults(redisUrl),
+      ...connectionDefaults,
       maxRetriesPerRequest: null,
       retryStrategy: (times: number) => {
         if (times > 10) return 30000
@@ -138,16 +139,18 @@ class LocalPubSubChannel<T> implements PubSubChannel<T> {
 
 export function createPubSubChannel<T>(config: PubSubChannelConfig): PubSubChannel<T> {
   const redisUrl = env.REDIS_URL
+  if (!redisUrl) return new LocalPubSubChannel<T>(config)
 
-  if (redisUrl) {
-    try {
-      logger.info(`${config.label}: Using Redis`)
-      return new RedisPubSubChannel<T>(redisUrl, config)
-    } catch (err) {
-      logger.error(`Failed to create Redis ${config.label}, falling back to local:`, err)
-      return new LocalPubSubChannel<T>(config)
-    }
+  // Resolve config-derived defaults outside the try so a missing
+  // REDIS_TLS_SERVERNAME (config error) surfaces instead of silently degrading
+  // to the in-process EventEmitter — that would break cross-replica pub/sub.
+  const connectionDefaults = getRedisConnectionDefaults(redisUrl)
+
+  try {
+    logger.info(`${config.label}: Using Redis`)
+    return new RedisPubSubChannel<T>(redisUrl, connectionDefaults, config)
+  } catch (err) {
+    logger.error(`Failed to create Redis ${config.label}, falling back to local:`, err)
+    return new LocalPubSubChannel<T>(config)
   }
-
-  return new LocalPubSubChannel<T>(config)
 }

--- a/apps/sim/lib/events/pubsub.ts
+++ b/apps/sim/lib/events/pubsub.ts
@@ -9,7 +9,7 @@ import { EventEmitter } from 'events'
 import { createLogger } from '@sim/logger'
 import Redis, { type RedisOptions } from 'ioredis'
 import { env } from '@/lib/core/config/env'
-import { resolveRedisTlsOptions } from '@/lib/core/config/redis'
+import { getRedisConnectionDefaults } from '@/lib/core/config/redis'
 
 const logger = createLogger('PubSub')
 
@@ -34,18 +34,13 @@ class RedisPubSubChannel<T> implements PubSubChannel<T> {
     redisUrl: string,
     private config: PubSubChannelConfig
   ) {
-    const tls = resolveRedisTlsOptions(redisUrl)
-
     const commonOpts = {
-      keepAlive: 1000,
-      connectTimeout: 10000,
+      ...getRedisConnectionDefaults(redisUrl),
       maxRetriesPerRequest: null,
-      enableOfflineQueue: true,
       retryStrategy: (times: number) => {
         if (times > 10) return 30000
         return Math.min(times * 500, 5000)
       },
-      ...(tls ? { tls } : {}),
     } satisfies RedisOptions
 
     this.pub = new Redis(redisUrl, { ...commonOpts, connectionName: `${config.label}-pub` })

--- a/apps/sim/lib/events/pubsub.ts
+++ b/apps/sim/lib/events/pubsub.ts
@@ -9,6 +9,7 @@ import { EventEmitter } from 'events'
 import { createLogger } from '@sim/logger'
 import Redis, { type RedisOptions } from 'ioredis'
 import { env } from '@/lib/core/config/env'
+import { resolveRedisTlsOptions } from '@/lib/core/config/redis'
 
 const logger = createLogger('PubSub')
 
@@ -33,6 +34,8 @@ class RedisPubSubChannel<T> implements PubSubChannel<T> {
     redisUrl: string,
     private config: PubSubChannelConfig
   ) {
+    const tls = resolveRedisTlsOptions(redisUrl)
+
     const commonOpts = {
       keepAlive: 1000,
       connectTimeout: 10000,
@@ -42,6 +45,7 @@ class RedisPubSubChannel<T> implements PubSubChannel<T> {
         if (times > 10) return 30000
         return Math.min(times * 500, 5000)
       },
+      ...(tls ? { tls } : {}),
     } satisfies RedisOptions
 
     this.pub = new Redis(redisUrl, { ...commonOpts, connectionName: `${config.label}-pub` })


### PR DESCRIPTION
- **fix(redis): pub/sub clients in `lib/events/pubsub.ts` were building their own ioredis instances directly (pub/sub needs dedicated connections), bypassing the SNI override added in #4635. trigger.dev tasks hit 'Hostname/IP does not match certificate's altnames' on every pub/sub connect against the PrivateLink VPCE IP. Export the helper as `resolveRedisTlsOptions` and apply it to the pub/sub clients too.**