### PR TITLE
improvement(copilot): drop unused columns from mothership chat detail reads

### DIFF
--- a/apps/sim/app/api/mothership/chats/[chatId]/route.test.ts
+++ b/apps/sim/app/api/mothership/chats/[chatId]/route.test.ts
@@ -47,8 +47,8 @@ vi.mock('drizzle-orm', () => ({
 vi.mock('@/lib/copilot/request/http', () => copilotHttpMock)
 
 vi.mock('@/lib/copilot/chat/lifecycle', () => ({
-  getAccessibleCopilotChat: mockGetAccessibleCopilotChat,
   getAccessibleCopilotChatAuth: mockGetAccessibleCopilotChat,
+  getAccessibleCopilotChatWithMessages: mockGetAccessibleCopilotChat,
 }))
 
 vi.mock('@/lib/copilot/chat/stream-liveness', () => ({

--- a/apps/sim/app/api/mothership/chats/[chatId]/route.ts
+++ b/apps/sim/app/api/mothership/chats/[chatId]/route.ts
@@ -13,8 +13,8 @@ import { parseRequest } from '@/lib/api/server'
 import { getLatestRunForStream } from '@/lib/copilot/async-runs/repository'
 import { buildEffectiveChatTranscript } from '@/lib/copilot/chat/effective-transcript'
 import {
-  getAccessibleCopilotChat,
   getAccessibleCopilotChatAuth,
+  getAccessibleCopilotChatWithMessages,
 } from '@/lib/copilot/chat/lifecycle'
 import { normalizeMessage } from '@/lib/copilot/chat/persisted-message'
 import { reconcileChatStreamMarkers } from '@/lib/copilot/chat/stream-liveness'
@@ -45,7 +45,7 @@ export const GET = withRouteHandler(
       if (!paramsResult.success) return paramsResult.response
       const { chatId } = paramsResult.data.params
 
-      const chat = await getAccessibleCopilotChat(chatId, userId)
+      const chat = await getAccessibleCopilotChatWithMessages(chatId, userId)
       if (!chat || chat.type !== 'mothership') {
         return NextResponse.json({ success: false, error: 'Chat not found' }, { status: 404 })
       }

--- a/apps/sim/lib/copilot/chat/lifecycle.ts
+++ b/apps/sim/lib/copilot/chat/lifecycle.ts
@@ -15,7 +15,7 @@ const logger = createLogger('CopilotChatLifecycle')
 
 export interface ChatLoadResult {
   chatId: string
-  chat: typeof copilotChats.$inferSelect | null
+  chat: CopilotChatDetailRow | null
   conversationHistory: unknown[]
   isNew: boolean
 }
@@ -34,9 +34,41 @@ const copilotChatAuthColumns = {
   type: copilotChats.type,
 } as const
 
+/**
+ * Column set for chat-detail callers that need the conversation transcript but
+ * not the copilot-only TOAST-able fields (`previewYaml`, `planArtifact`,
+ * `config`) or unused metadata (`model`, `pinned`, `lastSeenAt`). Selecting
+ * only these columns avoids the Postgres detoast cost on the dropped fields,
+ * which dominates latency for chats with large message histories.
+ */
+const copilotChatDetailColumns = {
+  ...copilotChatAuthColumns,
+  title: copilotChats.title,
+  messages: copilotChats.messages,
+  conversationId: copilotChats.conversationId,
+  resources: copilotChats.resources,
+  createdAt: copilotChats.createdAt,
+  updatedAt: copilotChats.updatedAt,
+} as const
+
 type CopilotChatAuthRow = Pick<
   typeof copilotChats.$inferSelect,
   'id' | 'userId' | 'workflowId' | 'workspaceId' | 'type'
+>
+
+export type CopilotChatDetailRow = Pick<
+  typeof copilotChats.$inferSelect,
+  | 'id'
+  | 'userId'
+  | 'workflowId'
+  | 'workspaceId'
+  | 'type'
+  | 'title'
+  | 'messages'
+  | 'conversationId'
+  | 'resources'
+  | 'createdAt'
+  | 'updatedAt'
 >
 
 async function authorizeCopilotChatRow<T extends CopilotChatAuthRow>(
@@ -99,12 +131,35 @@ export async function getAccessibleCopilotChatAuth(
 
 /**
  * Load the full copilot chat row after authorization. Use this only when the
- * caller actually consumes the heavy columns (`messages`, `planArtifact`,
- * `config`, etc.) — for example, chat resume or the GET-by-id endpoint.
+ * caller actually consumes copilot-only TOAST-able columns (`previewYaml`,
+ * `planArtifact`, `config`) or other extended metadata — for example the
+ * legacy copilot chat detail endpoint. Mothership chats and other consumers
+ * that only need the transcript should prefer `getAccessibleCopilotChatWithMessages`.
  */
 export async function getAccessibleCopilotChat(chatId: string, userId: string) {
   const [chat] = await db
     .select()
+    .from(copilotChats)
+    .where(and(eq(copilotChats.id, chatId), eq(copilotChats.userId, userId)))
+    .limit(1)
+
+  return authorizeCopilotChatRow(chat, chatId, userId)
+}
+
+/**
+ * Load a copilot chat with the conversation transcript and resources after
+ * authorization, omitting copilot-only TOAST-able fields (`previewYaml`,
+ * `planArtifact`, `config`) and unused metadata (`model`, `pinned`,
+ * `lastSeenAt`). Use this for the mothership chat detail endpoint and the
+ * shared `resolveOrCreateChat` path — every column read here is consumed
+ * downstream, and dropping the others avoids per-request detoast overhead.
+ */
+export async function getAccessibleCopilotChatWithMessages(
+  chatId: string,
+  userId: string
+): Promise<CopilotChatDetailRow | null> {
+  const [chat] = await db
+    .select(copilotChatDetailColumns)
     .from(copilotChats)
     .where(and(eq(copilotChats.id, chatId), eq(copilotChats.userId, userId)))
     .limit(1)
@@ -132,7 +187,7 @@ export async function resolveOrCreateChat(params: {
   }
 
   if (chatId) {
-    const chat = await getAccessibleCopilotChat(chatId, userId)
+    const chat = await getAccessibleCopilotChatWithMessages(chatId, userId)
 
     if (chat) {
       if (workflowId && chat.workflowId !== workflowId) {
@@ -189,7 +244,7 @@ export async function resolveOrCreateChat(params: {
       messages: [],
       lastSeenAt: now,
     })
-    .returning()
+    .returning(copilotChatDetailColumns)
 
   if (!newChat) {
     logger.warn('Failed to create new copilot chat row', { userId, workflowId, workspaceId })

--- a/apps/sim/lib/copilot/chat/process-contents.ts
+++ b/apps/sim/lib/copilot/chat/process-contents.ts
@@ -228,8 +228,8 @@ async function processPastChatFromDb(
   currentWorkspaceId?: string
 ): Promise<AgentContext | null> {
   try {
-    const { getAccessibleCopilotChat } = await import('./lifecycle')
-    const chat = await getAccessibleCopilotChat(chatId, userId)
+    const { getAccessibleCopilotChatWithMessages } = await import('./lifecycle')
+    const chat = await getAccessibleCopilotChatWithMessages(chatId, userId)
     if (!chat) {
       return null
     }


### PR DESCRIPTION
## Summary
- Added `getAccessibleCopilotChatWithMessages` that selects only the columns chat-detail callers actually consume — drops `previewYaml`, `planArtifact`, `config`, `model`, `pinned`, `lastSeenAt` from the SELECT
- Migrated mothership chat GET, `resolveOrCreateChat`, and `process-contents` to the lean helper; `resolveOrCreateChat`'s `RETURNING` clause now uses the same projection
- Kept the original full-row helper for the legacy copilot chat detail endpoint that still consumes the dropped fields
- Cuts Postgres TOAST detoast overhead on every mothership chat load — surfaced by PlanetScale insights showing p99 1.7s / max 55.4s / 208MB max egress on the existing full-row query
- No client/contract changes — the route response shape was already a fixed subset

## Type of Change
- [x] Improvement

## Testing
Tested manually. Type-check, API contract audit, and 96 affected tests (15 files) all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)