### PR TITLE
fix(env): schema treatment of empty string for redis url

### DIFF
--- a/apps/realtime/src/env.ts
+++ b/apps/realtime/src/env.ts
@@ -3,7 +3,10 @@ import { z } from 'zod'
 const EnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   DATABASE_URL: z.string().url(),
-  REDIS_URL: z.string().url().optional(),
+  REDIS_URL: z.preprocess(
+    (value) => (typeof value === 'string' && value.trim() === '' ? undefined : value),
+    z.string().url().optional()
+  ),
   BETTER_AUTH_URL: z.string().url(),
   BETTER_AUTH_SECRET: z.string().min(32),
   INTERNAL_API_SECRET: z.string().min(32),


### PR DESCRIPTION
## Summary
Docker compose injects as empty string which leads to failures if redis not setup.

## Type of Change
- [x] Bug fix

## Testing
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)