### PR TITLE
improvement(providers): tighten Gemini and vLLM agent-attachment ceilings

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -195,7 +195,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   vllm: {
     id: 'vllm',
-    fileAttachment: { maxBytes: 50 * 1024 * 1024, strategy: 'remote-url' },
+    fileAttachment: { maxBytes: 25 * 1024 * 1024, strategy: 'remote-url' },
     name: 'vLLM',
     icon: VllmIcon,
     description: 'Self-hosted vLLM with an OpenAI-compatible API',
@@ -1319,7 +1319,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   google: {
     id: 'google',
-    fileAttachment: { maxBytes: 100 * 1024 * 1024, strategy: 'files-api' },
+    fileAttachment: { maxBytes: 50 * 1024 * 1024, strategy: 'files-api' },
     name: 'Google',
     description: "Google's Gemini models",
     defaultModel: 'gemini-2.5-pro',


### PR DESCRIPTION
## Summary
Follow-up to the provider large-file attachment feature (#5092). A live-doc audit of each provider surfaced two ceilings set higher than the provider actually accepts:

- **Gemini: 100MB → 50MB.** Gemini hard-caps **PDFs at 50MB**. A 50–100MB PDF previously passed our gate, got buffered + uploaded to the File API + polled to ACTIVE, then failed at `generateContent` — wasted work and a confusing late error. 50MB respects the documented limit and is more memory-safe.
- **vLLM: 50MB → 25MB.** vLLM's default `VLLM_IMAGE_FETCH_TIMEOUT` is **5s**; a 50MB remote-URL fetch routinely exceeds it. 25MB aligns with that reality and matches Baseten (the other vLLM-backed provider).

Every other provider's strategy and limit was validated as correct against live docs in the same audit; these were the only two worth tightening. The `/models` provider pages read these values dynamically, so they update automatically.

## Type of Change
- [x] Improvement

## Testing
- `NODE_OPTIONS='--max-old-space-size=8192' bunx tsc --noEmit` clean
- `providers/attachments.test.ts` + `providers/vllm/index.test.ts` pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)