### PR TITLE
fix(storage): percent-encode object key in multipart fallback URL

### DIFF
--- a/apps/sim/lib/uploads/providers/s3/client.test.ts
+++ b/apps/sim/lib/uploads/providers/s3/client.test.ts
@@ -12,6 +12,7 @@ const {
   mockPutObjectCommand,
   mockGetObjectCommand,
   mockDeleteObjectCommand,
+  mockCompleteMultipartUploadCommand,
   mockGetSignedUrl,
   mockEnv,
   mockS3Config,
@@ -51,6 +52,7 @@ const {
     mockPutObjectCommand: vi.fn().mockImplementation(class {}),
     mockGetObjectCommand: vi.fn().mockImplementation(class {}),
     mockDeleteObjectCommand: vi.fn().mockImplementation(class {}),
+    mockCompleteMultipartUploadCommand: vi.fn().mockImplementation(class {}),
     mockGetSignedUrl: vi.fn(),
     mockEnv,
   }
@@ -61,6 +63,7 @@ vi.mock('@aws-sdk/client-s3', () => ({
   PutObjectCommand: mockPutObjectCommand,
   GetObjectCommand: mockGetObjectCommand,
   DeleteObjectCommand: mockDeleteObjectCommand,
+  CompleteMultipartUploadCommand: mockCompleteMultipartUploadCommand,
 }))
 
 vi.mock('@aws-sdk/s3-request-presigner', () => ({
@@ -92,6 +95,7 @@ vi.mock('@/lib/uploads/config', () => ({
 }))
 
 import {
+  completeS3MultipartUpload,
   deleteFromS3,
   downloadFromS3,
   getPresignedUrl,
@@ -396,6 +400,72 @@ describe('S3 Client', () => {
           secretAccessKey: 'test-secret-key',
         },
       })
+    })
+  })
+
+  describe('completeS3MultipartUpload fallback location', () => {
+    const parts = [{ ETag: 'etag-1', PartNumber: 1 }]
+
+    it('uses the SDK-provided Location when present', async () => {
+      mockSend.mockResolvedValueOnce({ Location: 'https://provided.example.com/object' })
+
+      const result = await completeS3MultipartUpload('kb/uuid-file.txt', 'upload-1', parts)
+
+      expect(result.location).toBe('https://provided.example.com/object')
+      expect(result.key).toBe('kb/uuid-file.txt')
+      expect(result.path).toBe('/api/files/serve/kb%2Fuuid-file.txt')
+    })
+
+    it('falls back to an AWS virtual-hosted URL when Location is absent', async () => {
+      mockSend.mockResolvedValueOnce({})
+
+      const result = await completeS3MultipartUpload('kb/uuid-file.txt', 'upload-1', parts)
+
+      expect(result.location).toBe(
+        'https://test-kb-bucket.s3.test-region.amazonaws.com/kb/uuid-file.txt'
+      )
+    })
+
+    it('builds a path-style fallback URL for a custom endpoint with forcePathStyle', async () => {
+      mockS3Config.endpoint = 'https://minio.example.com'
+      mockS3Config.forcePathStyle = true
+      mockSend.mockResolvedValueOnce({})
+
+      const result = await completeS3MultipartUpload('kb/uuid-file.txt', 'upload-1', parts)
+
+      expect(result.location).toBe('https://minio.example.com/test-kb-bucket/kb/uuid-file.txt')
+    })
+
+    it('builds a virtual-hosted fallback URL for a custom endpoint without forcePathStyle', async () => {
+      mockS3Config.endpoint = 'https://account.r2.cloudflarestorage.com'
+      mockS3Config.forcePathStyle = false
+      mockSend.mockResolvedValueOnce({})
+
+      const result = await completeS3MultipartUpload('kb/uuid-file.txt', 'upload-1', parts)
+
+      expect(result.location).toBe(
+        'https://test-kb-bucket.account.r2.cloudflarestorage.com/kb/uuid-file.txt'
+      )
+    })
+
+    it('strips a trailing slash from the custom endpoint before appending the key', async () => {
+      mockS3Config.endpoint = 'https://minio.example.com/'
+      mockS3Config.forcePathStyle = true
+      mockSend.mockResolvedValueOnce({})
+
+      const result = await completeS3MultipartUpload('kb/uuid-file.txt', 'upload-1', parts)
+
+      expect(result.location).toBe('https://minio.example.com/test-kb-bucket/kb/uuid-file.txt')
+    })
+
+    it('percent-encodes special characters per path segment, preserving slashes', async () => {
+      mockSend.mockResolvedValueOnce({})
+
+      const result = await completeS3MultipartUpload('kb/uuid-my file.txt', 'upload-1', parts)
+
+      expect(result.location).toBe(
+        'https://test-kb-bucket.s3.test-region.amazonaws.com/kb/uuid-my%20file.txt'
+      )
     })
   })
 })

--- a/apps/sim/lib/uploads/providers/s3/client.ts
+++ b/apps/sim/lib/uploads/providers/s3/client.ts
@@ -394,18 +394,22 @@ export async function getS3MultipartPartUrls(
  * addressing mode — path-style for MinIO/Ceph (`forcePathStyle`), virtual-hosted
  * (bucket as a subdomain) for R2 and friends. Falls back to the AWS
  * virtual-hosted host when no custom endpoint is set.
+ *
+ * The key is percent-encoded per path segment (preserving `/` separators) so
+ * keys containing spaces or reserved characters still yield a valid URL.
  */
 function buildObjectFallbackUrl(bucket: string, region: string, key: string): string {
+  const encodedKey = key.split('/').map(encodeURIComponent).join('/')
   if (S3_CONFIG.endpoint) {
     const base = S3_CONFIG.endpoint.replace(/\/+$/, '')
     if (S3_CONFIG.forcePathStyle) {
-      return `${base}/${bucket}/${key}`
+      return `${base}/${bucket}/${encodedKey}`
     }
     const url = new URL(base)
     url.hostname = `${bucket}.${url.hostname}`
-    return `${url.origin}/${key}`
+    return `${url.origin}/${encodedKey}`
   }
-  return `https://${bucket}.s3.${region}.amazonaws.com/${key}`
+  return `https://${bucket}.s3.${region}.amazonaws.com/${encodedKey}`
 }
 
 /**

--- a/apps/sim/lib/uploads/providers/s3/client.ts
+++ b/apps/sim/lib/uploads/providers/s3/client.ts
@@ -399,7 +399,10 @@ export async function getS3MultipartPartUrls(
  * keys containing spaces or reserved characters still yield a valid URL.
  */
 function buildObjectFallbackUrl(bucket: string, region: string, key: string): string {
-  const encodedKey = key.split('/').map(encodeURIComponent).join('/')
+  const encodedKey = key
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
   if (S3_CONFIG.endpoint) {
     const base = S3_CONFIG.endpoint.replace(/\/+$/, '')
     if (S3_CONFIG.forcePathStyle) {


### PR DESCRIPTION
## Summary
- `buildObjectFallbackUrl` constructed the object `location` from a raw key. A key containing spaces or reserved characters (`+`, `?`, `#`) — or the pre-existing AWS branch — would yield a structurally invalid URL
- Encode the key per path segment (preserving `/` separators) across all branches: AWS virtual-hosted, custom path-style, and custom virtual-hosted (R2)

## Context
Addresses a Greptile review comment on the v0.6.102 release PR (#4871). Not currently triggerable — keys are generated as `kb/<uuid>-<sanitizeFileName(name)>` and `sanitizeFileName` strips everything except `[a-zA-Z0-9.-]`, so only `/` can appear today. This is a robustness fix that future-proofs the `location` value and corrects the long-standing AWS branch.

## Type of Change
- [x] Bug fix

## Testing
- `bun run scripts/check-api-validation-contracts.ts` passes; biome clean
- `location` is informational (serving uses the encoded `path` + `/api/files/serve`), so no behavior change for existing valid keys

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)