### PR TITLE
fix(table): typewriter flash, Run-row completed-skip, dispatch-scope running count

### DIFF
--- a/apps/sim/app/api/table/[tableId]/dispatches/route.ts
+++ b/apps/sim/app/api/table/[tableId]/dispatches/route.ts
@@ -5,7 +5,7 @@ import { parseRequest } from '@/lib/api/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { countRunningCells, listActiveDispatches } from '@/lib/table/dispatcher'
+import { countActiveRunCells, listActiveDispatches } from '@/lib/table/dispatcher'
 import { accessError, checkAccess } from '@/app/api/table/utils'
 
 const logger = createLogger('TableDispatchesAPI')
@@ -37,10 +37,8 @@ export const GET = withRouteHandler(async (request: NextRequest, { params }: Rou
     const result = await checkAccess(tableId, authResult.userId, 'read')
     if (!result.ok) return accessError(result, requestId, tableId)
 
-    const [rows, running] = await Promise.all([
-      listActiveDispatches(tableId),
-      countRunningCells(tableId),
-    ])
+    const rows = await listActiveDispatches(tableId)
+    const running = await countActiveRunCells(tableId, rows)
     const dispatches: ActiveDispatch[] = rows.map((r) => ({
       id: r.id,
       status: r.status as 'pending' | 'dispatching',

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
@@ -303,25 +303,28 @@ const TYPEWRITER_MS_PER_CHAR = 15
  */
 function useTypewriter(text: string | null): string | null {
   const [revealed, setRevealed] = useState<string | null>(text)
-  const isFirstRunRef = useRef(true)
   const prevTextRef = useRef<string | null>(text)
+  const mountedRef = useRef(false)
+  const animateRef = useRef(false)
+
+  // Reset synchronously during render when `text` changes (not on first mount)
+  // so no frame ever shows the full new value before the animation begins —
+  // an effect-based reset lands one frame late and flashes the whole text.
+  if (prevTextRef.current !== text) {
+    prevTextRef.current = text
+    const animate = mountedRef.current && text !== null && text.length > 0
+    animateRef.current = animate
+    setRevealed(animate ? '' : text)
+  }
 
   useEffect(() => {
-    if (isFirstRunRef.current) {
-      isFirstRunRef.current = false
-      prevTextRef.current = text
-      setRevealed(text)
-      return
-    }
-    if (prevTextRef.current === text) return
-    prevTextRef.current = text
+    mountedRef.current = true
+  }, [])
 
-    if (text === null || text.length === 0) {
-      setRevealed(text)
-      return
-    }
-
-    const full = text
+  useEffect(() => {
+    if (!animateRef.current) return
+    animateRef.current = false
+    const full = text as string
     const start = performance.now()
     let raf = 0
     const tick = (now: number) => {
@@ -329,7 +332,6 @@ function useTypewriter(text: string | null): string | null {
       setRevealed(full.slice(0, chars))
       if (chars < full.length) raf = requestAnimationFrame(tick)
     }
-    setRevealed('')
     raf = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(raf)
   }, [text])

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/hooks/use-table-event-stream.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/hooks/use-table-event-stream.ts
@@ -73,11 +73,11 @@ export function useTableEventStream({
     let lastEventId = loadPointer(tableId)
     let reconnectAttempt = 0
 
-    const updateRunStateCounters = (
-      rowId: string,
-      wasInFlight: boolean,
-      isInFlight: boolean
-    ): void => {
+    // Keeps the per-row gutter (`runningByRowId`) live between dispatch events.
+    // `runningCellCount` (the "X running" badge) is NOT touched here — it's the
+    // server's dispatch-scope count, seeded optimistically on click and
+    // re-synced by `applyDispatch` on every window, so live matches reload.
+    const updateRunningByRow = (rowId: string, wasInFlight: boolean, isInFlight: boolean): void => {
       if (wasInFlight === isInFlight) return
       const delta = isInFlight ? 1 : -1
       queryClient.setQueryData<TableRunState>(tableKeys.activeDispatches(tableId), (prev) => {
@@ -87,11 +87,7 @@ export function useTableEventStream({
         const nextByRow = { ...prev.runningByRowId }
         if (nextForRow === 0) delete nextByRow[rowId]
         else nextByRow[rowId] = nextForRow
-        return {
-          ...prev,
-          runningCellCount: Math.max(0, prev.runningCellCount + delta),
-          runningByRowId: nextByRow,
-        }
+        return { ...prev, runningByRowId: nextByRow }
       })
     }
 
@@ -145,11 +141,7 @@ export function useTableEventStream({
           queryKey: tableKeys.activeDispatches(tableId),
         })
       } else {
-        updateRunStateCounters(
-          rowId,
-          wasInFlight,
-          isExecInFlight({ status } as RowExecutionMetadata)
-        )
+        updateRunningByRow(rowId, wasInFlight, isExecInFlight({ status } as RowExecutionMetadata))
       }
     }
 
@@ -195,6 +187,11 @@ export function useTableEventStream({
         merged[idx] = next
         return { ...base, dispatches: merged }
       })
+      // The dispatcher emits this once per window (after the window's cells
+      // finish + the cursor advances) and on completion. Re-sync the
+      // dispatch-scope `runningCellCount` from the server so the badge steps
+      // down per window and matches a reload exactly.
+      void queryClient.invalidateQueries({ queryKey: tableKeys.activeDispatches(tableId) })
     }
 
     const handlePrune = (payload: PrunedEvent): void => {

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -234,17 +234,40 @@ function countNewlyInFlight(before: RowExecutions, after: RowExecutions): number
   return n
 }
 
-/** Add optimistically-stamped cells to the run-state counter so the "X running"
- *  badge + per-row gutter Stop reflect them instantly (the optimistic stamp
- *  eats the dispatcher's `pending` SSE, so `applyCell` never bumps the count).
- *  Returns the prior snapshot for rollback, or `null` when nothing was bumped. */
+/** First-page `totalCount` from the rows infinite-query cache (or `null` when
+ *  rows haven't loaded yet). Lets a Run-all estimate the full-table cell count
+ *  even though only a page of rows is in memory. */
+function readTotalRowCount(
+  queryClient: ReturnType<typeof useQueryClient>,
+  tableId: string
+): number | null {
+  const entries = queryClient.getQueriesData<InfiniteData<TableRowsResponse, number>>({
+    queryKey: tableKeys.rowsRoot(tableId),
+    exact: false,
+  })
+  for (const [, data] of entries) {
+    const tc = data?.pages?.[0]?.totalCount
+    if (typeof tc === 'number') return tc
+  }
+  return null
+}
+
+/** Optimistically reflect a run on the "X running" badge + per-row gutter Stop
+ *  instantly (the optimistic stamp eats the dispatcher's `pending` SSE, so
+ *  `applyCell` never bumps the count, and the server's dispatch-scope count
+ *  isn't live until the first window). `stampedByRow` drives the per-row gutter
+ *  (loaded rows only); `cellCountDelta` is the badge delta — pass the full run
+ *  scope (rows × groups) for Run-all so it matches the server, or omit to use
+ *  the stamped total. Returns the prior snapshot for rollback. */
 function bumpRunState(
   queryClient: ReturnType<typeof useQueryClient>,
   tableId: string,
-  stampedByRow: Record<string, number>
+  stampedByRow: Record<string, number>,
+  cellCountDelta?: number
 ): { snapshot: TableRunState | undefined } | null {
-  const total = Object.values(stampedByRow).reduce((s, n) => s + n, 0)
-  if (total === 0) return null
+  const stampedTotal = Object.values(stampedByRow).reduce((s, n) => s + n, 0)
+  const countDelta = cellCountDelta ?? stampedTotal
+  if (countDelta === 0 && stampedTotal === 0) return null
   const snapshot = queryClient.getQueryData<TableRunState>(tableKeys.activeDispatches(tableId))
   queryClient.setQueryData<TableRunState>(tableKeys.activeDispatches(tableId), (prev) => {
     const base = prev ?? { dispatches: [], runningCellCount: 0, runningByRowId: {} }
@@ -254,7 +277,7 @@ function bumpRunState(
     }
     return {
       ...base,
-      runningCellCount: base.runningCellCount + total,
+      runningCellCount: base.runningCellCount + countDelta,
       runningByRowId: nextByRow,
     }
   })
@@ -1439,7 +1462,14 @@ export function useRunColumn({ workspaceId, tableId }: RowMutationContext) {
         return { ...r, data: nextData, executions: next }
       })
 
-      const bumped = bumpRunState(queryClient, tableId, stampedByRow)
+      // Badge counts the whole run scope (rows × groups), matching the server's
+      // dispatch-scope count — not just the loaded rows we could stamp. For
+      // Run-all that's the table's totalCount; for a scoped run, the rowIds.
+      const scopeRowCount = targetRowIds
+        ? targetRowIds.size
+        : (readTotalRowCount(queryClient, tableId) ?? Object.keys(stampedByRow).length)
+      const cellCountDelta = scopeRowCount * targetGroupIds.size
+      const bumped = bumpRunState(queryClient, tableId, stampedByRow, cellCountDelta)
       return { snapshots, runStateSnapshot: bumped?.snapshot, didBumpRunState: bumped !== null }
     },
     onError: (_err, _variables, context) => {

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -73,7 +73,6 @@ import type {
 } from '@/lib/table'
 import {
   areGroupDepsSatisfied,
-  areOutputsFilled,
   isExecInFlight,
   optimisticallyScheduleNewlyEligibleGroups,
 } from '@/lib/table/deps'
@@ -1418,12 +1417,10 @@ export function useRunColumn({ workspaceId, tableId }: RowMutationContext) {
           // dispatcher regardless of mode. Stamping pending here would leave
           // the cell flashing Queued indefinitely (no SSE event will arrive).
           if (group && !areGroupDepsSatisfied(group, r)) continue
-          // Mirror server eligibility for `mode: 'incomplete'`: skip cells whose
-          // outputs are filled, regardless of exec status. A cancelled/error
-          // cell with a leftover value from a prior run was rendering as filled
-          // but flipping to "queued" optimistically here even though the server
-          // would skip it.
-          if (runMode === 'incomplete' && group && areOutputsFilled(group, r)) continue
+          // Mirror server eligibility for manual `mode: 'incomplete'`: a
+          // `completed` group is done (even with a blank output) — only "Run
+          // all" re-runs it. error/cancelled/never-run cells still re-run.
+          if (runMode === 'incomplete' && exec?.status === 'completed') continue
           next[groupId] = buildPendingExec(exec)
           // Mirror the server-side bulk clear: wipe output values so the cell
           // doesn't render the stale completed value behind a pending badge.

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -234,22 +234,16 @@ function countNewlyInFlight(before: RowExecutions, after: RowExecutions): number
   return n
 }
 
-/** First-page `totalCount` from the rows infinite-query cache (or `null` when
- *  rows haven't loaded yet). Lets a Run-all estimate the full-table cell count
- *  even though only a page of rows is in memory. */
-function readTotalRowCount(
+/** The table's maintained, unfiltered `rowCount` from the detail cache (or
+ *  `null` when the detail hasn't loaded). This is the right scope for a Run-all
+ *  estimate: the dispatcher runs every row regardless of the active view
+ *  filter, whereas the rows query's `totalCount` is filter-scoped. */
+function readTableRowCount(
   queryClient: ReturnType<typeof useQueryClient>,
   tableId: string
 ): number | null {
-  const entries = queryClient.getQueriesData<InfiniteData<TableRowsResponse, number>>({
-    queryKey: tableKeys.rowsRoot(tableId),
-    exact: false,
-  })
-  for (const [, data] of entries) {
-    const tc = data?.pages?.[0]?.totalCount
-    if (typeof tc === 'number') return tc
-  }
-  return null
+  const def = queryClient.getQueryData<TableDefinition>(tableKeys.detail(tableId))
+  return typeof def?.rowCount === 'number' ? def.rowCount : null
 }
 
 /** Optimistically reflect a run on the "X running" badge + per-row gutter Stop
@@ -1467,7 +1461,7 @@ export function useRunColumn({ workspaceId, tableId }: RowMutationContext) {
       // Run-all that's the table's totalCount; for a scoped run, the rowIds.
       const scopeRowCount = targetRowIds
         ? targetRowIds.size
-        : (readTotalRowCount(queryClient, tableId) ?? Object.keys(stampedByRow).length)
+        : (readTableRowCount(queryClient, tableId) ?? Object.keys(stampedByRow).length)
       const cellCountDelta = scopeRowCount * targetGroupIds.size
       const bumped = bumpRunState(queryClient, tableId, stampedByRow, cellCountDelta)
       return { snapshots, runStateSnapshot: bumped?.snapshot, didBumpRunState: bumped !== null }

--- a/apps/sim/lib/table/dispatcher.ts
+++ b/apps/sim/lib/table/dispatcher.ts
@@ -208,13 +208,11 @@ export async function countActiveRunCells(
   dispatches?: DispatchRow[]
 ): Promise<{ total: number; byRowId: Record<string, number> }> {
   const active = dispatches ?? (await listActiveDispatches(tableId))
-  const sidecar = await countRunningCells(tableId)
-  if (active.length === 0) return sidecar
+  if (active.length === 0) return countRunningCells(tableId)
 
-  let total = 0
-  for (const d of active) {
+  const countRowsAhead = async (d: DispatchRow): Promise<number> => {
     const groupCount = d.scope.groupIds.length
-    if (groupCount === 0) continue
+    if (groupCount === 0) return 0
     const filters = [eq(userTableRows.tableId, tableId), gt(userTableRows.position, d.cursor)]
     if (d.scope.rowIds && d.scope.rowIds.length > 0) {
       filters.push(inArray(userTableRows.id, d.scope.rowIds))
@@ -223,8 +221,15 @@ export async function countActiveRunCells(
       .select({ rowsAhead: sql<number>`count(*)::int` })
       .from(userTableRows)
       .where(and(...filters))
-    total += (row?.rowsAhead ?? 0) * groupCount
+    return (row?.rowsAhead ?? 0) * groupCount
   }
+
+  // One round-trip per dispatch + the sidecar count, all in parallel.
+  const [sidecar, perDispatch] = await Promise.all([
+    countRunningCells(tableId),
+    Promise.all(active.map(countRowsAhead)),
+  ])
+  const total = perDispatch.reduce((sum, n) => sum + n, 0)
   return { total, byRowId: sidecar.byRowId }
 }
 

--- a/apps/sim/lib/table/dispatcher.ts
+++ b/apps/sim/lib/table/dispatcher.ts
@@ -195,6 +195,39 @@ export async function countRunningCells(
   return { total, byRowId }
 }
 
+/** Authoritative "cells queued or running" count for the table, derived from
+ *  active dispatches so it survives reload and matches the live count. For each
+ *  active dispatch every row in scope ahead of the cursor still has to run each
+ *  targeted group, so remaining work = (rows ahead of cursor) × |groupIds|.
+ *  Exact for Run-all; an upper bound for incomplete/new (rows the eligibility
+ *  filter later skips are still counted). Falls back to the sidecar in-flight
+ *  count when no dispatch is active (orphan stragglers). `byRowId` stays
+ *  sidecar-based — the client overlay renders queued rows ahead of the cursor. */
+export async function countActiveRunCells(
+  tableId: string,
+  dispatches?: DispatchRow[]
+): Promise<{ total: number; byRowId: Record<string, number> }> {
+  const active = dispatches ?? (await listActiveDispatches(tableId))
+  const sidecar = await countRunningCells(tableId)
+  if (active.length === 0) return sidecar
+
+  let total = 0
+  for (const d of active) {
+    const groupCount = d.scope.groupIds.length
+    if (groupCount === 0) continue
+    const filters = [eq(userTableRows.tableId, tableId), gt(userTableRows.position, d.cursor)]
+    if (d.scope.rowIds && d.scope.rowIds.length > 0) {
+      filters.push(inArray(userTableRows.id, d.scope.rowIds))
+    }
+    const [row] = await db
+      .select({ rowsAhead: sql<number>`count(*)::int` })
+      .from(userTableRows)
+      .where(and(...filters))
+    total += (row?.rowsAhead ?? 0) * groupCount
+  }
+  return { total, byRowId: sidecar.byRowId }
+}
+
 export async function listActiveDispatches(tableId: string): Promise<DispatchRow[]> {
   const rows = await db
     .select()

--- a/apps/sim/lib/table/dispatcher.ts
+++ b/apps/sim/lib/table/dispatcher.ts
@@ -65,67 +65,69 @@ export async function bulkClearWorkflowGroupCells(input: {
   // Pre-existing outputs on any other row must not be wiped by an auto-fire.
   if (mode === 'new') return
 
-  const outputCols = Array.from(new Set(groups.flatMap((g) => g.outputs.map((o) => o.columnName))))
   const groupIds = groups.map((g) => g.id)
+  const rowScope = rowIds && rowIds.length > 0 ? rowIds : null
 
-  // Step 1: clear the targeted output columns from `data` on every row in
-  // scope. Identical chain to the previous JSONB-only path.
-  let dataExpr: SQL = sql`coalesce(${userTableRows.data}, '{}'::jsonb)`
-  for (const col of outputCols) dataExpr = sql`(${dataExpr}) - ${col}::text`
-
-  const filters: SQL[] = [eq(userTableRows.tableId, tableId)]
-  if (rowIds && rowIds.length > 0) {
-    filters.push(inArray(userTableRows.id, rowIds))
-  }
-  if (mode === 'incomplete') {
-    // Skip rows where all output columns across all targeted groups already
-    // have a non-empty value — those are "completed-and-filled" and the
-    // eligibility predicate would skip them anyway.
-    const filledChecks = outputCols.map(
-      (col) => sql`coalesce(${userTableRows.data} ->> ${col}, '') != ''`
+  if (mode === 'all') {
+    // Run-all re-runs every targeted group: wipe all their output columns +
+    // executions for the rows in scope. (Prior in-flight runs were already
+    // cancelled by the caller.)
+    const outputCols = Array.from(
+      new Set(groups.flatMap((g) => g.outputs.map((o) => o.columnName)))
     )
-    const allFilled = filledChecks.reduce((acc, expr) => sql`${acc} AND ${expr}`)
-    filters.push(sql`NOT (${allFilled})`)
-    // Also skip rows where ANY targeted group has an in-flight exec — those
-    // belong to another dispatch and clobbering them would race. Encoded as
-    // a NOT EXISTS subquery against the sidecar's `(table_id, status)`
-    // partial index.
-    filters.push(
-      sql`NOT EXISTS (
+    let dataExpr: SQL = sql`coalesce(${userTableRows.data}, '{}'::jsonb)`
+    for (const col of outputCols) dataExpr = sql`(${dataExpr}) - ${col}::text`
+    const filters: SQL[] = [eq(userTableRows.tableId, tableId)]
+    if (rowScope) filters.push(inArray(userTableRows.id, rowScope))
+
+    await db.transaction(async (trx) => {
+      await trx
+        .update(userTableRows)
+        .set({ data: dataExpr, updatedAt: new Date() })
+        .where(and(...filters))
+      const execFilters: SQL[] = [
+        eq(tableRowExecutions.tableId, tableId),
+        inArray(tableRowExecutions.groupId, groupIds),
+      ]
+      if (rowScope) execFilters.push(inArray(tableRowExecutions.rowId, rowScope))
+      await trx.delete(tableRowExecutions).where(and(...execFilters))
+    })
+    return
+  }
+
+  // `incomplete`: clear per-group, not per-row. Only groups that are
+  // re-runnable (`error` / `cancelled`) get their output columns + exec wiped;
+  // `completed` and in-flight groups are left fully intact. A row-level "all
+  // filled" check would otherwise wipe a completed group's data + exec just
+  // because a *sibling* group on the same row is incomplete, re-running the
+  // completed one. (`never-run` groups have no exec/output to clear — the
+  // dispatcher runs them via eligibility.)
+  await db.transaction(async (trx) => {
+    for (const group of groups) {
+      const reRunnable = sql`EXISTS (
         SELECT 1 FROM ${tableRowExecutions} re
         WHERE re.row_id = ${userTableRows.id}
-          AND re.group_id = ANY(ARRAY[${sql.join(
-            groupIds.map((gid) => sql`${gid}`),
-            sql`, `
-          )}]::text[])
-          AND re.status IN ('queued', 'running', 'pending')
+          AND re.group_id = ${group.id}
+          AND re.status IN ('error', 'cancelled')
       )`
-    )
-  }
+      const filters: SQL[] = [eq(userTableRows.tableId, tableId), reRunnable]
+      if (rowScope) filters.push(inArray(userTableRows.id, rowScope))
 
-  await db.transaction(async (trx) => {
-    await trx
-      .update(userTableRows)
-      .set({ data: dataExpr, updatedAt: new Date() })
-      .where(and(...filters))
+      let dataExpr: SQL = sql`coalesce(${userTableRows.data}, '{}'::jsonb)`
+      for (const out of group.outputs) dataExpr = sql`(${dataExpr}) - ${out.columnName}::text`
+      await trx
+        .update(userTableRows)
+        .set({ data: dataExpr, updatedAt: new Date() })
+        .where(and(...filters))
 
-    // Step 2: delete the targeted groups' executions for the rows in scope.
-    // Reuse the same row-scope filter via a subquery.
-    const execFilters: SQL[] = [
-      eq(tableRowExecutions.tableId, tableId),
-      inArray(tableRowExecutions.groupId, groupIds),
-    ]
-    if (rowIds && rowIds.length > 0) {
-      execFilters.push(inArray(tableRowExecutions.rowId, rowIds))
+      const execFilters: SQL[] = [
+        eq(tableRowExecutions.tableId, tableId),
+        eq(tableRowExecutions.groupId, group.id),
+        sql`${tableRowExecutions.status} IN ('error', 'cancelled')`,
+      ]
+      if (rowScope) execFilters.push(inArray(tableRowExecutions.rowId, rowScope))
+      await trx.delete(tableRowExecutions).where(and(...execFilters))
     }
-    if (mode === 'incomplete') {
-      // For `incomplete`, only delete entries that aren't already in-flight
-      // — terminal states (completed/error/cancelled) get wiped so the
-      // dispatcher re-enqueues; in-flight entries stay so we don't race
-      // with their worker.
-      execFilters.push(sql`${tableRowExecutions.status} NOT IN ('queued', 'running', 'pending')`)
-    }
-    await trx.delete(tableRowExecutions).where(and(...execFilters))
   })
 }
 

--- a/apps/sim/lib/table/workflow-columns.ts
+++ b/apps/sim/lib/table/workflow-columns.ts
@@ -93,7 +93,14 @@ export function classifyEligibility(
   if (!isManualRun && completedAndFilled) return 'completed-on-auto'
   if (!isManualRun && status === 'error') return 'error-on-auto'
   if (!isManualRun && status === 'cancelled') return 'cancelled-on-auto'
-  if (mode === 'incomplete' && completedAndFilled) return 'completed-on-incomplete'
+  // Manual incomplete-mode runs (Run row / Run incomplete) treat a `completed`
+  // group as done even if an output is blank — only "Run all" re-runs it. The
+  // auto cascade still re-fills blank outputs (completedAndFilled).
+  if (mode === 'incomplete') {
+    if (isManualRun ? status === 'completed' : completedAndFilled) {
+      return 'completed-on-incomplete'
+    }
+  }
 
   if (isManualRun && group.autoRun === false) return 'manual-bypass'
   return areGroupDepsSatisfied(group, row) ? 'eligible' : 'deps-unmet'


### PR DESCRIPTION
Three table run-execution fixes (was split across #4685 + #4687, now combined).

## 1. Typewriter flash
A cell going Running → value flashed the **full** text for one frame, then restarted the type-out animation. The reset to empty happened in a `useEffect` (one frame late) while the render fell back to `revealed ?? kind.text`. Now the reset runs **synchronously during render** (the "adjust state when a prop changes" pattern), so the full-text frame never paints; animation still fires only on post-mount changes (SSE completions), not on first mount/scroll-in. Verified live via DOM instrumentation: 40 animations, 0 flashes (was 77/100).

## 2. Run-row re-running a completed workflow
On a row with one `completed` group and one `cancelled` group, "Run row" re-ran the completed one. Two causes, both fixed:
- `bulkClearWorkflowGroupCells` (incomplete mode) was **row-level** — it wiped *every* targeted group's data + exec on any row that wasn't fully filled, so a completed group got wiped because a sibling group on the row was incomplete. Now **per-group**: only `error`/`cancelled` groups are cleared; `completed` and in-flight groups are left intact.
- `classifyEligibility` now skips `completed` groups for manual `incomplete` runs (only "Run all" re-runs completed). Client optimistic stamp mirrors it.

## 3. "X running" count from dispatch scope (reload matches live)
The badge read the sidecar in-flight count, but the dispatcher only stamps a ~20-cell window at a time — so a 1000-row Run-all showed ~1000 live but ~20 on reload. Now derived from the active dispatches: `rows in scope ahead of cursor × |groupIds|` (persisted `scope` + `cursor`, so reload computes the same number). Exact for Run-all; an upper bound for incomplete/new (counts cells the eligibility filter later skips). `applyDispatch` re-syncs the badge per window; `applyCell` keeps `runningByRowId` live for the gutter; the optimistic on-click seed uses `totalCount × groups`.

## Type of Change
- [x] Bug fix

## Testing
tsc clean; vitest (lib/table + hooks/queries, 202 passing); lint clean. Typewriter verified live in-browser (0 flashes). Counter verified consistent live↔reload on a large Run-all.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)