### PR TITLE
fix(db): serialize concurrent migrations with a Postgres advisory lock

### DIFF
--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -64,7 +64,17 @@ try {
     await migrate(drizzle(client), { migrationsFolder: './migrations' })
     console.log('Migrations applied successfully.')
   } finally {
-    await client`SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY})`
+    try {
+      await client`SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY})`
+    } catch (unlockError) {
+      // A failed explicit unlock must never mask a successful migration with a
+      // non-zero exit — the session lock auto-releases on disconnect anyway, so
+      // log and move on rather than letting this reach the outer catch.
+      console.error(
+        'WARN: pg_advisory_unlock failed; the session lock will auto-release on disconnect.',
+        unlockError
+      )
+    }
   }
 } catch (error) {
   console.error('ERROR: Migration failed.')

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -64,17 +64,7 @@ try {
     await migrate(drizzle(client), { migrationsFolder: './migrations' })
     console.log('Migrations applied successfully.')
   } finally {
-    try {
-      await client`SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY})`
-    } catch (unlockError) {
-      // A failed explicit unlock must never mask a successful migration with a
-      // non-zero exit — the session lock auto-releases on disconnect anyway, so
-      // log and move on rather than letting this reach the outer catch.
-      console.error(
-        'WARN: pg_advisory_unlock failed; the session lock will auto-release on disconnect.',
-        unlockError
-      )
-    }
+    await releaseMigrationLock()
   }
 } catch (error) {
   console.error('ERROR: Migration failed.')
@@ -82,6 +72,24 @@ try {
   process.exit(1)
 } finally {
   await client.end()
+}
+
+/**
+ * Release the advisory lock without ever failing the process. The session-level
+ * lock auto-releases when the connection closes, so a thrown unlock — e.g. the
+ * connection dropped right after `migrate()` committed — must be swallowed.
+ * Letting it reach the outer `catch` would exit 1 and falsely report a
+ * successful migration as failed to the deploy orchestrator.
+ */
+async function releaseMigrationLock(): Promise<void> {
+  try {
+    await client`SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY})`
+  } catch (unlockError) {
+    console.error(
+      'WARN: pg_advisory_unlock failed; the session lock will auto-release on disconnect.',
+      unlockError
+    )
+  }
 }
 
 /**

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -38,12 +38,34 @@ if (!url) {
 
 const client = postgres(url, { max: 1, connect_timeout: 10 })
 
+/**
+ * Cross-process migration lock key (a stable, app-wide 64-bit constant).
+ *
+ * drizzle's `migrate()` has no built-in lock, so when a deployment starts N app
+ * replicas at once — each with a migration sidecar — all N read
+ * `__drizzle_migrations`, all see the same migration pending, and all try to apply
+ * it concurrently. One wins; the losers run the same DDL against already-mutated
+ * state and die (e.g. `DROP TABLE "form"` → `table "form" does not exist`,
+ * exit 1 / TaskFailedToStart).
+ *
+ * A session-level `pg_advisory_lock` serializes runners: the first to acquire it
+ * migrates while the rest block, then each loser acquires the lock, re-reads
+ * `__drizzle_migrations`, finds nothing pending, and exits cleanly. Session locks
+ * auto-release if the connection drops, so a crashed runner never wedges the lock.
+ */
+const MIGRATION_LOCK_KEY = 4_961_002_270n
+
 try {
   // statement_timeout=0: index builds (esp. CONCURRENTLY on large tables) can run
   // far longer than the app default; a migration must never be killed mid-build.
   await client`SET statement_timeout = 0`
-  await migrate(drizzle(client), { migrationsFolder: './migrations' })
-  console.log('Migrations applied successfully.')
+  await client`SELECT pg_advisory_lock(${MIGRATION_LOCK_KEY})`
+  try {
+    await migrate(drizzle(client), { migrationsFolder: './migrations' })
+    console.log('Migrations applied successfully.')
+  } finally {
+    await client`SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY})`
+  }
 } catch (error) {
   console.error('ERROR: Migration failed.')
   printMigrationError(error)


### PR DESCRIPTION
## Summary
- Wrap drizzle `migrate()` in a session-level `pg_advisory_lock` so concurrent migration sidecars serialize instead of racing
- Root cause: a deploy starts N app replicas at once, each with a migration sidecar; drizzle has no cross-process lock, so all N see the same migration pending and apply it concurrently — one wins, the losers run the same DDL against already-mutated state and exit 1 (`DROP TABLE "form"` → `table "form" does not exist` / TaskFailedToStart)
- With the lock, the winner migrates while the losers block, then re-read `__drizzle_migrations`, find nothing pending, and exit cleanly. Session locks auto-release on disconnect, so a crashed runner never wedges the lock

## Type of Change
- [x] Bug fix

## Testing
Tested manually — typecheck + lint pass. The current prod DB already has the migration applied (the race self-resolved on retry); this prevents recurrence on the next migration-bearing deploy.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)