### PR TITLE
improvement(memory): replace unbounded server caches with lru-cache to fix heap growth

### DIFF
--- a/apps/sim/lib/copilot/chat/payload.ts
+++ b/apps/sim/lib/copilot/chat/payload.ts
@@ -5,6 +5,7 @@ import { isPaid } from '@/lib/billing/plan-helpers'
 import { getToolEntry } from '@/lib/copilot/tool-executor/router'
 import { getCopilotToolDescription } from '@/lib/copilot/tools/descriptions'
 import { isHosted } from '@/lib/core/config/feature-flags'
+import { registerCache } from '@/lib/monitoring/cache-registry'
 import { buildMothershipToolsForRequest } from '@/lib/mothership/settings/runtime'
 import { trackChatUpload } from '@/lib/uploads/contexts/workspace/workspace-file-manager'
 import { tools } from '@/tools/registry'
@@ -27,6 +28,8 @@ setInterval(() => {
     if (entry.expiresAt <= now) toolSchemaCache.delete(key)
   }
 }, TOOL_SCHEMA_CACHE_TTL_MS).unref()
+
+registerCache('toolSchemaCache', () => toolSchemaCache.size)
 
 interface BuildPayloadParams {
   message: string

--- a/apps/sim/lib/copilot/chat/payload.ts
+++ b/apps/sim/lib/copilot/chat/payload.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
+import { LRUCache } from 'lru-cache'
 import { getHighestPrioritySubscription } from '@/lib/billing/core/subscription'
 import { isPaid } from '@/lib/billing/plan-helpers'
 import { getToolEntry } from '@/lib/copilot/tool-executor/router'
@@ -14,20 +15,10 @@ import { getLatestVersionTools, stripVersionSuffix } from '@/tools/utils'
 const logger = createLogger('CopilotChatPayload')
 const TOOL_SCHEMA_CACHE_TTL_MS = 30_000
 
-type ToolSchemaCacheEntry = {
-  expiresAt: number
-  value?: ToolSchema[]
-  promise?: Promise<ToolSchema[]>
-}
-
-const toolSchemaCache = new Map<string, ToolSchemaCacheEntry>()
-
-setInterval(() => {
-  const now = Date.now()
-  for (const [key, entry] of toolSchemaCache) {
-    if (entry.expiresAt <= now) toolSchemaCache.delete(key)
-  }
-}, TOOL_SCHEMA_CACHE_TTL_MS).unref()
+const toolSchemaCache = new LRUCache<string, Promise<ToolSchema[]>>({
+  max: 200,
+  ttl: TOOL_SCHEMA_CACHE_TTL_MS,
+})
 
 registerCache('toolSchemaCache', () => toolSchemaCache.size)
 
@@ -84,13 +75,10 @@ export async function buildIntegrationToolSchemas(
   workspaceId?: string
 ): Promise<ToolSchema[]> {
   const cacheKey = `${userId}:${workspaceId ?? ''}:${options.schemaSurface ?? 'copilot'}`
-  const now = Date.now()
+
   const cached = toolSchemaCache.get(cacheKey)
-  if (cached?.value && cached.expiresAt > now) {
-    return cached.value.map((tool) => ({ ...tool, input_schema: { ...tool.input_schema } }))
-  }
-  if (cached?.promise) {
-    const tools = await cached.promise
+  if (cached) {
+    const tools = await cached
     return tools.map((tool) => ({ ...tool, input_schema: { ...tool.input_schema } }))
   }
 
@@ -197,18 +185,10 @@ export async function buildIntegrationToolSchemas(
       )
     }
 
-    toolSchemaCache.set(cacheKey, {
-      value: integrationTools,
-      expiresAt: Date.now() + TOOL_SCHEMA_CACHE_TTL_MS,
-    })
-
     return integrationTools
   })()
 
-  toolSchemaCache.set(cacheKey, {
-    expiresAt: now + TOOL_SCHEMA_CACHE_TTL_MS,
-    promise,
-  })
+  toolSchemaCache.set(cacheKey, promise)
 
   const integrationTools = await promise
   return integrationTools.map((tool) => ({ ...tool, input_schema: { ...tool.input_schema } }))

--- a/apps/sim/lib/copilot/chat/payload.ts
+++ b/apps/sim/lib/copilot/chat/payload.ts
@@ -21,6 +21,13 @@ type ToolSchemaCacheEntry = {
 
 const toolSchemaCache = new Map<string, ToolSchemaCacheEntry>()
 
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, entry] of toolSchemaCache) {
+    if (entry.expiresAt <= now) toolSchemaCache.delete(key)
+  }
+}, TOOL_SCHEMA_CACHE_TTL_MS).unref()
+
 interface BuildPayloadParams {
   message: string
   workflowId?: string

--- a/apps/sim/lib/core/async-jobs/backends/database.ts
+++ b/apps/sim/lib/core/async-jobs/backends/database.ts
@@ -38,6 +38,7 @@ function rowToJob(row: AsyncJobRow): Job {
 const inlineAbortControllers = new Map<string, AbortController>()
 
 interface Semaphore {
+  limit: number
   available: number
   waiters: Array<() => void>
 }
@@ -46,7 +47,7 @@ const semaphores = new Map<string, Semaphore>()
 async function acquireSlot(key: string, limit: number): Promise<void> {
   let s = semaphores.get(key)
   if (!s) {
-    s = { available: limit, waiters: [] }
+    s = { limit, available: limit, waiters: [] }
     semaphores.set(key, s)
   }
   if (s.available > 0) {
@@ -65,6 +66,9 @@ function releaseSlot(key: string): void {
     return
   }
   s.available += 1
+  if (s.waiters.length === 0 && s.available === s.limit) {
+    semaphores.delete(key)
+  }
 }
 
 export class DatabaseJobQueue implements JobQueueBackend {

--- a/apps/sim/lib/core/async-jobs/backends/database.ts
+++ b/apps/sim/lib/core/async-jobs/backends/database.ts
@@ -66,7 +66,7 @@ function releaseSlot(key: string): void {
     return
   }
   s.available += 1
-  if (s.waiters.length === 0 && s.available === s.limit) {
+  if (s.available === s.limit) {
     semaphores.delete(key)
   }
 }

--- a/apps/sim/lib/environment/utils.ts
+++ b/apps/sim/lib/environment/utils.ts
@@ -10,6 +10,7 @@ import {
   getAccessibleEnvCredentials,
   syncPersonalEnvCredentialsForUser,
 } from '@/lib/credentials/environment'
+import { registerCache } from '@/lib/monitoring/cache-registry'
 import { checkWorkspaceAccess } from '@/lib/workspaces/permissions/utils'
 
 const logger = createLogger('EnvironmentUtils')
@@ -22,6 +23,15 @@ type EffectiveEnvCacheEntry = {
 }
 
 const effectiveEnvCache = new Map<string, EffectiveEnvCacheEntry>()
+
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, entry] of effectiveEnvCache) {
+    if (!entry.promise && entry.expiresAt <= now) effectiveEnvCache.delete(key)
+  }
+}, EFFECTIVE_ENV_CACHE_TTL_MS).unref()
+
+registerCache('effectiveEnvCache', () => effectiveEnvCache.size)
 
 function getEffectiveEnvCacheKey(userId: string, workspaceId?: string) {
   return `${userId}:${workspaceId ?? ''}`

--- a/apps/sim/lib/environment/utils.ts
+++ b/apps/sim/lib/environment/utils.ts
@@ -4,6 +4,7 @@ import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
 import { generateId } from '@sim/utils/id'
 import { eq, inArray } from 'drizzle-orm'
+import { LRUCache } from 'lru-cache'
 import { decryptSecret, encryptSecret } from '@/lib/core/security/encryption'
 import {
   createWorkspaceEnvCredentials,
@@ -16,20 +17,10 @@ import { checkWorkspaceAccess } from '@/lib/workspaces/permissions/utils'
 const logger = createLogger('EnvironmentUtils')
 const EFFECTIVE_ENV_CACHE_TTL_MS = 15_000
 
-type EffectiveEnvCacheEntry = {
-  expiresAt: number
-  value?: Record<string, string>
-  promise?: Promise<Record<string, string>>
-}
-
-const effectiveEnvCache = new Map<string, EffectiveEnvCacheEntry>()
-
-setInterval(() => {
-  const now = Date.now()
-  for (const [key, entry] of effectiveEnvCache) {
-    if (!entry.promise && entry.expiresAt <= now) effectiveEnvCache.delete(key)
-  }
-}, EFFECTIVE_ENV_CACHE_TTL_MS).unref()
+const effectiveEnvCache = new LRUCache<string, Promise<Record<string, string>>>({
+  max: 500,
+  ttl: EFFECTIVE_ENV_CACHE_TTL_MS,
+})
 
 registerCache('effectiveEnvCache', () => effectiveEnvCache.size)
 
@@ -335,37 +326,24 @@ export async function getEffectiveDecryptedEnv(
   workspaceId?: string
 ): Promise<Record<string, string>> {
   const cacheKey = getEffectiveEnvCacheKey(userId, workspaceId)
-  const now = Date.now()
+
   const cached = effectiveEnvCache.get(cacheKey)
-
-  if (cached?.value && cached.expiresAt > now) {
-    return { ...cached.value }
-  }
-
-  if (cached?.promise) {
-    const value = await cached.promise
+  if (cached) {
+    const value = await cached
     return { ...value }
   }
 
   const promise = getPersonalAndWorkspaceEnv(userId, workspaceId)
-    .then(({ personalDecrypted, workspaceDecrypted }) => {
-      const value = { ...personalDecrypted, ...workspaceDecrypted }
-      effectiveEnvCache.set(cacheKey, {
-        value,
-        expiresAt: Date.now() + EFFECTIVE_ENV_CACHE_TTL_MS,
-      })
-      return value
-    })
+    .then(({ personalDecrypted, workspaceDecrypted }) => ({
+      ...personalDecrypted,
+      ...workspaceDecrypted,
+    }))
     .catch((error) => {
       effectiveEnvCache.delete(cacheKey)
       throw error
     })
 
-  effectiveEnvCache.set(cacheKey, {
-    expiresAt: now + EFFECTIVE_ENV_CACHE_TTL_MS,
-    promise,
-  })
-
+  effectiveEnvCache.set(cacheKey, promise)
   const value = await promise
   return { ...value }
 }

--- a/apps/sim/lib/monitoring/cache-registry.ts
+++ b/apps/sim/lib/monitoring/cache-registry.ts
@@ -1,0 +1,13 @@
+const registry = new Map<string, () => number>()
+
+export function registerCache(name: string, getSize: () => number): void {
+  registry.set(name, getSize)
+}
+
+export function getCacheSizes(): Record<string, number> {
+  const sizes: Record<string, number> = {}
+  for (const [name, getSize] of registry) {
+    sizes[name] = getSize()
+  }
+  return sizes
+}

--- a/apps/sim/lib/monitoring/memory-telemetry.ts
+++ b/apps/sim/lib/monitoring/memory-telemetry.ts
@@ -5,6 +5,7 @@
 
 import v8 from 'node:v8'
 import { createLogger } from '@sim/logger'
+import { getCacheSizes } from '@/lib/monitoring/cache-registry'
 
 const logger = createLogger('MemoryTelemetry', { logLevel: 'INFO' })
 
@@ -33,6 +34,7 @@ export function startMemoryTelemetry(intervalMs = 60_000) {
           ? process.getActiveResourcesInfo().length
           : -1,
       uptimeMin: Math.round(process.uptime() / 60),
+      cacheSizes: getCacheSizes(),
     })
   }, intervalMs)
   timer.unref()

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -147,6 +147,7 @@
     "json5": "2.2.3",
     "jszip": "3.10.1",
     "jwt-decode": "^4.0.0",
+    "lru-cache": "11.3.6",
     "lucide-react": "^0.479.0",
     "mammoth": "^1.9.0",
     "mermaid": "11.15.0",

--- a/bun.lock
+++ b/bun.lock
@@ -202,6 +202,7 @@
         "json5": "2.2.3",
         "jszip": "3.10.1",
         "jwt-decode": "^4.0.0",
+        "lru-cache": "11.3.6",
         "lucide-react": "^0.479.0",
         "mammoth": "^1.9.0",
         "mermaid": "11.15.0",


### PR DESCRIPTION
## Summary

- Replaced two unbounded `Map`-based server-side caches (`toolSchemaCache` in `lib/copilot/chat/payload.ts`, `effectiveEnvCache` in `lib/environment/utils.ts`) with `LRUCache` from the `lru-cache` package, which provides automatic TTL expiry and a hard entry ceiling — eliminating the root cause of monotonic heap growth observed in production CloudWatch (24MB → 25GB)
- Removed all manual `setInterval` sweep timers and two-phase promise→value update patterns that were accumulating stale entries per unique `userId:workspaceId` pair indefinitely
- Added `cache-registry.ts` — a lightweight registry that lets any cache report its live size — and wired it into `MemoryTelemetry` so `cacheSizes` appears in every 60s memory snapshot log, giving us observability to confirm the fix post-deploy
- Fixed `semaphores` map in `DatabaseJobQueue` to self-clean when a key's waiters are drained and all slots are returned (defensive fix; map was dormant in production but would have leaked under load)

## Type of Change
- [x] Bug fix

## Testing

Tested manually — dev server runs clean, cache instrumentation visible in logs.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)