### PR TITLE
fix(mothership): clear chat input after sending a message mid-conversation

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -1099,9 +1099,10 @@ export const UserInput = forwardRef<UserInputHandle, UserInputProps>(function Us
 
     // Adopt value changes that bypassed React's change tracking (browser
     // autofill, password managers, grammar extensions — see facebook/react#2125)
-    // so state never drifts from the DOM. The render rebuilds the overlay and
-    // selection logic resumes on the next event.
-    if (textarea.value !== valueRef.current) {
+    // so state never drifts from the DOM. Skip when state is empty: submit clears
+    // `value` synchronously, but a select/mouseUp can fire while the textarea
+    // still holds the just-sent text, and adopting it would resurrect the message.
+    if (valueRef.current !== '' && textarea.value !== valueRef.current) {
       adoptDomValue(textarea)
       return
     }


### PR DESCRIPTION
## Summary
- Fixed the Mothership home chat input not clearing after sending a message mid-conversation: the message posts to the conversation as a user message, but the typed text stayed in the input.
- Root cause: the `handleSelectAdjust` DOM-drift adoption (added in mothership v0.2, `#4923`) re-adopted the stale textarea DOM value back into React state. After submit clears `value` to `''` synchronously, a `select`/`mouseUp` can fire while the controlled textarea still holds the just-sent text, so it got resurrected.
- Fix: skip adoption when state is empty — an empty input is never a legitimate adoption source (autofill/password-manager/grammar editors all mutate existing text).

## Type of Change
- [x] Bug fix

## Testing
Tested manually — sending messages mid-conversation now clears the input every time; mention/skill chipification and paste behavior unchanged.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
