### PR TITLE
fix(user-input): atomic chip selection, modifier-key handling, and stale overlay ghost

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/chip-selection.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/chip-selection.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  type ChipBound,
+  type Selection,
+  snapSelectionToChips,
+} from '@/app/workspace/[workspaceId]/home/components/user-input/chip-selection'
+
+// A chip occupying value indices [5, 12): e.g. " @Gmail " sitting at offset 5.
+const CHIP: ChipBound = { start: 5, end: 12 }
+
+const at = (pos: number): Selection => ({ start: pos, end: pos })
+
+describe('snapSelectionToChips', () => {
+  describe('collapsed caret', () => {
+    it('leaves a caret outside any chip untouched', () => {
+      expect(snapSelectionToChips(at(3), at(3), undefined, undefined)).toEqual(at(3))
+    })
+
+    it('snaps a caret in the chip near the start to the start edge', () => {
+      expect(snapSelectionToChips(at(6), at(6), CHIP, CHIP)).toEqual(at(5))
+    })
+
+    it('snaps a caret in the chip near the end to the end edge', () => {
+      expect(snapSelectionToChips(at(11), at(11), CHIP, CHIP)).toEqual(at(12))
+    })
+
+    it('snaps the exact midpoint to the start edge (ties favor start)', () => {
+      // distance to start (8.5-5=3.5) equals distance to end (12-8.5=3.5) only at
+      // 8.5; integer midpoint 8 is closer to start.
+      expect(snapSelectionToChips(at(8), at(8), CHIP, CHIP)).toEqual(at(5))
+    })
+
+    it('does not snap a caret resting exactly on an edge (edge is not "inside")', () => {
+      // findRangeContaining is strict, so an edge caret has no containing chip.
+      expect(snapSelectionToChips(at(5), at(5), undefined, undefined)).toEqual(at(5))
+      expect(snapSelectionToChips(at(12), at(12), undefined, undefined)).toEqual(at(12))
+    })
+  })
+
+  describe('ranged — fresh selection (both edges differ from prev)', () => {
+    it('expands a start edge inside a chip outward to the chip start', () => {
+      // select-all-like: prev was a caret at 20, new selection 8..30 grew both edges.
+      const out = snapSelectionToChips({ start: 8, end: 30 }, at(20), CHIP, undefined)
+      expect(out).toEqual({ start: 5, end: 30 })
+    })
+
+    it('expands an end edge inside a chip outward to the chip end', () => {
+      const out = snapSelectionToChips({ start: 0, end: 9 }, at(20), undefined, CHIP)
+      expect(out).toEqual({ start: 0, end: 12 })
+    })
+
+    it('expands both edges when each lands in a (different) chip', () => {
+      const chipB: ChipBound = { start: 20, end: 27 }
+      const out = snapSelectionToChips({ start: 8, end: 23 }, at(40), CHIP, chipB)
+      expect(out).toEqual({ start: 5, end: 27 })
+    })
+  })
+
+  describe('ranged — single moved edge (keyboard extend / shrink)', () => {
+    it('growing the end edge into a chip absorbs the whole chip', () => {
+      // prev 0..6, end moved 6 -> 9 (grew); start unchanged.
+      const out = snapSelectionToChips({ start: 0, end: 9 }, { start: 0, end: 6 }, undefined, CHIP)
+      expect(out).toEqual({ start: 0, end: 12 })
+    })
+
+    it('shrinking the end edge out of a chip releases the whole chip', () => {
+      // prev 0..14, end moved 14 -> 9 (shrank) into the chip; release to chip start.
+      const out = snapSelectionToChips({ start: 0, end: 9 }, { start: 0, end: 14 }, undefined, CHIP)
+      expect(out).toEqual({ start: 0, end: 5 })
+    })
+
+    it('growing the start edge leftward into a chip absorbs the whole chip', () => {
+      // prev 9..20, start moved 9 -> 6 (grew leftward, start < prev.start).
+      const out = snapSelectionToChips(
+        { start: 6, end: 20 },
+        { start: 9, end: 20 },
+        CHIP,
+        undefined
+      )
+      expect(out).toEqual({ start: 5, end: 20 })
+    })
+
+    it('shrinking the start edge rightward into a chip releases the whole chip', () => {
+      // prev 6..20, start moved 6 -> 9 (shrank rightward, start > prev.start) → chip end.
+      const out = snapSelectionToChips(
+        { start: 9, end: 20 },
+        { start: 6, end: 20 },
+        CHIP,
+        undefined
+      )
+      expect(out).toEqual({ start: 12, end: 20 })
+    })
+  })
+
+  describe('selection contained within one chip', () => {
+    it('clamps to a collapsed caret rather than inverting', () => {
+      // Both edges inside CHIP via a fresh selection: start→5, end→12 stays ordered.
+      // Construct an inverting case: a shrink where start snaps to 12 and end to 5.
+      const out = snapSelectionToChips({ start: 7, end: 9 }, { start: 5, end: 9 }, CHIP, CHIP)
+      expect(out.start).toBeLessThanOrEqual(out.end)
+    })
+  })
+
+  describe('no chips', () => {
+    it('returns the selection unchanged', () => {
+      const sel = { start: 2, end: 18 }
+      expect(snapSelectionToChips(sel, at(0), undefined, undefined)).toEqual(sel)
+    })
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/chip-selection.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/chip-selection.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure selection-snapping math for the mention-chip textarea, extracted from the
+ * `onSelect` handler so it can be unit-tested in isolation from DOM I/O.
+ *
+ * A mention chip occupies a contiguous `[start, end)` span of the textarea
+ * value. The UI treats each chip as atomic: a selection edge may never land
+ * strictly inside a chip. This function maps an observed selection to the
+ * nearest valid one.
+ */
+
+/** A half-open chip span `[start, end)` in textarea-value coordinates. */
+export interface ChipBound {
+  start: number
+  end: number
+}
+
+/** A selection or caret as reported by `selectionStart`/`selectionEnd`. */
+export interface Selection {
+  start: number
+  end: number
+}
+
+/**
+ * Snaps a selection so no edge sits inside a chip.
+ *
+ * - **Collapsed caret inside a chip** → nearest chip edge (so the caret can't
+ *   rest mid-chip).
+ * - **Ranged selection** → each edge inside a chip snaps to a chip boundary,
+ *   never collapsing the range. Which boundary depends on the gesture:
+ *   - A *lone moved edge* (keyboard extend/shrink, drag) snaps in its direction
+ *     of travel — growing absorbs the chip, shrinking releases it.
+ *   - A *fresh selection* (double-click, select-all) expands outward to include
+ *     touched chips whole. A fresh selection that happens to share one edge with
+ *     `prev` (e.g. select-all from a caret already at 0) takes the single-edge
+ *     path, but a grown edge expands outward there too — the paths differ only
+ *     for a *shrinking* edge, which implies a genuine single-edge gesture.
+ *
+ * @param sel - The observed selection.
+ * @param prev - The previously observed selection, used to infer which edge moved.
+ * @param startChip - The chip containing `sel.start`, if any.
+ * @param endChip - The chip containing `sel.end`, if any.
+ * @returns The snapped selection (equal to `sel` when no edge is inside a chip).
+ */
+export function snapSelectionToChips(
+  sel: Selection,
+  prev: Selection,
+  startChip: ChipBound | undefined,
+  endChip: ChipBound | undefined
+): Selection {
+  const { start, end } = sel
+
+  if (start === end) {
+    if (!startChip) return sel
+    const nearest =
+      start - startChip.start < startChip.end - start ? startChip.start : startChip.end
+    return { start: nearest, end: nearest }
+  }
+
+  const singleEdgeMoved = (start !== prev.start) !== (end !== prev.end)
+
+  let newStart = startChip
+    ? singleEdgeMoved && start > prev.start
+      ? startChip.end
+      : startChip.start
+    : start
+  const newEnd = endChip ? (singleEdgeMoved && end < prev.end ? endChip.start : endChip.end) : end
+
+  // A selection contained within a single chip snaps both edges; clamp so it
+  // collapses to a caret rather than inverting.
+  if (newStart > newEnd) newStart = newEnd
+
+  return { start: newStart, end: newEnd }
+}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/chip-selection.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/chip-selection.ts
@@ -23,17 +23,13 @@ export interface Selection {
 /**
  * Snaps a selection so no edge sits inside a chip.
  *
- * - **Collapsed caret inside a chip** → nearest chip edge (so the caret can't
- *   rest mid-chip).
- * - **Ranged selection** → each edge inside a chip snaps to a chip boundary,
- *   never collapsing the range. Which boundary depends on the gesture:
- *   - A *lone moved edge* (keyboard extend/shrink, drag) snaps in its direction
- *     of travel — growing absorbs the chip, shrinking releases it.
- *   - A *fresh selection* (double-click, select-all) expands outward to include
- *     touched chips whole. A fresh selection that happens to share one edge with
- *     `prev` (e.g. select-all from a caret already at 0) takes the single-edge
- *     path, but a grown edge expands outward there too — the paths differ only
- *     for a *shrinking* edge, which implies a genuine single-edge gesture.
+ * - **Collapsed caret inside a chip** → nearest chip edge.
+ * - **Ranged selection** → each edge inside a chip snaps to a boundary without
+ *   collapsing the range. A lone moved edge (keyboard extend/shrink, drag) snaps
+ *   in its direction of travel — growing absorbs the chip, shrinking releases
+ *   it; a fresh selection (double-click, select-all) expands outward. The two
+ *   paths differ only for a shrinking edge, so the gesture inference is safe
+ *   even when a fresh selection happens to share an edge with `prev`.
  *
  * @param sel - The observed selection.
  * @param prev - The previously observed selection, used to infer which edge moved.

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/constants.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/constants.ts
@@ -53,25 +53,34 @@ const FIELD_MIRROR_CLASSES = cn(
   'px-1 py-1 font-body text-[15px] leading-[24px] tracking-[-0.015em]'
 )
 
+/**
+ * The textarea grows to its full content height (`h-auto`, no internal scroll);
+ * the shared scroller clips and scrolls it. Its text is transparent so the
+ * mirror overlay shows through; only the caret paints.
+ */
 export const TEXTAREA_BASE_CLASSES = cn(
   FIELD_MIRROR_CLASSES,
-  'h-auto resize-none overflow-y-auto overflow-x-hidden',
+  'block h-auto resize-none overflow-hidden',
   'text-transparent caret-[var(--text-primary)] outline-none',
   'placeholder:font-[380] placeholder:text-[var(--text-subtle)]',
-  'focus-visible:ring-0 focus-visible:ring-offset-0',
-  '[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
+  'focus-visible:ring-0 focus-visible:ring-offset-0'
 )
 
 /**
- * Pinned to the textarea's box (`inset-0`) and clipped (`overflow-hidden`).
- * The box itself never scrolls — its content is translated to mirror the
- * textarea's scroll offset, so the compositor never holds scrolled textures
- * for it (a scrolled box can ghost stale paint after its content is cleared).
+ * Pinned over the full-height textarea (`inset-0` of the sizer). Both are flow
+ * children of the same scroller, so they scroll together natively — no JS
+ * scroll-sync, so the caret and mirrored text never drift apart.
  */
 export const OVERLAY_CLASSES = cn(
   FIELD_MIRROR_CLASSES,
-  'pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap',
+  'pointer-events-none absolute inset-0 whitespace-pre-wrap',
   'text-[var(--text-primary)]'
+)
+
+/** Single scroll container for the textarea + overlay; caps height and hides its scrollbar. */
+export const SCROLLER_CLASSES = cn(
+  'relative overflow-y-auto overflow-x-hidden',
+  '[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
 )
 
 export const SEND_BUTTON_BASE = 'h-[28px] w-[28px] rounded-full border-0 p-0 transition-colors'
@@ -79,14 +88,7 @@ export const SEND_BUTTON_ACTIVE =
   'bg-[#383838] hover:bg-[#575757] dark:bg-[#E0E0E0] dark:hover:bg-[#CFCFCF]'
 export const SEND_BUTTON_DISABLED = 'bg-[#808080] dark:bg-[#808080]'
 
-export const MAX_CHAT_TEXTAREA_HEIGHT = 200
 export const SPEECH_RECOGNITION_LANG = 'en-US'
-
-export function autoResizeTextarea(e: React.FormEvent<HTMLTextAreaElement>, maxHeight: number) {
-  const target = e.target as HTMLTextAreaElement
-  target.style.height = 'auto'
-  target.style.height = `${Math.min(target.scrollHeight, maxHeight)}px`
-}
 
 /**
  * Maps a {@link MothershipResource} (resource-picker domain) to a

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/constants.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/constants.ts
@@ -43,22 +43,35 @@ export interface PlusMenuHandle {
   selectActive: () => boolean
 }
 
+/**
+ * Box and typography shared by the textarea and its mirror overlay — both must
+ * produce identical line wrapping so the overlay text sits exactly over the
+ * (transparent) textarea text.
+ */
+const FIELD_MIRROR_CLASSES = cn(
+  'm-0 box-border min-h-[24px] w-full break-words [overflow-wrap:anywhere] border-0 bg-transparent',
+  'px-1 py-1 font-body text-[15px] leading-[24px] tracking-[-0.015em]'
+)
+
 export const TEXTAREA_BASE_CLASSES = cn(
-  'm-0 box-border h-auto min-h-[24px] w-full resize-none',
-  'overflow-y-auto overflow-x-hidden break-words [overflow-wrap:anywhere] border-0 bg-transparent',
-  'px-1 py-1 font-body text-[15px] leading-[24px] tracking-[-0.015em]',
+  FIELD_MIRROR_CLASSES,
+  'h-auto resize-none overflow-y-auto overflow-x-hidden',
   'text-transparent caret-[var(--text-primary)] outline-none',
   'placeholder:font-[380] placeholder:text-[var(--text-subtle)]',
   'focus-visible:ring-0 focus-visible:ring-offset-0',
   '[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
 )
 
+/**
+ * Pinned to the textarea's box (`inset-0`) and clipped (`overflow-hidden`) so
+ * stale paints can never escape the input. Not a scroll container — it mirrors
+ * the textarea's scroll position via programmatic `scrollTop`, which works on
+ * `overflow: hidden` boxes.
+ */
 export const OVERLAY_CLASSES = cn(
-  'pointer-events-none absolute top-0 left-0 m-0 box-border h-auto w-full resize-none',
-  'overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words [overflow-wrap:anywhere] border-0 bg-transparent',
-  'px-1 py-1 font-body text-[15px] leading-[24px] tracking-[-0.015em]',
-  'text-[var(--text-primary)] outline-none',
-  '[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
+  FIELD_MIRROR_CLASSES,
+  'pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap',
+  'text-[var(--text-primary)]'
 )
 
 export const SEND_BUTTON_BASE = 'h-[28px] w-[28px] rounded-full border-0 p-0 transition-colors'

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/constants.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/constants.ts
@@ -63,10 +63,10 @@ export const TEXTAREA_BASE_CLASSES = cn(
 )
 
 /**
- * Pinned to the textarea's box (`inset-0`) and clipped (`overflow-hidden`) so
- * stale paints can never escape the input. Not a scroll container — it mirrors
- * the textarea's scroll position via programmatic `scrollTop`, which works on
- * `overflow: hidden` boxes.
+ * Pinned to the textarea's box (`inset-0`) and clipped (`overflow-hidden`).
+ * The box itself never scrolls — its content is translated to mirror the
+ * textarea's scroll offset, so the compositor never holds scrolled textures
+ * for it (a scrolled box can ghost stale paint after its content is cleared).
  */
 export const OVERLAY_CLASSES = cn(
   FIELD_MIRROR_CLASSES,

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/index.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/index.ts
@@ -15,10 +15,9 @@ export type {
   WindowWithSpeech,
 } from './constants'
 export {
-  autoResizeTextarea,
-  MAX_CHAT_TEXTAREA_HEIGHT,
   mapResourceToContext,
   OVERLAY_CLASSES,
+  SCROLLER_CLASSES,
   SPEECH_RECOGNITION_LANG,
   TEXTAREA_BASE_CLASSES,
 } from './constants'

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -1030,7 +1030,7 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     ]
   )
 
-  /** Last observed selection; tells which edge of a range moved, and which way. */
+  /** Last selection reported by the DOM; tells which edge of a range moved, and which way. */
   const lastSelectionRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 })
 
   /**
@@ -1045,17 +1045,12 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     const start = textarea.selectionStart ?? 0
     const end = textarea.selectionEnd ?? 0
     const prev = lastSelectionRef.current
+    // Always track the raw observed selection — never an intended write that
+    // may get superseded — so edge-movement inference stays true to the DOM.
+    lastSelectionRef.current = { start, end }
 
-    // Deferred so in-flight click/drag processing can't override the write;
-    // bails if the selection moved again first (a newer event supersedes it).
-    const applySelection = (nextStart: number, nextEnd: number) => {
-      const direction = textarea.selectionDirection ?? undefined
-      setTimeout(() => {
-        if (textarea.selectionStart !== start || textarea.selectionEnd !== end) return
-        textarea.setSelectionRange(nextStart, nextEnd, direction)
-      }, 0)
-    }
-
+    let newStart = start
+    let newEnd = end
     if (start !== end) {
       const startRange = mentionTokensWithContext.findRangeContaining(start)
       const endRange = mentionTokensWithContext.findRangeContaining(end)
@@ -1063,37 +1058,40 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
       // of travel: growing absorbs the chip, shrinking releases it. Fresh
       // selections (double-click, select-all) expand outward.
       const singleEdgeMoved = (start !== prev.start) !== (end !== prev.end)
-      let newStart = startRange
+      newStart = startRange
         ? singleEdgeMoved && start > prev.start
           ? startRange.end
           : startRange.start
         : start
-      const newEnd = endRange
-        ? singleEdgeMoved && end < prev.end
-          ? endRange.start
-          : endRange.end
-        : end
+      newEnd = endRange ? (singleEdgeMoved && end < prev.end ? endRange.start : endRange.end) : end
       // A selection contained in one chip snaps both edges; don't let it invert.
       if (newStart > newEnd) {
         newStart = newEnd
       }
-      lastSelectionRef.current = { start: newStart, end: newEnd }
-      if (newStart !== start || newEnd !== end) {
-        applySelection(newStart, newEnd)
+    } else {
+      const r = mentionTokensWithContext.findRangeContaining(start)
+      if (r) {
+        const snapPos = start - r.start < r.end - start ? r.start : r.end
+        newStart = snapPos
+        newEnd = snapPos
       }
+    }
+
+    if (newStart !== start || newEnd !== end) {
+      // Deferred so in-flight click/drag processing can't override the write;
+      // bails if the selection moved again first (a newer event supersedes it).
+      // The write re-fires this handler, which then syncs the menus below.
+      const direction = textarea.selectionDirection ?? undefined
+      setTimeout(() => {
+        if (textarea.selectionStart !== start || textarea.selectionEnd !== end) return
+        textarea.setSelectionRange(newStart, newEnd, direction)
+      }, 0)
       return
     }
 
-    const r = mentionTokensWithContext.findRangeContaining(start)
-    if (r) {
-      const snapPos = start - r.start < r.end - start ? r.start : r.end
-      lastSelectionRef.current = { start: snapPos, end: snapPos }
-      applySelection(snapPos, snapPos)
-      return
-    }
-    lastSelectionRef.current = { start, end }
-    syncMentionState(textarea, textarea.value, start)
-    syncSlashState(textarea, textarea.value, start)
+    const focusPos = textarea.selectionDirection === 'backward' ? start : end
+    syncMentionState(textarea, textarea.value, focusPos)
+    syncSlashState(textarea, textarea.value, focusPos)
   }, [textareaRef, mentionTokensWithContext, syncMentionState, syncSlashState])
 
   const handleInput = useCallback(

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/lib/core/utils/cn'
 import { CHAT_ACCEPT_ATTRIBUTE } from '@/lib/uploads/utils/validation'
 import { ContextMentionIcon } from '@/app/workspace/[workspaceId]/home/components/context-mention-icon'
 import { useAvailableResources } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown'
+import { snapSelectionToChips } from '@/app/workspace/[workspaceId]/home/components/user-input/chip-selection'
 import type {
   PlusMenuHandle,
   SkillsMenuHandle,
@@ -1056,53 +1057,31 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     // may get superseded — so edge-movement inference stays true to the DOM.
     lastSelectionRef.current = { start, end }
 
-    // Reconciliation backstop for non-keyboard mutations; the render rebuilds
-    // the overlay and selection logic resumes on the next event.
+    // Adopt value changes that bypassed React's change tracking (browser
+    // autofill, password managers, grammar extensions — see facebook/react#2125)
+    // so state never drifts from the DOM. The render rebuilds the overlay and
+    // selection logic resumes on the next event.
     if (textarea.value !== valueRef.current) {
       adoptDomValue(textarea)
       return
     }
 
-    let newStart = start
-    let newEnd = end
-    if (start !== end) {
-      const startRange = mentionTokensWithContext.findRangeContaining(start)
-      const endRange = mentionTokensWithContext.findRangeContaining(end)
-      // A lone moved edge (keyboard extend/shrink, drag) snaps in its direction
-      // of travel: growing absorbs the chip, shrinking releases it. Fresh
-      // selections (double-click, select-all) expand outward. A fresh selection
-      // sharing one edge with `prev` (e.g. select-all from a caret at 0) takes
-      // the single-edge path, but a grown edge snaps outward there too — the
-      // two paths only differ for a shrinking edge, which implies a real
-      // single-edge gesture.
-      const singleEdgeMoved = (start !== prev.start) !== (end !== prev.end)
-      newStart = startRange
-        ? singleEdgeMoved && start > prev.start
-          ? startRange.end
-          : startRange.start
-        : start
-      newEnd = endRange ? (singleEdgeMoved && end < prev.end ? endRange.start : endRange.end) : end
-      // A selection contained in one chip snaps both edges; don't let it invert.
-      if (newStart > newEnd) {
-        newStart = newEnd
-      }
-    } else {
-      const r = mentionTokensWithContext.findRangeContaining(start)
-      if (r) {
-        const snapPos = start - r.start < r.end - start ? r.start : r.end
-        newStart = snapPos
-        newEnd = snapPos
-      }
-    }
+    const startChip = mentionTokensWithContext.findRangeContaining(start)
+    const endChip = start === end ? startChip : mentionTokensWithContext.findRangeContaining(end)
+    const snapped = snapSelectionToChips({ start, end }, prev, startChip, endChip)
 
-    if (newStart !== start || newEnd !== end) {
+    if (snapped.start !== start || snapped.end !== end) {
       // Deferred so in-flight click/drag processing can't override the write;
       // bails if the selection moved again first (a newer event supersedes it).
       // The write re-fires this handler, which then syncs the menus below.
       // Direction is read at apply time so it's never stale.
       setTimeout(() => {
         if (textarea.selectionStart !== start || textarea.selectionEnd !== end) return
-        textarea.setSelectionRange(newStart, newEnd, textarea.selectionDirection ?? undefined)
+        textarea.setSelectionRange(
+          snapped.start,
+          snapped.end,
+          textarea.selectionDirection ?? undefined
+        )
       }, 0)
       return
     }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -1053,6 +1053,13 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
   const handleSelectAdjust = useCallback(() => {
     const textarea = textareaRef.current
     if (!textarea) return
+    const start = textarea.selectionStart ?? 0
+    const end = textarea.selectionEnd ?? 0
+    const prev = lastSelectionRef.current
+    // Always track the raw observed selection — never an intended write that
+    // may get superseded — so edge-movement inference stays true to the DOM.
+    lastSelectionRef.current = { start, end }
+
     // Controlled-value reconciliation: state and DOM can only drift when an
     // edit's change event is lost (programmatic edits pair setValue
     // synchronously). The DOM is the user's intent — adopt it and let the
@@ -1062,12 +1069,6 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
       setValue(textarea.value)
       return
     }
-    const start = textarea.selectionStart ?? 0
-    const end = textarea.selectionEnd ?? 0
-    const prev = lastSelectionRef.current
-    // Always track the raw observed selection — never an intended write that
-    // may get superseded — so edge-movement inference stays true to the DOM.
-    lastSelectionRef.current = { start, end }
 
     let newStart = start
     let newEnd = end

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -1038,8 +1038,24 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     ]
   )
 
-  /** Last selection reported by the DOM; tells which edge of a range moved, and which way. */
-  const lastSelectionRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 })
+  // Selection one change ago, used to infer which edge of a range moved. Kept
+  // current by the `selectionchange` listener below — which fires on EVERY
+  // caret/selection change (typing, arrows, clicks, programmatic), unlike
+  // `select`/`mouseup` — so the inference is never fed a stale `prev`.
+  const prevSelectionRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 })
+
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    let last = { start: 0, end: 0 }
+    const onSelectionChange = () => {
+      if (document.activeElement !== textarea) return
+      prevSelectionRef.current = last
+      last = { start: textarea.selectionStart ?? 0, end: textarea.selectionEnd ?? 0 }
+    }
+    document.addEventListener('selectionchange', onSelectionChange)
+    return () => document.removeEventListener('selectionchange', onSelectionChange)
+  }, [textareaRef])
 
   /**
    * Keeps mention chips atomic under every selection gesture. A collapsed
@@ -1052,10 +1068,9 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     if (!textarea) return
     const start = textarea.selectionStart ?? 0
     const end = textarea.selectionEnd ?? 0
-    const prev = lastSelectionRef.current
-    // Always track the raw observed selection — never an intended write that
-    // may get superseded — so edge-movement inference stays true to the DOM.
-    lastSelectionRef.current = { start, end }
+    // `selectionchange` fires before this `select` handler, so prevSelectionRef
+    // already holds the selection from just before this change.
+    const prev = prevSelectionRef.current
 
     // Adopt value changes that bypassed React's change tracking (browser
     // autofill, password managers, grammar extensions — see facebook/react#2125)

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -834,7 +834,18 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
         }
       }
 
-      if (selectionLength === 0 && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+      // Hop chips on plain arrows only: Shift/Cmd/Alt/Ctrl variants and IME
+      // composition keep native handling; the select handler snaps any
+      // resulting edge inside a chip to a chip boundary.
+      if (
+        selectionLength === 0 &&
+        (e.key === 'ArrowLeft' || e.key === 'ArrowRight') &&
+        !e.shiftKey &&
+        !e.metaKey &&
+        !e.altKey &&
+        !e.ctrlKey &&
+        !e.nativeEvent.isComposing
+      ) {
         if (textarea) {
           if (e.key === 'ArrowLeft') {
             const nextPos = Math.max(0, selStart - 1)
@@ -858,7 +869,9 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
         }
       }
 
-      if (e.key.length === 1 || e.key === 'Space') {
+      // Block typing inside a chip (snap to its end instead). Cmd/Ctrl
+      // shortcuts (Cmd+A, Cmd+C, ...) don't insert text and must pass through.
+      if (e.key.length === 1 && !e.metaKey && !e.ctrlKey) {
         const blocked =
           selectionLength === 0 && !!mentionTokensWithContext.findRangeContaining(selStart)
         if (blocked) {
@@ -1017,20 +1030,70 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     ]
   )
 
+  /** Last observed selection; tells which edge of a range moved, and which way. */
+  const lastSelectionRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 })
+
+  /**
+   * Keeps mention chips atomic under every selection gesture. A collapsed
+   * caret inside a chip snaps to the nearest edge; a ranged selection edge
+   * inside a chip snaps to a chip boundary — never collapsed — so select-all,
+   * Shift+arrows, drag, and double-click all select chips whole.
+   */
   const handleSelectAdjust = useCallback(() => {
     const textarea = textareaRef.current
     if (!textarea) return
-    const pos = textarea.selectionStart ?? 0
-    const r = mentionTokensWithContext.findRangeContaining(pos)
-    if (r) {
-      const snapPos = pos - r.start < r.end - pos ? r.start : r.end
+    const start = textarea.selectionStart ?? 0
+    const end = textarea.selectionEnd ?? 0
+    const prev = lastSelectionRef.current
+
+    // Deferred so in-flight click/drag processing can't override the write;
+    // bails if the selection moved again first (a newer event supersedes it).
+    const applySelection = (nextStart: number, nextEnd: number) => {
+      const direction = textarea.selectionDirection ?? undefined
       setTimeout(() => {
-        textarea.setSelectionRange(snapPos, snapPos)
+        if (textarea.selectionStart !== start || textarea.selectionEnd !== end) return
+        textarea.setSelectionRange(nextStart, nextEnd, direction)
       }, 0)
+    }
+
+    if (start !== end) {
+      const startRange = mentionTokensWithContext.findRangeContaining(start)
+      const endRange = mentionTokensWithContext.findRangeContaining(end)
+      // A lone moved edge (keyboard extend/shrink, drag) snaps in its direction
+      // of travel: growing absorbs the chip, shrinking releases it. Fresh
+      // selections (double-click, select-all) expand outward.
+      const singleEdgeMoved = (start !== prev.start) !== (end !== prev.end)
+      let newStart = startRange
+        ? singleEdgeMoved && start > prev.start
+          ? startRange.end
+          : startRange.start
+        : start
+      const newEnd = endRange
+        ? singleEdgeMoved && end < prev.end
+          ? endRange.start
+          : endRange.end
+        : end
+      // A selection contained in one chip snaps both edges; don't let it invert.
+      if (newStart > newEnd) {
+        newStart = newEnd
+      }
+      lastSelectionRef.current = { start: newStart, end: newEnd }
+      if (newStart !== start || newEnd !== end) {
+        applySelection(newStart, newEnd)
+      }
       return
     }
-    syncMentionState(textarea, textarea.value, pos)
-    syncSlashState(textarea, textarea.value, pos)
+
+    const r = mentionTokensWithContext.findRangeContaining(start)
+    if (r) {
+      const snapPos = start - r.start < r.end - start ? r.start : r.end
+      lastSelectionRef.current = { start: snapPos, end: snapPos }
+      applySelection(snapPos, snapPos)
+      return
+    }
+    lastSelectionRef.current = { start, end }
+    syncMentionState(textarea, textarea.value, start)
+    syncSlashState(textarea, textarea.value, start)
   }, [textareaRef, mentionTokensWithContext, syncMentionState, syncSlashState])
 
   const handleInput = useCallback(
@@ -1230,12 +1293,8 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
       elements.push(
         <span key={`mention-${i}-${range.start}-${range.end}`}>
           <span className='relative'>
-            {/* Spacer reserves the real trigger glyph's width so the overlay's
-                advance matches the transparent textarea char-for-char —
-                hardcoding a width here would drift the text. For '@' the glyph is
-                ~1em; skill chips store an EM SPACE sentinel (SKILL_CHIP_TRIGGER)
-                in place of the narrow '/' so the centered 12px icon fits its slot
-                exactly like '@' does. */}
+            {/* Invisible trigger glyph keeps the overlay's advance identical to
+                the transparent textarea; the icon centers over its slot. */}
             <span className='invisible'>{range.token.charAt(0)}</span>
             {mentionIconNode}
           </span>
@@ -1274,16 +1333,8 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
         onRemoveFile={handleRemoveFile}
       />
 
-      {/* Clip the absolutely-positioned mirror overlay to the textarea's box.
-          The overlay is `h-auto`, so its content (e.g. the trailing-newline
-          sentinel on Shift+Enter) can exceed the textarea height and would
-          otherwise paint over the toolbar below. */}
-      <div className='relative overflow-hidden'>
-        <div
-          ref={overlayRef}
-          className={cn(OVERLAY_CLASSES, isInitialView ? 'max-h-[30vh]' : 'max-h-[200px]')}
-          aria-hidden='true'
-        >
+      <div className='relative'>
+        <div ref={overlayRef} className={OVERLAY_CLASSES} aria-hidden='true'>
           {overlayContent}
         </div>
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -1052,6 +1052,15 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
   const handleSelectAdjust = useCallback(() => {
     const textarea = textareaRef.current
     if (!textarea) return
+    // Controlled-value reconciliation: state and DOM can only drift when an
+    // edit's change event is lost (programmatic edits pair setValue
+    // synchronously). The DOM is the user's intent — adopt it and let the
+    // render rebuild the overlay; selection logic resumes on the next event.
+    if (textarea.value !== valueRef.current) {
+      valueRef.current = textarea.value
+      setValue(textarea.value)
+      return
+    }
     const start = textarea.selectionStart ?? 0
     const end = textarea.selectionEnd ?? 0
     const prev = lastSelectionRef.current

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -829,8 +829,9 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
 
       // Single-chip delete: remove the token's text atomically. A selection
       // delete falls through to the native edit; either way the context-sync
-      // effect prunes contexts whose last token is gone.
-      if ((e.key === 'Backspace' || e.key === 'Delete') && selectionLength === 0) {
+      // effect prunes contexts whose last token is gone. Cmd+Backspace
+      // (delete to line start) stays native — it spans more than one chip.
+      if ((e.key === 'Backspace' || e.key === 'Delete') && selectionLength === 0 && !e.metaKey) {
         const ranges = mentionTokensWithContext.mentionRanges
         const target =
           e.key === 'Backspace'

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -1068,8 +1068,6 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     if (!textarea) return
     const start = textarea.selectionStart ?? 0
     const end = textarea.selectionEnd ?? 0
-    // `selectionchange` fires before this `select` handler, so prevSelectionRef
-    // already holds the selection from just before this change.
     const prev = prevSelectionRef.current
 
     // Adopt value changes that bypassed React's change tracking (browser
@@ -1086,10 +1084,9 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     const snapped = snapSelectionToChips({ start, end }, prev, startChip, endChip)
 
     if (snapped.start !== start || snapped.end !== end) {
-      // Deferred so in-flight click/drag processing can't override the write;
-      // bails if the selection moved again first (a newer event supersedes it).
-      // The write re-fires this handler, which then syncs the menus below.
-      // Direction is read at apply time so it's never stale.
+      // Deferred so in-flight click/drag processing can't override the write,
+      // and bailed if the selection moved again first. The write re-fires this
+      // handler, which then syncs the menus.
       setTimeout(() => {
         if (textarea.selectionStart !== start || textarea.selectionEnd !== end) return
         textarea.setSelectionRange(

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -171,7 +171,7 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
   })
   const valueRef = useRef(value)
   valueRef.current = value
-  const overlayRef = useRef<HTMLDivElement>(null)
+  const overlayContentRef = useRef<HTMLDivElement>(null)
   const plusMenuRef = useRef<PlusMenuHandle>(null)
   const skillsMenuRef = useRef<SkillsMenuHandle>(null)
 
@@ -477,16 +477,26 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     ]
   )
 
+  /**
+   * Mirrors the textarea's scroll offset by translating the overlay content.
+   * The overlay box itself never scrolls — a scrolled box (even with
+   * `overflow: hidden`) is a compositor scroll container whose stale textures
+   * can ghost cleared content; a transform always repaints cleanly and never
+   * clamps, so the mirror tracks the textarea offset exactly.
+   */
+  const syncOverlayScroll = useCallback((scrollTop: number) => {
+    const content = overlayContentRef.current
+    if (content) content.style.transform = `translateY(${-scrollTop}px)`
+  }, [])
+
   useLayoutEffect(() => {
     const textarea = textareaRef.current
     if (!textarea) return
     const maxHeight = isInitialView ? window.innerHeight * 0.3 : MAX_CHAT_TEXTAREA_HEIGHT
     textarea.style.height = 'auto'
     textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeight)}px`
-    if (overlayRef.current) {
-      overlayRef.current.scrollTop = textarea.scrollTop
-    }
-  }, [value, isInitialView, textareaRef])
+    syncOverlayScroll(textarea.scrollTop)
+  }, [value, isInitialView, textareaRef, syncOverlayScroll])
 
   const handleResourceSelect = useCallback(
     (resource: MothershipResource) => {
@@ -1098,12 +1108,9 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     (e: React.FormEvent<HTMLTextAreaElement>) => {
       const maxHeight = isInitialView ? window.innerHeight * 0.3 : MAX_CHAT_TEXTAREA_HEIGHT
       autoResizeTextarea(e, maxHeight)
-
-      if (overlayRef.current) {
-        overlayRef.current.scrollTop = (e.target as HTMLTextAreaElement).scrollTop
-      }
+      syncOverlayScroll((e.target as HTMLTextAreaElement).scrollTop)
     },
-    [isInitialView]
+    [isInitialView, syncOverlayScroll]
   )
 
   const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -1190,11 +1197,12 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     filesRef.current.processFiles(dt.files)
   }, [])
 
-  const handleScroll = useCallback((e: React.UIEvent<HTMLTextAreaElement>) => {
-    if (overlayRef.current) {
-      overlayRef.current.scrollTop = e.currentTarget.scrollTop
-    }
-  }, [])
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLTextAreaElement>) => {
+      syncOverlayScroll(e.currentTarget.scrollTop)
+    },
+    [syncOverlayScroll]
+  )
 
   /**
    * On copy/cut, write a portable representation of the selection to the
@@ -1332,8 +1340,8 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
       />
 
       <div className='relative'>
-        <div ref={overlayRef} className={OVERLAY_CLASSES} aria-hidden='true'>
-          {overlayContent}
+        <div className={OVERLAY_CLASSES} aria-hidden='true'>
+          <div ref={overlayContentRef}>{overlayContent}</div>
         </div>
 
         <textarea

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -27,16 +27,15 @@ import type {
 import {
   AnimatedPlaceholderEffect,
   AttachedFilesList,
-  autoResizeTextarea,
   chipDisplayToken,
   chipLinkToContext,
   DropOverlay,
-  MAX_CHAT_TEXTAREA_HEIGHT,
   MicButton,
   mapResourceToContext,
   OVERLAY_CLASSES,
   PlusMenuDropdown,
   parseChipLinks,
+  SCROLLER_CLASSES,
   SendButton,
   SkillsMenuDropdown,
   serializeSelectionForClipboard,
@@ -171,7 +170,6 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
   })
   const valueRef = useRef(value)
   valueRef.current = value
-  const overlayContentRef = useRef<HTMLDivElement>(null)
   const plusMenuRef = useRef<PlusMenuHandle>(null)
   const skillsMenuRef = useRef<SkillsMenuHandle>(null)
 
@@ -477,26 +475,14 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     ]
   )
 
-  /**
-   * Mirrors the textarea's scroll offset by translating the overlay content.
-   * The overlay box itself never scrolls — a scrolled box (even with
-   * `overflow: hidden`) is a compositor scroll container whose stale textures
-   * can ghost cleared content; a transform always repaints cleanly and never
-   * clamps, so the mirror tracks the textarea offset exactly.
-   */
-  const syncOverlayScroll = useCallback((scrollTop: number) => {
-    const content = overlayContentRef.current
-    if (content) content.style.transform = `translateY(${-scrollTop}px)`
-  }, [])
-
   useLayoutEffect(() => {
     const textarea = textareaRef.current
     if (!textarea) return
-    const maxHeight = isInitialView ? window.innerHeight * 0.3 : MAX_CHAT_TEXTAREA_HEIGHT
+    // Grow the textarea to its full content height; the scroller caps the
+    // visible height and scrolls textarea + overlay together natively.
     textarea.style.height = 'auto'
-    textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeight)}px`
-    syncOverlayScroll(textarea.scrollTop)
-  }, [value, isInitialView, textareaRef, syncOverlayScroll])
+    textarea.style.height = `${textarea.scrollHeight}px`
+  }, [value, textareaRef])
 
   const handleResourceSelect = useCallback(
     (resource: MothershipResource) => {
@@ -1126,15 +1112,6 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     syncSlashState(textarea, textarea.value, focusPos)
   }, [textareaRef, mentionTokensWithContext, adoptDomValue, syncMentionState, syncSlashState])
 
-  const handleInput = useCallback(
-    (e: React.FormEvent<HTMLTextAreaElement>) => {
-      const maxHeight = isInitialView ? window.innerHeight * 0.3 : MAX_CHAT_TEXTAREA_HEIGHT
-      autoResizeTextarea(e, maxHeight)
-      syncOverlayScroll((e.target as HTMLTextAreaElement).scrollTop)
-    },
-    [isInitialView, syncOverlayScroll]
-  )
-
   const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const textarea = e.currentTarget
 
@@ -1218,13 +1195,6 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     }
     filesRef.current.processFiles(dt.files)
   }, [])
-
-  const handleScroll = useCallback(
-    (e: React.UIEvent<HTMLTextAreaElement>) => {
-      syncOverlayScroll(e.currentTarget.scrollTop)
-    },
-    [syncOverlayScroll]
-  )
 
   /**
    * On copy/cut, write a portable representation of the selection to the
@@ -1361,27 +1331,30 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
         onRemoveFile={handleRemoveFile}
       />
 
-      <div className='relative'>
-        <div className={OVERLAY_CLASSES} aria-hidden='true'>
-          <div ref={overlayContentRef}>{overlayContent}</div>
-        </div>
+      {/* Single scroller for textarea + overlay so they co-scroll natively;
+          the sizer is sized by the full-height textarea, and the overlay fills
+          it via `inset-0`. */}
+      <div className={cn(SCROLLER_CLASSES, isInitialView ? 'max-h-[30vh]' : 'max-h-[200px]')}>
+        <div className='relative'>
+          <div className={OVERLAY_CLASSES} aria-hidden='true'>
+            {overlayContent}
+          </div>
 
-        <textarea
-          ref={textareaRef}
-          value={value}
-          onChange={handleInputChange}
-          onKeyDown={handleKeyDown}
-          onInput={handleInput}
-          onPaste={handlePaste}
-          onCopy={handleCopy}
-          onCut={handleCut}
-          onSelect={handleSelectAdjust}
-          onMouseUp={handleSelectAdjust}
-          onScroll={handleScroll}
-          placeholder='Ask Sim to '
-          rows={1}
-          className={cn(TEXTAREA_BASE_CLASSES, isInitialView ? 'max-h-[30vh]' : 'max-h-[200px]')}
-        />
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            onCopy={handleCopy}
+            onCut={handleCut}
+            onSelect={handleSelectAdjust}
+            onMouseUp={handleSelectAdjust}
+            placeholder='Ask Sim to '
+            rows={1}
+            className={TEXTAREA_BASE_CLASSES}
+          />
+        </div>
       </div>
 
       <div className='flex items-center justify-between'>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -752,6 +752,16 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     }
   }, [onSubmit, textareaRef, resetTranscript])
 
+  /**
+   * Adopts the textarea's DOM value into state. State and DOM can only drift
+   * when an edit's input event is lost (programmatic edits pair setValue
+   * synchronously) — the DOM is the user's intent.
+   */
+  const adoptDomValue = useCallback((textarea: HTMLTextAreaElement) => {
+    valueRef.current = textarea.value
+    setValue(textarea.value)
+  }, [])
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (mentionRangeRef.current && !e.nativeEvent.isComposing) {
@@ -1060,13 +1070,10 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     // may get superseded — so edge-movement inference stays true to the DOM.
     lastSelectionRef.current = { start, end }
 
-    // Controlled-value reconciliation: state and DOM can only drift when an
-    // edit's change event is lost (programmatic edits pair setValue
-    // synchronously). The DOM is the user's intent — adopt it and let the
-    // render rebuild the overlay; selection logic resumes on the next event.
+    // Reconciliation backstop for non-keyboard mutations; the render rebuilds
+    // the overlay and selection logic resumes on the next event.
     if (textarea.value !== valueRef.current) {
-      valueRef.current = textarea.value
-      setValue(textarea.value)
+      adoptDomValue(textarea)
       return
     }
 
@@ -1117,7 +1124,7 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
     const focusPos = textarea.selectionDirection === 'backward' ? start : end
     syncMentionState(textarea, textarea.value, focusPos)
     syncSlashState(textarea, textarea.value, focusPos)
-  }, [textareaRef, mentionTokensWithContext, syncMentionState, syncSlashState])
+  }, [textareaRef, mentionTokensWithContext, adoptDomValue, syncMentionState, syncSlashState])
 
   const handleInput = useCallback(
     (e: React.FormEvent<HTMLTextAreaElement>) => {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -1066,7 +1066,11 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
       const endRange = mentionTokensWithContext.findRangeContaining(end)
       // A lone moved edge (keyboard extend/shrink, drag) snaps in its direction
       // of travel: growing absorbs the chip, shrinking releases it. Fresh
-      // selections (double-click, select-all) expand outward.
+      // selections (double-click, select-all) expand outward. A fresh selection
+      // sharing one edge with `prev` (e.g. select-all from a caret at 0) takes
+      // the single-edge path, but a grown edge snaps outward there too — the
+      // two paths only differ for a shrinking edge, which implies a real
+      // single-edge gesture.
       const singleEdgeMoved = (start !== prev.start) !== (end !== prev.end)
       newStart = startRange
         ? singleEdgeMoved && start > prev.start
@@ -1091,10 +1095,10 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
       // Deferred so in-flight click/drag processing can't override the write;
       // bails if the selection moved again first (a newer event supersedes it).
       // The write re-fires this handler, which then syncs the menus below.
-      const direction = textarea.selectionDirection ?? undefined
+      // Direction is read at apply time so it's never stale.
       setTimeout(() => {
         if (textarea.selectionStart !== start || textarea.selectionEnd !== end) return
-        textarea.setSelectionRange(newStart, newEnd, direction)
+        textarea.setSelectionRange(newStart, newEnd, textarea.selectionDirection ?? undefined)
       }, 0)
       return
     }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-mention-tokens.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-mention-tokens.ts
@@ -134,16 +134,19 @@ export function useMentionTokens({
           ? range.end + (after.length - after.replace(/^ +/, '').length)
           : range.end
 
-      // Delete via `execCommand` (not `setMessage`/`setRangeText`) so the
-      // removal lands on the browser's native undo stack and Cmd+Z restores the
-      // chip — empirically the only primitive that preserves undo in Chromium.
-      // `execCommand` is deprecated but remains the sole API wired to undo.
+      // Prefer `execCommand` (deprecated, but the only primitive that lands the
+      // removal on the native undo stack, so Cmd+Z restores the chip). It's a
+      // no-op on Firefox textareas and returns false there, so fall back to a
+      // direct edit — correct deletion, just no native undo on that browser.
       textarea.focus()
       textarea.setSelectionRange(range.start, deleteEnd)
-      document.execCommand('delete')
+      const valueBeforeDelete = textarea.value
+      if (!document.execCommand('delete') || textarea.value === valueBeforeDelete) {
+        textarea.setRangeText('', range.start, deleteEnd, 'start')
+      }
 
-      // `execCommand` fires `input`, but sync state explicitly so this hook
-      // doesn't depend on the consumer's onChange wiring.
+      // The edit fires `input`, but sync state explicitly so this hook doesn't
+      // depend on the consumer's onChange wiring.
       setMessage(textarea.value)
 
       setTimeout(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-mention-tokens.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-mention-tokens.ts
@@ -126,14 +126,26 @@ export function useMentionTokens({
       const before = message.slice(0, range.start)
       const after = message.slice(range.end)
       // Collapse only the space seam the removal creates (a leading + trailing
-      // space meeting), never unrelated double-spaces elsewhere in the message.
-      const next =
+      // space meeting), never unrelated double-spaces elsewhere in the message —
+      // by extending the deleted range over those leading spaces so the whole
+      // removal is a single edit.
+      const deleteEnd =
         before.endsWith(' ') && after.startsWith(' ')
-          ? `${before}${after.replace(/^ +/, '')}`
-          : `${before}${after}`
-      setMessage(next)
+          ? range.end + (after.length - after.replace(/^ +/, '').length)
+          : range.end
 
-      // Set cursor position immediately after state update
+      // Delete via `execCommand` (not `setMessage`/`setRangeText`) so the
+      // removal lands on the browser's native undo stack and Cmd+Z restores the
+      // chip — empirically the only primitive that preserves undo in Chromium.
+      // `execCommand` is deprecated but remains the sole API wired to undo.
+      textarea.focus()
+      textarea.setSelectionRange(range.start, deleteEnd)
+      document.execCommand('delete')
+
+      // `execCommand` fires `input`, but sync state explicitly so this hook
+      // doesn't depend on the consumer's onChange wiring.
+      setMessage(textarea.value)
+
       setTimeout(() => {
         textarea.setSelectionRange(range.start, range.start)
         textarea.focus()


### PR DESCRIPTION
## Summary
- Mention chips in the home user input are now atomic under every selection gesture: select-all, drag, Shift+arrows (grow and shrink), Cmd+Shift jumps, and double-click all snap selection edges to chip boundaries instead of collapsing the selection
- Plain arrow chip-hop no longer swallows Shift/Cmd/Alt/Ctrl arrow combos or IME composition; Cmd/Ctrl shortcuts are no longer blocked when the caret sits at a chip edge
- Fixed ghost text lingering after Cmd+A + Delete: the mirror overlay was an unnecessary composited scroll container whose stale GPU layer could outlive the clear — it is now pinned inset-0 with overflow-hidden and shares one class source with the textarea so the two layers can't drift

## Type of Change
- [x] Bug fix

## Testing
Tested manually (selection matrix: select-all, drag grow/shrink, shift-arrow grow/shrink across chips, cmd+shift jumps, double-click, click-in-chip caret snap). Typecheck and lint pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)