### PR TITLE
fix(gitlab): pin pagination cursor to configured host + consolidate isSameOrigin

### DIFF
--- a/apps/sim/connectors/gitlab/gitlab.ts
+++ b/apps/sim/connectors/gitlab/gitlab.ts
@@ -104,6 +104,21 @@ function parseNextLink(linkHeader: string | null): string | undefined {
 }
 
 /**
+ * Returns true when `candidate` resolves to the same origin as `base`. Used to
+ * pin a persisted pagination cursor to the configured GitLab host before
+ * following it with an `Authorization` header, so a tampered or corrupted
+ * `fileNextUrl` cannot exfiltrate the access token to an attacker-controlled
+ * host. Returns false on any unparseable URL.
+ */
+function isSameOrigin(candidate: string, base: string): boolean {
+  try {
+    return new URL(candidate).origin === new URL(base).origin
+  } catch {
+    return false
+  }
+}
+
+/**
  * Returns the ordered list of active sync phases for a content-type choice.
  */
 function activePhases(choice: ContentTypeChoice): SyncPhase[] {
@@ -741,6 +756,9 @@ export const gitlabConnector: ConnectorConfig = {
         per_page: String(PAGE_SIZE),
         pagination: 'keyset',
       })
+      if (state.fileNextUrl && !isSameOrigin(state.fileNextUrl, apiBase)) {
+        throw new Error('GitLab pagination cursor points to an unexpected host')
+      }
       const url =
         state.fileNextUrl ??
         `${apiBase}/projects/${encodedProject}/repository/tree?${treeParams.toString()}`

--- a/apps/sim/connectors/gitlab/gitlab.ts
+++ b/apps/sim/connectors/gitlab/gitlab.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { getErrorMessage, toError } from '@sim/utils/errors'
 import { GitLabIcon } from '@/components/icons'
+import { isSameOrigin } from '@/lib/core/utils/validation'
 import { fetchWithRetry, VALIDATE_RETRY_OPTIONS } from '@/lib/knowledge/documents/utils'
 import type { ConnectorConfig, ExternalDocument, ExternalDocumentList } from '@/connectors/types'
 import { computeContentHash, joinTagArray, parseTagDate } from '@/connectors/utils'
@@ -101,21 +102,6 @@ function parseNextLink(linkHeader: string | null): string | undefined {
     if (urlMatch) return urlMatch[1]
   }
   return undefined
-}
-
-/**
- * Returns true when `candidate` resolves to the same origin as `base`. Used to
- * pin a persisted pagination cursor to the configured GitLab host before
- * following it with an `Authorization` header, so a tampered or corrupted
- * `fileNextUrl` cannot exfiltrate the access token to an attacker-controlled
- * host. Returns false on any unparseable URL.
- */
-function isSameOrigin(candidate: string, base: string): boolean {
-  try {
-    return new URL(candidate).origin === new URL(base).origin
-  } catch {
-    return false
-  }
 }
 
 /**

--- a/apps/sim/lib/core/utils/validation.ts
+++ b/apps/sim/lib/core/utils/validation.ts
@@ -1,17 +1,18 @@
 import { getBaseUrl } from './urls'
 
 /**
- * Checks if a URL is same-origin with the application's base URL.
- * Used to prevent open redirect vulnerabilities.
+ * Checks if a URL is same-origin with a base URL. Defaults to the application's
+ * base URL, used to prevent open redirect vulnerabilities; pass an explicit
+ * `base` to pin a URL to another trusted origin (e.g. a configured API host)
+ * before following it with credentials.
  *
  * @param url - The URL to validate
+ * @param base - The origin to compare against (defaults to the app base URL)
  * @returns True if the URL is same-origin, false otherwise (secure default)
  */
-export function isSameOrigin(url: string): boolean {
+export function isSameOrigin(url: string, base: string = getBaseUrl()): boolean {
   try {
-    const targetUrl = new URL(url)
-    const appUrl = new URL(getBaseUrl())
-    return targetUrl.origin === appUrl.origin
+    return new URL(url).origin === new URL(base).origin
   } catch {
     return false
   }

--- a/apps/sim/tools/index.ts
+++ b/apps/sim/tools/index.ts
@@ -19,6 +19,7 @@ import {
 } from '@/lib/core/utils/stream-limits'
 import { getBaseUrl, getInternalApiBaseUrl } from '@/lib/core/utils/urls'
 import { isUserFile } from '@/lib/core/utils/user-file'
+import { isSameOrigin } from '@/lib/core/utils/validation'
 import { SIM_VIA_HEADER, serializeCallChain } from '@/lib/execution/call-chain'
 import { parseMcpToolId } from '@/lib/mcp/utils'
 import { resolveWorkspaceFileReference } from '@/lib/uploads/contexts/workspace/workspace-file-manager'
@@ -1364,17 +1365,7 @@ function isErrorResponse(
  * the platform's own workflow execution endpoints via absolute URL.
  */
 function isSelfOriginUrl(url: string): boolean {
-  try {
-    const targetOrigin = new URL(url).origin
-    const publicOrigin = new URL(getBaseUrl()).origin
-    if (targetOrigin === publicOrigin) return true
-
-    const internalOrigin = new URL(getInternalApiBaseUrl()).origin
-    if (targetOrigin === internalOrigin) return true
-  } catch {
-    return false
-  }
-  return false
+  return isSameOrigin(url, getBaseUrl()) || isSameOrigin(url, getInternalApiBaseUrl())
 }
 
 /**


### PR DESCRIPTION
## Summary
- The GitLab repository-tree keyset cursor stored GitLab's verbatim `rel="next"` URL and re-fetched it with an `Authorization: Bearer` header. A tampered or corrupted `fileNextUrl` could have leaked the access token to an attacker-controlled host. The connector now asserts the cursor's origin matches the configured `apiBase` before following it, failing closed on mismatch.
- Generalized the shared `isSameOrigin` util (`lib/core/utils/validation.ts`) to accept an optional `base` origin (defaults to the app base URL, so existing callers are unchanged).
- Replaced the GitLab connector's local origin helper and refactored the tools self-origin check to consume the shared util instead of duplicating URL-parsing.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run lint` and the API-validation contract check both pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)