### PR TITLE
fix(copilot): make user-message persistence idempotent on message_id

### DIFF
--- a/apps/sim/lib/copilot/chat/post.ts
+++ b/apps/sim/lib/copilot/chat/post.ts
@@ -326,10 +326,19 @@ async function persistUserMessage(params: {
         contexts,
       })
 
+      // Append the user message idempotently: only concatenate when the array
+      // doesn't already contain a message with this id. A repeated id here is
+      // always a retry/double-submit of the same message (the client mints a
+      // fresh id per distinct send), so skipping the append avoids duplicate
+      // entries while keeping the stream marker / updatedAt current.
       const [updated] = await db
         .update(copilotChats)
         .set({
-          messages: sql`${copilotChats.messages} || ${JSON.stringify([userMsg])}::jsonb`,
+          messages: sql`CASE
+            WHEN ${copilotChats.messages} @> ${JSON.stringify([{ id: userMessageId }])}::jsonb
+            THEN ${copilotChats.messages}
+            ELSE ${copilotChats.messages} || ${JSON.stringify([userMsg])}::jsonb
+          END`,
           conversationId: userMessageId,
           updatedAt: new Date(),
         })


### PR DESCRIPTION
## What

`persistUserMessage` (apps/sim/lib/copilot/chat/post.ts) appended the user message to `copilot_chats.messages` **unconditionally** — `messages || [userMsg]::jsonb` — with no check that the id already exists. This change guards the append so it only concatenates when the array doesn't already contain a message with that id.

## Why (root cause, verified)

A repeated POST for the same `userMessageId` (network retry, double-submit, React double-effect, or the send lock being bypassed when Redis is down / its 60s TTL expires) tacked on a **duplicate array entry**. The assistant append in `terminal-state.ts` is already guarded by a `findIndex` check; the user append was not — so duplicates only ever accrue on user messages.

**Evidence:** across prod, 100% of duplicated `message_id`s are `role:"user"` (zero assistant) — exactly what this asymmetry predicts. A deep trace of the client hook across **all** revisions confirmed the client mints a fresh id per distinct send (queued sends, queue-edit, retry, recovery, replay all verified), so a repeated id reaching the server is always the *same* message. The unconditional server append was the sole mechanism creating the duplicates.

## The fix

```sql
messages = CASE
  WHEN messages @> '[{"id": <userMessageId>}]'::jsonb THEN messages
  ELSE messages || '[<userMsg>]'::jsonb
END
```

- Safe: because the client never sends different content under a reused id, skipping on a present id can only ever suppress an identical retry — it never drops a distinct message.
- `conversationId` / `updatedAt` stay unconditional, so the active-stream marker still advances on a retry.
- The dual-write to `copilot_messages` is already idempotent (`ON CONFLICT DO UPDATE`), so no change needed there.

## Scope

Deliberately tiny — one SQL expression in `persistUserMessage`. No client change (the client is already correct). No schema change.

## Verification

- Semantics proven on real Postgres: starting from `[{id:A}]`, appending id `A` → stays 1 element; appending id `B` → 2 elements.
- `bun vitest run lib/copilot/chat` — 68 tests pass; type-check clean; biome clean; `check:api-validation` passes.

## Note

This stops *new* duplicates at the source. Historical duplicates (67 chats, mostly Sept–Oct 2025) are a separate, optional cleanup; they still live intact in the JSONB column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)