### PR TITLE
fix(rate-limiter): hosted-key queue follow-up fixes

### DIFF
--- a/apps/sim/background/workflow-column-execution.ts
+++ b/apps/sim/background/workflow-column-execution.ts
@@ -70,6 +70,10 @@ export async function executeWorkflowGroupCellJob(
       ...currentPayload,
       groupId: next.id,
       workflowId: next.workflowId,
+      // Re-derive from the target group rather than inheriting the prior group's
+      // value via the spread: a workflow group following an enrichment group would
+      // otherwise carry a stale enrichmentId.
+      enrichmentId: next.enrichmentId,
       executionId: generateId(),
     }
   }

--- a/apps/sim/background/workflow-column-execution.ts
+++ b/apps/sim/background/workflow-column-execution.ts
@@ -70,9 +70,7 @@ export async function executeWorkflowGroupCellJob(
       ...currentPayload,
       groupId: next.id,
       workflowId: next.workflowId,
-      // Re-derive from the target group rather than inheriting the prior group's
-      // value via the spread: a workflow group following an enrichment group would
-      // otherwise carry a stale enrichmentId.
+      // Re-derive so a workflow group after an enrichment group doesn't keep a stale enrichmentId.
       enrichmentId: next.enrichmentId,
       executionId: generateId(),
     }

--- a/apps/sim/lib/core/rate-limiter/hosted-key/hosted-key-rate-limiter.ts
+++ b/apps/sim/lib/core/rate-limiter/hosted-key/hosted-key-rate-limiter.ts
@@ -65,6 +65,7 @@ function interruptibleSleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise<void>((resolve) => {
     const onAbort = () => {
       clearTimeout(timer)
+      signal.removeEventListener('abort', onAbort)
       resolve()
     }
     const timer = setTimeout(() => {
@@ -72,6 +73,10 @@ function interruptibleSleep(ms: number, signal?: AbortSignal): Promise<void> {
       resolve()
     }, ms)
     signal.addEventListener('abort', onAbort, { once: true })
+    // Re-check after registering: if the signal fired between the guard above and
+    // addEventListener, the 'abort' event already dispatched and our listener would
+    // never run, leaving the sleep to run its full duration. onAbort is idempotent.
+    if (signal.aborted) onAbort()
   })
 }
 

--- a/apps/sim/lib/core/rate-limiter/hosted-key/hosted-key-rate-limiter.ts
+++ b/apps/sim/lib/core/rate-limiter/hosted-key/hosted-key-rate-limiter.ts
@@ -73,9 +73,7 @@ function interruptibleSleep(ms: number, signal?: AbortSignal): Promise<void> {
       resolve()
     }, ms)
     signal.addEventListener('abort', onAbort, { once: true })
-    // Re-check after registering: if the signal fired between the guard above and
-    // addEventListener, the 'abort' event already dispatched and our listener would
-    // never run, leaving the sleep to run its full duration. onAbort is idempotent.
+    // Catch an abort that fired between the guard above and addEventListener.
     if (signal.aborted) onAbort()
   })
 }

--- a/apps/sim/lib/core/rate-limiter/hosted-key/queue.test.ts
+++ b/apps/sim/lib/core/rate-limiter/hosted-key/queue.test.ts
@@ -170,24 +170,32 @@ describe('HostedKeyQueue', () => {
   })
 
   describe('refreshHeartbeat', () => {
-    it('writes the heartbeat key with TTL', async () => {
-      mockRedis.set.mockResolvedValueOnce('OK')
+    it('writes the heartbeat key with TTL and re-extends the queue list TTL', async () => {
+      mockRedis.pipeline.exec.mockResolvedValueOnce([
+        [null, 'OK'],
+        [null, 1],
+      ])
 
       await queue.refreshHeartbeat(provider, workspaceId, ticketId)
 
-      expect(mockRedis.set).toHaveBeenCalledWith(
+      expect(mockRedis.pipeline.set).toHaveBeenCalledWith(
         'hosted-queue-tkt:exa:workspace-1:ticket-1',
         '1',
         'EX',
         expect.any(Number)
       )
+      expect(mockRedis.pipeline.expire).toHaveBeenCalledWith(
+        'hosted-queue:exa:workspace-1',
+        expect.any(Number)
+      )
+      expect(mockRedis.pipeline.exec).toHaveBeenCalledTimes(1)
     })
 
     it('is a no-op when Redis is unavailable', async () => {
       redisConfigMockFns.mockGetRedisClient.mockReturnValueOnce(null)
 
       await expect(queue.refreshHeartbeat(provider, workspaceId, ticketId)).resolves.toBeUndefined()
-      expect(mockRedis.set).not.toHaveBeenCalled()
+      expect(mockRedis.multi).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/sim/lib/core/rate-limiter/hosted-key/queue.ts
+++ b/apps/sim/lib/core/rate-limiter/hosted-key/queue.ts
@@ -15,11 +15,9 @@ const TICKET_HEARTBEAT_TTL_SECONDS = 30
 export const HEARTBEAT_REFRESH_INTERVAL_MS = 10_000
 
 /**
- * TTL on the queue list itself. Set on every enqueue and re-extended by the head's
- * heartbeat while it actively waits, so a long-waiting head (whose budget can exceed
- * this TTL for enterprise async runs) never lets the list expire out from under the
- * waiters behind it. Prevents abandoned queues (whole workspace went silent) from
- * sticking around forever in Redis.
+ * TTL on the queue list itself. Set on enqueue and re-extended by the head's heartbeat,
+ * so a long-waiting head can't let the list expire out from under the waiters behind it.
+ * Prevents abandoned queues from sticking around forever in Redis.
  */
 const QUEUE_LIST_TTL_SECONDS = 600
 
@@ -150,12 +148,9 @@ export class HostedKeyQueue {
   }
 
   /**
-   * Refresh the ticket's heartbeat. Called periodically by the head while it's
-   * waiting on the bucket so it doesn't get reaped as dead. Also re-extends the
-   * queue list TTL: a head whose wait outlives {@link QUEUE_LIST_TTL_SECONDS}
-   * (possible for long enterprise async budgets) would otherwise let the list
-   * expire with no new enqueue to refresh it, dropping every waiter to "missing"
-   * and collapsing FIFO ordering into concurrent bucket racing.
+   * Refresh the ticket's heartbeat so the head isn't reaped as dead while waiting on the
+   * bucket. Also re-extends the queue list TTL so a wait outliving {@link QUEUE_LIST_TTL_SECONDS}
+   * doesn't let the list expire and collapse FIFO ordering.
    */
   async refreshHeartbeat(
     provider: string,

--- a/apps/sim/lib/core/rate-limiter/hosted-key/queue.ts
+++ b/apps/sim/lib/core/rate-limiter/hosted-key/queue.ts
@@ -15,8 +15,11 @@ const TICKET_HEARTBEAT_TTL_SECONDS = 30
 export const HEARTBEAT_REFRESH_INTERVAL_MS = 10_000
 
 /**
- * TTL on the queue list itself. Set on every enqueue. Prevents abandoned queues
- * (whole workspace went silent) from sticking around forever in Redis.
+ * TTL on the queue list itself. Set on every enqueue and re-extended by the head's
+ * heartbeat while it actively waits, so a long-waiting head (whose budget can exceed
+ * this TTL for enterprise async runs) never lets the list expire out from under the
+ * waiters behind it. Prevents abandoned queues (whole workspace went silent) from
+ * sticking around forever in Redis.
  */
 const QUEUE_LIST_TTL_SECONDS = 600
 
@@ -148,7 +151,11 @@ export class HostedKeyQueue {
 
   /**
    * Refresh the ticket's heartbeat. Called periodically by the head while it's
-   * waiting on the bucket so it doesn't get reaped as dead.
+   * waiting on the bucket so it doesn't get reaped as dead. Also re-extends the
+   * queue list TTL: a head whose wait outlives {@link QUEUE_LIST_TTL_SECONDS}
+   * (possible for long enterprise async budgets) would otherwise let the list
+   * expire with no new enqueue to refresh it, dropping every waiter to "missing"
+   * and collapsing FIFO ordering into concurrent bucket racing.
    */
   async refreshHeartbeat(
     provider: string,
@@ -158,9 +165,13 @@ export class HostedKeyQueue {
     const redis = getRedisClient()
     if (!redis) return
 
+    const listKey = queueListKey(provider, billingActorId)
     const hbKey = heartbeatKey(provider, billingActorId, ticketId)
     try {
-      await redis.set(hbKey, '1', 'EX', TICKET_HEARTBEAT_TTL_SECONDS)
+      const pipeline = redis.multi()
+      pipeline.set(hbKey, '1', 'EX', TICKET_HEARTBEAT_TTL_SECONDS)
+      pipeline.expire(listKey, QUEUE_LIST_TTL_SECONDS)
+      await pipeline.exec()
     } catch (error) {
       logger.warn(`Queue heartbeat refresh failed for ${hbKey}`, {
         error: toError(error).message,


### PR DESCRIPTION
## Summary
- Re-extend the hosted-key queue-list TTL on each head heartbeat, so a head waiting longer than the 600s list TTL (possible for long enterprise async budgets) can't let the list expire and drop every waiter to "missing", collapsing FIFO into concurrent bucket racing
- Close a TOCTOU window in `interruptibleSleep`: re-check `signal.aborted` after registering the listener so an abort firing in the gap still resolves immediately instead of sleeping the full duration
- Forward `enrichmentId: next.enrichmentId` explicitly when re-driving a workflow group, instead of inheriting a stale value from the prior group via the payload spread

Follow-up to the Greptile review findings on #4756. The Bugbot `cell-render.tsx` comment was intentionally skipped (dismissed as "feature isn't live yet").

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run lint` clean, `bun run check:api-validation:strict` passed, hosted-key tests (43) and workflow-columns tests (5) green.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)