### PR TITLE
improvement(resource-header): share floating-tooltip engine, prune dead overlay tooltips

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text.tsx
@@ -1,38 +1,29 @@
 'use client'
 
 import type React from 'react'
-import { memo, useEffect, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { memo, useRef } from 'react'
 import { cn } from '@/lib/core/utils/cn'
-
-const FLOATING_TOOLTIP_OFFSET = 16
-const FLOATING_TOOLTIP_EDGE_GUTTER = 16
-const FLOATING_TOOLTIP_EDGE_THRESHOLD = 360
+import {
+  FloatingTooltip,
+  isTextClipped,
+  useFloatingTooltip,
+  useIsOverflowing,
+} from '@/app/workspace/[workspaceId]/components/resource/components/floating-tooltip'
 
 interface FloatingOverflowTextProps {
+  /** Full text shown in the tooltip and used as the default visible content. */
   label: string
+  /** Optional custom visible content (e.g. highlighted text); defaults to `label`. */
   children?: React.ReactNode
   className?: string
+  /** Forces the tooltip even when the text is not visually clipped (e.g. content truncated upstream). */
   showWhen?: boolean
 }
 
-interface FloatingTooltipState {
-  visible: boolean
-  x: number
-  y: number
-  skew: number
-  scaleX: number
-  scaleY: number
-  alignX: 'left' | 'right'
-  alignY: 'above' | 'below'
-}
-
-interface PointerSnapshot {
-  x: number
-  y: number
-  time: number
-}
-
+/**
+ * Truncating text that fades its clipped edge and reveals the full value in a
+ * pointer-reactive floating tooltip on hover or focus.
+ */
 export const FloatingOverflowText = memo(function FloatingOverflowText({
   label,
   children,
@@ -40,98 +31,12 @@ export const FloatingOverflowText = memo(function FloatingOverflowText({
   showWhen,
 }: FloatingOverflowTextProps) {
   const textRef = useRef<HTMLSpanElement>(null)
-  const lastPointerRef = useRef<PointerSnapshot | null>(null)
-  const [isOverflowing, setIsOverflowing] = useState(false)
-  const [tooltipState, setTooltipState] = useState<FloatingTooltipState>({
-    visible: false,
-    x: 0,
-    y: 0,
-    skew: 0,
-    scaleX: 1,
-    scaleY: 1,
-    alignX: 'left',
-    alignY: 'below',
-  })
-
-  useEffect(() => {
+  const isOverflowing = useIsOverflowing(textRef)
+  const { state, handlers } = useFloatingTooltip(() => {
     const element = textRef.current
-    if (!element) return
-
-    const updateOverflowState = () => {
-      setIsOverflowing(isTextClipped(element))
-    }
-
-    updateOverflowState()
-
-    const resizeObserver = new ResizeObserver(updateOverflowState)
-    resizeObserver.observe(element)
-    window.addEventListener('resize', updateOverflowState)
-
-    return () => {
-      resizeObserver.disconnect()
-      window.removeEventListener('resize', updateOverflowState)
-    }
-  }, [])
-
-  const canShowTooltip = (element: HTMLSpanElement | null) => {
     if (!element || label.length === 0) return false
     return Boolean(showWhen) || isTextClipped(element)
-  }
-
-  const handleTooltipMove = (event: React.PointerEvent<HTMLSpanElement>) => {
-    if (!canShowTooltip(textRef.current)) return
-
-    const now = performance.now()
-    const previous = lastPointerRef.current
-    const elapsed = previous ? Math.max(now - previous.time, 16) : 16
-    const velocityX = previous ? ((event.clientX - previous.x) / elapsed) * 16 : 0
-    const velocityY = previous ? ((event.clientY - previous.y) / elapsed) * 16 : 0
-    const velocity = Math.hypot(velocityX, velocityY)
-    const position = getFloatingTooltipPosition(event.clientX, event.clientY)
-
-    lastPointerRef.current = { x: event.clientX, y: event.clientY, time: now }
-    setTooltipState({
-      visible: true,
-      ...position,
-      skew: clamp(velocityX * 0.11, -6, 6),
-      scaleX: 1 + Math.min(0.035, velocity / 1100),
-      scaleY: 1 - Math.min(0.02, velocity / 1500),
-    })
-  }
-
-  const showTooltip = (event: React.PointerEvent<HTMLSpanElement>) => {
-    if (!canShowTooltip(textRef.current)) return
-    const position = getFloatingTooltipPosition(event.clientX, event.clientY)
-    lastPointerRef.current = { x: event.clientX, y: event.clientY, time: performance.now() }
-    setIsOverflowing(true)
-    setTooltipState({
-      visible: true,
-      ...position,
-      skew: 0,
-      scaleX: 1,
-      scaleY: 1,
-    })
-  }
-
-  const showTooltipFromFocus = (event: React.FocusEvent<HTMLSpanElement>) => {
-    if (!canShowTooltip(textRef.current)) return
-    const rect = event.currentTarget.getBoundingClientRect()
-    const position = getFloatingTooltipPosition(rect.left + rect.width / 2, rect.bottom)
-    lastPointerRef.current = null
-    setIsOverflowing(true)
-    setTooltipState({
-      visible: true,
-      ...position,
-      skew: 0,
-      scaleX: 1,
-      scaleY: 1,
-    })
-  }
-
-  const hideTooltip = () => {
-    lastPointerRef.current = null
-    setTooltipState((current) => ({ ...current, visible: false, skew: 0, scaleX: 1, scaleY: 1 }))
-  }
+  })
 
   return (
     <>
@@ -143,86 +48,11 @@ export const FloatingOverflowText = memo(function FloatingOverflowText({
             '[mask-image:linear-gradient(to_right,black_calc(100%-18px),transparent)] hover:[mask-image:none] focus-visible:[mask-image:none]',
           className
         )}
-        onPointerEnter={showTooltip}
-        onPointerMove={handleTooltipMove}
-        onPointerLeave={hideTooltip}
-        onPointerDown={hideTooltip}
-        onFocus={showTooltipFromFocus}
-        onBlur={hideTooltip}
+        {...handlers}
       >
         {children ?? label}
       </span>
-      <FloatingTooltip label={label} state={tooltipState} />
+      <FloatingTooltip label={label} state={state} />
     </>
   )
 })
-
-function FloatingTooltip({ label, state }: { label: string; state: FloatingTooltipState }) {
-  if (typeof document === 'undefined' || !state.visible) return null
-
-  return createPortal(
-    <div
-      aria-hidden='true'
-      className={cn(
-        'pointer-events-none fixed top-0 left-0 z-[var(--z-tooltip)] w-fit max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border border-[var(--border)] bg-[var(--bg)] px-2 py-1.5 text-[var(--text-body)] text-xs opacity-100 shadow-sm transition-[opacity,filter,transform] duration-150 ease-out',
-        'motion-reduce:transition-none'
-      )}
-      style={{
-        transform: `${getFloatingTooltipTranslate(state)} skew(${state.skew}deg) scale(${state.scaleX}, ${state.scaleY})`,
-        transformOrigin: state.alignX === 'left' ? '12px 12px' : 'calc(100% - 12px) 12px',
-      }}
-    >
-      <span className='block whitespace-normal break-words text-left leading-[18px]'>{label}</span>
-    </div>,
-    document.body
-  )
-}
-
-function isTextClipped(element: HTMLElement): boolean {
-  return element.scrollWidth > element.clientWidth + 1
-}
-
-function getFloatingTooltipPosition(
-  clientX: number,
-  clientY: number
-): Pick<FloatingTooltipState, 'x' | 'y' | 'alignX' | 'alignY'> {
-  if (typeof window === 'undefined') {
-    return { x: clientX, y: clientY, alignX: 'left', alignY: 'below' }
-  }
-
-  const alignX = window.innerWidth - clientX < FLOATING_TOOLTIP_EDGE_THRESHOLD ? 'right' : 'left'
-  const alignY =
-    window.innerHeight - clientY < FLOATING_TOOLTIP_EDGE_THRESHOLD / 2 ? 'above' : 'below'
-
-  return {
-    x: clamp(
-      clientX,
-      FLOATING_TOOLTIP_EDGE_GUTTER,
-      window.innerWidth - FLOATING_TOOLTIP_EDGE_GUTTER
-    ),
-    y: clamp(
-      clientY,
-      FLOATING_TOOLTIP_EDGE_GUTTER,
-      window.innerHeight - FLOATING_TOOLTIP_EDGE_GUTTER
-    ),
-    alignX,
-    alignY,
-  }
-}
-
-function getFloatingTooltipTranslate(state: FloatingTooltipState): string {
-  const xOffset =
-    state.alignX === 'left'
-      ? `${FLOATING_TOOLTIP_OFFSET}px`
-      : `calc(-100% - ${FLOATING_TOOLTIP_OFFSET}px)`
-  const yOffset =
-    state.alignY === 'below'
-      ? `${FLOATING_TOOLTIP_OFFSET}px`
-      : `calc(-100% - ${FLOATING_TOOLTIP_OFFSET}px)`
-
-  return `translate3d(${state.x}px, ${state.y}px, 0) translate(${xOffset}, ${yOffset})`
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value))
-}

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/floating-tooltip.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/floating-tooltip.tsx
@@ -1,0 +1,232 @@
+'use client'
+
+import { memo, type RefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '@/lib/core/utils/cn'
+
+const TOOLTIP_OFFSET = 16
+const EDGE_GUTTER = 16
+const EDGE_THRESHOLD = 360
+const MIN_FRAME_MS = 16
+
+/**
+ * Resolved position and motion of a floating tooltip. `x`/`y` are viewport
+ * coordinates the tooltip anchors to; `alignX`/`alignY` flip the tooltip away
+ * from the nearest viewport edge; `skew`/`scale*` add the velocity-reactive
+ * flourish while the pointer is moving.
+ */
+export interface FloatingTooltipState {
+  visible: boolean
+  x: number
+  y: number
+  skew: number
+  scaleX: number
+  scaleY: number
+  alignX: 'left' | 'right'
+  alignY: 'above' | 'below'
+}
+
+interface PointerSnapshot {
+  x: number
+  y: number
+  time: number
+}
+
+/**
+ * Pointer/focus event handlers that drive a {@link useFloatingTooltip}. Spread
+ * onto the element that should reveal the tooltip on hover or focus.
+ */
+export interface FloatingTooltipHandlers {
+  onPointerEnter: (event: React.PointerEvent<HTMLElement>) => void
+  onPointerMove: (event: React.PointerEvent<HTMLElement>) => void
+  onPointerLeave: () => void
+  onPointerDown: () => void
+  onFocus: (event: React.FocusEvent<HTMLElement>) => void
+  onBlur: () => void
+}
+
+const HIDDEN_STATE: FloatingTooltipState = {
+  visible: false,
+  x: 0,
+  y: 0,
+  skew: 0,
+  scaleX: 1,
+  scaleY: 1,
+  alignX: 'left',
+  alignY: 'below',
+}
+
+/**
+ * Drives a pointer-reactive floating tooltip. `canShow` is queried on every
+ * gesture with the event target, letting the caller gate the tooltip on its own
+ * overflow measurement. Returns the current {@link FloatingTooltipState} to feed
+ * a {@link FloatingTooltip} and a stable set of {@link FloatingTooltipHandlers}
+ * to spread onto the trigger element.
+ */
+export function useFloatingTooltip(canShow: (target: HTMLElement) => boolean): {
+  state: FloatingTooltipState
+  handlers: FloatingTooltipHandlers
+} {
+  const canShowRef = useRef(canShow)
+  canShowRef.current = canShow
+
+  const lastPointerRef = useRef<PointerSnapshot | null>(null)
+  const [state, setState] = useState<FloatingTooltipState>(HIDDEN_STATE)
+
+  const handlers = useMemo<FloatingTooltipHandlers>(() => {
+    const hide = () => {
+      lastPointerRef.current = null
+      setState((current) => (current.visible ? HIDDEN_STATE : current))
+    }
+
+    const showStatic = (clientX: number, clientY: number) => {
+      lastPointerRef.current = { x: clientX, y: clientY, time: performance.now() }
+      setState({
+        visible: true,
+        ...getTooltipPosition(clientX, clientY),
+        skew: 0,
+        scaleX: 1,
+        scaleY: 1,
+      })
+    }
+
+    return {
+      onPointerEnter: (event) => {
+        if (!canShowRef.current(event.currentTarget)) return
+        showStatic(event.clientX, event.clientY)
+      },
+      onPointerMove: (event) => {
+        if (!canShowRef.current(event.currentTarget)) return
+        const now = performance.now()
+        const previous = lastPointerRef.current
+        const elapsed = previous ? Math.max(now - previous.time, MIN_FRAME_MS) : MIN_FRAME_MS
+        const velocityX = previous ? ((event.clientX - previous.x) / elapsed) * MIN_FRAME_MS : 0
+        const velocityY = previous ? ((event.clientY - previous.y) / elapsed) * MIN_FRAME_MS : 0
+        const velocity = Math.hypot(velocityX, velocityY)
+
+        lastPointerRef.current = { x: event.clientX, y: event.clientY, time: now }
+        setState({
+          visible: true,
+          ...getTooltipPosition(event.clientX, event.clientY),
+          skew: clamp(velocityX * 0.11, -6, 6),
+          scaleX: 1 + Math.min(0.035, velocity / 1100),
+          scaleY: 1 - Math.min(0.02, velocity / 1500),
+        })
+      },
+      onPointerLeave: hide,
+      onPointerDown: hide,
+      onFocus: (event) => {
+        const target = event.currentTarget
+        if (!canShowRef.current(target)) return
+        const rect = target.getBoundingClientRect()
+        lastPointerRef.current = null
+        setState({
+          visible: true,
+          ...getTooltipPosition(rect.left + rect.width / 2, rect.bottom),
+          skew: 0,
+          scaleX: 1,
+          scaleY: 1,
+        })
+      },
+      onBlur: hide,
+    }
+  }, [])
+
+  return { state, handlers }
+}
+
+/**
+ * Tracks whether a referenced element's text is horizontally clipped, staying in
+ * sync via a `ResizeObserver` and window resizes.
+ */
+export function useIsOverflowing(ref: RefObject<HTMLElement | null>): boolean {
+  const [isOverflowing, setIsOverflowing] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const update = () => setIsOverflowing(isTextClipped(element))
+    update()
+
+    const resizeObserver = new ResizeObserver(update)
+    resizeObserver.observe(element)
+    window.addEventListener('resize', update)
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', update)
+    }
+  }, [ref])
+
+  return isOverflowing
+}
+
+/** Whether an element's content is wider than its visible box. */
+export function isTextClipped(element: HTMLElement): boolean {
+  return element.scrollWidth > element.clientWidth + 1
+}
+
+/** Clamps `value` to the inclusive `[min, max]` range. */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+/**
+ * Portaled tooltip body positioned from a {@link FloatingTooltipState}. Renders
+ * nothing while hidden or during SSR.
+ */
+export const FloatingTooltip = memo(function FloatingTooltip({
+  label,
+  state,
+}: {
+  label: string
+  state: FloatingTooltipState
+}) {
+  if (typeof document === 'undefined' || !state.visible) return null
+
+  return createPortal(
+    <div
+      aria-hidden='true'
+      className={cn(
+        'pointer-events-none fixed top-0 left-0 z-[var(--z-tooltip)] w-fit max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border border-[var(--border)] bg-[var(--bg)] px-2 py-1.5 text-[var(--text-body)] text-xs opacity-100 shadow-sm transition-[opacity,filter,transform] duration-150 ease-out',
+        'motion-reduce:transition-none'
+      )}
+      style={{
+        transform: `${getTooltipTranslate(state)} skew(${state.skew}deg) scale(${state.scaleX}, ${state.scaleY})`,
+        transformOrigin: state.alignX === 'left' ? '12px 12px' : 'calc(100% - 12px) 12px',
+      }}
+    >
+      <span className='block whitespace-normal break-words text-left leading-[18px]'>{label}</span>
+    </div>,
+    document.body
+  )
+})
+
+function getTooltipPosition(
+  clientX: number,
+  clientY: number
+): Pick<FloatingTooltipState, 'x' | 'y' | 'alignX' | 'alignY'> {
+  if (typeof window === 'undefined') {
+    return { x: clientX, y: clientY, alignX: 'left', alignY: 'below' }
+  }
+
+  const alignX = window.innerWidth - clientX < EDGE_THRESHOLD ? 'right' : 'left'
+  const alignY = window.innerHeight - clientY < EDGE_THRESHOLD / 2 ? 'above' : 'below'
+
+  return {
+    x: clamp(clientX, EDGE_GUTTER, window.innerWidth - EDGE_GUTTER),
+    y: clamp(clientY, EDGE_GUTTER, window.innerHeight - EDGE_GUTTER),
+    alignX,
+    alignY,
+  }
+}
+
+function getTooltipTranslate(state: FloatingTooltipState): string {
+  const xOffset =
+    state.alignX === 'left' ? `${TOOLTIP_OFFSET}px` : `calc(-100% - ${TOOLTIP_OFFSET}px)`
+  const yOffset =
+    state.alignY === 'below' ? `${TOOLTIP_OFFSET}px` : `calc(-100% - ${TOOLTIP_OFFSET}px)`
+
+  return `translate3d(${state.x}px, ${state.y}px, 0) translate(${xOffset}, ${yOffset})`
+}

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
@@ -16,15 +16,17 @@ import {
   PopoverItem,
   PopoverSection,
 } from '@/components/emcn'
+import { POPOVER_ANIMATION_CLASSES } from '@/components/emcn/components/chip-date-picker/chip-date-picker'
 import { cn } from '@/lib/core/utils/cn'
 import { InlineRenameInput } from '@/app/workspace/[workspaceId]/components/inline-rename-input'
 import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
+import {
+  FloatingTooltip,
+  useFloatingTooltip,
+  useIsOverflowing,
+} from '@/app/workspace/[workspaceId]/components/resource/components/floating-tooltip'
 
 const HEADER_PLUS_ICON = <Plus className='mr-1.5 size-[14px] text-[var(--text-icon)]' />
-const TERMINAL_BREADCRUMB_LABELS = /^(Chunk #|New Chunk|Loading\.\.\.)/
-const FLOATING_TOOLTIP_OFFSET = 16
-const FLOATING_TOOLTIP_EDGE_GUTTER = 16
-const FLOATING_TOOLTIP_EDGE_THRESHOLD = 360
 
 export interface DropdownOption {
   label: string
@@ -47,6 +49,11 @@ export interface BreadcrumbItem {
   onClick?: () => void
   dropdownItems?: DropdownOption[]
   editing?: BreadcrumbEditing
+  /**
+   * Marks a non-navigable trailing crumb (e.g. "New Chunk", "Loading...") so the
+   * header sizes it as the terminal segment rather than the current resource.
+   */
+  terminal?: boolean
 }
 
 export interface HeaderAction {
@@ -94,9 +101,7 @@ export const ResourceHeader = memo(function ResourceHeader({
   const headerRef = useRef<HTMLDivElement>(null)
   const hasBreadcrumbs = breadcrumbs && breadcrumbs.length > 0
   const terminalBreadcrumbIndex =
-    hasBreadcrumbs && TERMINAL_BREADCRUMB_LABELS.test(breadcrumbs[breadcrumbs.length - 1].label)
-      ? breadcrumbs.length - 1
-      : -1
+    hasBreadcrumbs && breadcrumbs[breadcrumbs.length - 1].terminal ? breadcrumbs.length - 1 : -1
   const currentResourceIndex =
     terminalBreadcrumbIndex > -1
       ? terminalBreadcrumbIndex - 1
@@ -255,102 +260,10 @@ const BreadcrumbSegment = memo(function BreadcrumbSegment({
   className,
 }: BreadcrumbSegmentProps) {
   const labelRef = useRef<HTMLSpanElement>(null)
-  const lastPointerRef = useRef<PointerSnapshot | null>(null)
-  const [isOverflowing, setIsOverflowing] = useState(false)
-  const [tooltipState, setTooltipState] = useState<BreadcrumbFloatingTooltipState>({
-    visible: false,
-    x: 0,
-    y: 0,
-    skew: 0,
-    scaleX: 1,
-    scaleY: 1,
-    alignX: 'left',
-    alignY: 'below',
-  })
-
-  useEffect(() => {
-    const element = labelRef.current
-    if (!element) return
-
-    const updateOverflowState = () => {
-      setIsOverflowing(element.scrollWidth > element.clientWidth + 1)
-    }
-
-    updateOverflowState()
-
-    const resizeObserver = new ResizeObserver(updateOverflowState)
-    resizeObserver.observe(element)
-    window.addEventListener('resize', updateOverflowState)
-
-    return () => {
-      resizeObserver.disconnect()
-      window.removeEventListener('resize', updateOverflowState)
-    }
-  }, [])
-
-  const handleTooltipMove = (event: React.PointerEvent<HTMLElement>) => {
-    if (!isBreadcrumbTextClipped(labelRef.current, event.currentTarget)) return
-
-    const now = performance.now()
-    const previous = lastPointerRef.current
-    const elapsed = previous ? Math.max(now - previous.time, 16) : 16
-    const velocityX = previous ? ((event.clientX - previous.x) / elapsed) * 16 : 0
-    const velocityY = previous ? ((event.clientY - previous.y) / elapsed) * 16 : 0
-    const velocity = Math.hypot(velocityX, velocityY)
-    const position = getFloatingTooltipPosition(event.clientX, event.clientY)
-
-    lastPointerRef.current = { x: event.clientX, y: event.clientY, time: now }
-    setTooltipState({
-      visible: true,
-      ...position,
-      skew: clamp(velocityX * 0.11, -6, 6),
-      scaleX: 1 + Math.min(0.035, velocity / 1100),
-      scaleY: 1 - Math.min(0.02, velocity / 1500),
-    })
-  }
-
-  const showTooltip = (event: React.PointerEvent<HTMLElement>) => {
-    if (!isBreadcrumbTextClipped(labelRef.current, event.currentTarget)) return
-    const position = getFloatingTooltipPosition(event.clientX, event.clientY)
-    lastPointerRef.current = { x: event.clientX, y: event.clientY, time: performance.now() }
-    setIsOverflowing(true)
-    setTooltipState({
-      visible: true,
-      ...position,
-      skew: 0,
-      scaleX: 1,
-      scaleY: 1,
-    })
-  }
-
-  const showTooltipFromFocus = (event: React.FocusEvent<HTMLElement>) => {
-    if (!isBreadcrumbTextClipped(labelRef.current, event.currentTarget)) return
-    const rect = event.currentTarget.getBoundingClientRect()
-    const position = getFloatingTooltipPosition(rect.left + rect.width / 2, rect.bottom)
-    lastPointerRef.current = null
-    setIsOverflowing(true)
-    setTooltipState({
-      visible: true,
-      ...position,
-      skew: 0,
-      scaleX: 1,
-      scaleY: 1,
-    })
-  }
-
-  const hideTooltip = () => {
-    lastPointerRef.current = null
-    setTooltipState((current) => ({ ...current, visible: false, skew: 0, scaleX: 1, scaleY: 1 }))
-  }
-
-  const tooltipHandlers = {
-    onPointerEnter: showTooltip,
-    onPointerMove: handleTooltipMove,
-    onPointerLeave: hideTooltip,
-    onFocus: showTooltipFromFocus,
-    onBlur: hideTooltip,
-    onPointerDown: hideTooltip,
-  }
+  const isOverflowing = useIsOverflowing(labelRef)
+  const { state: tooltipState, handlers: tooltipHandlers } = useFloatingTooltip((target) =>
+    isBreadcrumbTextClipped(labelRef.current, target)
+  )
 
   if (editing?.isEditing) {
     return (
@@ -381,7 +294,7 @@ const BreadcrumbSegment = memo(function BreadcrumbSegment({
     return (
       <>
         <DropdownMenu>
-          <BreadcrumbFloatingTooltip label={label} state={tooltipState} />
+          <FloatingTooltip label={label} state={tooltipState} />
           <DropdownMenuTrigger asChild>
             <Button
               variant='subtle'
@@ -411,7 +324,7 @@ const BreadcrumbSegment = memo(function BreadcrumbSegment({
   if (onClick) {
     return (
       <>
-        <BreadcrumbFloatingTooltip label={label} state={tooltipState} />
+        <FloatingTooltip label={label} state={tooltipState} />
         <Button
           variant='subtle'
           className={cn(triggerClassName, className, 'border-0')}
@@ -426,7 +339,7 @@ const BreadcrumbSegment = memo(function BreadcrumbSegment({
 
   return (
     <>
-      <BreadcrumbFloatingTooltip label={label} state={tooltipState} />
+      <FloatingTooltip label={label} state={tooltipState} />
       <span
         className={cn(
           chipVariants({ variant: 'ghost', flush: true }),
@@ -476,6 +389,12 @@ function BreadcrumbLocationPopover({
     }, 120)
   }
 
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current)
+    }
+  }, [])
+
   return (
     <>
       <LocationFocusVeil visible={open} boundaryRef={veilBoundaryRef} />
@@ -500,7 +419,7 @@ function BreadcrumbLocationPopover({
               className
             )}
           >
-            <span className='relative inline-grid size-[14px] flex-shrink-0 place-items-center'>
+            <span className='relative inline-grid size-[14px] shrink-0 place-items-center'>
               <Icon className='col-start-1 row-start-1 size-[14px] text-[var(--text-icon)] opacity-100 blur-0 transition-[opacity,filter,transform] duration-200 ease-in-out group-hover:scale-[0.25] group-hover:opacity-0 group-hover:blur-[2px] group-focus-visible:scale-[0.25] group-focus-visible:opacity-0 group-focus-visible:blur-[2px] motion-reduce:transition-none' />
               <ArrowUpLeft
                 strokeWidth={1.55}
@@ -517,7 +436,10 @@ function BreadcrumbLocationPopover({
           maxWidth={300}
           maxHeight={420}
           border
-          className='data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-[var(--bg)] p-1.5 text-[var(--text-body)] shadow-sm data-[state=closed]:animate-out data-[state=open]:animate-in motion-reduce:animate-none'
+          className={cn(
+            POPOVER_ANIMATION_CLASSES,
+            'bg-[var(--bg)] p-1.5 text-[var(--text-body)] shadow-sm'
+          )}
           onMouseEnter={openPopover}
           onMouseLeave={scheduleClose}
           onMouseMove={openPopover}
@@ -608,7 +530,7 @@ function BreadcrumbLocationItem({
 }: BreadcrumbLocationItemProps) {
   const labelContent = (
     <>
-      <span className='flex size-[18px] flex-shrink-0 items-center justify-center'>
+      <span className='flex size-[18px] shrink-0 items-center justify-center'>
         {Icon ? (
           <Icon className='size-3 text-[var(--text-icon)]' />
         ) : (
@@ -668,50 +590,6 @@ interface BreadcrumbLabelProps {
   label: string
 }
 
-interface BreadcrumbFloatingTooltipState {
-  visible: boolean
-  x: number
-  y: number
-  skew: number
-  scaleX: number
-  scaleY: number
-  alignX: 'left' | 'right'
-  alignY: 'above' | 'below'
-}
-
-interface PointerSnapshot {
-  x: number
-  y: number
-  time: number
-}
-
-function BreadcrumbFloatingTooltip({
-  label,
-  state,
-}: {
-  label: string
-  state: BreadcrumbFloatingTooltipState
-}) {
-  if (typeof document === 'undefined' || !state.visible) return null
-
-  return createPortal(
-    <div
-      aria-hidden='true'
-      className={cn(
-        'pointer-events-none fixed top-0 left-0 z-[var(--z-tooltip)] w-fit max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border border-[var(--border)] bg-[var(--bg)] px-2 py-1.5 text-[var(--text-body)] text-xs opacity-100 shadow-sm transition-[opacity,filter,transform] duration-150 ease-out',
-        'motion-reduce:transition-none'
-      )}
-      style={{
-        transform: `${getFloatingTooltipTranslate(state)} skew(${state.skew}deg) scale(${state.scaleX}, ${state.scaleY})`,
-        transformOrigin: state.alignX === 'left' ? '12px 12px' : 'calc(100% - 12px) 12px',
-      }}
-    >
-      <span className='block whitespace-normal break-words text-left leading-[18px]'>{label}</span>
-    </div>,
-    document.body
-  )
-}
-
 function isBreadcrumbTextClipped(
   labelElement: HTMLSpanElement | null,
   triggerElement: HTMLElement
@@ -727,49 +605,4 @@ function isBreadcrumbTextClipped(
     triggerElement.scrollWidth > triggerElement.clientWidth + 1 ||
     labelElement.scrollWidth > visibleLabelWidth + 1
   )
-}
-
-function getFloatingTooltipPosition(
-  clientX: number,
-  clientY: number
-): Pick<BreadcrumbFloatingTooltipState, 'x' | 'y' | 'alignX' | 'alignY'> {
-  if (typeof window === 'undefined') {
-    return { x: clientX, y: clientY, alignX: 'left', alignY: 'below' }
-  }
-
-  const alignX = window.innerWidth - clientX < FLOATING_TOOLTIP_EDGE_THRESHOLD ? 'right' : 'left'
-  const alignY =
-    window.innerHeight - clientY < FLOATING_TOOLTIP_EDGE_THRESHOLD / 2 ? 'above' : 'below'
-
-  return {
-    x: clamp(
-      clientX,
-      FLOATING_TOOLTIP_EDGE_GUTTER,
-      window.innerWidth - FLOATING_TOOLTIP_EDGE_GUTTER
-    ),
-    y: clamp(
-      clientY,
-      FLOATING_TOOLTIP_EDGE_GUTTER,
-      window.innerHeight - FLOATING_TOOLTIP_EDGE_GUTTER
-    ),
-    alignX,
-    alignY,
-  }
-}
-
-function getFloatingTooltipTranslate(state: BreadcrumbFloatingTooltipState): string {
-  const xOffset =
-    state.alignX === 'left'
-      ? `${FLOATING_TOOLTIP_OFFSET}px`
-      : `calc(-100% - ${FLOATING_TOOLTIP_OFFSET}px)`
-  const yOffset =
-    state.alignY === 'below'
-      ? `${FLOATING_TOOLTIP_OFFSET}px`
-      : `calc(-100% - ${FLOATING_TOOLTIP_OFFSET}px)`
-
-  return `translate3d(${state.x}px, ${state.y}px, 0) translate(${xOffset}, ${yOffset})`
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value))
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -62,7 +62,6 @@ import {
   ResourceHeader,
   timeCell,
 } from '@/app/workspace/[workspaceId]/components'
-import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import { FilesActionBar } from '@/app/workspace/[workspaceId]/files/components/action-bar'
 import { DeleteConfirmModal } from '@/app/workspace/[workspaceId]/files/components/delete-confirm-modal'
 import { FileRowContextMenu } from '@/app/workspace/[workspaceId]/files/components/file-row-context-menu'
@@ -1720,10 +1719,7 @@ export function Files() {
             multiSelectValues={typeFilter}
             onMultiSelectChange={setTypeFilter}
             overlayContent={
-              <FloatingOverflowText
-                label={typeDisplayLabel}
-                className='block truncate text-[var(--text-primary)]'
-              />
+              <span className='truncate text-[var(--text-primary)]'>{typeDisplayLabel}</span>
             }
             showAllOption
             allOptionLabel='All'
@@ -1743,10 +1739,7 @@ export function Files() {
             multiSelectValues={sizeFilter}
             onMultiSelectChange={setSizeFilter}
             overlayContent={
-              <FloatingOverflowText
-                label={sizeDisplayLabel}
-                className='block truncate text-[var(--text-primary)]'
-              />
+              <span className='truncate text-[var(--text-primary)]'>{sizeDisplayLabel}</span>
             }
             showAllOption
             allOptionLabel='All'
@@ -1765,10 +1758,9 @@ export function Files() {
               multiSelectValues={uploadedByFilter}
               onMultiSelectChange={setUploadedByFilter}
               overlayContent={
-                <FloatingOverflowText
-                  label={uploadedByDisplayLabel}
-                  className='block truncate text-[var(--text-primary)]'
-                />
+                <span className='truncate text-[var(--text-primary)]'>
+                  {uploadedByDisplayLabel}
+                </span>
               }
               searchable
               searchPlaceholder='Search members...'

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
@@ -610,10 +610,7 @@ export function Document({
               void goToPage(1)
             }}
             overlayContent={
-              <FloatingOverflowText
-                label={enabledDisplayLabel}
-                className='block truncate text-[var(--text-primary)]'
-              />
+              <span className='truncate text-[var(--text-primary)]'>{enabledDisplayLabel}</span>
             }
             showAllOption
             allOptionLabel='All'
@@ -982,15 +979,15 @@ export function Document({
     ]
   )
 
-  const newChunkBreadcrumbs = useMemo(
-    () => [...editorBreadcrumbBase, { label: 'New Chunk' }],
+  const newChunkBreadcrumbs = useMemo<BreadcrumbItem[]>(
+    () => [...editorBreadcrumbBase, { label: 'New Chunk', terminal: true }],
     [editorBreadcrumbBase]
   )
 
-  const editChunkBreadcrumbs = useMemo(
+  const editChunkBreadcrumbs = useMemo<BreadcrumbItem[]>(
     () => [
       ...editorBreadcrumbBase,
-      { label: selectedChunk ? `Chunk #${selectedChunk.chunkIndex}` : '' },
+      { label: selectedChunk ? `Chunk #${selectedChunk.chunkIndex}` : '', terminal: true },
     ],
     [editorBreadcrumbBase, selectedChunk?.chunkIndex]
   )
@@ -1004,7 +1001,7 @@ export function Document({
         onClick: handleNavToKBDetail,
       },
       { label: effectiveDocumentName, icon: DocumentIcon, onClick: handleClearSelectedChunk },
-      { label: 'Loading...' },
+      { label: 'Loading...', terminal: true },
     ],
     [
       handleNavToKB,

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/logs-toolbar/logs-toolbar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/logs-toolbar/logs-toolbar.tsx
@@ -21,7 +21,6 @@ import { hasActiveFilters } from '@/lib/logs/filters'
 import { getTriggerOptions } from '@/lib/logs/get-trigger-options'
 import { captureEvent } from '@/lib/posthog/client'
 import { workflowBorderColor } from '@/lib/workspaces/colors'
-import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import {
   formatDateShort,
   type LogStatus,
@@ -551,10 +550,7 @@ export const LogsToolbar = memo(function LogsToolbar({
                             style={{ backgroundColor: selectedStatusColor, width: 8, height: 8 }}
                           />
                         )}
-                        <FloatingOverflowText
-                          label={statusDisplayLabel}
-                          className='block truncate'
-                        />
+                        <span className='truncate'>{statusDisplayLabel}</span>
                       </span>
                     }
                     showAllOption
@@ -587,10 +583,7 @@ export const LogsToolbar = memo(function LogsToolbar({
                             }}
                           />
                         )}
-                        <FloatingOverflowText
-                          label={workflowDisplayLabel}
-                          className='block truncate'
-                        />
+                        <span className='truncate'>{workflowDisplayLabel}</span>
                       </span>
                     }
                     searchable
@@ -614,10 +607,9 @@ export const LogsToolbar = memo(function LogsToolbar({
                     onMultiSelectChange={handleFolderFilterChange}
                     placeholder='All folders'
                     overlayContent={
-                      <FloatingOverflowText
-                        label={folderDisplayLabel}
-                        className='block truncate text-[var(--text-primary)]'
-                      />
+                      <span className='truncate text-[var(--text-primary)]'>
+                        {folderDisplayLabel}
+                      </span>
                     }
                     searchable
                     searchPlaceholder='Search folders...'
@@ -640,10 +632,9 @@ export const LogsToolbar = memo(function LogsToolbar({
                     onMultiSelectChange={handleTriggerFilterChange}
                     placeholder='All triggers'
                     overlayContent={
-                      <FloatingOverflowText
-                        label={triggerDisplayLabel}
-                        className='block truncate text-[var(--text-primary)]'
-                      />
+                      <span className='truncate text-[var(--text-primary)]'>
+                        {triggerDisplayLabel}
+                      </span>
                     }
                     searchable
                     searchPlaceholder='Search triggers...'
@@ -665,10 +656,9 @@ export const LogsToolbar = memo(function LogsToolbar({
                     onChange={handleTimeRangeChange}
                     placeholder='All time'
                     overlayContent={
-                      <FloatingOverflowText
-                        label={timeDisplayLabel}
-                        className='block truncate text-[var(--text-primary)]'
-                      />
+                      <span className='truncate text-[var(--text-primary)]'>
+                        {timeDisplayLabel}
+                      </span>
                     }
                     size='sm'
                     className='h-[32px] w-full rounded-md'
@@ -695,7 +685,7 @@ export const LogsToolbar = memo(function LogsToolbar({
                       style={{ backgroundColor: selectedStatusColor, width: 8, height: 8 }}
                     />
                   )}
-                  <FloatingOverflowText label={statusDisplayLabel} className='block truncate' />
+                  <span className='truncate'>{statusDisplayLabel}</span>
                 </span>
               }
               showAllOption
@@ -724,7 +714,7 @@ export const LogsToolbar = memo(function LogsToolbar({
                       }}
                     />
                   )}
-                  <FloatingOverflowText label={workflowDisplayLabel} className='block truncate' />
+                  <span className='truncate'>{workflowDisplayLabel}</span>
                 </span>
               }
               searchable
@@ -744,10 +734,7 @@ export const LogsToolbar = memo(function LogsToolbar({
               onMultiSelectChange={handleFolderFilterChange}
               placeholder='Folder'
               overlayContent={
-                <FloatingOverflowText
-                  label={folderDisplayLabel}
-                  className='block truncate text-[var(--text-primary)]'
-                />
+                <span className='truncate text-[var(--text-primary)]'>{folderDisplayLabel}</span>
               }
               searchable
               searchPlaceholder='Search folders...'
@@ -766,10 +753,7 @@ export const LogsToolbar = memo(function LogsToolbar({
               onMultiSelectChange={handleTriggerFilterChange}
               placeholder='Trigger'
               overlayContent={
-                <FloatingOverflowText
-                  label={triggerDisplayLabel}
-                  className='block truncate text-[var(--text-primary)]'
-                />
+                <span className='truncate text-[var(--text-primary)]'>{triggerDisplayLabel}</span>
               }
               searchable
               searchPlaceholder='Search triggers...'
@@ -788,10 +772,7 @@ export const LogsToolbar = memo(function LogsToolbar({
                 onChange={handleTimeRangeChange}
                 placeholder='Time'
                 overlayContent={
-                  <FloatingOverflowText
-                    label={timeDisplayLabel}
-                    className='block truncate text-[var(--text-primary)]'
-                  />
+                  <span className='truncate text-[var(--text-primary)]'>{timeDisplayLabel}</span>
                 }
                 size='sm'
                 align='end'

--- a/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
@@ -58,7 +58,6 @@ import {
   ResourceOptionsBar,
   ResourceTable,
 } from '@/app/workspace/[workspaceId]/components'
-import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import { useSearchState } from '@/app/workspace/[workspaceId]/logs/hooks/use-search-state'
 import type { Suggestion } from '@/app/workspace/[workspaceId]/logs/types'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
@@ -1409,7 +1408,7 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
                   style={{ backgroundColor: selectedStatusColor, width: 8, height: 8 }}
                 />
               )}
-              <FloatingOverflowText label={statusDisplayLabel} className='block truncate' />
+              <span className='truncate'>{statusDisplayLabel}</span>
             </span>
           }
           showAllOption
@@ -1439,7 +1438,7 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
                   }}
                 />
               )}
-              <FloatingOverflowText label={workflowDisplayLabel} className='block truncate' />
+              <span className='truncate'>{workflowDisplayLabel}</span>
             </span>
           }
           searchable
@@ -1460,10 +1459,7 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
           onMultiSelectChange={setFolderIds}
           placeholder='All folders'
           overlayContent={
-            <FloatingOverflowText
-              label={folderDisplayLabel}
-              className='block truncate text-[var(--text-primary)]'
-            />
+            <span className='truncate text-[var(--text-primary)]'>{folderDisplayLabel}</span>
           }
           searchable
           searchPlaceholder='Search folders...'
@@ -1483,10 +1479,7 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
           onMultiSelectChange={setTriggers}
           placeholder='All triggers'
           overlayContent={
-            <FloatingOverflowText
-              label={triggerDisplayLabel}
-              className='block truncate text-[var(--text-primary)]'
-            />
+            <span className='truncate text-[var(--text-primary)]'>{triggerDisplayLabel}</span>
           }
           searchable
           searchPlaceholder='Search triggers...'
@@ -1506,10 +1499,7 @@ function LogsFilterPanel({ searchQuery, onSearchQueryChange }: LogsFilterPanelPr
             onChange={handleTimeRangeChange}
             placeholder='All time'
             overlayContent={
-              <FloatingOverflowText
-                label={timeDisplayLabel}
-                className='block truncate text-[var(--text-primary)]'
-              />
+              <span className='truncate text-[var(--text-primary)]'>{timeDisplayLabel}</span>
             }
             size='sm'
             className='h-[32px] w-full rounded-md'

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
@@ -25,7 +25,6 @@ import {
   Resource,
   timeCell,
 } from '@/app/workspace/[workspaceId]/components'
-import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import { ScheduleModal } from '@/app/workspace/[workspaceId]/scheduled-tasks/components/create-schedule-modal'
 import { ScheduleContextMenu } from '@/app/workspace/[workspaceId]/scheduled-tasks/components/schedule-context-menu'
 import { ScheduleListContextMenu } from '@/app/workspace/[workspaceId]/scheduled-tasks/components/schedule-list-context-menu'
@@ -295,10 +294,9 @@ export function ScheduledTasks() {
             multiSelectValues={scheduleTypeFilter}
             onMultiSelectChange={setScheduleTypeFilter}
             overlayContent={
-              <FloatingOverflowText
-                label={scheduleTypeDisplayLabel}
-                className='block truncate text-[var(--text-primary)]'
-              />
+              <span className='truncate text-[var(--text-primary)]'>
+                {scheduleTypeDisplayLabel}
+              </span>
             }
             showAllOption
             allOptionLabel='All'
@@ -317,10 +315,7 @@ export function ScheduledTasks() {
             multiSelectValues={statusFilter}
             onMultiSelectChange={setStatusFilter}
             overlayContent={
-              <FloatingOverflowText
-                label={statusDisplayLabel}
-                className='block truncate text-[var(--text-primary)]'
-              />
+              <span className='truncate text-[var(--text-primary)]'>{statusDisplayLabel}</span>
             }
             showAllOption
             allOptionLabel='All'
@@ -336,10 +331,7 @@ export function ScheduledTasks() {
             multiSelectValues={healthFilter}
             onMultiSelectChange={setHealthFilter}
             overlayContent={
-              <FloatingOverflowText
-                label={healthDisplayLabel}
-                className='block truncate text-[var(--text-primary)]'
-              />
+              <span className='truncate text-[var(--text-primary)]'>{healthDisplayLabel}</span>
             }
             showAllOption
             allOptionLabel='All'

--- a/apps/sim/app/workspace/[workspaceId]/tables/tables.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/tables.tsx
@@ -25,7 +25,6 @@ import type {
   SortConfig,
 } from '@/app/workspace/[workspaceId]/components'
 import { ownerCell, Resource, timeCell } from '@/app/workspace/[workspaceId]/components'
-import { FloatingOverflowText } from '@/app/workspace/[workspaceId]/components/resource/components/floating-overflow-text'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
 import {
   ImportCsvDialog,
@@ -265,10 +264,7 @@ export function Tables() {
             multiSelectValues={rowCountFilter}
             onMultiSelectChange={setRowCountFilter}
             overlayContent={
-              <FloatingOverflowText
-                label={rowCountDisplayLabel}
-                className='block truncate text-[var(--text-primary)]'
-              />
+              <span className='truncate text-[var(--text-primary)]'>{rowCountDisplayLabel}</span>
             }
             showAllOption
             allOptionLabel='All'
@@ -285,10 +281,7 @@ export function Tables() {
               multiSelectValues={ownerFilter}
               onMultiSelectChange={setOwnerFilter}
               overlayContent={
-                <FloatingOverflowText
-                  label={ownerDisplayLabel}
-                  className='block truncate text-[var(--text-primary)]'
-                />
+                <span className='truncate text-[var(--text-primary)]'>{ownerDisplayLabel}</span>
               }
               searchable
               searchPlaceholder='Search members...'


### PR DESCRIPTION
## Summary
Cleanup on top of the breadcrumb-truncation feature (already on `improvement/platform`):

- Extract `useFloatingTooltip` / `useIsOverflowing` / `FloatingTooltip` into a shared `floating-tooltip` module — breadcrumb segments and `FloatingOverflowText` now share one implementation instead of duplicating ~150 lines.
- Replace the hardcoded terminal-label regex in `ResourceHeader` with a typed `terminal` flag on `BreadcrumbItem`.
- Clear the path-popover close timeout on unmount; reuse `POPOVER_ANIMATION_CLASSES`.
- Drop redundant manual overflow writes (fixes a sticky fade mask).
- Revert `FloatingOverflowText` inside `Combobox` `overlayContent` back to plain truncating spans (the overlay is `pointer-events-none`, so the tooltip never fired). Those filter files are now identical to platform.
- Normalize `flex-shrink-0` → `shrink-0`.

## Validation
- biome lint clean on all touched files; `bun run check:api-validation` passes (pure UI).
- All six `/cleanup` lenses pass.