### PR TITLE
feat(auth): OAuth-only signup with Microsoft provider

### DIFF
--- a/apps/sim/app/(auth)/components/oauth-provider-checker.tsx
+++ b/apps/sim/app/(auth)/components/oauth-provider-checker.tsx
@@ -1,5 +1,10 @@
 import { env } from '@/lib/core/config/env'
-import { isGithubAuthDisabled, isGoogleAuthDisabled, isProd } from '@/lib/core/config/feature-flags'
+import {
+  isGithubAuthDisabled,
+  isGoogleAuthDisabled,
+  isMicrosoftAuthDisabled,
+  isProd,
+} from '@/lib/core/config/feature-flags'
 
 export async function getOAuthProviderStatus() {
   const githubAvailable =
@@ -8,5 +13,8 @@ export async function getOAuthProviderStatus() {
   const googleAvailable =
     !!(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) && !isGoogleAuthDisabled
 
-  return { githubAvailable, googleAvailable, isProduction: isProd }
+  const microsoftAvailable =
+    !!(env.MICROSOFT_CLIENT_ID && env.MICROSOFT_CLIENT_SECRET) && !isMicrosoftAuthDisabled
+
+  return { githubAvailable, googleAvailable, microsoftAvailable, isProduction: isProd }
 }

--- a/apps/sim/app/(auth)/components/social-login-buttons.tsx
+++ b/apps/sim/app/(auth)/components/social-login-buttons.tsx
@@ -2,12 +2,13 @@
 
 import { type ReactNode, useState } from 'react'
 import { Button } from '@/components/emcn'
-import { GithubIcon, GoogleIcon } from '@/components/icons'
+import { GithubIcon, GoogleIcon, MicrosoftIcon } from '@/components/icons'
 import { client } from '@/lib/auth/auth-client'
 
 interface SocialLoginButtonsProps {
   githubAvailable: boolean
   googleAvailable: boolean
+  microsoftAvailable: boolean
   callbackURL?: string
   isProduction: boolean
   children?: ReactNode
@@ -16,12 +17,14 @@ interface SocialLoginButtonsProps {
 export function SocialLoginButtons({
   githubAvailable,
   googleAvailable,
+  microsoftAvailable,
   callbackURL = '/workspace',
   isProduction,
   children,
 }: SocialLoginButtonsProps) {
   const [isGithubLoading, setIsGithubLoading] = useState(false)
   const [isGoogleLoading, setIsGoogleLoading] = useState(false)
+  const [isMicrosoftLoading, setIsMicrosoftLoading] = useState(false)
 
   async function signInWithGithub() {
     if (!githubAvailable) return
@@ -69,6 +72,29 @@ export function SocialLoginButtons({
     }
   }
 
+  async function signInWithMicrosoft() {
+    if (!microsoftAvailable) return
+
+    setIsMicrosoftLoading(true)
+    try {
+      await client.signIn.social({ provider: 'microsoft', callbackURL })
+    } catch (err: any) {
+      let errorMessage = 'Failed to sign in with Microsoft'
+
+      if (err.message?.includes('account exists')) {
+        errorMessage = 'An account with this email already exists. Please sign in instead.'
+      } else if (err.message?.includes('cancelled')) {
+        errorMessage = 'Microsoft sign in was cancelled. Please try again.'
+      } else if (err.message?.includes('network')) {
+        errorMessage = 'Network error. Please check your connection and try again.'
+      } else if (err.message?.includes('rate limit')) {
+        errorMessage = 'Too many attempts. Please try again later.'
+      }
+    } finally {
+      setIsMicrosoftLoading(false)
+    }
+  }
+
   const githubButton = (
     <Button
       variant='outline'
@@ -93,7 +119,19 @@ export function SocialLoginButtons({
     </Button>
   )
 
-  const hasAnyOAuthProvider = githubAvailable || googleAvailable
+  const microsoftButton = (
+    <Button
+      variant='outline'
+      className='w-full rounded-sm border-[var(--landing-border-strong)] py-1.5 text-sm'
+      disabled={!microsoftAvailable || isMicrosoftLoading}
+      onClick={signInWithMicrosoft}
+    >
+      <MicrosoftIcon className='!h-[18px] !w-[18px] mr-1' />
+      {isMicrosoftLoading ? 'Connecting...' : 'Microsoft'}
+    </Button>
+  )
+
+  const hasAnyOAuthProvider = githubAvailable || googleAvailable || microsoftAvailable
 
   if (!hasAnyOAuthProvider && !children) {
     return null
@@ -102,6 +140,7 @@ export function SocialLoginButtons({
   return (
     <div className='grid gap-3 font-light'>
       {googleAvailable && googleButton}
+      {microsoftAvailable && microsoftButton}
       {githubAvailable && githubButton}
       {children}
     </div>

--- a/apps/sim/app/(auth)/login/login-form.tsx
+++ b/apps/sim/app/(auth)/login/login-form.tsx
@@ -78,10 +78,12 @@ const validatePassword = (passwordValue: string): string[] => {
 export default function LoginPage({
   githubAvailable,
   googleAvailable,
+  microsoftAvailable,
   isProduction,
 }: {
   githubAvailable: boolean
   googleAvailable: boolean
+  microsoftAvailable: boolean
   isProduction: boolean
 }) {
   const router = useRouter()
@@ -335,7 +337,7 @@ export default function LoginPage({
 
   const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED'))
   const emailEnabled = !isFalsy(getEnv('NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED'))
-  const hasSocial = githubAvailable || googleAvailable
+  const hasSocial = githubAvailable || googleAvailable || microsoftAvailable
   const hasOnlySSO = ssoEnabled && !emailEnabled && !hasSocial
   const showTopSSO = hasOnlySSO
   const showBottomSection = hasSocial || (ssoEnabled && !hasOnlySSO)
@@ -483,6 +485,7 @@ export default function LoginPage({
         <div className={cn(!emailEnabled ? 'mt-8' : undefined)}>
           <SocialLoginButtons
             googleAvailable={googleAvailable}
+            microsoftAvailable={microsoftAvailable}
             githubAvailable={githubAvailable}
             isProduction={isProduction}
             callbackURL={callbackUrl}

--- a/apps/sim/app/(auth)/login/page.tsx
+++ b/apps/sim/app/(auth)/login/page.tsx
@@ -10,13 +10,15 @@ export const metadata: Metadata = {
 export const dynamic = 'force-dynamic'
 
 export default async function LoginPage() {
-  const { githubAvailable, googleAvailable, isProduction } = await getOAuthProviderStatus()
+  const { githubAvailable, googleAvailable, microsoftAvailable, isProduction } =
+    await getOAuthProviderStatus()
 
   return (
     <Suspense fallback={null}>
       <LoginForm
         githubAvailable={githubAvailable}
         googleAvailable={googleAvailable}
+        microsoftAvailable={microsoftAvailable}
         isProduction={isProduction}
       />
     </Suspense>

--- a/apps/sim/app/(auth)/signup/page.tsx
+++ b/apps/sim/app/(auth)/signup/page.tsx
@@ -14,12 +14,14 @@ export default async function SignupPage() {
     return <div>Registration is disabled, please contact your admin.</div>
   }
 
-  const { githubAvailable, googleAvailable, isProduction } = await getOAuthProviderStatus()
+  const { githubAvailable, googleAvailable, microsoftAvailable, isProduction } =
+    await getOAuthProviderStatus()
 
   return (
     <SignupForm
       githubAvailable={githubAvailable}
       googleAvailable={googleAvailable}
+      microsoftAvailable={microsoftAvailable}
       isProduction={isProduction}
     />
   )

--- a/apps/sim/app/(auth)/signup/page.tsx
+++ b/apps/sim/app/(auth)/signup/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { isRegistrationDisabled } from '@/lib/core/config/feature-flags'
+import { isEmailSignupDisabled, isRegistrationDisabled } from '@/lib/core/config/feature-flags'
 import { getOAuthProviderStatus } from '@/app/(auth)/components/oauth-provider-checker'
 import SignupForm from '@/app/(auth)/signup/signup-form'
 
@@ -23,6 +23,7 @@ export default async function SignupPage() {
       googleAvailable={googleAvailable}
       microsoftAvailable={microsoftAvailable}
       isProduction={isProduction}
+      emailSignupEnabled={!isEmailSignupDisabled}
     />
   )
 }

--- a/apps/sim/app/(auth)/signup/signup-form.tsx
+++ b/apps/sim/app/(auth)/signup/signup-form.tsx
@@ -1,16 +1,76 @@
 'use client'
 
-import { Suspense, useEffect, useMemo, useRef } from 'react'
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
 import { createLogger } from '@sim/logger'
+import { Eye, EyeOff } from 'lucide-react'
 import Link from 'next/link'
-import { useSearchParams } from 'next/navigation'
-import { getEnv, isTruthy } from '@/lib/core/config/env'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { usePostHog } from 'posthog-js/react'
+import { Input, Label, Loader } from '@/components/emcn'
+import { client, useSession } from '@/lib/auth/auth-client'
+import { getEnv, isFalsy, isTruthy } from '@/lib/core/config/env'
 import { validateCallbackUrl } from '@/lib/core/security/input-validation'
-import { captureClientEvent } from '@/lib/posthog/client'
+import { cn } from '@/lib/core/utils/cn'
+import { quickValidateEmail } from '@/lib/messaging/email/validation'
+import { captureClientEvent, captureEvent } from '@/lib/posthog/client'
+import { AUTH_SUBMIT_BTN } from '@/app/(auth)/components/auth-button-classes'
 import { SocialLoginButtons } from '@/app/(auth)/components/social-login-buttons'
 import { SSOLoginButton } from '@/app/(auth)/components/sso-login-button'
 
 const logger = createLogger('SignupForm')
+
+const PASSWORD_VALIDATIONS = {
+  minLength: { regex: /.{8,}/, message: 'Password must be at least 8 characters long.' },
+  uppercase: {
+    regex: /(?=.*?[A-Z])/,
+    message: 'Password must include at least one uppercase letter.',
+  },
+  lowercase: {
+    regex: /(?=.*?[a-z])/,
+    message: 'Password must include at least one lowercase letter.',
+  },
+  number: { regex: /(?=.*?[0-9])/, message: 'Password must include at least one number.' },
+  special: {
+    regex: /(?=.*?[#?!@$%^&*-])/,
+    message: 'Password must include at least one special character.',
+  },
+}
+
+const NAME_VALIDATIONS = {
+  required: {
+    test: (value: string) => Boolean(value && typeof value === 'string'),
+    message: 'Name is required.',
+  },
+  notEmpty: {
+    test: (value: string) => value.trim().length > 0,
+    message: 'Name cannot be empty.',
+  },
+  validCharacters: {
+    regex: /^[\p{L}\s\-']+$/u,
+    message: 'Name can only contain letters, spaces, hyphens, and apostrophes.',
+  },
+  noConsecutiveSpaces: {
+    regex: /^(?!.*\s\s).*$/,
+    message: 'Name cannot contain consecutive spaces.',
+  },
+}
+
+const validateEmailField = (emailValue: string): string[] => {
+  const errors: string[] = []
+
+  if (!emailValue || !emailValue.trim()) {
+    errors.push('Email is required.')
+    return errors
+  }
+
+  const validation = quickValidateEmail(emailValue.trim().toLowerCase())
+  if (!validation.isValid) {
+    errors.push(validation.reason || 'Please enter a valid email address.')
+  }
+
+  return errors
+}
 
 interface SignupFormProps {
   githubAvailable: boolean
@@ -25,15 +85,29 @@ function SignupFormContent({
   microsoftAvailable,
   isProduction,
 }: SignupFormProps) {
+  const router = useRouter()
   const searchParams = useSearchParams()
-  const invalidCallbackRef = useRef(false)
+  const { refetch: refetchSession } = useSession()
+  const posthog = usePostHog()
+  const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
     captureClientEvent('signup_page_viewed', {})
   }, [])
-
+  const [showPassword, setShowPassword] = useState(false)
+  const [password, setPassword] = useState('')
+  const [passwordErrors, setPasswordErrors] = useState<string[]>([])
+  const [showValidationError, setShowValidationError] = useState(false)
+  const [email, setEmail] = useState(() => searchParams.get('email') ?? '')
+  const [emailError, setEmailError] = useState('')
+  const [emailErrors, setEmailErrors] = useState<string[]>([])
+  const [showEmailValidationError, setShowEmailValidationError] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+  const turnstileRef = useRef<TurnstileInstance>(null)
+  const [turnstileSiteKey] = useState(() => getEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY'))
   const rawRedirectUrl = searchParams.get('redirect') || searchParams.get('callbackUrl') || ''
   const isValidRedirectUrl = rawRedirectUrl ? validateCallbackUrl(rawRedirectUrl) : false
+  const invalidCallbackRef = useRef(false)
   if (rawRedirectUrl && !isValidRedirectUrl && !invalidCallbackRef.current) {
     invalidCallbackRef.current = true
     logger.warn('Invalid callback URL detected and blocked:', { url: rawRedirectUrl })
@@ -47,9 +121,245 @@ function SignupFormContent({
     [searchParams, redirectUrl]
   )
 
+  const [name, setName] = useState('')
+  const [nameErrors, setNameErrors] = useState<string[]>([])
+  const [showNameValidationError, setShowNameValidationError] = useState(false)
+
+  const validatePassword = (passwordValue: string): string[] => {
+    const errors: string[] = []
+
+    if (!PASSWORD_VALIDATIONS.minLength.regex.test(passwordValue)) {
+      errors.push(PASSWORD_VALIDATIONS.minLength.message)
+    }
+
+    if (!PASSWORD_VALIDATIONS.uppercase.regex.test(passwordValue)) {
+      errors.push(PASSWORD_VALIDATIONS.uppercase.message)
+    }
+
+    if (!PASSWORD_VALIDATIONS.lowercase.regex.test(passwordValue)) {
+      errors.push(PASSWORD_VALIDATIONS.lowercase.message)
+    }
+
+    if (!PASSWORD_VALIDATIONS.number.regex.test(passwordValue)) {
+      errors.push(PASSWORD_VALIDATIONS.number.message)
+    }
+
+    if (!PASSWORD_VALIDATIONS.special.regex.test(passwordValue)) {
+      errors.push(PASSWORD_VALIDATIONS.special.message)
+    }
+
+    return errors
+  }
+
+  const validateName = (nameValue: string): string[] => {
+    const errors: string[] = []
+
+    if (!NAME_VALIDATIONS.required.test(nameValue)) {
+      errors.push(NAME_VALIDATIONS.required.message)
+      return errors
+    }
+
+    if (!NAME_VALIDATIONS.notEmpty.test(nameValue)) {
+      errors.push(NAME_VALIDATIONS.notEmpty.message)
+      return errors
+    }
+
+    if (!NAME_VALIDATIONS.validCharacters.regex.test(nameValue.trim())) {
+      errors.push(NAME_VALIDATIONS.validCharacters.message)
+    }
+
+    if (!NAME_VALIDATIONS.noConsecutiveSpaces.regex.test(nameValue)) {
+      errors.push(NAME_VALIDATIONS.noConsecutiveSpaces.message)
+    }
+
+    return errors
+  }
+
+  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newPassword = e.target.value
+    setPassword(newPassword)
+
+    const errors = validatePassword(newPassword)
+    setPasswordErrors(errors)
+    setShowValidationError(false)
+  }
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const rawValue = e.target.value
+    setName(rawValue)
+
+    const errors = validateName(rawValue)
+    setNameErrors(errors)
+    setShowNameValidationError(false)
+  }
+
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newEmail = e.target.value
+    setEmail(newEmail)
+
+    const errors = validateEmailField(newEmail)
+    setEmailErrors(errors)
+    setShowEmailValidationError(false)
+
+    if (emailError) {
+      setEmailError('')
+    }
+  }
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setIsLoading(true)
+
+    const formData = new FormData(e.currentTarget)
+    const emailValueRaw = formData.get('email') as string
+    const emailValue = emailValueRaw.trim().toLowerCase()
+    const passwordValue = formData.get('password') as string
+    const nameValue = formData.get('name') as string
+
+    const trimmedName = nameValue.trim()
+
+    const nameValidationErrors = validateName(trimmedName)
+    setNameErrors(nameValidationErrors)
+    setShowNameValidationError(nameValidationErrors.length > 0)
+
+    const emailValidationErrors = validateEmailField(emailValue)
+    setEmailErrors(emailValidationErrors)
+    setShowEmailValidationError(emailValidationErrors.length > 0)
+
+    const errors = validatePassword(passwordValue)
+    setPasswordErrors(errors)
+
+    setShowValidationError(errors.length > 0)
+
+    try {
+      if (
+        nameValidationErrors.length > 0 ||
+        emailValidationErrors.length > 0 ||
+        errors.length > 0
+      ) {
+        setIsLoading(false)
+        return
+      }
+
+      if (trimmedName.length > 100) {
+        setNameErrors(['Name will be truncated to 100 characters. Please shorten your name.'])
+        setShowNameValidationError(true)
+        setIsLoading(false)
+        return
+      }
+
+      let token: string | undefined
+      const widget = turnstileRef.current
+      if (turnstileSiteKey && widget) {
+        try {
+          widget.reset()
+          widget.execute()
+          token = await widget.getResponsePromise()
+        } catch {
+          captureEvent(posthog, 'signup_failed', {
+            error_code: 'captcha_client_failure',
+          })
+          setFormError('Captcha verification failed. Please try again.')
+          setIsLoading(false)
+          return
+        }
+      }
+
+      setFormError(null)
+      const response = await client.signUp.email(
+        {
+          email: emailValue,
+          password: passwordValue,
+          name: trimmedName,
+        },
+        {
+          headers: {
+            ...(token ? { 'x-captcha-response': token } : {}),
+          },
+          onError: (ctx) => {
+            logger.warn('Signup error:', ctx.error)
+            const errorMessage: string[] = ['Failed to create account']
+
+            let errorCode = 'unknown'
+            if (ctx.error.code?.includes('USER_ALREADY_EXISTS')) {
+              errorCode = 'user_already_exists'
+              setEmailError('An account with this email already exists. Please sign in instead.')
+            } else if (
+              ctx.error.code?.includes('BAD_REQUEST') ||
+              ctx.error.message?.includes('Email and password sign up is not enabled')
+            ) {
+              errorCode = 'signup_disabled'
+              errorMessage.push('Email signup is currently disabled.')
+              setEmailError(errorMessage[0])
+            } else if (ctx.error.code?.includes('INVALID_EMAIL')) {
+              errorCode = 'invalid_email'
+              errorMessage.push('Please enter a valid email address.')
+              setEmailError(errorMessage[0])
+            } else if (ctx.error.code?.includes('PASSWORD_TOO_SHORT')) {
+              errorCode = 'password_too_short'
+              errorMessage.push('Password must be at least 8 characters long.')
+              setPasswordErrors(errorMessage)
+              setShowValidationError(true)
+            } else if (ctx.error.code?.includes('PASSWORD_TOO_LONG')) {
+              errorCode = 'password_too_long'
+              errorMessage.push('Password must be less than 128 characters long.')
+              setPasswordErrors(errorMessage)
+              setShowValidationError(true)
+            } else if (ctx.error.code?.includes('network')) {
+              errorCode = 'network_error'
+              errorMessage.push('Network error. Please check your connection and try again.')
+              setPasswordErrors(errorMessage)
+              setShowValidationError(true)
+            } else if (ctx.error.code?.includes('rate limit')) {
+              errorCode = 'rate_limited'
+              errorMessage.push('Too many requests. Please wait a moment before trying again.')
+              setPasswordErrors(errorMessage)
+              setShowValidationError(true)
+            } else {
+              setPasswordErrors(errorMessage)
+              setShowValidationError(true)
+            }
+
+            captureEvent(posthog, 'signup_failed', { error_code: errorCode })
+          },
+        }
+      )
+
+      if (!response || response.error) {
+        setIsLoading(false)
+        return
+      }
+
+      try {
+        await refetchSession()
+        logger.info('Session refreshed after successful signup')
+      } catch (sessionError) {
+        logger.error('Failed to refresh session after signup:', sessionError)
+      }
+
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem('verificationEmail', emailValue)
+        if (isInviteFlow && redirectUrl) {
+          sessionStorage.setItem('inviteRedirectUrl', redirectUrl)
+          sessionStorage.setItem('isInviteFlow', 'true')
+        }
+      }
+
+      router.push('/verify?fromSignup=true')
+    } catch (error) {
+      logger.error('Signup error:', error)
+      setIsLoading(false)
+    }
+  }
+
   const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED'))
+  const emailEnabled =
+    !isFalsy(getEnv('NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED')) &&
+    !isTruthy(getEnv('NEXT_PUBLIC_DISABLE_EMAIL_SIGNUP'))
   const hasSocial = githubAvailable || googleAvailable || microsoftAvailable
-  const callbackURL = redirectUrl || '/workspace'
+  const hasOnlySSO = ssoEnabled && !emailEnabled && !hasSocial
+  const showBottomSection = hasSocial || (ssoEnabled && !hasOnlySSO)
+  const showDivider = (emailEnabled || hasOnlySSO) && showBottomSection
 
   return (
     <>
@@ -58,24 +368,210 @@ function SignupFormContent({
           Create an account
         </h1>
         <p className='font-[430] font-season text-[color-mix(in_srgb,var(--landing-text-subtle)_60%,transparent)] text-lg leading-[125%] tracking-[0.02em]'>
-          Sign up with your preferred provider
+          Create an account or log in
         </p>
       </div>
 
-      {ssoEnabled && !hasSocial ? (
+      {hasOnlySSO && (
         <div className='mt-8'>
-          <SSOLoginButton callbackURL={callbackURL} variant='primary' />
+          <SSOLoginButton callbackURL={redirectUrl || '/workspace'} variant='primary' />
         </div>
-      ) : (
-        <div className='mt-8'>
+      )}
+
+      {emailEnabled && (
+        <form onSubmit={onSubmit} className='mt-8 space-y-10'>
+          <div className='space-y-6'>
+            <div className='space-y-2'>
+              <div className='flex items-center justify-between'>
+                <Label htmlFor='name'>Full name</Label>
+              </div>
+              <div className='relative'>
+                <Input
+                  id='name'
+                  name='name'
+                  placeholder='Enter your name'
+                  type='text'
+                  autoCapitalize='words'
+                  autoComplete='name'
+                  title='Name can only contain letters, spaces, hyphens, and apostrophes'
+                  value={name}
+                  onChange={handleNameChange}
+                  className={cn(
+                    showNameValidationError &&
+                      nameErrors.length > 0 &&
+                      'border-red-500 focus:border-red-500'
+                  )}
+                />
+                <div
+                  className={cn(
+                    'grid transition-[grid-template-rows] duration-200 ease-out',
+                    showNameValidationError && nameErrors.length > 0
+                      ? 'grid-rows-[1fr]'
+                      : 'grid-rows-[0fr]'
+                  )}
+                  aria-live={showNameValidationError && nameErrors.length > 0 ? 'polite' : 'off'}
+                >
+                  <div className='overflow-hidden'>
+                    <div className='mt-1 space-y-1 text-red-400 text-xs'>
+                      {nameErrors.map((error) => (
+                        <p key={error}>{error}</p>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className='space-y-2'>
+              <div className='flex items-center justify-between'>
+                <Label htmlFor='email'>Email</Label>
+              </div>
+              <div className='relative'>
+                <Input
+                  id='email'
+                  name='email'
+                  placeholder='Enter your email'
+                  autoCapitalize='none'
+                  autoComplete='email'
+                  autoCorrect='off'
+                  value={email}
+                  onChange={handleEmailChange}
+                  className={cn(
+                    (emailError || (showEmailValidationError && emailErrors.length > 0)) &&
+                      'border-red-500 focus:border-red-500'
+                  )}
+                />
+                <div
+                  className={cn(
+                    'grid transition-[grid-template-rows] duration-200 ease-out',
+                    (showEmailValidationError && emailErrors.length > 0) ||
+                      (emailError && !showEmailValidationError)
+                      ? 'grid-rows-[1fr]'
+                      : 'grid-rows-[0fr]'
+                  )}
+                  aria-live={
+                    (showEmailValidationError && emailErrors.length > 0) ||
+                    (emailError && !showEmailValidationError)
+                      ? 'polite'
+                      : 'off'
+                  }
+                >
+                  <div className='overflow-hidden'>
+                    <div className='mt-1 space-y-1 text-red-400 text-xs'>
+                      {showEmailValidationError && emailErrors.length > 0 ? (
+                        emailErrors.map((error) => <p key={error}>{error}</p>)
+                      ) : emailError && !showEmailValidationError ? (
+                        <p>{emailError}</p>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className='space-y-2'>
+              <div className='flex items-center justify-between'>
+                <Label htmlFor='password'>Password</Label>
+              </div>
+              <div className='relative'>
+                <div className='relative'>
+                  <Input
+                    id='password'
+                    name='password'
+                    type={showPassword ? 'text' : 'password'}
+                    autoCapitalize='none'
+                    autoComplete='new-password'
+                    placeholder='Enter your password'
+                    autoCorrect='off'
+                    value={password}
+                    onChange={handlePasswordChange}
+                    className={cn(
+                      'pr-10',
+                      showValidationError &&
+                        passwordErrors.length > 0 &&
+                        'border-red-500 focus:border-red-500'
+                    )}
+                  />
+                  <button
+                    type='button'
+                    onClick={() => setShowPassword(!showPassword)}
+                    className='-translate-y-1/2 absolute top-1/2 right-3 text-[var(--landing-text-muted)] transition hover:text-[var(--landing-text)]'
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  >
+                    {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                  </button>
+                </div>
+                <div
+                  className={cn(
+                    'grid transition-[grid-template-rows] duration-200 ease-out',
+                    showValidationError && passwordErrors.length > 0
+                      ? 'grid-rows-[1fr]'
+                      : 'grid-rows-[0fr]'
+                  )}
+                  aria-live={showValidationError && passwordErrors.length > 0 ? 'polite' : 'off'}
+                >
+                  <div className='overflow-hidden'>
+                    <div className='mt-1 space-y-1 text-red-400 text-xs'>
+                      {passwordErrors.map((error) => (
+                        <p key={error}>{error}</p>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {turnstileSiteKey && (
+            <Turnstile
+              ref={turnstileRef}
+              siteKey={turnstileSiteKey}
+              options={{ execution: 'execute', appearance: 'execute' }}
+            />
+          )}
+
+          {formError && (
+            <div className='text-red-400 text-xs'>
+              <p>{formError}</p>
+            </div>
+          )}
+
+          <button type='submit' disabled={isLoading} className={cn('!mt-6', AUTH_SUBMIT_BTN)}>
+            {isLoading ? (
+              <span className='flex items-center gap-2'>
+                <Loader className='size-4' animate />
+                Creating account…
+              </span>
+            ) : (
+              'Create account'
+            )}
+          </button>
+        </form>
+      )}
+
+      {showDivider && (
+        <div className='relative my-6 font-light'>
+          <div className='absolute inset-0 flex items-center'>
+            <div className='w-full border-[var(--landing-bg-elevated)] border-t' />
+          </div>
+          <div className='relative flex justify-center text-sm'>
+            <span className='bg-[var(--landing-bg)] px-4 font-[340] text-[var(--landing-text-muted)]'>
+              Or continue with
+            </span>
+          </div>
+        </div>
+      )}
+
+      {showBottomSection && (
+        <div className={cn(!emailEnabled ? 'mt-8' : undefined)}>
           <SocialLoginButtons
             githubAvailable={githubAvailable}
             googleAvailable={googleAvailable}
             microsoftAvailable={microsoftAvailable}
-            callbackURL={callbackURL}
+            callbackURL={redirectUrl || '/workspace'}
             isProduction={isProduction}
           >
-            {ssoEnabled && <SSOLoginButton callbackURL={callbackURL} variant='outline' />}
+            {ssoEnabled && !hasOnlySSO && (
+              <SSOLoginButton callbackURL={redirectUrl || '/workspace'} variant='outline' />
+            )}
           </SocialLoginButtons>
         </div>
       )}

--- a/apps/sim/app/(auth)/signup/signup-form.tsx
+++ b/apps/sim/app/(auth)/signup/signup-form.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { Suspense, useEffect, useMemo } from 'react'
+import { Suspense, useEffect, useMemo, useRef } from 'react'
 import { createLogger } from '@sim/logger'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { useSession } from '@/lib/auth/auth-client'
 import { getEnv, isTruthy } from '@/lib/core/config/env'
 import { validateCallbackUrl } from '@/lib/core/security/input-validation'
 import { captureClientEvent } from '@/lib/posthog/client'
@@ -27,7 +26,7 @@ function SignupFormContent({
   isProduction,
 }: SignupFormProps) {
   const searchParams = useSearchParams()
-  useSession()
+  const invalidCallbackRef = useRef(false)
 
   useEffect(() => {
     captureClientEvent('signup_page_viewed', {})
@@ -35,7 +34,8 @@ function SignupFormContent({
 
   const rawRedirectUrl = searchParams.get('redirect') || searchParams.get('callbackUrl') || ''
   const isValidRedirectUrl = rawRedirectUrl ? validateCallbackUrl(rawRedirectUrl) : false
-  if (rawRedirectUrl && !isValidRedirectUrl) {
+  if (rawRedirectUrl && !isValidRedirectUrl && !invalidCallbackRef.current) {
+    invalidCallbackRef.current = true
     logger.warn('Invalid callback URL detected and blocked:', { url: rawRedirectUrl })
   }
   const redirectUrl = isValidRedirectUrl ? rawRedirectUrl : ''

--- a/apps/sim/app/(auth)/signup/signup-form.tsx
+++ b/apps/sim/app/(auth)/signup/signup-form.tsx
@@ -77,6 +77,7 @@ interface SignupFormProps {
   googleAvailable: boolean
   microsoftAvailable: boolean
   isProduction: boolean
+  emailSignupEnabled: boolean
 }
 
 function SignupFormContent({
@@ -84,6 +85,7 @@ function SignupFormContent({
   googleAvailable,
   microsoftAvailable,
   isProduction,
+  emailSignupEnabled,
 }: SignupFormProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -354,8 +356,7 @@ function SignupFormContent({
 
   const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED'))
   const emailEnabled =
-    !isFalsy(getEnv('NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED')) &&
-    !isTruthy(getEnv('NEXT_PUBLIC_DISABLE_EMAIL_SIGNUP'))
+    !isFalsy(getEnv('NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED')) && emailSignupEnabled
   const hasSocial = githubAvailable || googleAvailable || microsoftAvailable
   const hasOnlySSO = ssoEnabled && !emailEnabled && !hasSocial
   const showBottomSection = hasSocial || (ssoEnabled && !hasOnlySSO)
@@ -615,6 +616,7 @@ export default function SignupPage({
   googleAvailable,
   microsoftAvailable,
   isProduction,
+  emailSignupEnabled,
 }: SignupFormProps) {
   return (
     <Suspense fallback={<div className='flex h-screen items-center justify-center'>Loading…</div>}>
@@ -623,6 +625,7 @@ export default function SignupPage({
         googleAvailable={googleAvailable}
         microsoftAvailable={microsoftAvailable}
         isProduction={isProduction}
+        emailSignupEnabled={emailSignupEnabled}
       />
     </Suspense>
   )

--- a/apps/sim/app/(auth)/signup/signup-form.tsx
+++ b/apps/sim/app/(auth)/signup/signup-form.tsx
@@ -1,109 +1,41 @@
 'use client'
 
-import { Suspense, useEffect, useMemo, useRef, useState } from 'react'
-import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
+import { Suspense, useEffect, useMemo } from 'react'
 import { createLogger } from '@sim/logger'
-import { Eye, EyeOff } from 'lucide-react'
 import Link from 'next/link'
-import { useRouter, useSearchParams } from 'next/navigation'
-import { usePostHog } from 'posthog-js/react'
-import { Input, Label, Loader } from '@/components/emcn'
-import { client, useSession } from '@/lib/auth/auth-client'
-import { getEnv, isFalsy, isTruthy } from '@/lib/core/config/env'
+import { useSearchParams } from 'next/navigation'
+import { useSession } from '@/lib/auth/auth-client'
+import { getEnv, isTruthy } from '@/lib/core/config/env'
 import { validateCallbackUrl } from '@/lib/core/security/input-validation'
-import { cn } from '@/lib/core/utils/cn'
-import { quickValidateEmail } from '@/lib/messaging/email/validation'
-import { captureClientEvent, captureEvent } from '@/lib/posthog/client'
-import { AUTH_SUBMIT_BTN } from '@/app/(auth)/components/auth-button-classes'
+import { captureClientEvent } from '@/lib/posthog/client'
 import { SocialLoginButtons } from '@/app/(auth)/components/social-login-buttons'
 import { SSOLoginButton } from '@/app/(auth)/components/sso-login-button'
 
 const logger = createLogger('SignupForm')
 
-const PASSWORD_VALIDATIONS = {
-  minLength: { regex: /.{8,}/, message: 'Password must be at least 8 characters long.' },
-  uppercase: {
-    regex: /(?=.*?[A-Z])/,
-    message: 'Password must include at least one uppercase letter.',
-  },
-  lowercase: {
-    regex: /(?=.*?[a-z])/,
-    message: 'Password must include at least one lowercase letter.',
-  },
-  number: { regex: /(?=.*?[0-9])/, message: 'Password must include at least one number.' },
-  special: {
-    regex: /(?=.*?[#?!@$%^&*-])/,
-    message: 'Password must include at least one special character.',
-  },
-}
-
-const NAME_VALIDATIONS = {
-  required: {
-    test: (value: string) => Boolean(value && typeof value === 'string'),
-    message: 'Name is required.',
-  },
-  notEmpty: {
-    test: (value: string) => value.trim().length > 0,
-    message: 'Name cannot be empty.',
-  },
-  validCharacters: {
-    regex: /^[\p{L}\s\-']+$/u,
-    message: 'Name can only contain letters, spaces, hyphens, and apostrophes.',
-  },
-  noConsecutiveSpaces: {
-    regex: /^(?!.*\s\s).*$/,
-    message: 'Name cannot contain consecutive spaces.',
-  },
-}
-
-const validateEmailField = (emailValue: string): string[] => {
-  const errors: string[] = []
-
-  if (!emailValue || !emailValue.trim()) {
-    errors.push('Email is required.')
-    return errors
-  }
-
-  const validation = quickValidateEmail(emailValue.trim().toLowerCase())
-  if (!validation.isValid) {
-    errors.push(validation.reason || 'Please enter a valid email address.')
-  }
-
-  return errors
-}
-
 interface SignupFormProps {
   githubAvailable: boolean
   googleAvailable: boolean
+  microsoftAvailable: boolean
   isProduction: boolean
 }
 
-function SignupFormContent({ githubAvailable, googleAvailable, isProduction }: SignupFormProps) {
-  const router = useRouter()
+function SignupFormContent({
+  githubAvailable,
+  googleAvailable,
+  microsoftAvailable,
+  isProduction,
+}: SignupFormProps) {
   const searchParams = useSearchParams()
-  const { refetch: refetchSession } = useSession()
-  const posthog = usePostHog()
-  const [isLoading, setIsLoading] = useState(false)
+  useSession()
 
   useEffect(() => {
     captureClientEvent('signup_page_viewed', {})
   }, [])
-  const [showPassword, setShowPassword] = useState(false)
-  const [password, setPassword] = useState('')
-  const [passwordErrors, setPasswordErrors] = useState<string[]>([])
-  const [showValidationError, setShowValidationError] = useState(false)
-  const [email, setEmail] = useState(() => searchParams.get('email') ?? '')
-  const [emailError, setEmailError] = useState('')
-  const [emailErrors, setEmailErrors] = useState<string[]>([])
-  const [showEmailValidationError, setShowEmailValidationError] = useState(false)
-  const [formError, setFormError] = useState<string | null>(null)
-  const turnstileRef = useRef<TurnstileInstance>(null)
-  const [turnstileSiteKey] = useState(() => getEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY'))
+
   const rawRedirectUrl = searchParams.get('redirect') || searchParams.get('callbackUrl') || ''
   const isValidRedirectUrl = rawRedirectUrl ? validateCallbackUrl(rawRedirectUrl) : false
-  const invalidCallbackRef = useRef(false)
-  if (rawRedirectUrl && !isValidRedirectUrl && !invalidCallbackRef.current) {
-    invalidCallbackRef.current = true
+  if (rawRedirectUrl && !isValidRedirectUrl) {
     logger.warn('Invalid callback URL detected and blocked:', { url: rawRedirectUrl })
   }
   const redirectUrl = isValidRedirectUrl ? rawRedirectUrl : ''
@@ -115,236 +47,9 @@ function SignupFormContent({ githubAvailable, googleAvailable, isProduction }: S
     [searchParams, redirectUrl]
   )
 
-  const [name, setName] = useState('')
-  const [nameErrors, setNameErrors] = useState<string[]>([])
-  const [showNameValidationError, setShowNameValidationError] = useState(false)
-
-  const validatePassword = (passwordValue: string): string[] => {
-    const errors: string[] = []
-
-    if (!PASSWORD_VALIDATIONS.minLength.regex.test(passwordValue)) {
-      errors.push(PASSWORD_VALIDATIONS.minLength.message)
-    }
-
-    if (!PASSWORD_VALIDATIONS.uppercase.regex.test(passwordValue)) {
-      errors.push(PASSWORD_VALIDATIONS.uppercase.message)
-    }
-
-    if (!PASSWORD_VALIDATIONS.lowercase.regex.test(passwordValue)) {
-      errors.push(PASSWORD_VALIDATIONS.lowercase.message)
-    }
-
-    if (!PASSWORD_VALIDATIONS.number.regex.test(passwordValue)) {
-      errors.push(PASSWORD_VALIDATIONS.number.message)
-    }
-
-    if (!PASSWORD_VALIDATIONS.special.regex.test(passwordValue)) {
-      errors.push(PASSWORD_VALIDATIONS.special.message)
-    }
-
-    return errors
-  }
-
-  const validateName = (nameValue: string): string[] => {
-    const errors: string[] = []
-
-    if (!NAME_VALIDATIONS.required.test(nameValue)) {
-      errors.push(NAME_VALIDATIONS.required.message)
-      return errors
-    }
-
-    if (!NAME_VALIDATIONS.notEmpty.test(nameValue)) {
-      errors.push(NAME_VALIDATIONS.notEmpty.message)
-      return errors
-    }
-
-    if (!NAME_VALIDATIONS.validCharacters.regex.test(nameValue.trim())) {
-      errors.push(NAME_VALIDATIONS.validCharacters.message)
-    }
-
-    if (!NAME_VALIDATIONS.noConsecutiveSpaces.regex.test(nameValue)) {
-      errors.push(NAME_VALIDATIONS.noConsecutiveSpaces.message)
-    }
-
-    return errors
-  }
-
-  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newPassword = e.target.value
-    setPassword(newPassword)
-
-    const errors = validatePassword(newPassword)
-    setPasswordErrors(errors)
-    setShowValidationError(false)
-  }
-
-  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const rawValue = e.target.value
-    setName(rawValue)
-
-    const errors = validateName(rawValue)
-    setNameErrors(errors)
-    setShowNameValidationError(false)
-  }
-
-  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newEmail = e.target.value
-    setEmail(newEmail)
-
-    const errors = validateEmailField(newEmail)
-    setEmailErrors(errors)
-    setShowEmailValidationError(false)
-
-    if (emailError) {
-      setEmailError('')
-    }
-  }
-
-  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    setIsLoading(true)
-
-    const formData = new FormData(e.currentTarget)
-    const emailValueRaw = formData.get('email') as string
-    const emailValue = emailValueRaw.trim().toLowerCase()
-    const passwordValue = formData.get('password') as string
-    const nameValue = formData.get('name') as string
-
-    const trimmedName = nameValue.trim()
-
-    const nameValidationErrors = validateName(trimmedName)
-    setNameErrors(nameValidationErrors)
-    setShowNameValidationError(nameValidationErrors.length > 0)
-
-    const emailValidationErrors = validateEmailField(emailValue)
-    setEmailErrors(emailValidationErrors)
-    setShowEmailValidationError(emailValidationErrors.length > 0)
-
-    const errors = validatePassword(passwordValue)
-    setPasswordErrors(errors)
-
-    setShowValidationError(errors.length > 0)
-
-    try {
-      if (
-        nameValidationErrors.length > 0 ||
-        emailValidationErrors.length > 0 ||
-        errors.length > 0
-      ) {
-        setIsLoading(false)
-        return
-      }
-
-      if (trimmedName.length > 100) {
-        setNameErrors(['Name will be truncated to 100 characters. Please shorten your name.'])
-        setShowNameValidationError(true)
-        setIsLoading(false)
-        return
-      }
-
-      let token: string | undefined
-      const widget = turnstileRef.current
-      if (turnstileSiteKey && widget) {
-        try {
-          widget.reset()
-          widget.execute()
-          token = await widget.getResponsePromise()
-        } catch {
-          captureEvent(posthog, 'signup_failed', {
-            error_code: 'captcha_client_failure',
-          })
-          setFormError('Captcha verification failed. Please try again.')
-          setIsLoading(false)
-          return
-        }
-      }
-
-      setFormError(null)
-      const response = await client.signUp.email(
-        {
-          email: emailValue,
-          password: passwordValue,
-          name: trimmedName,
-        },
-        {
-          headers: {
-            ...(token ? { 'x-captcha-response': token } : {}),
-          },
-          onError: (ctx) => {
-            logger.warn('Signup error:', ctx.error)
-            const errorMessage: string[] = ['Failed to create account']
-
-            let errorCode = 'unknown'
-            if (ctx.error.code?.includes('USER_ALREADY_EXISTS')) {
-              errorCode = 'user_already_exists'
-              setEmailError('An account with this email already exists. Please sign in instead.')
-            } else if (
-              ctx.error.code?.includes('BAD_REQUEST') ||
-              ctx.error.message?.includes('Email and password sign up is not enabled')
-            ) {
-              errorCode = 'signup_disabled'
-              errorMessage.push('Email signup is currently disabled.')
-              setEmailError(errorMessage[0])
-            } else if (ctx.error.code?.includes('INVALID_EMAIL')) {
-              errorCode = 'invalid_email'
-              errorMessage.push('Please enter a valid email address.')
-              setEmailError(errorMessage[0])
-            } else if (ctx.error.code?.includes('PASSWORD_TOO_SHORT')) {
-              errorCode = 'password_too_short'
-              errorMessage.push('Password must be at least 8 characters long.')
-              setPasswordErrors(errorMessage)
-              setShowValidationError(true)
-            } else if (ctx.error.code?.includes('PASSWORD_TOO_LONG')) {
-              errorCode = 'password_too_long'
-              errorMessage.push('Password must be less than 128 characters long.')
-              setPasswordErrors(errorMessage)
-              setShowValidationError(true)
-            } else if (ctx.error.code?.includes('network')) {
-              errorCode = 'network_error'
-              errorMessage.push('Network error. Please check your connection and try again.')
-              setPasswordErrors(errorMessage)
-              setShowValidationError(true)
-            } else if (ctx.error.code?.includes('rate limit')) {
-              errorCode = 'rate_limited'
-              errorMessage.push('Too many requests. Please wait a moment before trying again.')
-              setPasswordErrors(errorMessage)
-              setShowValidationError(true)
-            } else {
-              setPasswordErrors(errorMessage)
-              setShowValidationError(true)
-            }
-
-            captureEvent(posthog, 'signup_failed', { error_code: errorCode })
-          },
-        }
-      )
-
-      if (!response || response.error) {
-        setIsLoading(false)
-        return
-      }
-
-      try {
-        await refetchSession()
-        logger.info('Session refreshed after successful signup')
-      } catch (sessionError) {
-        logger.error('Failed to refresh session after signup:', sessionError)
-      }
-
-      if (typeof window !== 'undefined') {
-        sessionStorage.setItem('verificationEmail', emailValue)
-        if (isInviteFlow && redirectUrl) {
-          sessionStorage.setItem('inviteRedirectUrl', redirectUrl)
-          sessionStorage.setItem('isInviteFlow', 'true')
-        }
-      }
-
-      router.push('/verify?fromSignup=true')
-    } catch (error) {
-      logger.error('Signup error:', error)
-      setIsLoading(false)
-    }
-  }
+  const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED'))
+  const hasSocial = githubAvailable || googleAvailable || microsoftAvailable
+  const callbackURL = redirectUrl || '/workspace'
 
   return (
     <>
@@ -353,237 +58,24 @@ function SignupFormContent({ githubAvailable, googleAvailable, isProduction }: S
           Create an account
         </h1>
         <p className='font-[430] font-season text-[color-mix(in_srgb,var(--landing-text-subtle)_60%,transparent)] text-lg leading-[125%] tracking-[0.02em]'>
-          Create an account or log in
+          Sign up with your preferred provider
         </p>
       </div>
 
-      {/* SSO Login Button (primary top-only when it is the only method) */}
-      {(() => {
-        const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED'))
-        const emailEnabled = !isFalsy(getEnv('NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED'))
-        const hasSocial = githubAvailable || googleAvailable
-        const hasOnlySSO = ssoEnabled && !emailEnabled && !hasSocial
-        return hasOnlySSO
-      })() && (
+      {ssoEnabled && !hasSocial ? (
         <div className='mt-8'>
-          <SSOLoginButton callbackURL={redirectUrl || '/workspace'} variant='primary' />
+          <SSOLoginButton callbackURL={callbackURL} variant='primary' />
         </div>
-      )}
-
-      {/* Email/Password Form - show unless explicitly disabled */}
-      {!isFalsy(getEnv('NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED')) && (
-        <form onSubmit={onSubmit} className='mt-8 space-y-10'>
-          <div className='space-y-6'>
-            <div className='space-y-2'>
-              <div className='flex items-center justify-between'>
-                <Label htmlFor='name'>Full name</Label>
-              </div>
-              <div className='relative'>
-                <Input
-                  id='name'
-                  name='name'
-                  placeholder='Enter your name'
-                  type='text'
-                  autoCapitalize='words'
-                  autoComplete='name'
-                  title='Name can only contain letters, spaces, hyphens, and apostrophes'
-                  value={name}
-                  onChange={handleNameChange}
-                  className={cn(
-                    showNameValidationError &&
-                      nameErrors.length > 0 &&
-                      'border-red-500 focus:border-red-500'
-                  )}
-                />
-                <div
-                  className={cn(
-                    'grid transition-[grid-template-rows] duration-200 ease-out',
-                    showNameValidationError && nameErrors.length > 0
-                      ? 'grid-rows-[1fr]'
-                      : 'grid-rows-[0fr]'
-                  )}
-                  aria-live={showNameValidationError && nameErrors.length > 0 ? 'polite' : 'off'}
-                >
-                  <div className='overflow-hidden'>
-                    <div className='mt-1 space-y-1 text-red-400 text-xs'>
-                      {nameErrors.map((error) => (
-                        <p key={error}>{error}</p>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className='space-y-2'>
-              <div className='flex items-center justify-between'>
-                <Label htmlFor='email'>Email</Label>
-              </div>
-              <div className='relative'>
-                <Input
-                  id='email'
-                  name='email'
-                  placeholder='Enter your email'
-                  autoCapitalize='none'
-                  autoComplete='email'
-                  autoCorrect='off'
-                  value={email}
-                  onChange={handleEmailChange}
-                  className={cn(
-                    (emailError || (showEmailValidationError && emailErrors.length > 0)) &&
-                      'border-red-500 focus:border-red-500'
-                  )}
-                />
-                <div
-                  className={cn(
-                    'grid transition-[grid-template-rows] duration-200 ease-out',
-                    (showEmailValidationError && emailErrors.length > 0) ||
-                      (emailError && !showEmailValidationError)
-                      ? 'grid-rows-[1fr]'
-                      : 'grid-rows-[0fr]'
-                  )}
-                  aria-live={
-                    (showEmailValidationError && emailErrors.length > 0) ||
-                    (emailError && !showEmailValidationError)
-                      ? 'polite'
-                      : 'off'
-                  }
-                >
-                  <div className='overflow-hidden'>
-                    <div className='mt-1 space-y-1 text-red-400 text-xs'>
-                      {showEmailValidationError && emailErrors.length > 0 ? (
-                        emailErrors.map((error) => <p key={error}>{error}</p>)
-                      ) : emailError && !showEmailValidationError ? (
-                        <p>{emailError}</p>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className='space-y-2'>
-              <div className='flex items-center justify-between'>
-                <Label htmlFor='password'>Password</Label>
-              </div>
-              <div className='relative'>
-                <div className='relative'>
-                  <Input
-                    id='password'
-                    name='password'
-                    type={showPassword ? 'text' : 'password'}
-                    autoCapitalize='none'
-                    autoComplete='new-password'
-                    placeholder='Enter your password'
-                    autoCorrect='off'
-                    value={password}
-                    onChange={handlePasswordChange}
-                    className={cn(
-                      'pr-10',
-                      showValidationError &&
-                        passwordErrors.length > 0 &&
-                        'border-red-500 focus:border-red-500'
-                    )}
-                  />
-                  <button
-                    type='button'
-                    onClick={() => setShowPassword(!showPassword)}
-                    className='-translate-y-1/2 absolute top-1/2 right-3 text-[var(--landing-text-muted)] transition hover:text-[var(--landing-text)]'
-                    aria-label={showPassword ? 'Hide password' : 'Show password'}
-                  >
-                    {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-                  </button>
-                </div>
-                <div
-                  className={cn(
-                    'grid transition-[grid-template-rows] duration-200 ease-out',
-                    showValidationError && passwordErrors.length > 0
-                      ? 'grid-rows-[1fr]'
-                      : 'grid-rows-[0fr]'
-                  )}
-                  aria-live={showValidationError && passwordErrors.length > 0 ? 'polite' : 'off'}
-                >
-                  <div className='overflow-hidden'>
-                    <div className='mt-1 space-y-1 text-red-400 text-xs'>
-                      {passwordErrors.map((error) => (
-                        <p key={error}>{error}</p>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {turnstileSiteKey && (
-            <Turnstile
-              ref={turnstileRef}
-              siteKey={turnstileSiteKey}
-              options={{ execution: 'execute', appearance: 'execute' }}
-            />
-          )}
-
-          {formError && (
-            <div className='text-red-400 text-xs'>
-              <p>{formError}</p>
-            </div>
-          )}
-
-          <button type='submit' disabled={isLoading} className={cn('!mt-6', AUTH_SUBMIT_BTN)}>
-            {isLoading ? (
-              <span className='flex items-center gap-2'>
-                <Loader className='size-4' animate />
-                Creating account…
-              </span>
-            ) : (
-              'Create account'
-            )}
-          </button>
-        </form>
-      )}
-
-      {/* Divider - show when we have multiple auth methods */}
-      {(() => {
-        const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED'))
-        const emailEnabled = !isFalsy(getEnv('NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED'))
-        const hasSocial = githubAvailable || googleAvailable
-        const hasOnlySSO = ssoEnabled && !emailEnabled && !hasSocial
-        const showBottomSection = hasSocial || (ssoEnabled && !hasOnlySSO)
-        const showDivider = (emailEnabled || hasOnlySSO) && showBottomSection
-        return showDivider
-      })() && (
-        <div className='relative my-6 font-light'>
-          <div className='absolute inset-0 flex items-center'>
-            <div className='w-full border-[var(--landing-bg-elevated)] border-t' />
-          </div>
-          <div className='relative flex justify-center text-sm'>
-            <span className='bg-[var(--landing-bg)] px-4 font-[340] text-[var(--landing-text-muted)]'>
-              Or continue with
-            </span>
-          </div>
-        </div>
-      )}
-
-      {(() => {
-        const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED'))
-        const emailEnabled = !isFalsy(getEnv('NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED'))
-        const hasSocial = githubAvailable || googleAvailable
-        const hasOnlySSO = ssoEnabled && !emailEnabled && !hasSocial
-        const showBottomSection = hasSocial || (ssoEnabled && !hasOnlySSO)
-        return showBottomSection
-      })() && (
-        <div
-          className={cn(
-            isFalsy(getEnv('NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED')) ? 'mt-8' : undefined
-          )}
-        >
+      ) : (
+        <div className='mt-8'>
           <SocialLoginButtons
             githubAvailable={githubAvailable}
             googleAvailable={googleAvailable}
-            callbackURL={redirectUrl || '/workspace'}
+            microsoftAvailable={microsoftAvailable}
+            callbackURL={callbackURL}
             isProduction={isProduction}
           >
-            {isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED')) && (
-              <SSOLoginButton callbackURL={redirectUrl || '/workspace'} variant='outline' />
-            )}
+            {ssoEnabled && <SSOLoginButton callbackURL={callbackURL} variant='outline' />}
           </SocialLoginButtons>
         </div>
       )}
@@ -625,6 +117,7 @@ function SignupFormContent({ githubAvailable, googleAvailable, isProduction }: S
 export default function SignupPage({
   githubAvailable,
   googleAvailable,
+  microsoftAvailable,
   isProduction,
 }: SignupFormProps) {
   return (
@@ -632,6 +125,7 @@ export default function SignupPage({
       <SignupFormContent
         githubAvailable={githubAvailable}
         googleAvailable={googleAvailable}
+        microsoftAvailable={microsoftAvailable}
         isProduction={isProduction}
       />
     </Suspense>

--- a/apps/sim/app/(landing)/components/auth-modal/auth-modal.tsx
+++ b/apps/sim/app/(landing)/components/auth-modal/auth-modal.tsx
@@ -14,7 +14,7 @@ import {
   ModalTitle,
   ModalTrigger,
 } from '@/components/emcn'
-import { GithubIcon, GoogleIcon } from '@/components/icons'
+import { GithubIcon, GoogleIcon, MicrosoftIcon } from '@/components/icons'
 import { requestJson } from '@/lib/api/client/request'
 import { type AuthProviderStatusResponse, getAuthProvidersContract } from '@/lib/api/contracts/auth'
 import { client } from '@/lib/auth/auth-client'
@@ -40,6 +40,7 @@ let fetchPromise: Promise<AuthProviderStatusResponse> | null = null
 const FALLBACK_STATUS: ProviderStatus = {
   githubAvailable: false,
   googleAvailable: false,
+  microsoftAvailable: false,
   registrationDisabled: false,
 }
 
@@ -49,9 +50,10 @@ const SOCIAL_BTN =
 function fetchProviderStatus(): Promise<ProviderStatus> {
   if (fetchPromise) return fetchPromise
   fetchPromise = requestJson(getAuthProvidersContract, {})
-    .then(({ githubAvailable, googleAvailable, registrationDisabled }) => ({
+    .then(({ githubAvailable, googleAvailable, microsoftAvailable, registrationDisabled }) => ({
       githubAvailable,
       googleAvailable,
+      microsoftAvailable,
       registrationDisabled,
     }))
     .catch(() => {
@@ -66,14 +68,17 @@ export function AuthModal({ children, defaultView = 'login', source }: AuthModal
   const [open, setOpen] = useState(false)
   const [view, setView] = useState<AuthView>(defaultView)
   const [providerStatus, setProviderStatus] = useState<ProviderStatus | null>(null)
-  const [socialLoading, setSocialLoading] = useState<'github' | 'google' | null>(null)
+  const [socialLoading, setSocialLoading] = useState<'github' | 'google' | 'microsoft' | null>(null)
   const brand = useMemo(() => getBrandConfig(), [])
 
   useEffect(() => {
     fetchProviderStatus().then(setProviderStatus)
   }, [])
 
-  const hasSocial = providerStatus?.githubAvailable || providerStatus?.googleAvailable
+  const hasSocial =
+    providerStatus?.githubAvailable ||
+    providerStatus?.googleAvailable ||
+    providerStatus?.microsoftAvailable
   const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED'))
   const emailEnabled = !isFalsy(getEnv('NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED'))
   const hasModalContent = hasSocial || ssoEnabled
@@ -104,7 +109,7 @@ export function AuthModal({ children, defaultView = 'login', source }: AuthModal
     }
   }
 
-  async function handleSocialLogin(provider: 'github' | 'google') {
+  async function handleSocialLogin(provider: 'github' | 'google' | 'microsoft') {
     setSocialLoading(provider)
     try {
       await client.signIn.social({ provider, callbackURL: '/workspace' })
@@ -184,6 +189,19 @@ export function AuthModal({ children, defaultView = 'login', source }: AuthModal
                     </span>
                   </button>
                 )}
+                {providerStatus.microsoftAvailable && (
+                  <button
+                    type='button'
+                    onClick={() => handleSocialLogin('microsoft')}
+                    disabled={!!socialLoading}
+                    className={SOCIAL_BTN}
+                  >
+                    <MicrosoftIcon className='absolute left-4 size-[18px] shrink-0' />
+                    <span>
+                      {socialLoading === 'microsoft' ? 'Connecting...' : 'Continue with Microsoft'}
+                    </span>
+                  </button>
+                )}
                 {providerStatus.githubAvailable && (
                   <button
                     type='button'
@@ -204,7 +222,8 @@ export function AuthModal({ children, defaultView = 'login', source }: AuthModal
                 )}
               </div>
 
-              {emailEnabled && (
+              {/* Email option only available on login — signup is OAuth-only */}
+              {emailEnabled && view === 'login' && (
                 <>
                   <div className='relative my-4'>
                     <div className='absolute inset-0 flex items-center'>

--- a/apps/sim/app/api/auth/providers/route.ts
+++ b/apps/sim/app/api/auth/providers/route.ts
@@ -12,10 +12,11 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const parsed = await parseRequest(getAuthProvidersContract, request, {})
   if (!parsed.success) return parsed.response
 
-  const { githubAvailable, googleAvailable } = await getOAuthProviderStatus()
+  const { githubAvailable, googleAvailable, microsoftAvailable } = await getOAuthProviderStatus()
   return NextResponse.json({
     githubAvailable,
     googleAvailable,
+    microsoftAvailable,
     registrationDisabled: isRegistrationDisabled,
   })
 })

--- a/apps/sim/components/icons.tsx
+++ b/apps/sim/components/icons.tsx
@@ -2936,12 +2936,11 @@ export function ClickHouseIcon(props: SVGProps<SVGSVGElement>) {
 
 export function MicrosoftIcon(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 23 23' {...props}>
-      <path fill='#f3f3f3' d='M0 0h23v23H0z' />
-      <path fill='#f35325' d='M1 1h10v10H1z' />
-      <path fill='#81bc06' d='M12 1h10v10H12z' />
-      <path fill='#05a6f0' d='M1 12h10v10H1z' />
-      <path fill='#ffba08' d='M12 12h10v10H12z' />
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 109 109' {...props}>
+      <polygon fill='#F1511B' points='51.9,51.9 0,51.9 0,0 51.9,0' />
+      <polygon fill='#80CC28' points='109.3,51.9 57.3,51.9 57.3,0 109.3,0' />
+      <polygon fill='#00ADEF' points='51.9,109.3 0,109.3 0,57.4 51.9,57.4' />
+      <polygon fill='#FBBC09' points='109.3,109.3 57.3,109.3 57.3,57.4 109.3,57.4' />
     </svg>
   )
 }

--- a/apps/sim/lib/api/contracts/auth.ts
+++ b/apps/sim/lib/api/contracts/auth.ts
@@ -9,6 +9,7 @@ export const ssoProvidersQuerySchema = z.object({
 export const authProviderStatusResponseSchema = z.object({
   githubAvailable: z.boolean(),
   googleAvailable: z.boolean(),
+  microsoftAvailable: z.boolean(),
   registrationDisabled: z.boolean(),
 })
 

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -69,6 +69,7 @@ import {
   isGithubAuthDisabled,
   isGoogleAuthDisabled,
   isHosted,
+  isMicrosoftAuthDisabled,
   isOrganizationsEnabled,
   isRegistrationDisabled,
   isSignupEmailValidationEnabled,
@@ -724,6 +725,15 @@ export const auth = betterAuth({
         ],
       },
     }),
+    ...(!isMicrosoftAuthDisabled &&
+      env.MICROSOFT_CLIENT_ID &&
+      env.MICROSOFT_CLIENT_SECRET && {
+        microsoft: {
+          clientId: env.MICROSOFT_CLIENT_ID,
+          clientSecret: env.MICROSOFT_CLIENT_SECRET,
+          scope: ['openid', 'profile', 'email'],
+        },
+      }),
   },
   emailVerification: {
     autoSignInAfterVerification: true,

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -65,6 +65,7 @@ import {
   isAuthDisabled,
   isBillingEnabled,
   isEmailPasswordEnabled,
+  isEmailSignupDisabled,
   isEmailVerificationEnabled,
   isGithubAuthDisabled,
   isGoogleAuthDisabled,
@@ -883,6 +884,11 @@ export const auth = betterAuth({
             message: 'Email/password authentication is disabled. Please use SSO to sign in.',
           })
       }
+
+      if (isEmailSignupDisabled && ctx.path.startsWith('/sign-up/email'))
+        throw new APIError('FORBIDDEN', {
+          message: 'Email sign-up is disabled. Please use Google, Microsoft, or GitHub.',
+        })
 
       const isSignIn = ctx.path.startsWith('/sign-in')
       const isSignUp = ctx.path.startsWith('/sign-up')

--- a/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
@@ -10,7 +10,7 @@ export interface ToolRuntimeSchemaEntry {
 }
 
 export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
-  ['agent']: {
+  agent: {
     parameters: {
       properties: {
         request: {
@@ -23,7 +23,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['auth']: {
+  auth: {
     parameters: {
       properties: {
         request: {
@@ -36,7 +36,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['check_deployment_status']: {
+  check_deployment_status: {
     parameters: {
       type: 'object',
       properties: {
@@ -48,7 +48,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['complete_job']: {
+  complete_job: {
     parameters: {
       type: 'object',
       properties: {
@@ -61,7 +61,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['crawl_website']: {
+  crawl_website: {
     parameters: {
       type: 'object',
       properties: {
@@ -96,7 +96,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_file']: {
+  create_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -162,7 +162,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['create_file_folder']: {
+  create_file_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -180,7 +180,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_folder']: {
+  create_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -201,7 +201,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_workflow']: {
+  create_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -226,7 +226,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_workspace_mcp_server']: {
+  create_workspace_mcp_server: {
     parameters: {
       type: 'object',
       properties: {
@@ -259,7 +259,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['delete_file']: {
+  delete_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -289,7 +289,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['delete_file_folder']: {
+  delete_file_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -305,7 +305,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['delete_folder']: {
+  delete_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -321,7 +321,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['delete_workflow']: {
+  delete_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -337,7 +337,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['delete_workspace_mcp_server']: {
+  delete_workspace_mcp_server: {
     parameters: {
       type: 'object',
       properties: {
@@ -350,7 +350,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['deploy']: {
+  deploy: {
     parameters: {
       properties: {
         request: {
@@ -364,7 +364,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['deploy_api']: {
+  deploy_api: {
     parameters: {
       type: 'object',
       properties: {
@@ -448,7 +448,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       ],
     },
   },
-  ['deploy_chat']: {
+  deploy_chat: {
     parameters: {
       type: 'object',
       properties: {
@@ -607,7 +607,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       ],
     },
   },
-  ['deploy_mcp']: {
+  deploy_mcp: {
     parameters: {
       type: 'object',
       properties: {
@@ -723,7 +723,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['deploymentType', 'deploymentStatus'],
     },
   },
-  ['diff_workflows']: {
+  diff_workflows: {
     parameters: {
       type: 'object',
       properties: {
@@ -747,7 +747,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['download_to_workspace_file']: {
+  download_to_workspace_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -796,7 +796,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['edit_content']: {
+  edit_content: {
     parameters: {
       type: 'object',
       properties: {
@@ -828,7 +828,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['edit_workflow']: {
+  edit_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -867,7 +867,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['enrichment_run']: {
+  enrichment_run: {
     parameters: {
       type: 'object',
       properties: {
@@ -911,7 +911,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['matched', 'result'],
     },
   },
-  ['ffmpeg']: {
+  ffmpeg: {
     parameters: {
       type: 'object',
       properties: {
@@ -1092,7 +1092,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['file']: {
+  file: {
     parameters: {
       properties: {
         prompt: {
@@ -1105,7 +1105,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['function_execute']: {
+  function_execute: {
     parameters: {
       type: 'object',
       properties: {
@@ -1243,7 +1243,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_api_key']: {
+  generate_api_key: {
     parameters: {
       type: 'object',
       properties: {
@@ -1261,7 +1261,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_audio']: {
+  generate_audio: {
     parameters: {
       type: 'object',
       properties: {
@@ -1413,7 +1413,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_image']: {
+  generate_image: {
     parameters: {
       type: 'object',
       properties: {
@@ -1541,7 +1541,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_video']: {
+  generate_video: {
     parameters: {
       type: 'object',
       properties: {
@@ -1708,7 +1708,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_block_outputs']: {
+  get_block_outputs: {
     parameters: {
       type: 'object',
       properties: {
@@ -1729,7 +1729,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_block_upstream_references']: {
+  get_block_upstream_references: {
     parameters: {
       type: 'object',
       properties: {
@@ -1751,7 +1751,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_deployed_workflow_state']: {
+  get_deployed_workflow_state: {
     parameters: {
       type: 'object',
       properties: {
@@ -1764,7 +1764,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_deployment_log']: {
+  get_deployment_log: {
     parameters: {
       type: 'object',
       properties: {
@@ -1777,7 +1777,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_job_logs']: {
+  get_job_logs: {
     parameters: {
       type: 'object',
       properties: {
@@ -1802,7 +1802,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_page_contents']: {
+  get_page_contents: {
     parameters: {
       type: 'object',
       properties: {
@@ -1830,14 +1830,14 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_platform_actions']: {
+  get_platform_actions: {
     parameters: {
       type: 'object',
       properties: {},
     },
     resultSchema: undefined,
   },
-  ['get_workflow_data']: {
+  get_workflow_data: {
     parameters: {
       type: 'object',
       properties: {
@@ -1856,7 +1856,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_workflow_run_options']: {
+  get_workflow_run_options: {
     parameters: {
       type: 'object',
       properties: {
@@ -1869,7 +1869,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['glob']: {
+  glob: {
     parameters: {
       type: 'object',
       properties: {
@@ -1888,7 +1888,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['grep']: {
+  grep: {
     parameters: {
       type: 'object',
       properties: {
@@ -1936,7 +1936,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['job']: {
+  job: {
     parameters: {
       properties: {
         request: {
@@ -1949,7 +1949,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['knowledge']: {
+  knowledge: {
     parameters: {
       properties: {
         request: {
@@ -1962,7 +1962,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['knowledge_base']: {
+  knowledge_base: {
     parameters: {
       type: 'object',
       properties: {
@@ -2155,7 +2155,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['list_file_folders']: {
+  list_file_folders: {
     parameters: {
       type: 'object',
       properties: {
@@ -2167,7 +2167,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['list_folders']: {
+  list_folders: {
     parameters: {
       type: 'object',
       properties: {
@@ -2179,7 +2179,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['list_integration_tools']: {
+  list_integration_tools: {
     parameters: {
       properties: {
         integration: {
@@ -2193,14 +2193,14 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['list_user_workspaces']: {
+  list_user_workspaces: {
     parameters: {
       type: 'object',
       properties: {},
     },
     resultSchema: undefined,
   },
-  ['list_workspace_mcp_servers']: {
+  list_workspace_mcp_servers: {
     parameters: {
       type: 'object',
       properties: {
@@ -2213,7 +2213,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['load_deployment']: {
+  load_deployment: {
     parameters: {
       type: 'object',
       properties: {
@@ -2232,7 +2232,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['load_integration_tool']: {
+  load_integration_tool: {
     parameters: {
       properties: {
         tool_ids: {
@@ -2249,7 +2249,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_credential']: {
+  manage_credential: {
     parameters: {
       type: 'object',
       properties: {
@@ -2278,7 +2278,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_custom_tool']: {
+  manage_custom_tool: {
     parameters: {
       type: 'object',
       properties: {
@@ -2358,7 +2358,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_job']: {
+  manage_job: {
     parameters: {
       type: 'object',
       properties: {
@@ -2433,7 +2433,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_mcp_tool']: {
+  manage_mcp_tool: {
     parameters: {
       type: 'object',
       properties: {
@@ -2485,7 +2485,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_skill']: {
+  manage_skill: {
     parameters: {
       type: 'object',
       properties: {
@@ -2518,7 +2518,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['materialize_file']: {
+  materialize_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -2542,7 +2542,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['media']: {
+  media: {
     parameters: {
       properties: {
         prompt: {
@@ -2555,7 +2555,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['move_file']: {
+  move_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -2576,7 +2576,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['move_file_folder']: {
+  move_file_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -2594,7 +2594,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['move_folder']: {
+  move_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -2612,7 +2612,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['move_workflow']: {
+  move_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -2632,7 +2632,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['oauth_get_auth_link']: {
+  oauth_get_auth_link: {
     parameters: {
       type: 'object',
       properties: {
@@ -2646,7 +2646,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['oauth_request_access']: {
+  oauth_request_access: {
     parameters: {
       type: 'object',
       properties: {
@@ -2660,7 +2660,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['open_resource']: {
+  open_resource: {
     parameters: {
       type: 'object',
       properties: {
@@ -2694,7 +2694,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['promote_to_live']: {
+  promote_to_live: {
     parameters: {
       type: 'object',
       properties: {
@@ -2713,7 +2713,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['query_logs']: {
+  query_logs: {
     parameters: {
       type: 'object',
       properties: {
@@ -2824,7 +2824,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['read']: {
+  read: {
     parameters: {
       type: 'object',
       properties: {
@@ -2851,7 +2851,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['redeploy']: {
+  redeploy: {
     parameters: {
       type: 'object',
       properties: {
@@ -2930,7 +2930,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       ],
     },
   },
-  ['rename_file']: {
+  rename_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -2966,7 +2966,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['rename_file_folder']: {
+  rename_file_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -2983,7 +2983,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['rename_workflow']: {
+  rename_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -3000,7 +3000,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['research']: {
+  research: {
     parameters: {
       properties: {
         topic: {
@@ -3013,7 +3013,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['respond']: {
+  respond: {
     parameters: {
       additionalProperties: true,
       properties: {
@@ -3036,7 +3036,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['restore_resource']: {
+  restore_resource: {
     parameters: {
       type: 'object',
       properties: {
@@ -3054,7 +3054,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run']: {
+  run: {
     parameters: {
       properties: {
         context: {
@@ -3071,7 +3071,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_block']: {
+  run_block: {
     parameters: {
       type: 'object',
       properties: {
@@ -3103,7 +3103,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_from_block']: {
+  run_from_block: {
     parameters: {
       type: 'object',
       properties: {
@@ -3135,7 +3135,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_workflow']: {
+  run_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -3173,7 +3173,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_workflow_until_block']: {
+  run_workflow_until_block: {
     parameters: {
       type: 'object',
       properties: {
@@ -3216,7 +3216,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['scrape_page']: {
+  scrape_page: {
     parameters: {
       type: 'object',
       properties: {
@@ -3237,7 +3237,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_documentation']: {
+  search_documentation: {
     parameters: {
       type: 'object',
       properties: {
@@ -3254,7 +3254,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_library_docs']: {
+  search_library_docs: {
     parameters: {
       type: 'object',
       properties: {
@@ -3275,7 +3275,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_online']: {
+  search_online: {
     parameters: {
       type: 'object',
       properties: {
@@ -3315,7 +3315,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_patterns']: {
+  search_patterns: {
     parameters: {
       type: 'object',
       properties: {
@@ -3337,7 +3337,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['set_block_enabled']: {
+  set_block_enabled: {
     parameters: {
       type: 'object',
       properties: {
@@ -3359,7 +3359,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['set_environment_variables']: {
+  set_environment_variables: {
     parameters: {
       type: 'object',
       properties: {
@@ -3393,7 +3393,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['set_global_workflow_variables']: {
+  set_global_workflow_variables: {
     parameters: {
       type: 'object',
       properties: {
@@ -3434,7 +3434,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['superagent']: {
+  superagent: {
     parameters: {
       properties: {
         task: {
@@ -3448,7 +3448,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['table']: {
+  table: {
     parameters: {
       properties: {
         request: {
@@ -3461,7 +3461,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['update_deployment_version']: {
+  update_deployment_version: {
     parameters: {
       type: 'object',
       properties: {
@@ -3490,7 +3490,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['update_job_history']: {
+  update_job_history: {
     parameters: {
       type: 'object',
       properties: {
@@ -3508,7 +3508,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['update_workspace_mcp_server']: {
+  update_workspace_mcp_server: {
     parameters: {
       type: 'object',
       properties: {
@@ -3533,7 +3533,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['user_memory']: {
+  user_memory: {
     parameters: {
       type: 'object',
       properties: {
@@ -3582,7 +3582,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['user_table']: {
+  user_table: {
     parameters: {
       type: 'object',
       properties: {
@@ -3944,7 +3944,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['workflow']: {
+  workflow: {
     parameters: {
       properties: {
         prompt: {
@@ -3957,7 +3957,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['workspace_file']: {
+  workspace_file: {
     parameters: {
       type: 'object',
       properties: {

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -505,6 +505,7 @@ export const env = createEnv({
     NEXT_PUBLIC_DISABLE_PUBLIC_API:        z.boolean().optional(),                   // Disable public API access UI toggle globally
     NEXT_PUBLIC_INBOX_ENABLED:             z.boolean().optional(),                   // Enable inbox (Sim Mailer) on self-hosted
     NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED: z.boolean().optional().default(true), // Control visibility of email/password login forms
+    NEXT_PUBLIC_DISABLE_EMAIL_SIGNUP:          z.boolean().optional(),               // Hide email/password form on /signup only (set alongside DISABLE_EMAIL_SIGNUP)
     NEXT_PUBLIC_TURNSTILE_SITE_KEY:        z.string().min(1).optional(),           // Cloudflare Turnstile site key for captcha widget
   },
 
@@ -544,6 +545,7 @@ export const env = createEnv({
     NEXT_PUBLIC_DISABLE_PUBLIC_API: process.env.NEXT_PUBLIC_DISABLE_PUBLIC_API,
     NEXT_PUBLIC_INBOX_ENABLED: process.env.NEXT_PUBLIC_INBOX_ENABLED,
     NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED: process.env.NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED,
+    NEXT_PUBLIC_DISABLE_EMAIL_SIGNUP: process.env.NEXT_PUBLIC_DISABLE_EMAIL_SIGNUP,
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
     NEXT_PUBLIC_E2B_ENABLED: process.env.NEXT_PUBLIC_E2B_ENABLED,
     NEXT_PUBLIC_BEDROCK_DEFAULT_CREDENTIALS: process.env.NEXT_PUBLIC_BEDROCK_DEFAULT_CREDENTIALS,

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -318,6 +318,7 @@ export const env = createEnv({
     DISABLE_GOOGLE_AUTH:                   z.boolean().optional(),                 // Disable Google OAuth login even when credentials are configured
     DISABLE_GITHUB_AUTH:                   z.boolean().optional(),                 // Disable GitHub OAuth login even when credentials are configured
     DISABLE_MICROSOFT_AUTH:               z.boolean().optional(),                 // Disable Microsoft OAuth login even when credentials are configured
+    DISABLE_EMAIL_SIGNUP:                  z.boolean().optional(),                 // Block new email/password registrations while keeping email login working
 
     X_CLIENT_ID:                           z.string().optional(),                  // X (Twitter) OAuth client ID
     X_CLIENT_SECRET:                       z.string().optional(),                  // X (Twitter) OAuth client secret

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -317,6 +317,7 @@ export const env = createEnv({
     GITHUB_CLIENT_SECRET:                  z.string().optional(),                  // GitHub OAuth client secret
     DISABLE_GOOGLE_AUTH:                   z.boolean().optional(),                 // Disable Google OAuth login even when credentials are configured
     DISABLE_GITHUB_AUTH:                   z.boolean().optional(),                 // Disable GitHub OAuth login even when credentials are configured
+    DISABLE_MICROSOFT_AUTH:               z.boolean().optional(),                 // Disable Microsoft OAuth login even when credentials are configured
 
     X_CLIENT_ID:                           z.string().optional(),                  // X (Twitter) OAuth client ID
     X_CLIENT_SECRET:                       z.string().optional(),                  // X (Twitter) OAuth client secret

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -505,7 +505,6 @@ export const env = createEnv({
     NEXT_PUBLIC_DISABLE_PUBLIC_API:        z.boolean().optional(),                   // Disable public API access UI toggle globally
     NEXT_PUBLIC_INBOX_ENABLED:             z.boolean().optional(),                   // Enable inbox (Sim Mailer) on self-hosted
     NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED: z.boolean().optional().default(true), // Control visibility of email/password login forms
-    NEXT_PUBLIC_DISABLE_EMAIL_SIGNUP:          z.boolean().optional(),               // Hide email/password form on /signup only (set alongside DISABLE_EMAIL_SIGNUP)
     NEXT_PUBLIC_TURNSTILE_SITE_KEY:        z.string().min(1).optional(),           // Cloudflare Turnstile site key for captcha widget
   },
 
@@ -545,7 +544,6 @@ export const env = createEnv({
     NEXT_PUBLIC_DISABLE_PUBLIC_API: process.env.NEXT_PUBLIC_DISABLE_PUBLIC_API,
     NEXT_PUBLIC_INBOX_ENABLED: process.env.NEXT_PUBLIC_INBOX_ENABLED,
     NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED: process.env.NEXT_PUBLIC_EMAIL_PASSWORD_SIGNUP_ENABLED,
-    NEXT_PUBLIC_DISABLE_EMAIL_SIGNUP: process.env.NEXT_PUBLIC_DISABLE_EMAIL_SIGNUP,
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
     NEXT_PUBLIC_E2B_ENABLED: process.env.NEXT_PUBLIC_E2B_ENABLED,
     NEXT_PUBLIC_BEDROCK_DEFAULT_CREDENTIALS: process.env.NEXT_PUBLIC_BEDROCK_DEFAULT_CREDENTIALS,

--- a/apps/sim/lib/core/config/feature-flags.ts
+++ b/apps/sim/lib/core/config/feature-flags.ts
@@ -29,7 +29,7 @@ try {
 } catch {
   // invalid URL — isHosted stays false
 }
-export const isHosted = true //appHostname === 'sim.ai' || appHostname.endsWith('.sim.ai')
+export const isHosted = appHostname === 'sim.ai' || appHostname.endsWith('.sim.ai')
 
 /**
  * Is billing enforcement enabled

--- a/apps/sim/lib/core/config/feature-flags.ts
+++ b/apps/sim/lib/core/config/feature-flags.ts
@@ -255,6 +255,12 @@ export const isGoogleAuthDisabled = isTruthy(env.DISABLE_GOOGLE_AUTH)
 export const isGithubAuthDisabled = isTruthy(env.DISABLE_GITHUB_AUTH)
 
 /**
+ * Is Microsoft OAuth login disabled
+ * When true, the Microsoft OAuth login button is hidden even when credentials are configured
+ */
+export const isMicrosoftAuthDisabled = isTruthy(env.DISABLE_MICROSOFT_AUTH)
+
+/**
  * Is React Grab enabled for UI element debugging
  * When true and in development mode, enables React Grab for copying UI element context to clipboard
  */

--- a/apps/sim/lib/core/config/feature-flags.ts
+++ b/apps/sim/lib/core/config/feature-flags.ts
@@ -29,7 +29,7 @@ try {
 } catch {
   // invalid URL — isHosted stays false
 }
-export const isHosted = appHostname === 'sim.ai' || appHostname.endsWith('.sim.ai')
+export const isHosted = true //appHostname === 'sim.ai' || appHostname.endsWith('.sim.ai')
 
 /**
  * Is billing enforcement enabled
@@ -259,6 +259,13 @@ export const isGithubAuthDisabled = isTruthy(env.DISABLE_GITHUB_AUTH)
  * When true, the Microsoft OAuth login button is hidden even when credentials are configured
  */
 export const isMicrosoftAuthDisabled = isTruthy(env.DISABLE_MICROSOFT_AUTH)
+
+/**
+ * Is email/password signup disabled
+ * When true, new registrations via email/password are blocked at the server level.
+ * Existing users can still sign in with email/password.
+ */
+export const isEmailSignupDisabled = isTruthy(env.DISABLE_EMAIL_SIGNUP)
 
 /**
  * Is React Grab enabled for UI element debugging


### PR DESCRIPTION
## Summary
- Remove email/password form from /signup — Google, Microsoft, and GitHub OAuth only to deter bot signups
- Add Microsoft as a first-class social provider via Better Auth socialProviders (env: MICROSOFT_CLIENT_ID / MICROSOFT_CLIENT_SECRET / DISABLE_MICROSOFT_AUTH)
- Wire microsoftAvailable through provider checker, API contract, providers route, login form, signup form, and landing page auth modal
- Hide "Continue with email" in auth modal signup view — login view is completely unchanged
- Fix MicrosoftIcon SVG to use official brand colors (#F1511B, #80CC28, #00ADEF, #FBBC09) and correct proportions

## Type of Change
- [x] New feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)