### PR TITLE
feat(blocks): add external-service url to block metadata

### DIFF
--- a/.agents/skills/add-block/SKILL.md
+++ b/.agents/skills/add-block/SKILL.md
@@ -640,6 +640,7 @@ import type { BlockConfig, BlockMeta } from '@/blocks/types'
 
 export const {Service}BlockMeta = {
   tags: ['messaging', 'automation'],   // Same tags as the block's tags field
+  url: 'https://{service}.com',         // Canonical homepage of the external service
   templates: [                          // Optional but strongly encouraged
     {
       icon: {Service}Icon,
@@ -666,6 +667,7 @@ export const {Service}BlockMeta = {
 
 - **Import `BlockMeta`** from `@/blocks/types` alongside `BlockConfig`
 - **`tags`** must match the `tags` array on the block config exactly
+- **`url`** is the canonical homepage of the external service the block integrates with (e.g. `'https://exa.ai'`, `'https://salesforce.com'`) — the catalog "link back to the tool". It is distinct from `BlockConfig.docsLink`, which points at Sim's own integration docs on `docs.sim.ai`. Use the service's real root domain over `https` (verify it actually resolves), no tracking params, no trailing slash. Omit `url` only for first-party/built-in blocks that have no external service (e.g. `agent`, `function`, `condition`, `api`, `response`)
 - **Templates are optional** but should be added for any integration that has a recognizable use case — aim for 2–4 templates per block
 - **Template `prompt`** should start with "Build a workflow that..." or "Create a workflow that..." and be concrete enough to generate a real workflow in Mothership
 - **Template `modules`** lists the Sim modules the template relies on: `'knowledge-base' | 'tables' | 'files' | 'workflows' | 'scheduled' | 'agent'`
@@ -906,6 +908,7 @@ All tool IDs referenced in `tools.access` and returned by `tools.config.tool` MU
 - [ ] Outputs match tool outputs
 - [ ] Block registered in `registry.ts` blocks object (alphabetically)
 - [ ] `{Service}BlockMeta` exported at bottom of block file with `tags` and `templates`
+- [ ] `url` set on `{Service}BlockMeta` to the external service's verified homepage (omit only for first-party blocks with no external service)
 - [ ] `skills` added to `{Service}BlockMeta`, each grounded in the block's `tools.access` and derived from a real online-sourced use case (not invented)
 - [ ] `BlockMeta` imported from `@/blocks/types` alongside `BlockConfig`
 - [ ] Block meta registered in `registry.ts` blocksMeta object (alphabetically)

--- a/.claude/commands/add-block.md
+++ b/.claude/commands/add-block.md
@@ -794,6 +794,7 @@ import type { BlockMeta } from '@/blocks/types'
 
 export const {Service}BlockMeta = {
   tags: ['tag1', 'tag2'],                  // IntegrationTag[]
+  url: 'https://{service}.com',            // external service homepage (verify it resolves) — NOT docs.sim.ai
   templates: [
     {
       icon: {Service}Icon,
@@ -845,6 +846,7 @@ Derive templates from the service's real use cases. Each prompt should name a co
 - [ ] Optional/rarely-used fields set to `mode: 'advanced'`
 - [ ] Timestamps and complex inputs have `wandConfig` enabled
 - [ ] Exported `{Service}BlockMeta` with at least 7 templates
+- [ ] `url` set on `{Service}BlockMeta` to the external service's verified homepage (omit only for first-party blocks with no external service)
 - [ ] `skills` added to `{Service}BlockMeta`, each grounded in `tools.access` and sourced from a real online use case (not invented)
 
 ## Final Validation (Required)

--- a/apps/sim/blocks/blocks/agentmail.ts
+++ b/apps/sim/blocks/blocks/agentmail.ts
@@ -623,6 +623,7 @@ export const AgentMailBlock: BlockConfig = {
 
 export const AgentMailBlockMeta = {
   tags: ['messaging', 'automation'],
+  url: 'https://agentmail.to',
   templates: [
     {
       icon: AgentMailIcon,

--- a/apps/sim/blocks/blocks/agentphone.ts
+++ b/apps/sim/blocks/blocks/agentphone.ts
@@ -752,6 +752,7 @@ export const AgentPhoneBlock: BlockConfig = {
 
 export const AgentPhoneBlockMeta = {
   tags: ['messaging', 'automation'],
+  url: 'https://agentphone.ai',
   templates: [
     {
       icon: AgentPhoneIcon,

--- a/apps/sim/blocks/blocks/agiloft.ts
+++ b/apps/sim/blocks/blocks/agiloft.ts
@@ -433,7 +433,8 @@ export const AgiloftBlock: BlockConfig = {
 }
 
 export const AgiloftBlockMeta = {
-  tags: ['automation'],
+  tags: ['automation', 'e-signatures'],
+  url: 'https://www.agiloft.com',
   templates: [
     {
       icon: AgiloftIcon,

--- a/apps/sim/blocks/blocks/agiloft.ts
+++ b/apps/sim/blocks/blocks/agiloft.ts
@@ -433,7 +433,7 @@ export const AgiloftBlock: BlockConfig = {
 }
 
 export const AgiloftBlockMeta = {
-  tags: ['automation', 'e-signatures'],
+  tags: ['automation'],
   url: 'https://www.agiloft.com',
   templates: [
     {

--- a/apps/sim/blocks/blocks/ahrefs.ts
+++ b/apps/sim/blocks/blocks/ahrefs.ts
@@ -575,6 +575,7 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
 
 export const AhrefsBlockMeta = {
   tags: ['seo', 'marketing', 'data-analytics'],
+  url: 'https://ahrefs.com',
   templates: [
     {
       icon: AhrefsIcon,

--- a/apps/sim/blocks/blocks/airtable.ts
+++ b/apps/sim/blocks/blocks/airtable.ts
@@ -348,6 +348,7 @@ Return ONLY the valid JSON object - no explanations, no markdown.`,
 
 export const AirtableBlockMeta = {
   tags: ['spreadsheet', 'automation'],
+  url: 'https://www.airtable.com',
   templates: [
     {
       icon: AirtableIcon,

--- a/apps/sim/blocks/blocks/airweave.ts
+++ b/apps/sim/blocks/blocks/airweave.ts
@@ -105,6 +105,7 @@ export const AirweaveBlock: BlockConfig<AirweaveSearchResponse> = {
 
 export const AirweaveBlockMeta = {
   tags: ['vector-search', 'knowledge-base'],
+  url: 'https://airweave.ai',
   templates: [
     {
       icon: AirweaveIcon,

--- a/apps/sim/blocks/blocks/algolia.ts
+++ b/apps/sim/blocks/blocks/algolia.ts
@@ -649,6 +649,7 @@ Return ONLY the JSON array.`,
 
 export const AlgoliaBlockMeta = {
   tags: ['vector-search', 'knowledge-base'],
+  url: 'https://www.algolia.com',
   templates: [
     {
       icon: AlgoliaIcon,

--- a/apps/sim/blocks/blocks/amplitude.ts
+++ b/apps/sim/blocks/blocks/amplitude.ts
@@ -748,6 +748,7 @@ export const AmplitudeBlock: BlockConfig = {
 
 export const AmplitudeBlockMeta = {
   tags: ['data-analytics', 'marketing'],
+  url: 'https://amplitude.com',
   templates: [
     {
       icon: AmplitudeIcon,

--- a/apps/sim/blocks/blocks/apify.ts
+++ b/apps/sim/blocks/blocks/apify.ts
@@ -240,6 +240,7 @@ Return ONLY the valid JSON object - no explanations, no markdown.`,
 
 export const ApifyBlockMeta = {
   tags: ['web-scraping', 'automation', 'data-analytics'],
+  url: 'https://apify.com',
   templates: [
     {
       icon: ApifyIcon,

--- a/apps/sim/blocks/blocks/apollo.ts
+++ b/apps/sim/blocks/blocks/apollo.ts
@@ -1375,6 +1375,7 @@ Return ONLY the timestamp string in ISO 8601 format - no explanations, no quotes
 
 export const ApolloBlockMeta = {
   tags: ['enrichment', 'sales-engagement'],
+  url: 'https://www.apollo.io',
   templates: [
     {
       icon: Users,

--- a/apps/sim/blocks/blocks/appconfig.ts
+++ b/apps/sim/blocks/blocks/appconfig.ts
@@ -588,6 +588,7 @@ export const AppConfigBlock: BlockConfig<
 
 export const AppConfigBlockMeta = {
   tags: ['cloud', 'feature-flags', 'automation'],
+  url: 'https://aws.amazon.com/systems-manager/features/appconfig',
   templates: [
     {
       icon: AppConfigIcon,

--- a/apps/sim/blocks/blocks/arxiv.ts
+++ b/apps/sim/blocks/blocks/arxiv.ts
@@ -156,6 +156,7 @@ export const ArxivBlock: BlockConfig<ArxivResponse> = {
 
 export const ArxivBlockMeta = {
   tags: ['document-processing', 'knowledge-base'],
+  url: 'https://arxiv.org',
   templates: [
     {
       icon: ArxivIcon,

--- a/apps/sim/blocks/blocks/asana.ts
+++ b/apps/sim/blocks/blocks/asana.ts
@@ -369,6 +369,7 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
 
 export const AsanaBlockMeta = {
   tags: ['project-management', 'ticketing', 'automation'],
+  url: 'https://asana.com',
   templates: [
     {
       icon: AsanaIcon,

--- a/apps/sim/blocks/blocks/ashby.ts
+++ b/apps/sim/blocks/blocks/ashby.ts
@@ -970,6 +970,7 @@ Output only the ISO 8601 timestamp string, nothing else.`,
 
 export const AshbyBlockMeta = {
   tags: ['hiring'],
+  url: 'https://ashbyhq.com',
   templates: [
     {
       icon: AshbyIcon,

--- a/apps/sim/blocks/blocks/athena.ts
+++ b/apps/sim/blocks/blocks/athena.ts
@@ -470,6 +470,7 @@ Return ONLY the SQL query — no explanations, no markdown code blocks.`,
 
 export const AthenaBlockMeta = {
   tags: ['cloud', 'data-analytics'],
+  url: 'https://aws.amazon.com/athena',
   templates: [
     {
       icon: AthenaIcon,

--- a/apps/sim/blocks/blocks/attio.ts
+++ b/apps/sim/blocks/blocks/attio.ts
@@ -1327,6 +1327,7 @@ workspace-member.created
 
 export const AttioBlockMeta = {
   tags: ['sales-engagement', 'enrichment'],
+  url: 'https://attio.com',
   templates: [
     {
       icon: AttioIcon,

--- a/apps/sim/blocks/blocks/azure_devops.ts
+++ b/apps/sim/blocks/blocks/azure_devops.ts
@@ -627,6 +627,7 @@ export const AzureDevOpsBlock: BlockConfig<AzureDevOpsResponse> = {
 
 export const AzureDevOpsBlockMeta = {
   tags: ['version-control', 'ci-cd', 'project-management'],
+  url: 'https://azure.microsoft.com/products/devops',
   templates: [
     {
       icon: AzureIcon,

--- a/apps/sim/blocks/blocks/box.ts
+++ b/apps/sim/blocks/blocks/box.ts
@@ -601,6 +601,7 @@ export const BoxBlock: BlockConfig = {
 
 export const BoxBlockMeta = {
   tags: ['cloud', 'content-management', 'e-signatures'],
+  url: 'https://www.box.com',
   templates: [
     {
       icon: BoxCompanyIcon,

--- a/apps/sim/blocks/blocks/brandfetch.ts
+++ b/apps/sim/blocks/blocks/brandfetch.ts
@@ -100,6 +100,7 @@ export const BrandfetchBlock: BlockConfig<BrandfetchGetBrandResponse | Brandfetc
 
 export const BrandfetchBlockMeta = {
   tags: ['enrichment', 'marketing'],
+  url: 'https://brandfetch.com',
   templates: [
     {
       icon: BrandfetchIcon,

--- a/apps/sim/blocks/blocks/brex.ts
+++ b/apps/sim/blocks/blocks/brex.ts
@@ -572,6 +572,7 @@ export const BrexBlock: BlockConfig<BrexResponse> = {
 
 export const BrexBlockMeta = {
   tags: ['payments'],
+  url: 'https://www.brex.com',
   templates: [
     {
       icon: BrexIcon,

--- a/apps/sim/blocks/blocks/brightdata.ts
+++ b/apps/sim/blocks/blocks/brightdata.ts
@@ -346,6 +346,7 @@ export const BrightDataBlock: BlockConfig<BrightDataResponse> = {
 
 export const BrightDataBlockMeta = {
   tags: ['web-scraping', 'automation'],
+  url: 'https://brightdata.com',
   templates: [
     {
       icon: BrightDataIcon,

--- a/apps/sim/blocks/blocks/browser_use.ts
+++ b/apps/sim/blocks/blocks/browser_use.ts
@@ -214,6 +214,7 @@ export const BrowserUseBlock: BlockConfig<BrowserUseResponse> = {
 
 export const BrowserUseBlockMeta = {
   tags: ['web-scraping', 'automation', 'agentic'],
+  url: 'https://browser-use.com',
   templates: [
     {
       icon: BrowserUseIcon,

--- a/apps/sim/blocks/blocks/calcom.ts
+++ b/apps/sim/blocks/blocks/calcom.ts
@@ -920,6 +920,7 @@ Return ONLY valid JSON - no explanations.`,
 
 export const CalComBlockMeta = {
   tags: ['scheduling', 'calendar', 'meeting'],
+  url: 'https://cal.com',
   templates: [
     {
       icon: CalComIcon,

--- a/apps/sim/blocks/blocks/calendly.ts
+++ b/apps/sim/blocks/blocks/calendly.ts
@@ -330,6 +330,7 @@ Return ONLY the timestamp string in ISO 8601 format - no explanations, no quotes
 
 export const CalendlyBlockMeta = {
   tags: ['scheduling', 'calendar', 'meeting'],
+  url: 'https://calendly.com',
   templates: [
     {
       icon: CalendlyIcon,

--- a/apps/sim/blocks/blocks/circleback.ts
+++ b/apps/sim/blocks/blocks/circleback.ts
@@ -54,6 +54,7 @@ export const CirclebackBlock: BlockConfig = {
 
 export const CirclebackBlockMeta = {
   tags: ['meeting', 'note-taking'],
+  url: 'https://circleback.ai',
   templates: [
     {
       icon: CirclebackIcon,

--- a/apps/sim/blocks/blocks/clay.ts
+++ b/apps/sim/blocks/blocks/clay.ts
@@ -71,6 +71,7 @@ Plain Text: Best for populating a table in free-form style.
 
 export const ClayBlockMeta = {
   tags: ['enrichment', 'sales-engagement', 'data-analytics'],
+  url: 'https://www.clay.com',
   templates: [
     {
       icon: ClayIcon,

--- a/apps/sim/blocks/blocks/clerk.ts
+++ b/apps/sim/blocks/blocks/clerk.ts
@@ -412,6 +412,7 @@ export const ClerkBlock: BlockConfig<ClerkResponse> = {
 
 export const ClerkBlockMeta = {
   tags: ['identity', 'automation'],
+  url: 'https://clerk.com',
   templates: [
     {
       icon: ClerkIcon,

--- a/apps/sim/blocks/blocks/clickhouse.ts
+++ b/apps/sim/blocks/blocks/clickhouse.ts
@@ -467,6 +467,7 @@ export const ClickHouseBlock: BlockConfig<ClickHouseResponse> = {
 
 export const ClickHouseBlockMeta = {
   tags: ['data-warehouse', 'data-analytics'],
+  url: 'https://clickhouse.com',
   templates: [
     {
       icon: ClickHouseIcon,

--- a/apps/sim/blocks/blocks/cloudflare.ts
+++ b/apps/sim/blocks/blocks/cloudflare.ts
@@ -1100,6 +1100,7 @@ Return ONLY the comma-separated URLs - no explanations, no extra text.`,
 
 export const CloudflareBlockMeta = {
   tags: ['cloud', 'monitoring'],
+  url: 'https://www.cloudflare.com',
   templates: [
     {
       icon: CloudflareIcon,

--- a/apps/sim/blocks/blocks/cloudformation.ts
+++ b/apps/sim/blocks/blocks/cloudformation.ts
@@ -331,6 +331,7 @@ export const CloudFormationBlock: BlockConfig<
 
 export const CloudFormationBlockMeta = {
   tags: ['cloud'],
+  url: 'https://aws.amazon.com/cloudformation',
   templates: [
     {
       icon: CloudFormationIcon,

--- a/apps/sim/blocks/blocks/cloudwatch.ts
+++ b/apps/sim/blocks/blocks/cloudwatch.ts
@@ -879,6 +879,7 @@ Return ONLY the numeric timestamp - no explanations, no quotes, no extra text.`,
 
 export const CloudWatchBlockMeta = {
   tags: ['cloud', 'monitoring'],
+  url: 'https://aws.amazon.com/cloudwatch',
   templates: [
     {
       icon: CloudWatchIcon,

--- a/apps/sim/blocks/blocks/codepipeline.ts
+++ b/apps/sim/blocks/blocks/codepipeline.ts
@@ -504,6 +504,7 @@ export const CodePipelineBlock: BlockConfig<
 
 export const CodePipelineBlockMeta = {
   tags: ['cloud', 'ci-cd'],
+  url: 'https://aws.amazon.com/codepipeline',
   templates: [
     {
       icon: CodePipelineIcon,

--- a/apps/sim/blocks/blocks/confluence.ts
+++ b/apps/sim/blocks/blocks/confluence.ts
@@ -1604,6 +1604,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
 
 export const ConfluenceBlockMeta = {
   tags: ['knowledge-base', 'content-management', 'note-taking'],
+  url: 'https://www.atlassian.com/software/confluence',
   templates: [
     {
       icon: PagerDutyIcon,

--- a/apps/sim/blocks/blocks/convex.ts
+++ b/apps/sim/blocks/blocks/convex.ts
@@ -199,6 +199,7 @@ Return ONLY the JSON object - no explanations, no markdown, no extra text.`,
 
 export const ConvexBlockMeta = {
   tags: ['cloud'],
+  url: 'https://www.convex.dev',
   templates: [
     {
       icon: ConvexIcon,

--- a/apps/sim/blocks/blocks/crowdstrike.ts
+++ b/apps/sim/blocks/blocks/crowdstrike.ts
@@ -213,6 +213,7 @@ export const CrowdStrikeBlock: BlockConfig<CrowdStrikeResponse> = {
 
 export const CrowdStrikeBlockMeta = {
   tags: ['identity', 'monitoring'],
+  url: 'https://www.crowdstrike.com',
   templates: [
     {
       icon: CrowdStrikeIcon,

--- a/apps/sim/blocks/blocks/cursor.ts
+++ b/apps/sim/blocks/blocks/cursor.ts
@@ -280,6 +280,7 @@ export const CursorV2Block: BlockConfig<CursorResponse> = {
 
 export const CursorBlockMeta = {
   tags: ['agentic', 'automation'],
+  url: 'https://cursor.com',
   templates: [
     {
       icon: CursorIcon,

--- a/apps/sim/blocks/blocks/dagster.ts
+++ b/apps/sim/blocks/blocks/dagster.ts
@@ -671,6 +671,7 @@ Return ONLY the comma-separated asset keys - no explanations, no extra text.`,
 
 export const DagsterBlockMeta = {
   tags: ['data-analytics', 'automation'],
+  url: 'https://dagster.io',
   templates: [
     {
       icon: DagsterIcon,

--- a/apps/sim/blocks/blocks/databricks.ts
+++ b/apps/sim/blocks/blocks/databricks.ts
@@ -474,6 +474,7 @@ Return ONLY the numeric timestamp in milliseconds - no explanations, no extra te
 
 export const DatabricksBlockMeta = {
   tags: ['data-warehouse', 'data-analytics', 'cloud'],
+  url: 'https://www.databricks.com',
   templates: [
     {
       icon: DatabricksIcon,

--- a/apps/sim/blocks/blocks/datadog.ts
+++ b/apps/sim/blocks/blocks/datadog.ts
@@ -836,6 +836,7 @@ Return ONLY the numeric timestamp - no explanations, no quotes, no extra text.`,
 
 export const DatadogBlockMeta = {
   tags: ['monitoring', 'incident-management', 'error-tracking'],
+  url: 'https://www.datadoghq.com',
   templates: [
     {
       icon: DatadogIcon,

--- a/apps/sim/blocks/blocks/daytona.ts
+++ b/apps/sim/blocks/blocks/daytona.ts
@@ -565,6 +565,7 @@ export const DaytonaBlock: BlockConfig = {
 
 export const DaytonaBlockMeta = {
   tags: ['agentic', 'cloud', 'automation'],
+  url: 'https://www.daytona.io',
   templates: [
     {
       icon: DaytonaIcon,

--- a/apps/sim/blocks/blocks/devin.ts
+++ b/apps/sim/blocks/blocks/devin.ts
@@ -319,6 +319,7 @@ RULES:
 
 export const DevinBlockMeta = {
   tags: ['agentic', 'automation'],
+  url: 'https://devin.ai',
   templates: [
     {
       icon: DevinIcon,

--- a/apps/sim/blocks/blocks/discord.ts
+++ b/apps/sim/blocks/blocks/discord.ts
@@ -799,6 +799,7 @@ export const DiscordBlock: BlockConfig<DiscordResponse> = {
 
 export const DiscordBlockMeta = {
   tags: ['messaging', 'webhooks', 'automation'],
+  url: 'https://discord.com',
   templates: [
     {
       icon: DiscordIcon,

--- a/apps/sim/blocks/blocks/docusign.ts
+++ b/apps/sim/blocks/blocks/docusign.ts
@@ -375,6 +375,7 @@ export const DocuSignBlock: BlockConfig<DocuSignResponse> = {
 
 export const DocuSignBlockMeta = {
   tags: ['e-signatures', 'document-processing'],
+  url: 'https://www.docusign.com',
   templates: [
     {
       icon: DocuSignIcon,

--- a/apps/sim/blocks/blocks/dropbox.ts
+++ b/apps/sim/blocks/blocks/dropbox.ts
@@ -404,6 +404,7 @@ Return ONLY the timestamp string - no explanations, no quotes, no extra text.`,
 
 export const DropboxBlockMeta = {
   tags: ['cloud', 'document-processing'],
+  url: 'https://www.dropbox.com',
   templates: [
     {
       icon: DropboxIcon,

--- a/apps/sim/blocks/blocks/dspy.ts
+++ b/apps/sim/blocks/blocks/dspy.ts
@@ -8,6 +8,7 @@ export const DSPyBlock: BlockConfig = {
   description: 'Run predictions using self-hosted DSPy programs',
   longDescription:
     'Integrate with your self-hosted DSPy programs for LLM-powered predictions. Supports Predict, Chain of Thought, and ReAct agents. DSPy is the framework for programming—not prompting—language models.',
+  docsLink: 'https://docs.sim.ai/integrations/dspy',
   category: 'tools',
   integrationType: IntegrationType.AI,
   bgColor: '#FFFFFF',
@@ -178,6 +179,7 @@ export const DSPyBlock: BlockConfig = {
 
 export const DSPyBlockMeta = {
   tags: ['llm', 'agentic', 'automation'],
+  url: 'https://dspy.ai',
   templates: [
     {
       icon: DsPyIcon,

--- a/apps/sim/blocks/blocks/dub.ts
+++ b/apps/sim/blocks/blocks/dub.ts
@@ -890,6 +890,7 @@ export const DubBlock: BlockConfig<DubResponse> = {
 
 export const DubBlockMeta = {
   tags: ['link-management', 'marketing', 'data-analytics'],
+  url: 'https://dub.co',
   templates: [
     {
       icon: DubIcon,

--- a/apps/sim/blocks/blocks/duckduckgo.ts
+++ b/apps/sim/blocks/blocks/duckduckgo.ts
@@ -71,6 +71,7 @@ export const DuckDuckGoBlock: BlockConfig<DuckDuckGoResponse> = {
 
 export const DuckDuckGoBlockMeta = {
   tags: ['web-scraping'],
+  url: 'https://duckduckgo.com',
   templates: [
     {
       icon: DuckDuckGoIcon,

--- a/apps/sim/blocks/blocks/dynamodb.ts
+++ b/apps/sim/blocks/blocks/dynamodb.ts
@@ -831,6 +831,7 @@ Return ONLY the expression - no explanations.`,
 
 export const DynamoDBBlockMeta = {
   tags: ['cloud', 'data-analytics'],
+  url: 'https://aws.amazon.com/dynamodb',
   templates: [
     {
       icon: DynamoDBIcon,

--- a/apps/sim/blocks/blocks/elasticsearch.ts
+++ b/apps/sim/blocks/blocks/elasticsearch.ts
@@ -537,6 +537,7 @@ Return ONLY valid JSON - no explanations, no markdown code blocks.`,
 
 export const ElasticsearchBlockMeta = {
   tags: ['vector-search', 'data-analytics'],
+  url: 'https://www.elastic.co/elasticsearch',
   templates: [
     {
       icon: ElasticsearchIcon,

--- a/apps/sim/blocks/blocks/elevenlabs.ts
+++ b/apps/sim/blocks/blocks/elevenlabs.ts
@@ -106,6 +106,7 @@ export const ElevenLabsBlock: BlockConfig<ElevenLabsBlockResponse> = {
 
 export const ElevenLabsBlockMeta = {
   tags: ['text-to-speech'],
+  url: 'https://elevenlabs.io',
   templates: [
     {
       icon: ElevenLabsIcon,

--- a/apps/sim/blocks/blocks/emailbison.ts
+++ b/apps/sim/blocks/blocks/emailbison.ts
@@ -628,6 +628,7 @@ function emptyToUndefined(value: unknown): unknown {
 
 export const EmailBisonBlockMeta = {
   tags: ['sales-engagement', 'email-marketing', 'automation'],
+  url: 'https://emailbison.com',
   templates: [
     {
       icon: EmailBisonIcon,

--- a/apps/sim/blocks/blocks/enrich.ts
+++ b/apps/sim/blocks/blocks/enrich.ts
@@ -740,6 +740,7 @@ export const EnrichBlock: BlockConfig = {
 
 export const EnrichBlockMeta = {
   tags: ['enrichment'],
+  url: 'https://www.enrich.so',
   templates: [
     {
       icon: EnrichSoIcon,

--- a/apps/sim/blocks/blocks/evernote.ts
+++ b/apps/sim/blocks/blocks/evernote.ts
@@ -310,6 +310,7 @@ export const EvernoteBlock: BlockConfig = {
 
 export const EvernoteBlockMeta = {
   tags: ['note-taking', 'knowledge-base'],
+  url: 'https://evernote.com',
   templates: [
     {
       icon: EvernoteIcon,

--- a/apps/sim/blocks/blocks/exa.ts
+++ b/apps/sim/blocks/blocks/exa.ts
@@ -446,7 +446,7 @@ export const ExaBlock: BlockConfig<ExaResponse> = {
 }
 
 export const ExaBlockMeta = {
-  tags: ['web-scraping', 'vector-search'],
+  tags: ['web-scraping'],
   url: 'https://exa.ai',
   templates: [
     {

--- a/apps/sim/blocks/blocks/exa.ts
+++ b/apps/sim/blocks/blocks/exa.ts
@@ -446,7 +446,8 @@ export const ExaBlock: BlockConfig<ExaResponse> = {
 }
 
 export const ExaBlockMeta = {
-  tags: ['web-scraping'],
+  tags: ['web-scraping', 'vector-search'],
+  url: 'https://exa.ai',
   templates: [
     {
       icon: ExaAIIcon,

--- a/apps/sim/blocks/blocks/extend.ts
+++ b/apps/sim/blocks/blocks/extend.ts
@@ -211,6 +211,7 @@ export const ExtendV2Block: BlockConfig<ExtendParserOutput> = {
 
 export const ExtendBlockMeta = {
   tags: ['document-processing', 'ocr'],
+  url: 'https://www.extend.ai',
   templates: [
     {
       icon: ExtendIcon,

--- a/apps/sim/blocks/blocks/fathom.ts
+++ b/apps/sim/blocks/blocks/fathom.ts
@@ -213,6 +213,7 @@ export const FathomBlock: BlockConfig<FathomResponse> = {
 
 export const FathomBlockMeta = {
   tags: ['meeting', 'note-taking'],
+  url: 'https://fathom.ai',
   templates: [
     {
       icon: FathomIcon,

--- a/apps/sim/blocks/blocks/findymail.ts
+++ b/apps/sim/blocks/blocks/findymail.ts
@@ -435,6 +435,7 @@ export const FindymailBlock: BlockConfig<FindymailResponse> = {
 
 export const FindymailBlockMeta = {
   tags: ['enrichment', 'sales-engagement'],
+  url: 'https://www.findymail.com',
   templates: [
     {
       icon: FindymailIcon,

--- a/apps/sim/blocks/blocks/firecrawl.ts
+++ b/apps/sim/blocks/blocks/firecrawl.ts
@@ -660,6 +660,7 @@ Example 2 - Product Data:
 
 export const FirecrawlBlockMeta = {
   tags: ['web-scraping', 'automation'],
+  url: 'https://www.firecrawl.dev',
   templates: [
     {
       icon: FirecrawlIcon,

--- a/apps/sim/blocks/blocks/fireflies.ts
+++ b/apps/sim/blocks/blocks/fireflies.ts
@@ -693,6 +693,7 @@ export const FirefliesV2Block: BlockConfig<FirefliesResponse> = {
 
 export const FirefliesBlockMeta = {
   tags: ['meeting', 'note-taking'],
+  url: 'https://fireflies.ai',
   templates: [
     {
       icon: FirefliesIcon,
@@ -791,4 +792,5 @@ export const FirefliesBlockMeta = {
 
 export const FirefliesV2BlockMeta = {
   tags: ['meeting', 'note-taking'],
+  url: 'https://fireflies.ai',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/gamma.ts
+++ b/apps/sim/blocks/blocks/gamma.ts
@@ -342,6 +342,7 @@ Example: "folder_abc123, folder_def456"`,
 
 export const GammaBlockMeta = {
   tags: ['document-processing', 'content-management'],
+  url: 'https://gamma.app',
   templates: [
     {
       icon: GammaIcon,

--- a/apps/sim/blocks/blocks/github.ts
+++ b/apps/sim/blocks/blocks/github.ts
@@ -2065,6 +2065,7 @@ export const GitHubV2Block: BlockConfig<GitHubResponse> = {
 
 export const GitHubBlockMeta = {
   tags: ['version-control', 'ci-cd'],
+  url: 'https://github.com',
   templates: [
     {
       icon: GithubIcon,
@@ -2191,4 +2192,5 @@ export const GitHubBlockMeta = {
 
 export const GitHubV2BlockMeta = {
   tags: ['version-control', 'ci-cd'],
+  url: 'https://github.com',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/gitlab.ts
+++ b/apps/sim/blocks/blocks/gitlab.ts
@@ -750,6 +750,7 @@ Return ONLY the commit message - no explanations, no extra text.`,
 
 export const GitLabBlockMeta = {
   tags: ['version-control', 'ci-cd'],
+  url: 'https://about.gitlab.com',
   templates: [
     {
       icon: GitLabIcon,

--- a/apps/sim/blocks/blocks/gmail.ts
+++ b/apps/sim/blocks/blocks/gmail.ts
@@ -645,6 +645,7 @@ export const GmailV2Block: BlockConfig<GmailToolResponse> = {
 
 export const GmailBlockMeta = {
   tags: ['google-workspace', 'messaging'],
+  url: 'https://www.google.com/gmail/about',
   templates: [
     {
       icon: GmailIcon,
@@ -759,4 +760,5 @@ export const GmailBlockMeta = {
 
 export const GmailV2BlockMeta = {
   tags: ['google-workspace', 'messaging'],
+  url: 'https://www.google.com/gmail/about',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/gong.ts
+++ b/apps/sim/blocks/blocks/gong.ts
@@ -924,6 +924,7 @@ Return ONLY the timestamp string in ISO 8601 format - no explanations, no quotes
 
 export const GongBlockMeta = {
   tags: ['meeting', 'sales-engagement', 'speech-to-text'],
+  url: 'https://www.gong.io',
   templates: [
     {
       icon: GongIcon,

--- a/apps/sim/blocks/blocks/google.ts
+++ b/apps/sim/blocks/blocks/google.ts
@@ -94,6 +94,7 @@ Return ONLY the search query - no explanations, no quotes around the whole thing
 
 export const GoogleSearchBlockMeta = {
   tags: ['web-scraping', 'seo'],
+  url: 'https://developers.google.com/custom-search',
   templates: [
     {
       icon: GoogleIcon,

--- a/apps/sim/blocks/blocks/google_ads.ts
+++ b/apps/sim/blocks/blocks/google_ads.ts
@@ -295,6 +295,7 @@ Return ONLY the GAQL query - no explanations, no quotes, no extra text.`,
 
 export const GoogleAdsBlockMeta = {
   tags: ['marketing', 'google-workspace', 'data-analytics'],
+  url: 'https://ads.google.com',
   templates: [
     {
       icon: GoogleAdsIcon,

--- a/apps/sim/blocks/blocks/google_bigquery.ts
+++ b/apps/sim/blocks/blocks/google_bigquery.ts
@@ -288,6 +288,7 @@ Return ONLY the JSON array - no explanations, no wrapping, no extra text.`,
 
 export const GoogleBigQueryBlockMeta = {
   tags: ['data-warehouse', 'google-workspace', 'data-analytics'],
+  url: 'https://cloud.google.com/bigquery',
   templates: [
     {
       icon: GoogleBigQueryIcon,

--- a/apps/sim/blocks/blocks/google_books.ts
+++ b/apps/sim/blocks/blocks/google_books.ts
@@ -204,6 +204,7 @@ export const GoogleBooksBlock: BlockConfig = {
 
 export const GoogleBooksBlockMeta = {
   tags: ['google-workspace', 'knowledge-base', 'content-management'],
+  url: 'https://books.google.com',
   templates: [
     {
       icon: GoogleBooksIcon,

--- a/apps/sim/blocks/blocks/google_calendar.ts
+++ b/apps/sim/blocks/blocks/google_calendar.ts
@@ -711,6 +711,7 @@ export const GoogleCalendarV2Block: BlockConfig<GoogleCalendarResponse> = {
 
 export const GoogleCalendarBlockMeta = {
   tags: ['calendar', 'scheduling', 'google-workspace'],
+  url: 'https://workspace.google.com/products/calendar',
   templates: [
     {
       icon: GoogleCalendarIcon,
@@ -814,4 +815,5 @@ export const GoogleCalendarBlockMeta = {
 
 export const GoogleCalendarV2BlockMeta = {
   tags: ['calendar', 'scheduling', 'google-workspace'],
+  url: 'https://workspace.google.com/products/calendar',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/google_contacts.ts
+++ b/apps/sim/blocks/blocks/google_contacts.ts
@@ -276,6 +276,7 @@ export const GoogleContactsBlock: BlockConfig<GoogleContactsResponse> = {
 
 export const GoogleContactsBlockMeta = {
   tags: ['google-workspace', 'customer-support', 'enrichment'],
+  url: 'https://contacts.google.com',
   templates: [
     {
       icon: GoogleContactsIcon,

--- a/apps/sim/blocks/blocks/google_docs.ts
+++ b/apps/sim/blocks/blocks/google_docs.ts
@@ -215,6 +215,7 @@ Return ONLY the document content - no explanations, no extra text.`,
 
 export const GoogleDocsBlockMeta = {
   tags: ['google-workspace', 'document-processing', 'content-management'],
+  url: 'https://www.google.com/docs/about',
   templates: [
     {
       icon: GoogleDocsIcon,

--- a/apps/sim/blocks/blocks/google_drive.ts
+++ b/apps/sim/blocks/blocks/google_drive.ts
@@ -1212,6 +1212,7 @@ Return ONLY the query string - no explanations, no quotes around the whole thing
 
 export const GoogleDriveBlockMeta = {
   tags: ['cloud', 'google-workspace', 'document-processing'],
+  url: 'https://workspace.google.com/products/drive',
   templates: [
     {
       icon: BookOpen,

--- a/apps/sim/blocks/blocks/google_forms.ts
+++ b/apps/sim/blocks/blocks/google_forms.ts
@@ -471,6 +471,7 @@ Example for "Add a required multiple choice question about favorite color":
 
 export const GoogleFormsBlockMeta = {
   tags: ['google-workspace', 'forms', 'data-analytics'],
+  url: 'https://workspace.google.com/products/forms',
   templates: [
     {
       icon: GoogleFormsIcon,

--- a/apps/sim/blocks/blocks/google_groups.ts
+++ b/apps/sim/blocks/blocks/google_groups.ts
@@ -458,6 +458,7 @@ Return ONLY the description text - no explanations, no quotes, no extra text.`,
 
 export const GoogleGroupsBlockMeta = {
   tags: ['google-workspace', 'messaging', 'identity'],
+  url: 'https://groups.google.com',
   templates: [
     {
       icon: GoogleGroupsIcon,

--- a/apps/sim/blocks/blocks/google_maps.ts
+++ b/apps/sim/blocks/blocks/google_maps.ts
@@ -641,6 +641,7 @@ export const GoogleMapsBlock: BlockConfig = {
 
 export const GoogleMapsBlockMeta = {
   tags: ['google-workspace', 'enrichment'],
+  url: 'https://mapsplatform.google.com',
   templates: [
     {
       icon: GoogleMapsIcon,

--- a/apps/sim/blocks/blocks/google_meet.ts
+++ b/apps/sim/blocks/blocks/google_meet.ts
@@ -184,6 +184,7 @@ export const GoogleMeetBlock: BlockConfig<GoogleMeetResponse> = {
 
 export const GoogleMeetBlockMeta = {
   tags: ['meeting', 'google-workspace', 'scheduling'],
+  url: 'https://workspace.google.com/products/meet',
   templates: [
     {
       icon: GoogleMeetIcon,

--- a/apps/sim/blocks/blocks/google_pagespeed.ts
+++ b/apps/sim/blocks/blocks/google_pagespeed.ts
@@ -128,6 +128,7 @@ export const GooglePagespeedBlock: BlockConfig<GooglePagespeedAnalyzeResponse> =
 
 export const GooglePagespeedBlockMeta = {
   tags: ['google-workspace', 'seo', 'monitoring'],
+  url: 'https://pagespeed.web.dev',
   templates: [
     {
       icon: GooglePagespeedIcon,

--- a/apps/sim/blocks/blocks/google_sheets.ts
+++ b/apps/sim/blocks/blocks/google_sheets.ts
@@ -1091,6 +1091,7 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
 
 export const GoogleSheetsBlockMeta = {
   tags: ['spreadsheet', 'google-workspace', 'data-analytics'],
+  url: 'https://workspace.google.com/products/sheets',
   templates: [
     {
       icon: GoogleSheetsIcon,
@@ -1206,4 +1207,5 @@ export const GoogleSheetsBlockMeta = {
 
 export const GoogleSheetsV2BlockMeta = {
   tags: ['spreadsheet', 'google-workspace', 'data-analytics'],
+  url: 'https://workspace.google.com/products/sheets',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/google_slides.ts
+++ b/apps/sim/blocks/blocks/google_slides.ts
@@ -3498,6 +3498,7 @@ export const GoogleSlidesV2Block: BlockConfig<GoogleSlidesResponse> = {
 
 export const GoogleSlidesBlockMeta = {
   tags: ['google-workspace', 'document-processing', 'content-management'],
+  url: 'https://workspace.google.com/products/slides',
   templates: [
     {
       icon: GoogleSlidesIcon,
@@ -3601,4 +3602,5 @@ export const GoogleSlidesBlockMeta = {
 
 export const GoogleSlidesV2BlockMeta = {
   tags: ['google-workspace', 'document-processing', 'content-management'],
+  url: 'https://workspace.google.com/products/slides',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/google_tasks.ts
+++ b/apps/sim/blocks/blocks/google_tasks.ts
@@ -283,6 +283,7 @@ Return ONLY the timestamp - no explanations, no extra text.`,
 
 export const GoogleTasksBlockMeta = {
   tags: ['google-workspace', 'project-management', 'scheduling'],
+  url: 'https://workspace.google.com/products/tasks',
   templates: [
     {
       icon: GoogleTasksIcon,

--- a/apps/sim/blocks/blocks/google_translate.ts
+++ b/apps/sim/blocks/blocks/google_translate.ts
@@ -218,6 +218,7 @@ export const GoogleTranslateBlock: BlockConfig = {
 
 export const GoogleTranslateBlockMeta = {
   tags: ['google-workspace', 'content-management', 'automation'],
+  url: 'https://cloud.google.com/translate',
   templates: [
     {
       icon: GoogleTranslateIcon,

--- a/apps/sim/blocks/blocks/google_vault.ts
+++ b/apps/sim/blocks/blocks/google_vault.ts
@@ -549,6 +549,7 @@ Return ONLY the description text - no explanations, no quotes, no extra text.`,
 
 export const GoogleVaultBlockMeta = {
   tags: ['google-workspace', 'document-processing'],
+  url: 'https://support.google.com/vault',
   templates: [
     {
       icon: ShieldCheck,

--- a/apps/sim/blocks/blocks/grafana.ts
+++ b/apps/sim/blocks/blocks/grafana.ts
@@ -918,6 +918,7 @@ Return ONLY the folder title - no explanations, no quotes, no extra text.`,
 
 export const GrafanaBlockMeta = {
   tags: ['monitoring', 'data-analytics'],
+  url: 'https://grafana.com',
   templates: [
     {
       icon: GrafanaIcon,

--- a/apps/sim/blocks/blocks/grain.ts
+++ b/apps/sim/blocks/blocks/grain.ts
@@ -464,6 +464,7 @@ Return ONLY the search term - no explanations, no quotes, no extra text.`,
 
 export const GrainBlockMeta = {
   tags: ['meeting', 'note-taking'],
+  url: 'https://grain.com',
   templates: [
     {
       icon: GrainIcon,

--- a/apps/sim/blocks/blocks/granola.ts
+++ b/apps/sim/blocks/blocks/granola.ts
@@ -184,6 +184,7 @@ export const GranolaBlock: BlockConfig = {
 
 export const GranolaBlockMeta = {
   tags: ['meeting', 'note-taking'],
+  url: 'https://granola.ai',
   templates: [
     {
       icon: GranolaIcon,

--- a/apps/sim/blocks/blocks/greenhouse.ts
+++ b/apps/sim/blocks/blocks/greenhouse.ts
@@ -423,6 +423,7 @@ Return ONLY the ISO 8601 timestamp - no explanations, no extra text.`,
 
 export const GreenhouseBlockMeta = {
   tags: ['hiring'],
+  url: 'https://www.greenhouse.com',
   templates: [
     {
       icon: GreenhouseIcon,

--- a/apps/sim/blocks/blocks/greptile.ts
+++ b/apps/sim/blocks/blocks/greptile.ts
@@ -199,6 +199,7 @@ export const GreptileBlock: BlockConfig<GreptileResponse> = {
 
 export const GreptileBlockMeta = {
   tags: ['version-control', 'knowledge-base'],
+  url: 'https://www.greptile.com',
   templates: [
     {
       icon: SlackIcon,

--- a/apps/sim/blocks/blocks/hex.ts
+++ b/apps/sim/blocks/blocks/hex.ts
@@ -448,6 +448,7 @@ Example:
 
 export const HexBlockMeta = {
   tags: ['data-analytics'],
+  url: 'https://hex.tech',
   templates: [
     {
       icon: HexIcon,

--- a/apps/sim/blocks/blocks/hubspot.ts
+++ b/apps/sim/blocks/blocks/hubspot.ts
@@ -1259,6 +1259,7 @@ Return ONLY the JSON array of property names - no explanations, no markdown, no 
 
 export const HubSpotBlockMeta = {
   tags: ['marketing', 'sales-engagement', 'customer-support'],
+  url: 'https://www.hubspot.com',
   templates: [
     {
       icon: HubspotIcon,

--- a/apps/sim/blocks/blocks/huggingface.ts
+++ b/apps/sim/blocks/blocks/huggingface.ts
@@ -123,6 +123,7 @@ export const HuggingFaceBlock: BlockConfig<HuggingFaceChatResponse> = {
 
 export const HuggingFaceBlockMeta = {
   tags: ['llm', 'agentic'],
+  url: 'https://huggingface.co',
   templates: [
     {
       icon: HuggingFaceIcon,

--- a/apps/sim/blocks/blocks/hunter.ts
+++ b/apps/sim/blocks/blocks/hunter.ts
@@ -411,6 +411,7 @@ Return ONLY the search query text - no explanations.`,
 
 export const HunterBlockMeta = {
   tags: ['enrichment', 'sales-engagement'],
+  url: 'https://hunter.io',
   templates: [
     {
       icon: HunterIOIcon,

--- a/apps/sim/blocks/blocks/iam.ts
+++ b/apps/sim/blocks/blocks/iam.ts
@@ -667,6 +667,7 @@ export const IAMBlock: BlockConfig<IAMBaseResponse> = {
 
 export const IAMBlockMeta = {
   tags: ['cloud', 'identity'],
+  url: 'https://aws.amazon.com/iam',
   templates: [
     {
       icon: IAMIcon,

--- a/apps/sim/blocks/blocks/identity_center.ts
+++ b/apps/sim/blocks/blocks/identity_center.ts
@@ -438,6 +438,7 @@ export const IdentityCenterBlock: BlockConfig<IdentityCenterBaseResponse> = {
 
 export const IdentityCenterBlockMeta = {
   tags: ['cloud', 'identity'],
+  url: 'https://aws.amazon.com/iam/identity-center',
   templates: [
     {
       icon: IdentityCenterIcon,

--- a/apps/sim/blocks/blocks/incidentio.ts
+++ b/apps/sim/blocks/blocks/incidentio.ts
@@ -1227,6 +1227,7 @@ Return ONLY the JSON array - no explanations or markdown formatting.`,
 
 export const IncidentioBlockMeta = {
   tags: ['incident-management', 'monitoring'],
+  url: 'https://incident.io',
   templates: [
     {
       icon: IncidentioIcon,

--- a/apps/sim/blocks/blocks/infisical.ts
+++ b/apps/sim/blocks/blocks/infisical.ts
@@ -241,6 +241,7 @@ export const InfisicalBlock: BlockConfig<InfisicalResponse> = {
 
 export const InfisicalBlockMeta = {
   tags: ['secrets-management'],
+  url: 'https://infisical.com',
   templates: [
     {
       icon: InfisicalIcon,

--- a/apps/sim/blocks/blocks/instantly.ts
+++ b/apps/sim/blocks/blocks/instantly.ts
@@ -1255,6 +1255,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 export const InstantlyBlockMeta = {
   tags: ['sales-engagement', 'email-marketing', 'automation'],
+  url: 'https://instantly.ai',
   templates: [
     {
       icon: InstantlyIcon,

--- a/apps/sim/blocks/blocks/intercom.ts
+++ b/apps/sim/blocks/blocks/intercom.ts
@@ -1739,6 +1739,7 @@ export const IntercomV2Block: BlockConfig = {
 
 export const IntercomBlockMeta = {
   tags: ['customer-support', 'messaging'],
+  url: 'https://www.intercom.com',
   templates: [
     {
       icon: IntercomIcon,
@@ -1844,4 +1845,5 @@ export const IntercomBlockMeta = {
 
 export const IntercomV2BlockMeta = {
   tags: ['customer-support', 'messaging'],
+  url: 'https://www.intercom.com',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/jina.ts
+++ b/apps/sim/blocks/blocks/jina.ts
@@ -197,6 +197,7 @@ export const JinaBlock: BlockConfig<ReadUrlResponse | SearchResponse> = {
 
 export const JinaBlockMeta = {
   tags: ['web-scraping', 'knowledge-base'],
+  url: 'https://jina.ai',
   templates: [
     {
       icon: JinaAIIcon,

--- a/apps/sim/blocks/blocks/jira.ts
+++ b/apps/sim/blocks/blocks/jira.ts
@@ -1339,6 +1339,7 @@ Return ONLY the comment text - no explanations.`,
 
 export const JiraBlockMeta = {
   tags: ['project-management', 'ticketing'],
+  url: 'https://www.atlassian.com/software/jira',
   templates: [
     {
       icon: JiraIcon,

--- a/apps/sim/blocks/blocks/jira_service_management.ts
+++ b/apps/sim/blocks/blocks/jira_service_management.ts
@@ -1265,6 +1265,7 @@ Return ONLY the comment text - no explanations.`,
 
 export const JiraServiceManagementBlockMeta = {
   tags: ['customer-support', 'ticketing', 'incident-management'],
+  url: 'https://www.atlassian.com/software/jira/service-management',
   templates: [
     {
       icon: JiraServiceManagementIcon,

--- a/apps/sim/blocks/blocks/kalshi.ts
+++ b/apps/sim/blocks/blocks/kalshi.ts
@@ -940,6 +940,7 @@ export const KalshiV2Block: BlockConfig = {
 
 export const KalshiBlockMeta = {
   tags: ['prediction-markets', 'data-analytics'],
+  url: 'https://kalshi.com',
   templates: [
     {
       icon: KalshiIcon,
@@ -1036,4 +1037,5 @@ export const KalshiBlockMeta = {
 
 export const KalshiV2BlockMeta = {
   tags: ['prediction-markets', 'data-analytics'],
+  url: 'https://kalshi.com',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/ketch.ts
+++ b/apps/sim/blocks/blocks/ketch.ts
@@ -236,6 +236,7 @@ export const KetchBlock: BlockConfig<KetchResponse> = {
 
 export const KetchBlockMeta = {
   tags: ['identity'],
+  url: 'https://www.ketch.com',
   templates: [
     {
       icon: KetchIcon,

--- a/apps/sim/blocks/blocks/langsmith.ts
+++ b/apps/sim/blocks/blocks/langsmith.ts
@@ -299,6 +299,7 @@ Common patch fields: outputs, end_time, status, error`,
 
 export const LangsmithBlockMeta = {
   tags: ['monitoring', 'llm'],
+  url: 'https://www.langchain.com/langsmith',
   templates: [
     {
       icon: LangsmithIcon,

--- a/apps/sim/blocks/blocks/latex.ts
+++ b/apps/sim/blocks/blocks/latex.ts
@@ -239,6 +239,7 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
 
 export const LatexBlockMeta = {
   tags: ['document-processing'],
+  url: 'https://www.latex-project.org',
   templates: [
     {
       icon: LatexIcon,

--- a/apps/sim/blocks/blocks/launchdarkly.ts
+++ b/apps/sim/blocks/blocks/launchdarkly.ts
@@ -355,6 +355,7 @@ Return ONLY the resource specifier string - no explanations, no extra text.`,
 
 export const LaunchDarklyBlockMeta = {
   tags: ['feature-flags', 'ci-cd'],
+  url: 'https://launchdarkly.com',
   templates: [
     {
       icon: LaunchDarklyIcon,

--- a/apps/sim/blocks/blocks/lemlist.ts
+++ b/apps/sim/blocks/blocks/lemlist.ts
@@ -238,6 +238,7 @@ export const LemlistBlock: BlockConfig<LemlistResponse> = {
 
 export const LemlistBlockMeta = {
   tags: ['sales-engagement', 'email-marketing', 'automation'],
+  url: 'https://www.lemlist.com',
   templates: [
     {
       icon: LemlistIcon,

--- a/apps/sim/blocks/blocks/linear.ts
+++ b/apps/sim/blocks/blocks/linear.ts
@@ -2613,6 +2613,7 @@ export const LinearV2Block: BlockConfig<LinearResponse> = {
 
 export const LinearBlockMeta = {
   tags: ['project-management', 'ticketing'],
+  url: 'https://linear.app',
   templates: [
     {
       icon: LinearIcon,

--- a/apps/sim/blocks/blocks/linkedin.ts
+++ b/apps/sim/blocks/blocks/linkedin.ts
@@ -126,6 +126,7 @@ export const LinkedInBlock: BlockConfig<LinkedInResponse> = {
 
 export const LinkedInBlockMeta = {
   tags: ['marketing', 'sales-engagement'],
+  url: 'https://www.linkedin.com',
   templates: [
     {
       icon: LinkedInIcon,

--- a/apps/sim/blocks/blocks/linkup.ts
+++ b/apps/sim/blocks/blocks/linkup.ts
@@ -157,6 +157,7 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
 
 export const LinkupBlockMeta = {
   tags: ['web-scraping', 'enrichment'],
+  url: 'https://www.linkup.so',
   templates: [
     {
       icon: LinkupIcon,

--- a/apps/sim/blocks/blocks/linq.ts
+++ b/apps/sim/blocks/blocks/linq.ts
@@ -867,6 +867,7 @@ export const LinqBlock: BlockConfig = {
 
 export const LinqBlockMeta = {
   tags: ['messaging', 'automation', 'webhooks'],
+  url: 'https://www.linqapp.com',
   templates: [
     {
       icon: LinqIcon,

--- a/apps/sim/blocks/blocks/loops.ts
+++ b/apps/sim/blocks/blocks/loops.ts
@@ -538,6 +538,7 @@ Return ONLY the JSON object - no explanations, no extra text.`,
 
 export const LoopsBlockMeta = {
   tags: ['email-marketing', 'marketing', 'automation'],
+  url: 'https://loops.so',
   templates: [
     {
       icon: LoopsIcon,

--- a/apps/sim/blocks/blocks/luma.ts
+++ b/apps/sim/blocks/blocks/luma.ts
@@ -547,6 +547,7 @@ Return ONLY the ISO 8601 timestamp - no explanations, no quotes, no extra text.`
 
 export const LumaBlockMeta = {
   tags: ['events', 'calendar', 'scheduling'],
+  url: 'https://luma.com',
   templates: [
     {
       icon: LumaIcon,

--- a/apps/sim/blocks/blocks/mailchimp.ts
+++ b/apps/sim/blocks/blocks/mailchimp.ts
@@ -1463,6 +1463,7 @@ Return ONLY the JSON array - no explanations or markdown.`,
 
 export const MailchimpBlockMeta = {
   tags: ['email-marketing', 'marketing', 'automation'],
+  url: 'https://mailchimp.com',
   templates: [
     {
       icon: Mail,

--- a/apps/sim/blocks/blocks/mailgun.ts
+++ b/apps/sim/blocks/blocks/mailgun.ts
@@ -415,6 +415,7 @@ Return ONLY the JSON object - no explanations or markdown.`,
 
 export const MailgunBlockMeta = {
   tags: ['messaging', 'email-marketing'],
+  url: 'https://www.mailgun.com',
   templates: [
     {
       icon: MailgunIcon,

--- a/apps/sim/blocks/blocks/mem0.ts
+++ b/apps/sim/blocks/blocks/mem0.ts
@@ -274,6 +274,7 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
 
 export const Mem0BlockMeta = {
   tags: ['llm', 'knowledge-base', 'agentic'],
+  url: 'https://mem0.ai',
   templates: [
     {
       icon: Mem0Icon,

--- a/apps/sim/blocks/blocks/microsoft_ad.ts
+++ b/apps/sim/blocks/blocks/microsoft_ad.ts
@@ -397,6 +397,7 @@ export const MicrosoftAdBlock: BlockConfig<MicrosoftAdResponse> = {
 
 export const MicrosoftAdBlockMeta = {
   tags: ['identity', 'microsoft-365'],
+  url: 'https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id',
   templates: [
     {
       icon: AzureIcon,

--- a/apps/sim/blocks/blocks/microsoft_ad.ts
+++ b/apps/sim/blocks/blocks/microsoft_ad.ts
@@ -397,7 +397,7 @@ export const MicrosoftAdBlock: BlockConfig<MicrosoftAdResponse> = {
 
 export const MicrosoftAdBlockMeta = {
   tags: ['identity', 'microsoft-365'],
-  url: 'https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id',
+  url: 'https://www.microsoft.com/security/business/identity-access/microsoft-entra-id',
   templates: [
     {
       icon: AzureIcon,

--- a/apps/sim/blocks/blocks/microsoft_dataverse.ts
+++ b/apps/sim/blocks/blocks/microsoft_dataverse.ts
@@ -594,6 +594,7 @@ Return ONLY the expand expression - no $expand= prefix, no explanations.`,
 
 export const MicrosoftDataverseBlockMeta = {
   tags: ['microsoft-365', 'data-warehouse', 'cloud'],
+  url: 'https://www.microsoft.com/en-us/power-platform/dataverse',
   templates: [
     {
       icon: MicrosoftDataverseIcon,

--- a/apps/sim/blocks/blocks/microsoft_dataverse.ts
+++ b/apps/sim/blocks/blocks/microsoft_dataverse.ts
@@ -594,7 +594,7 @@ Return ONLY the expand expression - no $expand= prefix, no explanations.`,
 
 export const MicrosoftDataverseBlockMeta = {
   tags: ['microsoft-365', 'data-warehouse', 'cloud'],
-  url: 'https://www.microsoft.com/en-us/power-platform/dataverse',
+  url: 'https://www.microsoft.com/power-platform/dataverse',
   templates: [
     {
       icon: MicrosoftDataverseIcon,

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -676,6 +676,7 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
 
 export const MicrosoftExcelBlockMeta = {
   tags: ['spreadsheet', 'microsoft-365'],
+  url: 'https://www.microsoft.com/en-us/microsoft-365/excel',
   templates: [
     {
       icon: MicrosoftExcelIcon,
@@ -780,4 +781,5 @@ export const MicrosoftExcelBlockMeta = {
 
 export const MicrosoftExcelV2BlockMeta = {
   tags: ['spreadsheet', 'microsoft-365'],
+  url: 'https://www.microsoft.com/en-us/microsoft-365/excel',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/microsoft_excel.ts
+++ b/apps/sim/blocks/blocks/microsoft_excel.ts
@@ -676,7 +676,7 @@ Return ONLY the JSON array - no explanations, no markdown, no extra text.`,
 
 export const MicrosoftExcelBlockMeta = {
   tags: ['spreadsheet', 'microsoft-365'],
-  url: 'https://www.microsoft.com/en-us/microsoft-365/excel',
+  url: 'https://www.microsoft.com/microsoft-365/excel',
   templates: [
     {
       icon: MicrosoftExcelIcon,
@@ -781,5 +781,5 @@ export const MicrosoftExcelBlockMeta = {
 
 export const MicrosoftExcelV2BlockMeta = {
   tags: ['spreadsheet', 'microsoft-365'],
-  url: 'https://www.microsoft.com/en-us/microsoft-365/excel',
+  url: 'https://www.microsoft.com/microsoft-365/excel',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/microsoft_planner.ts
+++ b/apps/sim/blocks/blocks/microsoft_planner.ts
@@ -664,7 +664,7 @@ Return ONLY the timestamp string - no explanations, no quotes, no extra text.`,
 
 export const MicrosoftPlannerBlockMeta = {
   tags: ['project-management', 'microsoft-365'],
-  url: 'https://www.microsoft.com/en-us/microsoft-365/business/task-management-software',
+  url: 'https://www.microsoft.com/microsoft-365/business/task-management-software',
   templates: [
     {
       icon: MicrosoftPlannerIcon,

--- a/apps/sim/blocks/blocks/microsoft_planner.ts
+++ b/apps/sim/blocks/blocks/microsoft_planner.ts
@@ -664,6 +664,7 @@ Return ONLY the timestamp string - no explanations, no quotes, no extra text.`,
 
 export const MicrosoftPlannerBlockMeta = {
   tags: ['project-management', 'microsoft-365'],
+  url: 'https://www.microsoft.com/en-us/microsoft-365/business/task-management-software',
   templates: [
     {
       icon: MicrosoftPlannerIcon,

--- a/apps/sim/blocks/blocks/microsoft_teams.ts
+++ b/apps/sim/blocks/blocks/microsoft_teams.ts
@@ -483,7 +483,7 @@ export const MicrosoftTeamsBlock: BlockConfig<MicrosoftTeamsResponse> = {
 
 export const MicrosoftTeamsBlockMeta = {
   tags: ['messaging', 'microsoft-365'],
-  url: 'https://www.microsoft.com/en-us/microsoft-teams/group-chat-software',
+  url: 'https://www.microsoft.com/microsoft-teams/group-chat-software',
   templates: [
     {
       icon: MicrosoftTeamsIcon,

--- a/apps/sim/blocks/blocks/microsoft_teams.ts
+++ b/apps/sim/blocks/blocks/microsoft_teams.ts
@@ -483,6 +483,7 @@ export const MicrosoftTeamsBlock: BlockConfig<MicrosoftTeamsResponse> = {
 
 export const MicrosoftTeamsBlockMeta = {
   tags: ['messaging', 'microsoft-365'],
+  url: 'https://www.microsoft.com/en-us/microsoft-teams/group-chat-software',
   templates: [
     {
       icon: MicrosoftTeamsIcon,

--- a/apps/sim/blocks/blocks/millionverifier.ts
+++ b/apps/sim/blocks/blocks/millionverifier.ts
@@ -102,4 +102,5 @@ export const MillionVerifierBlock: BlockConfig<MillionVerifierResponse> = {
 
 export const MillionVerifierBlockMeta = {
   tags: ['enrichment', 'sales-engagement'],
+  url: 'https://www.millionverifier.com',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/mistral_parse.ts
+++ b/apps/sim/blocks/blocks/mistral_parse.ts
@@ -406,6 +406,7 @@ export const MistralParseV3Block: BlockConfig<MistralParserOutput> = {
 
 export const MistralParseBlockMeta = {
   tags: ['document-processing', 'ocr'],
+  url: 'https://mistral.ai',
   templates: [
     {
       icon: MistralIcon,

--- a/apps/sim/blocks/blocks/monday.ts
+++ b/apps/sim/blocks/blocks/monday.ts
@@ -483,6 +483,7 @@ export const MondayBlock: BlockConfig<MondayResponse> = {
 
 export const MondayBlockMeta = {
   tags: ['project-management', 'ticketing'],
+  url: 'https://monday.com',
   templates: [
     {
       icon: MondayIcon,

--- a/apps/sim/blocks/blocks/mongodb.ts
+++ b/apps/sim/blocks/blocks/mongodb.ts
@@ -965,6 +965,7 @@ Return ONLY the MongoDB query filter as valid JSON - no explanations, no markdow
 
 export const MongoDBBlockMeta = {
   tags: ['data-warehouse', 'cloud'],
+  url: 'https://www.mongodb.com',
   templates: [
     {
       icon: MongoDBIcon,

--- a/apps/sim/blocks/blocks/neo4j.ts
+++ b/apps/sim/blocks/blocks/neo4j.ts
@@ -703,6 +703,7 @@ Return ONLY valid JSON.`,
 
 export const Neo4jBlockMeta = {
   tags: ['data-warehouse', 'data-analytics'],
+  url: 'https://neo4j.com',
   templates: [
     {
       icon: Neo4jIcon,

--- a/apps/sim/blocks/blocks/neverbounce.ts
+++ b/apps/sim/blocks/blocks/neverbounce.ts
@@ -103,4 +103,5 @@ export const NeverBounceBlock: BlockConfig<NeverBounceResponse> = {
 
 export const NeverBounceBlockMeta = {
   tags: ['enrichment', 'sales-engagement'],
+  url: 'https://www.neverbounce.com',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/new_relic.ts
+++ b/apps/sim/blocks/blocks/new_relic.ts
@@ -355,6 +355,7 @@ Return ONLY the numeric timestamp - no explanations, no extra text.`,
 
 export const NewRelicBlockMeta = {
   tags: ['monitoring', 'error-tracking', 'incident-management'],
+  url: 'https://newrelic.com',
   templates: [
     {
       icon: NewRelicIcon,

--- a/apps/sim/blocks/blocks/notion.ts
+++ b/apps/sim/blocks/blocks/notion.ts
@@ -558,6 +558,7 @@ export const NotionV2Block: BlockConfig<any> = {
 
 export const NotionBlockMeta = {
   tags: ['note-taking', 'knowledge-base', 'content-management'],
+  url: 'https://www.notion.com',
   templates: [
     {
       icon: Send,
@@ -661,4 +662,5 @@ export const NotionBlockMeta = {
 
 export const NotionV2BlockMeta = {
   tags: ['note-taking', 'knowledge-base', 'content-management'],
+  url: 'https://www.notion.com',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/obsidian.ts
+++ b/apps/sim/blocks/blocks/obsidian.ts
@@ -272,6 +272,7 @@ export const ObsidianBlock: BlockConfig = {
 
 export const ObsidianBlockMeta = {
   tags: ['note-taking', 'knowledge-base'],
+  url: 'https://obsidian.md',
   templates: [
     {
       icon: ObsidianIcon,

--- a/apps/sim/blocks/blocks/okta.ts
+++ b/apps/sim/blocks/blocks/okta.ts
@@ -388,6 +388,7 @@ export const OktaBlock: BlockConfig<OktaResponse> = {
 
 export const OktaBlockMeta = {
   tags: ['identity', 'automation'],
+  url: 'https://www.okta.com',
   templates: [
     {
       icon: OktaIcon,

--- a/apps/sim/blocks/blocks/onedrive.ts
+++ b/apps/sim/blocks/blocks/onedrive.ts
@@ -433,7 +433,7 @@ export const OneDriveBlock: BlockConfig<OneDriveResponse> = {
 
 export const OneDriveBlockMeta = {
   tags: ['microsoft-365', 'cloud', 'document-processing'],
-  url: 'https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage',
+  url: 'https://www.microsoft.com/microsoft-365/onedrive',
   templates: [
     {
       icon: MicrosoftOneDriveIcon,

--- a/apps/sim/blocks/blocks/onedrive.ts
+++ b/apps/sim/blocks/blocks/onedrive.ts
@@ -433,6 +433,7 @@ export const OneDriveBlock: BlockConfig<OneDriveResponse> = {
 
 export const OneDriveBlockMeta = {
   tags: ['microsoft-365', 'cloud', 'document-processing'],
+  url: 'https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage',
   templates: [
     {
       icon: MicrosoftOneDriveIcon,

--- a/apps/sim/blocks/blocks/onepassword.ts
+++ b/apps/sim/blocks/blocks/onepassword.ts
@@ -270,6 +270,7 @@ Return ONLY valid JSON - no explanations, no markdown code blocks.`,
 
 export const OnePasswordBlockMeta = {
   tags: ['secrets-management', 'identity'],
+  url: 'https://1password.com',
   templates: [
     {
       icon: OnePasswordIcon,

--- a/apps/sim/blocks/blocks/openai.ts
+++ b/apps/sim/blocks/blocks/openai.ts
@@ -58,6 +58,7 @@ export const OpenAIBlock: BlockConfig = {
 
 export const OpenAIBlockMeta = {
   tags: ['llm', 'vector-search'],
+  url: 'https://openai.com',
   templates: [
     {
       icon: OpenAIIcon,

--- a/apps/sim/blocks/blocks/outlook.ts
+++ b/apps/sim/blocks/blocks/outlook.ts
@@ -459,6 +459,7 @@ export const OutlookBlock: BlockConfig<OutlookResponse> = {
 
 export const OutlookBlockMeta = {
   tags: ['microsoft-365', 'messaging', 'automation'],
+  url: 'https://www.microsoft.com/en-us/microsoft-365/outlook/email-and-calendar-software-microsoft-outlook',
   templates: [
     {
       icon: OutlookIcon,

--- a/apps/sim/blocks/blocks/outlook.ts
+++ b/apps/sim/blocks/blocks/outlook.ts
@@ -459,7 +459,7 @@ export const OutlookBlock: BlockConfig<OutlookResponse> = {
 
 export const OutlookBlockMeta = {
   tags: ['microsoft-365', 'messaging', 'automation'],
-  url: 'https://www.microsoft.com/en-us/microsoft-365/outlook/email-and-calendar-software-microsoft-outlook',
+  url: 'https://www.microsoft.com/microsoft-365/outlook',
   templates: [
     {
       icon: OutlookIcon,

--- a/apps/sim/blocks/blocks/pagerduty.ts
+++ b/apps/sim/blocks/blocks/pagerduty.ts
@@ -485,6 +485,7 @@ export const PagerDutyBlock: BlockConfig = {
 
 export const PagerDutyBlockMeta = {
   tags: ['incident-management', 'monitoring'],
+  url: 'https://www.pagerduty.com',
   templates: [
     {
       icon: PagerDutyIcon,

--- a/apps/sim/blocks/blocks/parallel.ts
+++ b/apps/sim/blocks/blocks/parallel.ts
@@ -277,6 +277,7 @@ export const ParallelBlock: BlockConfig<ToolResponse> = {
 
 export const ParallelBlockMeta = {
   tags: ['web-scraping', 'llm', 'agentic'],
+  url: 'https://parallel.ai',
   templates: [
     {
       icon: ParallelIcon,

--- a/apps/sim/blocks/blocks/peopledatalabs.ts
+++ b/apps/sim/blocks/blocks/peopledatalabs.ts
@@ -632,6 +632,7 @@ export const PeopleDataLabsBlock: BlockConfig<PdlPersonEnrichResponse> = {
 
 export const PeopleDataLabsBlockMeta = {
   tags: ['enrichment'],
+  url: 'https://www.peopledatalabs.com',
   templates: [
     {
       icon: PeopleDataLabsIcon,

--- a/apps/sim/blocks/blocks/perplexity.ts
+++ b/apps/sim/blocks/blocks/perplexity.ts
@@ -263,6 +263,7 @@ Return ONLY the date string in MM/DD/YYYY format - no explanations, no quotes, n
 
 export const PerplexityBlockMeta = {
   tags: ['llm', 'web-scraping', 'agentic'],
+  url: 'https://www.perplexity.ai',
   templates: [
     {
       icon: PerplexityIcon,

--- a/apps/sim/blocks/blocks/persona.ts
+++ b/apps/sim/blocks/blocks/persona.ts
@@ -565,6 +565,7 @@ export const PersonaBlock: BlockConfig<PersonaResponse> = {
 
 export const PersonaBlockMeta = {
   tags: ['identity'],
+  url: 'https://withpersona.com',
   templates: [
     {
       icon: PersonaIcon,

--- a/apps/sim/blocks/blocks/pinecone.ts
+++ b/apps/sim/blocks/blocks/pinecone.ts
@@ -330,6 +330,7 @@ export const PineconeBlock: BlockConfig<PineconeResponse> = {
 
 export const PineconeBlockMeta = {
   tags: ['vector-search', 'knowledge-base'],
+  url: 'https://www.pinecone.io',
   templates: [
     {
       icon: PineconeIcon,

--- a/apps/sim/blocks/blocks/pipedrive.ts
+++ b/apps/sim/blocks/blocks/pipedrive.ts
@@ -841,6 +841,7 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
 
 export const PipedriveBlockMeta = {
   tags: ['sales-engagement', 'project-management'],
+  url: 'https://www.pipedrive.com',
   templates: [
     {
       icon: PipedriveIcon,

--- a/apps/sim/blocks/blocks/polymarket.ts
+++ b/apps/sim/blocks/blocks/polymarket.ts
@@ -908,6 +908,7 @@ Return ONLY the Unix timestamp as a number - no explanations, no quotes, no extr
 
 export const PolymarketBlockMeta = {
   tags: ['prediction-markets', 'data-analytics'],
+  url: 'https://polymarket.com',
   templates: [
     {
       icon: PolymarketIcon,

--- a/apps/sim/blocks/blocks/posthog.ts
+++ b/apps/sim/blocks/blocks/posthog.ts
@@ -1328,6 +1328,7 @@ Return ONLY the timestamp string - no explanations, no quotes, no extra text.`,
 
 export const PostHogBlockMeta = {
   tags: ['data-analytics', 'monitoring', 'feature-flags'],
+  url: 'https://posthog.com',
   templates: [
     {
       icon: PosthogIcon,

--- a/apps/sim/blocks/blocks/profound.ts
+++ b/apps/sim/blocks/blocks/profound.ts
@@ -406,6 +406,7 @@ export const ProfoundBlock: BlockConfig = {
 
 export const ProfoundBlockMeta = {
   tags: ['seo', 'data-analytics'],
+  url: 'https://www.tryprofound.com',
   templates: [
     {
       icon: ProfoundIcon,

--- a/apps/sim/blocks/blocks/prospeo.ts
+++ b/apps/sim/blocks/blocks/prospeo.ts
@@ -536,6 +536,7 @@ export const ProspeoBlock: BlockConfig<ProspeoResponse> = {
 
 export const ProspeoBlockMeta = {
   tags: ['enrichment', 'sales-engagement'],
+  url: 'https://prospeo.io',
   templates: [
     {
       icon: ProspeoIcon,

--- a/apps/sim/blocks/blocks/pulse.ts
+++ b/apps/sim/blocks/blocks/pulse.ts
@@ -211,6 +211,7 @@ export const PulseV2Block: BlockConfig<PulseParserOutput> = {
 
 export const PulseBlockMeta = {
   tags: ['document-processing', 'ocr'],
+  url: 'https://www.runpulse.com',
   templates: [
     {
       icon: PulseIcon,

--- a/apps/sim/blocks/blocks/qdrant.ts
+++ b/apps/sim/blocks/blocks/qdrant.ts
@@ -249,6 +249,7 @@ Return ONLY the JSON object.`,
 
 export const QdrantBlockMeta = {
   tags: ['vector-search', 'knowledge-base'],
+  url: 'https://qdrant.tech',
   templates: [
     {
       icon: QdrantIcon,

--- a/apps/sim/blocks/blocks/quartr.ts
+++ b/apps/sim/blocks/blocks/quartr.ts
@@ -539,6 +539,7 @@ export const QuartrBlock: BlockConfig<ToolResponse> = {
 
 export const QuartrBlockMeta = {
   tags: ['data-analytics', 'enrichment', 'document-processing'],
+  url: 'https://quartr.com',
   templates: [
     {
       icon: QuartrIcon,

--- a/apps/sim/blocks/blocks/quiver.ts
+++ b/apps/sim/blocks/blocks/quiver.ts
@@ -239,6 +239,7 @@ export const QuiverBlock: BlockConfig<QuiverSvgResponse> = {
 
 export const QuiverBlockMeta = {
   tags: ['image-generation'],
+  url: 'https://quiver.ai',
   templates: [
     {
       icon: QuiverIcon,

--- a/apps/sim/blocks/blocks/railway.ts
+++ b/apps/sim/blocks/blocks/railway.ts
@@ -854,6 +854,7 @@ export const RailwayBlock: BlockConfig<RailwayResponse> = {
 
 export const RailwayBlockMeta = {
   tags: ['cloud', 'ci-cd'],
+  url: 'https://railway.com',
   templates: [
     {
       icon: RailwayIcon,

--- a/apps/sim/blocks/blocks/rb2b.ts
+++ b/apps/sim/blocks/blocks/rb2b.ts
@@ -219,6 +219,7 @@ export const RB2BBlock: BlockConfig<Rb2bResponse> = {
 
 export const RB2BBlockMeta = {
   tags: ['enrichment', 'sales-engagement', 'identity'],
+  url: 'https://rb2b.com',
   templates: [
     {
       icon: RB2BIcon,

--- a/apps/sim/blocks/blocks/rds.ts
+++ b/apps/sim/blocks/blocks/rds.ts
@@ -488,6 +488,7 @@ Return ONLY the JSON object.`,
 
 export const RDSBlockMeta = {
   tags: ['cloud'],
+  url: 'https://aws.amazon.com/rds',
   templates: [
     {
       icon: RDSIcon,

--- a/apps/sim/blocks/blocks/reddit.ts
+++ b/apps/sim/blocks/blocks/reddit.ts
@@ -1390,6 +1390,7 @@ Return ONLY the message content - no meta-commentary.`,
 
 export const RedditBlockMeta = {
   tags: ['content-management', 'web-scraping'],
+  url: 'https://www.reddit.com',
   templates: [
     {
       icon: RedditIcon,

--- a/apps/sim/blocks/blocks/redis.ts
+++ b/apps/sim/blocks/blocks/redis.ts
@@ -323,6 +323,7 @@ export const RedisBlock: BlockConfig<RedisResponse> = {
 
 export const RedisBlockMeta = {
   tags: ['cloud'],
+  url: 'https://redis.io',
   templates: [
     {
       icon: RedisIcon,

--- a/apps/sim/blocks/blocks/reducto.ts
+++ b/apps/sim/blocks/blocks/reducto.ts
@@ -233,6 +233,7 @@ export const ReductoV2Block: BlockConfig<ReductoParserOutput> = {
 
 export const ReductoBlockMeta = {
   tags: ['document-processing', 'ocr'],
+  url: 'https://reducto.ai',
   templates: [
     {
       icon: ReductoIcon,

--- a/apps/sim/blocks/blocks/resend.ts
+++ b/apps/sim/blocks/blocks/resend.ts
@@ -325,6 +325,7 @@ Return ONLY the email body - no explanations, no extra text.`,
 
 export const ResendBlockMeta = {
   tags: ['email-marketing', 'messaging'],
+  url: 'https://resend.com',
   templates: [
     {
       icon: ResendIcon,

--- a/apps/sim/blocks/blocks/revenuecat.ts
+++ b/apps/sim/blocks/blocks/revenuecat.ts
@@ -490,6 +490,7 @@ Return ONLY the numeric timestamp, no text.`,
 
 export const RevenueCatBlockMeta = {
   tags: ['payments', 'subscriptions'],
+  url: 'https://www.revenuecat.com',
   templates: [
     {
       icon: RevenueCatIcon,

--- a/apps/sim/blocks/blocks/rippling.ts
+++ b/apps/sim/blocks/blocks/rippling.ts
@@ -1475,6 +1475,7 @@ Return ONLY the sort expression - no explanations, no extra text.`,
 
 export const RipplingBlockMeta = {
   tags: ['hiring'],
+  url: 'https://www.rippling.com',
   templates: [
     {
       icon: RipplingIcon,

--- a/apps/sim/blocks/blocks/rootly.ts
+++ b/apps/sim/blocks/blocks/rootly.ts
@@ -2418,6 +2418,7 @@ export const RootlyBlock: BlockConfig<RootlyResponse> = {
 
 export const RootlyBlockMeta = {
   tags: ['incident-management', 'monitoring'],
+  url: 'https://rootly.com',
   templates: [
     {
       icon: RootlyIcon,

--- a/apps/sim/blocks/blocks/s3.ts
+++ b/apps/sim/blocks/blocks/s3.ts
@@ -416,6 +416,7 @@ export const S3Block: BlockConfig<S3Response> = {
 
 export const S3BlockMeta = {
   tags: ['cloud', 'automation'],
+  url: 'https://aws.amazon.com/s3',
   templates: [
     {
       icon: S3Icon,

--- a/apps/sim/blocks/blocks/salesforce.ts
+++ b/apps/sim/blocks/blocks/salesforce.ts
@@ -668,6 +668,7 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
 
 export const SalesforceBlockMeta = {
   tags: ['sales-engagement', 'customer-support'],
+  url: 'https://www.salesforce.com',
   templates: [
     {
       icon: SalesforceIcon,

--- a/apps/sim/blocks/blocks/sap_concur.ts
+++ b/apps/sim/blocks/blocks/sap_concur.ts
@@ -1901,6 +1901,7 @@ export const SapConcurBlock: BlockConfig<SapConcurProxyResponse> = {
 
 export const SapConcurBlockMeta = {
   tags: ['automation'],
+  url: 'https://www.concur.com',
   templates: [
     {
       icon: SapConcurIcon,

--- a/apps/sim/blocks/blocks/sap_s4hana.ts
+++ b/apps/sim/blocks/blocks/sap_s4hana.ts
@@ -1210,6 +1210,7 @@ Return ONLY the JSON array - no explanations, no extra text.`,
 
 export const SapS4HanaBlockMeta = {
   tags: ['automation'],
+  url: 'https://www.sap.com/products/erp/s4hana.html',
   templates: [
     {
       icon: SapS4HanaIcon,

--- a/apps/sim/blocks/blocks/secrets_manager.ts
+++ b/apps/sim/blocks/blocks/secrets_manager.ts
@@ -282,6 +282,7 @@ export const SecretsManagerBlock: BlockConfig<SecretsManagerBaseResponse> = {
 
 export const SecretsManagerBlockMeta = {
   tags: ['cloud', 'secrets-management'],
+  url: 'https://aws.amazon.com/secrets-manager',
   templates: [
     {
       icon: SecretsManagerIcon,

--- a/apps/sim/blocks/blocks/sendblue.ts
+++ b/apps/sim/blocks/blocks/sendblue.ts
@@ -281,6 +281,7 @@ export const SendblueBlock: BlockConfig = {
 
 export const SendblueBlockMeta = {
   tags: ['messaging', 'automation', 'webhooks'],
+  url: 'https://sendblue.com',
   templates: [
     {
       icon: SendblueIcon,

--- a/apps/sim/blocks/blocks/sendgrid.ts
+++ b/apps/sim/blocks/blocks/sendgrid.ts
@@ -687,6 +687,7 @@ Return ONLY the HTML content.`,
 
 export const SendGridBlockMeta = {
   tags: ['email-marketing', 'messaging'],
+  url: 'https://www.twilio.com/en-us/sendgrid',
   templates: [
     {
       icon: SendgridIcon,

--- a/apps/sim/blocks/blocks/sentry.ts
+++ b/apps/sim/blocks/blocks/sentry.ts
@@ -714,6 +714,7 @@ Return ONLY the timestamp string - no explanations, no quotes, no extra text.`,
 
 export const SentryBlockMeta = {
   tags: ['error-tracking', 'monitoring'],
+  url: 'https://sentry.io',
   templates: [
     {
       icon: Bug,

--- a/apps/sim/blocks/blocks/serper.ts
+++ b/apps/sim/blocks/blocks/serper.ts
@@ -100,6 +100,7 @@ export const SerperBlock: BlockConfig<SearchResponse> = {
 
 export const SerperBlockMeta = {
   tags: ['web-scraping', 'seo'],
+  url: 'https://serper.dev',
   templates: [
     {
       icon: SerperIcon,

--- a/apps/sim/blocks/blocks/servicenow.ts
+++ b/apps/sim/blocks/blocks/servicenow.ts
@@ -465,6 +465,7 @@ Output: {"state": "2", "assigned_to": "john.doe", "work_notes": "Assigned and st
 
 export const ServiceNowBlockMeta = {
   tags: ['customer-support', 'ticketing', 'incident-management'],
+  url: 'https://www.servicenow.com',
   templates: [
     {
       icon: ServiceNowIcon,

--- a/apps/sim/blocks/blocks/ses.ts
+++ b/apps/sim/blocks/blocks/ses.ts
@@ -499,6 +499,7 @@ export const SESBlock: BlockConfig<ToolResponse> = {
 
 export const SESBlockMeta = {
   tags: ['cloud', 'email-marketing', 'messaging'],
+  url: 'https://aws.amazon.com/ses',
   templates: [
     {
       icon: SESIcon,

--- a/apps/sim/blocks/blocks/sharepoint.ts
+++ b/apps/sim/blocks/blocks/sharepoint.ts
@@ -1052,7 +1052,7 @@ Return ONLY the JSON object - no explanations, no markdown, no extra text.`,
 
 export const SharepointBlockMeta = {
   tags: ['microsoft-365', 'content-management', 'document-processing'],
-  url: 'https://www.microsoft.com/en-us/microsoft-365/sharepoint/collaboration',
+  url: 'https://www.microsoft.com/microsoft-365/sharepoint/collaboration',
   templates: [
     {
       icon: MicrosoftSharepointIcon,

--- a/apps/sim/blocks/blocks/sharepoint.ts
+++ b/apps/sim/blocks/blocks/sharepoint.ts
@@ -1052,6 +1052,7 @@ Return ONLY the JSON object - no explanations, no markdown, no extra text.`,
 
 export const SharepointBlockMeta = {
   tags: ['microsoft-365', 'content-management', 'document-processing'],
+  url: 'https://www.microsoft.com/en-us/microsoft-365/sharepoint/collaboration',
   templates: [
     {
       icon: MicrosoftSharepointIcon,

--- a/apps/sim/blocks/blocks/shopify.ts
+++ b/apps/sim/blocks/blocks/shopify.ts
@@ -1031,6 +1031,7 @@ export const ShopifyBlock: BlockConfig<ShopifyResponse> = {
 
 export const ShopifyBlockMeta = {
   tags: ['payments', 'automation'],
+  url: 'https://www.shopify.com',
   templates: [
     {
       icon: ShopifyIcon,

--- a/apps/sim/blocks/blocks/similarweb.ts
+++ b/apps/sim/blocks/blocks/similarweb.ts
@@ -202,6 +202,7 @@ Return ONLY the date string in YYYY-MM format - no explanations, no quotes, no e
 
 export const SimilarwebBlockMeta = {
   tags: ['marketing', 'data-analytics', 'seo'],
+  url: 'https://www.similarweb.com',
   templates: [
     {
       icon: SimilarwebIcon,

--- a/apps/sim/blocks/blocks/sixtyfour.ts
+++ b/apps/sim/blocks/blocks/sixtyfour.ts
@@ -298,6 +298,7 @@ export const SixtyfourBlock: BlockConfig = {
 
 export const SixtyfourBlockMeta = {
   tags: ['enrichment', 'sales-engagement'],
+  url: 'https://sixtyfour.ai',
   templates: [
     {
       icon: SixtyfourIcon,

--- a/apps/sim/blocks/blocks/slack.ts
+++ b/apps/sim/blocks/blocks/slack.ts
@@ -2233,6 +2233,7 @@ Do not include any explanations, markdown formatting, or other text outside the 
 
 export const SlackBlockMeta = {
   tags: ['messaging', 'webhooks', 'automation'],
+  url: 'https://slack.com',
   templates: [
     {
       icon: SlackIcon,

--- a/apps/sim/blocks/blocks/spotify.ts
+++ b/apps/sim/blocks/blocks/spotify.ts
@@ -1368,7 +1368,7 @@ export const SpotifyBlock: BlockConfig<ToolResponse> = {
 
 export const SpotifyBlockMeta = {
   tags: ['content-management', 'automation'],
-  url: 'https://open.spotify.com',
+  url: 'https://www.spotify.com',
   templates: [
     {
       icon: SpotifyIcon,

--- a/apps/sim/blocks/blocks/spotify.ts
+++ b/apps/sim/blocks/blocks/spotify.ts
@@ -1368,6 +1368,7 @@ export const SpotifyBlock: BlockConfig<ToolResponse> = {
 
 export const SpotifyBlockMeta = {
   tags: ['content-management', 'automation'],
+  url: 'https://open.spotify.com',
   templates: [
     {
       icon: SpotifyIcon,

--- a/apps/sim/blocks/blocks/sqs.ts
+++ b/apps/sim/blocks/blocks/sqs.ts
@@ -159,6 +159,7 @@ export const SQSBlock: BlockConfig<SqsResponse> = {
 
 export const SQSBlockMeta = {
   tags: ['cloud', 'messaging', 'automation'],
+  url: 'https://aws.amazon.com/sqs',
   templates: [
     {
       icon: SQSIcon,

--- a/apps/sim/blocks/blocks/stagehand.ts
+++ b/apps/sim/blocks/blocks/stagehand.ts
@@ -424,6 +424,7 @@ Example 3 (Data Collection):
 
 export const StagehandBlockMeta = {
   tags: ['web-scraping', 'automation', 'agentic'],
+  url: 'https://www.stagehand.dev',
   templates: [
     {
       icon: StagehandIcon,

--- a/apps/sim/blocks/blocks/stripe.ts
+++ b/apps/sim/blocks/blocks/stripe.ts
@@ -845,6 +845,7 @@ export const StripeBlock: BlockConfig<StripeResponse> = {
 
 export const StripeBlockMeta = {
   tags: ['payments', 'subscriptions', 'webhooks'],
+  url: 'https://stripe.com',
   templates: [
     {
       icon: GoogleSheetsIcon,

--- a/apps/sim/blocks/blocks/sts.ts
+++ b/apps/sim/blocks/blocks/sts.ts
@@ -250,7 +250,7 @@ export const STSBlock: BlockConfig<STSBaseResponse> = {
 
 export const STSBlockMeta = {
   tags: ['cloud', 'identity'],
-  url: 'https://aws.amazon.com/iam',
+  url: 'https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html',
   templates: [
     {
       icon: STSIcon,

--- a/apps/sim/blocks/blocks/sts.ts
+++ b/apps/sim/blocks/blocks/sts.ts
@@ -250,6 +250,7 @@ export const STSBlock: BlockConfig<STSBaseResponse> = {
 
 export const STSBlockMeta = {
   tags: ['cloud', 'identity'],
+  url: 'https://aws.amazon.com/iam',
   templates: [
     {
       icon: STSIcon,

--- a/apps/sim/blocks/blocks/supabase.ts
+++ b/apps/sim/blocks/blocks/supabase.ts
@@ -1225,6 +1225,7 @@ Return ONLY the PostgREST filter expression - no explanations, no markdown, no e
 
 export const SupabaseBlockMeta = {
   tags: ['cloud', 'data-warehouse', 'vector-search'],
+  url: 'https://supabase.com',
   templates: [
     {
       icon: SupabaseIcon,

--- a/apps/sim/blocks/blocks/tailscale.ts
+++ b/apps/sim/blocks/blocks/tailscale.ts
@@ -340,7 +340,8 @@ export const TailscaleBlock: BlockConfig = {
 }
 
 export const TailscaleBlockMeta = {
-  tags: ['monitoring'],
+  tags: ['monitoring', 'identity'],
+  url: 'https://tailscale.com',
   templates: [
     {
       icon: TailscaleIcon,

--- a/apps/sim/blocks/blocks/tailscale.ts
+++ b/apps/sim/blocks/blocks/tailscale.ts
@@ -340,7 +340,7 @@ export const TailscaleBlock: BlockConfig = {
 }
 
 export const TailscaleBlockMeta = {
-  tags: ['monitoring', 'identity'],
+  tags: ['monitoring'],
   url: 'https://tailscale.com',
   templates: [
     {

--- a/apps/sim/blocks/blocks/tavily.ts
+++ b/apps/sim/blocks/blocks/tavily.ts
@@ -370,6 +370,7 @@ export const TavilyBlock: BlockConfig<TavilyResponse> = {
 
 export const TavilyBlockMeta = {
   tags: ['web-scraping', 'enrichment'],
+  url: 'https://tavily.com',
   templates: [
     {
       icon: TavilyIcon,

--- a/apps/sim/blocks/blocks/telegram.ts
+++ b/apps/sim/blocks/blocks/telegram.ts
@@ -429,6 +429,7 @@ export const TelegramBlock: BlockConfig<TelegramResponse> = {
 
 export const TelegramBlockMeta = {
   tags: ['messaging', 'webhooks', 'automation'],
+  url: 'https://telegram.org',
   templates: [
     {
       icon: TelegramIcon,

--- a/apps/sim/blocks/blocks/temporal.ts
+++ b/apps/sim/blocks/blocks/temporal.ts
@@ -817,6 +817,7 @@ Return ONLY a valid JSON object - no explanations, no extra text.`,
 
 export const TemporalBlockMeta = {
   tags: ['automation'],
+  url: 'https://temporal.io',
   templates: [
     {
       icon: TemporalIcon,

--- a/apps/sim/blocks/blocks/textract.ts
+++ b/apps/sim/blocks/blocks/textract.ts
@@ -292,6 +292,7 @@ export const TextractV2Block: BlockConfig<TextractParserOutput> = {
 
 export const TextractBlockMeta = {
   tags: ['document-processing', 'ocr', 'cloud'],
+  url: 'https://aws.amazon.com/textract',
   templates: [
     {
       icon: TextractIcon,

--- a/apps/sim/blocks/blocks/tinybird.ts
+++ b/apps/sim/blocks/blocks/tinybird.ts
@@ -386,6 +386,7 @@ export const TinybirdBlock: BlockConfig<TinybirdResponse> = {
 
 export const TinybirdBlockMeta = {
   tags: ['data-warehouse', 'data-analytics'],
+  url: 'https://www.tinybird.co',
   templates: [
     {
       icon: TinybirdIcon,

--- a/apps/sim/blocks/blocks/trello.ts
+++ b/apps/sim/blocks/blocks/trello.ts
@@ -528,6 +528,7 @@ Return ONLY the date/timestamp string - no explanations, no extra text.`,
 
 export const TrelloBlockMeta = {
   tags: ['project-management', 'ticketing'],
+  url: 'https://trello.com',
   templates: [
     {
       icon: TrelloIcon,

--- a/apps/sim/blocks/blocks/trigger_dev.ts
+++ b/apps/sim/blocks/blocks/trigger_dev.ts
@@ -1131,6 +1131,7 @@ Return ONLY the valid JSON object - no explanations, no markdown.`,
 
 export const TriggerDevBlockMeta = {
   tags: ['automation', 'ci-cd', 'monitoring'],
+  url: 'https://trigger.dev',
   templates: [
     {
       icon: TriggerDevIcon,

--- a/apps/sim/blocks/blocks/twilio.ts
+++ b/apps/sim/blocks/blocks/twilio.ts
@@ -76,6 +76,7 @@ export const TwilioSMSBlock: BlockConfig<TwilioSMSBlockOutput> = {
 
 export const TwilioSMSBlockMeta = {
   tags: ['messaging', 'automation'],
+  url: 'https://www.twilio.com',
   templates: [
     {
       icon: TwilioIcon,

--- a/apps/sim/blocks/blocks/twilio_voice.ts
+++ b/apps/sim/blocks/blocks/twilio_voice.ts
@@ -416,6 +416,7 @@ Return ONLY the date string in YYYY-MM-DD format - no explanations, no quotes, n
 
 export const TwilioVoiceBlockMeta = {
   tags: ['messaging', 'text-to-speech'],
+  url: 'https://www.twilio.com',
   templates: [
     {
       icon: TwilioIcon,

--- a/apps/sim/blocks/blocks/typeform.ts
+++ b/apps/sim/blocks/blocks/typeform.ts
@@ -458,6 +458,7 @@ Do not include any explanations, markdown formatting, or other text outside the 
 
 export const TypeformBlockMeta = {
   tags: ['forms', 'data-analytics'],
+  url: 'https://www.typeform.com',
   templates: [
     {
       icon: TypeformIcon,

--- a/apps/sim/blocks/blocks/upstash.ts
+++ b/apps/sim/blocks/blocks/upstash.ts
@@ -350,6 +350,7 @@ export const UpstashBlock: BlockConfig<UpstashResponse> = {
 
 export const UpstashBlockMeta = {
   tags: ['cloud'],
+  url: 'https://upstash.com',
   templates: [
     {
       icon: UpstashIcon,

--- a/apps/sim/blocks/blocks/vanta.ts
+++ b/apps/sim/blocks/blocks/vanta.ts
@@ -1131,6 +1131,7 @@ export const VantaBlock: BlockConfig<ToolResponse> = {
 
 export const VantaBlockMeta = {
   tags: ['monitoring', 'automation', 'document-processing'],
+  url: 'https://www.vanta.com',
   templates: [
     {
       icon: VantaIcon,

--- a/apps/sim/blocks/blocks/vercel.ts
+++ b/apps/sim/blocks/blocks/vercel.ts
@@ -1194,6 +1194,7 @@ export const VercelBlock: BlockConfig = {
 
 export const VercelBlockMeta = {
   tags: ['cloud', 'ci-cd'],
+  url: 'https://vercel.com',
   templates: [
     {
       icon: VercelIcon,

--- a/apps/sim/blocks/blocks/wealthbox.ts
+++ b/apps/sim/blocks/blocks/wealthbox.ts
@@ -277,6 +277,7 @@ Return ONLY the date/time string - no explanations, no quotes, no extra text.`,
 
 export const WealthboxBlockMeta = {
   tags: ['sales-engagement'],
+  url: 'https://www.wealthbox.com',
   templates: [
     {
       icon: WealthboxIcon,

--- a/apps/sim/blocks/blocks/webflow.ts
+++ b/apps/sim/blocks/blocks/webflow.ts
@@ -259,6 +259,7 @@ export const WebflowBlock: BlockConfig<WebflowResponse> = {
 
 export const WebflowBlockMeta = {
   tags: ['content-management', 'seo'],
+  url: 'https://webflow.com',
   templates: [
     {
       icon: WebflowIcon,

--- a/apps/sim/blocks/blocks/whatsapp.ts
+++ b/apps/sim/blocks/blocks/whatsapp.ts
@@ -179,6 +179,7 @@ export const WhatsAppBlock: BlockConfig<WhatsAppResponse> = {
 
 export const WhatsAppBlockMeta = {
   tags: ['messaging', 'automation'],
+  url: 'https://www.whatsapp.com',
   templates: [
     {
       icon: WhatsAppIcon,

--- a/apps/sim/blocks/blocks/wikipedia.ts
+++ b/apps/sim/blocks/blocks/wikipedia.ts
@@ -109,6 +109,7 @@ export const WikipediaBlock: BlockConfig<WikipediaResponse> = {
 
 export const WikipediaBlockMeta = {
   tags: ['knowledge-base'],
+  url: 'https://www.wikipedia.org',
   templates: [
     {
       icon: WikipediaIcon,

--- a/apps/sim/blocks/blocks/wiza.ts
+++ b/apps/sim/blocks/blocks/wiza.ts
@@ -628,6 +628,7 @@ Return ONLY the JSON object - no explanations, no extra text.`,
 
 export const WizaBlockMeta = {
   tags: ['enrichment', 'sales-engagement'],
+  url: 'https://wiza.co',
   templates: [
     {
       icon: WizaIcon,

--- a/apps/sim/blocks/blocks/wordpress.ts
+++ b/apps/sim/blocks/blocks/wordpress.ts
@@ -1017,6 +1017,7 @@ export const WordPressBlock: BlockConfig<WordPressResponse> = {
 
 export const WordPressBlockMeta = {
   tags: ['content-management', 'seo'],
+  url: 'https://wordpress.org',
   templates: [
     {
       icon: WordpressIcon,

--- a/apps/sim/blocks/blocks/workday.ts
+++ b/apps/sim/blocks/blocks/workday.ts
@@ -463,6 +463,7 @@ Output: {"Marital_Status_Reference":{"ID":{"attributes":{"wd:type":"Marital_Stat
 
 export const WorkdayBlockMeta = {
   tags: ['hiring'],
+  url: 'https://www.workday.com',
   templates: [
     {
       icon: WorkdayIcon,

--- a/apps/sim/blocks/blocks/x.ts
+++ b/apps/sim/blocks/blocks/x.ts
@@ -758,6 +758,7 @@ Return ONLY the timestamp string - no explanations, no quotes, no extra text.`,
 
 export const XBlockMeta = {
   tags: ['marketing', 'messaging'],
+  url: 'https://x.com',
   templates: [
     {
       icon: xIcon,

--- a/apps/sim/blocks/blocks/youtube.ts
+++ b/apps/sim/blocks/blocks/youtube.ts
@@ -551,6 +551,7 @@ Return ONLY the timestamp string - no explanations, no quotes, no extra text.`,
 
 export const YouTubeBlockMeta = {
   tags: ['marketing', 'content-management'],
+  url: 'https://www.youtube.com',
   templates: [
     {
       icon: YouTubeIcon,

--- a/apps/sim/blocks/blocks/zendesk.ts
+++ b/apps/sim/blocks/blocks/zendesk.ts
@@ -699,6 +699,7 @@ Return ONLY the search query - no explanations.`,
 
 export const ZendeskBlockMeta = {
   tags: ['customer-support', 'ticketing'],
+  url: 'https://www.zendesk.com',
   templates: [
     {
       icon: ZendeskIcon,

--- a/apps/sim/blocks/blocks/zep.ts
+++ b/apps/sim/blocks/blocks/zep.ts
@@ -303,6 +303,7 @@ export const ZepBlock: BlockConfig<ZepResponse> = {
 
 export const ZepBlockMeta = {
   tags: ['knowledge-base', 'agentic'],
+  url: 'https://www.getzep.com',
   templates: [
     {
       icon: ZepIcon,

--- a/apps/sim/blocks/blocks/zerobounce.ts
+++ b/apps/sim/blocks/blocks/zerobounce.ts
@@ -99,4 +99,5 @@ export const ZeroBounceBlock: BlockConfig<ZeroBounceResponse> = {
 
 export const ZeroBounceBlockMeta = {
   tags: ['enrichment', 'sales-engagement'],
+  url: 'https://www.zerobounce.net',
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/zoom.ts
+++ b/apps/sim/blocks/blocks/zoom.ts
@@ -671,6 +671,7 @@ Return ONLY the date string - no explanations, no quotes, no extra text.`,
 
 export const ZoomBlockMeta = {
   tags: ['meeting', 'calendar', 'scheduling'],
+  url: 'https://www.zoom.com',
   templates: [
     {
       icon: ZoomIcon,

--- a/apps/sim/blocks/blocks/zoominfo.ts
+++ b/apps/sim/blocks/blocks/zoominfo.ts
@@ -554,6 +554,7 @@ export const ZoomInfoBlock: BlockConfig<ZoomInfoResponse> = {
 
 export const ZoomInfoBlockMeta = {
   tags: ['enrichment', 'sales-engagement'],
+  url: 'https://www.zoominfo.com',
   templates: [
     {
       icon: ZoomInfoIcon,

--- a/apps/sim/blocks/types.ts
+++ b/apps/sim/blocks/types.ts
@@ -158,6 +158,12 @@ export interface SuggestedSkill {
 /** Presentation/catalog data for a block. Never read by the executor. */
 export interface BlockMeta {
   tags: readonly IntegrationTag[]
+  /**
+   * Canonical homepage of the external service this block integrates with
+   * (e.g. `https://exa.ai`). Distinct from `BlockConfig.docsLink`, which points
+   * at Sim's own integration docs. Links back to the tool from its catalog page.
+   */
+  url?: string
   templates?: readonly BlockTemplate[]
   /** Popular, ready-to-add skills for this integration, shown on its detail page. */
   skills?: readonly SuggestedSkill[]


### PR DESCRIPTION
## Summary
- Add an optional `url` field to `BlockMeta` — the integration's own homepage (e.g. `https://exa.ai`, `https://www.salesforce.com`), the "link back to the tool". It's distinct from `docsLink`, which points at Sim's own docs on `docs.sim.ai`.
- Populate `url` on all 209 integration blocks with homepages that were verified to resolve to the right service. Protocol/internal blocks with no single vendor site (IMAP, RSS, the built-in enrichment cascade) are intentionally left without one.
- Document the field in the `/add-block` skill and command (example, rule, and checklist entries).
- Backfill `dspy`'s missing `docsLink` and add a few accurate `tags` entries.

## Type of Change
- [x] New feature (catalog metadata)

## Testing
- `tsc --noEmit` passes (no new errors; the lone pre-existing `tailwind.config.ts` error is unrelated)
- `check:api-validation:strict` passes
- biome clean on all changed files
- Every URL was fetch/search-verified against the live site

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)