### PR TITLE
feat(models): add gemini 3.5 flash

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -1205,6 +1205,26 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     color: '#4285F4',
     models: [
       {
+        id: 'gemini-3.5-flash',
+        pricing: {
+          input: 1.5,
+          cachedInput: 0.15,
+          output: 9.0,
+          updatedAt: '2026-05-19',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['minimal', 'low', 'medium', 'high'],
+            default: 'medium',
+          },
+          maxOutputTokens: 65536,
+        },
+        contextWindow: 1048576,
+        releaseDate: '2026-05-19',
+        recommended: true,
+      },
+      {
         id: 'gemini-3.1-pro-preview',
         pricing: {
           input: 2.0,
@@ -1222,7 +1242,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1048576,
         releaseDate: '2026-02-19',
-        recommended: true,
       },
       {
         id: 'gemini-3.1-flash-lite-preview',
@@ -1366,6 +1385,24 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
       toolUsageControl: true,
     },
     models: [
+      {
+        id: 'vertex/gemini-3.5-flash',
+        pricing: {
+          input: 1.5,
+          cachedInput: 0.15,
+          output: 9.0,
+          updatedAt: '2026-05-19',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['minimal', 'low', 'medium', 'high'],
+            default: 'medium',
+          },
+        },
+        contextWindow: 1048576,
+        releaseDate: '2026-05-19',
+      },
       {
         id: 'vertex/gemini-3.1-pro-preview',
         pricing: {


### PR DESCRIPTION
## Summary
- Add `gemini-3.5-flash` to Google and Vertex providers in `models.ts`
- Set as new flagship `recommended: true` (removed from `gemini-3.1-pro-preview`)
- Pricing verified from Google docs: $1.50/M input, $9.00/M output, $0.15/M cached. 1M context, thinking levels min/low/medium/high (default medium)

## Type of Change
- [x] New feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)