### PR TITLE
feat(scheduled-tasks): pause/resume, mutation toasts, submit guards, empty state

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/schedule-calendar/components/calendar-event-chip/calendar-event-chip.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/schedule-calendar/components/calendar-event-chip/calendar-event-chip.tsx
@@ -24,7 +24,9 @@ interface CalendarEventChipProps {
  * details modal carries the state. The pill is the grid's real `<button>` (its
  * parent cells are plain clickable `<div>`s), so tasks are the tab-reachable
  * elements; clicks stop propagating so the cell underneath doesn't also open
- * the create modal.
+ * the create modal. A paused task (`task.disabled`) renders dimmed — the one
+ * status the pill signals visually, since a paused task can sit on the calendar
+ * indefinitely without running.
  */
 export function CalendarEventChip({
   event,
@@ -49,6 +51,7 @@ export function CalendarEventChip({
         chipContentGap,
         chipPrimaryFillTokens,
         'hover-hover:bg-[var(--text-body)] dark:hover-hover:bg-[var(--text-secondary)]',
+        event.task.disabled && 'opacity-45',
         className
       )}
     >

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/schedule-calendar/schedule-calendar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/schedule-calendar/schedule-calendar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Calendar, Chip, Plus } from '@/components/emcn'
 import { zonedClockDate } from '@/lib/core/utils/timezone'
 import {
   CalendarToolbar,
@@ -38,6 +39,32 @@ interface ScheduleCalendarProps {
   onShowDay: (date: Date) => void
   /** Day-bucketed events feeding both the month grid and the time grid. */
   eventsByDay?: Map<string, CalendarEvent[]>
+  /** The workspace has no scheduled tasks yet — show the first-run prompt instead of the grid. */
+  isEmpty?: boolean
+  /** Starts a blank create from the first-run prompt. */
+  onCreate: () => void
+}
+
+/**
+ * First-run prompt shown in place of the grid when the workspace has no
+ * scheduled tasks. The grid stays one click away — empty space and this CTA both
+ * open the create modal.
+ */
+function CalendarEmptyState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className='flex h-full flex-col items-center justify-center gap-3 px-6 text-center'>
+      <Calendar className='size-6 text-[var(--text-muted)]' />
+      <div className='flex flex-col gap-1'>
+        <p className='text-[var(--text-body)] text-base'>No scheduled tasks</p>
+        <p className='max-w-[320px] text-[var(--text-muted)] text-small'>
+          Schedule Sim to run on its own — daily digests, reminders, recurring checks.
+        </p>
+      </div>
+      <Chip variant='primary' leftIcon={Plus} onClick={onCreate}>
+        New scheduled task
+      </Chip>
+    </div>
+  )
 }
 
 /**
@@ -72,6 +99,8 @@ export function ScheduleCalendar({
   onTaskContextMenu,
   onShowDay,
   eventsByDay,
+  isEmpty = false,
+  onCreate,
 }: ScheduleCalendarProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const lastScrollSignalRef = useRef(0)
@@ -87,7 +116,7 @@ export function ScheduleCalendar({
 
   useEffect(() => {
     const region = scrollRef.current
-    if (!region) return
+    if (!region || isEmpty) return
     const behavior: ScrollBehavior =
       scrollSignal !== lastScrollSignalRef.current ? 'smooth' : 'auto'
     lastScrollSignalRef.current = scrollSignal
@@ -100,7 +129,7 @@ export function ScheduleCalendar({
     const target =
       headerHeight + timeToOffset(zonedClockDate(new Date(), timezone)) - region.clientHeight / 2
     region.scrollTo({ top: Math.max(0, target), behavior })
-  }, [scope, scrollSignal, timezone])
+  }, [scope, scrollSignal, timezone, isEmpty])
 
   return (
     <div className='relative flex min-h-0 flex-1 flex-col overflow-hidden'>
@@ -115,7 +144,9 @@ export function ScheduleCalendar({
         onScopeChange={onScopeChange}
       />
       <div ref={scrollRef} className='min-h-0 flex-1 overflow-auto overscroll-none'>
-        {grid.kind === 'month' ? (
+        {isEmpty ? (
+          <CalendarEmptyState onCreate={onCreate} />
+        ) : grid.kind === 'month' ? (
           <MonthGrid
             grid={grid}
             onSelectDay={(date) => onSelectSlot(date)}

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/schedule-calendar/schedule-calendar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/schedule-calendar/schedule-calendar.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Calendar, Chip, Plus } from '@/components/emcn'
 import { zonedClockDate } from '@/lib/core/utils/timezone'
 import {
   CalendarToolbar,
@@ -39,32 +38,6 @@ interface ScheduleCalendarProps {
   onShowDay: (date: Date) => void
   /** Day-bucketed events feeding both the month grid and the time grid. */
   eventsByDay?: Map<string, CalendarEvent[]>
-  /** The workspace has no scheduled tasks yet — show the first-run prompt instead of the grid. */
-  isEmpty?: boolean
-  /** Starts a blank create from the first-run prompt. */
-  onCreate: () => void
-}
-
-/**
- * First-run prompt shown in place of the grid when the workspace has no
- * scheduled tasks. The grid stays one click away — empty space and this CTA both
- * open the create modal.
- */
-function CalendarEmptyState({ onCreate }: { onCreate: () => void }) {
-  return (
-    <div className='flex h-full flex-col items-center justify-center gap-3 px-6 text-center'>
-      <Calendar className='size-6 text-[var(--text-muted)]' />
-      <div className='flex flex-col gap-1'>
-        <p className='text-[var(--text-body)] text-base'>No scheduled tasks</p>
-        <p className='max-w-[320px] text-[var(--text-muted)] text-small'>
-          Schedule Sim to run on its own — daily digests, reminders, recurring checks.
-        </p>
-      </div>
-      <Chip variant='primary' leftIcon={Plus} onClick={onCreate}>
-        New scheduled task
-      </Chip>
-    </div>
-  )
 }
 
 /**
@@ -99,8 +72,6 @@ export function ScheduleCalendar({
   onTaskContextMenu,
   onShowDay,
   eventsByDay,
-  isEmpty = false,
-  onCreate,
 }: ScheduleCalendarProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const lastScrollSignalRef = useRef(0)
@@ -116,7 +87,7 @@ export function ScheduleCalendar({
 
   useEffect(() => {
     const region = scrollRef.current
-    if (!region || isEmpty) return
+    if (!region) return
     const behavior: ScrollBehavior =
       scrollSignal !== lastScrollSignalRef.current ? 'smooth' : 'auto'
     lastScrollSignalRef.current = scrollSignal
@@ -129,7 +100,7 @@ export function ScheduleCalendar({
     const target =
       headerHeight + timeToOffset(zonedClockDate(new Date(), timezone)) - region.clientHeight / 2
     region.scrollTo({ top: Math.max(0, target), behavior })
-  }, [scope, scrollSignal, timezone, isEmpty])
+  }, [scope, scrollSignal, timezone])
 
   return (
     <div className='relative flex min-h-0 flex-1 flex-col overflow-hidden'>
@@ -144,9 +115,7 @@ export function ScheduleCalendar({
         onScopeChange={onScopeChange}
       />
       <div ref={scrollRef} className='min-h-0 flex-1 overflow-auto overscroll-none'>
-        {isEmpty ? (
-          <CalendarEmptyState onCreate={onCreate} />
-        ) : grid.kind === 'month' ? (
+        {grid.kind === 'month' ? (
           <MonthGrid
             grid={grid}
             onSelectDay={(date) => onSelectSlot(date)}

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-context-menu/task-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-context-menu/task-context-menu.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/emcn'
-import { Duplicate as DuplicateIcon, Pencil, Trash } from '@/components/emcn/icons'
+import { Duplicate as DuplicateIcon, Pause, Pencil, Play, Trash } from '@/components/emcn/icons'
 import type { ScheduledTask } from '@/app/workspace/[workspaceId]/scheduled-tasks/utils/schedule-events'
 
 interface TaskContextMenuProps {
@@ -19,13 +19,18 @@ interface TaskContextMenuProps {
   onEdit: () => void
   /** Opens a new-task modal pre-filled from this task. */
   onDuplicate: () => void
+  /** Pauses an active recurring task — suspends its future runs. */
+  onPause: () => void
+  /** Resumes a paused recurring task. */
+  onResume: () => void
   onDelete: () => void
 }
 
 /**
  * Right-click menu for a calendar task pill. Upcoming (`pending`) tasks can be
- * edited or deleted; any task can be duplicated into a new one. Finished tasks
- * open their read-only record on click, so the menu only offers Duplicate.
+ * edited or deleted, and recurring ones paused or resumed; any task can be
+ * duplicated into a new one. Finished tasks open their read-only record on
+ * click, so the menu only offers Duplicate.
  */
 export function TaskContextMenu({
   isOpen,
@@ -34,9 +39,13 @@ export function TaskContextMenu({
   task,
   onEdit,
   onDuplicate,
+  onPause,
+  onResume,
   onDelete,
 }: TaskContextMenuProps) {
   const isUpcoming = task?.status === 'pending'
+  /** Pause/Resume applies to recurring tasks only — one-time tasks carry no cadence. */
+  const canPauseResume = isUpcoming && task?.recurring === true
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={(open) => !open && onClose()} modal={false}>
@@ -67,6 +76,18 @@ export function TaskContextMenu({
               <Pencil />
               Edit
             </DropdownMenuItem>
+            {canPauseResume &&
+              (task?.disabled ? (
+                <DropdownMenuItem onSelect={onResume}>
+                  <Play />
+                  Resume
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onSelect={onPause}>
+                  <Pause />
+                  Pause
+                </DropdownMenuItem>
+              ))}
             <DropdownMenuItem onSelect={onDuplicate}>
               <DuplicateIcon />
               Duplicate

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
@@ -232,7 +232,8 @@ function TaskModalContent({
    * Submits the draft and waits for it to persist. The `submitting` guard blocks
    * a double-submit (Enter racing the click); on success the modal closes, on
    * failure it stays open so the draft survives — the mutation hook surfaces the
-   * error via toast, so no message is duplicated here.
+   * error via toast, so no message is duplicated here. `submitting` always resets
+   * in `finally`, so the button can never stick disabled if the modal is kept open.
    */
   const handleSubmit = async () => {
     if (!promptText || isPastLaunch || submitting) return
@@ -248,6 +249,8 @@ function TaskModalContent({
       })
       close()
     } catch {
+      // Failure keeps the modal open; the mutation hook surfaces the error via toast.
+    } finally {
       setSubmitting(false)
     }
   }

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
@@ -286,7 +286,17 @@ function TaskModalContent({
 
   const secondaryActions: ChipModalFooterSlotAction[] = [
     ...(edit && onRequestDelete
-      ? [{ label: 'Delete', variant: 'destructive' as const, onClick: onRequestDelete }]
+      ? [
+          {
+            label: 'Delete',
+            variant: 'destructive' as const,
+            onClick: onRequestDelete,
+            // Locked during a save: Delete bypasses the dismiss guard (it closes the
+            // modal via closeTask, not onOpenChange), so without this an in-flight
+            // edit and a delete could run against the same task at once.
+            disabled: submitting,
+          },
+        ]
       : []),
     {
       custom: (

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
@@ -224,6 +224,14 @@ function TaskModalContent({
     () => source?.recurrence ?? DEFAULT_RECURRENCE
   )
   const launchEditedRef = useRef(false)
+  /**
+   * Synchronous mirror of `submitting` that gates {@link handleSubmit}. The
+   * `submitting` state only reflects after a re-render, so two invocations in the
+   * same tick (Enter racing the click) could both pass a state-based guard; the
+   * ref flips immediately, so the second is rejected before it can fire a second
+   * mutation.
+   */
+  const submittingRef = useRef(false)
 
   /**
    * Re-seed a blank create's default launch when the effective zone resolves
@@ -258,15 +266,17 @@ function TaskModalContent({
   const promptText = editor.value.trim()
 
   /**
-   * Submits the draft and waits for it to persist. The `submitting` guard blocks
-   * a double-submit (Enter racing the click). The modal closes only when the save
-   * resolves; a rejection leaves it open so the draft survives — the mutation hook
-   * already surfaces the error via toast, so it is swallowed here rather than
-   * duplicated. `submitting` is always cleared, so the button can never stick
-   * disabled while the modal stays open.
+   * Submits the draft and waits for it to persist. The synchronous
+   * {@link submittingRef} guard blocks a double-submit (Enter racing the click).
+   * The modal closes only when the save resolves; a rejection leaves it open so
+   * the draft survives — the mutation hook already surfaces the error via toast,
+   * so it is swallowed here rather than duplicated. Both the ref and the
+   * `submitting` state are always cleared, so the button can never stick disabled
+   * while the modal stays open.
    */
   const handleSubmit = async () => {
-    if (!promptText || isPastLaunch || submitting) return
+    if (!promptText || isPastLaunch || submittingRef.current) return
+    submittingRef.current = true
     setSubmitting(true)
     const persisted = await Promise.resolve(
       onSubmit({
@@ -280,6 +290,7 @@ function TaskModalContent({
     )
       .then(() => true)
       .catch(() => false)
+    submittingRef.current = false
     setSubmitting(false)
     if (persisted) close()
   }

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
@@ -105,8 +105,12 @@ interface TaskModalProps {
   edit?: TaskEditSeed | null
   /** Pre-fill for a create (duplicate): opens in create mode with every field copied. */
   prefill?: TaskPrefill | null
-  /** Receives the captured draft on submit (create and save alike). */
-  onSubmit: (draft: TaskDraft) => void
+  /**
+   * Receives the captured draft on submit (create and save alike). May return a
+   * promise — the modal awaits it, keeping itself open until the task persists
+   * and closing only on success, so a failed save never silently discards the draft.
+   */
+  onSubmit: (draft: TaskDraft) => void | Promise<void>
   /** Asks the parent to start the delete flow (which handles the recurring this/all choice). */
   onRequestDelete?: () => void
 }
@@ -189,6 +193,7 @@ function TaskModalContent({
   const [recurrence, setRecurrence] = useState<Recurrence>(
     () => source?.recurrence ?? DEFAULT_RECURRENCE
   )
+  const [submitting, setSubmitting] = useState(false)
   const launchEditedRef = useRef(false)
 
   /**
@@ -223,17 +228,28 @@ function TaskModalContent({
 
   const promptText = editor.value.trim()
 
-  const handleSubmit = () => {
-    if (!promptText || isPastLaunch) return
-    onSubmit({
-      prompt: editor.getPlainValue().trim(),
-      contexts: editor.contexts.length > 0 ? editor.contexts : undefined,
-      launchDate,
-      launchTime,
-      timezone,
-      recurrence,
-    })
-    close()
+  /**
+   * Submits the draft and waits for it to persist. The `submitting` guard blocks
+   * a double-submit (Enter racing the click); on success the modal closes, on
+   * failure it stays open so the draft survives — the mutation hook surfaces the
+   * error via toast, so no message is duplicated here.
+   */
+  const handleSubmit = async () => {
+    if (!promptText || isPastLaunch || submitting) return
+    setSubmitting(true)
+    try {
+      await onSubmit({
+        prompt: editor.getPlainValue().trim(),
+        contexts: editor.contexts.length > 0 ? editor.contexts : undefined,
+        launchDate,
+        launchTime,
+        timezone,
+        recurrence,
+      })
+      close()
+    } catch {
+      setSubmitting(false)
+    }
   }
 
   const secondaryActions: ChipModalFooterSlotAction[] = [
@@ -270,9 +286,9 @@ function TaskModalContent({
         onCancel={close}
         secondaryActions={secondaryActions}
         primaryAction={{
-          label: edit ? 'Save' : 'Schedule',
+          label: submitting ? (edit ? 'Saving...' : 'Scheduling...') : edit ? 'Save' : 'Schedule',
           onClick: handleSubmit,
-          disabled: !promptText || isPastLaunch,
+          disabled: !promptText || isPastLaunch || submitting,
           disabledTooltip: isPastLaunch ? PAST_LAUNCH_MESSAGE : undefined,
         }}
       />

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
@@ -138,6 +138,13 @@ export function TaskModal({
    * Escape, and overlay click all route through this one handler — so an
    * in-progress create/edit can't be abandoned and lose its draft. `submitting`
    * lives here (not in the unmounted-on-close content) so this guard can see it.
+   *
+   * The programmatic close on a *successful* submit is intentionally NOT blocked:
+   * `handleSubmit` runs in the pre-submit render where `submitting` was still
+   * false, so its `close()` resolves to that render's handler and passes through,
+   * while user dismisses fire from the current (submitting) render and are caught
+   * here. Keep `submitting` as render state — moving it to a ref or memoizing this
+   * handler with `submitting` in deps would make the success-close start blocking.
    */
   const handleOpenChange = (next: boolean) => {
     if (!next && submitting) return

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
@@ -131,23 +131,44 @@ export function TaskModal({
   onSubmit,
   onRequestDelete,
 }: TaskModalProps) {
+  const [submitting, setSubmitting] = useState(false)
+
+  /**
+   * While a save is in flight, swallow every dismiss path — Cancel, header X,
+   * Escape, and overlay click all route through this one handler — so an
+   * in-progress create/edit can't be abandoned and lose its draft. `submitting`
+   * lives here (not in the unmounted-on-close content) so this guard can see it.
+   */
+  const handleOpenChange = (next: boolean) => {
+    if (!next && submitting) return
+    onOpenChange(next)
+  }
+
   return (
     <ChipModal
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={handleOpenChange}
       size='lg'
       srTitle={edit ? 'Edit scheduled task' : 'New scheduled task'}
     >
       <TaskModalContent
-        onOpenChange={onOpenChange}
+        onOpenChange={handleOpenChange}
         slot={slot}
         edit={edit}
         prefill={prefill}
         onSubmit={onSubmit}
         onRequestDelete={onRequestDelete}
+        submitting={submitting}
+        setSubmitting={setSubmitting}
       />
     </ChipModal>
   )
+}
+
+interface TaskModalContentProps extends Omit<TaskModalProps, 'open'> {
+  /** Whether a save is in flight — owned by {@link TaskModal} so the dismiss guard can read it. */
+  submitting: boolean
+  setSubmitting: (submitting: boolean) => void
 }
 
 /**
@@ -162,7 +183,9 @@ function TaskModalContent({
   prefill,
   onSubmit,
   onRequestDelete,
-}: Omit<TaskModalProps, 'open'>) {
+  submitting,
+  setSubmitting,
+}: TaskModalContentProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const source = edit ?? prefill
   const accountTimezone = useTimezone()
@@ -193,7 +216,6 @@ function TaskModalContent({
   const [recurrence, setRecurrence] = useState<Recurrence>(
     () => source?.recurrence ?? DEFAULT_RECURRENCE
   )
-  const [submitting, setSubmitting] = useState(false)
   const launchEditedRef = useRef(false)
 
   /**
@@ -287,6 +309,7 @@ function TaskModalContent({
       </ChipModalPromptBody>
       <ChipModalFooter
         onCancel={close}
+        cancelDisabled={submitting}
         secondaryActions={secondaryActions}
         primaryAction={{
           label: submitting ? (edit ? 'Saving...' : 'Scheduling...') : edit ? 'Save' : 'Schedule',

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
@@ -259,16 +259,17 @@ function TaskModalContent({
 
   /**
    * Submits the draft and waits for it to persist. The `submitting` guard blocks
-   * a double-submit (Enter racing the click); on success the modal closes, on
-   * failure it stays open so the draft survives — the mutation hook surfaces the
-   * error via toast, so no message is duplicated here. `submitting` always resets
-   * in `finally`, so the button can never stick disabled if the modal is kept open.
+   * a double-submit (Enter racing the click). The modal closes only when the save
+   * resolves; a rejection leaves it open so the draft survives — the mutation hook
+   * already surfaces the error via toast, so it is swallowed here rather than
+   * duplicated. `submitting` is always cleared, so the button can never stick
+   * disabled while the modal stays open.
    */
   const handleSubmit = async () => {
     if (!promptText || isPastLaunch || submitting) return
     setSubmitting(true)
-    try {
-      await onSubmit({
+    const persisted = await Promise.resolve(
+      onSubmit({
         prompt: editor.getPlainValue().trim(),
         contexts: editor.contexts.length > 0 ? editor.contexts : undefined,
         launchDate,
@@ -276,14 +277,19 @@ function TaskModalContent({
         timezone,
         recurrence,
       })
-      close()
-    } catch {
-      // Failure keeps the modal open; the mutation hook surfaces the error via toast.
-    } finally {
-      setSubmitting(false)
-    }
+    )
+      .then(() => true)
+      .catch(() => false)
+    setSubmitting(false)
+    if (persisted) close()
   }
 
+  /**
+   * Footer secondary actions. Delete is disabled while `submitting` because it
+   * bypasses the dismiss guard — it closes the modal via `closeTask`, not the
+   * guarded `onOpenChange` — so without the lock an in-flight edit and a delete
+   * could run against the same task at once.
+   */
   const secondaryActions: ChipModalFooterSlotAction[] = [
     ...(edit && onRequestDelete
       ? [
@@ -291,9 +297,6 @@ function TaskModalContent({
             label: 'Delete',
             variant: 'destructive' as const,
             onClick: onRequestDelete,
-            // Locked during a save: Delete bypasses the dismiss guard (it closes the
-            // modal via closeTask, not onOpenChange), so without this an in-flight
-            // edit and a delete could run against the same task at once.
             disabled: submitting,
           },
         ]

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/hooks/use-scheduled-tasks.ts
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/hooks/use-scheduled-tasks.ts
@@ -22,7 +22,9 @@ import {
 import {
   useCreateSchedule,
   useDeleteSchedule,
+  useDisableSchedule,
   useExcludeOccurrence,
+  useResumeSchedule,
   useUpdateSchedule,
   useWorkspaceSchedules,
 } from '@/hooks/queries/schedules'
@@ -83,6 +85,8 @@ export interface UseScheduledTasksParams {
 
 export interface UseScheduledTasksReturn {
   isLoading: boolean
+  /** Whether the workspace has any scheduled task at all — drives the first-run empty state. */
+  hasTasks: boolean
   /** Day-bucketed events feeding both the month grid and the time grid. */
   eventsByDay: Map<string, CalendarEvent[]>
   /** The task occurrence whose modal is open, or `null` when none is. */
@@ -91,12 +95,18 @@ export interface UseScheduledTasksReturn {
   closeTask: () => void
   /** Recovers the modal's edit seed (recurrence, launch) from a task's schedule. */
   editSeedFor: (task: ScheduledTask) => TaskEditSeed | null
-  createTask: (draft: TaskDraft) => void
-  updateTask: (scheduleId: string, draft: TaskDraft) => void
+  /** Resolves once the create persists; rejects on failure so the modal stays open. */
+  createTask: (draft: TaskDraft) => Promise<void>
+  /** Resolves once the edit persists; rejects on failure so the modal stays open. */
+  updateTask: (scheduleId: string, draft: TaskDraft) => Promise<void>
   /** Deletes the whole task (one-time or the entire recurring series). */
   deleteTask: (scheduleId: string) => void
   /** Deletes a single occurrence of a recurring task. */
   deleteOccurrence: (scheduleId: string, occurrence: Date) => void
+  /** Pauses a recurring task — suspends future runs until resumed. */
+  pauseTask: (scheduleId: string) => void
+  /** Resumes a paused recurring task, recomputing its next run from the cron. */
+  resumeTask: (scheduleId: string) => void
 }
 
 /**
@@ -115,6 +125,8 @@ export function useScheduledTasks({
   const updateSchedule = useUpdateSchedule()
   const deleteSchedule = useDeleteSchedule()
   const excludeOccurrence = useExcludeOccurrence()
+  const disableSchedule = useDisableSchedule()
+  const resumeSchedule = useResumeSchedule()
 
   const [selectedTask, setSelectedTask] = useState<ScheduledTask | null>(null)
 
@@ -128,6 +140,11 @@ export function useScheduledTasks({
   }, [schedules, rangeStart, rangeEnd])
 
   const eventsByDay = useMemo(() => bucketEventsByDay(events), [events])
+
+  const hasTasks = useMemo(
+    () => schedules.some((schedule) => schedule.sourceType === 'job'),
+    [schedules]
+  )
 
   const openTask = useCallback((task: ScheduledTask) => setSelectedTask(task), [])
   const closeTask = useCallback(() => setSelectedTask(null), [])
@@ -157,15 +174,16 @@ export function useScheduledTasks({
   )
 
   const createTask = useCallback(
-    (draft: TaskDraft) => createSchedule.mutate(draftToCreateBody(draft, workspaceId)),
+    async (draft: TaskDraft) => {
+      await createSchedule.mutateAsync(draftToCreateBody(draft, workspaceId))
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [workspaceId]
   )
 
   const updateTask = useCallback(
-    (scheduleId: string, draft: TaskDraft) => {
-      updateSchedule.mutate({ scheduleId, workspaceId, ...draftToUpdateBody(draft) })
-      setSelectedTask((current) => (current?.scheduleId === scheduleId ? null : current))
+    async (scheduleId: string, draft: TaskDraft) => {
+      await updateSchedule.mutateAsync({ scheduleId, workspaceId, ...draftToUpdateBody(draft) })
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [workspaceId]
@@ -189,8 +207,27 @@ export function useScheduledTasks({
     [workspaceId]
   )
 
+  const pauseTask = useCallback(
+    (scheduleId: string) => {
+      disableSchedule.mutate({ scheduleId, workspaceId })
+      setSelectedTask((current) => (current?.scheduleId === scheduleId ? null : current))
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [workspaceId]
+  )
+
+  const resumeTask = useCallback(
+    (scheduleId: string) => {
+      resumeSchedule.mutate({ scheduleId, workspaceId })
+      setSelectedTask((current) => (current?.scheduleId === scheduleId ? null : current))
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [workspaceId]
+  )
+
   return {
     isLoading,
+    hasTasks,
     eventsByDay,
     selectedTask,
     openTask,
@@ -200,5 +237,7 @@ export function useScheduledTasks({
     updateTask,
     deleteTask,
     deleteOccurrence,
+    pauseTask,
+    resumeTask,
   }
 }

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/hooks/use-scheduled-tasks.ts
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/hooks/use-scheduled-tasks.ts
@@ -85,8 +85,6 @@ export interface UseScheduledTasksParams {
 
 export interface UseScheduledTasksReturn {
   isLoading: boolean
-  /** Whether the workspace has any scheduled task at all — drives the first-run empty state. */
-  hasTasks: boolean
   /** Day-bucketed events feeding both the month grid and the time grid. */
   eventsByDay: Map<string, CalendarEvent[]>
   /** The task occurrence whose modal is open, or `null` when none is. */
@@ -140,11 +138,6 @@ export function useScheduledTasks({
   }, [schedules, rangeStart, rangeEnd])
 
   const eventsByDay = useMemo(() => bucketEventsByDay(events), [events])
-
-  const hasTasks = useMemo(
-    () => schedules.some((schedule) => schedule.sourceType === 'job'),
-    [schedules]
-  )
 
   const openTask = useCallback((task: ScheduledTask) => setSelectedTask(task), [])
   const closeTask = useCallback(() => setSelectedTask(null), [])
@@ -227,7 +220,6 @@ export function useScheduledTasks({
 
   return {
     isLoading,
-    hasTasks,
     eventsByDay,
     selectedTask,
     openTask,

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
@@ -218,9 +218,7 @@ export function ScheduledTasks() {
           if (!open) tasks.closeTask()
         }}
         edit={editSeed}
-        onSubmit={(draft) => {
-          if (editTask) tasks.updateTask(editTask.scheduleId, draft)
-        }}
+        onSubmit={(draft) => (editTask ? tasks.updateTask(editTask.scheduleId, draft) : undefined)}
         onRequestDelete={() => {
           setDeletingTask(editTask)
           tasks.closeTask()

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
@@ -168,8 +168,6 @@ export function ScheduledTasks() {
           onTaskContextMenu={handleTaskContextMenu}
           onShowDay={calendar.openDay}
           eventsByDay={tasks.eventsByDay}
-          isEmpty={!tasks.isLoading && !tasks.hasTasks}
-          onCreate={handleOpenCreate}
         />
       </Resource>
 

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
@@ -218,7 +218,9 @@ export function ScheduledTasks() {
           if (!open) tasks.closeTask()
         }}
         edit={editSeed}
-        onSubmit={(draft) => (editTask ? tasks.updateTask(editTask.scheduleId, draft) : undefined)}
+        onSubmit={(draft) => {
+          if (editTask) return tasks.updateTask(editTask.scheduleId, draft)
+        }}
         onRequestDelete={() => {
           setDeletingTask(editTask)
           tasks.closeTask()

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
@@ -113,6 +113,16 @@ export function ScheduledTasks() {
     if (contextTask) handleOpenTask(contextTask)
   }, [contextTask, handleOpenTask])
 
+  const handlePauseContextTask = useCallback(() => {
+    if (contextTask) tasks.pauseTask(contextTask.scheduleId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contextTask])
+
+  const handleResumeContextTask = useCallback(() => {
+    if (contextTask) tasks.resumeTask(contextTask.scheduleId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contextTask])
+
   const handleContentContextMenu = useCallback(
     (e: React.MouseEvent) => {
       const target = e.target as HTMLElement
@@ -158,6 +168,8 @@ export function ScheduledTasks() {
           onTaskContextMenu={handleTaskContextMenu}
           onShowDay={calendar.openDay}
           eventsByDay={tasks.eventsByDay}
+          isEmpty={!tasks.isLoading && !tasks.hasTasks}
+          onCreate={handleOpenCreate}
         />
       </Resource>
 
@@ -175,6 +187,8 @@ export function ScheduledTasks() {
         task={contextTask}
         onEdit={openContextTask}
         onDuplicate={handleDuplicate}
+        onPause={handlePauseContextTask}
+        onResume={handleResumeContextTask}
         onDelete={() => setDeletingTask(contextTask)}
       />
 

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/utils/schedule-events.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/utils/schedule-events.test.ts
@@ -20,6 +20,7 @@ function makeTask(overrides: Partial<ScheduledTask>): ScheduledTask {
     timezone: 'UTC',
     status: 'pending',
     recurring: false,
+    disabled: false,
     ...overrides,
   }
 }
@@ -173,13 +174,32 @@ describe('scheduleToTasks', () => {
     expect(runs).not.toContain('2026-06-12T12:00:00.000Z')
   })
 
-  it('produces nothing for a disabled schedule with no run history', () => {
+  it('flags active recurring occurrences as not disabled', () => {
+    const tasks = scheduleToTasks(
+      makeRow({ cronExpression: '0 12 * * *' }),
+      RANGE_START,
+      RANGE_END,
+      NOW
+    )
+    const pending = tasks.filter((t) => t.status === 'pending')
+    expect(pending.length).toBeGreaterThan(0)
+    expect(pending.every((t) => !t.disabled)).toBe(true)
+  })
+
+  it('expands a paused recurring schedule as disabled occurrences so it stays resumable', () => {
     const tasks = scheduleToTasks(
       makeRow({ status: 'disabled', cronExpression: '0 12 * * *' }),
       RANGE_START,
       RANGE_END,
       NOW
     )
+    const pending = tasks.filter((t) => t.status === 'pending')
+    expect(pending.length).toBe(5) // Jun 10–14 noon (NOW is Jun 10 00:00)
+    expect(pending.every((t) => t.disabled)).toBe(true)
+  })
+
+  it('produces nothing for a paused one-time task with no run history', () => {
+    const tasks = scheduleToTasks(makeRow({ status: 'disabled' }), RANGE_START, RANGE_END, NOW)
     expect(tasks).toHaveLength(0)
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/utils/schedule-events.ts
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/utils/schedule-events.ts
@@ -31,6 +31,12 @@ export interface ScheduledTask {
   status: ScheduledTaskStatus
   /** Whether the task repeats — drives edit seeding and the delete dialog. */
   recurring: boolean
+  /**
+   * Whether the parent schedule is paused. A paused recurring task still shows
+   * its upcoming occurrences (rendered dimmed) so it can be found and resumed;
+   * it will not run until resumed. Always `false` for past runs and one-time tasks.
+   */
+  disabled: boolean
 }
 
 /**
@@ -76,7 +82,11 @@ function withinRange(date: Date, rangeStart: Date, rangeEnd: Date): boolean {
 /**
  * Maps a persisted job schedule into the occurrences visible in `[rangeStart,
  * rangeEnd]`: upcoming runs (`pending`, expanded from the recurrence) plus the
- * schedule's most recent terminal run. `now` separates upcoming from past.
+ * schedule's most recent terminal run. `now` separates upcoming from past. A
+ * paused (`disabled`) recurring schedule still expands its upcoming occurrences
+ * — flagged `disabled` so the calendar can render them dimmed and offer Resume —
+ * since the cadence is intact and only suspended. `completed` schedules expand
+ * no future runs.
  */
 export function scheduleToTasks(
   row: WorkspaceScheduleRow,
@@ -85,6 +95,7 @@ export function scheduleToTasks(
   now: Date
 ): ScheduledTask[] {
   const recurring = Boolean(row.cronExpression)
+  const paused = row.status === 'disabled'
   // double-cast-allowed: contexts persist as open kind/label objects; the calendar consumes them as ChatContext
   const contexts = (row.contexts ?? undefined) as unknown as ChatContext[] | undefined
   const base = {
@@ -93,6 +104,7 @@ export function scheduleToTasks(
     contexts,
     timezone: row.timezone,
     recurring,
+    disabled: false,
   }
   const tasks: ScheduledTask[] = []
 
@@ -111,7 +123,7 @@ export function scheduleToTasks(
     return tasks
   }
 
-  if (row.status === 'active' && row.cronExpression) {
+  if ((row.status === 'active' || paused) && row.cronExpression) {
     const occurrences = expandOccurrences({
       cronExpression: row.cronExpression,
       timezone: row.timezone,
@@ -122,7 +134,13 @@ export function scheduleToTasks(
       endsAt: row.endsAt ? new Date(row.endsAt) : null,
     })
     for (const runAt of occurrences) {
-      tasks.push({ ...base, id: `${row.id}:${runAt.toISOString()}`, runAt, status: 'pending' })
+      tasks.push({
+        ...base,
+        id: `${row.id}:${runAt.toISOString()}`,
+        runAt,
+        status: 'pending',
+        disabled: paused,
+      })
     }
   }
 

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.tsx
@@ -46,6 +46,13 @@ const logger = createLogger('General')
 const TIMEZONE_OPTIONS = getTimezoneOptions()
 
 /**
+ * Shared trigger width for the three appearance dropdowns (Theme, Timezone, Snap
+ * to grid) so they line up as one column instead of three differently-sized
+ * pills. Wide enough for the longest common timezone label.
+ */
+const DROPDOWN_TRIGGER_CLASS = 'w-[240px] flex-shrink-0'
+
+/**
  * Extracts initials from a user's name.
  * @param name - The user's full name
  * @returns Up to 2 characters: first letters of first and last name, or just the first letter
@@ -401,26 +408,29 @@ export function General() {
             <div className='flex flex-col gap-4'>
               <div className='flex items-center justify-between'>
                 <Label htmlFor='theme-select'>Theme</Label>
-                <ChipSelect
-                  align='start'
-                  dropdownWidth={140}
-                  value={settings?.theme}
-                  onChange={handleThemeChange}
-                  placeholder='Select theme'
-                  options={[
-                    { label: 'System', value: 'system' },
-                    { label: 'Light', value: 'light' },
-                    { label: 'Dark', value: 'dark' },
-                  ]}
-                />
+                <div className={DROPDOWN_TRIGGER_CLASS}>
+                  <ChipSelect
+                    align='start'
+                    fullWidth
+                    dropdownWidth='trigger'
+                    value={settings?.theme}
+                    onChange={handleThemeChange}
+                    placeholder='Select theme'
+                    options={[
+                      { label: 'System', value: 'system' },
+                      { label: 'Light', value: 'light' },
+                      { label: 'Dark', value: 'dark' },
+                    ]}
+                  />
+                </div>
               </div>
 
               <div className='flex items-center justify-between gap-4'>
                 <Label>Timezone</Label>
-                <div className='w-[260px] flex-shrink-0'>
+                <div className={DROPDOWN_TRIGGER_CLASS}>
                   <ChipCombobox
                     align='start'
-                    dropdownWidth={260}
+                    dropdownWidth={240}
                     searchable
                     searchPlaceholder='Search timezones'
                     value={settings?.timezone ?? getBrowserTimezone()}
@@ -480,21 +490,24 @@ export function General() {
 
               <div className='flex items-center justify-between'>
                 <Label htmlFor='snap-to-grid'>Snap to grid</Label>
-                <ChipSelect
-                  align='start'
-                  dropdownWidth={140}
-                  value={String(snapToGridValue)}
-                  onChange={handleSnapToGridChange}
-                  placeholder='Select size'
-                  options={[
-                    { label: 'Off', value: '0' },
-                    { label: '10px', value: '10' },
-                    { label: '20px', value: '20' },
-                    { label: '30px', value: '30' },
-                    { label: '40px', value: '40' },
-                    { label: '50px', value: '50' },
-                  ]}
-                />
+                <div className={DROPDOWN_TRIGGER_CLASS}>
+                  <ChipSelect
+                    align='start'
+                    fullWidth
+                    dropdownWidth='trigger'
+                    value={String(snapToGridValue)}
+                    onChange={handleSnapToGridChange}
+                    placeholder='Select size'
+                    options={[
+                      { label: 'Off', value: '0' },
+                      { label: '10px', value: '10' },
+                      { label: '20px', value: '20' },
+                      { label: '30px', value: '30' },
+                      { label: '40px', value: '40' },
+                      { label: '50px', value: '50' },
+                    ]}
+                  />
+                </div>
               </div>
 
               <div className='flex items-center justify-between'>

--- a/apps/sim/hooks/queries/schedules.ts
+++ b/apps/sim/hooks/queries/schedules.ts
@@ -7,7 +7,6 @@ import { requestJson } from '@/lib/api/client/request'
 import { deployWorkflowContract } from '@/lib/api/contracts/deployments'
 import {
   type CreateScheduleBody,
-  type CreateScheduleResponse,
   createScheduleContract,
   deleteScheduleContract,
   disableScheduleContract,
@@ -393,55 +392,6 @@ export function useUpdateSchedule() {
 }
 
 /**
- * Builds the workspace-list row for a just-created job from the create response
- * (server-generated `id`/`status`/`cronExpression`/`nextRunAt`) plus the request
- * body. Seeded into the list cache on success so the new task renders instantly
- * and the first-run empty state never flashes between success and the refetch;
- * `onSettled` then reconciles it with the authoritative row.
- */
-function optimisticScheduleRow(
-  response: CreateScheduleResponse,
-  body: CreateScheduleBody,
-  nowIso: string
-): WorkspaceScheduleRow {
-  return {
-    id: response.schedule.id,
-    workflowId: null,
-    deploymentVersionId: null,
-    blockId: null,
-    cronExpression: response.schedule.cronExpression,
-    nextRunAt: response.schedule.nextRunAt,
-    lastRanAt: null,
-    lastQueuedAt: null,
-    triggerType: 'schedule',
-    timezone: body.timezone ?? 'UTC',
-    failedCount: 0,
-    infraRetryCount: 0,
-    status: response.schedule.status,
-    lastFailedAt: null,
-    sourceType: 'job',
-    jobTitle: body.title,
-    prompt: body.prompt,
-    lifecycle: body.lifecycle ?? 'persistent',
-    successCondition: null,
-    maxRuns: body.maxRuns ?? null,
-    runCount: 0,
-    sourceChatId: null,
-    sourceTaskName: null,
-    sourceUserId: null,
-    sourceWorkspaceId: body.workspaceId,
-    jobHistory: null,
-    contexts: body.contexts ?? null,
-    excludedDates: null,
-    endsAt: body.endsAt ?? null,
-    archivedAt: null,
-    createdAt: nowIso,
-    updatedAt: nowIso,
-    workflowName: null,
-  }
-}
-
-/**
  * Mutation to create a standalone scheduled job
  */
 export function useCreateSchedule() {
@@ -449,14 +399,8 @@ export function useCreateSchedule() {
 
   return useMutation({
     mutationFn: async (body: CreateScheduleBody) => requestJson(createScheduleContract, { body }),
-    onSuccess: (data, variables) => {
+    onSuccess: () => {
       toast.success('Task scheduled')
-      const nowIso = new Date().toISOString()
-      queryClient.setQueryData<WorkspaceScheduleRow[]>(
-        scheduleKeys.list(variables.workspaceId),
-        (current) =>
-          current ? [...current, optimisticScheduleRow(data, variables, nowIso)] : current
-      )
     },
     onError: (error) => {
       logger.error('Failed to create schedule', { error })

--- a/apps/sim/hooks/queries/schedules.ts
+++ b/apps/sim/hooks/queries/schedules.ts
@@ -7,6 +7,7 @@ import { requestJson } from '@/lib/api/client/request'
 import { deployWorkflowContract } from '@/lib/api/contracts/deployments'
 import {
   type CreateScheduleBody,
+  type CreateScheduleResponse,
   createScheduleContract,
   deleteScheduleContract,
   disableScheduleContract,
@@ -392,6 +393,55 @@ export function useUpdateSchedule() {
 }
 
 /**
+ * Builds the workspace-list row for a just-created job from the create response
+ * (server-generated `id`/`status`/`cronExpression`/`nextRunAt`) plus the request
+ * body. Seeded into the list cache on success so the new task renders instantly
+ * and the first-run empty state never flashes between success and the refetch;
+ * `onSettled` then reconciles it with the authoritative row.
+ */
+function optimisticScheduleRow(
+  response: CreateScheduleResponse,
+  body: CreateScheduleBody,
+  nowIso: string
+): WorkspaceScheduleRow {
+  return {
+    id: response.schedule.id,
+    workflowId: null,
+    deploymentVersionId: null,
+    blockId: null,
+    cronExpression: response.schedule.cronExpression,
+    nextRunAt: response.schedule.nextRunAt,
+    lastRanAt: null,
+    lastQueuedAt: null,
+    triggerType: 'schedule',
+    timezone: body.timezone ?? 'UTC',
+    failedCount: 0,
+    infraRetryCount: 0,
+    status: response.schedule.status,
+    lastFailedAt: null,
+    sourceType: 'job',
+    jobTitle: body.title,
+    prompt: body.prompt,
+    lifecycle: body.lifecycle ?? 'persistent',
+    successCondition: null,
+    maxRuns: body.maxRuns ?? null,
+    runCount: 0,
+    sourceChatId: null,
+    sourceTaskName: null,
+    sourceUserId: null,
+    sourceWorkspaceId: body.workspaceId,
+    jobHistory: null,
+    contexts: body.contexts ?? null,
+    excludedDates: null,
+    endsAt: body.endsAt ?? null,
+    archivedAt: null,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    workflowName: null,
+  }
+}
+
+/**
  * Mutation to create a standalone scheduled job
  */
 export function useCreateSchedule() {
@@ -399,8 +449,14 @@ export function useCreateSchedule() {
 
   return useMutation({
     mutationFn: async (body: CreateScheduleBody) => requestJson(createScheduleContract, { body }),
-    onSuccess: () => {
+    onSuccess: (data, variables) => {
       toast.success('Task scheduled')
+      const nowIso = new Date().toISOString()
+      queryClient.setQueryData<WorkspaceScheduleRow[]>(
+        scheduleKeys.list(variables.workspaceId),
+        (current) =>
+          current ? [...current, optimisticScheduleRow(data, variables, nowIso)] : current
+      )
     },
     onError: (error) => {
       logger.error('Failed to create schedule', { error })

--- a/apps/sim/hooks/queries/schedules.ts
+++ b/apps/sim/hooks/queries/schedules.ts
@@ -1,5 +1,7 @@
 import { createLogger } from '@sim/logger'
+import { getErrorMessage } from '@sim/utils/errors'
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from '@/components/emcn'
 import { isApiClientError } from '@/lib/api/client/errors'
 import { requestJson } from '@/lib/api/client/request'
 import { deployWorkflowContract } from '@/lib/api/contracts/deployments'
@@ -213,8 +215,54 @@ export function useDisableSchedule() {
 
       return { workspaceId }
     },
+    onSuccess: () => {
+      toast.success('Task paused')
+    },
     onError: (error) => {
       logger.error('Failed to disable schedule', { error })
+      toast.error("Couldn't pause task", { description: getErrorMessage(error) })
+    },
+    onSettled: async (data) => {
+      if (!data) return
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: scheduleKeys.list(data.workspaceId) }),
+        queryClient.invalidateQueries({ queryKey: scheduleKeys.details() }),
+      ])
+    },
+  })
+}
+
+/**
+ * Mutation to resume (reactivate) a paused standalone job schedule. Keyed by
+ * `workspaceId` so it invalidates the workspace list; the workflow-block variant
+ * {@link useReactivateSchedule} keys by `workflowId`/`blockId` instead. Resuming
+ * recomputes `nextRunAt` from the schedule's cron, so it applies to recurring
+ * tasks only — one-time tasks carry no cadence to resume.
+ */
+export function useResumeSchedule() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      scheduleId,
+      workspaceId,
+    }: {
+      scheduleId: string
+      workspaceId: string
+    }) => {
+      await requestJson(reactivateScheduleContract, {
+        params: { id: scheduleId },
+        body: { action: 'reactivate' },
+      })
+
+      return { workspaceId }
+    },
+    onSuccess: () => {
+      toast.success('Task resumed')
+    },
+    onError: (error) => {
+      logger.error('Failed to resume schedule', { error })
+      toast.error("Couldn't resume task", { description: getErrorMessage(error) })
     },
     onSettled: async (data) => {
       if (!data) return
@@ -246,8 +294,12 @@ export function useDeleteSchedule() {
 
       return { workspaceId }
     },
+    onSuccess: () => {
+      toast.success('Task deleted')
+    },
     onError: (error) => {
       logger.error('Failed to delete schedule', { error })
+      toast.error("Couldn't delete task", { description: getErrorMessage(error) })
     },
     onSettled: async (data) => {
       if (!data) return
@@ -283,8 +335,12 @@ export function useExcludeOccurrence() {
 
       return { workspaceId }
     },
+    onSuccess: () => {
+      toast.success('Occurrence removed')
+    },
     onError: (error) => {
       logger.error('Failed to delete occurrence', { error })
+      toast.error("Couldn't remove occurrence", { description: getErrorMessage(error) })
     },
     onSettled: async (data) => {
       if (!data) return
@@ -318,8 +374,12 @@ export function useUpdateSchedule() {
 
       return { workspaceId }
     },
+    onSuccess: () => {
+      toast.success('Task updated')
+    },
     onError: (error) => {
       logger.error('Failed to update schedule', { error })
+      toast.error("Couldn't update task", { description: getErrorMessage(error) })
     },
     onSettled: async (data) => {
       if (!data) return
@@ -339,8 +399,12 @@ export function useCreateSchedule() {
 
   return useMutation({
     mutationFn: async (body: CreateScheduleBody) => requestJson(createScheduleContract, { body }),
+    onSuccess: () => {
+      toast.success('Task scheduled')
+    },
     onError: (error) => {
       logger.error('Failed to create schedule', { error })
+      toast.error("Couldn't schedule task", { description: getErrorMessage(error) })
     },
     onSettled: (_data, _error, variables) =>
       queryClient.invalidateQueries({ queryKey: scheduleKeys.list(variables.workspaceId) }),


### PR DESCRIPTION
## Summary
- Adds a control & trust layer to the scheduled-tasks module — the calendar was solid, but mutations failed silently and there was no way to pause a task or recover from a blank first-run.
- **Toasts on every job mutation** (create / update / delete / exclude-occurrence / pause / resume) — failures surface instead of vanishing; the modal/dialog no longer closes a failed save into the void.
- **Submit guards** — the create/edit modal now awaits persistence: it stays open until the task saves (closing only on success), and the submit button is disabled in-flight so Enter racing the click can't double-create.
- **Pause / Resume recurring tasks** — one context-menu item that swaps Pause↔Resume, reusing the existing `disable`/`reactivate` endpoints. Paused occurrences render dimmed so a suspended task stays visible and resumable instead of disappearing.
- **First-run empty state** — a centered prompt + CTA when the workspace has no scheduled tasks, replacing the blank grid.

## Type of Change
- [x] New feature

## Testing
- 45 unit tests pass (incl. new cases: active vs. paused recurring expansion, paused one-time produces nothing)
- typecheck clean (sole error is pre-existing `tailwind.config.ts`), biome clean, `check:api-validation` and `check:react-query` pass
- Pause/Resume is gated to recurring tasks only — one-time tasks carry no cadence to resume (the `reactivate` endpoint requires a cron)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)