### PR TITLE
fix(credential-sets): security hardening

### DIFF
--- a/apps/sim/app/api/credential-sets/invitations/route.ts
+++ b/apps/sim/app/api/credential-sets/invitations/route.ts
@@ -1,7 +1,7 @@
 import { db } from '@sim/db'
 import { credentialSet, credentialSetInvitation, organization, user } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
-import { and, eq, gt, isNull, or } from 'drizzle-orm'
+import { and, eq, gt } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
@@ -16,6 +16,9 @@ export const GET = withRouteHandler(async () => {
   }
 
   try {
+    // Scope to invitations addressed to the caller's own email only. Open-link
+    // (null-email) invites carry a bearer token redeemed via the out-of-band URL
+    // and must never be listed, or any user could accept another org's invite.
     const invitations = await db
       .select({
         invitationId: credentialSetInvitation.id,
@@ -37,10 +40,7 @@ export const GET = withRouteHandler(async () => {
       .leftJoin(user, eq(credentialSetInvitation.invitedBy, user.id))
       .where(
         and(
-          or(
-            eq(credentialSetInvitation.email, session.user.email),
-            isNull(credentialSetInvitation.email)
-          ),
+          eq(credentialSetInvitation.email, session.user.email),
           eq(credentialSetInvitation.status, 'pending'),
           gt(credentialSetInvitation.expiresAt, new Date())
         )


### PR DESCRIPTION
## Summary
- `GET /api/credential-sets/invitations` returned every pending, unexpired link-only (null-email) invitation across **all organizations**, including the bearer `token`. Any authenticated user could enumerate those tokens and accept another org's invitation via `POST /api/credential-sets/invite/[token]` (which skips the email check when `email IS NULL`), joining that org's credential set — cross-tenant broken access control.
- Root cause: the `isNull(email)` branch in the listing's `WHERE` clause had no organization scoping, broadcasting open-invite tokens to everyone.
- Fix: scope the listing strictly to invitations addressed to the caller's own email. Open-link invites stay redeemable only via the out-of-band `/credential-account/[token]` URL, where possession of the unguessable token is the intended (and now non-enumerable) secret.

## Type of Change
- [x] Bug fix (security — cross-tenant privilege escalation)

## Testing
Tested manually. `bun run check:api-validation` passes; changed file typechecks clean. In-app "Pending Invitations" still lists email-addressed invites (token returned is the caller's own, and accept still enforces the email match).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)