### PR TITLE
fix(jira): add classic JSM scopes to close granular scope-set gap

### DIFF
--- a/apps/docs/content/docs/en/integrations/atlassian-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/atlassian-service-account.mdx
@@ -90,7 +90,7 @@ The service account inherits permissions from the project/space roles you grant 
     Add more scopes only if you need the corresponding operations (delete, manage webhooks, etc.). The full list of scopes Sim's blocks may use is documented in [Atlassian's developer reference](https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/).
 
     <Callout type="warn">
-      Prefer the classic scopes above over granular equivalents. Atlassian enforces an endpoint's granular scope list as all-or-nothing, so a token built from a partial granular set fails with `Unauthorized; scope does not match` even though each individual scope was granted. The classic scopes each cover their product's endpoints on their own.
+      Prefer the classic scopes above over granular equivalents. Atlassian enforces an endpoint's granular scope list as all-or-nothing, so a token built from a partial granular set fails with `Unauthorized; scope does not match` even though each individual scope was granted. The classic scopes each cover their product's endpoints on their own. If your organization only permits granular scopes, include every scope listed for each endpoint in Atlassian's reference — Jira Service Management request operations also require `read:user:jira`.
     </Callout>
 
     <div className="flex justify-center">

--- a/apps/docs/content/docs/en/integrations/atlassian-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/atlassian-service-account.mdx
@@ -64,11 +64,18 @@ The service account inherits permissions from the project/space roles you grant 
   <Step>
     Select the scopes the token needs. The minimum set Sim's Jira and Confluence blocks expect is:
 
-    **Jira (granular):**
+    **Jira (classic):**
     ```
     read:jira-user
     read:jira-work
     write:jira-work
+    ```
+
+    **Jira Service Management (classic):**
+    ```
+    read:servicedesk-request
+    write:servicedesk-request
+    manage:servicedesk-customer
     ```
 
     **Confluence (granular):**
@@ -81,6 +88,10 @@ The service account inherits permissions from the project/space roles you grant 
     ```
 
     Add more scopes only if you need the corresponding operations (delete, manage webhooks, etc.). The full list of scopes Sim's blocks may use is documented in [Atlassian's developer reference](https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/).
+
+    <Callout type="warn">
+      Prefer the classic scopes above over granular equivalents. Atlassian enforces an endpoint's granular scope list as all-or-nothing, so a token built from a partial granular set fails with `Unauthorized; scope does not match` even though each individual scope was granted. The classic scopes each cover their product's endpoints on their own.
+    </Callout>
 
     <div className="flex justify-center">
       <Image

--- a/apps/sim/connectors/jsm/jsm.ts
+++ b/apps/sim/connectors/jsm/jsm.ts
@@ -334,6 +334,12 @@ export const jsmConnector: ConnectorConfig = {
     mode: 'oauth',
     provider: 'jira',
     requiredScopes: [
+      /**
+       * Atlassian enforces granular scope sets all-or-nothing; the classic scope
+       * alone authorizes the request read endpoints, so require it to flag stale
+       * credentials that predate it in the provider scope list.
+       */
+      'read:servicedesk-request',
       'read:servicedesk:jira-service-management',
       'read:request:jira-service-management',
       'read:request.comment:jira-service-management',

--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -515,12 +515,18 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
           'read:me',
           'offline_access',
           'read:issue.vote:jira',
+          'read:user:jira',
           'delete:issue:jira',
           'delete:comment:jira',
           'delete:attachment:jira',
           'delete:issue-worklog:jira',
           'delete:issue-link:jira',
-          // Jira Service Management scopes
+          // Jira Service Management scopes. The classic scopes are required: Atlassian
+          // enforces an endpoint's granular scope set as all-of, and several JSM request
+          // endpoints include scopes outside this list in their granular sets.
+          'read:servicedesk-request',
+          'write:servicedesk-request',
+          'manage:servicedesk-customer',
           'read:servicedesk:jira-service-management',
           'read:requesttype:jira-service-management',
           'read:request:jira-service-management',

--- a/apps/sim/lib/oauth/utils.ts
+++ b/apps/sim/lib/oauth/utils.ts
@@ -168,6 +168,9 @@ export const SCOPE_DESCRIPTIONS: Record<string, string> = {
   'delete:issue-link:jira': 'Delete links between Jira issues',
 
   // Jira Service Management scopes
+  'read:servicedesk-request': 'View service desk requests',
+  'write:servicedesk-request': 'Create and update service desk requests',
+  'manage:servicedesk-customer': 'Manage service desk customers and organizations',
   'read:servicedesk:jira-service-management': 'View service desks and their settings',
   'read:requesttype:jira-service-management': 'View request types available in service desks',
   'read:request:jira-service-management': 'View customer requests in service desks',


### PR DESCRIPTION
## Summary
- Add classic JSM scopes (`read:servicedesk-request`, `write:servicedesk-request`, `manage:servicedesk-customer`) and granular `read:user:jira` to the Jira OAuth provider scope list
- Atlassian enforces an endpoint's granular scope set as all-of, not any-of — JSM request endpoints list `read:user:jira` in their granular sets, so tokens built from our granular-only list failed with `Unauthorized; scope does not match` even though every individual scope was granted; each classic scope authorizes its endpoints standalone
- Add display names for the new scopes in the consent/credential UI
- Require `read:servicedesk-request` on the JSM knowledge connector so stale credentials surface a reconnect prompt instead of failing mid-sync
- Update the Atlassian service-account docs to include the JSM classic scopes in the minimum set, with a callout explaining the all-or-nothing granular enforcement

## Type of Change
- [x] Bug fix

## Testing
Audited every Jira/JSM tool endpoint against Atlassian's API docs to confirm each operation now has a fully satisfied scope path (classic or complete granular). The classic-scope fix is verified against a live JSM instance. oauth/blocks/connector test suites pass (347 tests); `check:api-validation` passes.

Note for deploy: the Atlassian developer console app must have all four new scopes enabled before this reaches production — the three classic JSM scopes (`read:servicedesk-request`, `write:servicedesk-request`, `manage:servicedesk-customer`) and the granular `read:user:jira`, or new Jira connections will fail at the consent screen. Existing connections are unaffected either way (no execution-time scope gate; refresh preserves the original grant).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
