### PR TITLE
fix(helm): allow host[:port][/path] form in global.imageRegistry schema

### DIFF
--- a/helm/sim/values.schema.json
+++ b/helm/sim/values.schema.json
@@ -8,8 +8,7 @@
       "properties": {
         "imageRegistry": {
           "type": "string",
-          "format": "hostname",
-          "description": "Global Docker image registry"
+          "description": "Global Docker image registry (host[:port][/path]). Supports plain hosts (registry.example.com), host:port (registry.example.com:5000), and host+path forms used by Artifactory virtual repos, Harbor projects, GCR (gcr.io/project-id), and ECR-with-namespace."
         },
         "useRegistryForAllImages": {
           "type": "boolean",


### PR DESCRIPTION
## Summary
- Drop \`format: hostname\` from \`global.imageRegistry\` in \`helm/sim/values.schema.json\` — JSON Schema's hostname format (RFC 1123) forbids \`/\`, which rejected the host+path form used by Artifactory virtual repos, Harbor projects, GCR (\`gcr.io/project-id\`), and ECR-with-namespace.
- The chart's image helper (\`_helpers.tpl\`) already renders \`{registry}/{repository}:{tag}\` and supports the host+path form — only the schema was blocking it.
- Matches the bitnami common-chart convention: validate \`imageRegistry\` as a plain string, defer to Docker for the actual reference parse.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)