### PR TITLE
feat(models): add Claude Fable 5

### DIFF
--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -82,6 +82,7 @@ const THINKING_BUDGET_TOKENS: Record<string, number> = {
 
 /**
  * Checks if a model supports adaptive thinking (thinking.type: "adaptive").
+ * Fable 5 supports ONLY adaptive thinking (always on; type: "disabled" is rejected).
  * Opus 4.8 and Opus 4.7 support ONLY adaptive thinking (no extended thinking / budget_tokens).
  * Opus 4.6 and Sonnet 4.6 support both extended and adaptive thinking — use adaptive.
  * Opus 4.5 supports effort but NOT adaptive thinking — it uses budget_tokens with type: "enabled".
@@ -89,6 +90,7 @@ const THINKING_BUDGET_TOKENS: Record<string, number> = {
 function supportsAdaptiveThinking(modelId: string): boolean {
   const normalizedModel = modelId.toLowerCase()
   return (
+    normalizedModel.includes('fable-5') ||
     normalizedModel.includes('opus-4-8') ||
     normalizedModel.includes('opus-4.8') ||
     normalizedModel.includes('opus-4-7') ||

--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -105,7 +105,7 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 /**
  * Builds the thinking configuration for the Anthropic API based on model capabilities and level.
  *
- * - Opus 4.8, Opus 4.7: Uses adaptive thinking only (no extended thinking support)
+ * - Fable 5, Opus 4.8, Opus 4.7: Uses adaptive thinking only (no extended thinking support)
  * - Opus 4.6, Sonnet 4.6: Uses adaptive thinking with effort parameter
  * - Other models: Uses budget_tokens-based extended thinking
  *

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -632,6 +632,24 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     },
     models: [
       {
+        id: 'claude-fable-5',
+        pricing: {
+          input: 10.0,
+          cachedInput: 1.0,
+          output: 50.0,
+          updatedAt: '2026-06-09',
+        },
+        capabilities: {
+          maxOutputTokens: 128000,
+          thinking: {
+            levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+            default: 'high',
+          },
+        },
+        contextWindow: 1000000,
+        releaseDate: '2026-06-09',
+      },
+      {
         id: 'claude-opus-4-8',
         pricing: {
           input: 5.0,


### PR DESCRIPTION
## Summary
- Add `claude-fable-5` to the Anthropic provider in `models.ts` — Anthropic's new most-capable widely-released model (GA June 9, 2026)
- Pricing: \$10/M input, \$1/M cached input, \$50/M output; 1M context window; 128k max output — all verified against the official models overview, pricing, and launch docs
- Effort/thinking levels `low | medium | high | xhigh | max` (default `high`), matching the Opus 4.8 adaptive-thinking profile
- Patch `supportsAdaptiveThinking()` in `anthropic/core.ts` to recognize `fable-5` — Fable 5 is adaptive-thinking-only and rejects `budget_tokens` extended thinking, so without this any selected thinking level would route to the wrong path (and `xhigh`/`max` would silently no-op)
- Deliberately omitted `nativeStructuredOutputs` (not in Fable 5's launch feature list) and `temperature` (incompatible with always-on adaptive thinking), consistent with the Opus 4.8/4.7 entries

## Type of Change
- [x] New feature

## Testing
Tested manually — `bun run lint` passes; verified Fable 5 routes through the adaptive-thinking path for all five effort levels

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)