### PR TITLE
fix(files): support Safari < 17.4 in PDF preview

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
@@ -146,12 +146,8 @@ const IframePreview = memo(function IframePreview({
   }
 
   return (
-    <PreviewErrorBoundary label='PDF'>
-      <PdfViewerCore
-        key={`${file.id}:${preview.dataUpdatedAt}`}
-        source={bufferSource}
-        filename={file.name}
-      />
+    <PreviewErrorBoundary key={`${file.id}:${preview.dataUpdatedAt}`} label='PDF'>
+      <PdfViewerCore source={bufferSource} filename={file.name} />
     </PreviewErrorBoundary>
   )
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
@@ -20,6 +20,7 @@ import { resolvePreviewType } from './preview-panel'
 import {
   PREVIEW_LOADING_OVERLAY,
   PreviewError,
+  PreviewErrorBoundary,
   PreviewLoadingFrame,
   resolvePreviewError,
 } from './preview-shared'
@@ -145,11 +146,13 @@ const IframePreview = memo(function IframePreview({
   }
 
   return (
-    <PdfViewerCore
-      key={`${file.id}:${preview.dataUpdatedAt}`}
-      source={bufferSource}
-      filename={file.name}
-    />
+    <PreviewErrorBoundary label='PDF'>
+      <PdfViewerCore
+        key={`${file.id}:${preview.dataUpdatedAt}`}
+        source={bufferSource}
+        filename={file.name}
+      />
+    </PreviewErrorBoundary>
   )
 })
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/pdf-viewer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/pdf-viewer.tsx
@@ -1,5 +1,10 @@
 'use client'
 
+/**
+ * Must precede the react-pdf import: pdf.js calls the polyfilled APIs while
+ * its module evaluates, which throws on Safari < 17.4 without them.
+ */
+import '@/lib/core/utils/browser-polyfills'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createLogger } from '@sim/logger'
 import { pdfjs, Document as ReactPdfDocument, Page as ReactPdfPage } from 'react-pdf'
@@ -8,8 +13,12 @@ import { PREVIEW_LOADING_OVERLAY } from '@/app/workspace/[workspaceId]/files/com
 import { PreviewToolbar } from '@/app/workspace/[workspaceId]/files/components/file-viewer/preview-toolbar'
 import { bindPreviewWheelZoom } from '@/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom'
 
+/**
+ * The worker runs in its own context that browser-polyfills cannot reach, so
+ * serve the legacy worker build, which bundles its own polyfills.
+ */
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  'pdfjs-dist/build/pdf.worker.min.mjs',
+  'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
   import.meta.url
 ).href
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-shared.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-shared.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Component, type ReactNode } from 'react'
+import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { createLogger } from '@sim/logger'
 import { cn } from '@/lib/core/utils/cn'
 
@@ -33,6 +33,10 @@ interface PreviewErrorBoundaryState {
  * a preview module whose dynamic import rejected) and degrades to the standard
  * PreviewError fallback instead of unwinding to the route-level error boundary
  * and replacing the whole workspace view.
+ *
+ * Callers must `key` this boundary by the identity of the rendered content
+ * (e.g. file id + data version) — the error state resets only via remount, so
+ * keying the child alone would leave a tripped boundary stuck on the fallback.
  */
 export class PreviewErrorBoundary extends Component<
   PreviewErrorBoundaryProps,
@@ -46,8 +50,12 @@ export class PreviewErrorBoundary extends Component<
     return { hasError: true, error }
   }
 
-  public componentDidCatch(error: Error) {
-    logger.error('Preview crashed', { label: this.props.label, error: error.message })
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    logger.error('Preview crashed', {
+      label: this.props.label,
+      error: error.message,
+      componentStack: errorInfo.componentStack,
+    })
   }
 
   public render() {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-shared.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-shared.tsx
@@ -1,6 +1,10 @@
 'use client'
 
+import { Component, type ReactNode } from 'react'
+import { createLogger } from '@sim/logger'
 import { cn } from '@/lib/core/utils/cn'
+
+const logger = createLogger('FilePreview')
 
 export function PreviewError({ label, error }: { label: string; error: string }) {
   return (
@@ -11,6 +15,53 @@ export function PreviewError({ label, error }: { label: string; error: string })
       <p className='text-[13px] text-[var(--text-muted)]'>{error}</p>
     </div>
   )
+}
+
+interface PreviewErrorBoundaryProps {
+  /** Format label shown in the fallback, e.g. "PDF". */
+  label: string
+  children: ReactNode
+}
+
+interface PreviewErrorBoundaryState {
+  hasError: boolean
+  error?: Error
+}
+
+/**
+ * Error boundary for preview renderers. Catches render-time crashes (including
+ * a preview module whose dynamic import rejected) and degrades to the standard
+ * PreviewError fallback instead of unwinding to the route-level error boundary
+ * and replacing the whole workspace view.
+ */
+export class PreviewErrorBoundary extends Component<
+  PreviewErrorBoundaryProps,
+  PreviewErrorBoundaryState
+> {
+  public state: PreviewErrorBoundaryState = {
+    hasError: false,
+  }
+
+  public static getDerivedStateFromError(error: Error): PreviewErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  public componentDidCatch(error: Error) {
+    logger.error('Preview crashed', { label: this.props.label, error: error.message })
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <PreviewError
+          label={this.props.label}
+          error={this.state.error?.message ?? 'An unexpected error occurred'}
+        />
+      )
+    }
+
+    return this.props.children
+  }
 }
 
 export function resolvePreviewError(

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -1294,14 +1294,14 @@ export function Files() {
   }, [canEdit, uploading, closeListContextMenu])
 
   /**
-   * Tracks the route target whose preview mode has been applied. Starts unset
-   * (rather than at the initial route id) because on a hard load the files
-   * list may not have arrived when the mode initializer ran — a deep-linked
-   * previewable file would otherwise be locked into the code editor.
+   * Tracks the route target whose preview mode has been applied. Starts at
+   * null (the list view) rather than the initial route id because on a hard
+   * load the files list may not have arrived when the mode initializer ran —
+   * a deep-linked previewable file would otherwise be locked into the code
+   * editor. The effect therefore defers until the routed file record exists.
    */
-  const appliedModeFileIdRef = useRef<string | null | undefined>(undefined)
-  const routedFileLoaded =
-    fileIdFromRoute != null && files.some((file) => file.id === fileIdFromRoute)
+  const appliedModeFileIdRef = useRef<string | null>(null)
+  const routedFileLoaded = selectedFile != null
   useEffect(() => {
     if (fileIdFromRoute === appliedModeFileIdRef.current) return
     const isJustCreated =
@@ -1311,14 +1311,9 @@ export function Files() {
     }
     if (fileIdFromRoute != null && !routedFileLoaded && !isJustCreated) return
     appliedModeFileIdRef.current = fileIdFromRoute
-    const nextMode: PreviewMode = isJustCreated
-      ? 'editor'
-      : (() => {
-          const file = fileIdFromRoute
-            ? filesRef.current.find((f) => f.id === fileIdFromRoute)
-            : null
-          return file && isPreviewable(file) ? 'preview' : 'editor'
-        })()
+    const file = fileIdFromRoute ? selectedFileRef.current : null
+    const nextMode: PreviewMode =
+      !isJustCreated && file && isPreviewable(file) ? 'preview' : 'editor'
     setPreviewMode((current) => (nextMode === current ? current : nextMode))
   }, [fileIdFromRoute, isNewFile, routedFileLoaded])
 

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -1298,10 +1298,12 @@ export function Files() {
    * null (the list view) rather than the initial route id because on a hard
    * load the files list may not have arrived when the mode initializer ran —
    * a deep-linked previewable file would otherwise be locked into the code
-   * editor. The effect therefore defers until the routed file record exists.
+   * editor. The effect therefore defers until the routed file is resolvable:
+   * either its record exists, or the files query has settled (so a missing
+   * id decides 'editor' instead of waiting forever).
    */
   const appliedModeFileIdRef = useRef<string | null>(null)
-  const routedFileLoaded = selectedFile != null
+  const routedFileResolved = selectedFile != null || !isLoading
   useEffect(() => {
     if (fileIdFromRoute === appliedModeFileIdRef.current) return
     const isJustCreated =
@@ -1309,13 +1311,13 @@ export function Files() {
     if (justCreatedFileIdRef.current && !isJustCreated) {
       justCreatedFileIdRef.current = null
     }
-    if (fileIdFromRoute != null && !routedFileLoaded && !isJustCreated) return
+    if (fileIdFromRoute != null && !routedFileResolved && !isJustCreated) return
     appliedModeFileIdRef.current = fileIdFromRoute
     const file = fileIdFromRoute ? selectedFileRef.current : null
     const nextMode: PreviewMode =
       !isJustCreated && file && isPreviewable(file) ? 'preview' : 'editor'
     setPreviewMode((current) => (nextMode === current ? current : nextMode))
-  }, [fileIdFromRoute, isNewFile, routedFileLoaded])
+  }, [fileIdFromRoute, isNewFile, routedFileResolved])
 
   useEffect(() => {
     if (isNewFile && fileIdFromRoute) {

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -1293,15 +1293,24 @@ export function Files() {
     closeListContextMenu()
   }, [canEdit, uploading, closeListContextMenu])
 
-  const prevFileIdRef = useRef(fileIdFromRoute)
+  /**
+   * Tracks the route target whose preview mode has been applied. Starts unset
+   * (rather than at the initial route id) because on a hard load the files
+   * list may not have arrived when the mode initializer ran — a deep-linked
+   * previewable file would otherwise be locked into the code editor.
+   */
+  const appliedModeFileIdRef = useRef<string | null | undefined>(undefined)
+  const routedFileLoaded =
+    fileIdFromRoute != null && files.some((file) => file.id === fileIdFromRoute)
   useEffect(() => {
-    if (fileIdFromRoute === prevFileIdRef.current) return
-    prevFileIdRef.current = fileIdFromRoute
+    if (fileIdFromRoute === appliedModeFileIdRef.current) return
     const isJustCreated =
       isNewFile || (fileIdFromRoute != null && justCreatedFileIdRef.current === fileIdFromRoute)
     if (justCreatedFileIdRef.current && !isJustCreated) {
       justCreatedFileIdRef.current = null
     }
+    if (fileIdFromRoute != null && !routedFileLoaded && !isJustCreated) return
+    appliedModeFileIdRef.current = fileIdFromRoute
     const nextMode: PreviewMode = isJustCreated
       ? 'editor'
       : (() => {
@@ -1311,7 +1320,7 @@ export function Files() {
           return file && isPreviewable(file) ? 'preview' : 'editor'
         })()
     setPreviewMode((current) => (nextMode === current ? current : nextMode))
-  }, [fileIdFromRoute, isNewFile])
+  }, [fileIdFromRoute, isNewFile, routedFileLoaded])
 
   useEffect(() => {
     if (isNewFile && fileIdFromRoute) {

--- a/apps/sim/lib/core/utils/browser-polyfills.ts
+++ b/apps/sim/lib/core/utils/browser-polyfills.ts
@@ -1,0 +1,47 @@
+/**
+ * Polyfills for `Promise.withResolvers` (Safari < 17.4, Chrome < 119) and
+ * `URL.parse` (Safari < 18, Chrome < 126), which pdf.js 5.x calls at
+ * module-evaluation time. Without them, importing `react-pdf`/`pdfjs-dist`
+ * throws before anything renders, so this module must be imported for its
+ * side effects BEFORE those imports. The pdf.js worker runs in a separate
+ * context these polyfills cannot reach; it is covered by serving pdf.js's
+ * self-polyfilling legacy worker build (see pdf-viewer.tsx).
+ *
+ * Typed locally because the repo TS lib is ES2022, which predates both APIs.
+ */
+
+interface PromiseWithResolversResult<T> {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: unknown) => void
+}
+
+const promiseCtor = Promise as typeof Promise & {
+  withResolvers?: <T>() => PromiseWithResolversResult<T>
+}
+
+if (typeof promiseCtor.withResolvers !== 'function') {
+  promiseCtor.withResolvers = <T>(): PromiseWithResolversResult<T> => {
+    let resolve!: (value: T | PromiseLike<T>) => void
+    let reject!: (reason?: unknown) => void
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    return { promise, resolve, reject }
+  }
+}
+
+const urlCtor = URL as typeof URL & {
+  parse?: (url: string | URL, base?: string | URL) => URL | null
+}
+
+if (typeof urlCtor.parse !== 'function') {
+  urlCtor.parse = (url: string | URL, base?: string | URL): URL | null => {
+    try {
+      return new URL(url, base)
+    } catch {
+      return null
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes "Something went wrong" on every PDF preview (chat + Files tab) for Safari < 17.4 users — pdf.js 5.x calls `Promise.withResolvers` (Safari ≥ 17.4) and `URL.parse` (Safari ≥ 18) at module-evaluation time, so importing `react-pdf` threw an uncaught TypeError that unwound to the workspace error boundary
- Adds `lib/core/utils/browser-polyfills.ts`, imported for side effects before the `react-pdf` import in `pdf-viewer.tsx` (the crash happens while pdf.js evaluates, so import order matters)
- Switches `workerSrc` to the legacy pdf.js worker build — the worker runs in its own context that main-thread polyfills can't reach, and the legacy build bundles its own polyfills (same pdfjs-dist version, so the API/worker version handshake is unaffected)
- Wraps the PDF preview in a `PreviewErrorBoundary` (styled after the existing workflow `ErrorBoundary`) so a viewer crash degrades to the standard `PreviewError` fallback instead of replacing the whole workspace view

## Type of Change
- [x] Bug fix

## Testing
Reproduced the production incident headlessly: bundled the real `PdfViewerCore` against the exact PDF bytes prod served, removed the two APIs to simulate Safari 17.3 → crashed with `Promise.withResolvers is not a function` (blank render). With this fix the same simulation renders both pages with zero console errors; modern-browser profile verified unaffected. `tsc --noEmit` and `biome check` clean on all changed files.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)