### PR TITLE
feat(providers): add Claude Opus 4.8 model

### DIFF
--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -103,7 +103,7 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 /**
  * Builds the thinking configuration for the Anthropic API based on model capabilities and level.
  *
- * - Opus 4.7: Uses adaptive thinking only (no extended thinking support)
+ * - Opus 4.8, Opus 4.7: Uses adaptive thinking only (no extended thinking support)
  * - Opus 4.6, Sonnet 4.6: Uses adaptive thinking with effort parameter
  * - Other models: Uses budget_tokens-based extended thinking
  *

--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -82,13 +82,15 @@ const THINKING_BUDGET_TOKENS: Record<string, number> = {
 
 /**
  * Checks if a model supports adaptive thinking (thinking.type: "adaptive").
- * Opus 4.7 supports ONLY adaptive thinking (no extended thinking / budget_tokens).
+ * Opus 4.8 and Opus 4.7 support ONLY adaptive thinking (no extended thinking / budget_tokens).
  * Opus 4.6 and Sonnet 4.6 support both extended and adaptive thinking — use adaptive.
  * Opus 4.5 supports effort but NOT adaptive thinking — it uses budget_tokens with type: "enabled".
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
   const normalizedModel = modelId.toLowerCase()
   return (
+    normalizedModel.includes('opus-4-8') ||
+    normalizedModel.includes('opus-4.8') ||
     normalizedModel.includes('opus-4-7') ||
     normalizedModel.includes('opus-4.7') ||
     normalizedModel.includes('opus-4-6') ||

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -583,6 +583,26 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     },
     models: [
       {
+        id: 'claude-opus-4-8',
+        pricing: {
+          input: 5.0,
+          cachedInput: 0.5,
+          output: 25.0,
+          updatedAt: '2026-05-28',
+        },
+        capabilities: {
+          nativeStructuredOutputs: true,
+          maxOutputTokens: 128000,
+          thinking: {
+            levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+            default: 'high',
+          },
+        },
+        contextWindow: 1000000,
+        releaseDate: '2026-05-27',
+        recommended: true,
+      },
+      {
         id: 'claude-opus-4-7',
         pricing: {
           input: 5.0,
@@ -600,7 +620,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1000000,
         releaseDate: '2026-04-16',
-        recommended: true,
       },
       {
         id: 'claude-opus-4-6',


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-8` to Anthropic provider models with $5/$0.50/$25 pricing, 1M context, 128k max output, adaptive thinking (effort: low/medium/high/xhigh/max, default `high`), and `nativeStructuredOutputs`
- Swap `recommended: true` from Opus 4.7 to Opus 4.8 (new flagship per Anthropic docs)
- Extend `supportsAdaptiveThinking()` in `anthropic/core.ts` to match `opus-4-8` — without this the request would route to `budget_tokens`, which the Opus 4.8 API rejects with a 400

## Type of Change
- [x] New feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)