### PR TITLE
fix(mcp): probe-based OAuth detection in test-connection

### DIFF
--- a/apps/sim/app/api/mcp/servers/test-connection/route.ts
+++ b/apps/sim/app/api/mcp/servers/test-connection/route.ts
@@ -14,7 +14,7 @@ import {
 import { getParsedBody, withMcpAuth } from '@/lib/mcp/middleware'
 import { detectMcpAuthType } from '@/lib/mcp/oauth'
 import { resolveMcpConfigEnvVars } from '@/lib/mcp/resolve-config'
-import type { McpTransport } from '@/lib/mcp/types'
+import type { McpAuthType, McpTransport } from '@/lib/mcp/types'
 import { createMcpErrorResponse, createMcpSuccessResponse } from '@/lib/mcp/utils'
 
 const logger = createLogger('McpServerTestAPI')
@@ -33,7 +33,7 @@ interface TestConnectionResult {
   success: boolean
   error?: string
   authRequired?: boolean
-  authType?: 'none' | 'headers' | 'oauth'
+  authType?: McpAuthType
   serverInfo?: {
     name: string
     version: string
@@ -168,13 +168,15 @@ export const POST = withRouteHandler(
       const result: TestConnectionResult = { success: false }
 
       // Skip unauth connect when the server returns an RFC 9728 OAuth challenge.
-      const detectedAuthType = await detectMcpAuthType(testConfig.url)
-      if (detectedAuthType === 'oauth') {
-        result.authRequired = true
-        result.authType = 'oauth'
-        return createMcpSuccessResponse(result, 200)
+      if (testConfig.url) {
+        const detectedAuthType = await detectMcpAuthType(testConfig.url)
+        if (detectedAuthType === 'oauth') {
+          result.authRequired = true
+          result.authType = 'oauth'
+          return createMcpSuccessResponse(result, 200)
+        }
+        result.authType = detectedAuthType
       }
-      result.authType = detectedAuthType
 
       let client: McpClient | null = null
 

--- a/apps/sim/app/api/mcp/servers/test-connection/route.ts
+++ b/apps/sim/app/api/mcp/servers/test-connection/route.ts
@@ -12,6 +12,7 @@ import {
   validateMcpServerSsrf,
 } from '@/lib/mcp/domain-check'
 import { getParsedBody, withMcpAuth } from '@/lib/mcp/middleware'
+import { detectMcpAuthType } from '@/lib/mcp/oauth'
 import { resolveMcpConfigEnvVars } from '@/lib/mcp/resolve-config'
 import type { McpTransport } from '@/lib/mcp/types'
 import { createMcpErrorResponse, createMcpSuccessResponse } from '@/lib/mcp/utils'
@@ -31,6 +32,8 @@ function isUrlBasedTransport(transport: McpTransport): boolean {
 interface TestConnectionResult {
   success: boolean
   error?: string
+  authRequired?: boolean
+  authType?: 'none' | 'headers' | 'oauth'
   serverInfo?: {
     name: string
     version: string
@@ -163,6 +166,16 @@ export const POST = withRouteHandler(
       }
 
       const result: TestConnectionResult = { success: false }
+
+      // Skip unauth connect when the server returns an RFC 9728 OAuth challenge.
+      const detectedAuthType = await detectMcpAuthType(testConfig.url)
+      if (detectedAuthType === 'oauth') {
+        result.authRequired = true
+        result.authType = 'oauth'
+        return createMcpSuccessResponse(result, 200)
+      }
+      result.authType = detectedAuthType
+
       let client: McpClient | null = null
 
       try {

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
@@ -17,7 +17,7 @@ import {
   Textarea,
 } from '@/components/emcn'
 import { cn } from '@/lib/core/utils/cn'
-import type { McpTransport } from '@/lib/mcp/types'
+import type { McpAuthType, McpTransport } from '@/lib/mcp/types'
 import {
   checkEnvVarTrigger,
   EnvVarDropdown,
@@ -52,7 +52,7 @@ export interface McpServerFormConfig {
   timeout: number
   oauthClientId?: string
   oauthClientSecret?: string
-  authType?: 'none' | 'headers' | 'oauth'
+  authType?: McpAuthType
 }
 
 export interface McpServerFormModalProps {

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
@@ -52,6 +52,7 @@ export interface McpServerFormConfig {
   timeout: number
   oauthClientId?: string
   oauthClientSecret?: string
+  authType?: 'none' | 'headers' | 'oauth'
 }
 
 export interface McpServerFormModalProps {
@@ -109,11 +110,12 @@ interface EnvVarDropdownConfig {
 }
 
 function getTestButtonLabel(
-  testResult: { success: boolean; error?: string } | null,
+  testResult: { success: boolean; error?: string; authRequired?: boolean } | null,
   isTestingConnection: boolean
 ): string {
   if (isTestingConnection) return 'Testing...'
   if (testResult?.success) return 'Connection success'
+  if (testResult?.authRequired) return 'Requires OAuth'
   if (testResult && !testResult.success) return 'No connection: retry'
   return 'Test Connection'
 }
@@ -517,19 +519,11 @@ export function McpServerFormModal({
         workspaceId,
       })
 
-      if (!connectionResult.success) {
-        const errorText = (connectionResult.error || '').toLowerCase()
-        const looksLikeAuthRequired =
-          /\b401\b/.test(errorText) ||
-          errorText.includes('unauthorized') ||
-          errorText.includes('oauth') ||
-          errorText.includes('authentication')
-        if (!looksLikeAuthRequired) {
-          setSubmitError(
-            connectionResult.error || 'Connection test failed. Please check the URL and try again.'
-          )
-          return
-        }
+      if (!connectionResult.success && !connectionResult.authRequired) {
+        setSubmitError(
+          connectionResult.error || 'Connection test failed. Please check the URL and try again.'
+        )
+        return
       }
 
       await onSubmit({
@@ -538,6 +532,7 @@ export function McpServerFormModal({
         url: formData.url!,
         headers,
         timeout: formData.timeout || 30000,
+        authType: connectionResult.authType,
         oauthClientId:
           mode === 'edit'
             ? oauthClientIdChanged
@@ -587,7 +582,7 @@ export function McpServerFormModal({
         workspaceId,
       })
 
-      if (!connectionResult.success) {
+      if (!connectionResult.success && !connectionResult.authRequired) {
         setSubmitError(
           connectionResult.error || 'Connection test failed. Please check the URL and try again.'
         )
@@ -600,6 +595,7 @@ export function McpServerFormModal({
         url: config.url,
         headers: config.headers,
         timeout: 30000,
+        authType: connectionResult.authType,
       })
 
       onOpenChange(false)

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -54,6 +54,7 @@ export interface McpServerInput {
   enabled: boolean
   oauthClientId?: string
   oauthClientSecret?: string
+  authType?: 'none' | 'headers' | 'oauth'
 }
 
 async function fetchMcpServers(workspaceId: string, signal?: AbortSignal): Promise<McpServer[]> {

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -22,7 +22,13 @@ import {
 } from '@/lib/api/contracts/mcp'
 import { isLoopbackHostname } from '@/lib/core/utils/urls'
 import { sanitizeForHttp, sanitizeHeaders } from '@/lib/mcp/shared'
-import type { McpServerStatusConfig, McpTool, McpTransport, StoredMcpTool } from '@/lib/mcp/types'
+import type {
+  McpAuthType,
+  McpServerStatusConfig,
+  McpTool,
+  McpTransport,
+  StoredMcpTool,
+} from '@/lib/mcp/types'
 import { workflowMcpServerKeys } from '@/hooks/queries/workflow-mcp-servers'
 
 const logger = createLogger('McpQueries')
@@ -54,7 +60,7 @@ export interface McpServerInput {
   enabled: boolean
   oauthClientId?: string
   oauthClientSecret?: string
-  authType?: 'none' | 'headers' | 'oauth'
+  authType?: McpAuthType
 }
 
 async function fetchMcpServers(workspaceId: string, signal?: AbortSignal): Promise<McpServer[]> {

--- a/apps/sim/lib/api/contracts/mcp.ts
+++ b/apps/sim/lib/api/contracts/mcp.ts
@@ -252,6 +252,8 @@ export const mcpServerTestResultSchema = z.object({
   success: z.boolean(),
   message: z.string().optional(),
   error: z.string().optional(),
+  authRequired: z.boolean().optional(),
+  authType: mcpAuthTypeSchema.optional(),
   serverInfo: z
     .object({
       name: z.string(),


### PR DESCRIPTION
## Summary
- `test-connection` runs `detectMcpAuthType` first; on 401 + `resource_metadata` (RFC 9728) it returns `{ success: false, authRequired: true, authType: 'oauth' }` via the typed contract
- Both modal submit paths (regular form + Edit JSON) consume the structured `authRequired` flag — removes the prior regex heuristic on error message strings
- `authType` is threaded from `test-connection` through to the create call so `performCreateMcpServer` skips its own probe (one probe per add instead of two)
- Unblocks spec-compliant OAuth MCP servers like Semrush, Linear, Notion, Atlassian, Asana via the "Edit JSON" path

## Type of Change
- [x] Bug fix

## Testing
Tested manually against `https://mcp.semrush.com/v1/mcp` end-to-end:
- Add via Edit JSON → probe detects OAuth → modal proceeds → OAuth popup opens → consent → tokens stored
- Add via regular form → same flow
- Non-OAuth servers (Exa, Firecrawl) still surface the original error on real failures, no silent suppression

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)