### PR TITLE
fix(home,integrations): optical-center home input + integrations page render fix

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -309,11 +309,12 @@ export function Home({ chatId, userName, userId, initialResourceId = null }: Hom
         <div className='absolute top-[8.5px] right-[16px] z-10'>
           <CreditsChip />
         </div>
-        <div className='flex min-h-full flex-col items-center px-6 pt-[24vh] pb-[2vh]'>
+        {/* Asymmetric padding biases the group up so the full cluster (heading + input + suggestions) sits at the optical center */}
+        <div className='flex min-h-full flex-col items-center justify-center px-6 pt-[2vh] pb-[22vh]'>
           <h1 className='mb-7 max-w-[48rem] text-balance font-season text-[30px] text-[var(--text-primary)]'>
             What should we get done{firstName ? `, ${firstName}` : ''}?
           </h1>
-          <div ref={initialViewInputRef} className='w-full'>
+          <div ref={initialViewInputRef} className='relative w-full max-w-[48rem]'>
             <UserInput
               ref={initialViewUserInputRef}
               defaultValue={initialPrompt}
@@ -325,9 +326,12 @@ export function Home({ chatId, userName, userId, initialResourceId = null }: Hom
               onContextAdd={handleContextAdd}
               onContextRemove={handleInitialContextRemove}
             />
-            <SuggestedActions
-              onSelectPrompt={(prompt) => initialViewUserInputRef.current?.populatePrompt(prompt)}
-            />
+            {/* Anchored out of flow so expanding/collapsing never shifts the centered input */}
+            <div className='absolute inset-x-0 top-full'>
+              <SuggestedActions
+                onSelectPrompt={(prompt) => initialViewUserInputRef.current?.populatePrompt(prompt)}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/apps/sim/app/workspace/[workspaceId]/integrations/integrations.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/integrations.tsx
@@ -54,6 +54,7 @@ const INTEGRATION_BY_LOWER_NAME: ReadonlyMap<string, Integration> = new Map(
 const ALL_CATEGORY_SECTIONS: readonly { label: string; integrations: Integration[] }[] = (() => {
   const grouped = new Map<string, Integration[]>()
   for (const integration of INTEGRATIONS) {
+    if (!integration.integrationType) continue
     const bucket = grouped.get(integration.integrationType)
     if (bucket) bucket.push(integration)
     else grouped.set(integration.integrationType, [integration])

--- a/apps/sim/lib/integrations/integrations.json
+++ b/apps/sim/lib/integrations/integrations.json
@@ -9539,7 +9539,7 @@
     "triggerCount": 0,
     "authType": "api-key",
     "category": "tools",
-    "integrationTypes": ["sales"],
+    "integrationType": "sales",
     "tags": ["enrichment", "sales-engagement"]
   },
   {
@@ -9791,7 +9791,7 @@
     "triggerCount": 0,
     "authType": "api-key",
     "category": "tools",
-    "integrationTypes": ["sales"],
+    "integrationType": "sales",
     "tags": ["enrichment", "sales-engagement"]
   },
   {
@@ -15180,7 +15180,7 @@
     "triggerCount": 0,
     "authType": "api-key",
     "category": "tools",
-    "integrationTypes": ["sales"],
+    "integrationType": "sales",
     "tags": ["enrichment", "sales-engagement"]
   },
   {


### PR DESCRIPTION
## Summary
- Fix integrations page crash: the merged email-verification blocks (zerobounce, neverbounce, millionverifier) were serialized with a typo'd `integrationTypes: ["sales"]` instead of the singular `integrationType` the catalog reads, so they fell into an `undefined` bucket and `localeCompare` threw while sorting sections — erroring the whole page. Corrected the three entries and defensively skip any integration missing `integrationType` when grouping.
- Move the home empty-state input to the optical center: vertically center the heading + input as a unit and anchor suggested actions out of flow so expanding/collapsing never shifts the input. Bias the group slightly above true center so the full cluster reads as balanced rather than sagging.

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
