### PR TITLE
fix(tables): enforce plan limits in mothership user_table tool

### DIFF
--- a/apps/sim/lib/copilot/tools/server/table/user-table.test.ts
+++ b/apps/sim/lib/copilot/tools/server/table/user-table.test.ts
@@ -268,7 +268,8 @@ describe('userTableServerTool.create_from_file', () => {
     expect(createArgs.maxTables).toBe(3)
   })
 
-  it('rejects a file exceeding the plan row limit without creating a table', async () => {
+  it('truncates to the plan row limit and reports dropped rows', async () => {
+    // File has 2 data rows (Alice, Bob); plan cap is 1.
     mockGetWorkspaceTableLimits.mockResolvedValueOnce({ maxRowsPerTable: 1, maxTables: 3 })
 
     const result = await userTableServerTool.execute(
@@ -276,9 +277,12 @@ describe('userTableServerTool.create_from_file', () => {
       { userId: 'user-1', workspaceId: 'workspace-1' }
     )
 
-    expect(result.success).toBe(false)
-    expect(result.message).toMatch(/exceeds this plan's limit/i)
-    expect(mockCreateTable).not.toHaveBeenCalled()
+    expect(result.success).toBe(true)
+    expect(mockCreateTable).toHaveBeenCalledTimes(1)
+    const insertCall = mockBatchInsertRows.mock.calls[0][0] as { rows: unknown[] }
+    expect(insertCall.rows).toHaveLength(1)
+    expect(result.data?.rowCount).toBe(1)
+    expect(result.message).toMatch(/dropped 1 row/i)
     expect(mockDeleteTable).not.toHaveBeenCalled()
   })
 

--- a/apps/sim/lib/copilot/tools/server/table/user-table.test.ts
+++ b/apps/sim/lib/copilot/tools/server/table/user-table.test.ts
@@ -12,6 +12,9 @@ const {
   mockBatchInsertRows,
   mockReplaceTableRows,
   mockAddWorkflowGroup,
+  mockCreateTable,
+  mockDeleteTable,
+  mockGetWorkspaceTableLimits,
   fakeEnrichment,
 } = vi.hoisted(() => ({
   mockResolveWorkspaceFileReference: vi.fn(),
@@ -20,6 +23,9 @@ const {
   mockBatchInsertRows: vi.fn(),
   mockReplaceTableRows: vi.fn(),
   mockAddWorkflowGroup: vi.fn(),
+  mockCreateTable: vi.fn(),
+  mockDeleteTable: vi.fn(),
+  mockGetWorkspaceTableLimits: vi.fn(),
   fakeEnrichment: {
     id: 'work-email',
     name: 'Work Email',
@@ -54,13 +60,13 @@ vi.mock('@/lib/table/service', () => ({
   addWorkflowGroup: mockAddWorkflowGroup,
   batchInsertRows: mockBatchInsertRows,
   batchUpdateRows: vi.fn(),
-  createTable: vi.fn(),
+  createTable: mockCreateTable,
   deleteColumn: vi.fn(),
   deleteColumns: vi.fn(),
   deleteRow: vi.fn(),
   deleteRowsByFilter: vi.fn(),
   deleteRowsByIds: vi.fn(),
-  deleteTable: vi.fn(),
+  deleteTable: mockDeleteTable,
   getRowById: vi.fn(),
   getTableById: mockGetTableById,
   insertRow: vi.fn(),
@@ -72,6 +78,10 @@ vi.mock('@/lib/table/service', () => ({
   updateColumnType: vi.fn(),
   updateRow: vi.fn(),
   updateRowsByFilter: vi.fn(),
+}))
+
+vi.mock('@/lib/table/billing', () => ({
+  getWorkspaceTableLimits: mockGetWorkspaceTableLimits,
 }))
 
 import { userTableServerTool } from '@/lib/copilot/tools/server/table/user-table'
@@ -229,6 +239,86 @@ describe('userTableServerTool.import_file', () => {
     expect(result.success).toBe(false)
     expect(result.message).toMatch(/missing required columns/i)
     expect(mockBatchInsertRows).not.toHaveBeenCalled()
+  })
+})
+
+describe('userTableServerTool.create_from_file', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockResolveWorkspaceFileReference.mockResolvedValue({ name: 'people.csv', type: 'text/csv' })
+    mockDownloadWorkspaceFile.mockResolvedValue(Buffer.from('name,age\nAlice,30\nBob,40'))
+    mockGetWorkspaceTableLimits.mockResolvedValue({ maxRowsPerTable: 1000, maxTables: 3 })
+    mockCreateTable.mockResolvedValue(buildTable({ id: 'tbl_new', name: 'people' }))
+    mockBatchInsertRows.mockImplementation(async (data: { rows: unknown[] }) =>
+      data.rows.map((_, i) => ({ id: `row_${i}` }))
+    )
+  })
+
+  it('stamps the workspace plan limits on the created table', async () => {
+    const result = await userTableServerTool.execute(
+      { operation: 'create_from_file', args: { fileId: 'file-1' } },
+      { userId: 'user-1', workspaceId: 'workspace-1' }
+    )
+
+    expect(result.success).toBe(true)
+    expect(mockGetWorkspaceTableLimits).toHaveBeenCalledWith('workspace-1')
+    expect(mockCreateTable).toHaveBeenCalledTimes(1)
+    const createArgs = mockCreateTable.mock.calls[0][0] as { maxRows: number; maxTables: number }
+    expect(createArgs.maxRows).toBe(1000)
+    expect(createArgs.maxTables).toBe(3)
+  })
+
+  it('rejects a file exceeding the plan row limit without creating a table', async () => {
+    mockGetWorkspaceTableLimits.mockResolvedValueOnce({ maxRowsPerTable: 1, maxTables: 3 })
+
+    const result = await userTableServerTool.execute(
+      { operation: 'create_from_file', args: { fileId: 'file-1' } },
+      { userId: 'user-1', workspaceId: 'workspace-1' }
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.message).toMatch(/exceeds this plan's limit/i)
+    expect(mockCreateTable).not.toHaveBeenCalled()
+    expect(mockDeleteTable).not.toHaveBeenCalled()
+  })
+
+  it('deletes the created table when row insertion fails', async () => {
+    mockBatchInsertRows.mockRejectedValueOnce(new Error('Maximum row limit (1000) reached'))
+
+    const result = await userTableServerTool.execute(
+      { operation: 'create_from_file', args: { fileId: 'file-1' } },
+      { userId: 'user-1', workspaceId: 'workspace-1' }
+    )
+
+    expect(result.success).toBe(false)
+    expect(mockDeleteTable).toHaveBeenCalledWith('tbl_new', expect.any(String))
+  })
+})
+
+describe('userTableServerTool.create', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetWorkspaceTableLimits.mockResolvedValue({ maxRowsPerTable: 1000, maxTables: 3 })
+    mockCreateTable.mockResolvedValue(buildTable({ id: 'tbl_new', name: 'People' }))
+  })
+
+  it('stamps the workspace plan limits on the created table', async () => {
+    const result = await userTableServerTool.execute(
+      {
+        operation: 'create',
+        args: {
+          name: 'People',
+          schema: { columns: [{ name: 'name', type: 'string', required: true }] },
+        },
+      },
+      { userId: 'user-1', workspaceId: 'workspace-1' }
+    )
+
+    expect(result.success).toBe(true)
+    expect(mockGetWorkspaceTableLimits).toHaveBeenCalledWith('workspace-1')
+    const createArgs = mockCreateTable.mock.calls[0][0] as { maxRows: number; maxTables: number }
+    expect(createArgs.maxRows).toBe(1000)
+    expect(createArgs.maxTables).toBe(3)
   })
 })
 

--- a/apps/sim/lib/copilot/tools/server/table/user-table.test.ts
+++ b/apps/sim/lib/copilot/tools/server/table/user-table.test.ts
@@ -249,6 +249,7 @@ describe('userTableServerTool.create_from_file', () => {
     mockDownloadWorkspaceFile.mockResolvedValue(Buffer.from('name,age\nAlice,30\nBob,40'))
     mockGetWorkspaceTableLimits.mockResolvedValue({ maxRowsPerTable: 1000, maxTables: 3 })
     mockCreateTable.mockResolvedValue(buildTable({ id: 'tbl_new', name: 'people' }))
+    mockDeleteTable.mockResolvedValue(undefined)
     mockBatchInsertRows.mockImplementation(async (data: { rows: unknown[] }) =>
       data.rows.map((_, i) => ({ id: `row_${i}` }))
     )
@@ -286,8 +287,8 @@ describe('userTableServerTool.create_from_file', () => {
     expect(mockDeleteTable).not.toHaveBeenCalled()
   })
 
-  it('deletes the created table when row insertion fails', async () => {
-    mockBatchInsertRows.mockRejectedValueOnce(new Error('Maximum row limit (1000) reached'))
+  it('rolls back the created table and reports the reason when row insertion fails', async () => {
+    mockBatchInsertRows.mockRejectedValueOnce(new Error('Row 2: Column "email" must be unique'))
 
     const result = await userTableServerTool.execute(
       { operation: 'create_from_file', args: { fileId: 'file-1' } },
@@ -296,6 +297,8 @@ describe('userTableServerTool.create_from_file', () => {
 
     expect(result.success).toBe(false)
     expect(mockDeleteTable).toHaveBeenCalledWith('tbl_new', expect.any(String))
+    expect(result.message).toMatch(/rolled back/i)
+    expect(result.message).toMatch(/must be unique/i)
   })
 })
 

--- a/apps/sim/lib/copilot/tools/server/table/user-table.ts
+++ b/apps/sim/lib/copilot/tools/server/table/user-table.ts
@@ -788,8 +788,28 @@ export const userTableServerTool: BaseServerTool<UserTableArgs, UserTableResult>
           try {
             inserted = await batchInsertAll(table.id, coerced, table, workspaceId, context)
           } catch (insertError) {
-            await deleteTable(table.id, requestId).catch(() => {})
-            throw insertError
+            const cleanupRequestId = generateId().slice(0, 8)
+            await deleteTable(table.id, cleanupRequestId).catch((cleanupError) => {
+              logger.error('Failed to roll back table after import failure', {
+                tableId: table.id,
+                error: toError(cleanupError).message,
+              })
+            })
+            const reason = toError(insertError).message
+            const cause =
+              insertError instanceof Error && insertError.cause
+                ? toError(insertError.cause).message
+                : undefined
+            logger.error('Failed to import rows into new table', {
+              tableId: table.id,
+              fileName: file.name,
+              error: reason,
+              cause,
+            })
+            return {
+              success: false,
+              message: `Failed to import rows from "${file.name}" — the table was rolled back. ${cause ? `${reason} (${cause})` : reason}`,
+            }
           }
 
           logger.info('Table created from file', {

--- a/apps/sim/lib/copilot/tools/server/table/user-table.ts
+++ b/apps/sim/lib/copilot/tools/server/table/user-table.ts
@@ -767,12 +767,8 @@ export const userTableServerTool: BaseServerTool<UserTableArgs, UserTableResult>
           assertNotAborted()
           const planLimits = await getWorkspaceTableLimits(workspaceId)
 
-          if (rows.length > planLimits.maxRowsPerTable) {
-            return {
-              success: false,
-              message: `"${file.name}" has ${rows.length.toLocaleString()} rows, which exceeds this plan's limit of ${planLimits.maxRowsPerTable.toLocaleString()} rows per table.`,
-            }
-          }
+          const droppedRows = Math.max(0, rows.length - planLimits.maxRowsPerTable)
+          const rowsToImport = droppedRows > 0 ? rows.slice(0, planLimits.maxRowsPerTable) : rows
 
           const table = await createTable(
             {
@@ -787,7 +783,7 @@ export const userTableServerTool: BaseServerTool<UserTableArgs, UserTableResult>
             requestId
           )
 
-          const coerced = coerceRowsForTable(rows, { columns }, headerToColumn)
+          const coerced = coerceRowsForTable(rowsToImport, { columns }, headerToColumn)
           let inserted: number
           try {
             inserted = await batchInsertAll(table.id, coerced, table, workspaceId, context)
@@ -801,12 +797,19 @@ export const userTableServerTool: BaseServerTool<UserTableArgs, UserTableResult>
             fileName: file.name,
             columns: columns.length,
             rows: inserted,
+            droppedRows,
             userId: context.userId,
           })
 
+          const createdMessage = `Created table "${table.name}" with ${columns.length} columns and ${inserted.toLocaleString()} rows from "${file.name}"`
+          const message =
+            droppedRows > 0
+              ? `${createdMessage}. Dropped ${droppedRows.toLocaleString()} row(s) that exceed this plan's limit of ${planLimits.maxRowsPerTable.toLocaleString()} rows per table.`
+              : createdMessage
+
           return {
             success: true,
-            message: `Created table "${table.name}" with ${columns.length} columns and ${inserted} rows from "${file.name}"`,
+            message,
             data: {
               tableId: table.id,
               tableName: table.name,

--- a/apps/sim/lib/copilot/tools/server/table/user-table.ts
+++ b/apps/sim/lib/copilot/tools/server/table/user-table.ts
@@ -14,6 +14,7 @@ import {
   type CsvHeaderMapping,
   CsvImportValidationError,
   coerceRowsForTable,
+  getWorkspaceTableLimits,
   inferSchemaFromCsv,
   parseCsvBuffer,
   sanitizeName,
@@ -263,6 +264,7 @@ export const userTableServerTool: BaseServerTool<UserTableArgs, UserTableResult>
 
           const requestId = generateId().slice(0, 8)
           assertNotAborted()
+          const planLimits = await getWorkspaceTableLimits(workspaceId)
           const table = await createTable(
             {
               name: args.name,
@@ -270,6 +272,8 @@ export const userTableServerTool: BaseServerTool<UserTableArgs, UserTableResult>
               schema: args.schema,
               workspaceId,
               userId: context.userId,
+              maxRows: planLimits.maxRowsPerTable,
+              maxTables: planLimits.maxTables,
             },
             requestId
           )
@@ -761,6 +765,15 @@ export const userTableServerTool: BaseServerTool<UserTableArgs, UserTableResult>
           const tableName = args.name || file.name.replace(/\.[^.]+$/, '')
           const requestId = generateId().slice(0, 8)
           assertNotAborted()
+          const planLimits = await getWorkspaceTableLimits(workspaceId)
+
+          if (rows.length > planLimits.maxRowsPerTable) {
+            return {
+              success: false,
+              message: `"${file.name}" has ${rows.length.toLocaleString()} rows, which exceeds this plan's limit of ${planLimits.maxRowsPerTable.toLocaleString()} rows per table.`,
+            }
+          }
+
           const table = await createTable(
             {
               name: tableName,
@@ -768,12 +781,20 @@ export const userTableServerTool: BaseServerTool<UserTableArgs, UserTableResult>
               schema: { columns },
               workspaceId,
               userId: context.userId,
+              maxRows: planLimits.maxRowsPerTable,
+              maxTables: planLimits.maxTables,
             },
             requestId
           )
 
           const coerced = coerceRowsForTable(rows, { columns }, headerToColumn)
-          const inserted = await batchInsertAll(table.id, coerced, table, workspaceId, context)
+          let inserted: number
+          try {
+            inserted = await batchInsertAll(table.id, coerced, table, workspaceId, context)
+          } catch (insertError) {
+            await deleteTable(table.id, requestId).catch(() => {})
+            throw insertError
+          }
 
           logger.info('Table created from file', {
             tableId: table.id,


### PR DESCRIPTION
## Summary
- Mothership `user_table` tool (`create`, `create_from_file`) now resolves the workspace plan limits and passes `maxRows`/`maxTables` to `createTable`, matching the HTTP routes — previously it fell back to hardcoded defaults (10k rows / 100 tables) and bypassed plan caps
- `create_from_file` now rejects files exceeding the plan row limit up front (clean message, no orphan table) and deletes the table if row insertion fails mid-import

## Type of Change
- [x] Bug fix

## Testing
Tested manually; added unit tests (4 new, 17 passing). `bun run lint` and `bun run check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)