### PR TITLE
fix(auth): show "account already exists" on duplicate email signup

### DIFF
--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -844,6 +844,22 @@ export const auth = betterAuth({
         }
       }
 
+      if (ctx.path.startsWith('/sign-up/email') && ctx.body?.email) {
+        const signupEmail = ctx.body.email.toLowerCase()
+        const [existingUser] = await db
+          .select({ id: schema.user.id })
+          .from(schema.user)
+          .where(eq(schema.user.email, signupEmail))
+          .limit(1)
+
+        if (existingUser) {
+          throw new APIError('UNPROCESSABLE_ENTITY', {
+            message: 'User already exists',
+            code: 'USER_ALREADY_EXISTS',
+          })
+        }
+      }
+
       return
     }),
   },

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -844,7 +844,7 @@ export const auth = betterAuth({
         }
       }
 
-      if (ctx.path.startsWith('/sign-up/email') && ctx.body?.email) {
+      if (ctx.path === '/sign-up/email' && ctx.body?.email) {
         const signupEmail = ctx.body.email.toLowerCase()
         const [existingUser] = await db
           .select({ id: schema.user.id })


### PR DESCRIPTION
## Summary
- After the better-auth 1.3.12→1.6.11 upgrade, signing up with an already-registered email hit better-auth's generic anti-enumeration response (fake success, no DB write) when `requireEmailVerification` is on — so the signup form's existing `USER_ALREADY_EXISTS` handler never fired and the user was silently routed to `/verify` with no code (looked like "it took over the first account")
- Added a pre-create existence check in the auth `before` hook: for `/sign-up/email`, if the email already exists, throw `USER_ALREADY_EXISTS` so the inline "An account with this email already exists. Please sign in instead." message shows
- Consistent with how login ("No account found with this email") and social sign-in already reveal account existence; runs regardless of `EMAIL_VERIFICATION_ENABLED` so behavior is uniform across environments

## Notes
- No duplicate account or takeover was ever possible — the DB enforces `unique` on both `email` and `normalized_email`. This is a UX-consistency fix; the check mirrors better-auth's own `email.toLowerCase()` lookup
- Rare Gmail dot/`+` alias (only with `SIGNUP_EMAIL_VALIDATION_ENABLED`) and true concurrent-submit races still fall to the DB unique constraint (correct outcome, generic error) rather than the inline message

## Type of Change
- [x] Bug fix

## Testing
Tested manually: with email verification enabled, signing up with an existing email now shows "An account with this email already exists. Please sign in instead." instead of routing to the verify screen.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)