### PR TITLE
feat(undo-redo): migrate persistence from localStorage to IndexedDB

### DIFF
--- a/apps/sim/stores/index.ts
+++ b/apps/sim/stores/index.ts
@@ -6,6 +6,7 @@ import { environmentKeys } from '@/hooks/queries/environment'
 import { useExecutionStore } from '@/stores/execution'
 import { useMothershipDraftsStore } from '@/stores/mothership-drafts/store'
 import { consolePersistence, useTerminalConsoleStore } from '@/stores/terminal'
+import { clearPersistedUndoRedo } from '@/stores/undo-redo/storage'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
@@ -54,6 +55,9 @@ export async function clearUserData(): Promise<void> {
     const keysToKeep = ['next-favicon', 'theme']
     const keysToRemove = Object.keys(localStorage).filter((key) => !keysToKeep.includes(key))
     keysToRemove.forEach((key) => localStorage.removeItem(key))
+
+    // Persisted undo/redo lives in IndexedDB; remove it as well.
+    await clearPersistedUndoRedo()
 
     logger.info('User data cleared successfully')
   } catch (error) {

--- a/apps/sim/stores/undo-redo/storage.test.ts
+++ b/apps/sim/stores/undo-redo/storage.test.ts
@@ -176,12 +176,41 @@ describe('undo-redo IndexedDB storage adapter', () => {
       expect(idbStore.get(MIGRATION_KEY)).toBe(true)
     })
 
-    it('swallows IndexedDB errors so sign-out does not crash', async () => {
+    it('propagates IndexedDB errors so callers can surface the failure', async () => {
       const { clearPersistedUndoRedo, migrationReady } = await loadFreshModule()
       await migrationReady
 
       idbDel.mockRejectedValueOnce(new Error('idb delete failed'))
-      await expect(clearPersistedUndoRedo()).resolves.toBeUndefined()
+      await expect(clearPersistedUndoRedo()).rejects.toThrow('idb delete failed')
+    })
+  })
+
+  describe('hydration race', () => {
+    it('blocks setItem until the first getItem resolves', async () => {
+      const { indexedDBStorage, migrationReady } = await loadFreshModule()
+      await migrationReady
+      idbStore.set(STORE_KEY, 'persisted-snapshot')
+
+      let releaseRead: ((value: 'persisted-snapshot') => void) | null = null
+      idbGet.mockImplementationOnce(
+        () =>
+          new Promise<'persisted-snapshot'>((resolve) => {
+            releaseRead = resolve
+          })
+      )
+
+      const readPromise = indexedDBStorage.getItem(STORE_KEY)
+      const writePromise = indexedDBStorage.setItem(STORE_KEY, 'empty-state')
+
+      // Give the microtask queue a chance to process; the write must still be pending.
+      await Promise.resolve()
+      expect(idbStore.get(STORE_KEY)).toBe('persisted-snapshot')
+
+      releaseRead?.('persisted-snapshot')
+      await readPromise
+      await writePromise
+
+      expect(idbStore.get(STORE_KEY)).toBe('empty-state')
     })
   })
 })

--- a/apps/sim/stores/undo-redo/storage.test.ts
+++ b/apps/sim/stores/undo-redo/storage.test.ts
@@ -1,5 +1,5 @@
 /**
- * @vitest-environment node
+ * @vitest-environment jsdom
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -135,6 +135,14 @@ describe('undo-redo IndexedDB storage adapter', () => {
 
       await indexedDBStorage.removeItem(STORE_KEY)
       expect(idbStore.has(STORE_KEY)).toBe(false)
+    })
+
+    it('removeItem swallows IndexedDB errors', async () => {
+      const { indexedDBStorage, migrationReady } = await loadFreshModule()
+      await migrationReady
+
+      idbDel.mockRejectedValueOnce(new Error('idb delete failed'))
+      await expect(indexedDBStorage.removeItem(STORE_KEY)).resolves.toBeUndefined()
     })
 
     it('getItem swallows IndexedDB read errors and returns null', async () => {

--- a/apps/sim/stores/undo-redo/storage.test.ts
+++ b/apps/sim/stores/undo-redo/storage.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { idbStore, idbGet, idbSet, idbDel } = vi.hoisted(() => {
+  const store = new Map<string, unknown>()
+  return {
+    idbStore: store,
+    idbGet: vi.fn(async (key: string) => store.get(key) ?? undefined),
+    idbSet: vi.fn(async (key: string, value: unknown) => {
+      store.set(key, value)
+    }),
+    idbDel: vi.fn(async (key: string) => {
+      store.delete(key)
+    }),
+  }
+})
+
+vi.mock('idb-keyval', () => ({
+  get: idbGet,
+  set: idbSet,
+  del: idbDel,
+}))
+
+const STORE_KEY = 'workflow-undo-redo'
+const MIGRATION_KEY = 'workflow-undo-redo-migrated'
+
+async function loadFreshModule() {
+  vi.resetModules()
+  return await import('@/stores/undo-redo/storage')
+}
+
+describe('undo-redo IndexedDB storage adapter', () => {
+  beforeEach(() => {
+    idbStore.clear()
+    idbGet.mockClear()
+    idbSet.mockClear()
+    idbDel.mockClear()
+    localStorage.clear()
+    vi.mocked(localStorage.getItem).mockClear()
+    vi.mocked(localStorage.setItem).mockClear()
+    vi.mocked(localStorage.removeItem).mockClear()
+  })
+
+  describe('migration', () => {
+    it('copies localStorage data into IndexedDB and removes the localStorage key on first load', async () => {
+      const legacyPayload = JSON.stringify({ state: { stacks: {} }, version: 0 })
+      localStorage.setItem(STORE_KEY, legacyPayload)
+      idbSet.mockClear()
+
+      const { migrationReady } = await loadFreshModule()
+      await migrationReady
+
+      expect(idbSet).toHaveBeenCalledWith(STORE_KEY, legacyPayload)
+      expect(idbStore.get(STORE_KEY)).toBe(legacyPayload)
+      expect(localStorage.getItem(STORE_KEY)).toBeNull()
+      expect(idbStore.get(MIGRATION_KEY)).toBe(true)
+    })
+
+    it('skips data copy when localStorage is empty but still marks migration complete', async () => {
+      const { migrationReady } = await loadFreshModule()
+      await migrationReady
+
+      expect(idbSet).toHaveBeenCalledWith(MIGRATION_KEY, true)
+      expect(idbSet).not.toHaveBeenCalledWith(STORE_KEY, expect.anything())
+      expect(idbStore.get(MIGRATION_KEY)).toBe(true)
+    })
+
+    it('does not re-run when MIGRATION_KEY is already set', async () => {
+      idbStore.set(MIGRATION_KEY, true)
+      const legacyPayload = JSON.stringify({ state: { stacks: { foo: {} } }, version: 0 })
+      localStorage.setItem(STORE_KEY, legacyPayload)
+
+      const { migrationReady } = await loadFreshModule()
+      await migrationReady
+
+      expect(idbSet).not.toHaveBeenCalledWith(STORE_KEY, expect.anything())
+      expect(localStorage.getItem(STORE_KEY)).toBe(legacyPayload)
+    })
+
+    it('does not throw when IndexedDB set fails — leaves localStorage intact for retry', async () => {
+      idbSet.mockRejectedValueOnce(new Error('idb write failed'))
+      const legacyPayload = JSON.stringify({ state: { stacks: {} }, version: 0 })
+      localStorage.setItem(STORE_KEY, legacyPayload)
+
+      const { migrationReady } = await loadFreshModule()
+      await expect(migrationReady).resolves.toBeUndefined()
+
+      expect(localStorage.getItem(STORE_KEY)).toBe(legacyPayload)
+    })
+  })
+
+  describe('storage adapter', () => {
+    it('getItem awaits migration completion before reading', async () => {
+      const legacyPayload = JSON.stringify({ state: { stacks: { a: {} } }, version: 0 })
+      localStorage.setItem(STORE_KEY, legacyPayload)
+
+      const { indexedDBStorage, migrationReady } = await loadFreshModule()
+      const readPromise = indexedDBStorage.getItem(STORE_KEY)
+      await migrationReady
+      const value = await readPromise
+
+      expect(value).toBe(legacyPayload)
+    })
+
+    it('getItem returns null when key is absent', async () => {
+      const { indexedDBStorage, migrationReady } = await loadFreshModule()
+      await migrationReady
+
+      const value = await indexedDBStorage.getItem('does-not-exist')
+      expect(value).toBeNull()
+    })
+
+    it('setItem writes through to IndexedDB', async () => {
+      const { indexedDBStorage, migrationReady } = await loadFreshModule()
+      await migrationReady
+
+      await indexedDBStorage.setItem(STORE_KEY, 'new-value')
+      expect(idbStore.get(STORE_KEY)).toBe('new-value')
+    })
+
+    it('setItem swallows IndexedDB errors so the store never crashes the app', async () => {
+      const { indexedDBStorage, migrationReady } = await loadFreshModule()
+      await migrationReady
+
+      idbSet.mockRejectedValueOnce(new Error('idb quota'))
+      await expect(indexedDBStorage.setItem(STORE_KEY, 'x')).resolves.toBeUndefined()
+    })
+
+    it('removeItem deletes from IndexedDB', async () => {
+      const { indexedDBStorage, migrationReady } = await loadFreshModule()
+      await migrationReady
+      idbStore.set(STORE_KEY, 'present')
+
+      await indexedDBStorage.removeItem(STORE_KEY)
+      expect(idbStore.has(STORE_KEY)).toBe(false)
+    })
+
+    it('getItem swallows IndexedDB read errors and returns null', async () => {
+      const { indexedDBStorage, migrationReady } = await loadFreshModule()
+      await migrationReady
+
+      idbGet.mockRejectedValueOnce(new Error('idb read failed'))
+      const value = await indexedDBStorage.getItem(STORE_KEY)
+      expect(value).toBeNull()
+    })
+  })
+})

--- a/apps/sim/stores/undo-redo/storage.test.ts
+++ b/apps/sim/stores/undo-redo/storage.test.ts
@@ -154,4 +154,34 @@ describe('undo-redo IndexedDB storage adapter', () => {
       expect(value).toBeNull()
     })
   })
+
+  describe('clearPersistedUndoRedo', () => {
+    it('deletes the undo-redo key from IndexedDB', async () => {
+      const { clearPersistedUndoRedo, migrationReady } = await loadFreshModule()
+      await migrationReady
+      idbStore.set(STORE_KEY, 'present')
+
+      await clearPersistedUndoRedo()
+
+      expect(idbStore.has(STORE_KEY)).toBe(false)
+    })
+
+    it('leaves the migration flag intact so migration does not re-run', async () => {
+      const { clearPersistedUndoRedo, migrationReady } = await loadFreshModule()
+      await migrationReady
+      idbStore.set(STORE_KEY, 'present')
+
+      await clearPersistedUndoRedo()
+
+      expect(idbStore.get(MIGRATION_KEY)).toBe(true)
+    })
+
+    it('swallows IndexedDB errors so sign-out does not crash', async () => {
+      const { clearPersistedUndoRedo, migrationReady } = await loadFreshModule()
+      await migrationReady
+
+      idbDel.mockRejectedValueOnce(new Error('idb delete failed'))
+      await expect(clearPersistedUndoRedo()).resolves.toBeUndefined()
+    })
+  })
 })

--- a/apps/sim/stores/undo-redo/storage.ts
+++ b/apps/sim/stores/undo-redo/storage.ts
@@ -1,0 +1,86 @@
+import { createLogger } from '@sim/logger'
+import { del, get, set } from 'idb-keyval'
+import type { StateStorage } from 'zustand/middleware'
+
+const logger = createLogger('UndoRedoStorage')
+
+const STORE_KEY = 'workflow-undo-redo'
+const MIGRATION_KEY = 'workflow-undo-redo-migrated'
+
+let migrationPromiseInternal: Promise<void> | null = null
+
+/**
+ * Migrates existing undo/redo data from localStorage to IndexedDB.
+ * Runs once on first load; subsequent loads short-circuit on MIGRATION_KEY.
+ *
+ * On success the localStorage key is removed, freeing origin storage quota
+ * for the other persisted Zustand stores that share it.
+ */
+async function migrateFromLocalStorage(): Promise<void> {
+  if (typeof localStorage === 'undefined') return
+
+  try {
+    const migrated = await get<boolean>(MIGRATION_KEY)
+    if (migrated) return
+
+    const localData = localStorage.getItem(STORE_KEY)
+    if (localData) {
+      await set(STORE_KEY, localData)
+      localStorage.removeItem(STORE_KEY)
+      logger.info('Migrated undo-redo store from localStorage to IndexedDB')
+    }
+
+    await set(MIGRATION_KEY, true)
+  } catch (error) {
+    logger.warn('Migration from localStorage failed', { error })
+  }
+}
+
+if (typeof localStorage !== 'undefined') {
+  migrationPromiseInternal = migrateFromLocalStorage().finally(() => {
+    migrationPromiseInternal = null
+  })
+}
+
+/**
+ * Resolves when the one-time localStorage → IndexedDB migration finishes.
+ * Exposed for tests; production code reads through `indexedDBStorage.getItem`
+ * which already awaits this promise.
+ */
+export const migrationReady: Promise<void> = migrationPromiseInternal ?? Promise.resolve()
+
+export const indexedDBStorage: StateStorage = {
+  getItem: async (name: string): Promise<string | null> => {
+    if (typeof localStorage === 'undefined') return null
+
+    if (migrationPromiseInternal) {
+      await migrationPromiseInternal
+    }
+
+    try {
+      const value = await get<string>(name)
+      return value ?? null
+    } catch (error) {
+      logger.warn('IndexedDB read failed', { name, error })
+      return null
+    }
+  },
+
+  setItem: async (name: string, value: string): Promise<void> => {
+    if (typeof localStorage === 'undefined') return
+    try {
+      await set(name, value)
+    } catch (error) {
+      logger.warn('IndexedDB write failed', { name, error })
+    }
+  },
+
+  removeItem: async (name: string): Promise<void> => {
+    if (typeof localStorage === 'undefined') return
+    try {
+      await del(name)
+    } catch (error) {
+      logger.warn('IndexedDB delete failed', { name, error })
+    }
+  },
+}

--- a/apps/sim/stores/undo-redo/storage.ts
+++ b/apps/sim/stores/undo-redo/storage.ts
@@ -17,7 +17,7 @@ let migrationPromiseInternal: Promise<void> | null = null
  * for the other persisted Zustand stores that share it.
  */
 async function migrateFromLocalStorage(): Promise<void> {
-  if (typeof localStorage === 'undefined') return
+  if (typeof window === 'undefined') return
 
   try {
     const migrated = await get<boolean>(MIGRATION_KEY)
@@ -36,7 +36,7 @@ async function migrateFromLocalStorage(): Promise<void> {
   }
 }
 
-if (typeof localStorage !== 'undefined') {
+if (typeof window !== 'undefined') {
   migrationPromiseInternal = migrateFromLocalStorage().finally(() => {
     migrationPromiseInternal = null
   })
@@ -44,18 +44,21 @@ if (typeof localStorage !== 'undefined') {
 
 /**
  * Resolves when the one-time localStorage → IndexedDB migration finishes.
- * Exposed for tests; production code reads through `indexedDBStorage.getItem`
- * which already awaits this promise.
+ * Exposed for tests; production code reads through `indexedDBStorage`
+ * methods which already await this promise.
  */
 export const migrationReady: Promise<void> = migrationPromiseInternal ?? Promise.resolve()
 
+async function awaitMigration(): Promise<void> {
+  if (migrationPromiseInternal) {
+    await migrationPromiseInternal
+  }
+}
+
 export const indexedDBStorage: StateStorage = {
   getItem: async (name: string): Promise<string | null> => {
-    if (typeof localStorage === 'undefined') return null
-
-    if (migrationPromiseInternal) {
-      await migrationPromiseInternal
-    }
+    if (typeof window === 'undefined') return null
+    await awaitMigration()
 
     try {
       const value = await get<string>(name)
@@ -67,7 +70,9 @@ export const indexedDBStorage: StateStorage = {
   },
 
   setItem: async (name: string, value: string): Promise<void> => {
-    if (typeof localStorage === 'undefined') return
+    if (typeof window === 'undefined') return
+    await awaitMigration()
+
     try {
       await set(name, value)
     } catch (error) {
@@ -76,7 +81,9 @@ export const indexedDBStorage: StateStorage = {
   },
 
   removeItem: async (name: string): Promise<void> => {
-    if (typeof localStorage === 'undefined') return
+    if (typeof window === 'undefined') return
+    await awaitMigration()
+
     try {
       await del(name)
     } catch (error) {

--- a/apps/sim/stores/undo-redo/storage.ts
+++ b/apps/sim/stores/undo-redo/storage.ts
@@ -10,6 +10,14 @@ const MIGRATION_KEY = 'workflow-undo-redo-migrated'
 let migrationPromiseInternal: Promise<void> | null = null
 
 /**
+ * Resolves with the first `getItem` result that goes through the adapter.
+ * Used to gate writes until the initial rehydration read completes — without
+ * this, a `setItem` triggered before the async `getItem` returns would
+ * overwrite the IndexedDB snapshot with an empty in-memory state.
+ */
+let hydrationReadPromise: Promise<string | null> | null = null
+
+/**
  * Migrates existing undo/redo data from localStorage to IndexedDB.
  * Runs once on first load; subsequent loads short-circuit on MIGRATION_KEY.
  *
@@ -55,11 +63,23 @@ async function awaitMigration(): Promise<void> {
   }
 }
 
+async function awaitHydrationRead(): Promise<void> {
+  if (hydrationReadPromise) {
+    try {
+      await hydrationReadPromise
+    } catch {
+      // The read promise already swallowed its own errors; ignore here.
+    }
+  }
+}
+
 /**
  * Removes the persisted undo/redo payload from IndexedDB.
  *
  * Called from `clearUserData` on sign-out so undo history does not
- * survive across user sessions on the same device.
+ * survive across user sessions on the same device. Errors are
+ * propagated so callers can decide how to react (the default
+ * `clearUserData` already wraps this call in a try/catch).
  */
 export async function clearPersistedUndoRedo(): Promise<void> {
   if (typeof window === 'undefined') return
@@ -69,6 +89,7 @@ export async function clearPersistedUndoRedo(): Promise<void> {
     await del(STORE_KEY)
   } catch (error) {
     logger.warn('Failed to clear persisted undo-redo', { error })
+    throw error
   }
 }
 
@@ -77,18 +98,28 @@ export const indexedDBStorage: StateStorage = {
     if (typeof window === 'undefined') return null
     await awaitMigration()
 
-    try {
-      const value = await get<string>(name)
-      return value ?? null
-    } catch (error) {
-      logger.warn('IndexedDB read failed', { name, error })
-      return null
+    const readPromise = (async () => {
+      try {
+        const value = await get<string>(name)
+        return value ?? null
+      } catch (error) {
+        logger.warn('IndexedDB read failed', { name, error })
+        return null
+      }
+    })()
+
+    // Record the first read so concurrent writes can wait for it to complete.
+    if (!hydrationReadPromise) {
+      hydrationReadPromise = readPromise
     }
+
+    return await readPromise
   },
 
   setItem: async (name: string, value: string): Promise<void> => {
     if (typeof window === 'undefined') return
     await awaitMigration()
+    await awaitHydrationRead()
 
     try {
       await set(name, value)
@@ -100,6 +131,7 @@ export const indexedDBStorage: StateStorage = {
   removeItem: async (name: string): Promise<void> => {
     if (typeof window === 'undefined') return
     await awaitMigration()
+    await awaitHydrationRead()
 
     try {
       await del(name)

--- a/apps/sim/stores/undo-redo/storage.ts
+++ b/apps/sim/stores/undo-redo/storage.ts
@@ -55,6 +55,23 @@ async function awaitMigration(): Promise<void> {
   }
 }
 
+/**
+ * Removes the persisted undo/redo payload from IndexedDB.
+ *
+ * Called from `clearUserData` on sign-out so undo history does not
+ * survive across user sessions on the same device.
+ */
+export async function clearPersistedUndoRedo(): Promise<void> {
+  if (typeof window === 'undefined') return
+  await awaitMigration()
+
+  try {
+    await del(STORE_KEY)
+  } catch (error) {
+    logger.warn('Failed to clear persisted undo-redo', { error })
+  }
+}
+
 export const indexedDBStorage: StateStorage = {
   getItem: async (name: string): Promise<string | null> => {
     if (typeof window === 'undefined') return null

--- a/apps/sim/stores/undo-redo/store.ts
+++ b/apps/sim/stores/undo-redo/store.ts
@@ -3,6 +3,7 @@ import { UNDO_REDO_OPERATIONS } from '@sim/realtime-protocol/constants'
 import type { Edge } from 'reactflow'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
+import { indexedDBStorage } from '@/stores/undo-redo/storage'
 import type {
   BatchAddBlocksOperation,
   BatchAddEdgesOperation,
@@ -45,41 +46,6 @@ export async function runWithUndoRedoRecordingSuspended<T>(
 
 function getStackKey(workflowId: string, userId: string): string {
   return `${workflowId}:${userId}`
-}
-
-/**
- * Custom storage adapter for Zustand's persist middleware.
- * We need this wrapper to gracefully handle 'QuotaExceededError' when localStorage is full,
- * Without this, the default storage engine would throw and crash the application.
- * and to properly handle SSR/Node.js environments.
- */
-const safeStorageAdapter = {
-  getItem: (name: string): string | null => {
-    if (typeof localStorage === 'undefined') return null
-    try {
-      return localStorage.getItem(name)
-    } catch (e) {
-      logger.warn('Failed to read from localStorage', e)
-      return null
-    }
-  },
-  setItem: (name: string, value: string): void => {
-    if (typeof localStorage === 'undefined') return
-    try {
-      localStorage.setItem(name, value)
-    } catch (e) {
-      // Log warning but don't crash - this handles QuotaExceededError
-      logger.warn('Failed to save to localStorage', e)
-    }
-  },
-  removeItem: (name: string): void => {
-    if (typeof localStorage === 'undefined') return
-    try {
-      localStorage.removeItem(name)
-    } catch (e) {
-      logger.warn('Failed to remove from localStorage', e)
-    }
-  },
 }
 
 function isOperationApplicable(
@@ -501,7 +467,7 @@ export const useUndoRedoStore = create<UndoRedoState>()(
     }),
     {
       name: 'workflow-undo-redo',
-      storage: createJSONStorage(() => safeStorageAdapter),
+      storage: createJSONStorage(() => indexedDBStorage),
       partialize: (state) => ({
         stacks: state.stacks,
         capacity: state.capacity,


### PR DESCRIPTION
## Summary

Workflow undo/redo persistence currently lives in `localStorage` and stores operation snapshots that include full block state. Active editing of multiple workflows quickly fills the per-stack capacity with snapshots that can be several KB each, occupying the bulk of the origin's ~5 MB `localStorage` budget. Once the budget is exhausted, any other persisted Zustand store whose `setItem` is called next throws `QuotaExceededError`.

This PR moves `workflow-undo-redo` to IndexedDB using the same `idb-keyval` adapter pattern as `terminal-console-store` (#2812), aligning with the policy stated in #497 to minimize `localStorage` usage.

The earlier `safeStorageAdapter` (#2079) silently swallowed quota throws inside this store but did not free the origin budget that other small UI stores share, leaving them to throw uncaught `QuotaExceededError`. Migrating to IndexedDB removes the underlying contention.

## Changes

- New `apps/sim/stores/undo-redo/storage.ts` wrapping `idb-keyval`, mirroring `apps/sim/stores/terminal/console/storage.ts`. Includes a one-time `localStorage` → IndexedDB migration that copies any existing data and removes the legacy `localStorage` key on first module load.
- New `apps/sim/stores/undo-redo/storage.test.ts` covering migration idempotency, graceful failure on IndexedDB errors, and basic get/set/remove behavior (10 cases).
- `apps/sim/stores/undo-redo/store.ts`: drop the inline `safeStorageAdapter` and use the new `indexedDBStorage`.

Structured as two commits — first commit adds the adapter with no behavioral change, second commit swaps the store's persist middleware.

## Verification

Detailed reproduction steps are in #4737. Local verification:

1. Reproduce the cap-reached state on a workflow editor session (see #4737 step list).
2. Trigger any `setItem` on another small store (e.g., dismiss a notification) — `QuotaExceededError` thrown.
3. Apply this change and reload the editor — migration runs once, copying the existing `workflow-undo-redo` payload to IndexedDB and removing the `localStorage` key.
4. Retry the trigger from step 2 — no throw.

Fixes #4737