### PR TITLE
fix(auth): return 403 instead of 500 for blocked sign-in/sign-up attempts

### DIFF
--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -9,7 +9,7 @@ import { toError } from '@sim/utils/errors'
 import { generateId } from '@sim/utils/id'
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
-import { createAuthMiddleware } from 'better-auth/api'
+import { APIError, createAuthMiddleware } from 'better-auth/api'
 import { nextCookies } from 'better-auth/next-js'
 import {
   admin,
@@ -793,12 +793,16 @@ export const auth = betterAuth({
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
       if (ctx.path.startsWith('/sign-up') && isRegistrationDisabled)
-        throw new Error('Registration is disabled, please contact your admin.')
+        throw new APIError('FORBIDDEN', {
+          message: 'Registration is disabled, please contact your admin.',
+        })
 
       if (!isEmailPasswordEnabled) {
         const emailPasswordPaths = ['/sign-in/email', '/sign-up/email', '/email-otp']
         if (emailPasswordPaths.some((path) => ctx.path.startsWith(path)))
-          throw new Error('Email/password authentication is disabled. Please use SSO to sign in.')
+          throw new APIError('FORBIDDEN', {
+            message: 'Email/password authentication is disabled. Please use SSO to sign in.',
+          })
       }
 
       if (
@@ -826,13 +830,17 @@ export const auth = betterAuth({
           }
 
           if (!isAllowed) {
-            throw new Error('Access restricted. Please contact your administrator.')
+            throw new APIError('FORBIDDEN', {
+              message: 'Access restricted. Please contact your administrator.',
+            })
           }
         }
       }
 
       if (ctx.path.startsWith('/sign-up') && isSignupEmailBlocked(ctx.body?.email)) {
-        throw new Error('Sign-ups from this email domain are not allowed.')
+        throw new APIError('FORBIDDEN', {
+          message: 'Sign-ups from this email domain are not allowed.',
+        })
       }
 
       if (ctx.path === '/oauth2/authorize' || ctx.path === '/oauth2/token') {


### PR DESCRIPTION
## Summary
- The `hooks.before` auth middleware threw plain `Error`s for the four auth-policy gates (registration disabled, email/password disabled, login allowlist, blocked signup domains). better-auth surfaces an uncaught hook `Error` as a generic **500 SERVER_ERROR**, so a user hitting one of these gates saw "Failed to create account" with no actionable reason.
- Switched those four throws to `APIError('FORBIDDEN', { message })` so the endpoints return a clean **403** with the policy message, which the client surfaces directly.
- Genuine internal/server failures (reset-password & OTP email send, provider `getUserInfo` fetch, Microsoft ID-token parse) intentionally remain plain `Error`s so they keep surfacing as 500s.

### How this was found
Staging `POST /api/auth/sign-up/email` returned 500 for a `@gmail.com` signup. Staging has `ALLOWED_LOGIN_DOMAINS=sim.ai`, so Sim's allowlist gate correctly rejected the email — but as a 500 instead of a readable 403. The rejection itself is correct; only the status/message was wrong.

## Type of Change
- [x] Bug fix

## Testing
- `bun run type-check` clean (confirms `APIError` resolves from `better-auth/api` and `'FORBIDDEN'` is a valid status)
- `bun run test app/api/auth/` — 60/60 passing
- `bun run lint` clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)