### PR TITLE
fix(tools): pin resolved IP in DB connectors to prevent DNS-rebinding SSRF

### DIFF
--- a/apps/sim/app/api/tools/mongodb/utils.ts
+++ b/apps/sim/app/api/tools/mongodb/utils.ts
@@ -1,5 +1,8 @@
 import { MongoClient } from 'mongodb'
-import { validateDatabaseHost } from '@/lib/core/security/input-validation.server'
+import {
+  createPinnedLookup,
+  validateDatabaseHost,
+} from '@/lib/core/security/input-validation.server'
 import type { MongoDBCollectionInfo, MongoDBConnectionConfig } from '@/tools/mongodb/types'
 
 export async function createMongoDBConnection(config: MongoDBConnectionConfig) {
@@ -30,6 +33,7 @@ export async function createMongoDBConnection(config: MongoDBConnectionConfig) {
     connectTimeoutMS: 10000,
     socketTimeoutMS: 10000,
     maxPoolSize: 1,
+    lookup: createPinnedLookup(hostValidation.resolvedIP ?? config.host),
   })
 
   await client.connect()

--- a/apps/sim/app/api/tools/mysql/utils.ts
+++ b/apps/sim/app/api/tools/mysql/utils.ts
@@ -26,7 +26,7 @@ export async function createMySQLConnection(config: MySQLConnectionConfig) {
     user: config.username,
     password: config.password,
     stream: () => {
-      const socket = net.connect(config.port, resolvedIP)
+      const socket = net.connect({ host: resolvedIP, port: config.port, timeout: 10000 })
       socket.setNoDelay(true)
       return socket
     },

--- a/apps/sim/app/api/tools/mysql/utils.ts
+++ b/apps/sim/app/api/tools/mysql/utils.ts
@@ -25,7 +25,6 @@ export async function createMySQLConnection(config: MySQLConnectionConfig) {
     database: config.database,
     user: config.username,
     password: config.password,
-    // Pin socket to resolved IP to prevent DNS rebinding; mysql2 still uses config.host for TLS servername.
     stream: () => {
       const socket = net.connect(config.port, resolvedIP)
       socket.setNoDelay(true)

--- a/apps/sim/app/api/tools/mysql/utils.ts
+++ b/apps/sim/app/api/tools/mysql/utils.ts
@@ -1,3 +1,4 @@
+import net from 'node:net'
 import mysql from 'mysql2/promise'
 import { validateDatabaseHost } from '@/lib/core/security/input-validation.server'
 
@@ -16,12 +17,20 @@ export async function createMySQLConnection(config: MySQLConnectionConfig) {
     throw new Error(hostValidation.error)
   }
 
+  const resolvedIP = hostValidation.resolvedIP ?? config.host
+
   const connectionConfig: mysql.ConnectionOptions = {
     host: config.host,
     port: config.port,
     database: config.database,
     user: config.username,
     password: config.password,
+    // Pin socket to resolved IP to prevent DNS rebinding; mysql2 still uses config.host for TLS servername.
+    stream: () => {
+      const socket = net.connect(config.port, resolvedIP)
+      socket.setNoDelay(true)
+      return socket
+    },
   }
 
   if (config.ssl === 'disabled') {

--- a/apps/sim/app/api/tools/neo4j/utils.ts
+++ b/apps/sim/app/api/tools/neo4j/utils.ts
@@ -18,7 +18,6 @@ export async function createNeo4jDriver(config: Neo4jConnectionConfig) {
     protocol = config.encryption === 'enabled' ? 'bolt+s' : 'bolt'
   }
 
-  // neo4j-driver hardcodes TLS servername to the URI host with no override, so we only pin the IP for non-TLS to preserve Aura cert validation.
   const useIPPinning = !protocol.endsWith('+s')
   const resolvedIP = hostValidation.resolvedIP ?? config.host
   const uriHost = useIPPinning

--- a/apps/sim/app/api/tools/neo4j/utils.ts
+++ b/apps/sim/app/api/tools/neo4j/utils.ts
@@ -18,7 +18,15 @@ export async function createNeo4jDriver(config: Neo4jConnectionConfig) {
     protocol = config.encryption === 'enabled' ? 'bolt+s' : 'bolt'
   }
 
-  const uri = `${protocol}://${config.host}:${config.port}`
+  // neo4j-driver hardcodes TLS servername to the URI host with no override, so we only pin the IP for non-TLS to preserve Aura cert validation.
+  const useIPPinning = !protocol.endsWith('+s')
+  const resolvedIP = hostValidation.resolvedIP ?? config.host
+  const uriHost = useIPPinning
+    ? resolvedIP.includes(':')
+      ? `[${resolvedIP}]`
+      : resolvedIP
+    : config.host
+  const uri = `${protocol}://${uriHost}:${config.port}`
 
   const driverConfig: any = {
     maxConnectionPoolSize: 1,

--- a/apps/sim/app/api/tools/postgresql/utils.ts
+++ b/apps/sim/app/api/tools/postgresql/utils.ts
@@ -8,17 +8,18 @@ export async function createPostgresConnection(config: PostgresConnectionConfig)
     throw new Error(hostValidation.error)
   }
 
-  const sslConfig =
+  const resolvedHost = hostValidation.resolvedIP ?? config.host
+
+  // `rejectUnauthorized: false` matches postgres.js's `'require'` string semantics; `servername` is set so SNI works with the pinned IP host.
+  const sslConfig: boolean | 'prefer' | { rejectUnauthorized: boolean; servername?: string } =
     config.ssl === 'disabled'
       ? false
-      : config.ssl === 'required'
-        ? 'require'
-        : config.ssl === 'preferred'
-          ? 'prefer'
-          : 'require'
+      : config.ssl === 'preferred'
+        ? 'prefer'
+        : { rejectUnauthorized: false, servername: config.host }
 
   const sql = postgres({
-    host: config.host,
+    host: resolvedHost,
     port: config.port,
     database: config.database,
     username: config.username,

--- a/apps/sim/app/api/tools/postgresql/utils.ts
+++ b/apps/sim/app/api/tools/postgresql/utils.ts
@@ -10,7 +10,6 @@ export async function createPostgresConnection(config: PostgresConnectionConfig)
 
   const resolvedHost = hostValidation.resolvedIP ?? config.host
 
-  // `rejectUnauthorized: false` matches postgres.js's `'require'` string semantics; `servername` is set so SNI works with the pinned IP host.
   const sslConfig: boolean | 'prefer' | { rejectUnauthorized: boolean; servername?: string } =
     config.ssl === 'disabled'
       ? false

--- a/apps/sim/app/api/tools/postgresql/utils.ts
+++ b/apps/sim/app/api/tools/postgresql/utils.ts
@@ -9,12 +9,17 @@ export async function createPostgresConnection(config: PostgresConnectionConfig)
   }
 
   const resolvedHost = hostValidation.resolvedIP ?? config.host
+  const pinIP = config.ssl !== 'preferred'
 
-  const sslConfig: boolean | { rejectUnauthorized: boolean; servername?: string } =
-    config.ssl === 'disabled' ? false : { rejectUnauthorized: false, servername: config.host }
+  const sslConfig: boolean | 'prefer' | { rejectUnauthorized: boolean; servername?: string } =
+    config.ssl === 'disabled'
+      ? false
+      : config.ssl === 'preferred'
+        ? 'prefer'
+        : { rejectUnauthorized: false, servername: config.host }
 
   const sql = postgres({
-    host: resolvedHost,
+    host: pinIP ? resolvedHost : config.host,
     port: config.port,
     database: config.database,
     username: config.username,

--- a/apps/sim/app/api/tools/postgresql/utils.ts
+++ b/apps/sim/app/api/tools/postgresql/utils.ts
@@ -10,12 +10,8 @@ export async function createPostgresConnection(config: PostgresConnectionConfig)
 
   const resolvedHost = hostValidation.resolvedIP ?? config.host
 
-  const sslConfig: boolean | 'prefer' | { rejectUnauthorized: boolean; servername?: string } =
-    config.ssl === 'disabled'
-      ? false
-      : config.ssl === 'preferred'
-        ? 'prefer'
-        : { rejectUnauthorized: false, servername: config.host }
+  const sslConfig: boolean | { rejectUnauthorized: boolean; servername?: string } =
+    config.ssl === 'disabled' ? false : { rejectUnauthorized: false, servername: config.host }
 
   const sql = postgres({
     host: resolvedHost,

--- a/apps/sim/app/api/tools/redis/execute/route.ts
+++ b/apps/sim/app/api/tools/redis/execute/route.ts
@@ -46,7 +46,6 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         ? Number.parseInt(parsedUrl.pathname.slice(1), 10)
         : Number.NaN
 
-    // Pin to resolved IP to prevent DNS rebinding; for `rediss://`, pass original hostname as TLS servername.
     client = new Redis({
       host: resolvedIP,
       port,

--- a/apps/sim/app/api/tools/redis/execute/route.ts
+++ b/apps/sim/app/api/tools/redis/execute/route.ts
@@ -41,17 +41,26 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     const port = parsedUrl.port ? Number(parsedUrl.port) : 6379
     const username = parsedUrl.username ? decodeURIComponent(parsedUrl.username) : undefined
     const password = parsedUrl.password ? decodeURIComponent(parsedUrl.password) : undefined
-    const dbIndex =
-      parsedUrl.pathname && parsedUrl.pathname.length > 1
-        ? Number.parseInt(parsedUrl.pathname.slice(1), 10)
-        : Number.NaN
+
+    let db = 0
+    if (parsedUrl.pathname && parsedUrl.pathname.length > 1) {
+      const dbSegment = parsedUrl.pathname.slice(1)
+      const parsedDb = Number.parseInt(dbSegment, 10)
+      if (!Number.isFinite(parsedDb) || String(parsedDb) !== dbSegment) {
+        return NextResponse.json(
+          { error: `Invalid Redis database index in URL path: '${dbSegment}'` },
+          { status: 400 }
+        )
+      }
+      db = parsedDb
+    }
 
     client = new Redis({
       host: resolvedIP,
       port,
       username,
       password,
-      db: Number.isFinite(dbIndex) ? dbIndex : 0,
+      db,
       family: resolvedIP.includes(':') ? 6 : 4,
       tls: tlsEnabled ? { servername: hostname } : undefined,
       connectTimeout: 10000,

--- a/apps/sim/app/api/tools/redis/execute/route.ts
+++ b/apps/sim/app/api/tools/redis/execute/route.ts
@@ -36,7 +36,25 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       return NextResponse.json({ error: hostValidation.error }, { status: 400 })
     }
 
-    client = new Redis(url, {
+    const resolvedIP = hostValidation.resolvedIP ?? hostname
+    const tlsEnabled = parsedUrl.protocol === 'rediss:'
+    const port = parsedUrl.port ? Number(parsedUrl.port) : 6379
+    const username = parsedUrl.username ? decodeURIComponent(parsedUrl.username) : undefined
+    const password = parsedUrl.password ? decodeURIComponent(parsedUrl.password) : undefined
+    const dbIndex =
+      parsedUrl.pathname && parsedUrl.pathname.length > 1
+        ? Number.parseInt(parsedUrl.pathname.slice(1), 10)
+        : Number.NaN
+
+    // Pin to resolved IP to prevent DNS rebinding; for `rediss://`, pass original hostname as TLS servername.
+    client = new Redis({
+      host: resolvedIP,
+      port,
+      username,
+      password,
+      db: Number.isFinite(dbIndex) ? dbIndex : 0,
+      family: resolvedIP.includes(':') ? 6 : 4,
+      tls: tlsEnabled ? { servername: hostname } : undefined,
       connectTimeout: 10000,
       commandTimeout: 10000,
       maxRetriesPerRequest: 1,


### PR DESCRIPTION
## Summary
- `validateDatabaseHost` resolved an IP that was then discarded; the drivers re-resolved the hostname at connect time, leaving a DNS-rebinding TOCTOU window
- MongoDB: pass resolved IP via the MongoClient `lookup` option
- MySQL: pin the TCP socket via the `stream` factory; keep `config.host` for TLS servername
- PostgreSQL: connect to resolved IP; pass `ssl` as object with `servername` so SNI works against the pinned IP
- Redis: parse the URL explicitly and pass options-only (URL+options doesn't override `host` due to ioredis's `lodash.defaults`); set `tls.servername` for `rediss://`
- Neo4j: pin IP only for plain `bolt://`; leave `bolt+s`/`neo4j+s` unchanged so Aura cert validation keeps working (driver hardcodes servername with no override)

## Type of Change
- [x] Bug fix (security)

## Testing
Tested manually. Type-check, biome lint, and `bun run check:api-validation` all pass. Driver source code reviewed to verify each pinning mechanism reaches the underlying `net.connect`/`tls.connect` call.

Pre-merge verification still needed against live managed providers (Atlas, RDS, Heroku PG, ElastiCache TLS, Aura).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)