### PR TITLE
fix(workflows): get random workflow color when none provided on create

### DIFF
--- a/apps/sim/lib/workflows/orchestration/workflow-lifecycle.ts
+++ b/apps/sim/lib/workflows/orchestration/workflow-lifecycle.ts
@@ -6,6 +6,7 @@ import { toError } from '@sim/utils/errors'
 import { generateId } from '@sim/utils/id'
 import { and, eq, isNull, min, ne } from 'drizzle-orm'
 import { generateRequestId } from '@/lib/core/utils/request'
+import { getNextWorkflowColor } from '@/lib/workflows/colors'
 import { buildDefaultWorkflowArtifacts } from '@/lib/workflows/defaults'
 import { archiveWorkflow, restoreWorkflow } from '@/lib/workflows/lifecycle'
 import type { OrchestrationErrorCode } from '@/lib/workflows/orchestration/types'
@@ -212,6 +213,7 @@ export async function performCreateWorkflow(
         ? params.sortOrder
         : await nextWorkflowSortOrder(params.workspaceId, folderId)
     const now = new Date()
+    const color = params.color ?? getNextWorkflowColor()
     const { workflowState, subBlockValues, startBlockId } = buildDefaultWorkflowArtifacts()
 
     await db.transaction(async (tx) => {
@@ -223,7 +225,7 @@ export async function performCreateWorkflow(
         sortOrder,
         name,
         description: params.description,
-        color: params.color,
+        color,
         lastSynced: now,
         createdAt: now,
         updatedAt: now,
@@ -248,7 +250,7 @@ export async function performCreateWorkflow(
       metadata: {
         name,
         description: params.description || undefined,
-        color: params.color,
+        color,
         workspaceId: params.workspaceId,
         folderId: folderId || undefined,
         sortOrder,
@@ -261,7 +263,7 @@ export async function performCreateWorkflow(
         id: workflowId,
         name,
         description: params.description,
-        color: params.color,
+        color,
         workspaceId: params.workspaceId,
         folderId,
         sortOrder,


### PR DESCRIPTION
## Summary
- Mothership/copilot-created workflows were always blue — the server-side create path never passed a color, so the stored value was null and the display layer fell back to hardcoded #3972F6
- Defaulted the color centrally in `performCreateWorkflow` (`params.color ?? getNextWorkflowColor()`) so any caller omitting a color gets a random palette color
- UI-created workflows unchanged (they still pass their own color via the contract)

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run lint` and `bun run check:api-validation:strict` both pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)