### PR TITLE
fix(table): dispatcher cold-start, live run counter, smooth typewriter

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
@@ -297,14 +297,9 @@ const TYPEWRITER_MS_PER_CHAR = 15
  * practice means SSE-driven workflow completions arriving via
  * `useTableEventStream → applyCell()`.
  *
- * Driven by `requestAnimationFrame`, not `setInterval`: when many cells reveal
- * at once (a Run-all completing in waves), independent interval callbacks fire
- * at uncoordinated times and each forces its own React render + layout/paint —
- * O(cells) reflows over an un-virtualized grid, which degrades as more cells
- * fill. rAF callbacks for a frame all run before one paint, so React batches
- * every cell's update into a single render + paint per frame (~60fps,
- * independent of cell count). Reveal length is derived from elapsed time, so a
- * dropped frame catches up instead of slowing the animation.
+ * rAF-driven (not `setInterval`) so concurrent reveals batch into one
+ * render/paint per frame instead of O(cells) uncoordinated reflows; reveal
+ * length is elapsed-time based so dropped frames catch up rather than slow.
  */
 function useTypewriter(text: string | null): string | null {
   const [revealed, setRevealed] = useState<string | null>(text)

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
@@ -296,6 +296,15 @@ const TYPEWRITER_MS_PER_CHAR = 15
  * value statically — animation fires only for subsequent updates, which in
  * practice means SSE-driven workflow completions arriving via
  * `useTableEventStream → applyCell()`.
+ *
+ * Driven by `requestAnimationFrame`, not `setInterval`: when many cells reveal
+ * at once (a Run-all completing in waves), independent interval callbacks fire
+ * at uncoordinated times and each forces its own React render + layout/paint —
+ * O(cells) reflows over an un-virtualized grid, which degrades as more cells
+ * fill. rAF callbacks for a frame all run before one paint, so React batches
+ * every cell's update into a single render + paint per frame (~60fps,
+ * independent of cell count). Reveal length is derived from elapsed time, so a
+ * dropped frame catches up instead of slowing the animation.
  */
 function useTypewriter(text: string | null): string | null {
   const [revealed, setRevealed] = useState<string | null>(text)
@@ -317,14 +326,17 @@ function useTypewriter(text: string | null): string | null {
       return
     }
 
+    const full = text
+    const start = performance.now()
+    let raf = 0
+    const tick = (now: number) => {
+      const chars = Math.min(full.length, Math.floor((now - start) / TYPEWRITER_MS_PER_CHAR))
+      setRevealed(full.slice(0, chars))
+      if (chars < full.length) raf = requestAnimationFrame(tick)
+    }
     setRevealed('')
-    let i = 0
-    const id = window.setInterval(() => {
-      i++
-      setRevealed(text.slice(0, i))
-      if (i >= text.length) window.clearInterval(id)
-    }, TYPEWRITER_MS_PER_CHAR)
-    return () => window.clearInterval(id)
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
   }, [text])
 
   return revealed

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -1336,10 +1336,13 @@ export function useRunColumn({ workspaceId, tableId }: RowMutationContext) {
         queryClient.getQueryData<TableDefinition>(tableKeys.detail(tableId))?.schema
           .workflowGroups ?? []
       const groupsById = new Map(groups.map((g) => [g.id, g]))
+      // Tally cells flipped to pending per row so we can bump the run-state
+      // counter in lockstep with the optimistic cell stamps below.
+      const stampedByRow: Record<string, number> = {}
       const snapshots = await snapshotAndMutateRows(queryClient, tableId, (r) => {
         if (targetRowIds && !targetRowIds.has(r.id)) return null
         const executions = r.executions ?? {}
-        let changed = false
+        let stamped = 0
         const next: RowExecutions = { ...executions }
         const nextData = { ...r.data }
         for (const groupId of targetGroupIds) {
@@ -1367,20 +1370,70 @@ export function useRunColumn({ workspaceId, tableId }: RowMutationContext) {
               if (o.columnName in nextData) nextData[o.columnName] = null
             }
           }
-          changed = true
+          stamped++
         }
-        if (!changed) return null
+        if (stamped === 0) return null
+        stampedByRow[r.id] = stamped
         return { ...r, data: nextData, executions: next }
       })
-      return { snapshots }
+
+      // Bump the run-state counter to match the cells we just stamped. Without
+      // this the top-right "X running" badge and per-row gutter Stop button
+      // stay at zero until a refetch: the optimistic stamp marks the cell
+      // in-flight in the rows cache, so the dispatcher's real `pending` SSE
+      // event sees no `wasInFlight` transition and never bumps the counter.
+      const runStateSnapshot = queryClient.getQueryData<TableRunState>(
+        tableKeys.activeDispatches(tableId)
+      )
+      const totalStamped = Object.values(stampedByRow).reduce((s, n) => s + n, 0)
+      if (totalStamped > 0) {
+        queryClient.setQueryData<TableRunState>(tableKeys.activeDispatches(tableId), (prev) => {
+          const base = prev ?? { dispatches: [], runningCellCount: 0, runningByRowId: {} }
+          const nextByRow = { ...base.runningByRowId }
+          for (const [rid, n] of Object.entries(stampedByRow)) {
+            nextByRow[rid] = (nextByRow[rid] ?? 0) + n
+          }
+          return {
+            ...base,
+            runningCellCount: base.runningCellCount + totalStamped,
+            runningByRowId: nextByRow,
+          }
+        })
+      }
+      return { snapshots, runStateSnapshot, didBumpRunState: totalStamped > 0 }
     },
     onError: (_err, _variables, context) => {
       if (context?.snapshots) restoreCachedWorkflowCells(queryClient, context.snapshots)
+      // Roll back the optimistic counter bump to its pre-mutation value
+      // (possibly undefined, which clears the entry we created).
+      if (context?.didBumpRunState) {
+        queryClient.setQueryData(tableKeys.activeDispatches(tableId), context.runStateSnapshot)
+      }
     },
-    onSuccess: () => {
-      // Seed the active-dispatch overlay immediately (insertDispatch ran
-      // server-side before responding); rows cache stays owned by SSE.
-      void queryClient.invalidateQueries({ queryKey: tableKeys.activeDispatches(tableId) })
+    onSuccess: (data, { groupIds, runMode = 'all', rowIds }) => {
+      // Seed the dispatch into the overlay list (drives resolveCellExec's
+      // queued overlay for ahead-of-cursor rows). Upsert directly from the
+      // response instead of refetching — a refetch would reset the
+      // optimistic counter to the server's still-zero count (the dispatcher
+      // hasn't stamped cells yet).
+      const dispatchId = data?.data?.dispatchId
+      if (!dispatchId) return
+      queryClient.setQueryData<TableRunState>(tableKeys.activeDispatches(tableId), (prev) => {
+        const base = prev ?? { dispatches: [], runningCellCount: 0, runningByRowId: {} }
+        if (base.dispatches.some((d) => d.id === dispatchId)) return base
+        const dispatch: ActiveDispatch = {
+          id: dispatchId,
+          status: 'pending',
+          mode: runMode,
+          isManualRun: true,
+          cursor: -1,
+          scope: {
+            groupIds,
+            ...(rowIds && rowIds.length > 0 ? { rowIds } : {}),
+          },
+        }
+        return { ...base, dispatches: [...base.dispatches, dispatch] }
+      })
     },
   })
 }

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -1410,14 +1410,22 @@ export function useRunColumn({ workspaceId, tableId }: RowMutationContext) {
         queryClient.setQueryData(tableKeys.activeDispatches(tableId), context.runStateSnapshot)
       }
     },
-    onSuccess: (data, { groupIds, runMode = 'all', rowIds }) => {
+    onSuccess: (data, { groupIds, runMode = 'all', rowIds }, context) => {
       // Seed the dispatch into the overlay list (drives resolveCellExec's
       // queued overlay for ahead-of-cursor rows). Upsert directly from the
       // response instead of refetching — a refetch would reset the
       // optimistic counter to the server's still-zero count (the dispatcher
       // hasn't stamped cells yet).
       const dispatchId = data?.data?.dispatchId
-      if (!dispatchId) return
+      if (!dispatchId) {
+        // No dispatch was created (e.g. no matching groups / eligible rows).
+        // No SSE will arrive to reconcile the optimistic counter bump, so roll
+        // it back to its pre-mutation value.
+        if (context?.didBumpRunState) {
+          queryClient.setQueryData(tableKeys.activeDispatches(tableId), context.runStateSnapshot)
+        }
+        return
+      }
       queryClient.setQueryData<TableRunState>(tableKeys.activeDispatches(tableId), (prev) => {
         const base = prev ?? { dispatches: [], runningCellCount: 0, runningByRowId: {} }
         if (base.dispatches.some((d) => d.id === dispatchId)) return base

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -1336,8 +1336,7 @@ export function useRunColumn({ workspaceId, tableId }: RowMutationContext) {
         queryClient.getQueryData<TableDefinition>(tableKeys.detail(tableId))?.schema
           .workflowGroups ?? []
       const groupsById = new Map(groups.map((g) => [g.id, g]))
-      // Tally cells flipped to pending per row so we can bump the run-state
-      // counter in lockstep with the optimistic cell stamps below.
+      // Tally cells stamped per row to bump the run-state counter in lockstep.
       const stampedByRow: Record<string, number> = {}
       const snapshots = await snapshotAndMutateRows(queryClient, tableId, (r) => {
         if (targetRowIds && !targetRowIds.has(r.id)) return null
@@ -1377,11 +1376,10 @@ export function useRunColumn({ workspaceId, tableId }: RowMutationContext) {
         return { ...r, data: nextData, executions: next }
       })
 
-      // Bump the run-state counter to match the cells we just stamped. Without
-      // this the top-right "X running" badge and per-row gutter Stop button
-      // stay at zero until a refetch: the optimistic stamp marks the cell
-      // in-flight in the rows cache, so the dispatcher's real `pending` SSE
-      // event sees no `wasInFlight` transition and never bumps the counter.
+      // Bump the counter to match the stamped cells. Without it the "X running"
+      // badge + gutter Stop stay at zero until a refetch: the optimistic stamp
+      // already marks the cell in-flight, so the dispatcher's `pending` SSE
+      // sees no `wasInFlight` transition and never bumps the counter.
       const runStateSnapshot = queryClient.getQueryData<TableRunState>(
         tableKeys.activeDispatches(tableId)
       )
@@ -1404,23 +1402,18 @@ export function useRunColumn({ workspaceId, tableId }: RowMutationContext) {
     },
     onError: (_err, _variables, context) => {
       if (context?.snapshots) restoreCachedWorkflowCells(queryClient, context.snapshots)
-      // Roll back the optimistic counter bump to its pre-mutation value
-      // (possibly undefined, which clears the entry we created).
+      // Roll back the optimistic counter bump (snapshot may be undefined).
       if (context?.didBumpRunState) {
         queryClient.setQueryData(tableKeys.activeDispatches(tableId), context.runStateSnapshot)
       }
     },
     onSuccess: (data, { groupIds, runMode = 'all', rowIds }, context) => {
-      // Seed the dispatch into the overlay list (drives resolveCellExec's
-      // queued overlay for ahead-of-cursor rows). Upsert directly from the
-      // response instead of refetching — a refetch would reset the
-      // optimistic counter to the server's still-zero count (the dispatcher
-      // hasn't stamped cells yet).
+      // Seed the dispatch into the overlay (drives resolveCellExec for
+      // ahead-of-cursor rows) from the response — refetching would reset the
+      // optimistic counter to the server's still-zero count.
       const dispatchId = data?.data?.dispatchId
       if (!dispatchId) {
-        // No dispatch was created (e.g. no matching groups / eligible rows).
-        // No SSE will arrive to reconcile the optimistic counter bump, so roll
-        // it back to its pre-mutation value.
+        // No dispatch created → no SSE to reconcile the bump; roll it back.
         if (context?.didBumpRunState) {
           queryClient.setQueryData(tableKeys.activeDispatches(tableId), context.runStateSnapshot)
         }

--- a/apps/sim/lib/table/trigger.ts
+++ b/apps/sim/lib/table/trigger.ts
@@ -9,8 +9,6 @@
 import { createLogger } from '@sim/logger'
 import { generateShortId } from '@sim/utils/id'
 import type { RowData, TableRow, TableSchema } from '@/lib/table/types'
-import { fetchActiveWebhooks } from '@/lib/webhooks/polling/utils'
-import { processPolledWebhookEvent } from '@/lib/webhooks/processor'
 
 const logger = createLogger('TableTrigger')
 
@@ -57,6 +55,11 @@ export async function fireTableTrigger(
   requestId: string
 ): Promise<void> {
   try {
+    // Lazy-imported: `@/lib/webhooks/processor` transitively pulls in the
+    // workflow executor + blocks stack. Importing it eagerly would force every
+    // consumer of `lib/table/service` (e.g. the dispatcher, which only needs
+    // `getTableById`) to pay that cold-start even when no trigger ever fires.
+    const { fetchActiveWebhooks } = await import('@/lib/webhooks/polling/utils')
     const webhooks = await fetchActiveWebhooks('table')
     if (webhooks.length === 0) return
 
@@ -73,6 +76,8 @@ export async function fireTableTrigger(
     })
 
     if (matching.length === 0) return
+
+    const { processPolledWebhookEvent } = await import('@/lib/webhooks/processor')
 
     logger.info(
       `[${requestId}] Firing ${matching.length} trigger(s) for ${rows.length} ${eventType} event(s) in table ${tableId}`

--- a/apps/sim/lib/table/trigger.ts
+++ b/apps/sim/lib/table/trigger.ts
@@ -55,10 +55,9 @@ export async function fireTableTrigger(
   requestId: string
 ): Promise<void> {
   try {
-    // Lazy-imported: `@/lib/webhooks/processor` transitively pulls in the
-    // workflow executor + blocks stack. Importing it eagerly would force every
-    // consumer of `lib/table/service` (e.g. the dispatcher, which only needs
-    // `getTableById`) to pay that cold-start even when no trigger ever fires.
+    // Lazy: the webhook utils/processor pull in the executor + blocks stack.
+    // Eager imports would force every `lib/table/service` consumer (e.g. the
+    // dispatcher) to pay that cold-start even when no trigger fires.
     const { fetchActiveWebhooks } = await import('@/lib/webhooks/polling/utils')
     const webhooks = await fetchActiveWebhooks('table')
     if (webhooks.length === 0) return

--- a/apps/sim/lib/table/workflow-columns.ts
+++ b/apps/sim/lib/table/workflow-columns.ts
@@ -205,11 +205,9 @@ export function buildPendingRuns(
  *  the inline runner, and the cancel key the inline backend uses to map a
  *  Stop click to the in-flight cell's AbortController.
  *
- *  The `runner` is only consumed by the database (inline) backend — the
- *  trigger.dev backend triggers by task id. Importing the cell job pulls in
- *  the entire executor + blocks stack, so on trigger.dev we skip the import
- *  entirely: the dispatcher container would otherwise pay a multi-second
- *  cold-start loading code it never runs (the cell runs in its own container). */
+ *  `runner` is only used by the database backend; trigger.dev triggers by task
+ *  id. The cell-job import pulls in the executor + blocks stack, so skip it on
+ *  trigger.dev to avoid a multi-second dispatcher cold-start. */
 export async function buildEnqueueItems(
   pendingRuns: WorkflowGroupCellPayload[]
 ): Promise<Array<{ payload: WorkflowGroupCellPayload; options: EnqueueOptions }>> {

--- a/apps/sim/lib/table/workflow-columns.ts
+++ b/apps/sim/lib/table/workflow-columns.ts
@@ -203,11 +203,20 @@ export function buildPendingRuns(
 /** Build the per-cell `{payload, options}` items for `queue.batchEnqueue` /
  *  `queue.batchEnqueueAndWait`. Hydrates trigger.dev tags, concurrency keys,
  *  the inline runner, and the cancel key the inline backend uses to map a
- *  Stop click to the in-flight cell's AbortController. */
+ *  Stop click to the in-flight cell's AbortController.
+ *
+ *  The `runner` is only consumed by the database (inline) backend — the
+ *  trigger.dev backend triggers by task id. Importing the cell job pulls in
+ *  the entire executor + blocks stack, so on trigger.dev we skip the import
+ *  entirely: the dispatcher container would otherwise pay a multi-second
+ *  cold-start loading code it never runs (the cell runs in its own container). */
 export async function buildEnqueueItems(
   pendingRuns: WorkflowGroupCellPayload[]
 ): Promise<Array<{ payload: WorkflowGroupCellPayload; options: EnqueueOptions }>> {
-  const { executeWorkflowGroupCellJob } = await import('@/background/workflow-column-execution')
+  const runner = isTriggerDevEnabled
+    ? undefined
+    : ((await import('@/background/workflow-column-execution'))
+        .executeWorkflowGroupCellJob as EnqueueOptions['runner'])
   return pendingRuns.map((runOpts) => ({
     payload: runOpts,
     options: {
@@ -225,7 +234,7 @@ export async function buildEnqueueItems(
       concurrencyKey: runOpts.tableId,
       concurrencyLimit: TABLE_CONCURRENCY_LIMIT,
       tags: cellTagsFor(runOpts),
-      runner: executeWorkflowGroupCellJob as EnqueueOptions['runner'],
+      ...(runner ? { runner } : {}),
       cancelKey: cellCancelKey(runOpts.tableId, runOpts.rowId, runOpts.groupId),
     },
   }))


### PR DESCRIPTION
## Summary
Three follow-up fixes after the chunked-dispatcher merge (#4672), each in its own commit.

- **Dispatcher cold-start (~6s → <2s queued→running):** `table-run-dispatcher` imported `lib/table/service` for `getTableById`, which eagerly pulled `lib/table/trigger` → `@/lib/webhooks/processor` → the whole workflow-executor stack into the dispatcher container. `trigger.ts` now lazy-imports the webhook processor inside `fireTableTrigger`, and `buildEnqueueItems` only imports the cell job (for the inline `runner`) on the database backend — the trigger.dev backend triggers by task id and ignores `runner`.
- **Live "X running" counter / gutter Stop button:** `useRunColumn` optimistically stamped cells `pending` in the rows cache but never bumped `runningCellCount`/`runningByRowId`, so the dispatcher's real `pending` SSE saw no `wasInFlight` transition and the counter stayed at 0 until a refetch ("shows up on refresh"). `onMutate` now bumps the counter for the cells it stamps (with rollback on error), and `onSuccess` seeds the dispatch into the overlay from the response instead of refetching (which reset the counter to the server's still-zero count).
- **Typewriter degrades with many concurrent reveals:** per-cell `setInterval` callbacks fired uncoordinated → O(cells) independent reflows over an un-virtualized grid. Switched to `requestAnimationFrame` (frame-batched, elapsed-time based) so all reveals render+paint once per frame.

## Type of Change
- [x] Bug fix

## Testing
Tested manually in staging (issues observed there); tsc, vitest (lib/table + hooks/queries, 202 passing), lint, and `check:api-validation:strict` all pass. Cold-start improvement diagnosed via trigger.dev run traces (dispatcher init dropped from ~8s).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)