### PR TITLE
fix(copilot): default SIM_AGENT_API_URL to www.copilot.sim.ai

### DIFF
--- a/apps/sim/lib/copilot/constants.ts
+++ b/apps/sim/lib/copilot/constants.ts
@@ -1,6 +1,6 @@
 import { env } from '@/lib/core/config/env'
 
-export const SIM_AGENT_API_URL_DEFAULT = 'https://copilot.sim.ai'
+export const SIM_AGENT_API_URL_DEFAULT = 'https://www.copilot.sim.ai'
 export const SIM_AGENT_VERSION = '3.0.0'
 
 /** Resolved copilot backend URL — reads from env with fallback to default. */


### PR DESCRIPTION
## Summary
- Change `SIM_AGENT_API_URL_DEFAULT` from `https://copilot.sim.ai` to `https://www.copilot.sim.ai` to avoid the LB redirect that drops the request path (e.g. `/api/copilot`)
- Resolves the workaround in [#3891](https://github.com/simstudioai/sim/issues/3891) where users had to manually set `SIM_AGENT_API_URL`

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)