### PR TITLE
fix(otel): make service.instance.id unique per process

### DIFF
--- a/apps/sim/instrumentation-node.ts
+++ b/apps/sim/instrumentation-node.ts
@@ -2,6 +2,7 @@
 // prefix (`sim-mothership:` / `go-mothership:`) to separate the two
 // halves of a mothership trace in the OTLP backend.
 
+import { hostname } from 'node:os'
 import type { Attributes, Context, Link, SpanKind } from '@opentelemetry/api'
 import { DiagConsoleLogger, DiagLogLevel, diag, TraceFlags, trace } from '@opentelemetry/api'
 import type {
@@ -259,10 +260,12 @@ async function initializeOpenTelemetry() {
       exportIntervalMillis: 60000,
     })
 
-    // Unique instance id per origin keeps Jaeger's clock-skew adjuster
-    // from grouping Sim+Go spans together (they'd see multi-second
-    // drift as intra-service and emit spurious warnings).
-    const serviceInstanceId = `${telemetryConfig.serviceName}-${SERVICE_INSTANCE_SLUG}`
+    // Must be unique per process: replicas sharing one instance id collapse
+    // into a single Prometheus series, so their independent cumulative
+    // counters interleave and corrupt rate()/increase(). The slug keeps Sim
+    // distinct from Go for Jaeger's clock-skew grouping; the hostname (the
+    // container id under ECS) makes each replica its own series.
+    const serviceInstanceId = `${telemetryConfig.serviceName}-${SERVICE_INSTANCE_SLUG}-${hostname()}`
     const resource = defaultResource().merge(
       resourceFromAttributes({
         [ATTR_SERVICE_NAME]: telemetryConfig.serviceName,


### PR DESCRIPTION
## Problem
Every Sim app replica reports OTel telemetry with the **same** hardcoded `service.instance.id` (`mothership-sim`), because `instrumentation-node.ts` builds it from a constant slug. With >1 replica (staging `app` runs 2 tasks), all replicas write to the **same Prometheus series**. Each process keeps its own independent cumulative counter, so the merged series interleaves values from two sources → phantom counter resets → `rate()`/`increase()` "add back" the drops and inflate.

Observed on staging (`grafanacloud-prom`):
- `resets(hosted_key_cost_charged_USD_total[40m])` = **7+** while `resets(hosted_key_used_total[...])` = **0**
- "Total cost charged" inflated to **~$0.72** from a few real cents
- `service_instance_id` / `instance` each have exactly **one** value despite 2 running tasks

No-`key` metrics (`cost_charged`, `throttled`, `queue_wait_*`, `queue_wait_exceeded`) collide fully; `key`-labeled ones (`used`/`failed`/`upstream`) are only probabilistically protected by the differing `key` label.

## Fix
Append `hostname()` (the container id under ECS/Fargate, unique per task) to `service.instance.id`. Each replica becomes its own clean cumulative-counter series, so `sum(rate(...))` / `sum(increase(...))` aggregate correctly across replicas. The `mothership-sim` prefix is preserved so Jaeger's clock-skew adjuster still separates Sim from Go spans.

## Notes
- Emitter-only fix; historical corrupted series won't self-heal, but data after deploy is clean.
- No dashboard changes needed — existing `sum(rate(...))`/`sum(increase(...))` queries become correct once instance ids are unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)