### PR TITLE
feat(google_docs): opt-in Markdown formatting for create operation

### DIFF
--- a/apps/sim/blocks/blocks/google_docs.ts
+++ b/apps/sim/blocks/blocks/google_docs.ts
@@ -155,6 +155,15 @@ Return ONLY the document content - no explanations, no extra text.`,
         placeholder: 'Describe the document content you want to create...',
       },
     },
+    // Markdown formatting toggle for create operation
+    {
+      id: 'markdown',
+      title: 'Interpret content as Markdown',
+      type: 'switch',
+      condition: { field: 'operation', value: 'create' },
+      description:
+        'Convert headings, bold/italic, lists, tables, links, code, and blockquotes into formatted Google Docs content. When off, content is inserted as plain text.',
+    },
   ],
   tools: {
     access: ['google_docs_read', 'google_docs_write', 'google_docs_create'],
@@ -193,6 +202,10 @@ Return ONLY the document content - no explanations, no extra text.`,
     title: { type: 'string', description: 'Document title' },
     folderId: { type: 'string', description: 'Parent folder identifier (canonical param)' },
     content: { type: 'string', description: 'Document content' },
+    markdown: {
+      type: 'boolean',
+      description: 'Interpret content as Markdown when creating a document',
+    },
   },
   outputs: {
     content: { type: 'string', description: 'Document content' },

--- a/apps/sim/tools/google_docs/create.ts
+++ b/apps/sim/tools/google_docs/create.ts
@@ -125,9 +125,16 @@ export const createTool: ToolConfig<GoogleDocsToolParams, GoogleDocsCreateRespon
       }
 
       if (shouldUseMarkdownUpload(params)) {
-        const boundary =
-          (params as GoogleDocsToolParams & { _boundary?: string })._boundary ??
-          `sim_gdocs_md_${generateShortId(24)}`
+        const boundary = (params as GoogleDocsToolParams & { _boundary?: string })._boundary
+        if (!boundary) {
+          // headers() runs before body() in formatRequestParams and stashes the boundary
+          // on the same params reference. Missing _boundary means that contract was broken,
+          // which would silently produce a Content-Type / body boundary mismatch (HTTP 400).
+          // Throw loudly instead of fabricating a mismatched boundary.
+          throw new Error(
+            'Multipart boundary missing on params — headers() must run before body() for markdown upload'
+          )
+        }
         return buildMarkdownMultipartBody(metadata, params.content ?? '', boundary)
       }
 
@@ -142,9 +149,9 @@ export const createTool: ToolConfig<GoogleDocsToolParams, GoogleDocsCreateRespon
 
     const documentId = result.output.metadata.documentId
 
-    // When markdown=true, content was already inserted via Drive's text/markdown
-    // import conversion during files.create — no follow-up write needed.
-    if (params.markdown) {
+    // When the markdown upload path ran, content was already inserted via Drive's
+    // text/markdown import conversion during files.create — no follow-up write needed.
+    if (shouldUseMarkdownUpload(params)) {
       return result
     }
 

--- a/apps/sim/tools/google_docs/create.ts
+++ b/apps/sim/tools/google_docs/create.ts
@@ -1,8 +1,36 @@
 import { createLogger } from '@sim/logger'
+import { generateShortId } from '@sim/utils/id'
 import type { GoogleDocsCreateResponse, GoogleDocsToolParams } from '@/tools/google_docs/types'
 import type { ToolConfig } from '@/tools/types'
 
 const logger = createLogger('GoogleDocsCreateTool')
+
+const DOC_MIME_TYPE = 'application/vnd.google-apps.document'
+
+/**
+ * Build a multipart/related body for Drive's files.create upload endpoint.
+ * Used when converting Markdown to a Google Doc in a single round-trip.
+ * See: https://developers.google.com/workspace/drive/api/guides/manage-uploads
+ */
+function buildMarkdownMultipartBody(
+  metadata: Record<string, unknown>,
+  markdownContent: string,
+  boundary: string
+): string {
+  return (
+    `--${boundary}\r\n` +
+    `Content-Type: application/json; charset=UTF-8\r\n\r\n` +
+    `${JSON.stringify(metadata)}\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Type: text/markdown\r\n\r\n` +
+    `${markdownContent}\r\n` +
+    `--${boundary}--`
+  )
+}
+
+function shouldUseMarkdownUpload(params: GoogleDocsToolParams): boolean {
+  return Boolean(params.markdown && params.content)
+}
 
 export const createTool: ToolConfig<GoogleDocsToolParams, GoogleDocsCreateResponse> = {
   id: 'google_docs_create',
@@ -46,17 +74,35 @@ export const createTool: ToolConfig<GoogleDocsToolParams, GoogleDocsCreateRespon
       visibility: 'hidden',
       description: 'The ID of the folder to create the document in (internal use)',
     },
+    markdown: {
+      type: 'boolean',
+      required: false,
+      visibility: 'user-or-llm',
+      description:
+        'When true, content is interpreted as Markdown and converted to formatted Google Docs content (headings, bold/italic, lists, tables, links, code blocks, blockquotes). Default: false (content inserted as plain text).',
+    },
   },
 
   request: {
-    url: () => {
-      return 'https://www.googleapis.com/drive/v3/files?supportsAllDrives=true'
+    url: (params) => {
+      return shouldUseMarkdownUpload(params)
+        ? 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&supportsAllDrives=true'
+        : 'https://www.googleapis.com/drive/v3/files?supportsAllDrives=true'
     },
     method: 'POST',
     headers: (params) => {
-      // Validate access token
       if (!params.accessToken) {
         throw new Error('Access token is required')
+      }
+
+      if (shouldUseMarkdownUpload(params)) {
+        const boundary = `sim_gdocs_md_${generateShortId(24)}`
+        // Stash on params so body() uses the matching boundary string
+        ;(params as GoogleDocsToolParams & { _boundary?: string })._boundary = boundary
+        return {
+          Authorization: `Bearer ${params.accessToken}`,
+          'Content-Type': `multipart/related; boundary=${boundary}`,
+        }
       }
 
       return {
@@ -69,18 +115,23 @@ export const createTool: ToolConfig<GoogleDocsToolParams, GoogleDocsCreateRespon
         throw new Error('Title is required')
       }
 
-      const requestBody: any = {
-        name: params.title,
-        mimeType: 'application/vnd.google-apps.document',
-      }
-
-      // Add parent folder if specified (prefer folderSelector over folderId)
       const folderId = params.folderSelector || params.folderId
+      const metadata: Record<string, unknown> = {
+        name: params.title,
+        mimeType: DOC_MIME_TYPE,
+      }
       if (folderId) {
-        requestBody.parents = [folderId]
+        metadata.parents = [folderId]
       }
 
-      return requestBody
+      if (shouldUseMarkdownUpload(params)) {
+        const boundary =
+          (params as GoogleDocsToolParams & { _boundary?: string })._boundary ??
+          `sim_gdocs_md_${generateShortId(24)}`
+        return buildMarkdownMultipartBody(metadata, params.content ?? '', boundary)
+      }
+
+      return metadata
     },
   },
 
@@ -90,6 +141,12 @@ export const createTool: ToolConfig<GoogleDocsToolParams, GoogleDocsCreateRespon
     }
 
     const documentId = result.output.metadata.documentId
+
+    // When markdown=true, content was already inserted via Drive's text/markdown
+    // import conversion during files.create — no follow-up write needed.
+    if (params.markdown) {
+      return result
+    }
 
     if (params.content && documentId) {
       try {
@@ -128,7 +185,7 @@ export const createTool: ToolConfig<GoogleDocsToolParams, GoogleDocsCreateRespon
       const metadata = {
         documentId,
         title: title || 'Untitled Document',
-        mimeType: 'application/vnd.google-apps.document',
+        mimeType: DOC_MIME_TYPE,
         url: `https://docs.google.com/document/d/${documentId}/edit`,
       }
 

--- a/apps/sim/tools/google_docs/types.ts
+++ b/apps/sim/tools/google_docs/types.ts
@@ -37,6 +37,7 @@ export interface GoogleDocsToolParams {
   content?: string
   folderId?: string
   folderSelector?: string
+  markdown?: boolean
 }
 
 export type GoogleDocsResponse =

--- a/apps/sim/tools/google_docs/write.ts
+++ b/apps/sim/tools/google_docs/write.ts
@@ -4,7 +4,8 @@ import type { ToolConfig } from '@/tools/types'
 export const writeTool: ToolConfig<GoogleDocsToolParams, GoogleDocsWriteResponse> = {
   id: 'google_docs_write',
   name: 'Write to Google Docs Document',
-  description: 'Write or update content in a Google Docs document',
+  description:
+    'Append content to a Google Docs document. Content is inserted literally; Markdown is not interpreted. For formatted output from Markdown, use the Create operation with the markdown toggle enabled.',
   version: '1.0',
   oauth: {
     required: true,


### PR DESCRIPTION
## Summary
- Add opt-in `markdown` toggle to the Google Docs `Create` operation that converts Markdown content (headings, bold/italic, lists, tables, links, code, blockquotes) to formatted Google Docs content via Drive API's `text/markdown` import conversion
- When `markdown: true`, switch from JSON `files.create` + `insertText` follow-up to a single multipart upload (`uploadType=multipart`) with `text/markdown` media and `application/vnd.google-apps.document` target — single round-trip, Google handles formatting server-side
- Default is `false` — existing callers see identical behavior (no breaking changes to URL, headers, body, postProcess flow, or response shape)
- Note `write` (append) description: it inserts content literally; for formatted output, use `create` with the markdown toggle
- Closes #4648

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
Tested manually. Verified backwards compatibility by code inspection: `shouldUseMarkdownUpload()` gates the new code path on `params.markdown && params.content`, so callers without the flag take the unchanged path. `bun run check:api-validation` passes. Type-check clean on changed files.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)