### PR TITLE
improvement(resource-header): refine breadcrumb truncation ux

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import type React from 'react'
+import { memo, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '@/lib/core/utils/cn'
+
+const FLOATING_TOOLTIP_OFFSET = 16
+const FLOATING_TOOLTIP_EDGE_GUTTER = 16
+const FLOATING_TOOLTIP_EDGE_THRESHOLD = 360
+
+interface FloatingOverflowTextProps {
+  label: string
+  children?: React.ReactNode
+  className?: string
+  showWhen?: boolean
+}
+
+interface FloatingTooltipState {
+  visible: boolean
+  x: number
+  y: number
+  skew: number
+  scaleX: number
+  scaleY: number
+  alignX: 'left' | 'right'
+  alignY: 'above' | 'below'
+}
+
+interface PointerSnapshot {
+  x: number
+  y: number
+  time: number
+}
+
+export const FloatingOverflowText = memo(function FloatingOverflowText({
+  label,
+  children,
+  className,
+  showWhen,
+}: FloatingOverflowTextProps) {
+  const textRef = useRef<HTMLSpanElement>(null)
+  const lastPointerRef = useRef<PointerSnapshot | null>(null)
+  const [isOverflowing, setIsOverflowing] = useState(false)
+  const [tooltipState, setTooltipState] = useState<FloatingTooltipState>({
+    visible: false,
+    x: 0,
+    y: 0,
+    skew: 0,
+    scaleX: 1,
+    scaleY: 1,
+    alignX: 'left',
+    alignY: 'below',
+  })
+
+  useEffect(() => {
+    const element = textRef.current
+    if (!element) return
+
+    const updateOverflowState = () => {
+      setIsOverflowing(isTextClipped(element))
+    }
+
+    updateOverflowState()
+
+    const resizeObserver = new ResizeObserver(updateOverflowState)
+    resizeObserver.observe(element)
+    window.addEventListener('resize', updateOverflowState)
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', updateOverflowState)
+    }
+  }, [])
+
+  const canShowTooltip = (element: HTMLSpanElement | null) => {
+    if (!element || label.length === 0) return false
+    return Boolean(showWhen) || isTextClipped(element)
+  }
+
+  const handleTooltipMove = (event: React.PointerEvent<HTMLSpanElement>) => {
+    if (!canShowTooltip(textRef.current)) return
+
+    const now = performance.now()
+    const previous = lastPointerRef.current
+    const elapsed = previous ? Math.max(now - previous.time, 16) : 16
+    const velocityX = previous ? ((event.clientX - previous.x) / elapsed) * 16 : 0
+    const velocityY = previous ? ((event.clientY - previous.y) / elapsed) * 16 : 0
+    const velocity = Math.hypot(velocityX, velocityY)
+    const position = getFloatingTooltipPosition(event.clientX, event.clientY)
+
+    lastPointerRef.current = { x: event.clientX, y: event.clientY, time: now }
+    setTooltipState({
+      visible: true,
+      ...position,
+      skew: clamp(velocityX * 0.11, -6, 6),
+      scaleX: 1 + Math.min(0.035, velocity / 1100),
+      scaleY: 1 - Math.min(0.02, velocity / 1500),
+    })
+  }
+
+  const showTooltip = (event: React.PointerEvent<HTMLSpanElement>) => {
+    if (!canShowTooltip(textRef.current)) return
+    const position = getFloatingTooltipPosition(event.clientX, event.clientY)
+    lastPointerRef.current = { x: event.clientX, y: event.clientY, time: performance.now() }
+    setIsOverflowing(true)
+    setTooltipState({
+      visible: true,
+      ...position,
+      skew: 0,
+      scaleX: 1,
+      scaleY: 1,
+    })
+  }
+
+  const showTooltipFromFocus = (event: React.FocusEvent<HTMLSpanElement>) => {
+    if (!canShowTooltip(textRef.current)) return
+    const rect = event.currentTarget.getBoundingClientRect()
+    const position = getFloatingTooltipPosition(rect.left + rect.width / 2, rect.bottom)
+    lastPointerRef.current = null
+    setIsOverflowing(true)
+    setTooltipState({
+      visible: true,
+      ...position,
+      skew: 0,
+      scaleX: 1,
+      scaleY: 1,
+    })
+  }
+
+  const hideTooltip = () => {
+    lastPointerRef.current = null
+    setTooltipState((current) => ({ ...current, visible: false, skew: 0, scaleX: 1, scaleY: 1 }))
+  }
+
+  return (
+    <>
+      <span
+        ref={textRef}
+        className={cn(
+          'min-w-0',
+          isOverflowing &&
+            '[mask-image:linear-gradient(to_right,black_calc(100%-18px),transparent)] hover:[mask-image:none] focus-visible:[mask-image:none]',
+          className
+        )}
+        onPointerEnter={showTooltip}
+        onPointerMove={handleTooltipMove}
+        onPointerLeave={hideTooltip}
+        onPointerDown={hideTooltip}
+        onFocus={showTooltipFromFocus}
+        onBlur={hideTooltip}
+      >
+        {children ?? label}
+      </span>
+      <FloatingTooltip label={label} state={tooltipState} />
+    </>
+  )
+})
+
+function FloatingTooltip({ label, state }: { label: string; state: FloatingTooltipState }) {
+  if (typeof document === 'undefined' || !state.visible) return null
+
+  return createPortal(
+    <div
+      aria-hidden='true'
+      className={cn(
+        'pointer-events-none fixed top-0 left-0 z-[var(--z-tooltip)] w-fit max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border border-[var(--border)] bg-[var(--bg)] px-2 py-1.5 text-[var(--text-body)] text-xs opacity-100 shadow-sm transition-[opacity,filter,transform] duration-150 ease-out',
+        'motion-reduce:transition-none'
+      )}
+      style={{
+        transform: `${getFloatingTooltipTranslate(state)} skew(${state.skew}deg) scale(${state.scaleX}, ${state.scaleY})`,
+        transformOrigin: state.alignX === 'left' ? '12px 12px' : 'calc(100% - 12px) 12px',
+      }}
+    >
+      <span className='block whitespace-normal break-words text-left leading-[18px]'>{label}</span>
+    </div>,
+    document.body
+  )
+}
+
+function isTextClipped(element: HTMLElement): boolean {
+  return element.scrollWidth > element.clientWidth + 1
+}
+
+function getFloatingTooltipPosition(
+  clientX: number,
+  clientY: number
+): Pick<FloatingTooltipState, 'x' | 'y' | 'alignX' | 'alignY'> {
+  if (typeof window === 'undefined') {
+    return { x: clientX, y: clientY, alignX: 'left', alignY: 'below' }
+  }
+
+  const alignX = window.innerWidth - clientX < FLOATING_TOOLTIP_EDGE_THRESHOLD ? 'right' : 'left'
+  const alignY =
+    window.innerHeight - clientY < FLOATING_TOOLTIP_EDGE_THRESHOLD / 2 ? 'above' : 'below'
+
+  return {
+    x: clamp(
+      clientX,
+      FLOATING_TOOLTIP_EDGE_GUTTER,
+      window.innerWidth - FLOATING_TOOLTIP_EDGE_GUTTER
+    ),
+    y: clamp(
+      clientY,
+      FLOATING_TOOLTIP_EDGE_GUTTER,
+      window.innerHeight - FLOATING_TOOLTIP_EDGE_GUTTER
+    ),
+    alignX,
+    alignY,
+  }
+}
+
+function getFloatingTooltipTranslate(state: FloatingTooltipState): string {
+  const xOffset =
+    state.alignX === 'left'
+      ? `${FLOATING_TOOLTIP_OFFSET}px`
+      : `calc(-100% - ${FLOATING_TOOLTIP_OFFSET}px)`
+  const yOffset =
+    state.alignY === 'below'
+      ? `${FLOATING_TOOLTIP_OFFSET}px`
+      : `calc(-100% - ${FLOATING_TOOLTIP_OFFSET}px)`
+
+  return `translate3d(${state.x}px, ${state.y}px, 0) translate(${xOffset}, ${yOffset})`
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
@@ -15,10 +15,10 @@ import {
   PopoverContent,
   PopoverItem,
   PopoverSection,
-  Tooltip,
 } from '@/components/emcn'
 import { cn } from '@/lib/core/utils/cn'
 import { InlineRenameInput } from '@/app/workspace/[workspaceId]/components/inline-rename-input'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 
 const HEADER_PLUS_ICON = <Plus className='mr-1.5 size-[14px] text-[var(--text-icon)]' />
 const TERMINAL_BREADCRUMB_LABELS = /^(Chunk #|New Chunk|Loading\.\.\.)/
@@ -113,64 +113,55 @@ export const ResourceHeader = memo(function ResourceHeader({
       )}
     >
       <div className='flex min-w-0 items-center justify-between gap-3'>
-        <Tooltip.Provider>
-          <div className='flex min-w-0 flex-1 items-center gap-2 overflow-hidden'>
-            {hasBreadcrumbs ? (
-              breadcrumbs.map((crumb, i) => {
-                const segmentClassName = getBreadcrumbSegmentClassName(
-                  i,
-                  breadcrumbs.length,
-                  currentResourceIndex,
-                  terminalBreadcrumbIndex
-                )
-                const LocationIcon = i === 0 ? (crumb.icon ?? Icon) : undefined
+        <div className='flex min-w-0 flex-1 items-center gap-2 overflow-hidden'>
+          {hasBreadcrumbs ? (
+            breadcrumbs.map((crumb, i) => {
+              const segmentClassName = getBreadcrumbSegmentClassName(
+                i,
+                breadcrumbs.length,
+                currentResourceIndex,
+                terminalBreadcrumbIndex
+              )
+              const LocationIcon = i === 0 ? (crumb.icon ?? Icon) : undefined
 
-                return (
-                  <Fragment key={`${crumb.label}-${i}`}>
-                    {i > 0 && (
-                      <span className='mx-0.5 shrink-0 select-none text-[var(--text-icon)] text-sm'>
-                        /
-                      </span>
-                    )}
-                    {LocationIcon ? (
-                      <BreadcrumbLocationPopover
-                        icon={LocationIcon}
-                        breadcrumbs={breadcrumbs}
-                        className={segmentClassName}
-                        veilBoundaryRef={headerRef}
-                      />
-                    ) : (
-                      <BreadcrumbSegment
-                        icon={crumb.icon}
-                        label={crumb.label}
-                        onClick={crumb.onClick}
-                        dropdownItems={crumb.dropdownItems}
-                        editing={crumb.editing}
-                        className={segmentClassName}
-                      />
-                    )}
-                  </Fragment>
-                )
-              })
-            ) : (
-              <>
-                {Icon && <Icon className='size-[14px] shrink-0 text-[var(--text-icon)]' />}
-                {title && (
-                  <Tooltip.Root>
-                    <Tooltip.Trigger asChild>
-                      <h1 className='truncate font-medium text-[var(--text-body)] text-sm'>
-                        {title}
-                      </h1>
-                    </Tooltip.Trigger>
-                    <Tooltip.Content className='max-w-[min(520px,calc(100vw-2rem))] whitespace-normal break-words px-2.5 py-2 text-left leading-5'>
-                      {title}
-                    </Tooltip.Content>
-                  </Tooltip.Root>
-                )}
-              </>
-            )}
-          </div>
-        </Tooltip.Provider>
+              return (
+                <Fragment key={`${crumb.label}-${i}`}>
+                  {i > 0 && (
+                    <span className='mx-0.5 shrink-0 select-none text-[var(--text-icon)] text-sm'>
+                      /
+                    </span>
+                  )}
+                  {LocationIcon ? (
+                    <BreadcrumbLocationPopover
+                      icon={LocationIcon}
+                      breadcrumbs={breadcrumbs}
+                      className={segmentClassName}
+                      veilBoundaryRef={headerRef}
+                    />
+                  ) : (
+                    <BreadcrumbSegment
+                      icon={crumb.icon}
+                      label={crumb.label}
+                      onClick={crumb.onClick}
+                      dropdownItems={crumb.dropdownItems}
+                      editing={crumb.editing}
+                      className={segmentClassName}
+                    />
+                  )}
+                </Fragment>
+              )
+            })
+          ) : (
+            <>
+              {Icon && <Icon className='size-[14px] shrink-0 text-[var(--text-icon)]' />}
+              {title && (
+                <h1 className='min-w-0 flex-1 font-medium text-[var(--text-body)] text-sm'>
+                  <FloatingOverflowText label={title} className='block truncate' />
+                </h1>
+              )}
+            </>
+          )}
+        </div>
         <div className='flex shrink-0 items-center gap-1.5'>
           {leadingActions}
           {actions?.map((action) => {

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
@@ -1,17 +1,30 @@
-import { Fragment, memo } from 'react'
+import { Fragment, forwardRef, memo, useEffect, useRef, useState } from 'react'
+import { ArrowUpLeft } from 'lucide-react'
+import { createPortal } from 'react-dom'
 import {
   Button,
   ChevronDown,
+  chipVariants,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   Plus,
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverItem,
+  PopoverSection,
+  Tooltip,
 } from '@/components/emcn'
 import { cn } from '@/lib/core/utils/cn'
 import { InlineRenameInput } from '@/app/workspace/[workspaceId]/components/inline-rename-input'
 
 const HEADER_PLUS_ICON = <Plus className='mr-1.5 size-[14px] text-[var(--text-icon)]' />
+const TERMINAL_BREADCRUMB_LABELS = /^(Chunk #|New Chunk|Loading\.\.\.)/
+const FLOATING_TOOLTIP_OFFSET = 16
+const FLOATING_TOOLTIP_EDGE_GUTTER = 16
+const FLOATING_TOOLTIP_EDGE_THRESHOLD = 360
 
 export interface DropdownOption {
   label: string
@@ -30,6 +43,7 @@ export interface BreadcrumbEditing {
 
 export interface BreadcrumbItem {
   label: string
+  icon?: React.ElementType
   onClick?: () => void
   dropdownItems?: DropdownOption[]
   editing?: BreadcrumbEditing
@@ -77,38 +91,87 @@ export const ResourceHeader = memo(function ResourceHeader({
   trailingActions,
   createTrigger,
 }: ResourceHeaderProps) {
+  const headerRef = useRef<HTMLDivElement>(null)
   const hasBreadcrumbs = breadcrumbs && breadcrumbs.length > 0
+  const terminalBreadcrumbIndex =
+    hasBreadcrumbs && TERMINAL_BREADCRUMB_LABELS.test(breadcrumbs[breadcrumbs.length - 1].label)
+      ? breadcrumbs.length - 1
+      : -1
+  const currentResourceIndex =
+    terminalBreadcrumbIndex > -1
+      ? terminalBreadcrumbIndex - 1
+      : hasBreadcrumbs && breadcrumbs.length > 2
+        ? breadcrumbs.length - 1
+        : -1
 
   return (
     <div
+      ref={headerRef}
       className={cn(
         'border-[var(--border)] border-b',
         hasBreadcrumbs ? 'px-4 py-[8.5px]' : 'px-6 py-2.5'
       )}
     >
-      <div className='flex items-center justify-between'>
-        <div className='flex items-center gap-3'>
-          {hasBreadcrumbs ? (
-            breadcrumbs.map((crumb, i) => (
-              <Fragment key={crumb.label}>
-                {i > 0 && <span className='select-none text-[var(--text-icon)] text-sm'>/</span>}
-                <BreadcrumbSegment
-                  icon={i === 0 ? Icon : undefined}
-                  label={crumb.label}
-                  onClick={crumb.onClick}
-                  dropdownItems={crumb.dropdownItems}
-                  editing={crumb.editing}
-                />
-              </Fragment>
-            ))
-          ) : (
-            <>
-              {Icon && <Icon className='size-[14px] text-[var(--text-icon)]' />}
-              {title && <h1 className='font-medium text-[var(--text-body)] text-sm'>{title}</h1>}
-            </>
-          )}
-        </div>
-        <div className='flex items-center gap-1.5'>
+      <div className='flex min-w-0 items-center justify-between gap-3'>
+        <Tooltip.Provider>
+          <div className='flex min-w-0 flex-1 items-center gap-2 overflow-hidden'>
+            {hasBreadcrumbs ? (
+              breadcrumbs.map((crumb, i) => {
+                const segmentClassName = getBreadcrumbSegmentClassName(
+                  i,
+                  breadcrumbs.length,
+                  currentResourceIndex,
+                  terminalBreadcrumbIndex
+                )
+                const LocationIcon = i === 0 ? (crumb.icon ?? Icon) : undefined
+
+                return (
+                  <Fragment key={`${crumb.label}-${i}`}>
+                    {i > 0 && (
+                      <span className='mx-0.5 shrink-0 select-none text-[var(--text-icon)] text-sm'>
+                        /
+                      </span>
+                    )}
+                    {LocationIcon ? (
+                      <BreadcrumbLocationPopover
+                        icon={LocationIcon}
+                        breadcrumbs={breadcrumbs}
+                        className={segmentClassName}
+                        veilBoundaryRef={headerRef}
+                      />
+                    ) : (
+                      <BreadcrumbSegment
+                        icon={crumb.icon}
+                        label={crumb.label}
+                        onClick={crumb.onClick}
+                        dropdownItems={crumb.dropdownItems}
+                        editing={crumb.editing}
+                        className={segmentClassName}
+                      />
+                    )}
+                  </Fragment>
+                )
+              })
+            ) : (
+              <>
+                {Icon && <Icon className='size-[14px] shrink-0 text-[var(--text-icon)]' />}
+                {title && (
+                  <Tooltip.Root>
+                    <Tooltip.Trigger asChild>
+                      <h1 className='truncate font-medium text-[var(--text-body)] text-sm'>
+                        {title}
+                      </h1>
+                    </Tooltip.Trigger>
+                    <Tooltip.Content className='max-w-[min(520px,calc(100vw-2rem))] whitespace-normal break-words px-2.5 py-2 text-left leading-5'>
+                      {title}
+                    </Tooltip.Content>
+                  </Tooltip.Root>
+                )}
+              </>
+            )}
+          </div>
+        </Tooltip.Provider>
+        <div className='flex shrink-0 items-center gap-1.5'>
           {leadingActions}
           {actions?.map((action) => {
             const ActionIcon = action.icon
@@ -119,7 +182,7 @@ export const ResourceHeader = memo(function ResourceHeader({
                 disabled={action.disabled}
                 variant='subtle'
                 className={cn(
-                  'px-2 py-1 text-caption',
+                  'whitespace-nowrap px-2 py-1 text-caption',
                   action.active !== undefined && 'rounded-lg',
                   action.active === true &&
                     'bg-[var(--surface-active)] hover-hover:bg-[var(--surface-active)]',
@@ -142,7 +205,7 @@ export const ResourceHeader = memo(function ResourceHeader({
                 onClick={create.onClick}
                 disabled={create.disabled}
                 variant='subtle'
-                className='px-2 py-1 text-caption'
+                className='whitespace-nowrap px-2 py-1 text-caption'
               >
                 {HEADER_PLUS_ICON}
                 {create.label}
@@ -154,12 +217,42 @@ export const ResourceHeader = memo(function ResourceHeader({
   )
 })
 
+function getBreadcrumbSegmentClassName(
+  index: number,
+  total: number,
+  currentResourceIndex: number,
+  terminalBreadcrumbIndex: number
+): string {
+  if (index === terminalBreadcrumbIndex) {
+    return 'shrink-0 max-w-[10rem]'
+  }
+
+  if (index === 0) {
+    return 'shrink-0'
+  }
+
+  if (currentResourceIndex > -1) {
+    if (index === currentResourceIndex) {
+      return 'min-w-0 flex-[0_1_auto] max-w-[56%]'
+    }
+
+    return 'min-w-0 flex-[0_1_auto] max-w-[34%]'
+  }
+
+  if (total > 2) {
+    return 'min-w-0 flex-[0_1_auto] max-w-[42%]'
+  }
+
+  return 'min-w-0 flex-[0_1_auto] max-w-[min(32rem,55vw)]'
+}
+
 interface BreadcrumbSegmentProps {
   icon?: React.ElementType
   label: string
   onClick?: () => void
   dropdownItems?: DropdownOption[]
   editing?: BreadcrumbEditing
+  className?: string
 }
 
 const BreadcrumbSegment = memo(function BreadcrumbSegment({
@@ -168,10 +261,109 @@ const BreadcrumbSegment = memo(function BreadcrumbSegment({
   onClick,
   dropdownItems,
   editing,
+  className,
 }: BreadcrumbSegmentProps) {
+  const labelRef = useRef<HTMLSpanElement>(null)
+  const lastPointerRef = useRef<PointerSnapshot | null>(null)
+  const [isOverflowing, setIsOverflowing] = useState(false)
+  const [tooltipState, setTooltipState] = useState<BreadcrumbFloatingTooltipState>({
+    visible: false,
+    x: 0,
+    y: 0,
+    skew: 0,
+    scaleX: 1,
+    scaleY: 1,
+    alignX: 'left',
+    alignY: 'below',
+  })
+
+  useEffect(() => {
+    const element = labelRef.current
+    if (!element) return
+
+    const updateOverflowState = () => {
+      setIsOverflowing(element.scrollWidth > element.clientWidth + 1)
+    }
+
+    updateOverflowState()
+
+    const resizeObserver = new ResizeObserver(updateOverflowState)
+    resizeObserver.observe(element)
+    window.addEventListener('resize', updateOverflowState)
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', updateOverflowState)
+    }
+  }, [])
+
+  const handleTooltipMove = (event: React.PointerEvent<HTMLElement>) => {
+    if (!isBreadcrumbTextClipped(labelRef.current, event.currentTarget)) return
+
+    const now = performance.now()
+    const previous = lastPointerRef.current
+    const elapsed = previous ? Math.max(now - previous.time, 16) : 16
+    const velocityX = previous ? ((event.clientX - previous.x) / elapsed) * 16 : 0
+    const velocityY = previous ? ((event.clientY - previous.y) / elapsed) * 16 : 0
+    const velocity = Math.hypot(velocityX, velocityY)
+    const position = getFloatingTooltipPosition(event.clientX, event.clientY)
+
+    lastPointerRef.current = { x: event.clientX, y: event.clientY, time: now }
+    setTooltipState({
+      visible: true,
+      ...position,
+      skew: clamp(velocityX * 0.11, -6, 6),
+      scaleX: 1 + Math.min(0.035, velocity / 1100),
+      scaleY: 1 - Math.min(0.02, velocity / 1500),
+    })
+  }
+
+  const showTooltip = (event: React.PointerEvent<HTMLElement>) => {
+    if (!isBreadcrumbTextClipped(labelRef.current, event.currentTarget)) return
+    const position = getFloatingTooltipPosition(event.clientX, event.clientY)
+    lastPointerRef.current = { x: event.clientX, y: event.clientY, time: performance.now() }
+    setIsOverflowing(true)
+    setTooltipState({
+      visible: true,
+      ...position,
+      skew: 0,
+      scaleX: 1,
+      scaleY: 1,
+    })
+  }
+
+  const showTooltipFromFocus = (event: React.FocusEvent<HTMLElement>) => {
+    if (!isBreadcrumbTextClipped(labelRef.current, event.currentTarget)) return
+    const rect = event.currentTarget.getBoundingClientRect()
+    const position = getFloatingTooltipPosition(rect.left + rect.width / 2, rect.bottom)
+    lastPointerRef.current = null
+    setIsOverflowing(true)
+    setTooltipState({
+      visible: true,
+      ...position,
+      skew: 0,
+      scaleX: 1,
+      scaleY: 1,
+    })
+  }
+
+  const hideTooltip = () => {
+    lastPointerRef.current = null
+    setTooltipState((current) => ({ ...current, visible: false, skew: 0, scaleX: 1, scaleY: 1 }))
+  }
+
+  const tooltipHandlers = {
+    onPointerEnter: showTooltip,
+    onPointerMove: handleTooltipMove,
+    onPointerLeave: hideTooltip,
+    onFocus: showTooltipFromFocus,
+    onBlur: hideTooltip,
+    onPointerDown: hideTooltip,
+  }
+
   if (editing?.isEditing) {
     return (
-      <span className='inline-flex items-center px-2 py-1'>
+      <span className={cn('inline-flex h-[30px] min-w-0 items-center px-2', className)}>
         {Icon && <Icon className='mr-3 size-[14px] text-[var(--text-icon)]' />}
         <InlineRenameInput
           value={editing.value}
@@ -185,46 +377,408 @@ const BreadcrumbSegment = memo(function BreadcrumbSegment({
 
   const content = (
     <>
-      {Icon && <Icon className='mr-3 size-[14px] text-[var(--text-icon)]' />}
-      {label}
+      {Icon && <Icon className='size-[14px] shrink-0 text-[var(--text-icon)]' />}
+      <BreadcrumbLabel ref={labelRef} isOverflowing={isOverflowing} label={label} />
     </>
+  )
+  const triggerClassName = cn(
+    chipVariants({ variant: 'ghost', flush: true }),
+    'group min-w-0 max-w-full justify-start font-medium transition-colors'
   )
 
   if (dropdownItems && dropdownItems.length > 0) {
     return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant='subtle' className='px-2 py-1 font-medium text-sm'>
-            {content}
-            <ChevronDown className='ml-2 h-[7px] w-[9px] shrink-0 text-[var(--text-muted)]' />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align='start'>
-          {dropdownItems.map((item) => {
-            const ItemIcon = item.icon
-            return (
-              <DropdownMenuItem key={item.label} onClick={item.onClick} disabled={item.disabled}>
-                {ItemIcon && <ItemIcon className='size-[14px]' />}
-                {item.label}
-              </DropdownMenuItem>
-            )
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <>
+        <DropdownMenu>
+          <BreadcrumbFloatingTooltip label={label} state={tooltipState} />
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant='subtle'
+              className={cn(triggerClassName, className, 'border-0')}
+              {...tooltipHandlers}
+            >
+              {content}
+              <ChevronDown className='ml-auto h-[7px] w-[9px] shrink-0 text-[var(--text-muted)]' />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='start'>
+            {dropdownItems.map((item) => {
+              const ItemIcon = item.icon
+              return (
+                <DropdownMenuItem key={item.label} onClick={item.onClick} disabled={item.disabled}>
+                  {ItemIcon && <ItemIcon className='size-[14px]' />}
+                  {item.label}
+                </DropdownMenuItem>
+              )
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </>
     )
   }
 
   if (onClick) {
     return (
-      <Button variant='subtle' className='px-2 py-1 font-medium text-sm' onClick={onClick}>
-        {content}
-      </Button>
+      <>
+        <BreadcrumbFloatingTooltip label={label} state={tooltipState} />
+        <Button
+          variant='subtle'
+          className={cn(triggerClassName, className, 'border-0')}
+          onClick={onClick}
+          {...tooltipHandlers}
+        >
+          {content}
+        </Button>
+      </>
     )
   }
 
   return (
-    <span className='inline-flex items-center px-2 py-1 font-medium text-[var(--text-body)] text-sm'>
-      {content}
-    </span>
+    <>
+      <BreadcrumbFloatingTooltip label={label} state={tooltipState} />
+      <span
+        className={cn(
+          chipVariants({ variant: 'ghost', flush: true }),
+          'group min-w-0 max-w-full cursor-default justify-start font-medium',
+          className
+        )}
+        {...tooltipHandlers}
+      >
+        {content}
+      </span>
+    </>
   )
 })
+
+interface BreadcrumbLocationPopoverProps {
+  icon: React.ElementType
+  breadcrumbs: BreadcrumbItem[]
+  className?: string
+  veilBoundaryRef: React.RefObject<HTMLDivElement | null>
+}
+
+function BreadcrumbLocationPopover({
+  icon: Icon,
+  breadcrumbs,
+  className,
+  veilBoundaryRef,
+}: BreadcrumbLocationPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const rootBreadcrumb = breadcrumbs[0]
+
+  const openPopover = () => {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current)
+      closeTimeoutRef.current = null
+    }
+    setOpen(true)
+  }
+
+  const scheduleClose = () => {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current)
+    }
+    closeTimeoutRef.current = setTimeout(() => {
+      setOpen(false)
+      closeTimeoutRef.current = null
+    }, 120)
+  }
+
+  return (
+    <>
+      <LocationFocusVeil visible={open} boundaryRef={veilBoundaryRef} />
+      <Popover size='md' open={open} onOpenChange={setOpen}>
+        <PopoverAnchor asChild>
+          <button
+            type='button'
+            aria-label={rootBreadcrumb?.label ?? 'Path'}
+            onClick={rootBreadcrumb?.onClick}
+            onFocus={openPopover}
+            onBlur={scheduleClose}
+            onMouseEnter={openPopover}
+            onMouseLeave={scheduleClose}
+            onMouseMove={openPopover}
+            onPointerEnter={openPopover}
+            onPointerLeave={scheduleClose}
+            onPointerMove={openPopover}
+            className={cn(
+              chipVariants({ variant: 'ghost', flush: true }),
+              'max-w-none px-2 transition-colors',
+              open && 'relative z-[var(--z-popover)]',
+              className
+            )}
+          >
+            <span className='relative inline-grid size-[14px] flex-shrink-0 place-items-center'>
+              <Icon className='col-start-1 row-start-1 size-[14px] text-[var(--text-icon)] opacity-100 blur-0 transition-[opacity,filter,transform] duration-200 ease-in-out group-hover:scale-[0.25] group-hover:opacity-0 group-hover:blur-[2px] group-focus-visible:scale-[0.25] group-focus-visible:opacity-0 group-focus-visible:blur-[2px] motion-reduce:transition-none' />
+              <ArrowUpLeft
+                strokeWidth={1.55}
+                className='col-start-1 row-start-1 size-[14px] scale-[0.25] text-[var(--text-icon)] opacity-0 blur-[2px] transition-[opacity,filter,transform] duration-200 ease-in-out group-hover:scale-100 group-hover:opacity-100 group-hover:blur-0 group-focus-visible:scale-100 group-focus-visible:opacity-100 group-focus-visible:blur-0 motion-reduce:transition-none'
+              />
+            </span>
+          </button>
+        </PopoverAnchor>
+        <PopoverContent
+          side='bottom'
+          align='start'
+          sideOffset={6}
+          minWidth={220}
+          maxWidth={300}
+          maxHeight={420}
+          border
+          className='data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-[var(--bg)] p-1.5 text-[var(--text-body)] shadow-sm data-[state=closed]:animate-out data-[state=open]:animate-in motion-reduce:animate-none'
+          onMouseEnter={openPopover}
+          onMouseLeave={scheduleClose}
+          onMouseMove={openPopover}
+          onPointerEnter={openPopover}
+          onPointerLeave={scheduleClose}
+          onPointerMove={openPopover}
+        >
+          <PopoverSection className='px-1.5 py-0.5 text-xs'>
+            <span className='inline-flex items-center gap-1'>
+              <span className='text-[var(--text-body)]'>Path</span>
+              <span className='text-[var(--text-muted)] opacity-70'>/</span>
+            </span>
+          </PopoverSection>
+          <div className='flex flex-col gap-0.5'>
+            {breadcrumbs.map((crumb, index) => (
+              <BreadcrumbLocationItem
+                key={`${crumb.label}-${index}`}
+                icon={crumb.icon || (index === 0 ? Icon : undefined)}
+                label={crumb.label}
+                onClick={crumb.onClick}
+                active={index === breadcrumbs.length - 1}
+              />
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </>
+  )
+}
+
+function LocationFocusVeil({
+  visible,
+  boundaryRef,
+}: {
+  visible: boolean
+  boundaryRef: React.RefObject<HTMLDivElement | null>
+}) {
+  const [bounds, setBounds] = useState({ top: 0, left: 0 })
+
+  useEffect(() => {
+    if (!visible) return
+
+    const updateBounds = () => {
+      const boundary = boundaryRef.current
+      if (!boundary) return
+
+      const rect = boundary.getBoundingClientRect()
+      setBounds({ top: rect.top, left: rect.left })
+    }
+
+    updateBounds()
+    window.addEventListener('resize', updateBounds)
+    window.addEventListener('scroll', updateBounds, true)
+
+    return () => {
+      window.removeEventListener('resize', updateBounds)
+      window.removeEventListener('scroll', updateBounds, true)
+    }
+  }, [boundaryRef, visible])
+
+  if (typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      aria-hidden='true'
+      className={cn(
+        'pointer-events-none fixed right-0 bottom-0 z-[calc(var(--z-popover)-1)] bg-[var(--bg)] transition-opacity duration-150 ease-out motion-reduce:transition-none',
+        visible ? 'opacity-60' : 'opacity-0'
+      )}
+      style={{ top: bounds.top, left: bounds.left }}
+    />,
+    document.body
+  )
+}
+
+interface BreadcrumbLocationItemProps {
+  icon?: React.ElementType
+  label: string
+  onClick?: () => void
+  active: boolean
+}
+
+function BreadcrumbLocationItem({
+  icon: Icon,
+  label,
+  onClick,
+  active,
+}: BreadcrumbLocationItemProps) {
+  const labelContent = (
+    <>
+      <span className='flex size-[18px] flex-shrink-0 items-center justify-center'>
+        {Icon ? (
+          <Icon className='size-3 text-[var(--text-icon)]' />
+        ) : (
+          <span className='size-1.5 rounded-full bg-[var(--text-muted)]' />
+        )}
+      </span>
+      <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
+    </>
+  )
+
+  if (onClick) {
+    return (
+      <PopoverItem
+        active={active}
+        onClick={onClick}
+        className='h-7 items-center gap-1.5 px-1.5 py-0 text-xs'
+      >
+        {labelContent}
+      </PopoverItem>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex h-7 min-w-0 items-center gap-1.5 rounded-lg px-1.5 text-[var(--text-body)] text-xs',
+        active && 'bg-[var(--surface-active)]'
+      )}
+    >
+      {labelContent}
+    </div>
+  )
+}
+
+const BreadcrumbLabel = memo(
+  forwardRef<HTMLSpanElement, BreadcrumbLabelProps>(function BreadcrumbLabel(
+    { isOverflowing, label },
+    ref
+  ) {
+    return (
+      <span
+        ref={ref}
+        className={cn(
+          'min-w-0 truncate',
+          isOverflowing &&
+            '[mask-image:linear-gradient(to_right,black_calc(100%-18px),transparent)] group-hover:[mask-image:none] group-focus-visible:[mask-image:none]'
+        )}
+      >
+        {label}
+      </span>
+    )
+  })
+)
+
+interface BreadcrumbLabelProps {
+  isOverflowing: boolean
+  label: string
+}
+
+interface BreadcrumbFloatingTooltipState {
+  visible: boolean
+  x: number
+  y: number
+  skew: number
+  scaleX: number
+  scaleY: number
+  alignX: 'left' | 'right'
+  alignY: 'above' | 'below'
+}
+
+interface PointerSnapshot {
+  x: number
+  y: number
+  time: number
+}
+
+function BreadcrumbFloatingTooltip({
+  label,
+  state,
+}: {
+  label: string
+  state: BreadcrumbFloatingTooltipState
+}) {
+  if (typeof document === 'undefined' || !state.visible) return null
+
+  return createPortal(
+    <div
+      aria-hidden='true'
+      className={cn(
+        'pointer-events-none fixed top-0 left-0 z-[var(--z-tooltip)] w-fit max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border border-[var(--border)] bg-[var(--bg)] px-2 py-1.5 text-[var(--text-body)] text-xs opacity-100 shadow-sm transition-[opacity,filter,transform] duration-150 ease-out',
+        'motion-reduce:transition-none'
+      )}
+      style={{
+        transform: `${getFloatingTooltipTranslate(state)} skew(${state.skew}deg) scale(${state.scaleX}, ${state.scaleY})`,
+        transformOrigin: state.alignX === 'left' ? '12px 12px' : 'calc(100% - 12px) 12px',
+      }}
+    >
+      <span className='block whitespace-normal break-words text-left leading-[18px]'>{label}</span>
+    </div>,
+    document.body
+  )
+}
+
+function isBreadcrumbTextClipped(
+  labelElement: HTMLSpanElement | null,
+  triggerElement: HTMLElement
+): boolean {
+  if (!labelElement) return false
+
+  const labelWidth = labelElement.getBoundingClientRect().width
+  const triggerWidth = triggerElement.getBoundingClientRect().width
+  const visibleLabelWidth = Math.min(labelWidth, triggerWidth)
+
+  return (
+    labelElement.scrollWidth > labelElement.clientWidth + 1 ||
+    triggerElement.scrollWidth > triggerElement.clientWidth + 1 ||
+    labelElement.scrollWidth > visibleLabelWidth + 1
+  )
+}
+
+function getFloatingTooltipPosition(
+  clientX: number,
+  clientY: number
+): Pick<BreadcrumbFloatingTooltipState, 'x' | 'y' | 'alignX' | 'alignY'> {
+  if (typeof window === 'undefined') {
+    return { x: clientX, y: clientY, alignX: 'left', alignY: 'below' }
+  }
+
+  const alignX = window.innerWidth - clientX < FLOATING_TOOLTIP_EDGE_THRESHOLD ? 'right' : 'left'
+  const alignY =
+    window.innerHeight - clientY < FLOATING_TOOLTIP_EDGE_THRESHOLD / 2 ? 'above' : 'below'
+
+  return {
+    x: clamp(
+      clientX,
+      FLOATING_TOOLTIP_EDGE_GUTTER,
+      window.innerWidth - FLOATING_TOOLTIP_EDGE_GUTTER
+    ),
+    y: clamp(
+      clientY,
+      FLOATING_TOOLTIP_EDGE_GUTTER,
+      window.innerHeight - FLOATING_TOOLTIP_EDGE_GUTTER
+    ),
+    alignX,
+    alignY,
+  }
+}
+
+function getFloatingTooltipTranslate(state: BreadcrumbFloatingTooltipState): string {
+  const xOffset =
+    state.alignX === 'left'
+      ? `${FLOATING_TOOLTIP_OFFSET}px`
+      : `calc(-100% - ${FLOATING_TOOLTIP_OFFSET}px)`
+  const yOffset =
+    state.alignY === 'below'
+      ? `${FLOATING_TOOLTIP_OFFSET}px`
+      : `calc(-100% - ${FLOATING_TOOLTIP_OFFSET}px)`
+
+  return `translate3d(${state.x}px, ${state.y}px, 0) translate(${xOffset}, ${yOffset})`
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
@@ -525,10 +525,10 @@ function BreadcrumbLocationPopover({
           onPointerLeave={scheduleClose}
           onPointerMove={openPopover}
         >
-          <PopoverSection className='px-1.5 py-0.5 text-xs'>
+          <PopoverSection className='px-1.5 py-0.5 text-[var(--text-muted)] text-xs'>
             <span className='inline-flex items-center gap-1'>
-              <span className='text-[var(--text-body)]'>Path</span>
-              <span className='text-[var(--text-muted)] opacity-70'>/</span>
+              <span>Path</span>
+              <span className='opacity-70'>/</span>
             </span>
           </PopoverSection>
           <div className='flex flex-col gap-0.5'>

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options-bar/resource-options-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options-bar/resource-options-bar.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/emcn'
 import { POPOVER_ANIMATION_CLASSES } from '@/components/emcn/components/chip-date-picker/chip-date-picker'
 import { cn } from '@/lib/core/utils/cn'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 
 const SEARCH_ICON = (
   <Search className='pointer-events-none size-[14px] shrink-0 text-[var(--text-icon)]' />
@@ -123,7 +124,7 @@ export const ResourceOptionsBar = memo(function ResourceOptionsBar({
               className='max-w-[280px] px-2 py-1 text-caption'
               onClick={tag.onRemove}
             >
-              <span className='truncate'>{tag.label}</span>
+              <FloatingOverflowText label={tag.label} className='block truncate' />
               <span className='ml-1 shrink-0 text-[var(--text-icon)] text-micro'>✕</span>
             </Button>
           ))}
@@ -206,12 +207,14 @@ const SearchSection = memo(function SearchSection({ search }: { search: SearchCo
             key={`${tag.label}-${tag.value}`}
             variant='subtle'
             className={cn(
-              'shrink-0 px-2 py-1 text-caption',
+              'max-w-[280px] shrink-0 px-2 py-1 text-caption',
               search.highlightedTagIndex === i && 'ring-1 ring-[var(--border-focus)] ring-offset-1'
             )}
             onClick={tag.onRemove}
           >
-            {tag.label}: {tag.value}
+            <FloatingOverflowText label={`${tag.label}: ${tag.value}`} className='block truncate'>
+              {tag.label}: {tag.value}
+            </FloatingOverflowText>
             <span className='ml-1 text-[var(--text-icon)] text-micro'>✕</span>
           </Button>
         ))}

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/resource.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/resource.tsx
@@ -12,6 +12,7 @@ import {
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { ArrowDown, ArrowUp, Button, Checkbox, Loader, Plus, Skeleton } from '@/components/emcn'
 import { cn } from '@/lib/core/utils/cn'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import type { BreadcrumbItem, CreateAction, HeaderAction } from './components/resource-header'
 import { ResourceHeader } from './components/resource-header'
 import type { FilterTag, SearchConfig, SortConfig } from './components/resource-options-bar'
@@ -478,7 +479,7 @@ const CellContent = memo(function CellContent({ icon, label, content, primary }:
       )}
     >
       {icon && <span className='flex-shrink-0 text-[var(--text-icon)]'>{icon}</span>}
-      <span className='truncate'>{label}</span>
+      <FloatingOverflowText label={label} className='block truncate' />
     </span>
   )
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -62,6 +62,7 @@ import {
   ResourceHeader,
   timeCell,
 } from '@/app/workspace/[workspaceId]/components'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import { FilesActionBar } from '@/app/workspace/[workspaceId]/files/components/action-bar'
 import { DeleteConfirmModal } from '@/app/workspace/[workspaceId]/files/components/delete-confirm-modal'
 import { FileRowContextMenu } from '@/app/workspace/[workspaceId]/files/components/file-row-context-menu'
@@ -1719,7 +1720,10 @@ export function Files() {
             multiSelectValues={typeFilter}
             onMultiSelectChange={setTypeFilter}
             overlayContent={
-              <span className='truncate text-[var(--text-primary)]'>{typeDisplayLabel}</span>
+              <FloatingOverflowText
+                label={typeDisplayLabel}
+                className='block truncate text-[var(--text-primary)]'
+              />
             }
             showAllOption
             allOptionLabel='All'
@@ -1739,7 +1743,10 @@ export function Files() {
             multiSelectValues={sizeFilter}
             onMultiSelectChange={setSizeFilter}
             overlayContent={
-              <span className='truncate text-[var(--text-primary)]'>{sizeDisplayLabel}</span>
+              <FloatingOverflowText
+                label={sizeDisplayLabel}
+                className='block truncate text-[var(--text-primary)]'
+              />
             }
             showAllOption
             allOptionLabel='All'
@@ -1758,9 +1765,10 @@ export function Files() {
               multiSelectValues={uploadedByFilter}
               onMultiSelectChange={setUploadedByFilter}
               overlayContent={
-                <span className='truncate text-[var(--text-primary)]'>
-                  {uploadedByDisplayLabel}
-                </span>
+                <FloatingOverflowText
+                  label={uploadedByDisplayLabel}
+                  className='block truncate text-[var(--text-primary)]'
+                />
               }
               searchable
               searchPlaceholder='Search members...'

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
@@ -34,6 +34,7 @@ import {
   Resource,
   ResourceHeader,
 } from '@/app/workspace/[workspaceId]/components'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import {
   ChunkContextMenu,
   ChunkEditor,
@@ -609,7 +610,10 @@ export function Document({
               void goToPage(1)
             }}
             overlayContent={
-              <span className='truncate text-[var(--text-primary)]'>{enabledDisplayLabel}</span>
+              <FloatingOverflowText
+                label={enabledDisplayLabel}
+                className='block truncate text-[var(--text-primary)]'
+              />
             }
             showAllOption
             allOptionLabel='All'
@@ -900,39 +904,43 @@ export function Document({
       ]
     }
 
-    return displayChunks.map((chunk: ChunkData) => ({
-      id: chunk.id,
-      cells: {
-        content: {
-          content: (
-            <span
-              className='block min-w-0 truncate text-[var(--text-primary)] text-sm'
-              title={chunk.content}
-            >
-              <SearchHighlight
-                text={truncateContent(chunk.content, 150, searchQuery)}
-                searchQuery={searchQuery}
-              />
-            </span>
-          ),
+    return displayChunks.map((chunk: ChunkData) => {
+      const previewContent = truncateContent(chunk.content, 150, searchQuery)
+
+      return {
+        id: chunk.id,
+        cells: {
+          content: {
+            content: (
+              <FloatingOverflowText
+                label={chunk.content}
+                showWhen={previewContent !== chunk.content}
+                className='block truncate text-[var(--text-primary)] text-sm'
+              >
+                <SearchHighlight text={previewContent} searchQuery={searchQuery} />
+              </FloatingOverflowText>
+            ),
+          },
+          index: {
+            content: (
+              <span className='font-mono text-[var(--text-primary)] text-sm'>
+                {chunk.chunkIndex}
+              </span>
+            ),
+          },
+          tokens: {
+            label: formatTokenCount(chunk.tokenCount),
+          },
+          status: {
+            content: (
+              <Badge variant={chunk.enabled ? 'green' : 'gray'} size='sm'>
+                {chunk.enabled ? 'Enabled' : 'Disabled'}
+              </Badge>
+            ),
+          },
         },
-        index: {
-          content: (
-            <span className='font-mono text-[var(--text-primary)] text-sm'>{chunk.chunkIndex}</span>
-          ),
-        },
-        tokens: {
-          label: formatTokenCount(chunk.tokenCount),
-        },
-        status: {
-          content: (
-            <Badge variant={chunk.enabled ? 'green' : 'gray'} size='sm'>
-              {chunk.enabled ? 'Enabled' : 'Disabled'}
-            </Badge>
-          ),
-        },
-      },
-    }))
+      }
+    })
   }, [isCompleted, documentData?.processingStatus, displayChunks, searchQuery])
 
   const emptyMessage = combinedError ? 'Error loading document' : undefined

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
@@ -14,6 +14,7 @@ import {
   Combobox,
   Trash,
 } from '@/components/emcn'
+import { Database } from '@/components/emcn/icons'
 import { SearchHighlight } from '@/components/ui/search-highlight'
 import type { ChunkData } from '@/lib/knowledge/types'
 import { formatTokenCount } from '@/lib/tokenization'
@@ -40,8 +41,10 @@ import {
   DocumentTagsModal,
 } from '@/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components'
 import { ActionBar } from '@/app/workspace/[workspaceId]/knowledge/[id]/components'
+import { getDocumentIcon } from '@/app/workspace/[workspaceId]/knowledge/components'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
 import { useContextMenu } from '@/app/workspace/[workspaceId]/w/components/sidebar/hooks'
+import { CONNECTOR_REGISTRY } from '@/connectors/registry'
 import { useDocument, useDocumentChunks, useKnowledgeBase } from '@/hooks/kb/use-knowledge'
 import {
   useBulkChunkOperation,
@@ -295,6 +298,11 @@ export function Document({
   const isConnectorDocument = Boolean(documentData?.connectorId)
   const effectiveKnowledgeBaseName = knowledgeBase?.name || knowledgeBaseName || 'Knowledge Base'
   const effectiveDocumentName = documentData?.filename || documentName || 'Document'
+  const ConnectorIcon = documentData?.connectorType
+    ? CONNECTOR_REGISTRY[documentData.connectorType]?.icon
+    : null
+  const DocumentIcon =
+    ConnectorIcon || getDocumentIcon(documentData?.mimeType ?? '', effectiveDocumentName)
   const isCompleted = documentData?.processingStatus === 'completed'
   const canEdit = userPermissions.canEdit === true
 
@@ -457,15 +465,24 @@ export function Document({
     () =>
       combinedError
         ? [
-            { label: 'Knowledge Base', onClick: handleNavToKB },
-            { label: effectiveKnowledgeBaseName, onClick: handleNavToKBDetail },
+            { label: 'Knowledge Base', icon: Database, onClick: handleNavToKB },
+            {
+              label: effectiveKnowledgeBaseName,
+              icon: Database,
+              onClick: handleNavToKBDetail,
+            },
             { label: 'Error' },
           ]
         : [
-            { label: 'Knowledge Base', onClick: handleNavToKB },
-            { label: effectiveKnowledgeBaseName, onClick: handleNavToKBDetail },
+            { label: 'Knowledge Base', icon: Database, onClick: handleNavToKB },
+            {
+              label: effectiveKnowledgeBaseName,
+              icon: Database,
+              onClick: handleNavToKBDetail,
+            },
             {
               label: effectiveDocumentName,
+              icon: DocumentIcon,
               editing: docRename.editingId
                 ? {
                     isEditing: true,
@@ -492,6 +509,7 @@ export function Document({
       handleNavToKBDetail,
       effectiveKnowledgeBaseName,
       effectiveDocumentName,
+      DocumentIcon,
       docRename.editingId,
       docRename.editValue,
       docRename.setEditValue,
@@ -938,15 +956,20 @@ export function Document({
 
   const editorBreadcrumbBase = useMemo<BreadcrumbItem[]>(
     () => [
-      { label: 'Knowledge Base', onClick: handleNavToKB },
-      { label: effectiveKnowledgeBaseName, onClick: handleNavToKBDetail },
-      { label: effectiveDocumentName, onClick: handleBackAttempt },
+      { label: 'Knowledge Base', icon: Database, onClick: handleNavToKB },
+      {
+        label: effectiveKnowledgeBaseName,
+        icon: Database,
+        onClick: handleNavToKBDetail,
+      },
+      { label: effectiveDocumentName, icon: DocumentIcon, onClick: handleBackAttempt },
     ],
     [
       handleNavToKB,
       handleNavToKBDetail,
       effectiveKnowledgeBaseName,
       effectiveDocumentName,
+      DocumentIcon,
       handleBackAttempt,
     ]
   )
@@ -966,9 +989,13 @@ export function Document({
 
   const loadingBreadcrumbs = useMemo<BreadcrumbItem[]>(
     () => [
-      { label: 'Knowledge Base', onClick: handleNavToKB },
-      { label: effectiveKnowledgeBaseName, onClick: handleNavToKBDetail },
-      { label: effectiveDocumentName, onClick: handleClearSelectedChunk },
+      { label: 'Knowledge Base', icon: Database, onClick: handleNavToKB },
+      {
+        label: effectiveKnowledgeBaseName,
+        icon: Database,
+        onClick: handleNavToKBDetail,
+      },
+      { label: effectiveDocumentName, icon: DocumentIcon, onClick: handleClearSelectedChunk },
       { label: 'Loading...' },
     ],
     [
@@ -976,6 +1003,7 @@ export function Document({
       handleNavToKBDetail,
       effectiveKnowledgeBaseName,
       effectiveDocumentName,
+      DocumentIcon,
       handleClearSelectedChunk,
     ]
   )

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -795,10 +795,12 @@ export function KnowledgeBase({
   const breadcrumbs: BreadcrumbItem[] = [
     {
       label: 'Knowledge Base',
+      icon: Database,
       onClick: () => router.push(`/workspace/${workspaceId}/knowledge`),
     },
     {
       label: knowledgeBaseName,
+      icon: Database,
       editing: kbRename.editingId
         ? {
             isEditing: true,

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -45,6 +45,7 @@ import type {
   SortConfig,
 } from '@/app/workspace/[workspaceId]/components'
 import { Resource } from '@/app/workspace/[workspaceId]/components'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import {
   ActionBar,
   AddConnectorModal,
@@ -1071,14 +1072,9 @@ export function KnowledgeBase({
                   <span className='flex-shrink-0 text-[var(--text-icon)]'>
                     <DocIcon className='size-[14px]' />
                   </span>
-                  <Tooltip.Root>
-                    <Tooltip.Trigger asChild>
-                      <span className='min-w-0 truncate'>
-                        <SearchHighlight text={doc.filename} searchQuery={searchQuery} />
-                      </span>
-                    </Tooltip.Trigger>
-                    <Tooltip.Content side='top'>{doc.filename}</Tooltip.Content>
-                  </Tooltip.Root>
+                  <FloatingOverflowText label={doc.filename} className='block truncate'>
+                    <SearchHighlight text={doc.filename} searchQuery={searchQuery} />
+                  </FloatingOverflowText>
                 </span>
               ),
             },

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/knowledge.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/knowledge.tsx
@@ -56,7 +56,7 @@ const COLUMNS: ResourceColumn[] = [
   { id: 'updated', header: 'Last Updated' },
 ]
 
-const DATABASE_ICON = <Database className='size-[14px]' />
+const KNOWLEDGE_BASE_ICON = <Database className='size-[14px]' />
 
 const CONNECTOR_FILTER_OPTIONS: ChipDropdownOption[] = [
   { value: 'all', label: 'All' },
@@ -299,7 +299,7 @@ export function Knowledge() {
           id: kb.id,
           cells: {
             name: {
-              icon: DATABASE_ICON,
+              icon: KNOWLEDGE_BASE_ICON,
               label: kb.name,
             },
             documents: {

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/workflows-list/workflows-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/workflows-list/workflows-list.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'next/navigation'
 import { cn } from '@/lib/core/utils/cn'
 import { handleKeyboardActivation } from '@/lib/core/utils/keyboard'
 import { workflowBorderColor } from '@/lib/workspaces/colors'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import {
   DELETED_WORKFLOW_COLOR,
   DELETED_WORKFLOW_LABEL,
@@ -106,9 +107,10 @@ function WorkflowsListInner({
                         backgroundClip: 'padding-box',
                       }}
                     />
-                    <span className='min-w-0 truncate font-medium text-[var(--text-primary)] text-caption'>
-                      {workflow.workflowName}
-                    </span>
+                    <FloatingOverflowText
+                      label={workflow.workflowName}
+                      className='block truncate font-medium text-[var(--text-primary)] text-caption'
+                    />
                   </div>
 
                   {/* Status bar - takes most of the space */}

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/logs-toolbar/logs-toolbar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/logs-toolbar/logs-toolbar.tsx
@@ -21,6 +21,7 @@ import { hasActiveFilters } from '@/lib/logs/filters'
 import { getTriggerOptions } from '@/lib/logs/get-trigger-options'
 import { captureEvent } from '@/lib/posthog/client'
 import { workflowBorderColor } from '@/lib/workspaces/colors'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import {
   formatDateShort,
   type LogStatus,
@@ -550,7 +551,10 @@ export const LogsToolbar = memo(function LogsToolbar({
                             style={{ backgroundColor: selectedStatusColor, width: 8, height: 8 }}
                           />
                         )}
-                        <span className='truncate'>{statusDisplayLabel}</span>
+                        <FloatingOverflowText
+                          label={statusDisplayLabel}
+                          className='block truncate'
+                        />
                       </span>
                     }
                     showAllOption
@@ -583,7 +587,10 @@ export const LogsToolbar = memo(function LogsToolbar({
                             }}
                           />
                         )}
-                        <span className='truncate'>{workflowDisplayLabel}</span>
+                        <FloatingOverflowText
+                          label={workflowDisplayLabel}
+                          className='block truncate'
+                        />
                       </span>
                     }
                     searchable
@@ -607,9 +614,10 @@ export const LogsToolbar = memo(function LogsToolbar({
                     onMultiSelectChange={handleFolderFilterChange}
                     placeholder='All folders'
                     overlayContent={
-                      <span className='truncate text-[var(--text-primary)]'>
-                        {folderDisplayLabel}
-                      </span>
+                      <FloatingOverflowText
+                        label={folderDisplayLabel}
+                        className='block truncate text-[var(--text-primary)]'
+                      />
                     }
                     searchable
                     searchPlaceholder='Search folders...'
@@ -632,9 +640,10 @@ export const LogsToolbar = memo(function LogsToolbar({
                     onMultiSelectChange={handleTriggerFilterChange}
                     placeholder='All triggers'
                     overlayContent={
-                      <span className='truncate text-[var(--text-primary)]'>
-                        {triggerDisplayLabel}
-                      </span>
+                      <FloatingOverflowText
+                        label={triggerDisplayLabel}
+                        className='block truncate text-[var(--text-primary)]'
+                      />
                     }
                     searchable
                     searchPlaceholder='Search triggers...'
@@ -656,9 +665,10 @@ export const LogsToolbar = memo(function LogsToolbar({
                     onChange={handleTimeRangeChange}
                     placeholder='All time'
                     overlayContent={
-                      <span className='truncate text-[var(--text-primary)]'>
-                        {timeDisplayLabel}
-                      </span>
+                      <FloatingOverflowText
+                        label={timeDisplayLabel}
+                        className='block truncate text-[var(--text-primary)]'
+                      />
                     }
                     size='sm'
                     className='h-[32px] w-full rounded-md'
@@ -685,7 +695,7 @@ export const LogsToolbar = memo(function LogsToolbar({
                       style={{ backgroundColor: selectedStatusColor, width: 8, height: 8 }}
                     />
                   )}
-                  <span className='truncate'>{statusDisplayLabel}</span>
+                  <FloatingOverflowText label={statusDisplayLabel} className='block truncate' />
                 </span>
               }
               showAllOption
@@ -714,7 +724,7 @@ export const LogsToolbar = memo(function LogsToolbar({
                       }}
                     />
                   )}
-                  <span className='truncate'>{workflowDisplayLabel}</span>
+                  <FloatingOverflowText label={workflowDisplayLabel} className='block truncate' />
                 </span>
               }
               searchable
@@ -734,7 +744,10 @@ export const LogsToolbar = memo(function LogsToolbar({
               onMultiSelectChange={handleFolderFilterChange}
               placeholder='Folder'
               overlayContent={
-                <span className='truncate text-[var(--text-primary)]'>{folderDisplayLabel}</span>
+                <FloatingOverflowText
+                  label={folderDisplayLabel}
+                  className='block truncate text-[var(--text-primary)]'
+                />
               }
               searchable
               searchPlaceholder='Search folders...'
@@ -753,7 +766,10 @@ export const LogsToolbar = memo(function LogsToolbar({
               onMultiSelectChange={handleTriggerFilterChange}
               placeholder='Trigger'
               overlayContent={
-                <span className='truncate text-[var(--text-primary)]'>{triggerDisplayLabel}</span>
+                <FloatingOverflowText
+                  label={triggerDisplayLabel}
+                  className='block truncate text-[var(--text-primary)]'
+                />
               }
               searchable
               searchPlaceholder='Search triggers...'
@@ -772,7 +788,10 @@ export const LogsToolbar = memo(function LogsToolbar({
                 onChange={handleTimeRangeChange}
                 placeholder='Time'
                 overlayContent={
-                  <span className='truncate text-[var(--text-primary)]'>{timeDisplayLabel}</span>
+                  <FloatingOverflowText
+                    label={timeDisplayLabel}
+                    className='block truncate text-[var(--text-primary)]'
+                  />
                 }
                 size='sm'
                 align='end'

--- a/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
@@ -58,6 +58,7 @@ import {
   ResourceOptionsBar,
   ResourceTable,
 } from '@/app/workspace/[workspaceId]/components'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import { useSearchState } from '@/app/workspace/[workspaceId]/logs/hooks/use-search-state'
 import type { Suggestion } from '@/app/workspace/[workspaceId]/logs/types'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
@@ -1408,7 +1409,7 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
                   style={{ backgroundColor: selectedStatusColor, width: 8, height: 8 }}
                 />
               )}
-              <span className='truncate'>{statusDisplayLabel}</span>
+              <FloatingOverflowText label={statusDisplayLabel} className='block truncate' />
             </span>
           }
           showAllOption
@@ -1438,7 +1439,7 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
                   }}
                 />
               )}
-              <span className='truncate'>{workflowDisplayLabel}</span>
+              <FloatingOverflowText label={workflowDisplayLabel} className='block truncate' />
             </span>
           }
           searchable
@@ -1459,7 +1460,10 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
           onMultiSelectChange={setFolderIds}
           placeholder='All folders'
           overlayContent={
-            <span className='truncate text-[var(--text-primary)]'>{folderDisplayLabel}</span>
+            <FloatingOverflowText
+              label={folderDisplayLabel}
+              className='block truncate text-[var(--text-primary)]'
+            />
           }
           searchable
           searchPlaceholder='Search folders...'
@@ -1479,7 +1483,10 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
           onMultiSelectChange={setTriggers}
           placeholder='All triggers'
           overlayContent={
-            <span className='truncate text-[var(--text-primary)]'>{triggerDisplayLabel}</span>
+            <FloatingOverflowText
+              label={triggerDisplayLabel}
+              className='block truncate text-[var(--text-primary)]'
+            />
           }
           searchable
           searchPlaceholder='Search triggers...'
@@ -1499,7 +1506,10 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
             onChange={handleTimeRangeChange}
             placeholder='All time'
             overlayContent={
-              <span className='truncate text-[var(--text-primary)]'>{timeDisplayLabel}</span>
+              <FloatingOverflowText
+                label={timeDisplayLabel}
+                className='block truncate text-[var(--text-primary)]'
+              />
             }
             size='sm'
             className='h-[32px] w-full rounded-md'

--- a/apps/sim/app/workspace/[workspaceId]/providers/workspace-permissions-provider.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/workspace-permissions-provider.tsx
@@ -5,7 +5,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { createLogger } from '@sim/logger'
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'next/navigation'
-import { toast } from '@/components/emcn'
+import { useToast } from '@/components/emcn'
 import { useRegisterGlobalCommands } from '@/app/workspace/[workspaceId]/providers/global-commands-provider'
 import { createCommands } from '@/app/workspace/[workspaceId]/utils/commands-utils'
 import { useSocket } from '@/app/workspace/providers/socket-provider'
@@ -56,6 +56,7 @@ export function WorkspacePermissionsProvider({ children }: WorkspacePermissionsP
   const params = useParams()
   const workspaceId = params?.workspaceId as string
   const queryClient = useQueryClient()
+  const { toast } = useToast()
 
   const [hasShownOfflineNotification, setHasShownOfflineNotification] = useState(false)
   const hasOperationError = useOperationQueueStore((state) => state.hasOperationError)

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
@@ -25,6 +25,7 @@ import {
   Resource,
   timeCell,
 } from '@/app/workspace/[workspaceId]/components'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import { ScheduleModal } from '@/app/workspace/[workspaceId]/scheduled-tasks/components/create-schedule-modal'
 import { ScheduleContextMenu } from '@/app/workspace/[workspaceId]/scheduled-tasks/components/schedule-context-menu'
 import { ScheduleListContextMenu } from '@/app/workspace/[workspaceId]/scheduled-tasks/components/schedule-list-context-menu'
@@ -294,9 +295,10 @@ export function ScheduledTasks() {
             multiSelectValues={scheduleTypeFilter}
             onMultiSelectChange={setScheduleTypeFilter}
             overlayContent={
-              <span className='truncate text-[var(--text-primary)]'>
-                {scheduleTypeDisplayLabel}
-              </span>
+              <FloatingOverflowText
+                label={scheduleTypeDisplayLabel}
+                className='block truncate text-[var(--text-primary)]'
+              />
             }
             showAllOption
             allOptionLabel='All'
@@ -315,7 +317,10 @@ export function ScheduledTasks() {
             multiSelectValues={statusFilter}
             onMultiSelectChange={setStatusFilter}
             overlayContent={
-              <span className='truncate text-[var(--text-primary)]'>{statusDisplayLabel}</span>
+              <FloatingOverflowText
+                label={statusDisplayLabel}
+                className='block truncate text-[var(--text-primary)]'
+              />
             }
             showAllOption
             allOptionLabel='All'
@@ -331,7 +336,10 @@ export function ScheduledTasks() {
             multiSelectValues={healthFilter}
             onMultiSelectChange={setHealthFilter}
             overlayContent={
-              <span className='truncate text-[var(--text-primary)]'>{healthDisplayLabel}</span>
+              <FloatingOverflowText
+                label={healthDisplayLabel}
+                className='block truncate text-[var(--text-primary)]'
+              />
             }
             showAllOption
             allOptionLabel='All'

--- a/apps/sim/app/workspace/[workspaceId]/tables/tables.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/tables.tsx
@@ -25,6 +25,7 @@ import type {
   SortConfig,
 } from '@/app/workspace/[workspaceId]/components'
 import { ownerCell, Resource, timeCell } from '@/app/workspace/[workspaceId]/components'
+import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
 import {
   ImportCsvDialog,
@@ -264,7 +265,10 @@ export function Tables() {
             multiSelectValues={rowCountFilter}
             onMultiSelectChange={setRowCountFilter}
             overlayContent={
-              <span className='truncate text-[var(--text-primary)]'>{rowCountDisplayLabel}</span>
+              <FloatingOverflowText
+                label={rowCountDisplayLabel}
+                className='block truncate text-[var(--text-primary)]'
+              />
             }
             showAllOption
             allOptionLabel='All'
@@ -281,7 +285,10 @@ export function Tables() {
               multiSelectValues={ownerFilter}
               onMultiSelectChange={setOwnerFilter}
               overlayContent={
-                <span className='truncate text-[var(--text-primary)]'>{ownerDisplayLabel}</span>
+                <FloatingOverflowText
+                  label={ownerDisplayLabel}
+                  className='block truncate text-[var(--text-primary)]'
+                />
               }
               searchable
               searchPlaceholder='Search members...'

--- a/apps/sim/lib/core/security/csp.ts
+++ b/apps/sim/lib/core/security/csp.ts
@@ -48,6 +48,7 @@ export interface CSPDirectives {
 const STATIC_SCRIPT_SRC = [
   "'self'",
   "'unsafe-inline'",
+  ...(isDev ? ["'unsafe-eval'"] : []),
   'https://*.google.com',
   'https://apis.google.com',
   'https://challenges.cloudflare.com',


### PR DESCRIPTION
## Summary
- Added adaptive breadcrumb truncation for resource headers with overflow-aware floating title tooltips
- Added the compact Path / location dropdown on hover from the root breadcrumb icon
- Updated knowledge base and document breadcrumb iconography so the path hierarchy is clearer
- Fixed local preview issues from dev CSP and early toast calls

## Type of Change
- [x] Improvement

## Testing
- `bun run lint`
- `bun run check:api-validation:strict`
- `bun run type-check` from `apps/sim`
- Tested manually in localhost preview

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)