### PR TITLE
fix(sso): re-check domain conflict before write and reject IP-address domains

### DIFF
--- a/apps/sim/app/api/auth/sso/register/route.ts
+++ b/apps/sim/app/api/auth/sso/register/route.ts
@@ -81,28 +81,33 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       return orgId ? provider.organizationId === orgId : false
     }
 
-    const existingProviders = await db
-      .select({
-        userId: ssoProvider.userId,
-        organizationId: ssoProvider.organizationId,
-      })
-      .from(ssoProvider)
-      .where(sql`lower(${ssoProvider.domain}) = ${domain}`)
-    const conflictingProvider = existingProviders.find((provider) => !isOwnedByCaller(provider))
+    const findDomainConflict = async () =>
+      (
+        await db
+          .select({
+            userId: ssoProvider.userId,
+            organizationId: ssoProvider.organizationId,
+          })
+          .from(ssoProvider)
+          .where(sql`lower(${ssoProvider.domain}) = ${domain}`)
+      ).find((provider) => !isOwnedByCaller(provider))
 
-    if (conflictingProvider) {
-      logger.warn('Rejected SSO registration for domain owned by another tenant', {
-        domain,
-        orgId,
-        userId: session.user.id,
-      })
-      return NextResponse.json(
+    const domainConflictResponse = () =>
+      NextResponse.json(
         {
           error: 'This domain is already registered for SSO by another organization.',
           code: 'SSO_DOMAIN_ALREADY_REGISTERED',
         },
         { status: 409 }
       )
+
+    if (await findDomainConflict()) {
+      logger.warn('Rejected SSO registration for domain owned by another tenant', {
+        domain,
+        orgId,
+        userId: session.user.id,
+      })
+      return domainConflictResponse()
     }
 
     const headers: Record<string, string> = {}
@@ -445,6 +450,15 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         2
       ),
     })
+
+    if (await findDomainConflict()) {
+      logger.warn('Rejected SSO registration: domain was claimed during registration', {
+        domain,
+        orgId,
+        userId: session.user.id,
+      })
+      return domainConflictResponse()
+    }
 
     const registration = await auth.api.registerSSOProvider({
       body: providerConfig,

--- a/apps/sim/lib/auth/sso/domain.test.ts
+++ b/apps/sim/lib/auth/sso/domain.test.ts
@@ -35,4 +35,10 @@ describe('normalizeSSODomain', () => {
     expect(normalizeSSODomain('not a domain')).toBeNull()
     expect(normalizeSSODomain('company')).toBeNull()
   })
+
+  it('rejects bare IP addresses and numeric TLDs', () => {
+    expect(normalizeSSODomain('10.0.0.1')).toBeNull()
+    expect(normalizeSSODomain('192.168.1.1')).toBeNull()
+    expect(normalizeSSODomain('company.123')).toBeNull()
+  })
 })

--- a/apps/sim/lib/auth/sso/domain.ts
+++ b/apps/sim/lib/auth/sso/domain.ts
@@ -19,7 +19,10 @@ export function normalizeSSODomain(input: string): string | null {
   value = value.replace(/\.$/, '')
 
   if (!/^[a-z0-9-]+(\.[a-z0-9-]+)+$/.test(value)) return null
-  if (value.split('.').some((label) => label.length === 0 || label.length > 63)) return null
+
+  const labels = value.split('.')
+  if (labels.some((label) => label.length === 0 || label.length > 63)) return null
+  if (/^\d+$/.test(labels[labels.length - 1])) return null
 
   return value
 }


### PR DESCRIPTION
## Summary
- Re-run the SSO domain-ownership conflict check immediately before `auth.api.registerSSOProvider`, in addition to the early fail-fast check, so the gap between check and write no longer spans the OIDC discovery fetches (narrows the TOCTOU window from seconds to ms).
- `normalizeSSODomain` now rejects bare IPv4 addresses and numeric TLDs (e.g. `10.0.0.1`), which are never registrable email domains.
- Full atomicity (unique index on `lower(domain)`) is blocked on deduping existing duplicate provider rows — tracked in #4824.

## Type of Change
- [x] Bug fix

## Testing
Tested manually; added unit cases for IP/numeric-TLD rejection. (Existing SSO register route tests cover the conflict/ownership paths.)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)