### PR TITLE
fix(sidebar): pass showDelete to hide delete menu for non-admin members

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -612,7 +612,8 @@ export function FolderItem({
           !userPermissions.canEdit || isDuplicatingSelection || !hasExportableContent
         }
         disableExport={!userPermissions.canEdit || isExporting || !hasExportableContent}
-        disableDelete={!userPermissions.canEdit || effectiveLocked || !canDeleteSelection}
+        showDelete={userPermissions.canAdmin}
+        disableDelete={effectiveLocked || !canDeleteSelection}
         onToggleLock={handleToggleLock}
         showLock={!isMixedSelection && selectedFolders.size <= 1}
         disableLock={!userPermissions.canAdmin || inheritedFolderLocked}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -524,7 +524,8 @@ export function WorkflowItem({
         disableDuplicate={!userPermissions.canEdit || isDuplicatingSelection}
         disableExport={!userPermissions.canEdit}
         disableColorChange={!userPermissions.canEdit || effectiveLocked}
-        disableDelete={!userPermissions.canEdit || !canDeleteSelection || effectiveLocked}
+        showDelete={userPermissions.canAdmin}
+        disableDelete={!canDeleteSelection || effectiveLocked}
         onToggleLock={handleToggleLock}
         showLock={!isMixedSelection && selectedWorkflows.size <= 1}
         disableLock={!userPermissions.canAdmin || inheritedFolderLocked}


### PR DESCRIPTION
## Summary

Fixes #4695

Write/Read workspace members see the Delete option in the workflow/folder context menu, but the DELETE API enforces `action: 'admin'`, so it always fails with 403. The `ContextMenu` component already has a `showDelete` prop with conditional rendering, but `workflow-item` and `folder-item` never pass it, leaving it at the default `true`.

This PR passes `showDelete={userPermissions.canAdmin}` from both components so non-admin users no longer see the Delete menu. `disableDelete` is simplified to only check `canDeleteSelection` and `effectiveLocked`, since permission gating is now handled by `showDelete`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Testing

- Verified with admin, write, and read permission levels by directly modifying the `permissions` table
  - **Admin**: Delete menu visible, deletion works
  - **Write**: Delete menu hidden
  - **Read**: Delete menu hidden
  - **Admin (last workflow)**: Delete menu visible but disabled

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Existing tests pass locally
- [x] I agree to the terms of the contributor license agreement