### PR TITLE
fix(tables): stop insert-row flicker and return order_key from rows list

### DIFF
--- a/apps/sim/app/api/table/[tableId]/rows/route.ts
+++ b/apps/sim/app/api/table/[tableId]/rows/route.ts
@@ -284,6 +284,7 @@ export const GET = withRouteHandler(
             data: r.data,
             executions: r.executions,
             position: r.position,
+            orderKey: r.orderKey ?? undefined,
             createdAt:
               r.createdAt instanceof Date ? r.createdAt.toISOString() : String(r.createdAt),
             updatedAt:

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -605,6 +605,17 @@ export function useCreateTableRow({ workspaceId, tableId }: RowMutationContext) 
       // prior executions, so the stamped set is the full delta).
       const stampedCount = countNewlyInFlight({}, stamped.executions ?? {})
       if (stampedCount > 0) bumpRunState(queryClient, tableId, { [row.id]: stampedCount })
+
+      // `reconcileCreatedRow` only patches the default-order view. Filtered /
+      // column-sorted rows queries can't be reconciled from that heuristic
+      // (membership, sort position, and `totalCount` are query-specific), so
+      // refetch them — active ones update now, inactive ones on next view. The
+      // default view stays optimistic, so the common case never refetches.
+      queryClient.invalidateQueries({
+        queryKey: tableKeys.rowsRoot(tableId),
+        exact: false,
+        predicate: (query) => !isDefaultOrderRowsQuery(query.queryKey),
+      })
     },
     onError: (error) => {
       if (isValidationError(error)) return
@@ -654,11 +665,34 @@ function patchCachedRows(
 }
 
 /**
+ * A cached rows query whose ordering matches {@link reconcileCreatedRow}'s
+ * orderKey/position heuristic: the default view with no active filter or sort.
+ * Filtered or column-sorted variants encode a non-null `filter`/`sort` in their
+ * params key — their membership, order, and `totalCount` are query-specific, so
+ * an optimistic splice can't be trusted there (they're refetched instead). The
+ * `find`/`write` subtrees aren't row-list data and never match.
+ */
+function isDefaultOrderRowsQuery(queryKey: readonly unknown[]): boolean {
+  if (queryKey.includes('find') || queryKey.includes('write')) return false
+  const last = queryKey[queryKey.length - 1]
+  if (typeof last !== 'string') return false
+  try {
+    const params = JSON.parse(last) as { filter?: unknown; sort?: unknown }
+    return params.filter == null && params.sort == null
+  } catch {
+    return false
+  }
+}
+
+/**
  * Splice a server-returned new row into the paginated row cache. Bumps the
  * `position` of any cached row at or past the new row's position, then inserts
  * the row into the overlapping page (or appends to the last page when the
- * position lies past everything fetched). `onSettled` invalidation reconciles
- * drift after the next refetch.
+ * position lies past everything fetched).
+ *
+ * Scoped to the default-order rows queries only — the orderKey/position
+ * heuristic matches the unfiltered, unsorted server order, not an active filter
+ * or column sort. Filtered/sorted queries are refetched by the caller.
  */
 function reconcileCreatedRow(
   queryClient: ReturnType<typeof useQueryClient>,
@@ -666,7 +700,11 @@ function reconcileCreatedRow(
   row: TableRow
 ) {
   queryClient.setQueriesData<InfiniteData<TableRowsResponse, number>>(
-    { queryKey: tableKeys.rowsRoot(tableId), exact: false },
+    {
+      queryKey: tableKeys.rowsRoot(tableId),
+      exact: false,
+      predicate: (query) => isDefaultOrderRowsQuery(query.queryKey),
+    },
     (old) => {
       if (!old) return old
       if (old.pages.some((p) => p.rows.some((r) => r.id === row.id))) return old

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -177,6 +177,26 @@ function invalidateRowCount(queryClient: ReturnType<typeof useQueryClient>, tabl
   queryClient.invalidateQueries({ queryKey: tableKeys.lists() })
 }
 
+/**
+ * Invalidate only the row-count surfaces — the table detail and the tables
+ * list, both of which carry the unfiltered `rowCount`. Deliberately leaves
+ * `rowsRoot` (the rows infinite query) untouched so an offset-paginated refetch
+ * can't resolve late and clobber rows already spliced in optimistically. Use
+ * for inserts, where `reconcileCreatedRow` is the source of truth for the rows
+ * cache and its `totalCount`.
+ *
+ * `rowsRoot` is nested under `detail` (`[...detail(tableId), 'rows']`), so the
+ * detail invalidation MUST be `exact` — a prefix match would cascade into the
+ * rows queries and trigger the very refetch this helper exists to avoid.
+ */
+function invalidateRowCountSurfaces(
+  queryClient: ReturnType<typeof useQueryClient>,
+  tableId: string
+) {
+  queryClient.invalidateQueries({ queryKey: tableKeys.detail(tableId), exact: true })
+  queryClient.invalidateQueries({ queryKey: tableKeys.lists() })
+}
+
 function invalidateTableSchema(queryClient: ReturnType<typeof useQueryClient>, tableId: string) {
   queryClient.invalidateQueries({ queryKey: tableKeys.detail(tableId) })
   queryClient.invalidateQueries({ queryKey: tableKeys.rowsRoot(tableId) })
@@ -591,7 +611,10 @@ export function useCreateTableRow({ workspaceId, tableId }: RowMutationContext) 
       toast.error(error.message, { duration: 5000 })
     },
     onSettled: () => {
-      invalidateRowCount(queryClient, tableId)
+      // `reconcileCreatedRow` (onSuccess) is the source of truth for the rows
+      // cache + its `totalCount`; only refresh the count surfaces here so a late
+      // offset refetch can't clobber freshly-inserted rows (insert-flicker).
+      invalidateRowCountSurfaces(queryClient, tableId)
     },
   })
 }
@@ -654,9 +677,19 @@ function reconcileCreatedRow(
       // path so un-keyed rows aren't yanked to the front by an empty-string sort.
       const byKey =
         row.orderKey != null && old.pages.every((p) => p.rows.every((r) => r.orderKey != null))
+      // Compare order keys bytewise to match the server's `COLLATE "C"` ordering
+      // and the `>=` checks in `fitsAfter` — `localeCompare` is locale-aware and
+      // would place the new row in a different slot than the server (e.g. an
+      // uppercase-prefixed key), leaving it visibly misordered until next reload.
       const sortRows = (rows: TableRow[]) =>
         byKey
-          ? [...rows].sort((a, b) => (a.orderKey as string).localeCompare(b.orderKey as string))
+          ? [...rows].sort((a, b) =>
+              (a.orderKey as string) < (b.orderKey as string)
+                ? -1
+                : (a.orderKey as string) > (b.orderKey as string)
+                  ? 1
+                  : 0
+            )
           : [...rows].sort((a, b) => a.position - b.position)
       const fitsAfter = (last: TableRow | undefined) =>
         last === undefined ||


### PR DESCRIPTION
## Summary
- Stop the rows insert flicker: `useCreateTableRow.onSettled` invalidated `tableKeys.detail(tableId)`, which prefix-matches the nested `rowsRoot` rows query and forced an un-cancelled refetch on every insert — a late offset refetch could resolve after the optimistic splice and clobber freshly-inserted rows. Now invalidate `detail` with `exact: true` (+ `lists()`) so the count surfaces refresh without cascading into the rows query.
- Compare order keys **bytewise** in `reconcileCreatedRow` (was `localeCompare`) to match the server's `COLLATE "C"` ordering and the existing `fitsAfter` checks.
- Include `order_key` in the `GET /rows` list response — it was dropped in the route's row mapping (the POST/batch handlers already returned it), so the client never saw keys and `reconcileCreatedRow` always fell back to the position path. Surfacing it activates the key-ordered path and makes insert-above/below place correctly with no refetch.

## Type of Change
- [x] Bug fix

## Testing
Tested manually via Chrome DevTools against a live table:
- 5 rapid inserts → 0 rows refetches (was 1 per insert), row count grew monotonically with no dips — no flicker.
- Insert-above on a keyed table → new row got a key between its neighbors and landed directly above the anchor, POST only (no GET refetch).
- `bun run lint` clean; `bun run check:api-validation:strict` passes.

> Note: this is the client half of fractional ordering. It's correct in the fully-converged state (migration 0228 applied → backfill complete → flag on). Order the rollout so order_keys exist before the flag flips; in flag-off / null-keyed tables the position path still matches the server.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)