### PR TITLE
fix(slack): request reactions:read in OAuth URL, drop im:history

### DIFF
--- a/apps/sim/app/api/tools/slack/read-messages/route.ts
+++ b/apps/sim/app/api/tools/slack/read-messages/route.ts
@@ -105,7 +105,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           {
             success: false,
             error:
-              'Missing required permissions. Please reconnect your Slack account with the necessary scopes (channels:history, groups:history, im:history).',
+              'Missing required permissions. Reconnect your Slack account to grant channel history access (channels:history, groups:history). Reading direct message history is not supported with the Sim bot.',
           },
           { status: 400 }
         )

--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -703,7 +703,6 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
           'chat:write',
           'chat:write.public',
           'im:write',
-          'im:history',
           'im:read',
           'users:read',
           // TODO: Add 'users:read.email' once Slack app review is approved
@@ -712,6 +711,7 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
           'canvases:read',
           'canvases:write',
           'reactions:write',
+          'reactions:read',
         ],
       },
     },


### PR DESCRIPTION
## Summary
Reconciles the Slack OAuth scope set with Slack Marketplace reviewer feedback (June 2):
- **Add `reactions:read`** — it was configured in the Slack app settings (and powers the reaction trigger) but missing from the OAuth URL, which the reviewer flagged.
- **Remove `im:history`** — a bot can't be added to a human-to-human DM, so `im:history` only powers the App Home Messages tab (now disabled). Our "Read Messages from a DM" justification didn't hold; per the reviewer, the scope is removed.

`im:write` / `im:read` are retained (opening/identifying a DM to send a message), and were not flagged.

Note: also remove `im:history` from the Slack app dashboard bot scopes to match.

## Type of Change
- [x] Bug fix

## Testing
`biome` passes. Scope-only change.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)