### PR TITLE
feat(academy): enable academy pages

### DIFF
--- a/apps/sim/app/academy/layout.tsx
+++ b/apps/sim/app/academy/layout.tsx
@@ -1,10 +1,6 @@
 import type React from 'react'
 import type { Metadata } from 'next'
-import { notFound } from 'next/navigation'
 import { SITE_URL } from '@/lib/core/utils/urls'
-
-// TODO: Remove notFound() call to make academy pages public once content is ready
-const ACADEMY_ENABLED = false
 
 export const metadata: Metadata = {
   title: {
@@ -22,10 +18,6 @@ export const metadata: Metadata = {
 }
 
 export default function AcademyLayout({ children }: { children: React.ReactNode }) {
-  if (!ACADEMY_ENABLED) {
-    notFound()
-  }
-
   return (
     <div className='min-h-screen bg-[#1C1C1C] font-[430] font-season text-[#ECECEC]'>
       {children}


### PR DESCRIPTION
## Summary
- Remove `ACADEMY_ENABLED = false` gate and `notFound()` guard from academy layout
- Academy pages at `/academy` and sub-routes are now publicly accessible

## Type of Change
- [x] Feature

## Testing
Tested manually — `/academy` routes load correctly

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)