### PR TITLE
fix(security): neutralize CSV formula injection in logs export

### DIFF
--- a/apps/sim/app/api/logs/export/route.ts
+++ b/apps/sim/app/api/logs/export/route.ts
@@ -5,6 +5,7 @@ import { and, desc, eq, sql } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { MATERIALIZE_CONCURRENCY, mapWithConcurrency } from '@/lib/core/utils/concurrency'
+import { neutralizeCsvFormula } from '@/lib/core/utils/csv'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { materializeExecutionData } from '@/lib/logs/execution/trace-store'
 import { buildFilterConditions, LogFilterParamsSchema } from '@/lib/logs/filters'
@@ -13,14 +14,6 @@ import { expandFolderIdsWithDescendants } from '@/lib/logs/folder-expansion'
 const logger = createLogger('LogsExportAPI')
 
 export const revalidate = 0
-
-/**
- * Prefixes a single quote to values starting with a spreadsheet formula trigger
- * (`=`, `+`, `-`, `@`, tab, CR), neutralizing CSV injection in Excel/Sheets.
- */
-function neutralizeCsvFormula(value: string): string {
-  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value
-}
 
 function escapeCsv(value: any): string {
   if (value === null || value === undefined) return ''

--- a/apps/sim/app/api/logs/export/route.ts
+++ b/apps/sim/app/api/logs/export/route.ts
@@ -14,9 +14,17 @@ const logger = createLogger('LogsExportAPI')
 
 export const revalidate = 0
 
+/**
+ * Prefixes a single quote to values starting with a spreadsheet formula trigger
+ * (`=`, `+`, `-`, `@`, tab, CR), neutralizing CSV injection in Excel/Sheets.
+ */
+function neutralizeCsvFormula(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value
+}
+
 function escapeCsv(value: any): string {
   if (value === null || value === undefined) return ''
-  const str = String(value)
+  const str = neutralizeCsvFormula(String(value))
   if (/[",\n]/.test(str)) {
     return `"${str.replace(/"/g, '""')}"`
   }

--- a/apps/sim/app/api/logs/export/route.ts
+++ b/apps/sim/app/api/logs/export/route.ts
@@ -17,7 +17,7 @@ export const revalidate = 0
 
 function escapeCsv(value: any): string {
   if (value === null || value === undefined) return ''
-  const str = neutralizeCsvFormula(String(value))
+  const str = typeof value === 'string' ? neutralizeCsvFormula(value) : String(value)
   if (/[",\n]/.test(str)) {
     return `"${str.replace(/"/g, '""')}"`
   }

--- a/apps/sim/app/api/table/[tableId]/export/route.ts
+++ b/apps/sim/app/api/table/[tableId]/export/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { tableExportFormatSchema, tableIdParamsSchema } from '@/lib/api/contracts/tables'
 import { getValidationErrorMessage } from '@/lib/api/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
+import { neutralizeCsvFormula } from '@/lib/core/utils/csv'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { buildNameById, getColumnId, rowDataIdToName } from '@/lib/table/column-keys'
@@ -117,14 +118,6 @@ export const GET = withRouteHandler(async (request: NextRequest, { params }: Rou
 function sanitizeFilename(name: string): string {
   const cleaned = name.replace(/[^a-zA-Z0-9_-]+/g, '_').replace(/^_+|_+$/g, '')
   return cleaned || 'table'
-}
-
-/**
- * Prefixes a single quote to values starting with a spreadsheet formula trigger
- * (`=`, `+`, `-`, `@`, tab, CR), neutralizing CSV injection in Excel/Sheets.
- */
-function neutralizeCsvFormula(value: string): string {
-  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value
 }
 
 /**

--- a/apps/sim/lib/core/utils/csv.ts
+++ b/apps/sim/lib/core/utils/csv.ts
@@ -1,0 +1,7 @@
+/**
+ * Prefixes a single quote to values starting with a spreadsheet formula trigger
+ * (`=`, `+`, `-`, `@`, tab, CR), neutralizing CSV injection in Excel/Sheets.
+ */
+export function neutralizeCsvFormula(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value
+}


### PR DESCRIPTION
## Summary
- Neutralize spreadsheet formula triggers (`=`, `+`, `-`, `@`, tab, CR) in `GET /api/logs/export` CSV output by prefixing affected cells with a single quote
- Closes a stored, cross-user CSV/formula injection vector via workflow names and execution output (RFC-4180 quoting alone doesn't stop Excel/Sheets from evaluating formulas)
- Mirrors the existing `neutralizeCsvFormula()` already used in the table export route

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)