### PR TITLE
fix(chat): fail closed when embed gate cannot resolve workspace

### DIFF
--- a/apps/sim/app/api/chat/utils.test.ts
+++ b/apps/sim/app/api/chat/utils.test.ts
@@ -4,6 +4,8 @@
  * @vitest-environment node
  */
 import {
+  dbChainMock,
+  dbChainMockFns,
   encryptionMock,
   encryptionMockFns,
   loggingSessionMock,
@@ -33,6 +35,8 @@ const {
   mockIsWorkspaceApiExecutionEntitled: vi.fn().mockResolvedValue(true),
   flagState: { isBillingEnabled: false, isFreeApiDeploymentGateEnabled: true },
 }))
+
+vi.mock('@sim/db', () => dbChainMock)
 
 vi.mock('@/lib/billing/core/api-access', () => ({
   isWorkspaceApiExecutionEntitled: mockIsWorkspaceApiExecutionEntitled,
@@ -480,6 +484,7 @@ describe('assertChatEmbedAllowed', () => {
     flagState.isBillingEnabled = true
     flagState.isFreeApiDeploymentGateEnabled = true
     mockIsWorkspaceApiExecutionEntitled.mockResolvedValue(true)
+    dbChainMockFns.limit.mockResolvedValue([{ workspaceId: 'ws-1' }])
   })
 
   it('returns 403 for a cross-site origin when the owner is on the free plan', async () => {
@@ -499,6 +504,17 @@ describe('assertChatEmbedAllowed', () => {
       'req-1'
     )
     expect(res).toBeNull()
+  })
+
+  it('returns 403 for a cross-site origin when the workflow has no active workspace', async () => {
+    dbChainMockFns.limit.mockResolvedValueOnce([])
+    const res = await assertChatEmbedAllowed(
+      chatRequest('https://evil.example.com'),
+      'wf-1',
+      'req-1'
+    )
+    expect(res?.status).toBe(403)
+    expect(mockIsWorkspaceApiExecutionEntitled).not.toHaveBeenCalled()
   })
 
   it('allows a first-party *.sim.ai origin without gating', async () => {

--- a/apps/sim/app/api/chat/utils.ts
+++ b/apps/sim/app/api/chat/utils.ts
@@ -81,7 +81,14 @@ export async function assertChatEmbedAllowed(
     .where(and(eq(workflow.id, workflowId), isNull(workflow.archivedAt)))
     .limit(1)
 
-  if (!(await isWorkspaceApiExecutionEntitled(wf?.workspaceId ?? undefined))) {
+  if (!wf?.workspaceId) {
+    logger.warn(
+      `[${requestId}] Chat embed blocked: no active workspace for workflow ${workflowId}, origin=${origin}`
+    )
+    return createErrorResponse('This chat is currently unavailable', 403)
+  }
+
+  if (!(await isWorkspaceApiExecutionEntitled(wf.workspaceId))) {
     logger.warn(`[${requestId}] Chat embed blocked: workspace on free plan, origin=${origin}`)
     return createErrorResponse('Embedding this chat on external sites requires a paid plan', 403)
   }


### PR DESCRIPTION
## Summary
- Harden the cross-origin chat embed paywall (`assertChatEmbedAllowed`) to fail **closed** when the workflow row can't be resolved (archived/deleted), instead of inheriting `isWorkspaceApiExecutionEntitled`'s `undefined → entitled` default and silently skipping the gate.
- Defense-in-depth only: the triggering state is currently unreachable — archiving a workflow atomically archives + deactivates its chat in the same transaction (`lib/workflows/lifecycle.ts`), and the route filters chats on `isNull(archivedAt)` + `isActive` before the gate runs. This guards against a future refactor breaking that invariant.
- Added a test covering the missing-workspace path; wired the embed tests to the chainable `@sim/db` mock so the workflow lookup is controllable.

## Type of Change
- [x] Bug fix (hardening)

## Testing
- `vitest run app/api/chat/utils.test.ts` — 23 passed
- `vitest run app/api/chat/[identifier]/route.test.ts` — 16 passed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)