### PR TITLE
fix(slack): only parse scoped user id for oauth credentials

### DIFF
--- a/apps/sim/app/api/tools/slack/channels/route.ts
+++ b/apps/sim/app/api/tools/slack/channels/route.ts
@@ -93,7 +93,11 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       accessToken = resolvedToken
       logger.info('Using OAuth token for Slack API')
 
-      if (authz.resolvedCredentialId) {
+      // resolvedCredentialId is an account.id only for OAuth credentials; the
+      // service_account path returns a credential.id, which must not be used as
+      // an account lookup key. Slack never uses service accounts, but guard
+      // explicitly so the lookup is correct by construction.
+      if (authz.credentialType === 'oauth' && authz.resolvedCredentialId) {
         const [accountRow] = await db
           .select({ accountId: account.accountId })
           .from(account)

--- a/apps/sim/app/api/tools/slack/channels/route.ts
+++ b/apps/sim/app/api/tools/slack/channels/route.ts
@@ -93,10 +93,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       accessToken = resolvedToken
       logger.info('Using OAuth token for Slack API')
 
-      // resolvedCredentialId is an account.id only for OAuth credentials; the
-      // service_account path returns a credential.id, which must not be used as
-      // an account lookup key. Slack never uses service accounts, but guard
-      // explicitly so the lookup is correct by construction.
+      // resolvedCredentialId is an account.id only for OAuth credentials
+      // (the service_account path returns a credential.id).
       if (authz.credentialType === 'oauth' && authz.resolvedCredentialId) {
         const [accountRow] = await db
           .select({ accountId: account.accountId })


### PR DESCRIPTION
## Summary
- Follow-up to #4779. The channel-privacy scoping looked up `account.id` using `authz.resolvedCredentialId`, but that value is an `account.id` only for OAuth credentials — the `service_account` path in `credential-access.ts` returns a `credential.id`. Guard the lookup on `credentialType === 'oauth'` so it's correct by construction.
- Not reachable for Slack today (Slack has no service-account support), and the prior behavior was fail-safe (`is_member` fallback, no leak), but this makes intent explicit and avoids a misdirected account lookup if that ever changes.

## Type of Change
- [x] Bug fix

## Testing
Tested manually; `tsc`, `biome`, and `check:api-validation` pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)