### PR TITLE
feat(slack): request channels:manage and groups:write for conversation ops

### DIFF
--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -696,8 +696,10 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
         scopes: [
           'channels:read',
           'channels:history',
+          'channels:manage',
           'groups:read',
           'groups:history',
+          'groups:write',
           'chat:write',
           'chat:write.public',
           'im:write',


### PR DESCRIPTION
## Summary
- Add `channels:manage` and `groups:write` to the Slack OAuth scope set so the "Create Conversation" and "Invite to Conversation" operations work with the hosted (Sim Bot) OAuth credential — these call `conversations.create`/`conversations.invite`, which require those scopes for public and private channels respectively
- Without them the operations fail at runtime with `missing_scope` on OAuth credentials (custom bot tokens are unaffected; they bring their own scopes)
- Verified against the code that these are the only OAuth-token methods missing scopes; `reactions:read` was intentionally NOT added since `reactions.get` is only used by the custom-bot trigger path, never the OAuth token

## Type of Change
- [x] Bug fix

## Testing
Tested manually; `lint` passes. Note: existing Slack OAuth connections must reconnect to pick up the new scopes (the credential selector surfaces the reconnect prompt).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)