### PR TITLE
fix(providers): allow HTTP for self-hosted vLLM endpoints

### DIFF
--- a/apps/sim/providers/vllm/index.test.ts
+++ b/apps/sim/providers/vllm/index.test.ts
@@ -155,7 +155,8 @@ describe('vllmProvider', () => {
 
       expect(mockValidateUrlWithDNS).toHaveBeenCalledWith(
         'https://my-vllm.example.com',
-        'vLLM endpoint'
+        'vLLM endpoint',
+        { allowHttp: true }
       )
       expect(mockCreatePinnedFetch).toHaveBeenCalledWith('203.0.113.10')
       expect(openAIArgs[0].baseURL).toBe('https://my-vllm.example.com/v1')

--- a/apps/sim/providers/vllm/index.ts
+++ b/apps/sim/providers/vllm/index.ts
@@ -108,10 +108,16 @@ export const vllmProvider: ProviderConfig = {
      * central SSRF guard and pin the connection to the resolved IP to defeat DNS
      * rebinding. The operator-configured `VLLM_BASE_URL` is trusted and left
      * unvalidated, mirroring the Azure providers.
+     *
+     * `allowHttp` is enabled because self-hosted vLLM is frequently served over
+     * plain HTTP; this only relaxes the protocol requirement — the private/reserved
+     * IP blocklist and blocked-port checks still apply, so SSRF protection is intact.
      */
     let pinnedFetch: typeof fetch | undefined
     if (userProvidedEndpoint) {
-      const validation = await validateUrlWithDNS(userProvidedEndpoint, 'vLLM endpoint')
+      const validation = await validateUrlWithDNS(userProvidedEndpoint, 'vLLM endpoint', {
+        allowHttp: true,
+      })
       if (!validation.isValid) {
         logger.warn('Blocked SSRF attempt via vLLM endpoint', {
           endpoint: userProvidedEndpoint,


### PR DESCRIPTION
## Summary
- Follow-up to #5077 (SSRF validate+pin for the vLLM endpoint), which merged before this refinement could be added.
- Pass `{ allowHttp: true }` to `validateUrlWithDNS` for the user-supplied vLLM endpoint so self-hosted vLLM served over plain `http://` on a public host is accepted. Without this it's rejected with "must use https:// protocol".
- This only relaxes the **protocol** check. The private/reserved-IP blocklist (literal host + DNS-resolved IP) and the blocked-port list still apply, so the SSRF protection from #5077 is fully intact — `http://169.254.169.254`, `http://10.0.0.5`, etc. remain blocked.
- Both reviewers on #5077 flagged this (Greptile P2, Cursor Bugbot Medium); the base PR merged before it landed.

## Type of Change
- [x] Bug fix (security follow-up)

## Testing
- `apps/sim/providers/vllm/index.test.ts` asserts the endpoint is validated with `{ allowHttp: true }`; 15/15 pass.
- `tsc --noEmit`, `biome check`, `bun run check:api-validation` clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)