### PR TITLE
fix(oauth): follower last-chance read after poll deadline

### DIFF
--- a/apps/sim/lib/concurrency/__tests__/leader-lock.test.ts
+++ b/apps/sim/lib/concurrency/__tests__/leader-lock.test.ts
@@ -120,10 +120,11 @@ describe('withLeaderLock', () => {
   it('follower does a final read after timeout to catch a just-finished leader', async () => {
     redisConfigMockFns.mockAcquireLock.mockResolvedValueOnce(false)
 
+    // pollInterval=5, maxWait=9 → loop exits after 2 in-loop polls (T+5, T+10);
+    // the third call (polls=3) is the post-deadline last-chance read.
     let polls = 0
     const onFollower = vi.fn(async () => {
       polls += 1
-      // Return null during the poll loop, value on the post-deadline read.
       if (polls <= 2) return null
       return 'late-leader'
     })
@@ -131,12 +132,13 @@ describe('withLeaderLock', () => {
     const result = await withLeaderLock<string>({
       key: 'k',
       pollIntervalMs: 5,
-      maxWaitMs: 12,
+      maxWaitMs: 9,
       onLeader: async () => 'should-not-run',
       onFollower,
     })
 
     expect(result).toBe('late-leader')
+    expect(onFollower).toHaveBeenCalledTimes(3)
   })
 
   it('follower returns null after timeout', async () => {

--- a/apps/sim/lib/concurrency/__tests__/leader-lock.test.ts
+++ b/apps/sim/lib/concurrency/__tests__/leader-lock.test.ts
@@ -117,6 +117,28 @@ describe('withLeaderLock', () => {
     expect(onFollower.mock.calls.length).toBeGreaterThanOrEqual(2)
   })
 
+  it('follower does a final read after timeout to catch a just-finished leader', async () => {
+    redisConfigMockFns.mockAcquireLock.mockResolvedValueOnce(false)
+
+    let polls = 0
+    const onFollower = vi.fn(async () => {
+      polls += 1
+      // Return null during the poll loop, value on the post-deadline read.
+      if (polls <= 2) return null
+      return 'late-leader'
+    })
+
+    const result = await withLeaderLock<string>({
+      key: 'k',
+      pollIntervalMs: 5,
+      maxWaitMs: 12,
+      onLeader: async () => 'should-not-run',
+      onFollower,
+    })
+
+    expect(result).toBe('late-leader')
+  })
+
   it('follower returns null after timeout', async () => {
     redisConfigMockFns.mockAcquireLock.mockResolvedValueOnce(false)
 

--- a/apps/sim/lib/concurrency/leader-lock.ts
+++ b/apps/sim/lib/concurrency/leader-lock.ts
@@ -64,6 +64,10 @@ export async function withLeaderLock<T>(opts: LeaderLockOptions<T>): Promise<T |
     if (value !== null) return value
   }
 
+  // The leader may have persisted between our final poll and now; one last check.
+  const lastChance = await onFollower()
+  if (lastChance !== null) return lastChance
+
   logger.warn('Follower timed out waiting for leader', { key, maxWaitMs })
   return null
 }


### PR DESCRIPTION
## Summary
- Addresses the cursor-bot follow-up on #4706: when a coalesced refresh leader takes longer than the follower's 3s poll window, the follower returned null even if the leader persisted moments later. Adds a single last-chance DB read after the poll loop so a just-finished leader is still caught.
- Trade-off: 1 extra DB read only in the rare timeout case. No-op in the common path.

## Type of Change
- [x] Bug fix

## Testing
- New unit test: `follower does a final read after timeout to catch a just-finished leader` in `lib/concurrency/__tests__/leader-lock.test.ts`
- 14/14 concurrency tests passing
- Lint clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)