### PR TITLE
feat(sidebar): add ⌘B shortcut to collapse/expand sidebar

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
@@ -10,6 +10,7 @@ export type CommandId =
   | 'accept-diff-changes'
   | 'add-agent'
   | 'add-workflow'
+  | 'collapse-sidebar'
   | 'goto-logs'
   | 'open-search'
   | 'open-workflow-search-replace'
@@ -56,6 +57,11 @@ export const COMMAND_DEFINITIONS: Record<CommandId, CommandDefinition> = {
     id: 'add-workflow',
     shortcut: 'Mod+Shift+P',
     allowInEditable: false,
+  },
+  'collapse-sidebar': {
+    id: 'collapse-sidebar',
+    shortcut: 'Mod+B',
+    allowInEditable: true,
   },
   'goto-logs': {
     id: 'goto-logs',

--- a/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
@@ -61,7 +61,7 @@ export const COMMAND_DEFINITIONS: Record<CommandId, CommandDefinition> = {
   'collapse-sidebar': {
     id: 'collapse-sidebar',
     shortcut: 'Mod+B',
-    allowInEditable: true,
+    allowInEditable: false,
   },
   'goto-logs': {
     id: 'goto-logs',
@@ -149,4 +149,34 @@ export function createCommand(input: CreateCommandInput): GlobalCommand {
  */
 export function createCommands(inputs: CreateCommandInput[]): GlobalCommand[] {
   return inputs.map((input) => createCommand(input))
+}
+
+/** Display symbols for shortcut modifiers on macOS. */
+const MAC_MODIFIER_SYMBOLS: Record<string, string> = {
+  Mod: '⌘',
+  Shift: '⇧',
+  Alt: '⌥',
+}
+
+/** Display labels for shortcut modifiers on Windows/Linux. */
+const NON_MAC_MODIFIER_LABELS: Record<string, string> = {
+  Mod: 'Ctrl',
+  Shift: 'Shift',
+  Alt: 'Alt',
+}
+
+/**
+ * Formats a command's shortcut for display, deriving the keys from
+ * {@link COMMAND_DEFINITIONS} so tooltips never drift from the registered
+ * binding. macOS renders compact symbols (`⌘⇧P`); other platforms render
+ * `+`-joined labels (`Ctrl+Shift+P`).
+ *
+ * @param id - Command whose shortcut to format.
+ * @param isMac - Whether to render macOS symbols instead of Windows/Linux labels.
+ */
+export function formatCommandShortcut(id: CommandId, isMac: boolean): string {
+  const tokens = COMMAND_DEFINITIONS[id].shortcut.split('+')
+  return isMac
+    ? tokens.map((token) => MAC_MODIFIER_SYMBOLS[token] ?? token).join('')
+    : tokens.map((token) => NON_MAC_MODIFIER_LABELS[token] ?? token).join('+')
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
@@ -15,6 +15,7 @@ import {
   Plus,
   Send,
   Skeleton,
+  Tooltip,
 } from '@/components/emcn'
 import { ManageWorkspace, PanelLeft } from '@/components/emcn/icons'
 import { cn } from '@/lib/core/utils/cn'
@@ -68,6 +69,8 @@ interface WorkspaceHeaderProps {
   isCollapsed?: boolean
   /** Callback to expand the sidebar from collapsed state */
   onExpandSidebar?: () => void
+  /** Formatted keyboard shortcut shown in the expand affordance tooltip */
+  expandShortcut?: string
 }
 
 /**
@@ -93,6 +96,7 @@ function WorkspaceHeaderImpl({
   sessionUserId,
   isCollapsed = false,
   onExpandSidebar,
+  expandShortcut,
 }: WorkspaceHeaderProps) {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false)
@@ -270,41 +274,52 @@ function WorkspaceHeaderImpl({
   return (
     <div className='min-w-0 flex-1'>
       {isMounted && isCollapsed ? (
-        <button
-          type='button'
-          aria-label='Expand sidebar'
-          onClick={onExpandSidebar}
-          className={chipVariants({ fullWidth: true })}
-        >
-          <div className='relative flex size-[16px] flex-shrink-0 items-center justify-center'>
-            {!activeWorkspaceFull ? (
-              <Skeleton className='size-[16px] rounded-sm' />
-            ) : (
-              <>
-                {activeWorkspaceFull.logoUrl ? (
-                  <img
-                    src={activeWorkspaceFull.logoUrl}
-                    alt={activeWorkspaceFull.name || 'Workspace logo'}
-                    className='size-[16px] rounded-sm object-cover group-hover:invisible'
-                  />
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <button
+              type='button'
+              aria-label='Expand sidebar'
+              onClick={onExpandSidebar}
+              className={chipVariants({ fullWidth: true })}
+            >
+              <div className='relative flex size-[16px] flex-shrink-0 items-center justify-center'>
+                {!activeWorkspaceFull ? (
+                  <Skeleton className='size-[16px] rounded-sm' />
                 ) : (
-                  <div
-                    className='flex size-[16px] items-center justify-center rounded-sm font-medium text-[9px] text-white leading-none group-hover:invisible'
-                    style={{
-                      backgroundColor: activeWorkspaceFull.color ?? 'var(--brand-accent)',
-                    }}
-                  >
-                    {workspaceInitial}
-                  </div>
+                  <>
+                    {activeWorkspaceFull.logoUrl ? (
+                      <img
+                        src={activeWorkspaceFull.logoUrl}
+                        alt={activeWorkspaceFull.name || 'Workspace logo'}
+                        className='size-[16px] rounded-sm object-cover group-hover:invisible'
+                      />
+                    ) : (
+                      <div
+                        className='flex size-[16px] items-center justify-center rounded-sm font-medium text-[9px] text-white leading-none group-hover:invisible'
+                        style={{
+                          backgroundColor: activeWorkspaceFull.color ?? 'var(--brand-accent)',
+                        }}
+                      >
+                        {workspaceInitial}
+                      </div>
+                    )}
+                    <PanelLeft
+                      aria-hidden
+                      className='pointer-events-none invisible absolute inset-0 m-auto size-[16px] rotate-180 text-[var(--text-icon)] group-hover:visible'
+                    />
+                  </>
                 )}
-                <PanelLeft
-                  aria-hidden
-                  className='pointer-events-none invisible absolute inset-0 m-auto size-[16px] rotate-180 text-[var(--text-icon)] group-hover:visible'
-                />
-              </>
+              </div>
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content side='right'>
+            {expandShortcut ? (
+              <Tooltip.Shortcut keys={expandShortcut}>Expand sidebar</Tooltip.Shortcut>
+            ) : (
+              <p>Expand sidebar</p>
             )}
-          </div>
-        </button>
+          </Tooltip.Content>
+        </Tooltip.Root>
       ) : isMounted && isWorkspaceReady ? (
         <DropdownMenu
           open={isWorkspaceMenuOpen}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -118,18 +118,20 @@ export function SidebarTooltip({
   label,
   enabled,
   side = 'right',
+  shortcut,
 }: {
   children: React.ReactElement
   label: string
   enabled: boolean
   side?: 'right' | 'bottom'
+  shortcut?: string
 }) {
   if (!enabled) return children
   return (
     <Tooltip.Root>
       <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
       <Tooltip.Content side={side}>
-        <p>{label}</p>
+        {shortcut ? <Tooltip.Shortcut keys={shortcut}>{label}</Tooltip.Shortcut> : <p>{label}</p>}
       </Tooltip.Content>
     </Tooltip.Root>
   )
@@ -1218,6 +1220,12 @@ export const Sidebar = memo(function Sidebar() {
           handleCreateWorkflow()
         },
       },
+      {
+        id: 'collapse-sidebar',
+        handler: () => {
+          toggleCollapsed()
+        },
+      },
     ])
   )
 
@@ -1268,7 +1276,12 @@ export const Sidebar = memo(function Sidebar() {
                 isCollapsed={isCollapsed}
                 onExpandSidebar={toggleCollapsed}
               />
-              <SidebarTooltip label='Collapse sidebar' enabled={!isCollapsed} side='bottom'>
+              <SidebarTooltip
+                label='Collapse sidebar'
+                enabled={!isCollapsed}
+                side='bottom'
+                shortcut={isMac ? '⌘B' : 'Ctrl+B'}
+              >
                 <button
                   type='button'
                   onClick={toggleCollapsed}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -46,7 +46,10 @@ import { buildFolderTree, getFolderPath } from '@/lib/folders/tree'
 import { captureEvent } from '@/lib/posthog/client'
 import { useRegisterGlobalCommands } from '@/app/workspace/[workspaceId]/providers/global-commands-provider'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
-import { createCommands } from '@/app/workspace/[workspaceId]/utils/commands-utils'
+import {
+  createCommands,
+  formatCommandShortcut,
+} from '@/app/workspace/[workspaceId]/utils/commands-utils'
 import {
   CollapsedChatFlyoutItem,
   CollapsedFolderItems,
@@ -390,6 +393,7 @@ export const Sidebar = memo(function Sidebar() {
   }, [isCollapsed])
 
   const isMac = isMacPlatform()
+  const collapseShortcut = formatCommandShortcut('collapse-sidebar', isMac)
 
   const [showCollapsedTooltips, setShowCollapsedTooltips] = useState(isCollapsed)
 
@@ -1275,12 +1279,13 @@ export const Sidebar = memo(function Sidebar() {
                 sessionUserId={sessionData?.user?.id}
                 isCollapsed={isCollapsed}
                 onExpandSidebar={toggleCollapsed}
+                expandShortcut={collapseShortcut}
               />
               <SidebarTooltip
                 label='Collapse sidebar'
                 enabled={!isCollapsed}
                 side='bottom'
-                shortcut={isMac ? '⌘B' : 'Ctrl+B'}
+                shortcut={collapseShortcut}
               >
                 <button
                   type='button'


### PR DESCRIPTION
## Summary
- Added `⌘B` (Ctrl+B on Windows) global shortcut to collapse/expand the workspace sidebar
- Registered as a first-class entry in the central command registry (`collapse-sidebar`, `Mod+B`)
- Surfaced the shortcut in the collapse button's tooltip via the existing `Tooltip.Shortcut`, platform-aware (⌘ vs Ctrl)

## Type of Change
- [x] New feature

## Testing
Tested manually — ⌘B toggles the sidebar from anywhere in the workspace; tooltip shows the shortcut.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
