### PR TITLE
feat(ci): run db migrations from github ci with environment-scoped secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,33 @@ jobs:
             echo "ℹ️ Not a release commit"
           fi
 
+  # Run database migrations before images are pushed: the ECR push triggers
+  # CodePipeline, so migrating first guarantees the schema is in place before
+  # the new app version deploys (replaces the removed ECS migration sidecar)
+  migrate:
+    name: Migrate DB
+    needs: [test-build]
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
+    uses: ./.github/workflows/migrations.yml
+    with:
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+    secrets: inherit
+
+  # Same ordering for dev (schema push before the dev image lands in ECR)
+  migrate-dev:
+    name: Migrate Dev DB
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    uses: ./.github/workflows/migrations.yml
+    with:
+      environment: dev
+    secrets: inherit
+
   # Dev: build all 3 images for ECR only (no GHCR, no ARM64)
   build-dev:
     name: Build Dev ECR
-    needs: [detect-version]
+    needs: [detect-version, migrate-dev]
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
@@ -108,7 +131,7 @@ jobs:
   # Main/staging: build AMD64 images and push to ECR + GHCR
   build-amd64:
     name: Build AMD64
-    needs: [test-build, detect-version]
+    needs: [test-build, detect-version, migrate]
     if: >-
       github.event_name == 'push' &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
@@ -317,14 +340,6 @@ jobs:
               "${IMAGE_BASE}:${VERSION}-arm64"
             docker manifest push "${IMAGE_BASE}:${VERSION}"
           fi
-
-  # Run database migrations for dev
-  migrate-dev:
-    name: Migrate Dev DB
-    needs: [build-dev]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-    uses: ./.github/workflows/migrations.yml
-    secrets: inherit
 
   # Check if docs changed
   check-docs-changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
     uses: ./.github/workflows/migrations.yml
     with:
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'db-production' || 'db-staging' }}
     secrets: inherit
 
   # Same ordering for dev (schema push before the dev image lands in ECR)
@@ -66,7 +66,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     uses: ./.github/workflows/migrations.yml
     with:
-      environment: dev
+      environment: db-dev
     secrets: inherit
 
   # Dev: build all 3 images for ECR only (no GHCR, no ARM64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
     uses: ./.github/workflows/migrations.yml
     with:
-      environment: ${{ github.ref == 'refs/heads/main' && 'db-production' || 'db-staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     secrets: inherit
 
   # Same ordering for dev (schema push before the dev image lands in ECR)
@@ -66,7 +66,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     uses: ./.github/workflows/migrations.yml
     with:
-      environment: db-dev
+      environment: dev
     secrets: inherit
 
   # Dev: build all 3 images for ECR only (no GHCR, no ARM64)

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -2,7 +2,21 @@ name: Database Migrations
 
 on:
   workflow_call:
+    inputs:
+      environment:
+        description: Target GitHub environment (production, staging, or dev)
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      environment:
+        description: Target GitHub environment
+        required: true
+        type: choice
+        options:
+          - production
+          - staging
+          - dev
 
 permissions:
   contents: read
@@ -11,6 +25,7 @@ jobs:
   migrate:
     name: Apply Database Migrations
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: ${{ inputs.environment }}
 
     steps:
       - name: Checkout code
@@ -35,15 +50,23 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # MIGRATIONS_DATABASE_URL is an environment-scoped secret with no repo-level
+      # fallback: if it's missing on the target environment it resolves to empty and
+      # the guard below fails the job, instead of silently inheriting another
+      # environment's database
       - name: Apply database schema changes
         working-directory: ./packages/db
         env:
-          DATABASE_URL: ${{ github.ref == 'refs/heads/main' && secrets.DATABASE_URL || github.ref == 'refs/heads/dev' && secrets.DEV_DATABASE_URL || secrets.STAGING_DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.MIGRATIONS_DATABASE_URL }}
         run: |
-          if [ "${{ github.ref }}" = "refs/heads/dev" ]; then
-            echo "Dev environment detected — pushing schema with drizzle-kit (db:push)"
+          if [ -z "$DATABASE_URL" ]; then
+            echo "ERROR: MIGRATIONS_DATABASE_URL is not set on environment '${{ inputs.environment }}'" >&2
+            exit 1
+          fi
+
+          echo "Applying versioned migrations (db:migrate)"
+          bun run ./scripts/migrate.ts
+          if [ "${{ inputs.environment }}" = "dev" ]; then
+            echo "Dev environment — also pushing unversioned schema drift (db:push)"
             bun run db:push --force
-          else
-            echo "Applying versioned migrations (db:migrate)"
-            bun run ./scripts/migrate.ts
           fi

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -63,9 +63,10 @@ jobs:
             exit 1
           fi
 
-          echo "Applying versioned migrations (db:migrate)"
-          bun run ./scripts/migrate.ts
           if [ "${ENVIRONMENT}" = "dev" ]; then
-            echo "Dev environment — also pushing unversioned schema drift (db:push)"
+            echo "Dev environment — pushing schema directly (db:push)"
             bun run db:push --force
+          else
+            echo "Applying versioned migrations (db:migrate)"
+            bun run ./scripts/migrate.ts
           fi

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: Target GitHub environment (production, staging, or dev)
+        description: Target GitHub environment (db-production, db-staging, or db-dev)
         required: true
         type: string
   workflow_dispatch:
@@ -14,9 +14,9 @@ on:
         required: true
         type: choice
         options:
-          - production
-          - staging
-          - dev
+          - db-production
+          - db-staging
+          - db-dev
 
 permissions:
   contents: read
@@ -67,7 +67,7 @@ jobs:
 
           echo "Applying versioned migrations (db:migrate)"
           bun run ./scripts/migrate.ts
-          if [ "${ENVIRONMENT}" = "dev" ]; then
+          if [ "${ENVIRONMENT}" = "db-dev" ]; then
             echo "Dev environment — also pushing unversioned schema drift (db:push)"
             bun run db:push --force
           fi

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -58,15 +58,16 @@ jobs:
         working-directory: ./packages/db
         env:
           DATABASE_URL: ${{ secrets.MIGRATIONS_DATABASE_URL }}
+          ENVIRONMENT: ${{ inputs.environment }}
         run: |
           if [ -z "$DATABASE_URL" ]; then
-            echo "ERROR: MIGRATIONS_DATABASE_URL is not set on environment '${{ inputs.environment }}'" >&2
+            echo "ERROR: MIGRATIONS_DATABASE_URL is not set on environment '${ENVIRONMENT}'" >&2
             exit 1
           fi
 
           echo "Applying versioned migrations (db:migrate)"
           bun run ./scripts/migrate.ts
-          if [ "${{ inputs.environment }}" = "dev" ]; then
+          if [ "${ENVIRONMENT}" = "dev" ]; then
             echo "Dev environment — also pushing unversioned schema drift (db:push)"
             bun run db:push --force
           fi

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -62,6 +62,12 @@ jobs:
             echo "ERROR: no database URL secret resolved for environment '${ENVIRONMENT}'" >&2
             exit 1
           fi
+          case "$DATABASE_URL" in
+            *:6432*)
+              echo "ERROR: '${ENVIRONMENT}' database URL targets PgBouncer (port 6432); migrations need a direct connection (port 5432) — session advisory locks and SET don't survive transaction pooling" >&2
+              exit 1
+              ;;
+          esac
 
           if [ "${ENVIRONMENT}" = "dev" ]; then
             echo "Dev environment — pushing schema directly (db:push)"

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -4,19 +4,19 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: Target GitHub environment (db-production, db-staging, or db-dev)
+        description: Target environment (production, staging, or dev)
         required: true
         type: string
   workflow_dispatch:
     inputs:
       environment:
-        description: Target GitHub environment
+        description: Target environment
         required: true
         type: choice
         options:
-          - db-production
-          - db-staging
-          - db-dev
+          - production
+          - staging
+          - dev
 
 permissions:
   contents: read
@@ -25,7 +25,6 @@ jobs:
   migrate:
     name: Apply Database Migrations
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    environment: ${{ inputs.environment }}
 
     steps:
       - name: Checkout code
@@ -50,24 +49,23 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # MIGRATIONS_DATABASE_URL is an environment-scoped secret with no repo-level
-      # fallback: if it's missing on the target environment it resolves to empty and
-      # the guard below fails the job, instead of silently inheriting another
-      # environment's database
+      # The expression maps the explicit environment input to exactly one repo
+      # secret, so the job never holds another environment's database URL. An
+      # unknown environment resolves to empty and the guard below fails the job.
       - name: Apply database schema changes
         working-directory: ./packages/db
         env:
-          DATABASE_URL: ${{ secrets.MIGRATIONS_DATABASE_URL }}
+          DATABASE_URL: ${{ inputs.environment == 'production' && secrets.DATABASE_URL || inputs.environment == 'staging' && secrets.STAGING_DATABASE_URL || inputs.environment == 'dev' && secrets.DEV_DATABASE_URL || '' }}
           ENVIRONMENT: ${{ inputs.environment }}
         run: |
           if [ -z "$DATABASE_URL" ]; then
-            echo "ERROR: MIGRATIONS_DATABASE_URL is not set on environment '${ENVIRONMENT}'" >&2
+            echo "ERROR: no database URL secret resolved for environment '${ENVIRONMENT}'" >&2
             exit 1
           fi
 
           echo "Applying versioned migrations (db:migrate)"
           bun run ./scripts/migrate.ts
-          if [ "${ENVIRONMENT}" = "db-dev" ]; then
+          if [ "${ENVIRONMENT}" = "dev" ]; then
             echo "Dev environment — also pushing unversioned schema drift (db:push)"
             bun run db:push --force
           fi

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -62,12 +62,6 @@ jobs:
             echo "ERROR: no database URL secret resolved for environment '${ENVIRONMENT}'" >&2
             exit 1
           fi
-          case "$DATABASE_URL" in
-            *:6432*)
-              echo "ERROR: '${ENVIRONMENT}' database URL targets PgBouncer (port 6432); migrations need a direct connection (port 5432) — session advisory locks and SET don't survive transaction pooling" >&2
-              exit 1
-              ;;
-          esac
 
           if [ "${ENVIRONMENT}" = "dev" ]; then
             echo "Dev environment — pushing schema directly (db:push)"


### PR DESCRIPTION
## Summary
- replaces the removed ECS migration sidecar (infra: `feat/decouple-migration`): migrations now run as a GitHub CI job that gates the ECR image push, so the schema is migrated before CodePipeline deploys the new app version
- `migrations.yml` is now a reusable workflow taking an explicit `environment` input (`production` / `staging` / `dev`) that maps to exactly one of the existing repo secrets (`DATABASE_URL` / `STAGING_DATABASE_URL` / `DEV_DATABASE_URL`) — the job never holds another environment's URL, and an unresolved value fails fast instead of falling through
- dev keeps `db:push --force` only (matching previous sidecar/CI behavior); staging/main apply versioned migrations; dev/staging/main image builds all depend on their migrate job
- manual `workflow_dispatch` now takes an explicit environment choice instead of inferring from the dispatching ref
- uses existing repo secrets — no settings changes needed before merge. Note: the `*DATABASE_URL` secrets must be direct (port 5432) connections, not pooled (PgBouncer 6432) — the advisory lock, `SET statement_timeout`, and `CREATE INDEX CONCURRENTLY` are all session-scoped

## Type of Change
- [x] New feature

## Testing
`bun run lint` and `bun run check:api-validation:strict` pass; workflow YAML validated with actionlint. First real run happens on merge to staging.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



