### PR TITLE
improvement(integrations): tighten resend, azure_devops icon, loops trim

### DIFF
--- a/apps/sim/blocks/blocks/azure_devops.ts
+++ b/apps/sim/blocks/blocks/azure_devops.ts
@@ -1,4 +1,4 @@
-import { AzureDevOpsIcon } from '@/components/icons'
+import { AzureIcon } from '@/components/icons'
 import type { BlockConfig } from '@/blocks/types'
 import { AuthMode, IntegrationType } from '@/blocks/types'
 import type { AzureDevOpsBasicWorkItemType, AzureDevOpsResponse } from '@/tools/azure_devops/types'
@@ -23,7 +23,7 @@ export const AzureDevOpsBlock: BlockConfig<AzureDevOpsResponse> = {
   integrationType: IntegrationType.DeveloperTools,
   tags: ['ci-cd', 'project-management', 'version-control'],
   bgColor: '#0078D4',
-  icon: AzureDevOpsIcon,
+  icon: AzureIcon,
   authMode: AuthMode.ApiKey,
   triggerAllowed: true,
 

--- a/apps/sim/blocks/blocks/resend.ts
+++ b/apps/sim/blocks/blocks/resend.ts
@@ -221,7 +221,7 @@ Return ONLY the email body - no explanations, no extra text.`,
       title: 'Unsubscribed',
       type: 'dropdown',
       options: [
-        { label: "Don't Change", id: '' },
+        { label: 'Use Default', id: '' },
         { label: 'No', id: 'false' },
         { label: 'Yes', id: 'true' },
       ],

--- a/apps/sim/blocks/blocks/resend.ts
+++ b/apps/sim/blocks/blocks/resend.ts
@@ -221,10 +221,11 @@ Return ONLY the email body - no explanations, no extra text.`,
       title: 'Unsubscribed',
       type: 'dropdown',
       options: [
+        { label: "Don't Change", id: '' },
         { label: 'No', id: 'false' },
         { label: 'Yes', id: 'true' },
       ],
-      value: () => 'false',
+      value: () => '',
       condition: { field: 'operation', value: ['create_contact', 'update_contact'] },
     },
 
@@ -267,7 +268,9 @@ Return ONLY the email body - no explanations, no extra text.`,
       params: (params) => {
         const { operation, ...rest } = params
 
-        if (rest.unsubscribed !== undefined) {
+        if (rest.unsubscribed === undefined || rest.unsubscribed === '') {
+          rest.unsubscribed = undefined
+        } else {
           rest.unsubscribed = rest.unsubscribed === 'true'
         }
 

--- a/apps/sim/tools/loops/send_event.ts
+++ b/apps/sim/tools/loops/send_event.ts
@@ -61,7 +61,7 @@ export const loopsSendEventTool: ToolConfig<LoopsSendEventParams, LoopsSendEvent
       }
 
       const body: Record<string, unknown> = {
-        eventName: params.eventName,
+        eventName: params.eventName.trim(),
       }
 
       if (params.email) body.email = params.email.trim()

--- a/apps/sim/tools/resend/get_email.ts
+++ b/apps/sim/tools/resend/get_email.ts
@@ -83,16 +83,42 @@ export const resendGetEmailTool: ToolConfig<GetEmailParams, GetEmailResult> = {
   outputs: {
     id: { type: 'string', description: 'Email ID' },
     from: { type: 'string', description: 'Sender email address' },
-    to: { type: 'json', description: 'Recipient email addresses' },
+    to: {
+      type: 'array',
+      description: 'Recipient email addresses',
+      items: { type: 'string', description: 'Recipient email address' },
+    },
     subject: { type: 'string', description: 'Email subject' },
     html: { type: 'string', description: 'HTML email content' },
     text: { type: 'string', description: 'Plain text email content', optional: true },
-    cc: { type: 'json', description: 'CC email addresses' },
-    bcc: { type: 'json', description: 'BCC email addresses' },
-    replyTo: { type: 'json', description: 'Reply-to email addresses' },
+    cc: {
+      type: 'array',
+      description: 'CC email addresses',
+      items: { type: 'string', description: 'CC email address' },
+    },
+    bcc: {
+      type: 'array',
+      description: 'BCC email addresses',
+      items: { type: 'string', description: 'BCC email address' },
+    },
+    replyTo: {
+      type: 'array',
+      description: 'Reply-to email addresses',
+      items: { type: 'string', description: 'Reply-to email address' },
+    },
     lastEvent: { type: 'string', description: 'Last event status (e.g., delivered, bounced)' },
     createdAt: { type: 'string', description: 'Email creation timestamp' },
     scheduledAt: { type: 'string', description: 'Scheduled send timestamp', optional: true },
-    tags: { type: 'json', description: 'Email tags as name-value pairs' },
+    tags: {
+      type: 'array',
+      description: 'Email tags as name-value pairs',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'Tag name' },
+          value: { type: 'string', description: 'Tag value' },
+        },
+      },
+    },
   },
 }

--- a/apps/sim/tools/resend/list_contacts.ts
+++ b/apps/sim/tools/resend/list_contacts.ts
@@ -54,9 +54,19 @@ export const resendListContactsTool: ToolConfig<ListContactsParams, ListContacts
 
   outputs: {
     contacts: {
-      type: 'json',
-      description:
-        'Array of contacts with id, email, first_name, last_name, created_at, unsubscribed',
+      type: 'array',
+      description: 'Array of contacts',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Contact ID' },
+          email: { type: 'string', description: 'Contact email address' },
+          first_name: { type: 'string', description: 'Contact first name' },
+          last_name: { type: 'string', description: 'Contact last name' },
+          created_at: { type: 'string', description: 'Contact creation timestamp' },
+          unsubscribed: { type: 'boolean', description: 'Whether the contact is unsubscribed' },
+        },
+      },
     },
     hasMore: { type: 'boolean', description: 'Whether there are more contacts to retrieve' },
   },

--- a/apps/sim/tools/resend/list_domains.ts
+++ b/apps/sim/tools/resend/list_domains.ts
@@ -68,8 +68,18 @@ export const resendListDomainsTool: ToolConfig<ListDomainsParams, ListDomainsRes
 
   outputs: {
     domains: {
-      type: 'json',
-      description: 'Array of domains with id, name, status, region, and createdAt',
+      type: 'array',
+      description: 'Array of domains',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Domain ID' },
+          name: { type: 'string', description: 'Domain name' },
+          status: { type: 'string', description: 'Domain verification status' },
+          region: { type: 'string', description: 'Region the domain is configured in' },
+          createdAt: { type: 'string', description: 'Domain creation timestamp' },
+        },
+      },
     },
     hasMore: { type: 'boolean', description: 'Whether there are more domains to retrieve' },
   },

--- a/apps/sim/tools/resend/send.ts
+++ b/apps/sim/tools/resend/send.ts
@@ -103,13 +103,11 @@ export const resendSendTool: ToolConfig<MailSendParams, MailSendResult> = {
 
   transformResponse: async (response: Response, params): Promise<MailSendResult> => {
     const result = await response.json()
-    const sent = result.success === true
 
     return {
-      success: sent,
-      ...(sent ? {} : { error: result.message || 'Failed to send email' }),
+      success: true,
       output: {
-        success: sent,
+        success: true,
         id: result.data?.id || '',
         to: params?.to || '',
         subject: params?.subject || '',

--- a/apps/sim/tools/resend/send.ts
+++ b/apps/sim/tools/resend/send.ts
@@ -103,11 +103,13 @@ export const resendSendTool: ToolConfig<MailSendParams, MailSendResult> = {
 
   transformResponse: async (response: Response, params): Promise<MailSendResult> => {
     const result = await response.json()
+    const sent = result.success === true
 
     return {
-      success: true,
+      success: sent,
+      ...(sent ? {} : { error: result.message || 'Failed to send email' }),
       output: {
-        success: result.success,
+        success: sent,
         id: result.data?.id || '',
         to: params?.to || '',
         subject: params?.subject || '',


### PR DESCRIPTION
## Summary
- audit Resend integration against live API docs: propagate send errors, type list/get_email/list_domains outputs with items shape, make unsubscribed dropdown default to "Don't Change" so updates don't silently reset subscription state
- azure_devops: use AzureIcon (AzureDevOpsIcon no longer exported)
- loops: trim eventName on send

## Type of Change
- [x] Improvement

## Testing
Tested manually. TypeScript compiles clean across all touched files.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)