### PR TITLE
improvement(redis-cleanup): schedule, async workflow, hitl base64 cache cleanup

### DIFF
--- a/apps/sim/background/schedule-execution.ts
+++ b/apps/sim/background/schedule-execution.ts
@@ -350,12 +350,7 @@ async function runWorkflowExecution({
 
     throw error
   } finally {
-    void cleanupExecutionBase64Cache(executionId).catch((cleanupError) => {
-      logger.warn(`[${requestId}] Failed to cleanup base64 cache`, {
-        executionId,
-        error: toError(cleanupError).message,
-      })
-    })
+    void cleanupExecutionBase64Cache(executionId)
   }
 }
 

--- a/apps/sim/background/schedule-execution.ts
+++ b/apps/sim/background/schedule-execution.ts
@@ -21,6 +21,7 @@ import {
 import { preprocessExecution } from '@/lib/execution/preprocessing'
 import { LoggingSession } from '@/lib/logs/execution/logging-session'
 import { buildTraceSpans } from '@/lib/logs/execution/trace-spans/trace-spans'
+import { cleanupExecutionBase64Cache } from '@/lib/uploads/utils/user-file-base64.server'
 import {
   executeWorkflowCore,
   wasExecutionFinalizedByCore,
@@ -348,6 +349,13 @@ async function runWorkflowExecution({
     })
 
     throw error
+  } finally {
+    void cleanupExecutionBase64Cache(executionId).catch((cleanupError) => {
+      logger.warn(`[${requestId}] Failed to cleanup base64 cache`, {
+        executionId,
+        error: toError(cleanupError).message,
+      })
+    })
   }
 }
 

--- a/apps/sim/background/workflow-execution.ts
+++ b/apps/sim/background/workflow-execution.ts
@@ -198,12 +198,7 @@ export async function executeWorkflowJob(payload: WorkflowExecutionPayload) {
 
       throw error
     } finally {
-      void cleanupExecutionBase64Cache(executionId).catch((cleanupError) => {
-        logger.warn(`[${requestId}] Failed to cleanup base64 cache`, {
-          executionId,
-          error: toError(cleanupError).message,
-        })
-      })
+      void cleanupExecutionBase64Cache(executionId)
     }
   })
 }

--- a/apps/sim/background/workflow-execution.ts
+++ b/apps/sim/background/workflow-execution.ts
@@ -7,6 +7,7 @@ import { createTimeoutAbortController, getTimeoutErrorMessage } from '@/lib/core
 import { preprocessExecution } from '@/lib/execution/preprocessing'
 import { LoggingSession } from '@/lib/logs/execution/logging-session'
 import { buildTraceSpans } from '@/lib/logs/execution/trace-spans/trace-spans'
+import { cleanupExecutionBase64Cache } from '@/lib/uploads/utils/user-file-base64.server'
 import {
   executeWorkflowCore,
   wasExecutionFinalizedByCore,
@@ -196,6 +197,13 @@ export async function executeWorkflowJob(payload: WorkflowExecutionPayload) {
       })
 
       throw error
+    } finally {
+      void cleanupExecutionBase64Cache(executionId).catch((cleanupError) => {
+        logger.warn(`[${requestId}] Failed to cleanup base64 cache`, {
+          executionId,
+          error: toError(cleanupError).message,
+        })
+      })
     }
   })
 }

--- a/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
+++ b/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
@@ -1364,12 +1364,7 @@ export class PauseResumeManager {
           })
         })
       }
-      void cleanupExecutionBase64Cache(resumeExecutionId).catch((error) => {
-        logger.warn('Failed to cleanup base64 cache for resume execution', {
-          resumeExecutionId,
-          error: toError(error).message,
-        })
-      })
+      void cleanupExecutionBase64Cache(resumeExecutionId)
     }
 
     if (executionError || !result) {

--- a/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
+++ b/apps/sim/lib/workflows/executor/human-in-the-loop-manager.ts
@@ -16,6 +16,7 @@ import {
 import { compactBlockLogs, compactExecutionPayload } from '@/lib/execution/payloads/serializer'
 import { preprocessExecution } from '@/lib/execution/preprocessing'
 import { LoggingSession } from '@/lib/logs/execution/logging-session'
+import { cleanupExecutionBase64Cache } from '@/lib/uploads/utils/user-file-base64.server'
 import { executeWorkflowCore } from '@/lib/workflows/executor/execution-core'
 import type { ExecutionEvent } from '@/lib/workflows/executor/execution-events'
 import { ExecutionSnapshot } from '@/executor/execution/snapshot'
@@ -1363,6 +1364,12 @@ export class PauseResumeManager {
           })
         })
       }
+      void cleanupExecutionBase64Cache(resumeExecutionId).catch((error) => {
+        logger.warn('Failed to cleanup base64 cache for resume execution', {
+          resumeExecutionId,
+          error: toError(error).message,
+        })
+      })
     }
 
     if (executionError || !result) {


### PR DESCRIPTION
## Summary

Base64 cache cleanup on schedule, async workflow, hitl resume on execution end instead of waiting for ttl

## Type of Change
- [x] Other: Code cleanup

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)