### PR TITLE
fix(fathom): skip getDocument when header cache is missing

### DIFF
--- a/apps/sim/connectors/fathom/fathom.ts
+++ b/apps/sim/connectors/fathom/fathom.ts
@@ -498,18 +498,28 @@ export const fathomConnector: ConnectorConfig = {
       }
 
       const header = readCachedHeader(syncContext, externalId)
+      if (!header) {
+        logger.warn(
+          'No cached header for Fathom meeting; skipping to avoid an un-refreshable record',
+          {
+            externalId,
+          }
+        )
+        return null
+      }
+
       const content = formatMeetingContent(header, transcript, summary).trim()
       if (!content) return null
 
       return {
         externalId,
-        title: header?.title ?? 'Untitled Fathom Meeting',
+        title: header.title,
         content,
         contentDeferred: false,
         mimeType: 'text/plain',
-        sourceUrl: header?.sourceUrl,
-        contentHash: header?.contentHash ?? `fathom:${externalId}`,
-        metadata: { ...(header?.metadata ?? { recordingId: externalId }) },
+        sourceUrl: header.sourceUrl,
+        contentHash: header.contentHash,
+        metadata: { ...header.metadata },
       }
     } catch (error) {
       logger.warn('Failed to get Fathom meeting', {


### PR DESCRIPTION
## Summary
- Follow-up to the merged connectors PR (#4849), addressing a greptile review note on the release PR (#4858)
- `Fathom getDocument` previously emitted a degraded record when the cached `FathomMeetingHeader` was missing — `'Untitled Fathom Meeting'` title, no `sourceUrl`, and a timing-less `contentHash` (`fathom:${id}`) that would never trigger re-indexing on change
- Now it returns `null` (with a warn log) when the header is absent, so an incomplete, un-refreshable record can't pollute the index. In the normal sync flow `listDocuments` always populates the header cache before `getDocument` runs, so this only guards the edge case (standalone/retry call with no populated `syncContext`) — and the meeting is retried on the next sync once the cache is populated

## Type of Change
- [x] Bug fix (hardening)

## Testing
Tested manually — type-check clean, lint clean, 100 connector tests pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)