### PR TITLE
improvement(chat-voice): modernize ElevenLabs TTS to Flash v2.5

### DIFF
--- a/apps/sim/app/api/proxy/tts/stream/route.ts
+++ b/apps/sim/app/api/proxy/tts/stream/route.ts
@@ -92,7 +92,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       return new Response('ElevenLabs service not configured', { status: 503 })
     }
 
-    const endpoint = `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream`
+    const query = new URLSearchParams({ output_format: 'mp3_44100_128' })
+    const endpoint = `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream?${query.toString()}`
 
     const response = await fetch(endpoint, {
       method: 'POST',
@@ -104,17 +105,13 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       body: JSON.stringify({
         text,
         model_id: modelId,
-        optimize_streaming_latency: 4,
-        output_format: 'mp3_22050_32', // Fastest format
         voice_settings: {
           stability: 0.5,
           similarity_boost: 0.8,
           style: 0.0,
           use_speaker_boost: false,
         },
-        enable_ssml_parsing: false,
-        apply_text_normalization: 'off',
-        use_pvc_as_ivc: false,
+        apply_text_normalization: 'auto',
       }),
     })
 

--- a/apps/sim/app/chat/[identifier]/chat.tsx
+++ b/apps/sim/app/chat/[identifier]/chat.tsx
@@ -44,7 +44,7 @@ interface ChatRequestPayload {
 }
 
 const DEFAULT_VOICE_SETTINGS = {
-  voiceId: 'EXAVITQu4vr4xnSDxMaL', // Default ElevenLabs voice (Bella)
+  voiceId: 'cgSgspJ2msm6clMCkdW9', // Default ElevenLabs voice (Jessica) — Flash v2.5-optimized
 }
 
 /**

--- a/apps/sim/app/chat/hooks/use-audio-streaming.ts
+++ b/apps/sim/app/chat/hooks/use-audio-streaming.ts
@@ -79,7 +79,7 @@ export function useAudioStreaming(sharedAudioContextRef?: RefObject<AudioContext
     const { text, options } = item
     const {
       voiceId,
-      modelId = 'eleven_turbo_v2_5',
+      modelId = 'eleven_flash_v2_5',
       chatId,
       onAudioStart,
       onAudioEnd,

--- a/apps/sim/lib/api/contracts/media/tts-stream.ts
+++ b/apps/sim/lib/api/contracts/media/tts-stream.ts
@@ -5,7 +5,7 @@ export const ttsStreamBodySchema = z
   .object({
     text: z.string().min(1),
     voiceId: z.string().min(1),
-    modelId: z.string().optional().default('eleven_turbo_v2_5'),
+    modelId: z.string().optional().default('eleven_flash_v2_5'),
     chatId: z.string().min(1),
   })
   .passthrough()


### PR DESCRIPTION
## Summary
- Switch deployed-chat default TTS model from `eleven_turbo_v2_5` to `eleven_flash_v2_5` — ElevenLabs now recommends Flash over Turbo in all cases (functionally equivalent, ~75ms latency, built for real-time/Agents)
- Replace the legacy default voice **Sarah** (`EXAVITQu4vr4xnSDxMaL`) with **Jessica** (`cgSgspJ2msm6clMCkdW9`) — Sarah has no high-quality `eleven_flash_v2_5` base; Jessica is a current premade conversational voice optimized for Flash v2.5. Verified against the live account.
- Drop the deprecated `optimize_streaming_latency` knob and the legacy `use_pvc_as_ivc` / `enable_ssml_parsing` flags from the proxy request
- Move `output_format` to the query string (where ElevenLabs reads it) and raise it from `mp3_22050_32` (32 kbps) to `mp3_44100_128` for noticeably better audio quality
- Switch `apply_text_normalization` from `off` to `auto` so numbers/dates are pronounced correctly (level-4 latency mode had silently disabled the normalizer)

Scope is limited to the deployed-chat voice path (`/api/proxy/tts/stream`, its contract, the audio-streaming hook, and the chat default voice). STT (`scribe_v2_realtime`, single-use token flow) was already current and is untouched.

## Type of Change
- [x] Improvement

## Testing
Smoke-tested the exact new request (Jessica + `eleven_flash_v2_5` + `output_format=mp3_44100_128` + `apply_text_normalization=auto`) against the live ElevenLabs API → HTTP 200, valid 128 kbps / 44.1 kHz MP3, numbers/dates normalized correctly. `bun run check:api-validation` and `tsc --noEmit` pass clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)