### PR TITLE
fix(mcp): enforce tool name validation in deploy modal

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
@@ -13,8 +13,8 @@ import {
   Skeleton,
   Textarea,
 } from '@/components/emcn'
+import { cn } from '@/lib/core/utils/cn'
 import { generateToolInputSchema, sanitizeToolName } from '@/lib/mcp/workflow-tool-schema'
-import { cn } from '@/lib/utils'
 import { normalizeInputFormatValue } from '@/lib/workflows/input-format'
 import { isInputDefinitionTrigger } from '@/lib/workflows/triggers/input-definition-triggers'
 import type { InputFormatField } from '@/lib/workflows/types'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
@@ -33,8 +33,12 @@ import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 const logger = createLogger('McpToolDeploy')
 
-/** MCP tool names allow lowercase letters, numbers, and underscores only */
-const TOOL_NAME_PATTERN = /^[a-z0-9_]+$/
+/**
+ * Mirrors the server's `sanitizeToolName` output: lowercase alphanumerics with single
+ * underscores between segments. Disallows leading/trailing and consecutive underscores so
+ * the validated name matches exactly what the server persists (no silent rewrite).
+ */
+const TOOL_NAME_PATTERN = /^[a-z0-9]+(_[a-z0-9]+)*$/
 const MAX_TOOL_NAME_LENGTH = 64
 
 /** InputFormatField with guaranteed name (after normalization) */
@@ -178,7 +182,7 @@ export function McpDeploy({
       return `Tool name must be ${MAX_TOOL_NAME_LENGTH} characters or fewer`
     }
     if (!TOOL_NAME_PATTERN.test(trimmed)) {
-      return 'Tool name can only contain lowercase letters, numbers, and underscores'
+      return 'Use lowercase letters and numbers, separated by single underscores'
     }
     return null
   }, [toolName])
@@ -593,11 +597,15 @@ export function McpDeploy({
             <span className='truncate text-[var(--text-primary)]'>{selectedServersLabel}</span>
           }
         />
-        {!toolName.trim() && (
+        {!toolName.trim() ? (
           <p className='mt-[6.5px] text-[var(--text-secondary)] text-xs'>
             Enter a tool name to select servers
           </p>
-        )}
+        ) : toolNameError ? (
+          <p className='mt-[6.5px] text-[var(--text-secondary)] text-xs'>
+            Fix the tool name to select servers
+          </p>
+        ) : null}
       </div>
 
       {saveErrors.length > 0 && (

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
@@ -14,6 +14,7 @@ import {
   Textarea,
 } from '@/components/emcn'
 import { generateToolInputSchema, sanitizeToolName } from '@/lib/mcp/workflow-tool-schema'
+import { cn } from '@/lib/utils'
 import { normalizeInputFormatValue } from '@/lib/workflows/input-format'
 import { isInputDefinitionTrigger } from '@/lib/workflows/triggers/input-definition-triggers'
 import type { InputFormatField } from '@/lib/workflows/types'
@@ -31,6 +32,10 @@ import { EMPTY_SUBBLOCK_VALUES, useSubBlockStore } from '@/stores/workflows/subb
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 const logger = createLogger('McpToolDeploy')
+
+/** MCP tool names allow lowercase letters, numbers, and underscores only */
+const TOOL_NAME_PATTERN = /^[a-z0-9_]+$/
+const MAX_TOOL_NAME_LENGTH = 64
 
 /** InputFormatField with guaranteed name (after normalization) */
 type NormalizedField = InputFormatField & { name: string }
@@ -166,6 +171,18 @@ export function McpDeploy({
     [inputFormat, parameterDescriptions]
   )
 
+  const toolNameError = useMemo(() => {
+    const trimmed = toolName.trim()
+    if (!trimmed) return null
+    if (trimmed.length > MAX_TOOL_NAME_LENGTH) {
+      return `Tool name must be ${MAX_TOOL_NAME_LENGTH} characters or fewer`
+    }
+    if (!TOOL_NAME_PATTERN.test(trimmed)) {
+      return 'Tool name can only contain lowercase letters, numbers, and underscores'
+    }
+    return null
+  }, [toolName])
+
   const [serverToolsMap, setServerToolsMap] = useState<
     Record<string, { tool: WorkflowMcpTool | null; isLoading: boolean }>
   >({})
@@ -270,11 +287,11 @@ export function McpDeploy({
     (hasToolConfigurationChanges && selectedServerIdsForForm.length > 0)
 
   useEffect(() => {
-    onCanSaveChange?.(hasChanges && !!toolName.trim())
-  }, [hasChanges, toolName, onCanSaveChange])
+    onCanSaveChange?.(hasChanges && !!toolName.trim() && !toolNameError)
+  }, [hasChanges, toolName, toolNameError, onCanSaveChange])
 
   const handleSave = async () => {
-    if (!toolName.trim()) return
+    if (!toolName.trim() || toolNameError) return
 
     const currentIds = new Set(selectedServerIds)
     const nextIds = new Set(selectedServerIdsForForm)
@@ -492,9 +509,16 @@ export function McpDeploy({
           value={toolName}
           onChange={(e) => setToolName(e.target.value)}
           placeholder='e.g., book_flight'
+          aria-invalid={!!toolNameError}
+          className={cn(toolNameError && 'border-[var(--text-error)]')}
         />
-        <p className='mt-[6.5px] text-[var(--text-secondary)] text-xs'>
-          Use lowercase letters, numbers, and underscores only
+        <p
+          className={cn(
+            'mt-[6.5px] text-xs',
+            toolNameError ? 'text-[var(--text-error)]' : 'text-[var(--text-secondary)]'
+          )}
+        >
+          {toolNameError ?? 'Use lowercase letters, numbers, and underscores only'}
         </p>
       </div>
 
@@ -564,7 +588,7 @@ export function McpDeploy({
           placeholder='Select servers...'
           searchable
           searchPlaceholder='Search servers...'
-          disabled={!toolName.trim() || isPending}
+          disabled={!toolName.trim() || !!toolNameError || isPending}
           overlayContent={
             <span className='truncate text-[var(--text-primary)]'>{selectedServersLabel}</span>
           }


### PR DESCRIPTION
## Summary
- The MCP "Tool name" field showed the rule "lowercase letters, numbers, and underscores only" but never enforced it — invalid input (e.g. `epic-sun3 3`) saved silently, then the server rewrote it to `epic_sun3_3`, so the persisted name differed from what the user typed
- Added client-side validation mirroring the Chat tab's identifier pattern: blocks save, disables the server selector, and surfaces an inline error + red border when the name has invalid characters or exceeds 64 chars

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)