### PR TITLE
improvement(workflow-mcp): single-source MCP tool params, deploy status, chip styling

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/a2a/a2a.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/a2a/a2a.tsx
@@ -23,6 +23,7 @@ import type { AgentAuthentication, AgentCapabilities } from '@/lib/a2a/types'
 import { getBaseUrl } from '@/lib/core/utils/urls'
 import { normalizeInputFormatValue } from '@/lib/workflows/input-format'
 import { StartBlockPath, TriggerUtils } from '@/lib/workflows/triggers/triggers'
+import { isDefaultDescription } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/lib/default-description'
 import {
   useA2AAgentByWorkflow,
   useCreateA2AAgent,
@@ -42,20 +43,6 @@ interface InputFormatField {
   type?: string
   value?: unknown
   collapsed?: boolean
-}
-
-/**
- * Check if a description is a default/placeholder value that should be filtered out
- */
-function isDefaultDescription(desc: string | null | undefined, workflowName: string): boolean {
-  if (!desc) return true
-  const normalized = desc.toLowerCase().trim()
-  return (
-    normalized === '' ||
-    normalized === 'new workflow' ||
-    normalized === 'your first workflow - start building here!' ||
-    normalized === workflowName.toLowerCase()
-  )
 }
 
 type CodeLanguage = 'curl' | 'python' | 'javascript' | 'typescript'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/api-info-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/api-info-modal.tsx
@@ -20,6 +20,7 @@ import {
 import { normalizeInputFormatValue } from '@/lib/workflows/input-format'
 import { isInputDefinitionTrigger } from '@/lib/workflows/triggers/input-definition-triggers'
 import type { InputFormatField } from '@/lib/workflows/types'
+import { isDefaultDescription } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/lib/default-description'
 import { useDeploymentInfo, useUpdatePublicApi } from '@/hooks/queries/deployments'
 import { useUpdateWorkflow, useWorkflowMap } from '@/hooks/queries/workflows'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
@@ -89,14 +90,12 @@ export function ApiInfoModal({ open, onOpenChange, workflowId }: ApiInfoModalPro
 
   useEffect(() => {
     if (open) {
-      const normalizedDesc = workflowMetadata?.description?.toLowerCase().trim()
-      const isDefaultDescription =
-        !workflowMetadata?.description ||
-        workflowMetadata.description === workflowMetadata.name ||
-        normalizedDesc === 'new workflow' ||
-        normalizedDesc === 'your first workflow - start building here!'
-
-      const initialDescription = isDefaultDescription ? '' : workflowMetadata?.description || ''
+      const initialDescription = isDefaultDescription(
+        workflowMetadata?.description,
+        workflowMetadata?.name || ''
+      )
+        ? ''
+        : workflowMetadata?.description || ''
       setDescription(initialDescription)
       initialDescriptionRef.current = initialDescription
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
@@ -8,17 +8,18 @@ import {
   Button,
   ChipCombobox,
   ChipInput,
+  ChipTextarea,
   type ComboboxOption,
   Label,
   Skeleton,
-  Textarea,
 } from '@/components/emcn'
 import { cn } from '@/lib/core/utils/cn'
-import { generateParameterSchema, sanitizeToolName } from '@/lib/mcp/workflow-tool-schema'
+import { sanitizeToolName } from '@/lib/mcp/workflow-tool-schema'
 import { normalizeInputFormatValue } from '@/lib/workflows/input-format'
 import { isInputDefinitionTrigger } from '@/lib/workflows/triggers/input-definition-triggers'
 import type { InputFormatField } from '@/lib/workflows/types'
 import { CreateWorkflowMcpServerModal } from '@/app/workspace/[workspaceId]/settings/components/workflow-mcp-servers/components/create-workflow-mcp-server-modal'
+import { isDefaultDescription } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/lib/default-description'
 import {
   useAddWorkflowMcpTool,
   useDeleteWorkflowMcpTool,
@@ -28,6 +29,7 @@ import {
   type WorkflowMcpServer,
   type WorkflowMcpTool,
 } from '@/hooks/queries/workflow-mcp-servers'
+import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
 import { EMPTY_SUBBLOCK_VALUES, useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
@@ -52,22 +54,14 @@ interface McpDeployProps {
   onAddedToServer?: () => void
   onSubmittingChange?: (submitting: boolean) => void
   onCanSaveChange?: (canSave: boolean) => void
+  /** Reports whether this workflow is currently exposed as a tool on any server. */
+  onExposedChange?: (exposed: boolean) => void
 }
 
 function haveSameServerSelection(a: string[], b: string[]): boolean {
   if (a.length !== b.length) return false
   const bSet = new Set(b)
   return a.every((id) => bSet.has(id))
-}
-
-function haveSameParameterDescriptions(
-  a: Record<string, string>,
-  b: Record<string, string>
-): boolean {
-  const aKeys = Object.keys(a)
-  const bKeys = Object.keys(b)
-  if (aKeys.length !== bKeys.length) return false
-  return aKeys.every((key) => a[key] === b[key])
 }
 
 /**
@@ -102,6 +96,7 @@ export function McpDeploy({
   onAddedToServer,
   onSubmittingChange,
   onCanSaveChange,
+  onExposedChange,
 }: McpDeployProps) {
   const params = useParams()
   const workspaceId = params.workspaceId as string
@@ -111,6 +106,7 @@ export function McpDeploy({
   const addToolMutation = useAddWorkflowMcpTool()
   const deleteToolMutation = useDeleteWorkflowMcpTool()
   const updateToolMutation = useUpdateWorkflowMcpTool()
+  const { collaborativeSetSubblockValue } = useCollaborativeWorkflow()
 
   const blocks = useWorkflowStore((state) => state.blocks)
 
@@ -142,23 +138,31 @@ export function McpDeploy({
   }, [starterBlockId, subBlockValues, blocks])
 
   const [toolName, setToolName] = useState(() => sanitizeToolName(workflowName))
-  const [toolDescription, setToolDescription] = useState(() => {
-    const normalizedDesc = workflowDescription?.toLowerCase().trim()
-    const isDefaultDescription =
-      !workflowDescription ||
-      workflowDescription === workflowName ||
-      normalizedDesc === 'new workflow' ||
-      normalizedDesc === 'your first workflow - start building here!'
-
-    return isDefaultDescription ? '' : workflowDescription
-  })
-  const [parameterDescriptions, setParameterDescriptions] = useState<Record<string, string>>({})
+  const [toolDescription, setToolDescription] = useState(() =>
+    isDefaultDescription(workflowDescription, workflowName) ? '' : (workflowDescription ?? '')
+  )
   const [pendingServerChanges, setPendingServerChanges] = useState<Set<string>>(() => new Set())
   const [saveErrors, setSaveErrors] = useState<string[]>([])
 
-  const parameterSchema = useMemo(
-    () => generateParameterSchema(inputFormat, parameterDescriptions),
-    [inputFormat, parameterDescriptions]
+  /**
+   * Per-parameter descriptions live on the start block's input format — the single
+   * source of truth shared by every deployment surface. The tool's parameter schema
+   * is derived server-side from the deployed workflow on each deploy, so the tool can
+   * never drift from what actually runs and descriptions are never wiped by a redeploy.
+   * Editing a description here mutates the workflow and surfaces the redeploy prompt.
+   */
+  const updateFieldDescription = useCallback(
+    (fieldName: string, description: string) => {
+      if (!starterBlockId) return
+      const currentFields = normalizeInputFormatValue(
+        useSubBlockStore.getState().getValue(starterBlockId, 'inputFormat')
+      ) as NormalizedField[]
+      const nextFields = currentFields.map((field) =>
+        field.name === fieldName ? { ...field, description } : field
+      )
+      collaborativeSetSubblockValue(starterBlockId, 'inputFormat', nextFields)
+    },
+    [starterBlockId, collaborativeSetSubblockValue]
   )
 
   const toolNameError = useMemo(() => {
@@ -207,7 +211,6 @@ export function McpDeploy({
   const [savedValues, setSavedValues] = useState<{
     toolName: string
     toolDescription: string
-    parameterDescriptions: Record<string, string>
   } | null>(null)
 
   useEffect(() => {
@@ -219,38 +222,15 @@ export function McpDeploy({
         const initialToolName = toolInfo.tool.toolName
 
         const loadedDescription = toolInfo.tool.toolDescription || ''
-        const normalizedLoadedDesc = loadedDescription.toLowerCase().trim()
-        const isDefaultDescription =
-          !loadedDescription ||
-          loadedDescription === workflowName ||
-          normalizedLoadedDesc === 'new workflow' ||
-          normalizedLoadedDesc === 'your first workflow - start building here!'
-        const initialToolDescription = isDefaultDescription ? '' : loadedDescription
-
-        const schema = toolInfo.tool.parameterSchema as Record<string, unknown> | undefined
-        const properties = schema?.properties as
-          | Record<string, { description?: string }>
-          | undefined
-        const initialParameterDescriptions: Record<string, string> = {}
-        if (properties) {
-          for (const [name, prop] of Object.entries(properties)) {
-            if (
-              prop.description &&
-              prop.description !== name &&
-              prop.description !== 'Array of file objects'
-            ) {
-              initialParameterDescriptions[name] = prop.description
-            }
-          }
-        }
+        const initialToolDescription = isDefaultDescription(loadedDescription, workflowName)
+          ? ''
+          : loadedDescription
 
         setToolName(initialToolName)
         setToolDescription(initialToolDescription)
-        setParameterDescriptions(initialParameterDescriptions)
         setSavedValues({
           toolName: initialToolName,
           toolDescription: initialToolDescription,
-          parameterDescriptions: initialParameterDescriptions,
         })
         break
       }
@@ -263,11 +243,8 @@ export function McpDeploy({
     if (!savedValues) return false
     if (toolName !== savedValues.toolName) return true
     if (toolDescription !== savedValues.toolDescription) return true
-    if (!haveSameParameterDescriptions(parameterDescriptions, savedValues.parameterDescriptions)) {
-      return true
-    }
     return false
-  }, [toolName, toolDescription, parameterDescriptions, savedValues])
+  }, [toolName, toolDescription, savedValues])
   const hasServerSelectionChanges = useMemo(
     () => !haveSameServerSelection(selectedServerIdsForForm, selectedServerIds),
     [selectedServerIdsForForm, selectedServerIds]
@@ -279,6 +256,10 @@ export function McpDeploy({
   useEffect(() => {
     onCanSaveChange?.(hasChanges && !!toolName.trim() && !toolNameError)
   }, [hasChanges, toolName, toolNameError, onCanSaveChange])
+
+  useEffect(() => {
+    onExposedChange?.(selectedServerIds.length > 0)
+  }, [selectedServerIds, onExposedChange])
 
   const handleSave = async () => {
     if (!toolName.trim() || toolNameError) return
@@ -307,7 +288,6 @@ export function McpDeploy({
             workflowId,
             toolName: toolName.trim(),
             toolDescription: toolDescription.trim() || undefined,
-            parameterSchema,
           })
           addedEntries[serverId] = { tool: addedTool, isLoading: false }
           onAddedToServer?.()
@@ -363,7 +343,6 @@ export function McpDeploy({
               toolId: toolInfo.tool.id,
               toolName: toolName.trim(),
               toolDescription: toolDescription.trim() || undefined,
-              parameterSchema,
             })
           } catch (error) {
             const serverName = servers.find((s) => s.id === serverId)?.name || serverId
@@ -387,7 +366,6 @@ export function McpDeploy({
         setSavedValues({
           toolName,
           toolDescription,
-          parameterDescriptions: { ...parameterDescriptions },
         })
         onCanSaveChange?.(false)
       }
@@ -516,7 +494,7 @@ export function McpDeploy({
         <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
           Description
         </Label>
-        <Textarea
+        <ChipTextarea
           placeholder='Describe what this tool does...'
           className='min-h-[100px] resize-none'
           value={toolDescription}
@@ -529,6 +507,9 @@ export function McpDeploy({
           <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
             Parameters ({inputFormat.length})
           </Label>
+          <p className='mb-[6.5px] pl-0.5 text-[var(--text-secondary)] text-xs'>
+            Descriptions are part of the workflow's inputs. Redeploy to apply changes to the tool.
+          </p>
           <div className='flex flex-col gap-2'>
             {inputFormat.map((field) => (
               <div
@@ -549,13 +530,8 @@ export function McpDeploy({
                   <div className='flex flex-col gap-1.5'>
                     <Label className='text-small'>Description</Label>
                     <ChipInput
-                      value={parameterDescriptions[field.name] || ''}
-                      onChange={(e) =>
-                        setParameterDescriptions((prev) => ({
-                          ...prev,
-                          [field.name]: e.target.value,
-                        }))
-                      }
+                      value={field.description ?? ''}
+                      onChange={(e) => updateFieldDescription(field.name, e.target.value)}
                       placeholder={`Enter description for ${field.name}`}
                     />
                   </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
@@ -65,11 +65,9 @@ function haveSameServerSelection(a: string[], b: string[]): boolean {
 }
 
 /**
- * Resolves the start block's input fields from the subblock store, falling back
- * to the block's persisted value when the store entry is empty (fields hydrated
- * from block defaults). Shared by the display memo and the description writer so
- * both read the exact same source — a writer that skipped the fallback could
- * persist `[]` and wipe every field.
+ * Resolves the start block's input fields from the subblock store, falling back to
+ * the block's persisted value when the store entry is empty. Shared by the display
+ * memo and the description writer so both read the exact same source.
  */
 function resolveInputFormatFields(
   storeValue: unknown,
@@ -157,11 +155,9 @@ export function McpDeploy({
   const [saveErrors, setSaveErrors] = useState<string[]>([])
 
   /**
-   * Per-parameter descriptions live on the start block's input format — the single
-   * source of truth shared by every deployment surface. The tool's parameter schema
-   * is derived server-side from the deployed workflow on each deploy, so the tool can
-   * never drift from what actually runs and descriptions are never wiped by a redeploy.
-   * Editing a description here mutates the workflow and surfaces the redeploy prompt.
+   * Persists a parameter description to the start block's input format, the single
+   * source the deployed tool schema is derived from. Bails on an empty resolution so
+   * a transient read can never overwrite existing fields.
    */
   const updateFieldDescription = useCallback(
     (fieldName: string, description: string) => {
@@ -170,8 +166,6 @@ export function McpDeploy({
         useSubBlockStore.getState().getValue(starterBlockId, 'inputFormat'),
         useWorkflowStore.getState().blocks[starterBlockId]?.subBlocks?.inputFormat?.value
       )
-      // Never persist an empty list: the description inputs only render when fields
-      // exist, so an empty resolution means a transient state we must not write back.
       if (currentFields.length === 0) return
       const nextFields = currentFields.map((field) =>
         field.name === fieldName ? { ...field, description } : field

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
@@ -77,6 +77,26 @@ function pickRawInputFormat(storeValue: unknown, blockFallbackValue: unknown): u
 }
 
 /**
+ * Extracts real per-parameter descriptions from a previously-saved tool schema,
+ * skipping the synthetic fallbacks the generator emits (the field name itself, or
+ * the file-array placeholder). Used only as a display fallback so descriptions on
+ * legacy tools — saved before descriptions moved to the start block — stay visible.
+ */
+function extractToolSchemaDescriptions(parameterSchema: unknown): Record<string, string> {
+  const properties = (parameterSchema as { properties?: Record<string, { description?: string }> })
+    ?.properties
+  if (!properties) return {}
+  const descriptions: Record<string, string> = {}
+  for (const [name, prop] of Object.entries(properties)) {
+    const description = prop?.description
+    if (description && description !== name && description !== 'Array of file objects') {
+      descriptions[name] = description
+    }
+  }
+  return descriptions
+}
+
+/**
  * Component to query tools for a single server and report back via callback.
  */
 function ServerToolsQuery({
@@ -224,6 +244,14 @@ export function McpDeploy({
     toolName: string
     toolDescription: string
   } | null>(null)
+  /**
+   * Descriptions read from an existing tool's saved schema, shown as a fallback when
+   * the start block has none yet — keeps descriptions from tools saved before the
+   * start-block migration visible. Editing one writes through to the start block.
+   */
+  const [legacyParameterDescriptions, setLegacyParameterDescriptions] = useState<
+    Record<string, string>
+  >({})
 
   useEffect(() => {
     if (savedValues) return
@@ -240,6 +268,7 @@ export function McpDeploy({
 
         setToolName(initialToolName)
         setToolDescription(initialToolDescription)
+        setLegacyParameterDescriptions(extractToolSchemaDescriptions(toolInfo.tool.parameterSchema))
         setSavedValues({
           toolName: initialToolName,
           toolDescription: initialToolDescription,
@@ -542,7 +571,7 @@ export function McpDeploy({
                   <div className='flex flex-col gap-1.5'>
                     <Label className='text-small'>Description</Label>
                     <ChipInput
-                      value={field.description ?? ''}
+                      value={field.description ?? legacyParameterDescriptions[field.name] ?? ''}
                       onChange={(e) => updateFieldDescription(field.name, e.target.value)}
                       placeholder={`Enter description for ${field.name}`}
                     />

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
@@ -65,6 +65,22 @@ function haveSameServerSelection(a: string[], b: string[]): boolean {
 }
 
 /**
+ * Resolves the start block's input fields from the subblock store, falling back
+ * to the block's persisted value when the store entry is empty (fields hydrated
+ * from block defaults). Shared by the display memo and the description writer so
+ * both read the exact same source — a writer that skipped the fallback could
+ * persist `[]` and wipe every field.
+ */
+function resolveInputFormatFields(
+  storeValue: unknown,
+  blockFallbackValue: unknown
+): NormalizedField[] {
+  const fromStore = normalizeInputFormatValue(storeValue) as NormalizedField[]
+  if (fromStore.length > 0) return fromStore
+  return normalizeInputFormatValue(blockFallbackValue) as NormalizedField[]
+}
+
+/**
  * Component to query tools for a single server and report back via callback.
  */
 function ServerToolsQuery({
@@ -127,14 +143,10 @@ export function McpDeploy({
 
   const inputFormat = useMemo((): NormalizedField[] => {
     if (!starterBlockId) return []
-
-    const storeValue = subBlockValues[starterBlockId]?.inputFormat
-    const normalized = normalizeInputFormatValue(storeValue) as NormalizedField[]
-    if (normalized.length > 0) return normalized
-
-    const startBlock = blocks[starterBlockId]
-    const blockValue = startBlock?.subBlocks?.inputFormat?.value
-    return normalizeInputFormatValue(blockValue) as NormalizedField[]
+    return resolveInputFormatFields(
+      subBlockValues[starterBlockId]?.inputFormat,
+      blocks[starterBlockId]?.subBlocks?.inputFormat?.value
+    )
   }, [starterBlockId, subBlockValues, blocks])
 
   const [toolName, setToolName] = useState(() => sanitizeToolName(workflowName))
@@ -154,9 +166,13 @@ export function McpDeploy({
   const updateFieldDescription = useCallback(
     (fieldName: string, description: string) => {
       if (!starterBlockId) return
-      const currentFields = normalizeInputFormatValue(
-        useSubBlockStore.getState().getValue(starterBlockId, 'inputFormat')
-      ) as NormalizedField[]
+      const currentFields = resolveInputFormatFields(
+        useSubBlockStore.getState().getValue(starterBlockId, 'inputFormat'),
+        useWorkflowStore.getState().blocks[starterBlockId]?.subBlocks?.inputFormat?.value
+      )
+      // Never persist an empty list: the description inputs only render when fields
+      // exist, so an empty resolution means a transient state we must not write back.
+      if (currentFields.length === 0) return
       const nextFields = currentFields.map((field) =>
         field.name === fieldName ? { ...field, description } : field
       )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
@@ -65,17 +65,15 @@ function haveSameServerSelection(a: string[], b: string[]): boolean {
 }
 
 /**
- * Resolves the start block's input fields from the subblock store, falling back to
- * the block's persisted value when the store entry is empty. Shared by the display
- * memo and the description writer so both read the exact same source.
+ * Picks the active raw input-format array: the subblock store value, or the block's
+ * persisted value when the store holds no named fields. Returns the array untouched
+ * (no filtering) so the writer can preserve in-progress fields; the display memo
+ * normalizes the result. Shared so both read the exact same source.
  */
-function resolveInputFormatFields(
-  storeValue: unknown,
-  blockFallbackValue: unknown
-): NormalizedField[] {
-  const fromStore = normalizeInputFormatValue(storeValue) as NormalizedField[]
-  if (fromStore.length > 0) return fromStore
-  return normalizeInputFormatValue(blockFallbackValue) as NormalizedField[]
+function pickRawInputFormat(storeValue: unknown, blockFallbackValue: unknown): unknown[] {
+  const storeArray = Array.isArray(storeValue) ? storeValue : []
+  if (normalizeInputFormatValue(storeArray).length > 0) return storeArray
+  return Array.isArray(blockFallbackValue) ? blockFallbackValue : []
 }
 
 /**
@@ -141,10 +139,12 @@ export function McpDeploy({
 
   const inputFormat = useMemo((): NormalizedField[] => {
     if (!starterBlockId) return []
-    return resolveInputFormatFields(
-      subBlockValues[starterBlockId]?.inputFormat,
-      blocks[starterBlockId]?.subBlocks?.inputFormat?.value
-    )
+    return normalizeInputFormatValue(
+      pickRawInputFormat(
+        subBlockValues[starterBlockId]?.inputFormat,
+        blocks[starterBlockId]?.subBlocks?.inputFormat?.value
+      )
+    ) as NormalizedField[]
   }, [starterBlockId, subBlockValues, blocks])
 
   const [toolName, setToolName] = useState(() => sanitizeToolName(workflowName))
@@ -156,19 +156,21 @@ export function McpDeploy({
 
   /**
    * Persists a parameter description to the start block's input format, the single
-   * source the deployed tool schema is derived from. Bails on an empty resolution so
-   * a transient read can never overwrite existing fields.
+   * source the deployed tool schema is derived from. Maps over the raw array so every
+   * other field — including unnamed, in-progress rows — is preserved untouched.
    */
   const updateFieldDescription = useCallback(
     (fieldName: string, description: string) => {
       if (!starterBlockId) return
-      const currentFields = resolveInputFormatFields(
+      const rawFields = pickRawInputFormat(
         useSubBlockStore.getState().getValue(starterBlockId, 'inputFormat'),
         useWorkflowStore.getState().blocks[starterBlockId]?.subBlocks?.inputFormat?.value
       )
-      if (currentFields.length === 0) return
-      const nextFields = currentFields.map((field) =>
-        field.name === fieldName ? { ...field, description } : field
+      if (rawFields.length === 0) return
+      const nextFields = rawFields.map((field) =>
+        field && typeof field === 'object' && (field as { name?: string }).name === fieldName
+          ? { ...field, description }
+          : field
       )
       collaborativeSetSubblockValue(starterBlockId, 'inputFormat', nextFields)
     },

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/deploy-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/deploy-modal.tsx
@@ -126,6 +126,7 @@ export function DeployModal({
   const [undeployTargetWorkflowId, setUndeployTargetWorkflowId] = useState<string | null>(null)
   const [mcpToolSubmitting, setMcpToolSubmitting] = useState(false)
   const [mcpToolCanSave, setMcpToolCanSave] = useState(false)
+  const [mcpToolExposed, setMcpToolExposed] = useState(false)
   const [a2aSubmitting, setA2aSubmitting] = useState(false)
   const [a2aCanSave, setA2aCanSave] = useState(false)
   const [a2aNeedsRepublish, setA2aNeedsRepublish] = useState(false)
@@ -642,6 +643,7 @@ export function DeployModal({
                     isDeployed={isDeployed}
                     onSubmittingChange={setMcpToolSubmitting}
                     onCanSaveChange={setMcpToolCanSave}
+                    onExposedChange={setMcpToolExposed}
                   />
                 )}
               </ModalTabsContent>
@@ -733,7 +735,13 @@ export function DeployModal({
           )}
           {activeTab === 'mcp' && isDeployed && hasMcpServers && (
             <ModalFooter className='items-center justify-between'>
-              <div />
+              {mcpToolExposed ? (
+                <Badge variant={needsRedeployment ? 'amber' : 'green'} size='lg' dot>
+                  {needsRedeployment ? 'Update deployment' : 'Live'}
+                </Badge>
+              ) : (
+                <div />
+              )}
               <div className='flex items-center gap-2'>
                 <Button
                   type='button'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/lib/default-description.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/lib/default-description.ts
@@ -1,8 +1,4 @@
-/**
- * Placeholder descriptions auto-assigned to new workflows. These should be
- * treated as "no description" so deployment surfaces (API info, MCP tool, A2A
- * agent) don't echo boilerplate back to the user as if it were intentional copy.
- */
+/** Placeholder descriptions auto-assigned to new workflows; treated as "no description". */
 const DEFAULT_WORKFLOW_DESCRIPTIONS = [
   'new workflow',
   'your first workflow - start building here!',
@@ -10,9 +6,8 @@ const DEFAULT_WORKFLOW_DESCRIPTIONS = [
 
 /**
  * Returns true when a workflow description is empty or a known auto-generated
- * placeholder (including the workflow name used as a fallback description).
- * Shared by every deployment tab so the "is this a real description?" rule has
- * a single definition.
+ * placeholder (including the workflow name used as a fallback). Shared by every
+ * deployment tab so the "is this a real description?" rule has one definition.
  */
 export function isDefaultDescription(
   description: string | null | undefined,

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/lib/default-description.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/lib/default-description.ts
@@ -1,0 +1,28 @@
+/**
+ * Placeholder descriptions auto-assigned to new workflows. These should be
+ * treated as "no description" so deployment surfaces (API info, MCP tool, A2A
+ * agent) don't echo boilerplate back to the user as if it were intentional copy.
+ */
+const DEFAULT_WORKFLOW_DESCRIPTIONS = [
+  'new workflow',
+  'your first workflow - start building here!',
+] as const
+
+/**
+ * Returns true when a workflow description is empty or a known auto-generated
+ * placeholder (including the workflow name used as a fallback description).
+ * Shared by every deployment tab so the "is this a real description?" rule has
+ * a single definition.
+ */
+export function isDefaultDescription(
+  description: string | null | undefined,
+  workflowName: string
+): boolean {
+  if (!description) return true
+  const normalized = description.toLowerCase().trim()
+  return (
+    normalized === '' ||
+    normalized === workflowName.toLowerCase().trim() ||
+    (DEFAULT_WORKFLOW_DESCRIPTIONS as readonly string[]).includes(normalized)
+  )
+}

--- a/apps/sim/lib/copilot/tools/handlers/deployment/deploy.test.ts
+++ b/apps/sim/lib/copilot/tools/handlers/deployment/deploy.test.ts
@@ -1,0 +1,235 @@
+/**
+ * @vitest-environment node
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ExecutionContext } from '@/lib/copilot/request/types'
+
+const {
+  ensureWorkflowAccessMock,
+  getDeployedWorkflowInputFormatMock,
+  generateParameterSchemaMock,
+  loadWorkflowFromNormalizedTablesMock,
+  saveWorkflowToNormalizedTablesMock,
+  notifyWorkflowUpdatedMock,
+  performCreateWorkflowMcpToolMock,
+  performUpdateWorkflowMcpToolMock,
+} = vi.hoisted(() => ({
+  ensureWorkflowAccessMock: vi.fn(),
+  getDeployedWorkflowInputFormatMock: vi.fn(),
+  generateParameterSchemaMock: vi.fn(),
+  loadWorkflowFromNormalizedTablesMock: vi.fn(),
+  saveWorkflowToNormalizedTablesMock: vi.fn(),
+  notifyWorkflowUpdatedMock: vi.fn(),
+  performCreateWorkflowMcpToolMock: vi.fn(),
+  performUpdateWorkflowMcpToolMock: vi.fn(),
+}))
+
+vi.mock('@sim/db', () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+  chat: {},
+  workflow: {},
+  workflowMcpServer: {},
+  workflowMcpTool: {},
+}))
+
+vi.mock('@/lib/core/utils/urls', () => ({
+  getBaseUrl: () => 'http://localhost:3000',
+}))
+
+vi.mock('@/lib/mcp/orchestration', () => ({
+  performCreateWorkflowMcpTool: performCreateWorkflowMcpToolMock,
+  performUpdateWorkflowMcpTool: performUpdateWorkflowMcpToolMock,
+  performDeleteWorkflowMcpTool: vi.fn(),
+}))
+
+vi.mock('@/lib/mcp/workflow-mcp-sync', () => ({
+  getDeployedWorkflowInputFormat: getDeployedWorkflowInputFormatMock,
+}))
+
+vi.mock('@/lib/mcp/workflow-tool-schema', () => ({
+  generateParameterSchema: generateParameterSchemaMock,
+  sanitizeToolName: (value: string) => value,
+}))
+
+vi.mock('@/lib/workflows/notify-socket', () => ({
+  notifyWorkflowUpdated: notifyWorkflowUpdatedMock,
+}))
+
+vi.mock('@/lib/workflows/orchestration', () => ({
+  performChatDeploy: vi.fn(),
+  performChatUndeploy: vi.fn(),
+  performFullDeploy: vi.fn(),
+  performFullUndeploy: vi.fn(),
+}))
+
+vi.mock('@/lib/workflows/persistence/utils', () => ({
+  loadWorkflowFromNormalizedTables: loadWorkflowFromNormalizedTablesMock,
+  saveWorkflowToNormalizedTables: saveWorkflowToNormalizedTablesMock,
+}))
+
+vi.mock('@/lib/workflows/triggers/input-definition-triggers', () => ({
+  isInputDefinitionTrigger: (type: string | undefined) => type === 'starter',
+}))
+
+vi.mock('@/app/api/chat/utils', () => ({
+  checkChatAccess: vi.fn(),
+  checkWorkflowAccessForChatCreation: vi.fn(),
+}))
+
+vi.mock('../access', () => ({
+  ensureWorkflowAccess: ensureWorkflowAccessMock,
+}))
+
+import { db } from '@sim/db'
+import { executeDeployMcp } from './deploy'
+
+const CONTEXT = { userId: 'user-1', workflowId: 'wf-1' } as ExecutionContext
+
+/** Single-row select chain ending in `.limit()`, matching the handler's queries. */
+function selectChain(result: unknown[]) {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    limit: vi.fn(() => Promise.resolve(result)),
+  }
+  return chain
+}
+
+function updateChain() {
+  const chain = {
+    set: vi.fn(() => chain),
+    where: vi.fn(() => Promise.resolve()),
+  }
+  return chain
+}
+
+/** Draft state with a single start block exposing one `query` input field. */
+function draftWithQueryField(description?: string) {
+  return {
+    blocks: {
+      start: {
+        id: 'start',
+        type: 'starter',
+        subBlocks: {
+          inputFormat: {
+            id: 'inputFormat',
+            type: 'input-format',
+            value: [
+              { id: 'f1', name: 'query', type: 'string', ...(description ? { description } : {}) },
+            ],
+          },
+        },
+      },
+    },
+    edges: [],
+    loops: {},
+    parallels: {},
+  }
+}
+
+function startBlockInputFields(state: { blocks: Record<string, any> }) {
+  return state.blocks.start.subBlocks.inputFormat.value as Array<Record<string, unknown>>
+}
+
+describe('executeDeployMcp parameter-description persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ensureWorkflowAccessMock.mockResolvedValue({
+      workflow: { id: 'wf-1', workspaceId: 'ws-1', name: 'tool', isDeployed: true },
+    })
+    // 1st select = server lookup, 2nd select = existing tool lookup (none).
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([{ id: 'srv-1', name: 'My Server' }]) as never)
+      .mockReturnValueOnce(selectChain([]) as never)
+    vi.mocked(db.update).mockReturnValue(updateChain() as never)
+    getDeployedWorkflowInputFormatMock.mockResolvedValue([{ name: 'query', type: 'string' }])
+    generateParameterSchemaMock.mockReturnValue({ type: 'object', properties: {} })
+    loadWorkflowFromNormalizedTablesMock.mockResolvedValue(draftWithQueryField())
+    saveWorkflowToNormalizedTablesMock.mockResolvedValue({ success: true })
+    performCreateWorkflowMcpToolMock.mockResolvedValue({
+      success: true,
+      tool: { id: 'tool-1', toolName: 'tool' },
+    })
+  })
+
+  it('persists supplied descriptions onto the draft start block and notifies the socket', async () => {
+    const result = await executeDeployMcp(
+      {
+        workflowId: 'wf-1',
+        serverId: 'srv-1',
+        parameterDescriptions: [{ name: 'query', description: 'Search text' }],
+      },
+      CONTEXT
+    )
+
+    expect(result.success).toBe(true)
+    expect(saveWorkflowToNormalizedTablesMock).toHaveBeenCalledTimes(1)
+
+    const [savedWorkflowId, savedState] = saveWorkflowToNormalizedTablesMock.mock.calls[0]
+    expect(savedWorkflowId).toBe('wf-1')
+    const fields = startBlockInputFields(savedState)
+    // Description applied, every other field property preserved.
+    expect(fields[0]).toMatchObject({
+      id: 'f1',
+      name: 'query',
+      type: 'string',
+      description: 'Search text',
+    })
+    expect(notifyWorkflowUpdatedMock).toHaveBeenCalledWith('wf-1')
+
+    // The tool schema is still generated with the descriptions for immediate effect.
+    expect(generateParameterSchemaMock).toHaveBeenCalledWith([{ name: 'query', type: 'string' }], {
+      query: 'Search text',
+    })
+    expect(performCreateWorkflowMcpToolMock).toHaveBeenCalledWith(
+      expect.objectContaining({ parameterSchema: { type: 'object', properties: {} } })
+    )
+  })
+
+  it('does not touch the draft when no descriptions are supplied', async () => {
+    const result = await executeDeployMcp({ workflowId: 'wf-1', serverId: 'srv-1' }, CONTEXT)
+
+    expect(result.success).toBe(true)
+    expect(loadWorkflowFromNormalizedTablesMock).not.toHaveBeenCalled()
+    expect(saveWorkflowToNormalizedTablesMock).not.toHaveBeenCalled()
+    expect(notifyWorkflowUpdatedMock).not.toHaveBeenCalled()
+  })
+
+  it('does not write when the supplied description already matches the start block', async () => {
+    loadWorkflowFromNormalizedTablesMock.mockResolvedValue(draftWithQueryField('Search text'))
+
+    const result = await executeDeployMcp(
+      {
+        workflowId: 'wf-1',
+        serverId: 'srv-1',
+        parameterDescriptions: [{ name: 'query', description: 'Search text' }],
+      },
+      CONTEXT
+    )
+
+    expect(result.success).toBe(true)
+    expect(loadWorkflowFromNormalizedTablesMock).toHaveBeenCalledTimes(1)
+    expect(saveWorkflowToNormalizedTablesMock).not.toHaveBeenCalled()
+    expect(notifyWorkflowUpdatedMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores descriptions for fields that are not in the start block', async () => {
+    const result = await executeDeployMcp(
+      {
+        workflowId: 'wf-1',
+        serverId: 'srv-1',
+        parameterDescriptions: [{ name: 'nonexistent', description: 'orphan' }],
+      },
+      CONTEXT
+    )
+
+    expect(result.success).toBe(true)
+    // Field doesn't exist → nothing changes → no write.
+    expect(saveWorkflowToNormalizedTablesMock).not.toHaveBeenCalled()
+    expect(notifyWorkflowUpdatedMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/lib/copilot/tools/handlers/deployment/deploy.ts
+++ b/apps/sim/lib/copilot/tools/handlers/deployment/deploy.ts
@@ -1,5 +1,5 @@
 import { db } from '@sim/db'
-import { chat, workflowMcpServer, workflowMcpTool } from '@sim/db/schema'
+import { chat, workflowMcpServer, workflowMcpTool, workflow as workflowTable } from '@sim/db/schema'
 import { toError } from '@sim/utils/errors'
 import { and, eq, isNull } from 'drizzle-orm'
 import type { ExecutionContext, ToolCallResult } from '@/lib/copilot/request/types'
@@ -11,13 +11,20 @@ import {
 } from '@/lib/mcp/orchestration'
 import { getDeployedWorkflowInputFormat } from '@/lib/mcp/workflow-mcp-sync'
 import { generateParameterSchema, sanitizeToolName } from '@/lib/mcp/workflow-tool-schema'
+import { notifyWorkflowUpdated } from '@/lib/workflows/notify-socket'
 import {
   performChatDeploy,
   performChatUndeploy,
   performFullDeploy,
   performFullUndeploy,
 } from '@/lib/workflows/orchestration'
+import {
+  loadWorkflowFromNormalizedTables,
+  saveWorkflowToNormalizedTables,
+} from '@/lib/workflows/persistence/utils'
+import { isInputDefinitionTrigger } from '@/lib/workflows/triggers/input-definition-triggers'
 import { checkChatAccess, checkWorkflowAccessForChatCreation } from '@/app/api/chat/utils'
+import type { BlockState, WorkflowState } from '@/stores/workflows/workflow/types'
 import { ensureWorkflowAccess } from '../access'
 import type { DeployApiParams, DeployChatParams, DeployMcpParams } from '../param-types'
 
@@ -487,6 +494,75 @@ export async function executeDeployChat(
   }
 }
 
+/**
+ * Persists per-parameter descriptions onto the workflow's draft start block input
+ * format — the single source of truth the deployed tool schema is regenerated from.
+ * Writing them here (rather than only onto the tool) keeps them durable: a later
+ * redeploy regenerates the tool schema from these fields instead of wiping them.
+ * Matches fields by name, preserves every other field property, and no-ops when
+ * nothing changes. Mirrors the load → mutate → save → notify pattern used by the
+ * copilot workflow mutation handlers.
+ */
+async function persistParameterDescriptionsToStartBlock(
+  workflowId: string,
+  descriptions: Record<string, string>
+): Promise<void> {
+  if (Object.keys(descriptions).length === 0) return
+
+  const normalized = await loadWorkflowFromNormalizedTables(workflowId)
+  if (!normalized?.blocks) return
+
+  const blocks = normalized.blocks as Record<string, BlockState>
+  const startBlockId = Object.keys(blocks).find((id) => isInputDefinitionTrigger(blocks[id]?.type))
+  if (!startBlockId) return
+
+  const startBlock = blocks[startBlockId]
+  const inputFormatSubBlock = startBlock.subBlocks?.inputFormat
+  const rawFields = inputFormatSubBlock?.value
+  if (!Array.isArray(rawFields) || rawFields.length === 0) return
+
+  let changed = false
+  const nextFields = rawFields.map((field) => {
+    if (!field || typeof field !== 'object') return field
+    const name = (field as { name?: string }).name
+    if (!name || !(name in descriptions)) return field
+    const nextDescription = descriptions[name]
+    if ((field as { description?: string }).description === nextDescription) return field
+    changed = true
+    return { ...field, description: nextDescription }
+  })
+  if (!changed) return
+
+  const nextState: WorkflowState = {
+    blocks: {
+      ...blocks,
+      [startBlockId]: {
+        ...startBlock,
+        subBlocks: {
+          ...startBlock.subBlocks,
+          inputFormat: { ...inputFormatSubBlock, value: nextFields },
+        },
+      },
+    },
+    edges: normalized.edges || [],
+    loops: normalized.loops || {},
+    parallels: normalized.parallels || {},
+    lastSaved: Date.now(),
+  }
+
+  const saveResult = await saveWorkflowToNormalizedTables(workflowId, nextState)
+  if (!saveResult.success) {
+    throw new Error(saveResult.error || 'Failed to persist parameter descriptions')
+  }
+
+  await db
+    .update(workflowTable)
+    .set({ lastSynced: new Date(), updatedAt: new Date() })
+    .where(eq(workflowTable.id, workflowId))
+
+  notifyWorkflowUpdated(workflowId)
+}
+
 export async function executeDeployMcp(
   params: DeployMcpParams,
   context: ExecutionContext
@@ -607,10 +683,13 @@ export async function executeDeployMcp(
       workflowRecord.description ||
       `Execute ${workflowRecord.name} workflow`
     /**
-     * Build the parameter schema exactly as the deploy modal does: overlay the
-     * caller-supplied per-parameter descriptions onto the workflow's deployed
-     * input format, then generate the schema. Names/types/required come from the
-     * workflow's input trigger — this tool only sets descriptions.
+     * Descriptions are workflow-input data: persist them onto the draft start block
+     * so they live with the workflow and survive future redeploys (single source of
+     * truth, matching the deploy modal). Then build the tool schema from the deployed
+     * input format overlaid with the same descriptions so the tool is correct
+     * immediately — the deploy modal relies on a redeploy for this, but this tool
+     * doesn't redeploy, so it sets the schema directly. Both paths converge: the next
+     * redeploy regenerates the schema from these now-persisted start-block fields.
      */
     const inputFormat = await getDeployedWorkflowInputFormat(workflowId)
     const parameterDescriptions = Object.fromEntries(
@@ -618,6 +697,7 @@ export async function executeDeployMcp(
         .filter((entry) => entry && typeof entry.name === 'string' && entry.name.trim() !== '')
         .map((entry) => [entry.name, entry.description ?? ''])
     )
+    await persistParameterDescriptionsToStartBlock(workflowId, parameterDescriptions)
     const parameterSchema = generateParameterSchema(inputFormat, parameterDescriptions)
     const baseUrl = getBaseUrl()
     const mcpServerUrl = `${baseUrl}/api/mcp/serve/${serverId}`

--- a/apps/sim/lib/copilot/tools/handlers/workflow/mutations.ts
+++ b/apps/sim/lib/copilot/tools/handlers/workflow/mutations.ts
@@ -7,15 +7,14 @@ import { mergeSubblockStateWithValues } from '@sim/workflow-persistence/subblock
 import { eq } from 'drizzle-orm'
 import { performCreateWorkspaceApiKey } from '@/lib/api-key/orchestration'
 import type { ExecutionContext, ToolCallResult } from '@/lib/copilot/request/types'
-import { env } from '@/lib/core/config/env'
 import { generateRequestId } from '@/lib/core/utils/request'
-import { getSocketServerUrl } from '@/lib/core/utils/urls'
 import { executeWorkflow } from '@/lib/workflows/executor/execute-workflow'
 import {
   getExecutionInputForWorkflow,
   getExecutionStateForWorkflow,
   getLatestExecutionStateWithExecutionId,
 } from '@/lib/workflows/executor/execution-state'
+import { notifyWorkflowUpdated } from '@/lib/workflows/notify-socket'
 import {
   performCreateFolder,
   performCreateWorkflow,
@@ -285,19 +284,6 @@ function findDescendants(containerId: string, blocksById: Record<string, BlockSt
   }
 
   return descendants
-}
-
-function notifyWorkflowUpdated(workflowId: string): void {
-  fetch(`${getSocketServerUrl()}/api/workflow-updated`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': env.INTERNAL_API_SECRET,
-    },
-    body: JSON.stringify({ workflowId }),
-  }).catch((error) => {
-    logger.warn('Failed to notify socket server of workflow update', { workflowId, error })
-  })
 }
 
 import type {

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/index.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/index.ts
@@ -10,8 +10,6 @@ import {
   type BaseServerTool,
   type ServerToolContext,
 } from '@/lib/copilot/tools/server/base-tool'
-import { env } from '@/lib/core/config/env'
-import { getSocketServerUrl } from '@/lib/core/utils/urls'
 import {
   applyTargetedLayout,
   getTargetedLayoutImpact,
@@ -21,6 +19,7 @@ import {
   DEFAULT_HORIZONTAL_SPACING,
   DEFAULT_VERTICAL_SPACING,
 } from '@/lib/workflows/autolayout/constants'
+import { notifyWorkflowUpdated } from '@/lib/workflows/notify-socket'
 import { extractAndPersistCustomTools } from '@/lib/workflows/persistence/custom-tools-persistence'
 import {
   loadWorkflowFromNormalizedTables,
@@ -345,16 +344,7 @@ export const editWorkflowServerTool: BaseServerTool<EditWorkflowParams, unknown>
 
     logger.info('Workflow state persisted to database', { workflowId })
 
-    fetch(`${getSocketServerUrl()}/api/workflow-updated`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': env.INTERNAL_API_SECRET,
-      },
-      body: JSON.stringify({ workflowId }),
-    }).catch((error) => {
-      logger.warn('Failed to notify socket server of workflow update', { workflowId, error })
-    })
+    notifyWorkflowUpdated(workflowId)
 
     const sanitizationWarnings = validation.warnings.length > 0 ? validation.warnings : undefined
 

--- a/apps/sim/lib/workflows/notify-socket.ts
+++ b/apps/sim/lib/workflows/notify-socket.ts
@@ -1,0 +1,24 @@
+import { createLogger } from '@sim/logger'
+import { env } from '@/lib/core/config/env'
+import { getSocketServerUrl } from '@/lib/core/utils/urls'
+
+const logger = createLogger('NotifyWorkflowSocket')
+
+/**
+ * Notifies the realtime socket server that a workflow's persisted state changed
+ * out-of-band (e.g. a server-side copilot mutation), so connected editors refetch
+ * instead of showing stale canvas state. Fire-and-forget: failures are logged, not
+ * thrown, since the persisted change has already succeeded.
+ */
+export function notifyWorkflowUpdated(workflowId: string): void {
+  fetch(`${getSocketServerUrl()}/api/workflow-updated`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': env.INTERNAL_API_SECRET,
+    },
+    body: JSON.stringify({ workflowId }),
+  }).catch((error) => {
+    logger.warn('Failed to notify socket server of workflow update', { workflowId, error })
+  })
+}


### PR DESCRIPTION
## Summary
- Make the start block's input format the single source of truth for MCP tool parameter descriptions — the deploy modal now writes them back collaboratively, so they persist with the workflow and survive redeploys (fixes descriptions getting wiped on workflow edits)
- Derive the tool parameter schema from the **deployed** workflow rather than the draft, so a saved tool can never advertise params the running workflow doesn't have
- Add a `Live` / `Update deployment` status badge to the MCP tab, mirroring the A2A tab, so drift between the tool and the deployed workflow is visible and actionable
- Swap the legacy `Textarea` for `ChipTextarea` on the tool Description (it predated `ChipTextarea` and was never migrated)
- Extract the duplicated `isDefaultDescription` helper (copy-pasted across the MCP, A2A, and API-info surfaces) into one shared util

## Context
The MCP tab had three competing sources of truth for parameter descriptions (start block, a private modal overlay, and the saved tool schema) that silently overwrote each other. The result: descriptions wiped on every redeploy, and a "Save Tool" that could push a param set different from what the deployed workflow actually runs. This collapses everything to one rule: **the MCP tool always mirrors the deployed workflow.**

## Type of Change
- [x] Bug fix
- [x] Improvement

## Testing
Tested manually; typecheck, lint, and \`check:api-validation\` pass.

## Follow-up (not in this PR)
- The copilot \`deploy_mcp\` tool still sets parameter descriptions directly on the tool rather than on the start block, so copilot-set descriptions could still be regenerated on redeploy. Aligning it is a separate change on a different surface.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)