### PR TITLE
ci(migrations): fail dev schema push with an actionable error on rename/drop prompt

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -69,7 +69,18 @@ jobs:
 
           if [ "${ENVIRONMENT}" = "dev" ]; then
             echo "Dev environment — pushing schema directly (db:push)"
-            bun run db:push --force
+            # `--force` only suppresses the data-loss confirm, not drizzle's
+            # rename-vs-drop prompt, which fires (and crashes, no TTY) when a
+            # diff both adds and drops tables/columns at once. Turn that opaque
+            # crash into an actionable failure instead of a bare stack trace.
+            push_output="$(bun run db:push --force 2>&1)" && push_status=0 || push_status=$?
+            echo "$push_output"
+            if [ "$push_status" -ne 0 ]; then
+              if printf '%s' "$push_output" | grep -q 'Interactive prompts require a TTY'; then
+                echo "::error title=Dev schema push needs manual reconciliation::drizzle-kit push hit an interactive rename/drop prompt that CI cannot answer. The dev DB has drifted from schema.ts: it still holds table(s)/column(s) the schema no longer declares while the schema also adds new ones, so drizzle cannot tell a rename from a drop+create. Fix: drop the stale objects on the dev DB to match schema.ts — the same DROPs the latest versioned migration already applied to staging/prod (grep packages/db/migrations for the most recent DROP TABLE / DROP COLUMN) — then re-run this workflow. --force cannot bypass this prompt."
+              fi
+              exit "$push_status"
+            fi
           else
             echo "Applying versioned migrations (db:migrate)"
             bun run ./scripts/migrate.ts


### PR DESCRIPTION
## Problem

The dev DB migration step runs `bun run db:push --force`. When CI ran it against the dev DB it crashed with:

> Error: Interactive prompts require a TTY terminal ... at promptNamedWithSchemasConflict ... at tablesResolver

`--force` only suppresses drizzle's **data-loss** confirmation. It does **not** suppress the **rename-vs-drop** disambiguation prompt (`promptNamedWithSchemasConflict`), which fires whenever a diff contains **both** new and missing objects at the same level — drizzle can't tell a rename from a drop+create, so it asks. In CI there's no TTY, so `hanji` throws before reading input (piping an answer can't help).

This happened because the dev DB drifted: migration `0231_sim_trigger_workspace_events.sql` (#4941) **creates** `sim_trigger_state` **and drops** `workspace_notification_delivery` / `workspace_notification_subscription` in one shot. Staging/prod run `db:migrate` and apply it cleanly; only **dev** (which uses `db:push`, no migration journal) sees it as an ambiguous diff and prompts.

## Change

CI already failed here — just opaquely. This converts the bare stack trace into an actionable failure: the dev push step captures the output, and on the specific `Interactive prompts require a TTY` error emits a GitHub `::error::` annotation explaining the cause and the fix (drop the stale objects on the dev DB to match `schema.ts` — the same DROPs the versioned migration already applied to staging/prod). Exit status is preserved either way; success path is unchanged.

No detection/auto-reconcile script — deliberately fail loud and let a human reconcile, matching how staging/prod already handle the drop via the versioned migration.

## Test

Verified the capture + exit-code logic under `bash -e -o pipefail`: failure captures status, emits the annotation, and propagates the non-zero exit; success path falls through untouched. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)