### PR TITLE
improvement(auth): layer disposable-email-domains into signup email validation

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -69,7 +69,18 @@ jobs:
 
           if [ "${ENVIRONMENT}" = "dev" ]; then
             echo "Dev environment — pushing schema directly (db:push)"
-            bun run db:push --force
+            # `--force` only suppresses the data-loss confirm, not drizzle's
+            # rename-vs-drop prompt, which fires (and crashes, no TTY) when a
+            # diff both adds and drops tables/columns at once. Turn that opaque
+            # crash into an actionable failure instead of a bare stack trace.
+            push_output="$(bun run db:push --force 2>&1)" && push_status=0 || push_status=$?
+            echo "$push_output"
+            if [ "$push_status" -ne 0 ]; then
+              if printf '%s' "$push_output" | grep -q 'Interactive prompts require a TTY'; then
+                echo "::error title=Dev schema push needs manual reconciliation::drizzle-kit push hit an interactive rename/drop prompt that CI cannot answer. The dev DB has drifted from schema.ts: it still holds table(s)/column(s) the schema no longer declares while the schema also adds new ones, so drizzle cannot tell a rename from a drop+create. Fix: drop the stale objects on the dev DB to match schema.ts — the same DROPs the latest versioned migration already applied to staging/prod (grep packages/db/migrations for the most recent DROP TABLE / DROP COLUMN) — then re-run this workflow. --force cannot bypass this prompt."
+              fi
+              exit "$push_status"
+            fi
           else
             echo "Applying versioned migrations (db:migrate)"
             bun run ./scripts/migrate.ts

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -21,6 +21,7 @@ import {
   organization,
 } from 'better-auth/plugins'
 import { emailHarmony } from 'better-auth-harmony'
+import { validateEmail as validateEmailWithMailchecker } from 'better-auth-harmony/email'
 import { and, count, eq, inArray, sql } from 'drizzle-orm'
 import { headers } from 'next/headers'
 import Stripe from 'stripe'
@@ -78,6 +79,7 @@ import {
 import { PlatformEvents } from '@/lib/core/telemetry'
 import { getBaseUrl, isLocalhostUrl, parseOriginList } from '@/lib/core/utils/urls'
 import { processCredentialDraft } from '@/lib/credentials/draft-processor'
+import { isDisposableEmailDomain } from '@/lib/messaging/email/disposable-domains.server'
 import { sendEmail } from '@/lib/messaging/email/mailer'
 import { getFromEmailAddress, getPersonalEmailFrom } from '@/lib/messaging/email/utils'
 import { quickValidateEmail } from '@/lib/messaging/email/validation'
@@ -930,7 +932,14 @@ export const auth = betterAuth({
     }),
   },
   plugins: [
-    ...(isSignupEmailValidationEnabled ? [emailHarmony()] : []),
+    ...(isSignupEmailValidationEnabled
+      ? [
+          emailHarmony({
+            validator: (email) =>
+              validateEmailWithMailchecker(email) && !isDisposableEmailDomain(email),
+          }),
+        ]
+      : []),
     ...(env.TURNSTILE_SECRET_KEY
       ? [
           captcha({

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -935,8 +935,8 @@ export const auth = betterAuth({
     ...(isSignupEmailValidationEnabled
       ? [
           emailHarmony({
-            validator: (email) =>
-              validateEmailWithMailchecker(email) && !isDisposableEmailDomain(email),
+            validator: async (email) =>
+              validateEmailWithMailchecker(email) && !(await isDisposableEmailDomain(email)),
           }),
         ]
       : []),

--- a/apps/sim/lib/messaging/email/disposable-domains.d.ts
+++ b/apps/sim/lib/messaging/email/disposable-domains.d.ts
@@ -1,0 +1,10 @@
+/** Ambient types for `disposable-email-domains` — ships JSON arrays with no bundled types. */
+declare module 'disposable-email-domains' {
+  const domains: string[]
+  export default domains
+}
+
+declare module 'disposable-email-domains/wildcard.json' {
+  const baseDomains: string[]
+  export default baseDomains
+}

--- a/apps/sim/lib/messaging/email/disposable-domains.server.test.ts
+++ b/apps/sim/lib/messaging/email/disposable-domains.server.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { isDisposableEmailDomain } from '@/lib/messaging/email/disposable-domains.server'
+
+describe('isDisposableEmailDomain', () => {
+  it('flags a known disposable domain', () => {
+    expect(isDisposableEmailDomain('someone@mailinator.com')).toBe(true)
+  })
+
+  it('flags a subdomain of a wildcard base domain', () => {
+    expect(isDisposableEmailDomain('someone@inbox.10mail.org')).toBe(true)
+  })
+
+  it('is case-insensitive on the domain', () => {
+    expect(isDisposableEmailDomain('Someone@MailInator.com')).toBe(true)
+  })
+
+  it('allows a normal provider domain', () => {
+    expect(isDisposableEmailDomain('someone@gmail.com')).toBe(false)
+  })
+
+  it('allows a custom catch-all domain that is not on the list', () => {
+    expect(isDisposableEmailDomain('sim6dc088f506@lordfortescue.org.uk')).toBe(false)
+  })
+
+  it('returns false for malformed input with no domain', () => {
+    expect(isDisposableEmailDomain('not-an-email')).toBe(false)
+  })
+})

--- a/apps/sim/lib/messaging/email/disposable-domains.server.test.ts
+++ b/apps/sim/lib/messaging/email/disposable-domains.server.test.ts
@@ -5,27 +5,31 @@ import { describe, expect, it } from 'vitest'
 import { isDisposableEmailDomain } from '@/lib/messaging/email/disposable-domains.server'
 
 describe('isDisposableEmailDomain', () => {
-  it('flags a known disposable domain', () => {
-    expect(isDisposableEmailDomain('someone@mailinator.com')).toBe(true)
+  it('flags a known disposable domain', async () => {
+    expect(await isDisposableEmailDomain('someone@mailinator.com')).toBe(true)
   })
 
-  it('flags a subdomain of a wildcard base domain', () => {
-    expect(isDisposableEmailDomain('someone@inbox.10mail.org')).toBe(true)
+  it('flags a subdomain of a wildcard base domain', async () => {
+    expect(await isDisposableEmailDomain('someone@inbox.10mail.org')).toBe(true)
   })
 
-  it('is case-insensitive on the domain', () => {
-    expect(isDisposableEmailDomain('Someone@MailInator.com')).toBe(true)
+  it('flags the bare wildcard base domain itself', async () => {
+    expect(await isDisposableEmailDomain('someone@10mail.org')).toBe(true)
   })
 
-  it('allows a normal provider domain', () => {
-    expect(isDisposableEmailDomain('someone@gmail.com')).toBe(false)
+  it('is case-insensitive on the domain', async () => {
+    expect(await isDisposableEmailDomain('Someone@MailInator.com')).toBe(true)
   })
 
-  it('allows a custom catch-all domain that is not on the list', () => {
-    expect(isDisposableEmailDomain('sim6dc088f506@lordfortescue.org.uk')).toBe(false)
+  it('allows a normal provider domain', async () => {
+    expect(await isDisposableEmailDomain('someone@gmail.com')).toBe(false)
   })
 
-  it('returns false for malformed input with no domain', () => {
-    expect(isDisposableEmailDomain('not-an-email')).toBe(false)
+  it('allows a custom catch-all domain that is not on the list', async () => {
+    expect(await isDisposableEmailDomain('sim6dc088f506@lordfortescue.org.uk')).toBe(false)
+  })
+
+  it('returns false for malformed input with no domain', async () => {
+    expect(await isDisposableEmailDomain('not-an-email')).toBe(false)
   })
 })

--- a/apps/sim/lib/messaging/email/disposable-domains.server.ts
+++ b/apps/sim/lib/messaging/email/disposable-domains.server.ts
@@ -1,0 +1,19 @@
+import disposableDomains from 'disposable-email-domains'
+import wildcardBaseDomains from 'disposable-email-domains/wildcard.json'
+
+const exactDomains = new Set(disposableDomains)
+
+/**
+ * Server-only disposable-email-domain check backed by the `disposable-email-domains`
+ * package (~120K exact domains plus wildcard base domains). Layered alongside
+ * better-auth-harmony's bundled Mailchecker list at the signup gate.
+ *
+ * Never import from client code — the dataset would bloat the browser bundle.
+ * Matches exact domains and any subdomain of a wildcard base domain.
+ */
+export function isDisposableEmailDomain(email: string): boolean {
+  const domain = email.split('@')[1]?.toLowerCase()
+  if (!domain) return false
+  if (exactDomains.has(domain)) return true
+  return wildcardBaseDomains.some((base) => domain === base || domain.endsWith(`.${base}`))
+}

--- a/apps/sim/lib/messaging/email/disposable-domains.server.ts
+++ b/apps/sim/lib/messaging/email/disposable-domains.server.ts
@@ -1,19 +1,32 @@
-import disposableDomains from 'disposable-email-domains'
-import wildcardBaseDomains from 'disposable-email-domains/wildcard.json'
-
-const exactDomains = new Set(disposableDomains)
+let cache: { exact: Set<string>; wildcards: string[] } | undefined
 
 /**
- * Server-only disposable-email-domain check backed by the `disposable-email-domains`
- * package (~120K exact domains plus wildcard base domains). Layered alongside
- * better-auth-harmony's bundled Mailchecker list at the signup gate.
+ * Lazily loads the `disposable-email-domains` dataset (~120K exact domains plus
+ * wildcard base domains) on first use and memoizes it. Deferred behind a dynamic
+ * import so deployments with signup email validation disabled never load it.
+ */
+async function loadDisposableData(): Promise<{ exact: Set<string>; wildcards: string[] }> {
+  if (!cache) {
+    const [{ default: exactList }, { default: wildcards }] = await Promise.all([
+      import('disposable-email-domains'),
+      import('disposable-email-domains/wildcard.json'),
+    ])
+    cache = { exact: new Set(exactList), wildcards }
+  }
+  return cache
+}
+
+/**
+ * Server-only disposable-email-domain check. Layered alongside better-auth-harmony's
+ * bundled Mailchecker list at the signup gate. Matches exact domains and any subdomain
+ * of (or the bare) wildcard base domain.
  *
  * Never import from client code — the dataset would bloat the browser bundle.
- * Matches exact domains and any subdomain of a wildcard base domain.
  */
-export function isDisposableEmailDomain(email: string): boolean {
+export async function isDisposableEmailDomain(email: string): Promise<boolean> {
   const domain = email.split('@')[1]?.toLowerCase()
   if (!domain) return false
-  if (exactDomains.has(domain)) return true
-  return wildcardBaseDomains.some((base) => domain === base || domain.endsWith(`.${base}`))
+  const { exact, wildcards } = await loadDisposableData()
+  if (exact.has(domain)) return true
+  return wildcards.some((base) => domain === base || domain.endsWith(`.${base}`))
 }

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -126,6 +126,7 @@
     "csv-parse": "6.1.0",
     "date-fns": "4.1.0",
     "decimal.js": "10.6.0",
+    "disposable-email-domains": "1.0.62",
     "docx": "^9.6.1",
     "docx-preview": "^0.3.7",
     "drizzle-orm": "^0.45.2",

--- a/bun.lock
+++ b/bun.lock
@@ -185,6 +185,7 @@
         "csv-parse": "6.1.0",
         "date-fns": "4.1.0",
         "decimal.js": "10.6.0",
+        "disposable-email-domains": "1.0.62",
         "docx": "^9.6.1",
         "docx-preview": "^0.3.7",
         "drizzle-orm": "^0.45.2",
@@ -2211,6 +2212,8 @@
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
 
     "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
+
+    "disposable-email-domains": ["disposable-email-domains@1.0.62", "", {}, "sha512-LBQvhRw7mznQTPoyZbsmYeNOZt1pN5aCsx4BAU/3siVFuiM9f2oyKzUaB8v1jbxFjE3aYqYiMo63kAL4pHgfWQ=="],
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 


### PR DESCRIPTION
## Summary
- Add the `disposable-email-domains` package (exact + wildcard lists) as an extra signup gate, composed **into** `better-auth-harmony`'s validator alongside its bundled Mailchecker list — an email is rejected if either flags it (union, not replacement).
- New server-only `isDisposableEmailDomain()` module + ambient types; kept out of the client bundle so the ~120K dataset never ships to the browser. Client `quickValidateEmail` keeps its small fast-feedback set.
- Still gated behind the existing `SIGNUP_EMAIL_VALIDATION_ENABLED` flag.

## Type of Change
- [x] Improvement (defense-in-depth)

## Testing
- New unit tests for `isDisposableEmailDomain` (exact, wildcard subdomain, case-insensitivity, normal domain, custom catch-all, malformed) — all passing
- `bun run lint` clean, `bun run check:api-validation:strict` passed, `tsc --noEmit` 0 errors

## Note
- This is the generic-throwaway-service layer; it does not block privately-registered catch-all domains (e.g. the recent botnet) — those still need `BLOCKED_SIGNUP_DOMAINS` / `BLOCKED_EMAIL_MX_HOSTS`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)