### PR TITLE
fix(files): RFC 5987 encode Content-Disposition filenames

### DIFF
--- a/apps/sim/app/api/files/export/[id]/route.ts
+++ b/apps/sim/app/api/files/export/[id]/route.ts
@@ -13,6 +13,7 @@ import { USE_BLOB_STORAGE } from '@/lib/uploads/config'
 import { downloadFile } from '@/lib/uploads/core/storage-service'
 import { getFileMetadataById } from '@/lib/uploads/server/metadata'
 import { verifyFileAccess } from '@/app/api/files/authorization'
+import { encodeFilenameForHeader } from '@/app/api/files/utils'
 
 const logger = createLogger('FilesExportAPI')
 
@@ -95,7 +96,7 @@ export const GET = withRouteHandler(
         status: 200,
         headers: {
           'Content-Type': 'text/markdown; charset=utf-8',
-          'Content-Disposition': `attachment; filename="${mdName}"`,
+          'Content-Disposition': `attachment; ${encodeFilenameForHeader(mdName)}`,
           'Content-Length': String(mdBytes.length),
         },
       })
@@ -158,7 +159,7 @@ export const GET = withRouteHandler(
       status: 200,
       headers: {
         'Content-Type': 'application/zip',
-        'Content-Disposition': `attachment; filename="${zipName}"`,
+        'Content-Disposition': `attachment; ${encodeFilenameForHeader(zipName)}`,
         'Content-Length': String(zipBuffer.length),
       },
     })

--- a/apps/sim/app/api/files/utils.ts
+++ b/apps/sim/app/api/files/utils.ts
@@ -191,7 +191,7 @@ function getSecureFileHeaders(filename: string, originalContentType: string) {
   }
 }
 
-function encodeFilenameForHeader(storageKey: string): string {
+export function encodeFilenameForHeader(storageKey: string): string {
   const filename = storageKey.split('/').pop() || storageKey
 
   const hasNonAscii = /[^\x00-\x7F]/.test(filename)

--- a/apps/sim/app/api/v1/admin/folders/[id]/export/route.ts
+++ b/apps/sim/app/api/v1/admin/folders/[id]/export/route.ts
@@ -21,6 +21,7 @@ import { parseRequest } from '@/lib/api/server'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { exportFolderToZip, sanitizePathSegment } from '@/lib/workflows/operations/import-export'
 import { loadWorkflowFromNormalizedTables } from '@/lib/workflows/persistence/utils'
+import { encodeFilenameForHeader } from '@/app/api/files/utils'
 import { withAdminAuthParams } from '@/app/api/v1/admin/middleware'
 import {
   internalErrorResponse,
@@ -242,7 +243,7 @@ export const GET = withRouteHandler(
         status: 200,
         headers: {
           'Content-Type': 'application/zip',
-          'Content-Disposition': `attachment; filename="${filename}"`,
+          'Content-Disposition': `attachment; ${encodeFilenameForHeader(filename)}`,
           'Content-Length': arrayBuffer.byteLength.toString(),
         },
       })

--- a/apps/sim/app/api/v1/admin/workspaces/[id]/export/route.ts
+++ b/apps/sim/app/api/v1/admin/workspaces/[id]/export/route.ts
@@ -21,6 +21,7 @@ import { parseRequest } from '@/lib/api/server'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { exportWorkspaceToZip, sanitizePathSegment } from '@/lib/workflows/operations/import-export'
 import { loadWorkflowFromNormalizedTables } from '@/lib/workflows/persistence/utils'
+import { encodeFilenameForHeader } from '@/app/api/files/utils'
 import { withAdminAuthParams } from '@/app/api/v1/admin/middleware'
 import {
   internalErrorResponse,
@@ -162,7 +163,7 @@ export const GET = withRouteHandler(
         status: 200,
         headers: {
           'Content-Type': 'application/zip',
-          'Content-Disposition': `attachment; filename="${filename}"`,
+          'Content-Disposition': `attachment; ${encodeFilenameForHeader(filename)}`,
           'Content-Length': arrayBuffer.byteLength.toString(),
         },
       })


### PR DESCRIPTION
## Summary
- Downloading files with non-ASCII characters in the name (e.g. em-dash `—`) returned 500 from `/api/files/export/[id]` because the `Content-Disposition` header value isn't valid ISO-8859-1
- Switched broken routes to the existing `encodeFilenameForHeader` helper (RFC 5987 `filename=...; filename*=UTF-8''...`); also fixed admin folder/workspace ZIP exports which used `sanitizePathSegment` (keeps Unicode letters) and had the same latent bug

## Type of Change
- [x] Bug fix

## Testing
Tested manually — reproduced the 500 in prod logs (`Header '17' has invalid value: 'attachment; filename="Linear Pagination Loop — Reference.md"'`), audited every `Content-Disposition` callsite in the app, fixed only the ones whose filename source can contain non-ASCII

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)