### PR TITLE
feat(landing): add AI-generated content disclaimer to integration landing page

### DIFF
--- a/apps/sim/app/(landing)/integrations/(shell)/[slug]/page.tsx
+++ b/apps/sim/app/(landing)/integrations/(shell)/[slug]/page.tsx
@@ -517,6 +517,24 @@ export default async function IntegrationPage({ params }: { params: Promise<{ sl
           </>
         )}
 
+        {/* AI-generated content disclaimer (integration-specific) */}
+        {landingContent?.aiDisclaimer && (
+          <>
+            <section aria-labelledby='ai-disclaimer-heading' className='px-6 py-10'>
+              <h2
+                id='ai-disclaimer-heading'
+                className='mb-4 text-[20px] text-white leading-[100%] tracking-[-0.02em]'
+              >
+                AI-generated content
+              </h2>
+              <p className='max-w-[700px] text-[15px] text-[var(--landing-text-body)] leading-[150%] tracking-[0.02em]'>
+                {landingContent.aiDisclaimer}
+              </p>
+            </section>
+            <div className='h-px w-full bg-[var(--landing-bg-elevated)]' />
+          </>
+        )}
+
         {/* How to automate */}
         <section aria-labelledby='how-it-works-heading' className='px-6 py-10'>
           <h2

--- a/apps/sim/app/(landing)/integrations/data/integrations.json
+++ b/apps/sim/app/(landing)/integrations/data/integrations.json
@@ -13528,7 +13528,8 @@
       "privacy": {
         "body": "Sim requests only the Slack permissions its actions and triggers need, and never shows private channel names or messages to people who are not members of those channels in Slack.",
         "href": "/privacy"
-      }
+      },
+      "aiDisclaimer": "Sim agents use AI models to generate messages and responses sent to Slack. AI-generated content can be inaccurate or incomplete — review automated outputs before relying on them, especially for important communications."
     }
   },
   {

--- a/apps/sim/app/(landing)/integrations/data/landing-content.ts
+++ b/apps/sim/app/(landing)/integrations/data/landing-content.ts
@@ -37,5 +37,7 @@ export const INTEGRATION_LANDING_CONTENT: Record<string, IntegrationLandingConte
       body: 'Sim requests only the Slack permissions its actions and triggers need, and never shows private channel names or messages to people who are not members of those channels in Slack.',
       href: '/privacy',
     },
+    aiDisclaimer:
+      'Sim agents use AI models to generate messages and responses sent to Slack. AI-generated content can be inaccurate or incomplete — review automated outputs before relying on them, especially for important communications.',
   },
 }

--- a/apps/sim/app/(landing)/integrations/data/types.ts
+++ b/apps/sim/app/(landing)/integrations/data/types.ts
@@ -40,6 +40,11 @@ export interface IntegrationLandingContent {
     body: string
     href: string
   }
+  /**
+   * Disclaimer about AI-generated content, required by some marketplaces for
+   * apps with an AI component (e.g. Slack's AI-components guideline).
+   */
+  aiDisclaimer?: string
 }
 
 export interface Integration {


### PR DESCRIPTION
## Summary
- Add an optional `aiDisclaimer` field to the integration landing content (`types.ts` + `landing-content.ts`), rendered as an independent "AI-generated content" section and baked into `integrations.json` via docs-gen
- Populate it for Slack to satisfy Slack's AI-components guideline (disclaimer must appear on the landing page)
- Same data-driven pattern as the existing install/privacy sections — no hardcoding, flows through generation

## Type of Change
- [x] New content

## Testing
`bun run lint`, `tsc`, `biome` pass; docs generation is idempotent; `integrations.json` validated.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)