### PR TITLE
improvement(auth): suffix-match BLOCKED_SIGNUP_DOMAINS to catch subdomain rotation

### DIFF
--- a/apps/sim/lib/auth/auth.test.ts
+++ b/apps/sim/lib/auth/auth.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { isEmailInDenylist } from '@/lib/auth/auth'
+
+describe('isEmailInDenylist', () => {
+  it('returns false when denylist is null, empty, or email is missing', () => {
+    expect(isEmailInDenylist('a@example.com', null)).toBe(false)
+    expect(isEmailInDenylist('a@example.com', [])).toBe(false)
+    expect(isEmailInDenylist(null, ['example.com'])).toBe(false)
+    expect(isEmailInDenylist(undefined, ['example.com'])).toBe(false)
+    expect(isEmailInDenylist('', ['example.com'])).toBe(false)
+  })
+
+  it('returns false when email has no @', () => {
+    expect(isEmailInDenylist('not-an-email', ['example.com'])).toBe(false)
+  })
+
+  it('matches exact domain', () => {
+    expect(isEmailInDenylist('user@dpdns.org', ['dpdns.org'])).toBe(true)
+    expect(isEmailInDenylist('user@DPDNS.ORG', ['dpdns.org'])).toBe(true)
+  })
+
+  it('matches arbitrary-depth subdomains of a listed parent zone', () => {
+    expect(isEmailInDenylist('user@xx.lucky04.dpdns.org', ['dpdns.org'])).toBe(true)
+    expect(isEmailInDenylist('user@a.b.c.qzz.io', ['qzz.io'])).toBe(true)
+  })
+
+  it('does not match look-alike domains', () => {
+    expect(isEmailInDenylist('user@xdpdns.org', ['dpdns.org'])).toBe(false)
+    expect(isEmailInDenylist('user@notdpdns.org', ['dpdns.org'])).toBe(false)
+  })
+
+  it('does not match disallowed domains', () => {
+    expect(isEmailInDenylist('user@gmail.com', ['dpdns.org', 'qzz.io'])).toBe(false)
+    expect(isEmailInDenylist('user@example.com', ['dpdns.org'])).toBe(false)
+  })
+
+  it('handles multiple denylist entries', () => {
+    const denylist = ['dpdns.org', 'qzz.io', 'cc.cd']
+    expect(isEmailInDenylist('user@foo.dpdns.org', denylist)).toBe(true)
+    expect(isEmailInDenylist('user@bar.qzz.io', denylist)).toBe(true)
+    expect(isEmailInDenylist('user@baz.cc.cd', denylist)).toBe(true)
+    expect(isEmailInDenylist('user@example.com', denylist)).toBe(false)
+  })
+})

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -143,8 +143,17 @@ function getMicrosoftUserInfoFromIdToken(tokens: { accessToken?: string }, provi
 }
 
 const blockedSignupDomains = env.BLOCKED_SIGNUP_DOMAINS
-  ? new Set(env.BLOCKED_SIGNUP_DOMAINS.split(',').map((d) => d.trim().toLowerCase()))
+  ? env.BLOCKED_SIGNUP_DOMAINS.split(',')
+      .map((d) => d.trim().toLowerCase())
+      .filter(Boolean)
   : null
+
+function isSignupEmailBlocked(email: string | undefined | null): boolean {
+  if (!blockedSignupDomains || !email) return false
+  const domain = email.split('@')[1]?.toLowerCase()
+  if (!domain) return false
+  return blockedSignupDomains.some((entry) => domain === entry || domain.endsWith(`.${entry}`))
+}
 
 const additionalTrustedOrigins = parseOriginList(env.TRUSTED_ORIGINS, (value) =>
   logger.warn('Ignoring invalid entry in TRUSTED_ORIGINS', { value })
@@ -219,11 +228,8 @@ export const auth = betterAuth({
     user: {
       create: {
         before: async (user) => {
-          if (blockedSignupDomains) {
-            const emailDomain = user.email?.split('@')[1]?.toLowerCase()
-            if (emailDomain && blockedSignupDomains.has(emailDomain)) {
-              throw new Error('Sign-ups from this email domain are not allowed.')
-            }
+          if (isSignupEmailBlocked(user.email)) {
+            throw new Error('Sign-ups from this email domain are not allowed.')
           }
           return { data: user }
         },
@@ -814,14 +820,8 @@ export const auth = betterAuth({
         }
       }
 
-      if (ctx.path.startsWith('/sign-up') && blockedSignupDomains) {
-        const requestEmail = ctx.body?.email?.toLowerCase()
-        if (requestEmail) {
-          const emailDomain = requestEmail.split('@')[1]
-          if (emailDomain && blockedSignupDomains.has(emailDomain)) {
-            throw new Error('Sign-ups from this email domain are not allowed.')
-          }
-        }
+      if (ctx.path.startsWith('/sign-up') && isSignupEmailBlocked(ctx.body?.email)) {
+        throw new Error('Sign-ups from this email domain are not allowed.')
       }
 
       if (ctx.path === '/oauth2/authorize' || ctx.path === '/oauth2/token') {

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -143,16 +143,27 @@ function getMicrosoftUserInfoFromIdToken(tokens: { accessToken?: string }, provi
 }
 
 const blockedSignupDomains = env.BLOCKED_SIGNUP_DOMAINS
-  ? env.BLOCKED_SIGNUP_DOMAINS.split(',')
-      .map((d) => d.trim().toLowerCase())
-      .filter(Boolean)
+  ? Array.from(
+      new Set(
+        env.BLOCKED_SIGNUP_DOMAINS.split(',')
+          .map((d) => d.trim().toLowerCase())
+          .filter(Boolean)
+      )
+    )
   : null
 
-function isSignupEmailBlocked(email: string | undefined | null): boolean {
-  if (!blockedSignupDomains || !email) return false
+export function isEmailInDenylist(
+  email: string | undefined | null,
+  denylist: readonly string[] | null
+): boolean {
+  if (!denylist || denylist.length === 0 || !email) return false
   const domain = email.split('@')[1]?.toLowerCase()
   if (!domain) return false
-  return blockedSignupDomains.some((entry) => domain === entry || domain.endsWith(`.${entry}`))
+  return denylist.some((entry) => domain === entry || domain.endsWith(`.${entry}`))
+}
+
+function isSignupEmailBlocked(email: string | undefined | null): boolean {
+  return isEmailInDenylist(email, blockedSignupDomains)
 }
 
 const additionalTrustedOrigins = parseOriginList(env.TRUSTED_ORIGINS, (value) =>


### PR DESCRIPTION
## Summary
- Switch BLOCKED_SIGNUP_DOMAINS matching from exact `Set.has()` to suffix-aware: an entry of `dpdns.org` now blocks `dpdns.org` and any `*.dpdns.org`.
- Replaces inline domain extraction at both call sites (`databaseHooks.user.create.before` and the `/sign-up` request hook) with a single `isSignupEmailBlocked()` helper.

## Type of Change
- [x] Improvement

## Testing
Tested manually — `isSignupEmailBlocked('a@dpdns.org')`, `isSignupEmailBlocked('a@xx.lucky04.dpdns.org')`, and `isSignupEmailBlocked('a@example.com')` behave as expected against a denylist of `[dpdns.org]`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)