### PR TITLE
fix(mothership): scope mothership block tool permissions to the executing user

### DIFF
--- a/apps/sim/lib/copilot/request/lifecycle/run.test.ts
+++ b/apps/sim/lib/copilot/request/lifecycle/run.test.ts
@@ -222,4 +222,37 @@ describe('runCopilotLifecycle', () => {
       })
     )
   })
+
+  it('propagates payload userPermission into the generated execution context', async () => {
+    let capturedExecContext: ExecutionContext | undefined
+    mockGetEffectiveDecryptedEnv.mockResolvedValueOnce({})
+    mockRunStreamLoop.mockImplementationOnce(
+      async (
+        _fetchUrl: string,
+        _fetchOptions: RequestInit,
+        _context: StreamingContext,
+        execContext: ExecutionContext
+      ): Promise<void> => {
+        capturedExecContext = execContext
+      }
+    )
+
+    await runCopilotLifecycle(
+      { message: 'hello', messageId: 'stream-1', userPermission: 'write' },
+      {
+        userId: 'user-1',
+        workspaceId: 'ws-1',
+        chatId: 'chat-1',
+      }
+    )
+
+    expect(capturedExecContext).toEqual(
+      expect.objectContaining({
+        userId: 'user-1',
+        workspaceId: 'ws-1',
+        chatId: 'chat-1',
+        userPermission: 'write',
+      })
+    )
+  })
 })

--- a/apps/sim/lib/copilot/request/lifecycle/run.ts
+++ b/apps/sim/lib/copilot/request/lifecycle/run.ts
@@ -472,6 +472,8 @@ async function buildExecutionContext(
   const userTimezone =
     typeof requestPayload?.userTimezone === 'string' ? requestPayload.userTimezone : undefined
   const requestMode = typeof requestPayload?.mode === 'string' ? requestPayload.mode : undefined
+  const userPermission =
+    typeof requestPayload?.userPermission === 'string' ? requestPayload.userPermission : undefined
 
   let execContext: ExecutionContext
   if (workflowId) {
@@ -490,6 +492,7 @@ async function buildExecutionContext(
   if (userTimezone) execContext.userTimezone = userTimezone
   execContext.copilotToolExecution = true
   if (requestMode) execContext.requestMode = requestMode
+  if (userPermission) execContext.userPermission = userPermission
   execContext.messageId =
     typeof requestPayload?.messageId === 'string' ? requestPayload.messageId : undefined
   execContext.executionId = executionId


### PR DESCRIPTION
## Summary
- `buildExecutionContext` now reads `userPermission` from the request payload and sets it on the execution context, so Mothership block runs enforce the executing user's workspace permissions
- The execute route already resolved and forwarded `userPermission`, but the headless/block lifecycle path dropped it — tools ran with `userPermission: undefined` (writes either hard-denied or silently unenforced depending on the tool)
- Brings the block path to parity with the interactive Mothership chat path, which already sets this
- Added a regression test asserting payload `userPermission` propagates into the generated execution context

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `run.test.ts` passes (3/3); verified the new test fails without the fix. `bun run lint` clean; `bun run check:api-validation:strict` passed.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)