### PR TITLE
chore(providers): remove claude-fable-5 model

### DIFF
--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -82,7 +82,6 @@ const THINKING_BUDGET_TOKENS: Record<string, number> = {
 
 /**
  * Checks if a model supports adaptive thinking (thinking.type: "adaptive").
- * Fable 5 supports ONLY adaptive thinking (always on; type: "disabled" is rejected).
  * Opus 4.8 and Opus 4.7 support ONLY adaptive thinking (no extended thinking / budget_tokens).
  * Opus 4.6 and Sonnet 4.6 support both extended and adaptive thinking — use adaptive.
  * Opus 4.5 supports effort but NOT adaptive thinking — it uses budget_tokens with type: "enabled".
@@ -90,7 +89,6 @@ const THINKING_BUDGET_TOKENS: Record<string, number> = {
 function supportsAdaptiveThinking(modelId: string): boolean {
   const normalizedModel = modelId.toLowerCase()
   return (
-    normalizedModel.includes('fable-5') ||
     normalizedModel.includes('opus-4-8') ||
     normalizedModel.includes('opus-4.8') ||
     normalizedModel.includes('opus-4-7') ||
@@ -105,7 +103,7 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 /**
  * Builds the thinking configuration for the Anthropic API based on model capabilities and level.
  *
- * - Fable 5, Opus 4.8, Opus 4.7: Uses adaptive thinking only (no extended thinking support)
+ * - Opus 4.8, Opus 4.7: Uses adaptive thinking only (no extended thinking support)
  * - Opus 4.6, Sonnet 4.6: Uses adaptive thinking with effort parameter
  * - Other models: Uses budget_tokens-based extended thinking
  *

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -635,25 +635,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     },
     models: [
       {
-        id: 'claude-fable-5',
-        pricing: {
-          input: 10.0,
-          cachedInput: 1.0,
-          output: 50.0,
-          updatedAt: '2026-06-09',
-        },
-        capabilities: {
-          nativeStructuredOutputs: true,
-          maxOutputTokens: 128000,
-          thinking: {
-            levels: ['low', 'medium', 'high', 'xhigh', 'max'],
-            default: 'high',
-          },
-        },
-        contextWindow: 1000000,
-        releaseDate: '2026-06-09',
-      },
-      {
         id: 'claude-opus-4-8',
         pricing: {
           input: 5.0,


### PR DESCRIPTION
## Summary
- Remove the `claude-fable-5` model entry from the Anthropic provider model list
- Drop the `fable-5` branch from adaptive-thinking detection and clean up the related TSDoc in `anthropic/core.ts`

## Type of Change
- [x] Chore (maintenance)

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)