### PR TITLE
feat(chat): add scheduled tasks as a viewable resource

### DIFF
--- a/apps/sim/app/api/copilot/chat/resources/route.ts
+++ b/apps/sim/app/api/copilot/chat/resources/route.ts
@@ -17,6 +17,7 @@ import {
   createUnauthorizedResponse,
 } from '@/lib/copilot/request/http'
 import type { ChatResource, ResourceType } from '@/lib/copilot/resources/persistence'
+import { GENERIC_RESOURCE_TITLES } from '@/lib/copilot/resources/types'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 
 const logger = createLogger('CopilotChatResourcesAPI')
@@ -30,15 +31,6 @@ const VALID_RESOURCE_TYPES = new Set<ResourceType>([
   'scheduledtask',
   'log',
   'integration',
-])
-const GENERIC_TITLES = new Set([
-  'Table',
-  'File',
-  'Workflow',
-  'Knowledge Base',
-  'Folder',
-  'Scheduled Task',
-  'Log',
 ])
 
 export const POST = withRouteHandler(async (req: NextRequest) => {
@@ -85,7 +77,7 @@ export const POST = withRouteHandler(async (req: NextRequest) => {
 
     let merged: ChatResource[]
     if (prev) {
-      if (GENERIC_TITLES.has(prev.title) && !GENERIC_TITLES.has(resource.title)) {
+      if (GENERIC_RESOURCE_TITLES.has(prev.title) && !GENERIC_RESOURCE_TITLES.has(resource.title)) {
         merged = existing.map((r) =>
           `${r.type}:${r.id}` === key ? { ...r, title: resource.title } : r
         )

--- a/apps/sim/app/api/copilot/chat/resources/route.ts
+++ b/apps/sim/app/api/copilot/chat/resources/route.ts
@@ -27,10 +27,19 @@ const VALID_RESOURCE_TYPES = new Set<ResourceType>([
   'workflow',
   'knowledgebase',
   'folder',
+  'scheduledtask',
   'log',
   'integration',
 ])
-const GENERIC_TITLES = new Set(['Table', 'File', 'Workflow', 'Knowledge Base', 'Folder', 'Log'])
+const GENERIC_TITLES = new Set([
+  'Table',
+  'File',
+  'Workflow',
+  'Knowledge Base',
+  'Folder',
+  'Scheduled Task',
+  'Log',
+])
 
 export const POST = withRouteHandler(async (req: NextRequest) => {
   try {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/chat-context-kind-registry/chat-context-kind-registry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/chat-context-kind-registry/chat-context-kind-registry.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import {
+  Calendar,
   Database,
   Folder as FolderIcon,
   Library,
@@ -78,6 +79,10 @@ export const CHAT_CONTEXT_KIND_REGISTRY: Record<ChatContextKind, ChatContextKind
   filefolder: {
     label: 'File folder',
     renderIcon: ({ className }) => <FolderIcon className={className} />,
+  },
+  scheduledtask: {
+    label: 'Scheduled task',
+    renderIcon: ({ className }) => <Calendar className={className} />,
   },
   past_chat: {
     label: 'Past chat',

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import { truncate } from '@sim/utils/string'
 import {
   Button,
   DropdownMenu,
@@ -30,6 +31,7 @@ import { useFolders } from '@/hooks/queries/folders'
 import { useKnowledgeBasesQuery } from '@/hooks/queries/kb/knowledge'
 import { useLogsList } from '@/hooks/queries/logs'
 import { useMothershipChats } from '@/hooks/queries/mothership-chats'
+import { useWorkspaceSchedules } from '@/hooks/queries/schedules'
 import { useTablesList } from '@/hooks/queries/tables'
 import { useWorkflows } from '@/hooks/queries/workflows'
 import { useWorkspaceFileFolders } from '@/hooks/queries/workspace-file-folders'
@@ -77,6 +79,7 @@ export function useAvailableResources(
   const { data: folders = [] } = useFolders(workspaceId)
   const { data: fileFolders = [] } = useWorkspaceFileFolders(workspaceId)
   const { data: tasks = [] } = useMothershipChats(workspaceId)
+  const { data: schedules = [] } = useWorkspaceSchedules(workspaceId)
   const { data: logsData } = useLogsList(workspaceId, LOG_DROPDOWN_FILTERS)
   const logs = useMemo(() => (logsData?.pages ?? []).flatMap((page) => page.logs), [logsData])
 
@@ -156,6 +159,16 @@ export function useAvailableResources(
         })),
       },
       {
+        type: 'scheduledtask' as const,
+        items: schedules
+          .filter((s) => s.sourceType === 'job')
+          .map((s) => ({
+            id: s.id,
+            name: s.jobTitle || truncate(s.prompt ?? '', 40) || 'Scheduled Task',
+            isOpen: existingKeys.has(`scheduledtask:${s.id}`),
+          })),
+      },
+      {
         type: 'log' as const,
         items: logs.map((log) => {
           const workflowName = log.workflow?.name ?? log.workflowId ?? 'Unknown'
@@ -179,6 +192,7 @@ export function useAvailableResources(
     files,
     knowledgeBases,
     tasks,
+    schedules,
     logs,
     existingKeys,
     excludeTypes,

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
@@ -2,9 +2,11 @@
 
 import { lazy, memo, Suspense, useEffect, useMemo, useRef } from 'react'
 import { createLogger } from '@sim/logger'
+import { format } from 'date-fns'
 import { useRouter } from 'next/navigation'
 import { Button, PlayOutline, Skeleton, Tooltip } from '@/components/emcn'
 import {
+  Calendar,
   Download,
   FileX,
   Folder as FolderIcon,
@@ -24,6 +26,7 @@ import {
 import { canonicalWorkspaceFilePath } from '@/lib/copilot/vfs/path-utils'
 import { triggerFileDownload } from '@/lib/uploads/client/download'
 import { getFileExtension, getMimeTypeFromExtension } from '@/lib/uploads/utils/file-utils'
+import { parseCronToHumanReadable } from '@/lib/workflows/schedules/utils'
 import {
   FileViewer,
   type PreviewMode,
@@ -50,6 +53,7 @@ import { useUsageLimits } from '@/app/workspace/[workspaceId]/w/[workflowId]/com
 import { useWorkflowExecution } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution'
 import { useFolders } from '@/hooks/queries/folders'
 import { useLogDetail } from '@/hooks/queries/logs'
+import { useWorkspaceSchedules } from '@/hooks/queries/schedules'
 import { downloadTableExport } from '@/hooks/queries/tables'
 import { useWorkflows } from '@/hooks/queries/workflows'
 import { useWorkspaceFiles } from '@/hooks/queries/workspace-files'
@@ -182,6 +186,15 @@ export const ResourceContent = memo(function ResourceContent({
     case 'folder':
       return <EmbeddedFolder key={resource.id} workspaceId={workspaceId} folderId={resource.id} />
 
+    case 'scheduledtask':
+      return (
+        <EmbeddedScheduledTask
+          key={resource.id}
+          workspaceId={workspaceId}
+          scheduleId={resource.id}
+        />
+      )
+
     case 'log':
       return (
         <EmbeddedLog
@@ -233,6 +246,8 @@ export function ResourceActions({ workspaceId, resource }: ResourceActionsProps)
       )
     case 'log':
       return <EmbeddedLogActions workspaceId={workspaceId} logId={resource.id} />
+    case 'scheduledtask':
+      return <EmbeddedScheduledTaskActions workspaceId={workspaceId} />
     case 'folder':
     case 'generic':
       return null
@@ -644,6 +659,141 @@ function EmbeddedFolder({ workspaceId, folderId }: EmbeddedFolderProps) {
         </div>
       )}
     </div>
+  )
+}
+
+const SCHEDULE_STATUS_LABEL: Record<string, string> = {
+  active: 'Active',
+  disabled: 'Paused',
+  completed: 'Completed',
+}
+
+function formatScheduleInstant(iso: string | null): string {
+  if (!iso) return '—'
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime()) ? '—' : format(date, "EEE, MMM d 'at' h:mm a")
+}
+
+interface ScheduledTaskFieldProps {
+  title: string
+  value: string
+}
+
+function ScheduledTaskField({ title, value }: ScheduledTaskFieldProps) {
+  return (
+    <div className='flex flex-col gap-1'>
+      <span className='text-[var(--text-muted)] text-caption'>{title}</span>
+      <span className='text-[var(--text-body)] text-small'>{value}</span>
+    </div>
+  )
+}
+
+interface EmbeddedScheduledTaskProps {
+  workspaceId: string
+  scheduleId: string
+}
+
+function EmbeddedScheduledTask({ workspaceId, scheduleId }: EmbeddedScheduledTaskProps) {
+  const { data: schedules = [], isLoading } = useWorkspaceSchedules(workspaceId)
+  const schedule = useMemo(
+    () => schedules.find((s) => s.id === scheduleId),
+    [schedules, scheduleId]
+  )
+
+  if (isLoading && !schedule) return LOADING_SKELETON
+
+  if (!schedule) {
+    return (
+      <div className='flex h-full flex-col items-center justify-center gap-3'>
+        <Calendar className='size-[32px] text-[var(--text-icon)]' />
+        <div className='flex flex-col items-center gap-1'>
+          <h2 className='font-medium text-[20px] text-[var(--text-primary)]'>
+            Scheduled task not found
+          </h2>
+          <p className='text-[var(--text-body)] text-small'>
+            This scheduled task may have been deleted
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const title = schedule.jobTitle || schedule.prompt || 'Scheduled task'
+  const timing = schedule.cronExpression
+    ? parseCronToHumanReadable(schedule.cronExpression, schedule.timezone)
+    : 'Runs once'
+  const status = SCHEDULE_STATUS_LABEL[schedule.status] ?? schedule.status
+
+  return (
+    <div className='flex h-full flex-col gap-6 overflow-y-auto p-6'>
+      <div className='flex items-center gap-2'>
+        <Calendar className='size-[16px] flex-shrink-0 text-[var(--text-icon)]' />
+        <h2 className='truncate font-medium text-[16px] text-[var(--text-primary)]'>{title}</h2>
+      </div>
+
+      <div className='grid grid-cols-2 gap-4'>
+        <ScheduledTaskField title='Status' value={status} />
+        <ScheduledTaskField title='Schedule' value={timing} />
+        <ScheduledTaskField title='Next run' value={formatScheduleInstant(schedule.nextRunAt)} />
+        <ScheduledTaskField title='Last run' value={formatScheduleInstant(schedule.lastRanAt)} />
+      </div>
+
+      <div className='flex flex-col gap-1'>
+        <span className='text-[var(--text-muted)] text-caption'>Prompt</span>
+        <p className='whitespace-pre-wrap text-[var(--text-body)] text-small'>
+          {schedule.prompt || '—'}
+        </p>
+      </div>
+
+      {schedule.jobHistory && schedule.jobHistory.length > 0 && (
+        <div className='flex flex-col gap-2'>
+          <span className='text-[var(--text-muted)] text-caption'>Recent runs</span>
+          <div className='flex flex-col gap-2'>
+            {schedule.jobHistory.slice(0, 5).map((run) => (
+              <div
+                key={run.timestamp}
+                className='flex flex-col gap-1 rounded-[6px] bg-[var(--surface-4)] px-3 py-2'
+              >
+                <span className='text-[var(--text-tertiary)] text-caption'>
+                  {formatScheduleInstant(run.timestamp)}
+                </span>
+                <span className='text-[var(--text-body)] text-small'>{run.summary}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface EmbeddedScheduledTaskActionsProps {
+  workspaceId: string
+}
+
+function EmbeddedScheduledTaskActions({ workspaceId }: EmbeddedScheduledTaskActionsProps) {
+  const router = useRouter()
+
+  const handleOpenScheduledTasks = () => {
+    router.push(`/workspace/${workspaceId}/scheduled-tasks`)
+  }
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>
+        <Button
+          variant='subtle'
+          onClick={handleOpenScheduledTasks}
+          className={RESOURCE_TAB_ICON_BUTTON_CLASS}
+          aria-label='Open in scheduled tasks'
+        >
+          <SquareArrowUpRight className={RESOURCE_TAB_ICON_CLASS} />
+        </Button>
+      </Tooltip.Trigger>
+      <Tooltip.Content side='bottom'>
+        <p>Open in scheduled tasks</p>
+      </Tooltip.Content>
+    </Tooltip.Root>
   )
 }
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
@@ -694,7 +694,7 @@ interface EmbeddedScheduledTaskProps {
 }
 
 function EmbeddedScheduledTask({ workspaceId, scheduleId }: EmbeddedScheduledTaskProps) {
-  const { data: schedules = [], isLoading } = useWorkspaceSchedules(workspaceId)
+  const { data: schedules = [], isLoading, isError } = useWorkspaceSchedules(workspaceId)
   const schedule = useMemo(
     () => schedules.find((s) => s.id === scheduleId),
     [schedules, scheduleId]
@@ -703,16 +703,18 @@ function EmbeddedScheduledTask({ workspaceId, scheduleId }: EmbeddedScheduledTas
   if (isLoading && !schedule) return LOADING_SKELETON
 
   if (!schedule) {
+    // A failed list query also yields no schedule; keep that distinct from a
+    // genuinely missing task so we don't tell the user it was deleted.
+    const heading = isError ? "Couldn't load scheduled task" : 'Scheduled task not found'
+    const detail = isError
+      ? 'Something went wrong loading this scheduled task. Try again.'
+      : 'This scheduled task may have been deleted'
     return (
       <div className='flex h-full flex-col items-center justify-center gap-3'>
         <Calendar className='size-[32px] text-[var(--text-icon)]' />
         <div className='flex flex-col items-center gap-1'>
-          <h2 className='font-medium text-[20px] text-[var(--text-primary)]'>
-            Scheduled task not found
-          </h2>
-          <p className='text-[var(--text-body)] text-small'>
-            This scheduled task may have been deleted
-          </p>
+          <h2 className='font-medium text-[20px] text-[var(--text-primary)]'>{heading}</h2>
+          <p className='text-[var(--text-body)] text-small'>{detail}</p>
         </div>
       </div>
     )
@@ -749,9 +751,9 @@ function EmbeddedScheduledTask({ workspaceId, scheduleId }: EmbeddedScheduledTas
         <div className='flex flex-col gap-2'>
           <span className='text-[var(--text-muted)] text-caption'>Recent runs</span>
           <div className='flex flex-col gap-2'>
-            {schedule.jobHistory.slice(0, 5).map((run) => (
+            {schedule.jobHistory.slice(0, 5).map((run, index) => (
               <div
-                key={run.timestamp}
+                key={`${run.timestamp}-${index}`}
                 className='flex flex-col gap-1 rounded-[6px] bg-[var(--surface-4)] px-3 py-2'
               >
                 <span className='text-[var(--text-tertiary)] text-caption'>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
@@ -703,8 +703,6 @@ function EmbeddedScheduledTask({ workspaceId, scheduleId }: EmbeddedScheduledTas
   if (isLoading && !schedule) return LOADING_SKELETON
 
   if (!schedule) {
-    // A failed list query also yields no schedule; keep that distinct from a
-    // genuinely missing task so we don't tell the user it was deleted.
     const heading = isError ? "Couldn't load scheduled task" : 'Scheduled task not found'
     const detail = isError
       ? 'Something went wrong loading this scheduled task. Try again.'

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry/resource-registry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry/resource-registry.tsx
@@ -3,6 +3,7 @@
 import type { ElementType, ReactNode } from 'react'
 import type { QueryClient } from '@tanstack/react-query'
 import {
+  Calendar,
   Connections,
   Database,
   File as FileIcon,
@@ -23,6 +24,7 @@ import { getBareIconStyle, type StyleableIcon } from '@/blocks/icon-color'
 import { knowledgeKeys } from '@/hooks/queries/kb/knowledge'
 import { logKeys } from '@/hooks/queries/logs'
 import { mothershipChatKeys } from '@/hooks/queries/mothership-chats'
+import { scheduleKeys } from '@/hooks/queries/schedules'
 import { tableKeys } from '@/hooks/queries/tables'
 import { folderKeys } from '@/hooks/queries/utils/folder-keys'
 import { invalidateWorkflowLists } from '@/hooks/queries/utils/invalidate-workflow-lists'
@@ -183,6 +185,15 @@ export const RESOURCE_REGISTRY: Record<MothershipResourceType, ResourceTypeConfi
     ),
     renderDropdownItem: (props) => <DefaultDropdownItem {...props} />,
   },
+  scheduledtask: {
+    type: 'scheduledtask',
+    label: 'Scheduled Tasks',
+    icon: Calendar,
+    renderTabIcon: (_resource, className) => (
+      <Calendar className={cn(className, 'text-[var(--text-icon)]')} />
+    ),
+    renderDropdownItem: (props) => <IconDropdownItem {...props} icon={Calendar} />,
+  },
   log: {
     type: 'log',
     label: 'Logs',
@@ -240,6 +251,9 @@ const RESOURCE_INVALIDATORS: Record<
   },
   task: (qc, wId) => {
     qc.invalidateQueries({ queryKey: mothershipChatKeys.list(wId) })
+  },
+  scheduledtask: (qc, wId) => {
+    qc.invalidateQueries({ queryKey: scheduleKeys.list(wId) })
   },
   log: (qc, _wId, id) => {
     qc.invalidateQueries({ queryKey: logKeys.details() })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/chip-clipboard-codec.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/chip-clipboard-codec.ts
@@ -27,6 +27,7 @@ const PORTABLE_KIND_TO_ID_FIELD = {
   file: 'fileId',
   folder: 'folderId',
   filefolder: 'fileFolderId',
+  scheduledtask: 'scheduleId',
   knowledge: 'knowledgeId',
   past_chat: 'chatId',
   workflow: 'workflowId',
@@ -207,6 +208,8 @@ export function chipLinkToContext(link: ParsedChipLink): ChatContext {
       return { kind: 'folder', folderId: link.id, label: link.label }
     case 'filefolder':
       return { kind: 'filefolder', fileFolderId: link.id, label: link.label }
+    case 'scheduledtask':
+      return { kind: 'scheduledtask', scheduleId: link.id, label: link.label }
     case 'knowledge':
       return { kind: 'knowledge', knowledgeId: link.id, label: link.label }
     case 'past_chat':

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/constants.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/constants.ts
@@ -112,6 +112,7 @@ const RESOURCE_TO_CONTEXT: Record<
   task: (r) => ({ kind: 'past_chat', chatId: r.id, label: r.title }),
   log: (r) => ({ kind: 'logs', executionId: r.id, label: r.title }),
   integration: (r) => ({ kind: 'integration', blockType: r.id, label: r.title }),
+  scheduledtask: (r) => ({ kind: 'scheduledtask', scheduleId: r.id, label: r.title }),
   generic: (r) => ({ kind: 'docs', label: r.title }),
 }
 

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
@@ -294,6 +294,8 @@ function isChatContext(value: unknown): value is ChatContext {
       return typeof value.folderId === 'string'
     case 'filefolder':
       return typeof value.fileFolderId === 'string'
+    case 'scheduledtask':
+      return typeof value.scheduleId === 'string'
     case 'docs':
       return true
     case 'slash_command':

--- a/apps/sim/lib/api/contracts/copilot.ts
+++ b/apps/sim/lib/api/contracts/copilot.ts
@@ -92,6 +92,7 @@ const copilotResourceTypeSchema = z.enum([
   'workflow',
   'knowledgebase',
   'folder',
+  'scheduledtask',
   'log',
 ])
 

--- a/apps/sim/lib/copilot/resources/persistence.ts
+++ b/apps/sim/lib/copilot/resources/persistence.ts
@@ -3,7 +3,7 @@ import { copilotChats } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
 import { eq, sql } from 'drizzle-orm'
-import type { MothershipResource } from './types'
+import { GENERIC_RESOURCE_TITLES, type MothershipResource } from './types'
 
 export {
   extractDeletedResourcesFromToolResult,
@@ -42,7 +42,6 @@ export async function persistChatResources(
 
     const existing = Array.isArray(chat.resources) ? (chat.resources as ChatResource[]) : []
     const map = new Map<string, ChatResource>()
-    const GENERIC = new Set(['Table', 'File', 'Workflow', 'Knowledge Base', 'Folder', 'Log'])
 
     for (const r of existing) {
       map.set(`${r.type}:${r.id}`, r)
@@ -51,7 +50,10 @@ export async function persistChatResources(
     for (const r of toMerge) {
       const key = `${r.type}:${r.id}`
       const prev = map.get(key)
-      if (!prev || (GENERIC.has(prev.title) && !GENERIC.has(r.title))) {
+      if (
+        !prev ||
+        (GENERIC_RESOURCE_TITLES.has(prev.title) && !GENERIC_RESOURCE_TITLES.has(r.title))
+      ) {
         map.set(key, r)
       }
     }

--- a/apps/sim/lib/copilot/resources/types.ts
+++ b/apps/sim/lib/copilot/resources/types.ts
@@ -25,12 +25,7 @@ export function isEphemeralResource(resource: MothershipResource): boolean {
   return resource.type === 'generic' || resource.id === 'streaming-file'
 }
 
-/**
- * Placeholder resource titles emitted before a specific name is known. A more
- * specific title may overwrite one of these during dedup; a specific title is
- * never downgraded back to a placeholder. Shared by the chat-resource route and
- * the server-side persistence merge so the two stay in lockstep.
- */
+/** Placeholder resource titles that a more specific title may overwrite during dedup. */
 export const GENERIC_RESOURCE_TITLES = new Set<string>([
   'Table',
   'File',

--- a/apps/sim/lib/copilot/resources/types.ts
+++ b/apps/sim/lib/copilot/resources/types.ts
@@ -25,6 +25,22 @@ export function isEphemeralResource(resource: MothershipResource): boolean {
   return resource.type === 'generic' || resource.id === 'streaming-file'
 }
 
+/**
+ * Placeholder resource titles emitted before a specific name is known. A more
+ * specific title may overwrite one of these during dedup; a specific title is
+ * never downgraded back to a placeholder. Shared by the chat-resource route and
+ * the server-side persistence merge so the two stay in lockstep.
+ */
+export const GENERIC_RESOURCE_TITLES = new Set<string>([
+  'Table',
+  'File',
+  'Workflow',
+  'Knowledge Base',
+  'Folder',
+  'Scheduled Task',
+  'Log',
+])
+
 export const VFS_DIR_TO_RESOURCE: Record<string, MothershipResourceType> = {
   tables: 'table',
   files: 'file',

--- a/apps/sim/lib/copilot/resources/types.ts
+++ b/apps/sim/lib/copilot/resources/types.ts
@@ -6,6 +6,7 @@ export const MothershipResourceType = {
   folder: 'folder',
   filefolder: 'filefolder',
   task: 'task',
+  scheduledtask: 'scheduledtask',
   log: 'log',
   integration: 'integration',
   generic: 'generic',

--- a/apps/sim/stores/panel/types.ts
+++ b/apps/sim/stores/panel/types.ts
@@ -31,6 +31,7 @@ export type ChatContext =
   | { kind: 'file'; fileId: string; label: string }
   | { kind: 'folder'; folderId: string; label: string }
   | { kind: 'filefolder'; fileFolderId: string; label: string }
+  | { kind: 'scheduledtask'; scheduleId: string; label: string }
   | { kind: 'docs'; label: string }
   | { kind: 'slash_command'; command: string; label: string }
   | { kind: 'integration'; blockType: string; label: string }


### PR DESCRIPTION
## Summary
- Add a new `scheduledtask` resource type so a scheduled task can be opened and viewed as a tab in Chat (we had no way to view one before)
- Registry config: Calendar icon, label, tab + dropdown renderers
- Add-resource dropdown now lists workspace scheduled tasks (jobs)
- Embedded detail viewer: status, schedule cadence, next/last run, prompt, and recent runs, with a not-found state
- "Open in scheduled tasks" tab action + React Query cache invalidation
- Contract enum + route validation so the resource persists on the chat

Agent-side mention/OpenResource wiring is intentionally left as a follow-up.

## Type of Change
- [x] New feature

## Testing
Tested manually. `tsc`, `check:api-validation`, and `check:react-query` all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)