### PR TITLE
fix(hubspot): selector fetchOptions default + credentialId validation

### DIFF
--- a/apps/sim/app/api/tools/hubspot/lists/route.ts
+++ b/apps/sim/app/api/tools/hubspot/lists/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { hubspotListsSelectorContract } from '@/lib/api/contracts/selectors/hubspot'
 import { parseRequest } from '@/lib/api/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
+import { validateAlphanumericId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
@@ -26,6 +27,12 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     const parsed = await parseRequest(hubspotListsSelectorContract, request, {})
     if (!parsed.success) return parsed.response
     const { credentialId, objectTypeId, query } = parsed.data.query
+
+    const credentialIdValidation = validateAlphanumericId(credentialId, 'credentialId', 255)
+    if (!credentialIdValidation.isValid) {
+      logger.warn(`[${requestId}] Invalid credential ID: ${credentialIdValidation.error}`)
+      return NextResponse.json({ error: credentialIdValidation.error }, { status: 400 })
+    }
 
     const authz = await authorizeCredentialUse(request, {
       credentialId,

--- a/apps/sim/app/api/tools/hubspot/owners/route.ts
+++ b/apps/sim/app/api/tools/hubspot/owners/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { hubspotOwnersSelectorContract } from '@/lib/api/contracts/selectors/hubspot'
 import { parseRequest } from '@/lib/api/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
+import { validateAlphanumericId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
@@ -26,6 +27,12 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     const parsed = await parseRequest(hubspotOwnersSelectorContract, request, {})
     if (!parsed.success) return parsed.response
     const { credentialId, query } = parsed.data.query
+
+    const credentialIdValidation = validateAlphanumericId(credentialId, 'credentialId', 255)
+    if (!credentialIdValidation.isValid) {
+      logger.warn(`[${requestId}] Invalid credential ID: ${credentialIdValidation.error}`)
+      return NextResponse.json({ error: credentialIdValidation.error }, { status: 400 })
+    }
 
     const authz = await authorizeCredentialUse(request, {
       credentialId,

--- a/apps/sim/app/api/tools/hubspot/pipelines/route.ts
+++ b/apps/sim/app/api/tools/hubspot/pipelines/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { hubspotPipelinesSelectorContract } from '@/lib/api/contracts/selectors/hubspot'
 import { parseRequest } from '@/lib/api/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
+import { validateAlphanumericId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
@@ -32,6 +33,12 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     const parsed = await parseRequest(hubspotPipelinesSelectorContract, request, {})
     if (!parsed.success) return parsed.response
     const { credentialId, objectType } = parsed.data.query
+
+    const credentialIdValidation = validateAlphanumericId(credentialId, 'credentialId', 255)
+    if (!credentialIdValidation.isValid) {
+      logger.warn(`[${requestId}] Invalid credential ID: ${credentialIdValidation.error}`)
+      return NextResponse.json({ error: credentialIdValidation.error }, { status: 400 })
+    }
 
     const authz = await authorizeCredentialUse(request, {
       credentialId,

--- a/apps/sim/app/api/tools/hubspot/properties/route.ts
+++ b/apps/sim/app/api/tools/hubspot/properties/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { hubspotPropertiesSelectorContract } from '@/lib/api/contracts/selectors/hubspot'
 import { parseRequest } from '@/lib/api/server'
 import { authorizeCredentialUse } from '@/lib/auth/credential-access'
+import { validateAlphanumericId } from '@/lib/core/security/input-validation'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { refreshAccessTokenIfNeeded } from '@/app/api/auth/oauth/utils'
@@ -35,6 +36,12 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     const parsed = await parseRequest(hubspotPropertiesSelectorContract, request, {})
     if (!parsed.success) return parsed.response
     const { credentialId, objectType, query } = parsed.data.query
+
+    const credentialIdValidation = validateAlphanumericId(credentialId, 'credentialId', 255)
+    if (!credentialIdValidation.isValid) {
+      logger.warn(`[${requestId}] Invalid credential ID: ${credentialIdValidation.error}`)
+      return NextResponse.json({ error: credentialIdValidation.error }, { status: 400 })
+    }
 
     const authz = await authorizeCredentialUse(request, {
       credentialId,

--- a/apps/sim/triggers/hubspot/poller.ts
+++ b/apps/sim/triggers/hubspot/poller.ts
@@ -200,9 +200,7 @@ export const hubspotPollingTrigger: TriggerConfig = {
         const credentialId = useSubBlockStore.getState().getValue(blockId, 'triggerCredentials') as
           | string
           | null
-        const objectType =
-          (useSubBlockStore.getState().getValue(blockId, 'objectType') as string | null) ??
-          'contact'
+        const objectType = resolveSelectedObjectType(blockId) ?? 'contact'
         if (!credentialId) throw new Error('No HubSpot credential selected')
         if (isCredentialSetValue(credentialId)) return []
         try {
@@ -231,9 +229,7 @@ export const hubspotPollingTrigger: TriggerConfig = {
         const credentialId = useSubBlockStore.getState().getValue(blockId, 'triggerCredentials') as
           | string
           | null
-        const objectType =
-          (useSubBlockStore.getState().getValue(blockId, 'objectType') as string | null) ??
-          'contact'
+        const objectType = resolveSelectedObjectType(blockId) ?? 'contact'
         const pipelineId = useSubBlockStore.getState().getValue(blockId, 'pipelineId') as
           | string
           | null

--- a/apps/sim/triggers/hubspot/poller.ts
+++ b/apps/sim/triggers/hubspot/poller.ts
@@ -14,6 +14,25 @@ import type { TriggerConfig } from '@/triggers/types'
 
 const logger = createLogger('HubSpotPollingTrigger')
 
+/**
+ * Resolves the effective object type from the subblock store. `getValue` returns `null`
+ * for fields the user hasn't interacted with yet, so we fall back to the dropdown's
+ * default ('contact') — otherwise the cascading property selectors render empty on
+ * first render even when the dropdown visibly shows "contact".
+ */
+function resolveSelectedObjectType(blockId: string): string | null {
+  const objectType = useSubBlockStore.getState().getValue(blockId, 'objectType') as string | null
+  const customId = useSubBlockStore.getState().getValue(blockId, 'customObjectTypeId') as
+    | string
+    | null
+  const selected = objectType ?? 'contact'
+  if (selected === 'custom') {
+    const trimmed = customId?.trim()
+    return trimmed ? trimmed : null
+  }
+  return selected
+}
+
 async function fetchHubSpotProperties(blockId: string, objectType: string) {
   const credentialId = useSubBlockStore.getState().getValue(blockId, 'triggerCredentials') as
     | string
@@ -128,13 +147,7 @@ export const hubspotPollingTrigger: TriggerConfig = {
       placeholder: 'Select a property',
       options: [],
       fetchOptions: async (blockId: string) => {
-        const objectType = useSubBlockStore.getState().getValue(blockId, 'objectType') as
-          | string
-          | null
-        const customId = useSubBlockStore.getState().getValue(blockId, 'customObjectTypeId') as
-          | string
-          | null
-        const resolved = objectType === 'custom' ? customId : objectType
+        const resolved = resolveSelectedObjectType(blockId)
         if (!resolved) throw new Error('Select an object type first')
         try {
           return await fetchHubSpotProperties(blockId, resolved)
@@ -162,13 +175,7 @@ export const hubspotPollingTrigger: TriggerConfig = {
       placeholder: 'Select properties (optional)',
       options: [],
       fetchOptions: async (blockId: string) => {
-        const objectType = useSubBlockStore.getState().getValue(blockId, 'objectType') as
-          | string
-          | null
-        const customId = useSubBlockStore.getState().getValue(blockId, 'customObjectTypeId') as
-          | string
-          | null
-        const resolved = objectType === 'custom' ? customId : objectType
+        const resolved = resolveSelectedObjectType(blockId)
         if (!resolved) return []
         try {
           return await fetchHubSpotProperties(blockId, resolved)
@@ -193,10 +200,10 @@ export const hubspotPollingTrigger: TriggerConfig = {
         const credentialId = useSubBlockStore.getState().getValue(blockId, 'triggerCredentials') as
           | string
           | null
-        const objectType = useSubBlockStore.getState().getValue(blockId, 'objectType') as
-          | string
-          | null
-        if (!credentialId || !objectType) return []
+        const objectType =
+          (useSubBlockStore.getState().getValue(blockId, 'objectType') as string | null) ??
+          'contact'
+        if (!credentialId) throw new Error('No HubSpot credential selected')
         if (isCredentialSetValue(credentialId)) return []
         try {
           const data = await requestJson(hubspotPipelinesSelectorContract, {
@@ -224,14 +231,15 @@ export const hubspotPollingTrigger: TriggerConfig = {
         const credentialId = useSubBlockStore.getState().getValue(blockId, 'triggerCredentials') as
           | string
           | null
-        const objectType = useSubBlockStore.getState().getValue(blockId, 'objectType') as
-          | string
-          | null
+        const objectType =
+          (useSubBlockStore.getState().getValue(blockId, 'objectType') as string | null) ??
+          'contact'
         const pipelineId = useSubBlockStore.getState().getValue(blockId, 'pipelineId') as
           | string
           | null
-        if (!credentialId || !objectType || !pipelineId) return []
+        if (!credentialId) throw new Error('No HubSpot credential selected')
         if (isCredentialSetValue(credentialId)) return []
+        if (!pipelineId) return []
         try {
           const data = await requestJson(hubspotPipelinesSelectorContract, {
             query: { credentialId, objectType },
@@ -259,7 +267,7 @@ export const hubspotPollingTrigger: TriggerConfig = {
         const credentialId = useSubBlockStore.getState().getValue(blockId, 'triggerCredentials') as
           | string
           | null
-        if (!credentialId) return []
+        if (!credentialId) throw new Error('No HubSpot credential selected')
         if (isCredentialSetValue(credentialId)) return []
         try {
           const data = await requestJson(hubspotOwnersSelectorContract, {


### PR DESCRIPTION
## Summary
- Fall back to the `objectType` default ('contact') in trigger selector `fetchOptions` so the properties/pipelines/stages/ownerId dropdowns populate on first paint instead of waiting for the user to re-pick the default.
- Validate `credentialId` with `validateAlphanumericId` in the 4 HubSpot selector routes (properties, lists, pipelines, owners), matching the Gmail/Webflow/Jira security pattern.

## Type of Change
- [x] Bug fix

## Testing
Tested manually — properties dropdown now populates immediately after selecting a credential. Type-check, `check:api-validation`, and lint-staged biome all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)