### PR TITLE
fix(realtime): re-check workspace role on mutating socket events

### DIFF
--- a/apps/realtime/src/handlers/operations.ts
+++ b/apps/realtime/src/handlers/operations.ts
@@ -15,7 +15,7 @@ import { assertWorkflowMutable, WorkflowLockedError } from '@sim/workflow-authz'
 import { ZodError } from 'zod'
 import { persistWorkflowOperation } from '@/database/operations'
 import type { AuthenticatedSocket } from '@/middleware/auth'
-import { checkRolePermission } from '@/middleware/permissions'
+import { checkWorkflowOperationPermission } from '@/middleware/permissions'
 import type { IRoomManager, UserSession } from '@/rooms'
 
 const logger = createLogger('OperationsHandlers')
@@ -125,11 +125,17 @@ export function setupOperationsHandlers(socket: AuthenticatedSocket, roomManager
 
         await roomManager.updateUserActivity(workflowId, socket.id, { lastActivity: Date.now() })
 
-        // Check permissions using cached role (no DB query)
-        const permissionCheck = checkRolePermission(userPresence.role, operation)
+        // Re-validate the workspace role against the DB (cached per pod for a short
+        // window) so revoked or downgraded collaborators lose write access live.
+        const permissionCheck = await checkWorkflowOperationPermission(
+          session.userId,
+          workflowId,
+          operation,
+          userPresence.role
+        )
         if (!permissionCheck.allowed) {
           logger.warn(
-            `User ${session.userId} (role: ${userPresence.role}) forbidden from ${operation} on ${target}`
+            `User ${session.userId} (role: ${permissionCheck.role ?? 'none'}) forbidden from ${operation} on ${target}`
           )
           emitOperationError({
             type: 'INSUFFICIENT_PERMISSIONS',

--- a/apps/realtime/src/handlers/subblocks.ts
+++ b/apps/realtime/src/handlers/subblocks.ts
@@ -7,7 +7,7 @@ import { assertWorkflowMutable, WorkflowLockedError } from '@sim/workflow-authz'
 import { isWorkflowBlockProtected } from '@sim/workflow-types/workflow'
 import { and, eq } from 'drizzle-orm'
 import type { AuthenticatedSocket } from '@/middleware/auth'
-import { checkRolePermission } from '@/middleware/permissions'
+import { checkWorkflowOperationPermission } from '@/middleware/permissions'
 import type { IRoomManager } from '@/rooms'
 
 const logger = createLogger('SubblocksHandlers')
@@ -136,7 +136,12 @@ export function setupSubblocksHandlers(socket: AuthenticatedSocket, roomManager:
         return
       }
 
-      const permissionCheck = checkRolePermission(userPresence.role, SUBBLOCK_OPERATIONS.UPDATE)
+      const permissionCheck = await checkWorkflowOperationPermission(
+        session.userId,
+        workflowId,
+        SUBBLOCK_OPERATIONS.UPDATE,
+        userPresence.role
+      )
       if (!permissionCheck.allowed) {
         socket.emit('operation-forbidden', {
           type: 'INSUFFICIENT_PERMISSIONS',

--- a/apps/realtime/src/handlers/variables.ts
+++ b/apps/realtime/src/handlers/variables.ts
@@ -6,7 +6,7 @@ import { getErrorMessage } from '@sim/utils/errors'
 import { assertWorkflowMutable, WorkflowLockedError } from '@sim/workflow-authz'
 import { eq } from 'drizzle-orm'
 import type { AuthenticatedSocket } from '@/middleware/auth'
-import { checkRolePermission } from '@/middleware/permissions'
+import { checkWorkflowOperationPermission } from '@/middleware/permissions'
 import type { IRoomManager } from '@/rooms'
 
 const logger = createLogger('VariablesHandlers')
@@ -124,7 +124,12 @@ export function setupVariablesHandlers(socket: AuthenticatedSocket, roomManager:
         return
       }
 
-      const permissionCheck = checkRolePermission(userPresence.role, VARIABLE_OPERATIONS.UPDATE)
+      const permissionCheck = await checkWorkflowOperationPermission(
+        session.userId,
+        workflowId,
+        VARIABLE_OPERATIONS.UPDATE,
+        userPresence.role
+      )
       if (!permissionCheck.allowed) {
         socket.emit('operation-forbidden', {
           type: 'INSUFFICIENT_PERMISSIONS',

--- a/apps/realtime/src/index.test.ts
+++ b/apps/realtime/src/index.test.ts
@@ -73,6 +73,10 @@ vi.mock('@/middleware/permissions', () => ({
   checkRolePermission: vi.fn().mockReturnValue({
     allowed: true,
   }),
+  checkWorkflowOperationPermission: vi.fn().mockResolvedValue({
+    allowed: true,
+    role: 'admin',
+  }),
 }))
 
 vi.mock('@/database/operations', () => ({

--- a/apps/realtime/src/middleware/permissions.test.ts
+++ b/apps/realtime/src/middleware/permissions.test.ts
@@ -13,8 +13,17 @@ import {
   ROLE_ALLOWED_OPERATIONS,
   SOCKET_OPERATIONS,
 } from '@sim/testing'
-import { describe, expect, it } from 'vitest'
-import { checkRolePermission } from '@/middleware/permissions'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockAuthorize } = vi.hoisted(() => ({
+  mockAuthorize: vi.fn(),
+}))
+
+vi.mock('@sim/workflow-authz', () => ({
+  authorizeWorkflowByWorkspacePermission: mockAuthorize,
+}))
+
+import { checkRolePermission, checkWorkflowOperationPermission } from '@/middleware/permissions'
 
 describe('checkRolePermission', () => {
   describe('admin role', () => {
@@ -277,5 +286,91 @@ describe('checkRolePermission', () => {
       const result = checkRolePermission('read', 'remove')
       expect(result.reason).toMatch(/Role '.*' not permitted to perform '.*'/)
     })
+  })
+})
+
+describe('checkWorkflowOperationPermission', () => {
+  const userId = 'user-1'
+  let workflowCounter = 0
+  let workflowId: string
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Unique workflowId per test so the module-level role cache never leaks across tests
+    workflowCounter += 1
+    workflowId = `wf-${workflowCounter}`
+  })
+
+  it('allows a write operation when the user still has write access', async () => {
+    mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'write' })
+
+    const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+
+    expect(result.allowed).toBe(true)
+    expect(result.role).toBe('write')
+  })
+
+  it('denies all writes once workspace access has been revoked', async () => {
+    mockAuthorize.mockResolvedValue({ allowed: false, workspacePermission: null })
+
+    const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'write')
+
+    expect(result.allowed).toBe(false)
+    expect(result.role).toBeNull()
+    expect(result.reason).toMatch(/revoked/i)
+  })
+
+  it('denies writes after a downgrade to read but still allows position updates', async () => {
+    mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'read' })
+
+    const denied = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'write')
+    expect(denied.allowed).toBe(false)
+    expect(denied.role).toBe('read')
+
+    const allowed = await checkWorkflowOperationPermission(
+      userId,
+      workflowId,
+      'update-position',
+      'write'
+    )
+    expect(allowed.allowed).toBe(true)
+    expect(allowed.role).toBe('read')
+  })
+
+  it('caches the role within the TTL to avoid a DB read on every operation', async () => {
+    mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'write' })
+
+    await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+    await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+
+    expect(mockAuthorize).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-reads the role after the cache TTL expires', async () => {
+    vi.useFakeTimers()
+    try {
+      mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'write' })
+      await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+
+      // Downgraded to read after the first check
+      mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'read' })
+      vi.advanceTimersByTime(31_000)
+
+      const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'write')
+      expect(mockAuthorize).toHaveBeenCalledTimes(2)
+      expect(result.allowed).toBe(false)
+      expect(result.role).toBe('read')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('falls back to the last known role on a transient DB error', async () => {
+    mockAuthorize.mockRejectedValue(new Error('db unavailable'))
+
+    const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'write')
+
+    expect(result.allowed).toBe(true)
+    expect(result.role).toBe('write')
   })
 })

--- a/apps/realtime/src/middleware/permissions.test.ts
+++ b/apps/realtime/src/middleware/permissions.test.ts
@@ -365,12 +365,52 @@ describe('checkWorkflowOperationPermission', () => {
     }
   })
 
-  it('falls back to the last known role on a transient DB error', async () => {
+  it('falls back to the join-time role on a transient DB error when nothing is cached yet', async () => {
     mockAuthorize.mockRejectedValue(new Error('db unavailable'))
 
     const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'write')
 
     expect(result.allowed).toBe(true)
     expect(result.role).toBe('write')
+  })
+
+  it('preserves a recorded revocation through a later transient DB error', async () => {
+    vi.useFakeTimers()
+    try {
+      // First check records the revocation (null) in the cache
+      mockAuthorize.mockResolvedValue({ allowed: false, workspacePermission: null })
+      const first = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'admin')
+      expect(first.allowed).toBe(false)
+      expect(first.role).toBeNull()
+
+      // TTL expires, then the DB blips on the next re-validation. The stale join-time
+      // role ('admin') must NOT resurrect access — the recorded revocation wins.
+      vi.advanceTimersByTime(31_000)
+      mockAuthorize.mockRejectedValue(new Error('db unavailable'))
+
+      const second = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'admin')
+      expect(second.allowed).toBe(false)
+      expect(second.role).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('uses the last cached role (not the join-time role) on a transient DB error', async () => {
+    vi.useFakeTimers()
+    try {
+      mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'write' })
+      await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+
+      vi.advanceTimersByTime(31_000)
+      mockAuthorize.mockRejectedValue(new Error('db unavailable'))
+
+      // fallbackRole is 'read', but the last recorded decision was 'write' — use that
+      const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+      expect(result.allowed).toBe(true)
+      expect(result.role).toBe('write')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/realtime/src/middleware/permissions.ts
+++ b/apps/realtime/src/middleware/permissions.ts
@@ -84,6 +84,104 @@ export function checkRolePermission(
 }
 
 /**
+ * TTL for the per-pod role cache backing live re-validation of mutating operations.
+ * Bounds how long a revoked or downgraded collaborator can retain write access on an
+ * already-connected socket.
+ */
+const ROLE_REVALIDATION_TTL_MS = 30_000
+
+/** Soft cap on cached entries before an opportunistic purge of expired ones runs. */
+const MAX_ROLE_CACHE_ENTRIES = 5_000
+
+interface CachedRole {
+  /** Authoritative workspace role, or `null` when the user has no access. */
+  role: string | null
+  expiresAt: number
+}
+
+/**
+ * Per-pod cache of authoritative workspace roles, keyed by `${userId}:${workflowId}`.
+ *
+ * Socket connections are sticky to a single pod, so a socket's mutating operations are
+ * always gated by the same pod's cache. We rely on TTL expiry (not cross-pod
+ * invalidation) to bound stale authorization to {@link ROLE_REVALIDATION_TTL_MS}, which
+ * keeps this correct under a multi-pod deployment without any shared state.
+ */
+const roleCache = new Map<string, CachedRole>()
+
+function purgeExpiredRoles(now: number): void {
+  for (const [key, entry] of roleCache) {
+    if (entry.expiresAt <= now) {
+      roleCache.delete(key)
+    }
+  }
+}
+
+/**
+ * Resolves a user's current workspace role for a workflow, re-reading the `permissions`
+ * table at most once per {@link ROLE_REVALIDATION_TTL_MS} per pod.
+ *
+ * Returns `null` when the user genuinely has no access (removed/revoked). On a transient
+ * DB failure it falls back to `fallbackRole` so a blip does not block legitimate editors
+ * — the subsequent persist would fail on its own if the database is truly unavailable.
+ */
+export async function resolveCurrentWorkflowRole(
+  userId: string,
+  workflowId: string,
+  fallbackRole: string
+): Promise<string | null> {
+  const now = Date.now()
+  const key = `${userId}:${workflowId}`
+  const cached = roleCache.get(key)
+  if (cached && cached.expiresAt > now) {
+    return cached.role
+  }
+
+  try {
+    const authorization = await authorizeWorkflowByWorkspacePermission({
+      workflowId,
+      userId,
+      action: 'read',
+    })
+    const role = authorization.allowed ? (authorization.workspacePermission ?? null) : null
+    if (roleCache.size >= MAX_ROLE_CACHE_ENTRIES) {
+      purgeExpiredRoles(now)
+    }
+    roleCache.set(key, { role, expiresAt: now + ROLE_REVALIDATION_TTL_MS })
+    return role
+  } catch (error) {
+    logger.warn(
+      `Failed to re-validate role for user ${userId} on workflow ${workflowId}; using last known role`,
+      error
+    )
+    return fallbackRole
+  }
+}
+
+/**
+ * Live permission gate for mutating socket operations. Re-validates the user's workspace
+ * role against the database (cached per pod for {@link ROLE_REVALIDATION_TTL_MS}) so that
+ * revoked or downgraded collaborators lose write access on an open connection without
+ * needing to rejoin the workflow.
+ */
+export async function checkWorkflowOperationPermission(
+  userId: string,
+  workflowId: string,
+  operation: string,
+  fallbackRole: string
+): Promise<{ allowed: boolean; reason?: string; role: string | null }> {
+  const role = await resolveCurrentWorkflowRole(userId, workflowId, fallbackRole)
+  if (!role) {
+    return {
+      allowed: false,
+      reason: 'Access to this workflow has been revoked',
+      role: null,
+    }
+  }
+  return { ...checkRolePermission(role, operation), role }
+}
+
+/**
  * Verifies a user's access to a workflow via workspace permissions.
  *
  * Returns `hasAccess: false` only for genuine denials (workflow missing/archived

--- a/apps/realtime/src/middleware/permissions.ts
+++ b/apps/realtime/src/middleware/permissions.ts
@@ -122,8 +122,10 @@ function purgeExpiredRoles(now: number): void {
  * table at most once per {@link ROLE_REVALIDATION_TTL_MS} per pod.
  *
  * Returns `null` when the user genuinely has no access (removed/revoked). On a transient
- * DB failure it falls back to `fallbackRole` so a blip does not block legitimate editors
- * — the subsequent persist would fail on its own if the database is truly unavailable.
+ * DB failure it reuses the last recorded decision for this (user, workflow) — including a
+ * previously recorded revocation (`null`) — and only falls back to `fallbackRole` when no
+ * decision has been recorded yet, so a blip neither blocks legitimate editors nor
+ * resurrects already-revoked access.
  */
 export async function resolveCurrentWorkflowRole(
   userId: string,
@@ -154,7 +156,12 @@ export async function resolveCurrentWorkflowRole(
       `Failed to re-validate role for user ${userId} on workflow ${workflowId}; using last known role`,
       error
     )
-    return fallbackRole
+    // Prefer the last recorded decision — even if expired, and even if it is `null` for an
+    // already-revoked user — so a recorded revocation survives a transient DB failure
+    // instead of reverting to the stale join-time role. Only trust `fallbackRole` when
+    // nothing has been recorded for this (user, workflow) yet.
+    const lastKnown = roleCache.get(key)
+    return lastKnown !== undefined ? lastKnown.role : fallbackRole
   }
 }
 


### PR DESCRIPTION
## Summary

Realtime server authorized a user once at join-workflow and cached the
workspace role in room presence, then trusted that cached role for every
subsequent workflow-operation, subblock-update, and variable-update with no
DB re-check and no revocation path. A collaborator removed from the workspace
or downgraded to read kept live write access on an open connection until they
disconnected.

Re-validate the role against the permissions table on each mutating event,
cached per pod for 30s to keep the hot path cheap. Revoked users are denied
(fail-closed); a transient DB error falls back to the last-known role so a
blip doesn't block legitimate editors.


## Type of Change
- [x] Other: Security Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)