### PR TITLE
feat(loader): Mothership thinking loader — Figma gradient + fixes

### DIFF
--- a/apps/sim/components/emcn/components/thinking-loader/thinking-loader.module.css
+++ b/apps/sim/components/emcn/components/thinking-loader/thinking-loader.module.css
@@ -18,6 +18,25 @@
 .frame {
   color: #4f4f4f;
   flex: none;
+  /* Loader fill is a radial gradient (center → edge) plus a soft white inner
+     glow, per the Figma loader spec. Stops and glow opacity are theme vars,
+     inherited by the gradient stops and feFlood inside the SVG, so one set of
+     defs serves both themes. Light: #A7A7A7 → #D6D6D6, glow white 0.9. */
+  --tl-grad-inner: #a7a7a7;
+  --tl-grad-outer: #d6d6d6;
+  --tl-glow: rgba(255, 255, 255, 0.9);
+}
+
+/* Gradient stops + glow flood read the theme vars via CSS (a raw `var()` in an
+   SVG presentation attribute would not resolve — it must come through CSS). */
+.gradInner {
+  stop-color: var(--tl-grad-inner);
+}
+.gradOuter {
+  stop-color: var(--tl-grad-outer);
+}
+.glow {
+  flood-color: var(--tl-glow);
 }
 
 /* Wall-clock phase lock: the component sets --tl-sync to a shared negative
@@ -31,6 +50,10 @@
 
 :global(.dark) .frame {
   color: #d6d6d6;
+  /* Dark: #4F4F4F → #6F6F6F, glow white 0.6. */
+  --tl-grad-inner: #4f4f4f;
+  --tl-grad-outer: #6f6f6f;
+  --tl-glow: rgba(255, 255, 255, 0.6);
 }
 
 .labelRow {

--- a/apps/sim/components/emcn/components/thinking-loader/thinking-loader.module.css
+++ b/apps/sim/components/emcn/components/thinking-loader/thinking-loader.module.css
@@ -121,13 +121,16 @@
   }
 }
 
-/* orbit — two blobs chase each other around a square track */
-.orbitA,
-.orbitB {
+/* orbit — two blobs chase each other around a square track. The second blob
+   is the track offset by 50% (opposite corner) via its OWN keyframes, not an
+   animation-delay: the shared wall-clock phase lock (.frame.frame *) forces
+   one delay on every element, which would otherwise stack both blobs and hide
+   one. */
+.orbitA {
   animation: orbit 2s infinite;
 }
 .orbitB {
-  animation-delay: -1s;
+  animation: orbit-b 2s infinite;
 }
 @keyframes orbit {
   0% {
@@ -144,6 +147,23 @@
   }
   100% {
     transform: translate(0, 0);
+  }
+}
+@keyframes orbit-b {
+  0% {
+    transform: translate(40px, 40px);
+  }
+  25% {
+    transform: translate(0, 40px);
+  }
+  50% {
+    transform: translate(0, 0);
+  }
+  75% {
+    transform: translate(40px, 0);
+  }
+  100% {
+    transform: translate(40px, 40px);
   }
 }
 

--- a/apps/sim/components/emcn/components/thinking-loader/thinking-loader.module.css
+++ b/apps/sim/components/emcn/components/thinking-loader/thinking-loader.module.css
@@ -16,15 +16,19 @@
  */
 
 .frame {
+  /* currentColor paints the squeeze ring's stroked arcs (the only non-filled
+     geometry). It tracks the loader polarity — dark on light, light on dark —
+     matching the gradient stops below. */
   color: #4f4f4f;
   flex: none;
   /* Loader fill is a radial gradient (center → edge) plus a soft white inner
      glow, per the Figma loader spec. Stops and glow opacity are theme vars,
      inherited by the gradient stops and feFlood inside the SVG, so one set of
-     defs serves both themes. Light: #A7A7A7 → #D6D6D6, glow white 0.9. */
-  --tl-grad-inner: #a7a7a7;
-  --tl-grad-outer: #d6d6d6;
-  --tl-glow: rgba(255, 255, 255, 0.9);
+     defs serves both themes. Light mode = the DARK-grey loader (reads on white):
+     #4F4F4F → #6F6F6F, glow white 0.6. */
+  --tl-grad-inner: #4f4f4f;
+  --tl-grad-outer: #6f6f6f;
+  --tl-glow: rgba(255, 255, 255, 0.6);
 }
 
 /* Gradient stops + glow flood read the theme vars via CSS (a raw `var()` in an
@@ -50,10 +54,11 @@
 
 :global(.dark) .frame {
   color: #d6d6d6;
-  /* Dark: #4F4F4F → #6F6F6F, glow white 0.6. */
-  --tl-grad-inner: #4f4f4f;
-  --tl-grad-outer: #6f6f6f;
-  --tl-glow: rgba(255, 255, 255, 0.6);
+  /* Dark mode = the LIGHT-grey loader (reads on dark): #A7A7A7 → #D6D6D6,
+     glow white 0.9. */
+  --tl-grad-inner: #a7a7a7;
+  --tl-grad-outer: #d6d6d6;
+  --tl-glow: rgba(255, 255, 255, 0.9);
 }
 
 .labelRow {

--- a/apps/sim/components/emcn/components/thinking-loader/thinking-loader.tsx
+++ b/apps/sim/components/emcn/components/thinking-loader/thinking-loader.tsx
@@ -257,8 +257,8 @@ export function ThinkingLoader({ variant, size = 20, label, className }: Thinkin
             k3='1'
             result='innerMask'
           />
-          {/* Glow color + per-theme opacity ride a CSS var (light 0.9 / dark
-              0.6) so one filter serves both themes. */}
+          {/* Glow color + per-theme opacity ride a CSS var (light 0.6 / dark
+              0.9) so one filter serves both themes. */}
           <feFlood className={styles.glow} result='glowColor' />
           <feComposite in='glowColor' in2='innerMask' operator='in' result='glow' />
           <feMerge>
@@ -267,8 +267,11 @@ export function ThinkingLoader({ variant, size = 20, label, className }: Thinkin
           </feMerge>
         </filter>
         {/* Radial gradient (center → edge), theme stops via CSS vars. Matches
-            the Figma loader: dark #4F4F4F→#6F6F6F, light #A7A7A7→#D6D6D6. */}
-        <radialGradient id={gradientId} cx='50' cy='50' r='50' gradientUnits='userSpaceOnUse'>
+            the Figma loader: light #4F4F4F→#6F6F6F, dark #A7A7A7→#D6D6D6.
+            objectBoundingBox (default units) so EACH blob is shaded on its own
+            box — Figma fits the gradient per shape, so small/offset dots read
+            glossy (center dark, edge light) instead of flat. */}
+        <radialGradient id={gradientId} cx='0.5' cy='0.5' r='0.5'>
           <stop className={styles.gradInner} />
           <stop offset='1' className={styles.gradOuter} />
         </radialGradient>

--- a/apps/sim/components/emcn/components/thinking-loader/thinking-loader.tsx
+++ b/apps/sim/components/emcn/components/thinking-loader/thinking-loader.tsx
@@ -180,6 +180,7 @@ export function ThinkingLoader({ variant, size = 20, label, className }: Thinkin
   const filterId = `tl-goo-${id}`
   const clipId = `tl-clip-${id}`
   const windowClipId = `tl-window-${id}`
+  const gradientId = `tl-grad-${id}`
   const [cycleVariant, setCycleVariant] = useState<ThinkingLoaderVariant>('metaballs')
   const cycling = variant === undefined
 
@@ -220,10 +221,57 @@ export function ThinkingLoader({ variant, size = 20, label, className }: Thinkin
       style={syncDelay ? ({ '--tl-sync': syncDelay } as CSSProperties) : undefined}
     >
       <defs>
-        <filter id={filterId} x='-30%' y='-30%' width='160%' height='160%'>
+        {/* sRGB so the radial gradient fill keeps its authored midtones
+            through the blur (linearRGB would wash the gradient out). The goo
+            crush runs first; the inner glow then rides the merged silhouette's
+            edge — a soft white inset, per the Figma loader spec. */}
+        <filter
+          id={filterId}
+          x='-30%'
+          y='-30%'
+          width='160%'
+          height='160%'
+          colorInterpolationFilters='sRGB'
+        >
           <feGaussianBlur in='SourceGraphic' stdDeviation='5' result='blur' />
-          <feColorMatrix in='blur' values='1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 19 -9' />
+          <feColorMatrix
+            in='blur'
+            values='1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 19 -9'
+            result='goo'
+          />
+          {/* Inner shadow from the goo silhouette's alpha (Figma technique:
+              blur the alpha, subtract it from itself to leave an inner ring,
+              tint white). stdDeviation 4.86 = the spec's 3.5 scaled 72→100. */}
+          <feColorMatrix
+            in='goo'
+            type='matrix'
+            values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 127 0'
+            result='gooAlpha'
+          />
+          <feGaussianBlur in='gooAlpha' stdDeviation='4.86' result='innerBlur' />
+          <feComposite
+            in='innerBlur'
+            in2='gooAlpha'
+            operator='arithmetic'
+            k2='-1'
+            k3='1'
+            result='innerMask'
+          />
+          {/* Glow color + per-theme opacity ride a CSS var (light 0.9 / dark
+              0.6) so one filter serves both themes. */}
+          <feFlood className={styles.glow} result='glowColor' />
+          <feComposite in='glowColor' in2='innerMask' operator='in' result='glow' />
+          <feMerge>
+            <feMergeNode in='goo' />
+            <feMergeNode in='glow' />
+          </feMerge>
         </filter>
+        {/* Radial gradient (center → edge), theme stops via CSS vars. Matches
+            the Figma loader: dark #4F4F4F→#6F6F6F, light #A7A7A7→#D6D6D6. */}
+        <radialGradient id={gradientId} cx='50' cy='50' r='50' gradientUnits='userSpaceOnUse'>
+          <stop className={styles.gradInner} />
+          <stop offset='1' className={styles.gradOuter} />
+        </radialGradient>
         {/* Shapes clip BEFORE the goo filter, so anything exiting the frame
             melts into the edge instead of getting a hard post-filter cut. */}
         <clipPath id={clipId}>
@@ -235,7 +283,7 @@ export function ThinkingLoader({ variant, size = 20, label, className }: Thinkin
           <rect x='12.5' y='12.5' width='75' height='75' />
         </clipPath>
       </defs>
-      <g filter={`url(#${filterId})`} fill='currentColor'>
+      <g filter={`url(#${filterId})`} fill={`url(#${gradientId})`}>
         {stages.map((v) => (
           <g
             key={v}


### PR DESCRIPTION
Brings the gooey **ThinkingLoader** (the cycling chat "Thinking…" indicator) in line with the Figma loader spec, and fixes a couple of rendering bugs along the way. Self-contained to `components/emcn/components/thinking-loader/*` — flows through automatically to every consumer (chat switcher, message stream, EMCN playground).

## What changed

**1. Figma gradient + inner glow** (`9675ffb`)
The flat `currentColor` fill becomes a radial gradient (center → edge) plus a soft white inner-shadow glow, matching `simMothershipLoader` in Figma. One set of SVG defs serves both themes via CSS custom properties (`--tl-grad-inner/-outer`, `--tl-glow`); the goo filter runs in sRGB so the gradient keeps its midtones through the metaball blur.

**2. Correct theme mapping + per-shape gradient** (`b1cc82c`)
- The dark-grey loader now shows in **light** mode (reads on white): `#4F4F4F → #6F6F6F`, glow 0.6. The light-grey loader shows in **dark** mode: `#A7A7A7 → #D6D6D6`, glow 0.9. (The initial pass had these inverted.)
- The gradient is now `objectBoundingBox` (per shape) instead of one canvas-wide radial — Figma fits the gradient to each shape's box, so every blob (including small/offset dots) reads glossy center-dark → edge-light instead of flat.

**3. Orbit shows both squares again** (`69d0a32`)
The orbit pattern's two blobs chase each other around a square track (second offset by a half-loop). It used `animation-delay: -1s` for the offset, but the shared wall-clock phase lock (`.frame.frame *` sets one delay on every element) is higher-specificity and clobbered it — so both blobs ran in lockstep, stacked, and one disappeared. The second blob now uses its own 50%-shifted `orbit-b` keyframes (same technique metaballs uses), so the phase lock no longer hides it.

## Theme reference

| | Gradient (center → edge) | White inner glow |
|---|---|---|
| Light mode (dark-grey loader) | `#4F4F4F → #6F6F6F` | 0.6 |
| Dark mode (light-grey loader) | `#A7A7A7 → #D6D6D6` | 0.9 |

## Verification
Exact Figma values pulled via the Figma MCP (`simMothershipLoader_lightTheme` / `_darkTheme`). Computed gradient stops + glow confirmed live in both themes in the running app and the EMCN playground; orbit verified showing both squares on opposite corners (distinct `orbit` / `orbit-b` transforms). Rendered against the Figma frames to confirm the per-shape gloss matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)