### PR TITLE
fix(docker): restore NEXT_PUBLIC_APP_URL build arg with dummy fallback

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -69,10 +69,18 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
     VERCEL_TELEMETRY_DISABLED=1 \
     DOCKER_BUILD=1
 
-# Provide dummy database URLs during image build so server code that imports @sim/db
-# can be evaluated without crashing. Runtime environments should override these.
+# Provide dummy values during image build so module-eval-time validators
+# (e.g. @sim/db connection init, getBaseUrl() in lib/core/utils/urls) don't
+# crash next build during page-data collection. Runtime environments must
+# override both. NEXT_PUBLIC_APP_URL is intentionally NOT read by
+# next.config.ts at build time — response CORS is computed at request time
+# in proxy.ts via getEnv(), so the localhost fallback below cannot leak
+# into production CORS response headers.
 ARG DATABASE_URL="postgresql://user:pass@localhost:5432/dummy"
 ENV DATABASE_URL=${DATABASE_URL}
+
+ARG NEXT_PUBLIC_APP_URL="http://localhost:3000"
+ENV NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
 
 # Per-platform cache id keeps arm64/amd64 SWC artifacts isolated.
 RUN --mount=type=cache,id=next-cache-${TARGETPLATFORM},target=/app/apps/sim/.next/cache \

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -69,13 +69,7 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
     VERCEL_TELEMETRY_DISABLED=1 \
     DOCKER_BUILD=1
 
-# Provide dummy values during image build so module-eval-time validators
-# (e.g. @sim/db connection init, getBaseUrl() in lib/core/utils/urls) don't
-# crash next build during page-data collection. Runtime environments must
-# override both. NEXT_PUBLIC_APP_URL is intentionally NOT read by
-# next.config.ts at build time — response CORS is computed at request time
-# in proxy.ts via getEnv(), so the localhost fallback below cannot leak
-# into production CORS response headers.
+# Dummy values so next build can evaluate modules. Override at runtime.
 ARG DATABASE_URL="postgresql://user:pass@localhost:5432/dummy"
 ENV DATABASE_URL=${DATABASE_URL}
 


### PR DESCRIPTION
## Summary

- PR #4658 removed `ARG NEXT_PUBLIC_APP_URL` from the Dockerfile. That broke `next build` in the Docker image: `getBaseUrl()` in `apps/sim/lib/core/utils/urls.ts` throws if `NEXT_PUBLIC_APP_URL` is unset, and it's evaluated at module load during page-data collection (fails at `/_not-found`).
- Restore the dummy build-time fallback (mirrors the existing `DATABASE_URL` pattern).

## Why this is safe (CORS fix from #4658 still holds)

The original bug was `next.config.ts` reading `NEXT_PUBLIC_APP_URL` at build time and baking it into static API CORS headers. #4658 removed that headers block. This change only restores a build-time arg so module evaluation succeeds; it does not reintroduce build-time CORS resolution:

- `next.config.ts` no longer reads `NEXT_PUBLIC_APP_URL` at build time
- `proxy.ts` calls `getEnv('NEXT_PUBLIC_APP_URL')` at request time
- No module-level expression captures `getBaseUrl()` (verified by grep) — every caller invokes it lazily
- The dummy `http://localhost:3000` only exists inside the build environment

## Test plan

- [x] Docker image builds cleanly (no `/_not-found` page-data collection failure)
- [x] Deployed container with real `NEXT_PUBLIC_APP_URL` env var serves correct `Access-Control-Allow-Origin` (not localhost)