### PR TITLE
fix(modal): preserve spacing in workspace delete confirmation label

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/delete-modal/delete-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/delete-modal/delete-modal.tsx
@@ -270,10 +270,10 @@ export function DeleteModal({
         <ChipModalField
           type='input'
           title={
-            <>
+            <span>
               Type <span className='font-medium text-[var(--text-primary)]'>{workspaceName}</span>{' '}
               to confirm
-            </>
+            </span>
           }
           value={confirmationText}
           onChange={setConfirmationText}


### PR DESCRIPTION
## Summary
- Fixed the workspace delete confirmation label rendering as `Type<workspace name>to confirm` with no spaces
- The label renders inside `ChipModalField`'s `inline-flex` `<Label>`, which drops whitespace-only text nodes between flex items; wrapping the title in a single `<span>` keeps the spaces as normal inline content
- Matches the existing pattern at `version-description-modal.tsx`

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)