### PR TITLE
improvement(logs): raise execution log size limits to 3MB / 512KB

### DIFF
--- a/apps/sim/lib/logs/execution/logger.test.ts
+++ b/apps/sim/lib/logs/execution/logger.test.ts
@@ -171,7 +171,7 @@ describe('ExecutionLogger', () => {
 
     test('summarizes oversized execution data before storage', () => {
       const loggerInstance = new ExecutionLogger() as any
-      const largePayload = 'x'.repeat(220_000)
+      const largePayload = 'x'.repeat(1_100_000)
       const executionState = {
         blockStates: {
           blockA: {
@@ -242,7 +242,7 @@ describe('ExecutionLogger', () => {
       )
       const storedBytes = Buffer.byteLength(JSON.stringify(compacted), 'utf8')
 
-      expect(storedBytes).toBeLessThanOrEqual(500 * 1024)
+      expect(storedBytes).toBeLessThanOrEqual(3 * 1024 * 1024)
       expect(compacted.executionDataTruncated).toBe(true)
       expect(compacted.executionState).toBeUndefined()
       expect(compacted.executionStateSummary).toEqual({

--- a/apps/sim/lib/logs/execution/logger.ts
+++ b/apps/sim/lib/logs/execution/logger.ts
@@ -53,9 +53,9 @@ const TRIGGER_COUNTER_MAP: Record<string, { key: string; column: string }> = {
 } as const
 
 const logger = createLogger('ExecutionLogger')
-const MAX_EXECUTION_DATA_BYTES = 500 * 1024
+const MAX_EXECUTION_DATA_BYTES = 3 * 1024 * 1024
 const MAX_TRACE_IO_BYTES = 8 * 1024
-const MAX_WORKFLOW_VALUE_BYTES = 64 * 1024
+const MAX_WORKFLOW_VALUE_BYTES = 512 * 1024
 const EXECUTION_LOG_STATEMENT_TIMEOUT_MS = 30_000
 const EXECUTION_LOG_LOCK_TIMEOUT_MS = 3_000
 const EXECUTION_LOG_IDLE_TIMEOUT_MS = 5_000


### PR DESCRIPTION
## Summary
- Bump `MAX_EXECUTION_DATA_BYTES` 500KB → 3MB
- Bump `MAX_WORKFLOW_VALUE_BYTES` 64KB → 512KB — this is what was summarizing `finalOutput` on agent outputs just over 64KB
- Update logger tests to exercise the truncation path against the new ceilings

## Type of Change
- [x] Improvement

## Testing
Tested manually. `bun run lint` and `bun run check:api-validation:strict` pass. Logger unit tests (13) pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)