### PR TITLE
fix(landing-nav): scroll to top on route change in shared shells

### DIFF
--- a/apps/sim/app/(landing)/blog/layout.tsx
+++ b/apps/sim/app/(landing)/blog/layout.tsx
@@ -2,6 +2,7 @@ import { getNavBlogPosts } from '@/lib/blog/registry'
 import { SITE_URL } from '@/lib/core/utils/urls'
 import Footer from '@/app/(landing)/components/footer/footer'
 import Navbar from '@/app/(landing)/components/navbar/navbar'
+import { ScrollToTop } from '@/app/(landing)/components/scroll-to-top'
 
 export default async function StudioLayout({ children }: { children: React.ReactNode }) {
   const blogPosts = await getNavBlogPosts()
@@ -29,6 +30,7 @@ export default async function StudioLayout({ children }: { children: React.React
 
   return (
     <div className='flex min-h-screen flex-col bg-[var(--landing-bg)] font-[430] font-season text-[var(--landing-text)]'>
+      <ScrollToTop />
       <script
         type='application/ld+json'
         dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}

--- a/apps/sim/app/(landing)/components/scroll-to-top.tsx
+++ b/apps/sim/app/(landing)/components/scroll-to-top.tsx
@@ -9,11 +9,13 @@ import { usePathname } from 'next/navigation'
  * where the outgoing layout's component instances unmount before the incoming
  * layout's effect runs.
  *
- * A timestamp window (rather than a sticky boolean) self-expires the signal —
- * a hash-only back/forward fires popstate but doesn't change `usePathname`, so
- * a boolean would never be consumed and would poison the next real navigation.
+ * Initialized to `-Infinity` so initial mounts don't mimic a recent popstate.
+ * Consumed on first use (reset back to `-Infinity`) so a real link navigation
+ * immediately after Back isn't swallowed. The timestamp window provides a
+ * safety net for popstates that never trigger a pathname effect (e.g.,
+ * hash-only back/forward), letting the signal self-expire.
  */
-let lastPopstateAt = 0
+let lastPopstateAt = Number.NEGATIVE_INFINITY
 const POPSTATE_WINDOW_MS = 200
 
 if (typeof window !== 'undefined') {
@@ -36,7 +38,10 @@ export function ScrollToTop() {
   const pathname = usePathname()
 
   useEffect(() => {
-    if (performance.now() - lastPopstateAt < POPSTATE_WINDOW_MS) return
+    if (performance.now() - lastPopstateAt < POPSTATE_WINDOW_MS) {
+      lastPopstateAt = Number.NEGATIVE_INFINITY
+      return
+    }
     if (window.location.hash) return
     window.scrollTo(0, 0)
   }, [pathname])

--- a/apps/sim/app/(landing)/components/scroll-to-top.tsx
+++ b/apps/sim/app/(landing)/components/scroll-to-top.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { usePathname } from 'next/navigation'
+
+/**
+ * Resets window scroll to the top on App Router pathname changes.
+ *
+ * Next.js's default scroll handling only brings the new Page element into view,
+ * which often resolves to "no scroll" inside shared layouts (see vercel/next.js#64435).
+ * Popstate-driven navigations are skipped so browser back/forward scroll restoration
+ * is preserved.
+ */
+export function ScrollToTop() {
+  const pathname = usePathname()
+  const isPopNavigationRef = useRef(false)
+
+  useEffect(() => {
+    const onPop = () => {
+      isPopNavigationRef.current = true
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [])
+
+  useEffect(() => {
+    if (isPopNavigationRef.current) {
+      isPopNavigationRef.current = false
+      return
+    }
+    window.scrollTo(0, 0)
+  }, [pathname])
+
+  return null
+}

--- a/apps/sim/app/(landing)/components/scroll-to-top.tsx
+++ b/apps/sim/app/(landing)/components/scroll-to-top.tsx
@@ -4,16 +4,21 @@ import { useEffect } from 'react'
 import { usePathname } from 'next/navigation'
 
 /**
- * Module-level flag so the popstate signal survives layout remounts when the
- * user navigates across sections (e.g., blog ↔ integrations ↔ models), where
- * the outgoing layout — and its component instances — unmount before the
- * incoming layout's effect runs.
+ * Timestamp of the most recent popstate. Module-scoped so it survives layout
+ * remounts when navigating across sections (e.g., blog ↔ integrations ↔ models),
+ * where the outgoing layout's component instances unmount before the incoming
+ * layout's effect runs.
+ *
+ * A timestamp window (rather than a sticky boolean) self-expires the signal —
+ * a hash-only back/forward fires popstate but doesn't change `usePathname`, so
+ * a boolean would never be consumed and would poison the next real navigation.
  */
-let isPopNavigation = false
+let lastPopstateAt = 0
+const POPSTATE_WINDOW_MS = 200
 
 if (typeof window !== 'undefined') {
   window.addEventListener('popstate', () => {
-    isPopNavigation = true
+    lastPopstateAt = performance.now()
   })
 }
 
@@ -23,18 +28,15 @@ if (typeof window !== 'undefined') {
  * Next.js's default scroll handling only brings the new Page element into view,
  * which often resolves to "no scroll" inside shared layouts (see vercel/next.js#64435).
  *
- * Popstate-driven navigations are skipped so browser back/forward scroll
- * restoration is preserved, and hash-anchor navigations are skipped so the
- * browser's native anchor scroll wins.
+ * Skipped when the pathname change closely follows a popstate (preserving browser
+ * back/forward scroll restoration) or when a hash anchor is targeted (letting the
+ * browser's native anchor scroll win).
  */
 export function ScrollToTop() {
   const pathname = usePathname()
 
   useEffect(() => {
-    if (isPopNavigation) {
-      isPopNavigation = false
-      return
-    }
+    if (performance.now() - lastPopstateAt < POPSTATE_WINDOW_MS) return
     if (window.location.hash) return
     window.scrollTo(0, 0)
   }, [pathname])

--- a/apps/sim/app/(landing)/components/scroll-to-top.tsx
+++ b/apps/sim/app/(landing)/components/scroll-to-top.tsx
@@ -1,33 +1,41 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { usePathname } from 'next/navigation'
+
+/**
+ * Module-level flag so the popstate signal survives layout remounts when the
+ * user navigates across sections (e.g., blog ↔ integrations ↔ models), where
+ * the outgoing layout — and its component instances — unmount before the
+ * incoming layout's effect runs.
+ */
+let isPopNavigation = false
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('popstate', () => {
+    isPopNavigation = true
+  })
+}
 
 /**
  * Resets window scroll to the top on App Router pathname changes.
  *
  * Next.js's default scroll handling only brings the new Page element into view,
  * which often resolves to "no scroll" inside shared layouts (see vercel/next.js#64435).
- * Popstate-driven navigations are skipped so browser back/forward scroll restoration
- * is preserved.
+ *
+ * Popstate-driven navigations are skipped so browser back/forward scroll
+ * restoration is preserved, and hash-anchor navigations are skipped so the
+ * browser's native anchor scroll wins.
  */
 export function ScrollToTop() {
   const pathname = usePathname()
-  const isPopNavigationRef = useRef(false)
 
   useEffect(() => {
-    const onPop = () => {
-      isPopNavigationRef.current = true
-    }
-    window.addEventListener('popstate', onPop)
-    return () => window.removeEventListener('popstate', onPop)
-  }, [])
-
-  useEffect(() => {
-    if (isPopNavigationRef.current) {
-      isPopNavigationRef.current = false
+    if (isPopNavigation) {
+      isPopNavigation = false
       return
     }
+    if (window.location.hash) return
     window.scrollTo(0, 0)
   }, [pathname])
 

--- a/apps/sim/app/(landing)/components/scroll-to-top.tsx
+++ b/apps/sim/app/(landing)/components/scroll-to-top.tsx
@@ -4,67 +4,16 @@ import { useEffect } from 'react'
 import { usePathname } from 'next/navigation'
 
 /**
- * Timestamp of the most recent popstate. Module-scoped so it survives layout
- * remounts when navigating across sections (e.g., blog ↔ integrations ↔ models),
- * where the outgoing layout's component instances unmount before the incoming
- * layout's effect runs.
- *
- * Initialized to `-Infinity` so initial mounts don't mimic a recent popstate.
- * Consumed on first use (reset back to `-Infinity`) so a real link navigation
- * immediately after Back isn't swallowed. The timestamp window provides a
- * safety net for popstates that never trigger a pathname effect (e.g.,
- * hash-only back/forward), letting the signal self-expire.
- */
-let lastPopstateAt = Number.NEGATIVE_INFINITY
-const POPSTATE_WINDOW_MS = 200
-
-/**
- * Captured at module evaluation time. When this module is bundled into the
- * initial page payload (direct load / reload of a shelled route), readyState
- * is still `loading` or `interactive`, the browser will restore scroll on
- * reload, and we should skip the first reset. When the module is dynamically
- * imported during a client-side navigation (e.g., user clicked from `/` into
- * `/blog/x`), readyState is already `complete` and the first mount is a real
- * route change that should scroll to top.
- */
-const wasInitialPageLoad = typeof document !== 'undefined' && document.readyState !== 'complete'
-
-/**
- * Tracks whether any `ScrollToTop` instance has run its mount effect yet.
- * Module-scoped so cross-section navigation (which mounts a fresh instance)
- * doesn't re-trigger the initial-mount guard.
- */
-let hasMounted = false
-
-if (typeof window !== 'undefined') {
-  window.addEventListener('popstate', () => {
-    lastPopstateAt = performance.now()
-  })
-}
-
-/**
  * Resets window scroll to the top on App Router pathname changes.
  *
  * Next.js's default scroll handling only brings the new Page element into view,
  * which often resolves to "no scroll" inside shared layouts (see vercel/next.js#64435).
- *
- * Skipped on the very first mount of an initial page load (so browser scroll
- * restoration on reload wins), when the pathname change closely follows a
- * popstate (preserving browser back/forward restoration), and when a hash
- * anchor is targeted (letting the browser's native anchor scroll win).
+ * Skipped when a hash anchor is targeted so the browser's native anchor scroll wins.
  */
 export function ScrollToTop() {
   const pathname = usePathname()
 
   useEffect(() => {
-    if (!hasMounted) {
-      hasMounted = true
-      if (wasInitialPageLoad) return
-    }
-    if (performance.now() - lastPopstateAt < POPSTATE_WINDOW_MS) {
-      lastPopstateAt = Number.NEGATIVE_INFINITY
-      return
-    }
     if (window.location.hash) return
     window.scrollTo(0, 0)
   }, [pathname])

--- a/apps/sim/app/(landing)/components/scroll-to-top.tsx
+++ b/apps/sim/app/(landing)/components/scroll-to-top.tsx
@@ -18,6 +18,15 @@ import { usePathname } from 'next/navigation'
 let lastPopstateAt = Number.NEGATIVE_INFINITY
 const POPSTATE_WINDOW_MS = 200
 
+/**
+ * Tracks whether any `ScrollToTop` instance has run its mount effect yet.
+ * Module-scoped so cross-section navigation (which mounts a fresh instance)
+ * still scrolls — only the very first mount on page load is treated as the
+ * initial render, letting the browser's native scroll restoration win on
+ * reload.
+ */
+let hasMounted = false
+
 if (typeof window !== 'undefined') {
   window.addEventListener('popstate', () => {
     lastPopstateAt = performance.now()
@@ -30,14 +39,19 @@ if (typeof window !== 'undefined') {
  * Next.js's default scroll handling only brings the new Page element into view,
  * which often resolves to "no scroll" inside shared layouts (see vercel/next.js#64435).
  *
- * Skipped when the pathname change closely follows a popstate (preserving browser
- * back/forward scroll restoration) or when a hash anchor is targeted (letting the
- * browser's native anchor scroll win).
+ * Skipped on the initial mount (so browser scroll restoration on reload wins),
+ * when the pathname change closely follows a popstate (preserving browser
+ * back/forward scroll restoration), and when a hash anchor is targeted (letting
+ * the browser's native anchor scroll win).
  */
 export function ScrollToTop() {
   const pathname = usePathname()
 
   useEffect(() => {
+    if (!hasMounted) {
+      hasMounted = true
+      return
+    }
     if (performance.now() - lastPopstateAt < POPSTATE_WINDOW_MS) {
       lastPopstateAt = Number.NEGATIVE_INFINITY
       return

--- a/apps/sim/app/(landing)/components/scroll-to-top.tsx
+++ b/apps/sim/app/(landing)/components/scroll-to-top.tsx
@@ -19,11 +19,20 @@ let lastPopstateAt = Number.NEGATIVE_INFINITY
 const POPSTATE_WINDOW_MS = 200
 
 /**
+ * Captured at module evaluation time. When this module is bundled into the
+ * initial page payload (direct load / reload of a shelled route), readyState
+ * is still `loading` or `interactive`, the browser will restore scroll on
+ * reload, and we should skip the first reset. When the module is dynamically
+ * imported during a client-side navigation (e.g., user clicked from `/` into
+ * `/blog/x`), readyState is already `complete` and the first mount is a real
+ * route change that should scroll to top.
+ */
+const wasInitialPageLoad = typeof document !== 'undefined' && document.readyState !== 'complete'
+
+/**
  * Tracks whether any `ScrollToTop` instance has run its mount effect yet.
  * Module-scoped so cross-section navigation (which mounts a fresh instance)
- * still scrolls — only the very first mount on page load is treated as the
- * initial render, letting the browser's native scroll restoration win on
- * reload.
+ * doesn't re-trigger the initial-mount guard.
  */
 let hasMounted = false
 
@@ -39,10 +48,10 @@ if (typeof window !== 'undefined') {
  * Next.js's default scroll handling only brings the new Page element into view,
  * which often resolves to "no scroll" inside shared layouts (see vercel/next.js#64435).
  *
- * Skipped on the initial mount (so browser scroll restoration on reload wins),
- * when the pathname change closely follows a popstate (preserving browser
- * back/forward scroll restoration), and when a hash anchor is targeted (letting
- * the browser's native anchor scroll win).
+ * Skipped on the very first mount of an initial page load (so browser scroll
+ * restoration on reload wins), when the pathname change closely follows a
+ * popstate (preserving browser back/forward restoration), and when a hash
+ * anchor is targeted (letting the browser's native anchor scroll win).
  */
 export function ScrollToTop() {
   const pathname = usePathname()
@@ -50,7 +59,7 @@ export function ScrollToTop() {
   useEffect(() => {
     if (!hasMounted) {
       hasMounted = true
-      return
+      if (wasInitialPageLoad) return
     }
     if (performance.now() - lastPopstateAt < POPSTATE_WINDOW_MS) {
       lastPopstateAt = Number.NEGATIVE_INFINITY

--- a/apps/sim/app/(landing)/integrations/(shell)/layout.tsx
+++ b/apps/sim/app/(landing)/integrations/(shell)/layout.tsx
@@ -2,6 +2,7 @@ import { getNavBlogPosts } from '@/lib/blog/registry'
 import { SITE_URL } from '@/lib/core/utils/urls'
 import Footer from '@/app/(landing)/components/footer/footer'
 import Navbar from '@/app/(landing)/components/navbar/navbar'
+import { ScrollToTop } from '@/app/(landing)/components/scroll-to-top'
 
 export default async function IntegrationsLayout({ children }: { children: React.ReactNode }) {
   const blogPosts = await getNavBlogPosts()
@@ -29,6 +30,7 @@ export default async function IntegrationsLayout({ children }: { children: React
 
   return (
     <div className='dark flex min-h-screen flex-col bg-[var(--landing-bg)] font-[430] font-season text-[var(--landing-text)]'>
+      <ScrollToTop />
       <script
         type='application/ld+json'
         dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}

--- a/apps/sim/app/(landing)/models/(shell)/layout.tsx
+++ b/apps/sim/app/(landing)/models/(shell)/layout.tsx
@@ -2,6 +2,7 @@ import { getNavBlogPosts } from '@/lib/blog/registry'
 import { SITE_URL } from '@/lib/core/utils/urls'
 import Footer from '@/app/(landing)/components/footer/footer'
 import Navbar from '@/app/(landing)/components/navbar/navbar'
+import { ScrollToTop } from '@/app/(landing)/components/scroll-to-top'
 
 export default async function ModelsLayout({ children }: { children: React.ReactNode }) {
   const blogPosts = await getNavBlogPosts()
@@ -24,6 +25,7 @@ export default async function ModelsLayout({ children }: { children: React.React
 
   return (
     <div className='dark flex min-h-screen flex-col bg-[var(--landing-bg)] font-[430] font-season text-[var(--landing-text)]'>
+      <ScrollToTop />
       <script
         type='application/ld+json'
         dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}


### PR DESCRIPTION
## Summary
- Mount a `<ScrollToTop />` client component in the blog, integrations, and models shared layouts to reset scroll on `usePathname` change
- Skip the reset on popstate-driven navigation so browser back/forward scroll restoration is preserved
- Works around documented Next.js App Router behavior where the framework only scrolls the new route segment into view, often resulting in no scroll inside shared layouts (vercel/next.js#64435)

## Type of Change
- [x] Bug fix

## Testing
Tested manually — recommend smoke testing listing → detail and detail → listing on blog, integrations, and models, plus browser back/forward

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)