### PR TITLE
fix(db): disable statement_timeout for migrations

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -39,4 +39,4 @@ jobs:
         working-directory: ./packages/db
         env:
           DATABASE_URL: ${{ github.ref == 'refs/heads/main' && secrets.DATABASE_URL || github.ref == 'refs/heads/dev' && secrets.DEV_DATABASE_URL || secrets.STAGING_DATABASE_URL }}
-        run: bunx drizzle-kit migrate --config=./drizzle.config.ts
+        run: bun run ./scripts/migrate.ts

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -12,6 +12,7 @@ if (!url) {
 const client = postgres(url, { max: 1, connect_timeout: 10 })
 
 try {
+  await client`SET statement_timeout = 0`
   await migrate(drizzle(client), { migrationsFolder: './migrations' })
   console.log('Migrations applied successfully.')
 } catch (error) {


### PR DESCRIPTION
## Summary
- Set `statement_timeout = 0` before running migrations in `packages/db/scripts/migrate.ts` so long-running DDL isn't killed by the session's statement timeout. Single connection (`max: 1`), so the SET applies to the whole migration run; no infra/ECS changes needed.
- Route the `Database Migrations` CI workflow through the now-guarded `migrate.ts` (`bun run ./scripts/migrate.ts`) instead of calling `drizzle-kit migrate` directly. That path applies migrations to the real dev/staging/prod DBs and previously had no timeout guard. Single source of truth, and it also picks up the richer migration error output.

## Type of Change
- [x] Bug fix

## Testing
Tested manually — lint and API boundary validation pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)