### PR TITLE
fix(files): zoom file viewer content, not the browser page

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -1071,15 +1071,20 @@ const HtmlPreview = memo(function HtmlPreview({ content }: { content: string }) 
 })
 
 function SvgPreview({ content }: { content: string }) {
-  const wrappedContent = `<!DOCTYPE html><html><head><style>body{margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;background:transparent;}svg{max-width:100%;max-height:100vh;}</style></head><body>${content}</body></html>`
+  const blobUrl = useMemo(
+    () => URL.createObjectURL(new Blob([content], { type: 'image/svg+xml' })),
+    [content]
+  )
+
+  useEffect(() => () => URL.revokeObjectURL(blobUrl), [blobUrl])
 
   return (
     <ZoomablePreview className='h-full' contentClassName='h-full w-full'>
-      <iframe
-        srcDoc={wrappedContent}
-        sandbox=''
-        title='SVG Preview'
-        className='h-full w-full border-0'
+      <img
+        src={blobUrl}
+        alt='SVG preview'
+        className='max-h-full max-w-full select-none object-contain'
+        draggable={false}
       />
     </ZoomablePreview>
   )

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -1071,12 +1071,13 @@ const HtmlPreview = memo(function HtmlPreview({ content }: { content: string }) 
 })
 
 function SvgPreview({ content }: { content: string }) {
-  const blobUrl = useMemo(
-    () => URL.createObjectURL(new Blob([content], { type: 'image/svg+xml' })),
-    [content]
-  )
+  const [blobUrl, setBlobUrl] = useState('')
 
-  useEffect(() => () => URL.revokeObjectURL(blobUrl), [blobUrl])
+  useEffect(() => {
+    const url = URL.createObjectURL(new Blob([content], { type: 'image/svg+xml' }))
+    setBlobUrl(url)
+    return () => URL.revokeObjectURL(url)
+  }, [content])
 
   return (
     <ZoomablePreview className='h-full' contentClassName='h-full w-full'>

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.ts
@@ -1,14 +1,36 @@
+interface BindPreviewWheelZoomOptions {
+  /**
+   * Called for non-modifier wheel events (two-finger scroll). When provided,
+   * the container's native scrolling is suppressed and the consumer drives
+   * pan via `deltaX` / `deltaY`. Use for transform-based viewers (e.g. image)
+   * where the content is not a real scroll container.
+   */
+  onPan?: (event: WheelEvent) => void
+}
+
 /**
- * Bind browser pinch/ctrl-wheel zoom and horizontal wheel gestures for preview scroll containers.
+ * Bind browser pinch/ctrl-wheel zoom and horizontal wheel gestures for preview
+ * scroll containers. Trackpad pinch fires `wheel` with `ctrlKey=true`; without
+ * a non-passive native listener the browser falls back to page zoom. `metaKey`
+ * is also accepted so Cmd+scroll zooms on macOS, matching Figma/tldraw/Excalidraw.
  */
 export function bindPreviewWheelZoom(
   container: HTMLElement,
-  onZoom: (event: WheelEvent) => void
+  onZoom: (event: WheelEvent) => void,
+  options: BindPreviewWheelZoomOptions = {}
 ): () => void {
+  const { onPan } = options
+
   const onWheel = (event: WheelEvent) => {
-    if (event.ctrlKey) {
+    if (event.ctrlKey || event.metaKey) {
       event.preventDefault()
       onZoom(event)
+      return
+    }
+
+    if (onPan) {
+      event.preventDefault()
+      onPan(event)
       return
     }
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/zoomable-preview.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/zoomable-preview.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import type { MouseEvent, ReactNode, WheelEvent } from 'react'
-import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/core/utils/cn'
 import { PreviewToolbar } from './preview-toolbar'
+import { bindPreviewWheelZoom } from './preview-wheel-zoom'
 
 const ZOOM_MIN = 0.25
 const ZOOM_MAX = 4
@@ -133,31 +134,39 @@ export function ZoomablePreview({
     applyZoom(clampZoom(zoom / ZOOM_BUTTON_FACTOR))
   }
 
-  const handleWheel = (e: WheelEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    if (e.ctrlKey || e.metaKey) {
-      hasInteractedRef.current = true
-      const rect = e.currentTarget.getBoundingClientRect()
-      applyZoom(
-        clampZoom(zoomRef.current * Math.exp(-e.deltaY * ZOOM_WHEEL_SENSITIVITY)),
-        e.clientX - rect.left,
-        e.clientY - rect.top
-      )
-    } else {
-      hasInteractedRef.current = true
-      setOffset((currentOffset) =>
-        clampOffset(
-          containerSizeRef.current,
-          contentSizeRef.current,
-          {
-            x: currentOffset.x - e.deltaX,
-            y: currentOffset.y - e.deltaY,
-          },
-          zoomRef.current
+  useEffect(() => {
+    const viewport = viewportRef.current
+    if (!viewport) return
+
+    return bindPreviewWheelZoom(
+      viewport,
+      (event) => {
+        hasInteractedRef.current = true
+        const rect = viewport.getBoundingClientRect()
+        applyZoom(
+          clampZoom(zoomRef.current * Math.exp(-event.deltaY * ZOOM_WHEEL_SENSITIVITY)),
+          event.clientX - rect.left,
+          event.clientY - rect.top
         )
-      )
-    }
-  }
+      },
+      {
+        onPan: (event) => {
+          hasInteractedRef.current = true
+          setOffset((currentOffset) =>
+            clampOffset(
+              containerSizeRef.current,
+              contentSizeRef.current,
+              {
+                x: currentOffset.x - event.deltaX,
+                y: currentOffset.y - event.deltaY,
+              },
+              zoomRef.current
+            )
+          )
+        },
+      }
+    )
+  }, [applyZoom])
 
   useLayoutEffect(() => {
     const updateSizes = () => {
@@ -257,7 +266,6 @@ export function ZoomablePreview({
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseUp}
-        onWheel={handleWheel}
       >
         <div className='pointer-events-none absolute inset-0 flex items-center justify-center'>
           <div


### PR DESCRIPTION
## Summary
- Switch image, SVG, mermaid, and inline-markdown-image previews to a native non-passive wheel listener so trackpad pinch zooms the content instead of the browser page.
- Accept `metaKey` alongside `ctrlKey` so Cmd+scroll on macOS zooms (matches Figma/tldraw/Excalidraw convention); this benefits all viewers using `bindPreviewWheelZoom` including PDF, DOCX, and PPTX.
- Render SVG file previews via `<img src={blobUrl}>` (browser-enforced secure static mode) instead of a sandboxed iframe — same security posture, and pinch events now reach the zoom container instead of being trapped in the iframe.

## Type of Change
- [x] Bug fix

## Testing
Tested manually — trackpad pinch on images, SVG files, PDFs, DOCX, and PPTX now zooms the file content. Cmd+scroll on Mac also zooms. Two-finger pan and toolbar buttons work as before.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)