### PR TITLE
fix(integrations): stop browser autofilling the service account API token field

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/integrations/components/connect-service-account-modal/connect-service-account-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/components/connect-service-account-modal/connect-service-account-modal.tsx
@@ -10,6 +10,7 @@ import {
   ChipModalField,
   ChipModalFooter,
   ChipModalHeader,
+  SecretInput,
 } from '@/components/emcn'
 import { isApiClientError } from '@/lib/api/client/errors'
 import { serviceAccountJsonSchema } from '@/lib/api/contracts/credentials'
@@ -355,19 +356,22 @@ function AtlassianServiceAccountModal({
         Add {serviceName} service account
       </ChipModalHeader>
       <ChipModalBody>
-        <ChipModalField
-          type='input'
-          inputType='password'
-          title='API token'
-          value={apiToken}
-          onChange={(value) => {
-            setApiToken(value)
-            if (error) setError(null)
-          }}
-          placeholder='Paste API token'
-          autoComplete='off'
-          required
-        />
+        <ChipModalField type='custom' title='API token' required>
+          <SecretInput
+            value={apiToken}
+            onChange={(value) => {
+              setApiToken(value)
+              if (error) setError(null)
+            }}
+            placeholder='Paste API token'
+            name='atlassian_service_account_api_token'
+            autoComplete='new-password'
+            autoCorrect='off'
+            autoCapitalize='off'
+            data-lpignore='true'
+            data-form-type='other'
+          />
+        </ChipModalField>
 
         <ChipModalField
           type='input'


### PR DESCRIPTION
## Summary
- Chrome's password manager was autofilling saved credentials into the API token field on the Atlassian service account modal — Chrome deliberately ignores `autocomplete='off'` on `type='password'` inputs
- Replaced the raw password input with the canonical `SecretInput` (via `ChipModalField type='custom'`), matching the existing MCP Client Secret field: plain `type='text'` with blur-masking so password managers have nothing to target, plus it discards synthetic autofill change events while blurred
- Carries the same autofill opt-out attributes as the canonical usage (`autoComplete='new-password'`, `data-lpignore`, `data-form-type`)

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)