### PR TITLE
fix(mothership): run client-routed workflow tools server-side in headless execution

### DIFF
--- a/apps/sim/lib/copilot/tool-executor/executor.test.ts
+++ b/apps/sim/lib/copilot/tool-executor/executor.test.ts
@@ -5,9 +5,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_EXECUTION_TIMEOUT_MS } from '@/lib/execution/constants'
 
-const { isKnownTool, isSimExecuted } = vi.hoisted(() => ({
+const { isKnownTool, isSimExecuted, isClientExecuted } = vi.hoisted(() => ({
   isKnownTool: vi.fn(),
   isSimExecuted: vi.fn(),
+  isClientExecuted: vi.fn(),
 }))
 
 const { executeAppTool } = vi.hoisted(() => ({
@@ -17,13 +18,14 @@ const { executeAppTool } = vi.hoisted(() => ({
 vi.mock('./router', () => ({
   isKnownTool,
   isSimExecuted,
+  isClientExecuted,
 }))
 
 vi.mock('@/tools', () => ({
   executeTool: executeAppTool,
 }))
 
-import { executeTool } from './executor'
+import { executeTool, registerHandler } from './executor'
 
 describe('copilot tool executor fallback', () => {
   beforeEach(() => {
@@ -57,6 +59,36 @@ describe('copilot tool executor fallback', () => {
       })
     )
     expect(result).toEqual({ success: true, output: { emails: [] } })
+  })
+
+  it('uses the registered handler for client-routed tools when running headless (Mothership block)', async () => {
+    isKnownTool.mockReturnValue(true)
+    isSimExecuted.mockReturnValue(false)
+    isClientExecuted.mockReturnValue(true)
+
+    const runWorkflowHandler = vi.fn().mockResolvedValue({ success: true, output: { ran: true } })
+    registerHandler('run_workflow', runWorkflowHandler)
+
+    const context = { userId: 'user-1', workflowId: 'workflow-1', workspaceId: 'ws-1' }
+    const result = await executeTool('run_workflow', { workflow_input: {} }, context)
+
+    expect(runWorkflowHandler).toHaveBeenCalledWith({ workflow_input: {} }, context)
+    expect(executeAppTool).not.toHaveBeenCalled()
+    expect(result).toEqual({ success: true, output: { ran: true } })
+  })
+
+  it('falls back to app tool executor for client-routed tools with no registered handler', async () => {
+    isKnownTool.mockReturnValue(true)
+    isSimExecuted.mockReturnValue(false)
+    isClientExecuted.mockReturnValue(true)
+    executeAppTool.mockResolvedValue({
+      success: false,
+      error: 'Tool not found: unknown_client_tool',
+    })
+
+    await executeTool('unknown_client_tool', {}, { userId: 'user-1' })
+
+    expect(executeAppTool).toHaveBeenCalledWith('unknown_client_tool', expect.any(Object))
   })
 
   it('converts function_execute timeout from seconds to milliseconds for copilot calls', async () => {

--- a/apps/sim/lib/copilot/tool-executor/executor.test.ts
+++ b/apps/sim/lib/copilot/tool-executor/executor.test.ts
@@ -25,11 +25,12 @@ vi.mock('@/tools', () => ({
   executeTool: executeAppTool,
 }))
 
-import { executeTool, registerHandler } from './executor'
+import { clearHandlers, executeTool, registerHandler } from './executor'
 
 describe('copilot tool executor fallback', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    clearHandlers()
   })
 
   it('falls back to app tool executor for dynamic sim tools', async () => {

--- a/apps/sim/lib/copilot/tool-executor/executor.ts
+++ b/apps/sim/lib/copilot/tool-executor/executor.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
 import { DEFAULT_EXECUTION_TIMEOUT_MS } from '@/lib/execution/constants'
 import { executeTool as executeAppTool } from '@/tools'
-import { isKnownTool, isSimExecuted } from './router'
+import { isClientExecuted, isKnownTool, isSimExecuted } from './router'
 import type {
   ToolCallDescriptor,
   ToolExecutionContext,
@@ -40,7 +40,13 @@ export async function executeTool(
   params: Record<string, unknown>,
   context: ToolExecutionContext
 ): Promise<ToolExecutionResult> {
-  const canUseRegisteredHandler = isKnownTool(toolId) && isSimExecuted(toolId)
+  // Client-routed tools (e.g. run_workflow) are normally executed in the browser and never
+  // reach this point in interactive mode. In headless mode (Mothership block, no browser) there
+  // is no client to delegate to, so fall back to the registered server-side handler when one
+  // exists — otherwise the call would route to executeAppTool and throw "Tool not found".
+  const canUseRegisteredHandler =
+    isKnownTool(toolId) &&
+    (isSimExecuted(toolId) || (isClientExecuted(toolId) && hasHandler(toolId)))
   if (!canUseRegisteredHandler) {
     const appParams = buildAppToolParams(toolId, params, context)
     return executeAppTool(toolId, appParams)

--- a/apps/sim/lib/copilot/tool-executor/executor.ts
+++ b/apps/sim/lib/copilot/tool-executor/executor.ts
@@ -35,6 +35,10 @@ export function hasHandler(toolId: string): boolean {
   return handlerRegistry.has(toolId)
 }
 
+export function clearHandlers(): void {
+  handlerRegistry.clear()
+}
+
 export async function executeTool(
   toolId: string,
   params: Record<string, unknown>,

--- a/apps/sim/lib/copilot/tool-executor/router.ts
+++ b/apps/sim/lib/copilot/tool-executor/router.ts
@@ -31,6 +31,10 @@ export function isGoExecuted(toolId: string): boolean {
   return getToolEntry(toolId)?.route === 'go'
 }
 
+export function isClientExecuted(toolId: string): boolean {
+  return getToolEntry(toolId)?.route === 'client'
+}
+
 export function isKnownTool(toolId: string): boolean {
   return isToolInCatalog(toolId)
 }


### PR DESCRIPTION
## Summary
- Fix headless Mothership (Mothership block, no browser) being unable to run workflows — `run_workflow`, `run_workflow_until_block`, `run_block`, and `run_from_block` all failed with `Tool not found`
- These tools are registered with `route: 'client'`, so the executor gate (`isSimExecuted`) skipped their registered server handlers and fell through to `executeAppTool`, which threw. Interactive runs delegate them to the browser before reaching the executor, so only the headless path was broken
- Allow a client-routed tool to use its registered server handler when one exists. Blast radius is exactly the four run tools — the only `route: 'client'` tools, all of which already have server handlers

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Added unit tests for the new headless routing (handler used for client tool with a registered handler; still falls back to `executeAppTool` when none). Confirmed against production ECS logs on `/api/mothership/execute`: 7x `run_workflow`, 2x `run_workflow_until_block`, plus `run_block`/`run_from_block`, all `Tool not found` from the autonomous `run` subagent (`executor: client`, `simExecutable: false`). Lint and `check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
