### PR TITLE
fix(memory): prune unbounded server-side caches causing heap growth

### DIFF
--- a/apps/sim/lib/copilot/chat/payload.ts
+++ b/apps/sim/lib/copilot/chat/payload.ts
@@ -5,6 +5,7 @@ import { isPaid } from '@/lib/billing/plan-helpers'
 import { getToolEntry } from '@/lib/copilot/tool-executor/router'
 import { getCopilotToolDescription } from '@/lib/copilot/tools/descriptions'
 import { isHosted } from '@/lib/core/config/feature-flags'
+import { registerCache } from '@/lib/monitoring/cache-registry'
 import { buildMothershipToolsForRequest } from '@/lib/mothership/settings/runtime'
 import { trackChatUpload } from '@/lib/uploads/contexts/workspace/workspace-file-manager'
 import { tools } from '@/tools/registry'
@@ -27,6 +28,8 @@ setInterval(() => {
     if (entry.expiresAt <= now) toolSchemaCache.delete(key)
   }
 }, TOOL_SCHEMA_CACHE_TTL_MS).unref()
+
+registerCache('toolSchemaCache', () => toolSchemaCache.size)
 
 interface BuildPayloadParams {
   message: string

--- a/apps/sim/lib/copilot/chat/payload.ts
+++ b/apps/sim/lib/copilot/chat/payload.ts
@@ -21,6 +21,13 @@ type ToolSchemaCacheEntry = {
 
 const toolSchemaCache = new Map<string, ToolSchemaCacheEntry>()
 
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, entry] of toolSchemaCache) {
+    if (entry.expiresAt <= now) toolSchemaCache.delete(key)
+  }
+}, TOOL_SCHEMA_CACHE_TTL_MS).unref()
+
 interface BuildPayloadParams {
   message: string
   workflowId?: string

--- a/apps/sim/lib/core/async-jobs/backends/database.ts
+++ b/apps/sim/lib/core/async-jobs/backends/database.ts
@@ -38,6 +38,7 @@ function rowToJob(row: AsyncJobRow): Job {
 const inlineAbortControllers = new Map<string, AbortController>()
 
 interface Semaphore {
+  limit: number
   available: number
   waiters: Array<() => void>
 }
@@ -46,7 +47,7 @@ const semaphores = new Map<string, Semaphore>()
 async function acquireSlot(key: string, limit: number): Promise<void> {
   let s = semaphores.get(key)
   if (!s) {
-    s = { available: limit, waiters: [] }
+    s = { limit, available: limit, waiters: [] }
     semaphores.set(key, s)
   }
   if (s.available > 0) {
@@ -65,6 +66,9 @@ function releaseSlot(key: string): void {
     return
   }
   s.available += 1
+  if (s.waiters.length === 0 && s.available === s.limit) {
+    semaphores.delete(key)
+  }
 }
 
 export class DatabaseJobQueue implements JobQueueBackend {

--- a/apps/sim/lib/environment/utils.ts
+++ b/apps/sim/lib/environment/utils.ts
@@ -10,6 +10,7 @@ import {
   getAccessibleEnvCredentials,
   syncPersonalEnvCredentialsForUser,
 } from '@/lib/credentials/environment'
+import { registerCache } from '@/lib/monitoring/cache-registry'
 import { checkWorkspaceAccess } from '@/lib/workspaces/permissions/utils'
 
 const logger = createLogger('EnvironmentUtils')
@@ -22,6 +23,15 @@ type EffectiveEnvCacheEntry = {
 }
 
 const effectiveEnvCache = new Map<string, EffectiveEnvCacheEntry>()
+
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, entry] of effectiveEnvCache) {
+    if (!entry.promise && entry.expiresAt <= now) effectiveEnvCache.delete(key)
+  }
+}, EFFECTIVE_ENV_CACHE_TTL_MS).unref()
+
+registerCache('effectiveEnvCache', () => effectiveEnvCache.size)
 
 function getEffectiveEnvCacheKey(userId: string, workspaceId?: string) {
   return `${userId}:${workspaceId ?? ''}`

--- a/apps/sim/lib/monitoring/cache-registry.ts
+++ b/apps/sim/lib/monitoring/cache-registry.ts
@@ -1,0 +1,13 @@
+const registry = new Map<string, () => number>()
+
+export function registerCache(name: string, getSize: () => number): void {
+  registry.set(name, getSize)
+}
+
+export function getCacheSizes(): Record<string, number> {
+  const sizes: Record<string, number> = {}
+  for (const [name, getSize] of registry) {
+    sizes[name] = getSize()
+  }
+  return sizes
+}

--- a/apps/sim/lib/monitoring/memory-telemetry.ts
+++ b/apps/sim/lib/monitoring/memory-telemetry.ts
@@ -5,6 +5,7 @@
 
 import v8 from 'node:v8'
 import { createLogger } from '@sim/logger'
+import { getCacheSizes } from '@/lib/monitoring/cache-registry'
 
 const logger = createLogger('MemoryTelemetry', { logLevel: 'INFO' })
 
@@ -33,6 +34,7 @@ export function startMemoryTelemetry(intervalMs = 60_000) {
           ? process.getActiveResourcesInfo().length
           : -1,
       uptimeMin: Math.round(process.uptime() / 60),
+      cacheSizes: getCacheSizes(),
     })
   }, intervalMs)
   timer.unref()


### PR DESCRIPTION
## Summary
- **`toolSchemaCache`** (`lib/copilot/chat/payload.ts`): module-level Map keyed by `userId:workspaceId` had a 30s TTL that was only checked on read — expired entries were never deleted. With ~7.5MB per entry (2,612 tool schemas) and hundreds of thousands of unique user/workspace pairs, this was accumulating gigabytes of heap over a server instance lifetime. Adds a `setInterval` sweep every 30s with `.unref()` to evict expired entries
- **`effectiveEnvCache`** (`lib/environment/utils.ts`): same pattern — 15s TTL, same unbounded accumulation, same fix applied
- **`semaphores`** (`lib/core/async-jobs/backends/database.ts`): `releaseSlot` never deleted entries from the Map. Added idle-state deletion when `available === limit && waiters.length === 0`. Safe under JS's single-threaded event loop; validated that `acquireSlot` always re-creates the entry with the correct limit if it's missing
- **`cache-registry`** (`lib/monitoring/cache-registry.ts`): new lightweight registry so any module can expose its cache size to telemetry without coupling. Both caches register on module load
- **`memory-telemetry`**: emits `cacheSizes` in every Memory snapshot log — confirms caches stay bounded in CloudWatch post-deploy

## Type of Change
- [x] Bug fix

## Testing
Validated with CloudWatch data spanning 7 days of production memory snapshots. Math confirmed: ~7.5MB/entry × thousands of unique users = tens of GB of accumulated heap consistent with observed 24MB → 25GB growth pattern. All fixes independently reviewed for correctness (Map iteration safety, `.unref()` behavior, semaphore race conditions under async scheduling).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)