### PR TITLE
fix(oauth): preflight Google integration config

### DIFF
--- a/apps/docs/content/docs/en/self-hosting/environment-variables.mdx
+++ b/apps/docs/content/docs/en/self-hosting/environment-variables.mdx
@@ -59,6 +59,17 @@ import { Callout } from 'fumadocs-ui/components/callout'
 | `GITHUB_CLIENT_ID` | GitHub OAuth client ID |
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth client secret |
 
+For Google integrations in self-hosted deployments, create a **Web application** OAuth client in Google Cloud and add the Sim callback for every Google service you plan to connect:
+
+```text
+https://<your-sim-host>/api/auth/oauth2/callback/google-sheets
+https://<your-sim-host>/api/auth/oauth2/callback/google-drive
+https://<your-sim-host>/api/auth/oauth2/callback/google-docs
+https://<your-sim-host>/api/auth/oauth2/callback/google-calendar
+```
+
+The host must match `NEXT_PUBLIC_APP_URL`. If the client ID, secret, or redirect URI do not match, Google returns `invalid_client` before Sim can complete the connection.
+
 ## Optional
 
 | Variable | Description |

--- a/apps/sim/app/api/auth/oauth/provider-config/route.ts
+++ b/apps/sim/app/api/auth/oauth/provider-config/route.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { getOAuthProviderConfigContract } from '@/lib/api/contracts/auth'
+import { parseRequest } from '@/lib/api/server'
+import { getSession } from '@/lib/auth'
+import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { getOAuthProviderConfigStatus } from '@/lib/oauth/provider-config'
+
+export const dynamic = 'force-dynamic'
+
+export const GET = withRouteHandler(async (request: NextRequest) => {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const parsed = await parseRequest(getOAuthProviderConfigContract, request, {})
+  if (!parsed.success) return parsed.response
+
+  return NextResponse.json(getOAuthProviderConfigStatus(parsed.data.query.providerId))
+})

--- a/apps/sim/app/workspace/[workspaceId]/components/oauth-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/oauth-modal.tsx
@@ -158,23 +158,25 @@ export function OAuthModal(props: OAuthModalProps) {
     setError(null)
 
     try {
+      const trimmedName = isConnect ? displayName.trim() : ''
       if (isConnect) {
-        const trimmedName = displayName.trim()
         if (!trimmedName) {
           setError('Display name is required.')
           return
         }
+      }
 
-        if (shouldPreflightOAuthProvider(providerId)) {
-          const providerConfig = await requestJson(getOAuthProviderConfigContract, {
-            query: { providerId },
-          })
-          if (!providerConfig.available) {
-            setError(providerConfig.message)
-            return
-          }
+      if (shouldPreflightOAuthProvider(providerId)) {
+        const providerConfig = await requestJson(getOAuthProviderConfigContract, {
+          query: { providerId },
+        })
+        if (!providerConfig.available) {
+          setError(providerConfig.message)
+          return
         }
+      }
 
+      if (isConnect) {
         await createDraft.mutateAsync({
           workspaceId,
           providerId,

--- a/apps/sim/app/workspace/[workspaceId]/components/oauth-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/oauth-modal.tsx
@@ -15,6 +15,8 @@ import {
   ModalFooter,
   ModalHeader,
 } from '@/components/emcn'
+import { requestJson } from '@/lib/api/client/request'
+import { getOAuthProviderConfigContract } from '@/lib/api/contracts/auth'
 import { client, useSession } from '@/lib/auth/auth-client'
 import type { OAuthReturnContext } from '@/lib/credentials/client-state'
 import { ADD_CONNECTOR_SEARCH_PARAM, writeOAuthReturnContext } from '@/lib/credentials/client-state'
@@ -30,6 +32,10 @@ import { useCreateCredentialDraft } from '@/hooks/queries/credentials'
 
 const logger = createLogger('OAuthModal')
 const EMPTY_SCOPES: string[] = []
+
+function shouldPreflightOAuthProvider(providerId: string): boolean {
+  return providerId === 'google' || providerId.startsWith('google-') || providerId === 'vertex-ai'
+}
 
 /**
  * Generates a default credential display name.
@@ -157,6 +163,16 @@ export function OAuthModal(props: OAuthModalProps) {
         if (!trimmedName) {
           setError('Display name is required.')
           return
+        }
+
+        if (shouldPreflightOAuthProvider(providerId)) {
+          const providerConfig = await requestJson(getOAuthProviderConfigContract, {
+            query: { providerId },
+          })
+          if (!providerConfig.available) {
+            setError(providerConfig.message)
+            return
+          }
         }
 
         await createDraft.mutateAsync({

--- a/apps/sim/lib/api/contracts/auth.ts
+++ b/apps/sim/lib/api/contracts/auth.ts
@@ -12,6 +12,19 @@ export const authProviderStatusResponseSchema = z.object({
   registrationDisabled: z.boolean(),
 })
 
+export const oauthProviderConfigQuerySchema = z.object({
+  providerId: z.string().min(1),
+})
+
+export const oauthProviderConfigResponseSchema = z.object({
+  providerId: z.string(),
+  available: z.boolean(),
+  status: z.enum(['ready', 'missing_env', 'placeholder_env', 'invalid_env']),
+  message: z.string(),
+  redirectUri: z.string().optional(),
+  requiredEnv: z.array(z.string()),
+})
+
 const ssoMappingSchema = z
   .object({
     id: z.string().default('sub'),
@@ -123,3 +136,17 @@ export const getAuthProvidersContract = defineRouteContract({
 })
 
 export type AuthProviderStatusResponse = ContractJsonResponse<typeof getAuthProvidersContract>
+
+export const getOAuthProviderConfigContract = defineRouteContract({
+  method: 'GET',
+  path: '/api/auth/oauth/provider-config',
+  query: oauthProviderConfigQuerySchema,
+  response: {
+    mode: 'json',
+    schema: oauthProviderConfigResponseSchema,
+  },
+})
+
+export type OAuthProviderConfigResponse = ContractJsonResponse<
+  typeof getOAuthProviderConfigContract
+>

--- a/apps/sim/lib/oauth/provider-config.test.ts
+++ b/apps/sim/lib/oauth/provider-config.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { getOAuthProviderConfigStatus, getOAuthRedirectUri } from '@/lib/oauth/provider-config'
+
+const ORIGINAL_ENV = { ...process.env }
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV }
+})
+
+describe('getOAuthProviderConfigStatus', () => {
+  it('reports missing Google OAuth env vars with the provider redirect URI', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
+    process.env.GOOGLE_CLIENT_ID = ''
+    process.env.GOOGLE_CLIENT_SECRET = ''
+
+    const status = getOAuthProviderConfigStatus('google-sheets')
+
+    expect(status.available).toBe(false)
+    expect(status.status).toBe('missing_env')
+    expect(status.requiredEnv).toEqual(['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'])
+    expect(status.redirectUri).toBe('http://localhost:3000/api/auth/oauth2/callback/google-sheets')
+    expect(status.message).toContain('GOOGLE_CLIENT_ID')
+    expect(status.message).toContain('GOOGLE_CLIENT_SECRET')
+  })
+
+  it('blocks placeholder Google OAuth credentials', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
+    process.env.GOOGLE_CLIENT_ID = 'your-google-client-id'
+    process.env.GOOGLE_CLIENT_SECRET = 'your-google-client-secret'
+
+    const status = getOAuthProviderConfigStatus('google-drive')
+
+    expect(status.available).toBe(false)
+    expect(status.status).toBe('placeholder_env')
+  })
+
+  it('rejects malformed Google OAuth client IDs before redirecting to Google', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
+    process.env.GOOGLE_CLIENT_ID = 'not-a-google-client'
+    process.env.GOOGLE_CLIENT_SECRET = 'real-secret'
+
+    const status = getOAuthProviderConfigStatus('google-sheets')
+
+    expect(status.available).toBe(false)
+    expect(status.status).toBe('invalid_env')
+    expect(status.message).toContain('.apps.googleusercontent.com')
+  })
+
+  it('accepts configured Google OAuth credentials', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://sim.example.com/'
+    process.env.GOOGLE_CLIENT_ID = '123.apps.googleusercontent.com'
+    process.env.GOOGLE_CLIENT_SECRET = 'real-secret'
+
+    const status = getOAuthProviderConfigStatus('google-sheets')
+
+    expect(status.available).toBe(true)
+    expect(status.status).toBe('ready')
+    expect(status.redirectUri).toBe(
+      'https://sim.example.com/api/auth/oauth2/callback/google-sheets'
+    )
+  })
+
+  it('does not block non-Google providers', () => {
+    const status = getOAuthProviderConfigStatus('slack')
+
+    expect(status.available).toBe(true)
+    expect(status.requiredEnv).toEqual([])
+  })
+})
+
+describe('getOAuthRedirectUri', () => {
+  it('normalizes a trailing slash on the base URL', () => {
+    expect(getOAuthRedirectUri('google-sheets', 'https://sim.example.com/')).toBe(
+      'https://sim.example.com/api/auth/oauth2/callback/google-sheets'
+    )
+  })
+})

--- a/apps/sim/lib/oauth/provider-config.ts
+++ b/apps/sim/lib/oauth/provider-config.ts
@@ -1,0 +1,97 @@
+import { getEnv } from '@/lib/core/config/env'
+import { getBaseUrl } from '@/lib/core/utils/urls'
+import type { OAuthProvider } from '@/lib/oauth/types'
+
+export type OAuthProviderConfigStatus = {
+  providerId: OAuthProvider | string
+  available: boolean
+  status: 'ready' | 'missing_env' | 'placeholder_env' | 'invalid_env'
+  message: string
+  redirectUri?: string
+  requiredEnv: string[]
+}
+
+const GOOGLE_CLIENT_ID_SUFFIX = '.apps.googleusercontent.com'
+const PLACEHOLDER_PATTERN = /^(|your-|change-me|changeme|example|<.*>)$/i
+
+function hasPlaceholderValue(value: string | undefined): boolean {
+  if (!value) return false
+  const normalized = value.trim()
+  return PLACEHOLDER_PATTERN.test(normalized) || normalized.includes('your-google-client')
+}
+
+function isGoogleProvider(providerId: string): boolean {
+  return providerId === 'google' || providerId.startsWith('google-') || providerId === 'vertex-ai'
+}
+
+export function getOAuthRedirectUri(providerId: string, baseUrl = getBaseUrl()): string {
+  return `${baseUrl.replace(/\/$/, '')}/api/auth/oauth2/callback/${providerId}`
+}
+
+export function getOAuthProviderConfigStatus(
+  providerId: OAuthProvider | string
+): OAuthProviderConfigStatus {
+  const requiredEnv = isGoogleProvider(providerId)
+    ? ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET']
+    : []
+
+  if (!isGoogleProvider(providerId)) {
+    return {
+      providerId,
+      available: true,
+      status: 'ready',
+      message: 'OAuth provider configuration is ready.',
+      requiredEnv,
+    }
+  }
+
+  const clientId = getEnv('GOOGLE_CLIENT_ID')?.trim()
+  const clientSecret = getEnv('GOOGLE_CLIENT_SECRET')?.trim()
+  const redirectUri = getOAuthRedirectUri(providerId)
+
+  if (!clientId || !clientSecret) {
+    const missing = [
+      !clientId ? 'GOOGLE_CLIENT_ID' : null,
+      !clientSecret ? 'GOOGLE_CLIENT_SECRET' : null,
+    ].filter(Boolean)
+    return {
+      providerId,
+      available: false,
+      status: 'missing_env',
+      message: `Google OAuth is not configured. Set ${missing.join(' and ')} and add ${redirectUri} as an authorized redirect URI in Google Cloud.`,
+      redirectUri,
+      requiredEnv,
+    }
+  }
+
+  if (hasPlaceholderValue(clientId) || hasPlaceholderValue(clientSecret)) {
+    return {
+      providerId,
+      available: false,
+      status: 'placeholder_env',
+      message: `Google OAuth still has placeholder credentials. Replace GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET, then add ${redirectUri} as an authorized redirect URI in Google Cloud.`,
+      redirectUri,
+      requiredEnv,
+    }
+  }
+
+  if (!clientId.endsWith(GOOGLE_CLIENT_ID_SUFFIX)) {
+    return {
+      providerId,
+      available: false,
+      status: 'invalid_env',
+      message: `GOOGLE_CLIENT_ID does not look like a Google OAuth web client ID. It should end with ${GOOGLE_CLIENT_ID_SUFFIX}, and ${redirectUri} must be registered as an authorized redirect URI.`,
+      redirectUri,
+      requiredEnv,
+    }
+  }
+
+  return {
+    providerId,
+    available: true,
+    status: 'ready',
+    message: 'Google OAuth provider configuration is ready.',
+    redirectUri,
+    requiredEnv,
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #860.

Self-hosted users can currently start the Google Sheets/Drive/Docs OAuth flow even when the Google integration OAuth env is missing, still placeholder text, or clearly not a Google web client ID. That sends them to Google and often ends in a confusing `invalid_client` page before Sim can explain what is wrong.

This adds a small authenticated preflight for Google integration OAuth that returns the exact callback URI Sim will use, blocks the obviously broken configurations before redirecting, and leaves non-Google providers untouched. I also added the callback URI examples to the self-hosting env docs.

## Verification

- `/Users/ritwij/.bun/bin/bun test apps/sim/lib/oauth/provider-config.test.ts`
- `/Users/ritwij/.bun/bin/bunx biome check apps/sim/lib/oauth/provider-config.ts apps/sim/lib/oauth/provider-config.test.ts apps/sim/app/api/auth/oauth/provider-config/route.ts apps/sim/lib/api/contracts/auth.ts 'apps/sim/app/workspace/[workspaceId]/components/oauth-modal.tsx' apps/docs/content/docs/en/self-hosting/environment-variables.mdx`\n- `/Users/ritwij/.bun/bin/bun run --cwd apps/sim type-check`