### PR TITLE
fix(sub-block): render tooltip field as Info icon in label

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
@@ -7,6 +7,7 @@ import {
   Check,
   Clipboard,
   ExternalLink,
+  Info,
 } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { Button, Input, Label, Tooltip } from '@/components/emcn/components'
@@ -271,6 +272,18 @@ const renderLabel = (
           config.title
         )}
         {required && <span className='ml-0.5'>*</span>}
+        {config.tooltip && (
+          <Tooltip.Root>
+            <Tooltip.Trigger asChild>
+              <span className='inline-flex'>
+                <Info className='size-3 flex-shrink-0 cursor-pointer text-muted-foreground' />
+              </span>
+            </Tooltip.Trigger>
+            <Tooltip.Content side='top'>
+              <p>{config.tooltip}</p>
+            </Tooltip.Content>
+          </Tooltip.Root>
+        )}
         {labelSuffix}
         {config.type === 'code' &&
           config.language === 'json' &&


### PR DESCRIPTION
## Problem

`SubBlockConfig.tooltip` is defined in `blocks/types.ts` but was never rendered in the `renderLabel` function of `sub-block.tsx`. Adding `tooltip: 'some help text'` to any sub-block definition had no visible effect in the UI.

## Solution

Added an `Info` icon from `lucide-react` that appears inline next to the field label (after the required asterisk). Hovering it shows the tooltip text via the existing `Tooltip.Root/Trigger/Content` pattern already used in the same file.

The tooltip renders inside the `<Label>` element, consistent with how the invalid-JSON `AlertTriangle` warning is handled in the same function.

## Testing

1. Add `tooltip: 'some help text'` to any sub-block definition in a block config
2. Open the workflow editor and find that block in the panel
3. An `Info` icon appears next to the field label
4. Hovering it shows the tooltip text

Closes #4071