### PR TITLE
fix(credentials): grant admin credential role to workspace admins

### DIFF
--- a/apps/sim/app/api/credentials/route.ts
+++ b/apps/sim/app/api/credentials/route.ts
@@ -22,7 +22,7 @@ import {
   normalizeAtlassianDomain,
   validateAtlassianServiceAccount,
 } from '@/lib/credentials/atlassian-service-account'
-import { getWorkspaceMemberUserIds } from '@/lib/credentials/environment'
+import { getWorkspaceAdminUserIds, getWorkspaceMemberUserIds } from '@/lib/credentials/environment'
 import { syncWorkspaceOAuthCredentialsForUser } from '@/lib/credentials/oauth'
 import { getServiceConfigByProviderId } from '@/lib/oauth'
 import {
@@ -535,7 +535,10 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       })
 
       if ((type === 'env_workspace' || type === 'service_account') && workspaceRow?.ownerId) {
-        const workspaceUserIds = await getWorkspaceMemberUserIds(workspaceId)
+        const [workspaceUserIds, adminUserIds] = await Promise.all([
+          getWorkspaceMemberUserIds(workspaceId),
+          getWorkspaceAdminUserIds(workspaceId),
+        ])
         if (workspaceUserIds.length > 0) {
           for (const memberUserId of workspaceUserIds) {
             await tx.insert(credentialMember).values({
@@ -543,7 +546,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
               credentialId,
               userId: memberUserId,
               role:
-                memberUserId === workspaceRow.ownerId || memberUserId === session.user.id
+                adminUserIds.has(memberUserId) || memberUserId === session.user.id
                   ? 'admin'
                   : 'member',
               status: 'active',

--- a/apps/sim/lib/credentials/environment.ts
+++ b/apps/sim/lib/credentials/environment.ts
@@ -37,6 +37,31 @@ export async function getWorkspaceMemberUserIds(workspaceId: string): Promise<st
   return Array.from(memberIds)
 }
 
+export async function getWorkspaceAdminUserIds(workspaceId: string): Promise<Set<string>> {
+  const [workspaceRows, adminPermissionRows] = await Promise.all([
+    db
+      .select({ ownerId: workspace.ownerId })
+      .from(workspace)
+      .where(eq(workspace.id, workspaceId))
+      .limit(1),
+    db
+      .select({ userId: permissions.userId })
+      .from(permissions)
+      .where(
+        and(
+          eq(permissions.entityType, 'workspace'),
+          eq(permissions.entityId, workspaceId),
+          eq(permissions.permissionType, 'admin')
+        )
+      ),
+  ])
+  const adminIds = new Set<string>(adminPermissionRows.map((row) => row.userId))
+  if (workspaceRows[0]?.ownerId) {
+    adminIds.add(workspaceRows[0].ownerId)
+  }
+  return adminIds
+}
+
 export async function getUserWorkspaceIds(userId: string): Promise<string[]> {
   const [permissionRows, ownedWorkspaceRows] = await Promise.all([
     db
@@ -64,7 +89,8 @@ export async function getUserWorkspaceIds(userId: string): Promise<string[]> {
 async function ensureWorkspaceCredentialMemberships(
   credentialId: string,
   memberUserIds: string[],
-  ownerUserId: string
+  ownerUserId: string,
+  adminUserIds: Set<string>
 ) {
   if (!memberUserIds.length) return
 
@@ -87,7 +113,7 @@ async function ensureWorkspaceCredentialMemberships(
   const now = new Date()
 
   for (const memberUserId of memberUserIds) {
-    const targetRole = memberUserId === ownerUserId ? 'admin' : 'member'
+    const targetRole = adminUserIds.has(memberUserId) ? 'admin' : 'member'
     const existing = byUserId.get(memberUserId)
     if (existing) {
       if (existing.status === 'revoked') {
@@ -126,13 +152,14 @@ export async function syncWorkspaceEnvCredentials(params: {
   actingUserId: string
 }) {
   const { workspaceId, envKeys, actingUserId } = params
-  const [[workspaceRow], memberUserIds] = await Promise.all([
+  const [[workspaceRow], memberUserIds, adminUserIds] = await Promise.all([
     db
       .select({ ownerId: workspace.ownerId })
       .from(workspace)
       .where(eq(workspace.id, workspaceId))
       .limit(1),
     getWorkspaceMemberUserIds(workspaceId),
+    getWorkspaceAdminUserIds(workspaceId),
   ])
 
   if (!workspaceRow) return
@@ -182,7 +209,7 @@ export async function syncWorkspaceEnvCredentials(params: {
   }
 
   for (const credentialId of credentialIdsToEnsureMembership) {
-    await ensureWorkspaceCredentialMemberships(credentialId, memberUserIds, workspaceRow.ownerId)
+    await ensureWorkspaceCredentialMemberships(credentialId, memberUserIds, workspaceRow.ownerId, adminUserIds)
   }
 
   if (normalizedKeys.length > 0) {
@@ -216,13 +243,14 @@ export async function createWorkspaceEnvCredentials(params: {
   const keys = Array.from(new Set(newKeys.filter(Boolean)))
   if (keys.length === 0) return
 
-  const [[workspaceRow], memberUserIds] = await Promise.all([
+  const [[workspaceRow], memberUserIds, adminUserIds] = await Promise.all([
     db
       .select({ ownerId: workspace.ownerId })
       .from(workspace)
       .where(eq(workspace.id, workspaceId))
       .limit(1),
     getWorkspaceMemberUserIds(workspaceId),
+    getWorkspaceAdminUserIds(workspaceId),
   ])
 
   if (!workspaceRow) return
@@ -259,7 +287,7 @@ export async function createWorkspaceEnvCredentials(params: {
       id: generateId(),
       credentialId,
       userId: memberUserId,
-      role: (memberUserId === ownerUserId ? 'admin' : 'member') as 'admin' | 'member',
+      role: (adminUserIds.has(memberUserId) ? 'admin' : 'member') as 'admin' | 'member',
       status: 'active' as const,
       joinedAt: now,
       invitedBy: ownerUserId,


### PR DESCRIPTION
## Problem

Workspace admin users (users with `permissionType = 'admin'` in the permissions table for a workspace) receive a `member` role on `credential_member` when a workspace-scoped secret is created. This prevents them from editing or deleting the secret, even though they have admin access to the workspace.

Root cause: three code paths that create `credential_member` rows determined the role solely by checking `memberUserId === ownerUserId`, ignoring the `permissions` table:

- `ensureWorkspaceCredentialMemberships` in `lib/credentials/environment.ts`
- `syncWorkspaceEnvCredentials` (calls the above)
- `createWorkspaceEnvCredentials` (inline bulk insert)
- POST handler in `app/api/credentials/route.ts`

## Solution

Add a `getWorkspaceAdminUserIds(workspaceId)` helper that returns a `Set<string>` containing:
- the workspace owner (`workspace.ownerId`)
- all users with `permissionType = 'admin'` on the workspace (`permissions` table)

Use this set instead of the bare owner ID check in all four affected paths so workspace admins receive `admin` on `credential_member`.

## Testing

1. Create a workspace with two members: owner and an admin user (set via the permissions panel)
2. As the owner, go to Settings → Secrets and create a workspace-scoped secret
3. Log in as the admin user — they should now be able to edit and delete the secret

Before this fix: admin user got `member` role and saw a permission error.  
After this fix: admin user gets `admin` role and can manage the secret.