### PR TITLE
fix(secrets): keep readonly secret names legible instead of dimming them

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/secrets/components/secrets-manager/secrets-manager.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/secrets/components/secrets-manager/secrets-manager.tsx
@@ -181,7 +181,7 @@ function WorkspaceVariableRow({
   return (
     <div className='contents'>
       <ChipInput
-        className={cn(!canRename && 'cursor-default')}
+        className={cn(!canRename && 'cursor-text')}
         value={renamingKey === envKey ? pendingKeyValue : envKey}
         onChange={(e) => {
           if (renamingKey !== envKey) onRenameStart(envKey)

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/secrets/components/secrets-manager/secrets-manager.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/secrets/components/secrets-manager/secrets-manager.tsx
@@ -181,7 +181,7 @@ function WorkspaceVariableRow({
   return (
     <div className='contents'>
       <ChipInput
-        className={cn(!canRename && 'cursor-not-allowed opacity-50')}
+        className={cn(!canRename && 'cursor-default')}
         value={renamingKey === envKey ? pendingKeyValue : envKey}
         onChange={(e) => {
           if (renamingKey !== envKey) onRenameStart(envKey)


### PR DESCRIPTION
## Summary
- Readonly viewers saw a workspace secret's **name** at `opacity-50` while the masked value next to it rendered at full opacity — an inconsistent, hostile treatment of content they need to read.
- Dropped the opacity dim on the non-renameable key field; non-editability is already conveyed by the read-only field and the absent Trash/rename affordances.
- The secret detail page was already correct (read-only fields at full opacity, copyable key), so this brings the list in line with it.

## Type of Change
- [x] Bug fix

## Testing
Tested manually as a readonly workspace viewer — name and masked value now render consistently at full opacity, still non-editable.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)