### PR TITLE
v0.7.9: agent file attachments, chat autoscroll, knowledge base upload, security fixes

### DIFF
--- a/apps/realtime/src/handlers/operations.ts
+++ b/apps/realtime/src/handlers/operations.ts
@@ -15,7 +15,7 @@ import { assertWorkflowMutable, WorkflowLockedError } from '@sim/workflow-authz'
 import { ZodError } from 'zod'
 import { persistWorkflowOperation } from '@/database/operations'
 import type { AuthenticatedSocket } from '@/middleware/auth'
-import { checkRolePermission } from '@/middleware/permissions'
+import { checkWorkflowOperationPermission } from '@/middleware/permissions'
 import type { IRoomManager, UserSession } from '@/rooms'
 
 const logger = createLogger('OperationsHandlers')
@@ -125,11 +125,17 @@ export function setupOperationsHandlers(socket: AuthenticatedSocket, roomManager
 
         await roomManager.updateUserActivity(workflowId, socket.id, { lastActivity: Date.now() })
 
-        // Check permissions using cached role (no DB query)
-        const permissionCheck = checkRolePermission(userPresence.role, operation)
+        // Re-validate the workspace role against the DB (cached per pod for a short
+        // window) so revoked or downgraded collaborators lose write access live.
+        const permissionCheck = await checkWorkflowOperationPermission(
+          session.userId,
+          workflowId,
+          operation,
+          userPresence.role
+        )
         if (!permissionCheck.allowed) {
           logger.warn(
-            `User ${session.userId} (role: ${userPresence.role}) forbidden from ${operation} on ${target}`
+            `User ${session.userId} (role: ${permissionCheck.role ?? 'none'}) forbidden from ${operation} on ${target}`
           )
           emitOperationError({
             type: 'INSUFFICIENT_PERMISSIONS',

--- a/apps/realtime/src/handlers/subblocks.ts
+++ b/apps/realtime/src/handlers/subblocks.ts
@@ -7,7 +7,7 @@ import { assertWorkflowMutable, WorkflowLockedError } from '@sim/workflow-authz'
 import { isWorkflowBlockProtected } from '@sim/workflow-types/workflow'
 import { and, eq } from 'drizzle-orm'
 import type { AuthenticatedSocket } from '@/middleware/auth'
-import { checkRolePermission } from '@/middleware/permissions'
+import { checkWorkflowOperationPermission } from '@/middleware/permissions'
 import type { IRoomManager } from '@/rooms'
 
 const logger = createLogger('SubblocksHandlers')
@@ -136,7 +136,12 @@ export function setupSubblocksHandlers(socket: AuthenticatedSocket, roomManager:
         return
       }
 
-      const permissionCheck = checkRolePermission(userPresence.role, SUBBLOCK_OPERATIONS.UPDATE)
+      const permissionCheck = await checkWorkflowOperationPermission(
+        session.userId,
+        workflowId,
+        SUBBLOCK_OPERATIONS.UPDATE,
+        userPresence.role
+      )
       if (!permissionCheck.allowed) {
         socket.emit('operation-forbidden', {
           type: 'INSUFFICIENT_PERMISSIONS',

--- a/apps/realtime/src/handlers/variables.ts
+++ b/apps/realtime/src/handlers/variables.ts
@@ -6,7 +6,7 @@ import { getErrorMessage } from '@sim/utils/errors'
 import { assertWorkflowMutable, WorkflowLockedError } from '@sim/workflow-authz'
 import { eq } from 'drizzle-orm'
 import type { AuthenticatedSocket } from '@/middleware/auth'
-import { checkRolePermission } from '@/middleware/permissions'
+import { checkWorkflowOperationPermission } from '@/middleware/permissions'
 import type { IRoomManager } from '@/rooms'
 
 const logger = createLogger('VariablesHandlers')
@@ -124,7 +124,12 @@ export function setupVariablesHandlers(socket: AuthenticatedSocket, roomManager:
         return
       }
 
-      const permissionCheck = checkRolePermission(userPresence.role, VARIABLE_OPERATIONS.UPDATE)
+      const permissionCheck = await checkWorkflowOperationPermission(
+        session.userId,
+        workflowId,
+        VARIABLE_OPERATIONS.UPDATE,
+        userPresence.role
+      )
       if (!permissionCheck.allowed) {
         socket.emit('operation-forbidden', {
           type: 'INSUFFICIENT_PERMISSIONS',

--- a/apps/realtime/src/index.test.ts
+++ b/apps/realtime/src/index.test.ts
@@ -73,6 +73,10 @@ vi.mock('@/middleware/permissions', () => ({
   checkRolePermission: vi.fn().mockReturnValue({
     allowed: true,
   }),
+  checkWorkflowOperationPermission: vi.fn().mockResolvedValue({
+    allowed: true,
+    role: 'admin',
+  }),
 }))
 
 vi.mock('@/database/operations', () => ({

--- a/apps/realtime/src/middleware/permissions.test.ts
+++ b/apps/realtime/src/middleware/permissions.test.ts
@@ -13,8 +13,17 @@ import {
   ROLE_ALLOWED_OPERATIONS,
   SOCKET_OPERATIONS,
 } from '@sim/testing'
-import { describe, expect, it } from 'vitest'
-import { checkRolePermission } from '@/middleware/permissions'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockAuthorize } = vi.hoisted(() => ({
+  mockAuthorize: vi.fn(),
+}))
+
+vi.mock('@sim/workflow-authz', () => ({
+  authorizeWorkflowByWorkspacePermission: mockAuthorize,
+}))
+
+import { checkRolePermission, checkWorkflowOperationPermission } from '@/middleware/permissions'
 
 describe('checkRolePermission', () => {
   describe('admin role', () => {
@@ -277,5 +286,131 @@ describe('checkRolePermission', () => {
       const result = checkRolePermission('read', 'remove')
       expect(result.reason).toMatch(/Role '.*' not permitted to perform '.*'/)
     })
+  })
+})
+
+describe('checkWorkflowOperationPermission', () => {
+  const userId = 'user-1'
+  let workflowCounter = 0
+  let workflowId: string
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Unique workflowId per test so the module-level role cache never leaks across tests
+    workflowCounter += 1
+    workflowId = `wf-${workflowCounter}`
+  })
+
+  it('allows a write operation when the user still has write access', async () => {
+    mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'write' })
+
+    const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+
+    expect(result.allowed).toBe(true)
+    expect(result.role).toBe('write')
+  })
+
+  it('denies all writes once workspace access has been revoked', async () => {
+    mockAuthorize.mockResolvedValue({ allowed: false, workspacePermission: null })
+
+    const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'write')
+
+    expect(result.allowed).toBe(false)
+    expect(result.role).toBeNull()
+    expect(result.reason).toMatch(/revoked/i)
+  })
+
+  it('denies writes after a downgrade to read but still allows position updates', async () => {
+    mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'read' })
+
+    const denied = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'write')
+    expect(denied.allowed).toBe(false)
+    expect(denied.role).toBe('read')
+
+    const allowed = await checkWorkflowOperationPermission(
+      userId,
+      workflowId,
+      'update-position',
+      'write'
+    )
+    expect(allowed.allowed).toBe(true)
+    expect(allowed.role).toBe('read')
+  })
+
+  it('caches the role within the TTL to avoid a DB read on every operation', async () => {
+    mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'write' })
+
+    await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+    await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+
+    expect(mockAuthorize).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-reads the role after the cache TTL expires', async () => {
+    vi.useFakeTimers()
+    try {
+      mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'write' })
+      await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+
+      // Downgraded to read after the first check
+      mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'read' })
+      vi.advanceTimersByTime(31_000)
+
+      const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'write')
+      expect(mockAuthorize).toHaveBeenCalledTimes(2)
+      expect(result.allowed).toBe(false)
+      expect(result.role).toBe('read')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('falls back to the join-time role on a transient DB error when nothing is cached yet', async () => {
+    mockAuthorize.mockRejectedValue(new Error('db unavailable'))
+
+    const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'write')
+
+    expect(result.allowed).toBe(true)
+    expect(result.role).toBe('write')
+  })
+
+  it('preserves a recorded revocation through a later transient DB error', async () => {
+    vi.useFakeTimers()
+    try {
+      // First check records the revocation (null) in the cache
+      mockAuthorize.mockResolvedValue({ allowed: false, workspacePermission: null })
+      const first = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'admin')
+      expect(first.allowed).toBe(false)
+      expect(first.role).toBeNull()
+
+      // TTL expires, then the DB blips on the next re-validation. The stale join-time
+      // role ('admin') must NOT resurrect access — the recorded revocation wins.
+      vi.advanceTimersByTime(31_000)
+      mockAuthorize.mockRejectedValue(new Error('db unavailable'))
+
+      const second = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'admin')
+      expect(second.allowed).toBe(false)
+      expect(second.role).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('uses the last cached role (not the join-time role) on a transient DB error', async () => {
+    vi.useFakeTimers()
+    try {
+      mockAuthorize.mockResolvedValue({ allowed: true, workspacePermission: 'write' })
+      await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+
+      vi.advanceTimersByTime(31_000)
+      mockAuthorize.mockRejectedValue(new Error('db unavailable'))
+
+      // fallbackRole is 'read', but the last recorded decision was 'write' — use that
+      const result = await checkWorkflowOperationPermission(userId, workflowId, 'update', 'read')
+      expect(result.allowed).toBe(true)
+      expect(result.role).toBe('write')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/realtime/src/middleware/permissions.ts
+++ b/apps/realtime/src/middleware/permissions.ts
@@ -84,6 +84,111 @@ export function checkRolePermission(
 }
 
 /**
+ * TTL for the per-pod role cache backing live re-validation of mutating operations.
+ * Bounds how long a revoked or downgraded collaborator can retain write access on an
+ * already-connected socket.
+ */
+const ROLE_REVALIDATION_TTL_MS = 30_000
+
+/** Soft cap on cached entries before an opportunistic purge of expired ones runs. */
+const MAX_ROLE_CACHE_ENTRIES = 5_000
+
+interface CachedRole {
+  /** Authoritative workspace role, or `null` when the user has no access. */
+  role: string | null
+  expiresAt: number
+}
+
+/**
+ * Per-pod cache of authoritative workspace roles, keyed by `${userId}:${workflowId}`.
+ *
+ * Socket connections are sticky to a single pod, so a socket's mutating operations are
+ * always gated by the same pod's cache. We rely on TTL expiry (not cross-pod
+ * invalidation) to bound stale authorization to {@link ROLE_REVALIDATION_TTL_MS}, which
+ * keeps this correct under a multi-pod deployment without any shared state.
+ */
+const roleCache = new Map<string, CachedRole>()
+
+function purgeExpiredRoles(now: number): void {
+  for (const [key, entry] of roleCache) {
+    if (entry.expiresAt <= now) {
+      roleCache.delete(key)
+    }
+  }
+}
+
+/**
+ * Resolves a user's current workspace role for a workflow, re-reading the `permissions`
+ * table at most once per {@link ROLE_REVALIDATION_TTL_MS} per pod.
+ *
+ * Returns `null` when the user genuinely has no access (removed/revoked). On a transient
+ * DB failure it reuses the last recorded decision for this (user, workflow) — including a
+ * previously recorded revocation (`null`) — and only falls back to `fallbackRole` when no
+ * decision has been recorded yet, so a blip neither blocks legitimate editors nor
+ * resurrects already-revoked access.
+ */
+export async function resolveCurrentWorkflowRole(
+  userId: string,
+  workflowId: string,
+  fallbackRole: string
+): Promise<string | null> {
+  const now = Date.now()
+  const key = `${userId}:${workflowId}`
+  const cached = roleCache.get(key)
+  if (cached && cached.expiresAt > now) {
+    return cached.role
+  }
+
+  try {
+    const authorization = await authorizeWorkflowByWorkspacePermission({
+      workflowId,
+      userId,
+      action: 'read',
+    })
+    const role = authorization.allowed ? (authorization.workspacePermission ?? null) : null
+    if (roleCache.size >= MAX_ROLE_CACHE_ENTRIES) {
+      purgeExpiredRoles(now)
+    }
+    roleCache.set(key, { role, expiresAt: now + ROLE_REVALIDATION_TTL_MS })
+    return role
+  } catch (error) {
+    logger.warn(
+      `Failed to re-validate role for user ${userId} on workflow ${workflowId}; using last known role`,
+      error
+    )
+    // Prefer the last recorded decision — even if expired, and even if it is `null` for an
+    // already-revoked user — so a recorded revocation survives a transient DB failure
+    // instead of reverting to the stale join-time role. Only trust `fallbackRole` when
+    // nothing has been recorded for this (user, workflow) yet.
+    const lastKnown = roleCache.get(key)
+    return lastKnown !== undefined ? lastKnown.role : fallbackRole
+  }
+}
+
+/**
+ * Live permission gate for mutating socket operations. Re-validates the user's workspace
+ * role against the database (cached per pod for {@link ROLE_REVALIDATION_TTL_MS}) so that
+ * revoked or downgraded collaborators lose write access on an open connection without
+ * needing to rejoin the workflow.
+ */
+export async function checkWorkflowOperationPermission(
+  userId: string,
+  workflowId: string,
+  operation: string,
+  fallbackRole: string
+): Promise<{ allowed: boolean; reason?: string; role: string | null }> {
+  const role = await resolveCurrentWorkflowRole(userId, workflowId, fallbackRole)
+  if (!role) {
+    return {
+      allowed: false,
+      reason: 'Access to this workflow has been revoked',
+      role: null,
+    }
+  }
+  return { ...checkRolePermission(role, operation), role }
+}
+
+/**
  * Verifies a user's access to a workflow via workspace permissions.
  *
  * Returns `hasAccess: false` only for genuine denials (workflow missing/archived

--- a/apps/sim/app/(landing)/models/(shell)/[provider]/page.tsx
+++ b/apps/sim/app/(landing)/models/(shell)/[provider]/page.tsx
@@ -13,6 +13,7 @@ import {
 import { ModelTimelineChart } from '@/app/(landing)/models/components/model-timeline-chart'
 import {
   buildProviderFaqs,
+  formatFileSize,
   formatPrice,
   formatTokenCount,
   getProviderBySlug,
@@ -204,9 +205,16 @@ export default async function ProviderModelsPage({
                 {provider.name} models
               </h1>
             </div>
-            <span className='shrink-0 font-martian-mono text-[var(--landing-text-subtle)] text-xs uppercase tracking-[0.1em]'>
-              {provider.modelCount} models
-            </span>
+            <div className='flex shrink-0 flex-col items-end gap-1'>
+              <span className='font-martian-mono text-[var(--landing-text-subtle)] text-xs uppercase tracking-[0.1em]'>
+                {provider.modelCount} models
+              </span>
+              {provider.maxFileAttachmentBytes ? (
+                <span className='font-martian-mono text-[var(--landing-text-subtle)] text-xs uppercase tracking-[0.1em]'>
+                  {formatFileSize(provider.maxFileAttachmentBytes)} file uploads
+                </span>
+              ) : null}
+            </div>
           </div>
         </div>
 

--- a/apps/sim/app/(landing)/models/utils.ts
+++ b/apps/sim/app/(landing)/models/utils.ts
@@ -127,6 +127,8 @@ export interface CatalogProvider {
   color?: string
   isReseller: boolean
   contextInformationAvailable: boolean
+  /** Max agent-block file attachment size in bytes when the provider exceeds the default. */
+  maxFileAttachmentBytes: number | null
   providerCapabilityTags: string[]
   modelCount: number
   models: CatalogModel[]
@@ -148,6 +150,18 @@ export function formatTokenCount(value?: number | null): string {
   }
 
   return value.toLocaleString('en-US')
+}
+
+export function formatFileSize(bytes?: number | null): string {
+  if (bytes == null) {
+    return 'Unknown'
+  }
+
+  const gb = bytes / (1024 * 1024 * 1024)
+  if (gb >= 1) {
+    return `${trimTrailingZeros(gb.toFixed(1))}GB`
+  }
+  return `${Math.round(bytes / (1024 * 1024))}MB`
 }
 
 export function formatPrice(price?: number | null): string {
@@ -507,6 +521,7 @@ const rawProviders = Object.values(PROVIDER_DEFINITIONS).map((provider) => {
     color: provider.color,
     isReseller: provider.isReseller ?? false,
     contextInformationAvailable: provider.contextInformationAvailable !== false,
+    maxFileAttachmentBytes: provider.fileAttachment?.maxBytes ?? null,
     providerCapabilityTags,
     modelCount: models.length,
     models,

--- a/apps/sim/app/api/files/presigned/route.test.ts
+++ b/apps/sim/app/api/files/presigned/route.test.ts
@@ -158,10 +158,10 @@ function setupFileApiMocks(
 
   storageServiceMockFns.mockHasCloudStorage.mockReturnValue(cloudEnabled)
   storageServiceMockFns.mockGeneratePresignedUploadUrl.mockImplementation(
-    async (opts: { fileName: string; context: string }) => {
+    async (opts: { fileName: string; context: string; customKey?: string }) => {
       const timestamp = Date.now()
       const safeFileName = opts.fileName.replace(/[^a-zA-Z0-9.-]/g, '_')
-      const key = `${opts.context}/${timestamp}-ik3a6w4-${safeFileName}`
+      const key = opts.customKey ?? `${opts.context}/${timestamp}-ik3a6w4-${safeFileName}`
       return {
         url: 'https://example.com/presigned-url',
         key,
@@ -369,7 +369,7 @@ describe('/api/files/presigned', () => {
       const data = await response.json()
 
       expect(response.status).toBe(200)
-      expect(data.fileInfo.key).toMatch(/^knowledge-base\/.*knowledge-doc\.pdf$/)
+      expect(data.fileInfo.key).toMatch(/^kb\/.*knowledge-doc\.pdf$/)
       expect(data.directUploadSupported).toBe(true)
     })
 

--- a/apps/sim/app/api/files/presigned/route.ts
+++ b/apps/sim/app/api/files/presigned/route.ts
@@ -9,6 +9,7 @@ import { CopilotFiles } from '@/lib/uploads'
 import type { StorageContext } from '@/lib/uploads/config'
 import { USE_BLOB_STORAGE } from '@/lib/uploads/config'
 import { generateExecutionFileKey } from '@/lib/uploads/contexts/execution/utils'
+import { generateKnowledgeBaseFileKey } from '@/lib/uploads/contexts/knowledge-base/knowledge-base-file-manager'
 import { generateWorkspaceFileKey } from '@/lib/uploads/contexts/workspace/workspace-file-manager'
 import { generatePresignedUploadUrl, hasCloudStorage } from '@/lib/uploads/core/storage-service'
 import { insertFileMetadata, recordKnowledgeBaseFileOwnership } from '@/lib/uploads/server/metadata'
@@ -268,12 +269,14 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         )
       }
 
+      const customKey = generateKnowledgeBaseFileKey(fileName)
       presignedUrlResponse = await generatePresignedUploadUrl({
         fileName,
         contentType,
         fileSize,
         context: 'knowledge-base',
         userId: sessionUserId,
+        customKey,
         expirationSeconds: 3600,
         metadata: { workspaceId },
       })

--- a/apps/sim/app/api/files/upload/route.ts
+++ b/apps/sim/app/api/files/upload/route.ts
@@ -19,6 +19,7 @@ import {
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { captureServerEvent } from '@/lib/posthog/server'
 import type { StorageContext } from '@/lib/uploads/config'
+import { generateKnowledgeBaseFileKey } from '@/lib/uploads/contexts/knowledge-base/knowledge-base-file-manager'
 import { generateWorkspaceFileKey } from '@/lib/uploads/contexts/workspace/workspace-file-manager'
 import { MAX_WORKSPACE_FORMDATA_FILE_SIZE } from '@/lib/uploads/shared/types'
 import { isImageFileType, resolveFileType } from '@/lib/uploads/utils/file-utils'
@@ -155,9 +156,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
         logger.info(`Uploading knowledge-base file: ${originalName}`)
 
-        const timestamp = Date.now()
-        const safeFileName = sanitizeFileName(originalName)
-        const storageKey = `kb/${timestamp}-${safeFileName}`
+        const storageKey = generateKnowledgeBaseFileKey(originalName)
 
         const metadata: Record<string, string> = {
           originalName: originalName,

--- a/apps/sim/app/api/providers/route.ts
+++ b/apps/sim/app/api/providers/route.ts
@@ -202,6 +202,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       responseFormat,
       workflowId,
       workspaceId,
+      userId: auth.userId,
       stream,
       messages,
       environmentVariables,

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/file-upload/file-upload.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/file-upload/file-upload.tsx
@@ -24,6 +24,8 @@ import {
   useWorkspaceFiles,
   workspaceFilesKeys,
 } from '@/hooks/queries/workspace-files'
+import { getProviderAttachmentMaxBytes } from '@/providers/attachments'
+import { getProviderFromModel } from '@/providers/utils'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
@@ -167,6 +169,7 @@ export function FileUpload({
 }: FileUploadProps) {
   const activeSearchTarget = useActiveSearchTarget()
   const [storeValue, setStoreValue] = useSubBlockValue(blockId, subBlockId)
+  const [modelValue] = useSubBlockValue(blockId, 'model')
   const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([])
   const [uploadProgress, setUploadProgress] = useState(0)
   const [uploadError, setUploadError] = useState<string | null>(null)
@@ -190,6 +193,17 @@ export function FileUpload({
   const queryClient = useQueryClient()
 
   const value = isPreview ? previewValue : storeValue
+
+  const maxSizeInBytes = useMemo(() => {
+    const fallback = maxSize * 1024 * 1024
+    if (typeof modelValue !== 'string' || !modelValue) return fallback
+    try {
+      return Math.max(fallback, getProviderAttachmentMaxBytes(getProviderFromModel(modelValue)))
+    } catch {
+      return fallback
+    }
+  }, [modelValue, maxSize])
+  const maxSizeLabel = `${Math.round(maxSizeInBytes / (1024 * 1024))}MB`
 
   /**
    * Checks if a file's MIME type matches the accepted types
@@ -278,25 +292,19 @@ export function FileUpload({
     const files = e.target.files
     if (!files || files.length === 0) return
 
-    const existingFiles = Array.isArray(value) ? value : value ? [value] : []
-    const existingTotalSize = existingFiles.reduce((sum, file) => sum + file.size, 0)
-
-    const maxSizeInBytes = maxSize * 1024 * 1024
     const validFiles: File[] = []
-    let totalNewSize = 0
     let sizeExceededFile: string | null = null
 
     for (let i = 0; i < files.length; i++) {
       const file = files[i]
-      if (existingTotalSize + totalNewSize + file.size > maxSizeInBytes) {
-        const errorMessage = `Adding ${file.name} would exceed the maximum size limit of ${maxSize}MB`
+      if (file.size > maxSizeInBytes) {
+        const errorMessage = `${file.name} exceeds the maximum file size of ${maxSizeLabel}`
         logger.error(errorMessage, activeWorkflowId)
         if (!sizeExceededFile) {
           sizeExceededFile = errorMessage
         }
       } else {
         validFiles.push(file)
-        totalNewSize += file.size
       }
     }
 

--- a/apps/sim/blocks/utils.test.ts
+++ b/apps/sim/blocks/utils.test.ts
@@ -47,6 +47,10 @@ vi.mock('@/lib/core/config/env-flags', () => ({
 }))
 
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getHostedModels: mockGetHostedModels,
   getProviderModels: mockGetProviderModels,
   getProviderIcon: mockGetProviderIcon,

--- a/apps/sim/executor/handlers/agent/agent-handler.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.ts
@@ -39,7 +39,11 @@ import { buildAPIUrl, buildAuthHeaders } from '@/executor/utils/http'
 import { stringifyJSON } from '@/executor/utils/json'
 import { resolveVertexCredential } from '@/executor/utils/vertex-credential'
 import { executeProviderRequest } from '@/providers'
-import { getProviderAttachmentMaxBytes, supportsFileAttachments } from '@/providers/attachments'
+import {
+  INLINE_ATTACHMENT_THRESHOLD_BYTES,
+  shouldUseLargeFilePath,
+  supportsFileAttachments,
+} from '@/providers/attachments'
 import { getProviderFromModel, transformBlockTool } from '@/providers/utils'
 import type { SerializedBlock } from '@/serializer/types'
 import { filterSchemaForLLM, type ToolSchema } from '@/tools/params'
@@ -760,10 +764,12 @@ export class AgentBlockHandler implements BlockHandler {
         allowLargeValueWorkflowScope: ctx.allowLargeValueWorkflowScope,
         userId: ctx.userId,
         logger,
-        maxBytes: getProviderAttachmentMaxBytes(providerId),
+        maxBytes: INLINE_ATTACHMENT_THRESHOLD_BYTES,
       })
 
-      const missingFile = hydratedFiles.find((file) => !file.base64)
+      const missingFile = hydratedFiles.find(
+        (file) => !file.base64 && !shouldUseLargeFilePath(file, providerId)
+      )
       if (missingFile) {
         throw new Error(
           `File "${missingFile.name}" could not be read for provider "${providerId}". The file may exceed the attachment size limit or may no longer be accessible.`

--- a/apps/sim/executor/types.ts
+++ b/apps/sim/executor/types.ts
@@ -20,6 +20,12 @@ export interface UserFile {
   key: string
   context?: string
   base64?: string
+  /** Provider Files API handle (OpenAI/Anthropic `file_...` id) set when a large file is uploaded instead of inlined as base64. */
+  providerFileId?: string
+  /** Provider File API uri (Gemini `fileUri`) set when a large file is uploaded instead of inlined as base64. */
+  providerFileUri?: string
+  /** Short-lived signed HTTPS URL passed to providers that fetch attachments by remote URL instead of inlining base64. */
+  remoteUrl?: string
 }
 
 export interface ParallelPauseScope {

--- a/apps/sim/hooks/use-auto-scroll.ts
+++ b/apps/sim/hooks/use-auto-scroll.ts
@@ -4,6 +4,26 @@ import { useCallback, useEffect, useRef } from 'react'
 const STICK_THRESHOLD = 30
 /** User must scroll back to within this distance to re-engage auto-scroll. */
 const REATTACH_THRESHOLD = 5
+/**
+ * An upward keyboard scroll ({@link SCROLL_UP_KEYS}) only emits `scroll` events, so
+ * its detach is honored when it lands within this window of the `keydown`. Wheel and
+ * touch detach directly via their own handlers, and scrollbar drags are tracked
+ * through {@link pointerDownRef}, so neither feeds this window.
+ *
+ * The guard exists because virtualizers (react-virtual) programmatically move
+ * `scrollTop` to keep content stable when a measured row's size changes —
+ * including the transient height *shrinks* a streaming markdown renderer emits as
+ * it re-parses each token. Without it, that upward programmatic scroll is misread
+ * as the user scrolling away and auto-scroll detaches mid-stream.
+ */
+const USER_GESTURE_WINDOW = 250
+/**
+ * Keys that scroll the viewport upward. Only these authorize a keyboard detach,
+ * mirroring the wheel handler's upward-only ({@link WheelEvent.deltaY} < 0) rule,
+ * so an unrelated keypress can't open the detach window. `Shift`+`Space` (handled
+ * in the listener) is the other upward shortcut; plain `Space` pages down.
+ */
+const SCROLL_UP_KEYS = new Set(['ArrowUp', 'PageUp', 'Home'])
 
 interface UseAutoScrollOptions {
   scrollOnMount?: boolean
@@ -13,9 +33,10 @@ interface UseAutoScrollOptions {
  * Manages sticky auto-scroll for a streaming chat container.
  *
  * Stays pinned to the bottom while content streams in. Detaches immediately
- * on any upward user gesture (wheel, touch, scrollbar drag). Once detached,
- * the user must scroll back to within {@link REATTACH_THRESHOLD} of the
- * bottom to re-engage.
+ * on any upward user gesture (wheel, touch, scrollbar drag, keyboard). Once
+ * detached, the user must scroll back to within {@link REATTACH_THRESHOLD} of
+ * the bottom to re-engage. Each streaming start re-seeds stickiness from the
+ * current scroll position, so a user who scrolled up beforehand stays put.
  *
  * Returns `ref` (callback ref for the scroll container) and `scrollToBottom`
  * for imperative use after layout-changing events like panel expansion.
@@ -32,6 +53,18 @@ export function useAutoScroll(
   const touchStartYRef = useRef(0)
   const rafIdRef = useRef(0)
   const scrollOnMountRef = useRef(scrollOnMount)
+  /**
+   * Whether the user is actively dragging the scrollbar — a pointer press on the
+   * container itself rather than its content. Reset on teardown so a pointer held
+   * as one stream ends can't leak into the next session and authorize a detach.
+   */
+  const pointerDownRef = useRef(false)
+  /**
+   * Timestamp of the last keyboard scroll, the only detach gesture that emits no
+   * wheel/touch/pointer signal. Gates {@link USER_GESTURE_WINDOW}; reset on teardown
+   * so a keypress near a stream's end can't carry into the next session.
+   */
+  const lastUserGestureAtRef = useRef(Number.NEGATIVE_INFINITY)
 
   const scrollToBottom = useCallback(() => {
     const el = containerRef.current
@@ -49,7 +82,6 @@ export function useAutoScroll(
     const el = containerRef.current
     if (!el) return
 
-    // Don't jump if the user scrolled up — keep their position.
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
     const isNearBottom = distanceFromBottom <= STICK_THRESHOLD
     stickyRef.current = isNearBottom
@@ -75,15 +107,43 @@ export function useAutoScroll(
       if (e.touches[0].clientY > touchStartYRef.current) detach()
     }
 
+    /**
+     * A scrollbar press targets the scroll container itself; a press on message
+     * content targets a descendant. Only the former is a scroll gesture, so a
+     * text-selection drag on content can't authorize a detach.
+     */
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.target === el) pointerDownRef.current = true
+    }
+    const onPointerUp = () => {
+      pointerDownRef.current = false
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (SCROLL_UP_KEYS.has(e.key) || (e.key === ' ' && e.shiftKey)) {
+        lastUserGestureAtRef.current = performance.now()
+      }
+    }
+
+    /**
+     * Re-engages when the user returns near the bottom, and detaches on an upward
+     * scroll — but only a genuine user scroll qualifies: an active scrollbar drag
+     * (pointer held) or a recent keyboard scroll. A programmatic upward scroll, e.g.
+     * a virtualizer re-pinning content on a row-size shrink, has neither and must not
+     * be mistaken for the user scrolling away.
+     */
     const onScroll = () => {
       const { scrollTop, scrollHeight, clientHeight } = el
       const distanceFromBottom = scrollHeight - scrollTop - clientHeight
       const threshold = userDetachedRef.current ? REATTACH_THRESHOLD : STICK_THRESHOLD
+      const userDriven =
+        pointerDownRef.current ||
+        performance.now() - lastUserGestureAtRef.current < USER_GESTURE_WINDOW
 
       if (distanceFromBottom <= threshold) {
         stickyRef.current = true
         userDetachedRef.current = false
       } else if (
+        userDriven &&
         scrollTop < prevScrollTopRef.current &&
         scrollHeight <= prevScrollHeightRef.current
       ) {
@@ -105,11 +165,12 @@ export function useAutoScroll(
       rafIdRef.current = requestAnimationFrame(guardedScroll)
     }
 
-    // CSS-driven height animations (e.g. Radix Collapsible expanding
-    // mid-stream) grow scrollHeight without triggering MutationObserver,
-    // so auto-scroll stops following. When any animation starts in the
-    // container, follow rAF for a short window so the container stays
-    // pinned to the bottom while the animation runs.
+    /**
+     * CSS-driven height animations (e.g. Radix Collapsible expanding mid-stream)
+     * grow scrollHeight without triggering MutationObserver, so auto-scroll stops
+     * following. When any animation starts in the container, follow rAF for a short
+     * window so the container stays pinned to the bottom while the animation runs.
+     */
     const onAnimationStart = () => {
       if (!stickyRef.current) return
       const until = performance.now() + 500
@@ -126,6 +187,10 @@ export function useAutoScroll(
     el.addEventListener('touchmove', onTouchMove, { passive: true })
     el.addEventListener('scroll', onScroll, { passive: true })
     el.addEventListener('animationstart', onAnimationStart)
+    el.addEventListener('pointerdown', onPointerDown, { passive: true })
+    el.addEventListener('keydown', onKeyDown, { passive: true })
+    window.addEventListener('pointerup', onPointerUp, { passive: true })
+    window.addEventListener('pointercancel', onPointerUp, { passive: true })
 
     const observer = new MutationObserver(onMutation)
     observer.observe(el, { childList: true, subtree: true, characterData: true })
@@ -136,8 +201,14 @@ export function useAutoScroll(
       el.removeEventListener('touchmove', onTouchMove)
       el.removeEventListener('scroll', onScroll)
       el.removeEventListener('animationstart', onAnimationStart)
+      el.removeEventListener('pointerdown', onPointerDown)
+      el.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('pointerup', onPointerUp)
+      window.removeEventListener('pointercancel', onPointerUp)
       observer.disconnect()
       cancelAnimationFrame(rafIdRef.current)
+      pointerDownRef.current = false
+      lastUserGestureAtRef.current = Number.NEGATIVE_INFINITY
       if (stickyRef.current) scrollToBottom()
     }
   }, [isStreaming, scrollToBottom])

--- a/apps/sim/hooks/use-auto-scroll.ts
+++ b/apps/sim/hooks/use-auto-scroll.ts
@@ -24,6 +24,16 @@ const USER_GESTURE_WINDOW = 250
  * in the listener) is the other upward shortcut; plain `Space` pages down.
  */
 const SCROLL_UP_KEYS = new Set(['ArrowUp', 'PageUp', 'Home'])
+/** How long to keep chasing the bottom while a CSS height animation plays. */
+const ANIMATION_FOLLOW_WINDOW = 500
+/**
+ * How long to keep chasing the bottom after streaming stops. End-of-turn content
+ * mounts just after `isStreaming` flips false — the suggested-follow-up options,
+ * the actions row (gated on `!isStreaming`), and the virtualizer's re-measure of
+ * the grown row — so a single final scroll fires before it lays out and leaves it
+ * clipped behind the input. Following for a short window pulls it into view.
+ */
+const POST_STREAM_SETTLE_WINDOW = 300
 
 interface UseAutoScrollOptions {
   scrollOnMount?: boolean
@@ -147,7 +157,7 @@ export function useAutoScroll(
         scrollTop < prevScrollTopRef.current &&
         scrollHeight <= prevScrollHeightRef.current
       ) {
-        stickyRef.current = false
+        detach()
       }
 
       prevScrollTopRef.current = scrollTop
@@ -166,21 +176,37 @@ export function useAutoScroll(
     }
 
     /**
-     * CSS-driven height animations (e.g. Radix Collapsible expanding mid-stream)
-     * grow scrollHeight without triggering MutationObserver, so auto-scroll stops
-     * following. When any animation starts in the container, follow rAF for a short
-     * window so the container stays pinned to the bottom while the animation runs.
+     * Chase the bottom every frame for `durationMs`. Catches height growth that
+     * arrives over several frames with no observed DOM mutation — a CSS height
+     * animation, or end-of-turn content and the virtualizer's re-measure settling
+     * after streaming stops.
+     *
+     * Self-interrupting: height growth leaves `scrollTop` exactly where we last
+     * put it, whereas a user scroll moves it up from there — so the moment
+     * `scrollTop` drops below our last write, we stop and never fight a real
+     * scroll, even with the gesture listeners already torn down.
      */
-    const onAnimationStart = () => {
+    const followToBottom = (durationMs: number) => {
       if (!stickyRef.current) return
-      const until = performance.now() + 500
+      const until = performance.now() + durationMs
+      let lastTop = -1
       const follow = () => {
         if (performance.now() > until || !stickyRef.current) return
+        if (lastTop >= 0 && el.scrollTop < lastTop - 1) return
         scrollToBottom()
+        lastTop = el.scrollTop
         requestAnimationFrame(follow)
       }
       requestAnimationFrame(follow)
     }
+
+    /**
+     * CSS-driven height animations (e.g. Radix Collapsible expanding mid-stream)
+     * grow scrollHeight without triggering MutationObserver, so auto-scroll stops
+     * following. Follow for a short window so the container stays pinned while the
+     * animation runs.
+     */
+    const onAnimationStart = () => followToBottom(ANIMATION_FOLLOW_WINDOW)
 
     el.addEventListener('wheel', onWheel, { passive: true })
     el.addEventListener('touchstart', onTouchStart, { passive: true })
@@ -209,7 +235,7 @@ export function useAutoScroll(
       cancelAnimationFrame(rafIdRef.current)
       pointerDownRef.current = false
       lastUserGestureAtRef.current = Number.NEGATIVE_INFINITY
-      if (stickyRef.current) scrollToBottom()
+      followToBottom(POST_STREAM_SETTLE_WINDOW)
     }
   }, [isStreaming, scrollToBottom])
 

--- a/apps/sim/lib/api-key/byok.test.ts
+++ b/apps/sim/lib/api-key/byok.test.ts
@@ -40,6 +40,10 @@ vi.mock('@/lib/core/config/env-flags', () => ({
 }))
 
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getHostedModels: vi.fn(() => []),
 }))
 

--- a/apps/sim/lib/uploads/contexts/knowledge-base/knowledge-base-file-manager.ts
+++ b/apps/sim/lib/uploads/contexts/knowledge-base/knowledge-base-file-manager.ts
@@ -1,0 +1,16 @@
+import { randomBytes } from 'crypto'
+import { sanitizeFileName } from '@/executor/constants'
+
+/**
+ * Generate a canonical knowledge-base storage key.
+ *
+ * Direct/presigned uploads previously used the generic `${context}/...` key
+ * shape (`knowledge-base/...`). New KB uploads should use the same `kb/...`
+ * prefix as server-side uploads so key-derived context inference is consistent.
+ */
+export function generateKnowledgeBaseFileKey(fileName: string): string {
+  const timestamp = Date.now()
+  const random = randomBytes(8).toString('hex')
+  const safeFileName = sanitizeFileName(fileName)
+  return `kb/${timestamp}-${random}-${safeFileName}`
+}

--- a/apps/sim/lib/uploads/utils/file-utils.test.ts
+++ b/apps/sim/lib/uploads/utils/file-utils.test.ts
@@ -1,8 +1,16 @@
 /**
  * @vitest-environment node
  */
+import { createLogger } from '@sim/logger'
 import { describe, expect, it } from 'vitest'
-import { isAbortError, isInternalFileUrl, isNetworkError } from '@/lib/uploads/utils/file-utils'
+import {
+  isAbortError,
+  isInternalFileUrl,
+  isNetworkError,
+  processSingleFileToUserFile,
+} from '@/lib/uploads/utils/file-utils'
+
+const logger = createLogger('FileUtilsTest')
 
 describe('isInternalFileUrl', () => {
   it('classifies relative serve paths as internal', () => {
@@ -70,5 +78,30 @@ describe('isNetworkError', () => {
     expect(isNetworkError(new Error('Validation failed: name is required'))).toBe(false)
     expect(isNetworkError('not an error')).toBe(false)
     expect(isNetworkError(null)).toBe(false)
+  })
+})
+
+describe('processSingleFileToUserFile', () => {
+  it('strips server-only provider file handles from untrusted input', () => {
+    const result = processSingleFileToUserFile(
+      {
+        id: 'file-1',
+        name: 'doc.pdf',
+        url: '/api/files/serve/workspace%2Fws-1%2Fdoc.pdf?context=workspace',
+        size: 1024,
+        type: 'application/pdf',
+        key: 'workspace/ws-1/doc.pdf',
+        providerFileId: 'file-injected',
+        providerFileUri: 'https://injected/uri',
+        remoteUrl: 'http://169.254.169.254/latest/meta-data',
+      } as never,
+      'req-1',
+      logger
+    )
+
+    expect(result.providerFileId).toBeUndefined()
+    expect(result.providerFileUri).toBeUndefined()
+    expect(result.remoteUrl).toBeUndefined()
+    expect(result.key).toBe('workspace/ws-1/doc.pdf')
   })
 })

--- a/apps/sim/lib/uploads/utils/file-utils.test.ts
+++ b/apps/sim/lib/uploads/utils/file-utils.test.ts
@@ -4,6 +4,7 @@
 import { createLogger } from '@sim/logger'
 import { describe, expect, it } from 'vitest'
 import {
+  inferContextFromKey,
   isAbortError,
   isInternalFileUrl,
   isNetworkError,
@@ -44,6 +45,32 @@ describe('isInternalFileUrl', () => {
     expect(isInternalFileUrl('data:text/plain;base64,abc')).toBe(false)
     // @ts-expect-error verifying runtime guard
     expect(isInternalFileUrl(undefined)).toBe(false)
+  })
+})
+
+describe('inferContextFromKey', () => {
+  it('maps both kb/ and knowledge-base/ prefixes to knowledge-base', () => {
+    expect(inferContextFromKey('kb/1700000000000-doc.pdf')).toBe('knowledge-base')
+    // Direct/presigned uploads key as `${context}/...`, i.e. `knowledge-base/...`
+    expect(inferContextFromKey('knowledge-base/1781612506186-b2442e0dc045cb6c-doc.txt')).toBe(
+      'knowledge-base'
+    )
+  })
+
+  it('maps the remaining context prefixes', () => {
+    expect(inferContextFromKey('chat/x')).toBe('chat')
+    expect(inferContextFromKey('copilot/x')).toBe('copilot')
+    expect(inferContextFromKey('execution/ws/wf/ex/x')).toBe('execution')
+    expect(inferContextFromKey('workspace/ws/x')).toBe('workspace')
+    expect(inferContextFromKey('profile-pictures/x')).toBe('profile-pictures')
+    expect(inferContextFromKey('og-images/x')).toBe('og-images')
+    expect(inferContextFromKey('workspace-logos/x')).toBe('workspace-logos')
+    expect(inferContextFromKey('logs/x')).toBe('logs')
+  })
+
+  it('throws for empty or unrecognized keys', () => {
+    expect(() => inferContextFromKey('')).toThrow()
+    expect(() => inferContextFromKey('mystery/x')).toThrow()
   })
 })
 

--- a/apps/sim/lib/uploads/utils/file-utils.ts
+++ b/apps/sim/lib/uploads/utils/file-utils.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@sim/logger'
+import { omit } from '@sim/utils/object'
 import type { StorageContext } from '@/lib/uploads'
 import { ACCEPTED_FILE_TYPES, SUPPORTED_DOCUMENT_EXTENSIONS } from '@/lib/uploads/utils/validation'
 import { isUuid } from '@/executor/constants'
@@ -697,12 +698,22 @@ function resolveInternalFileUrl(file: RawFileInput): string {
 }
 
 /**
+ * Provider large-file handles are populated by the server pipeline and must never be
+ * accepted from untrusted file input (they drive server-side fetch/upload).
+ */
+const PROVIDER_FILE_HANDLE_FIELDS: Array<'providerFileId' | 'providerFileUri' | 'remoteUrl'> = [
+  'providerFileId',
+  'providerFileUri',
+  'remoteUrl',
+]
+
+/**
  * Core conversion logic from RawFileInput to UserFile
  */
 function convertToUserFile(file: RawFileInput, requestId: string, logger: Logger): UserFile | null {
   if (isCompleteUserFile(file)) {
     return {
-      ...file,
+      ...omit(file, PROVIDER_FILE_HANDLE_FIELDS),
       url: resolveInternalFileUrl(file) || file.url,
     }
   }

--- a/apps/sim/lib/uploads/utils/file-utils.ts
+++ b/apps/sim/lib/uploads/utils/file-utils.ts
@@ -565,15 +565,19 @@ export function isInternalFileUrl(fileUrl: string): boolean {
 }
 
 /**
- * Infer storage context from file key using explicit prefixes
- * All files must use prefixed keys
+ * Infer storage context from a file key using its prefix.
+ *
+ * All stored files use prefixed keys. Knowledge-base objects carry one of two
+ * prefixes: `kb/` (server-side uploads) or `knowledge-base/` (direct/presigned
+ * uploads, whose default key is `${context}/...`). Both map to the same
+ * `knowledge-base` context.
  */
 export function inferContextFromKey(key: string): StorageContext {
   if (!key) {
     throw new Error('Cannot infer context from empty key')
   }
 
-  if (key.startsWith('kb/')) return 'knowledge-base'
+  if (key.startsWith('kb/') || key.startsWith('knowledge-base/')) return 'knowledge-base'
   if (key.startsWith('chat/')) return 'chat'
   if (key.startsWith('copilot/')) return 'copilot'
   if (key.startsWith('execution/')) return 'execution'
@@ -584,7 +588,7 @@ export function inferContextFromKey(key: string): StorageContext {
   if (key.startsWith('logs/')) return 'logs'
 
   throw new Error(
-    `File key must start with a context prefix (kb/, chat/, copilot/, execution/, workspace/, profile-pictures/, og-images/, workspace-logos/, or logs/). Got: ${key}`
+    `File key must start with a context prefix (kb/, knowledge-base/, chat/, copilot/, execution/, workspace/, profile-pictures/, og-images/, workspace-logos/, or logs/). Got: ${key}`
   )
 }
 

--- a/apps/sim/providers/attachments.test.ts
+++ b/apps/sim/providers/attachments.test.ts
@@ -7,11 +7,16 @@ import {
   buildAnthropicMessageContent,
   buildBedrockMessageContent,
   buildGeminiMessageParts,
+  buildOpenAICompatibleChatContent,
   buildOpenAIMessageContent,
   buildOpenRouterMessageContent,
   formatMessagesForProvider,
+  getProviderAttachmentMaxBytes,
+  getProviderFileStrategy,
+  INLINE_ATTACHMENT_THRESHOLD_BYTES,
   inferAttachmentMimeType,
   prepareProviderAttachments,
+  shouldUseLargeFilePath,
 } from '@/providers/attachments'
 
 const imageFile: UserFile = {
@@ -268,5 +273,135 @@ describe('provider attachments', () => {
         'deepseek'
       )
     ).toThrow('not supported')
+  })
+})
+
+describe('provider large-file capability', () => {
+  it('reports per-provider strategy and ceiling, defaulting others to inline', () => {
+    expect(getProviderFileStrategy('openai')).toBe('files-api')
+    expect(getProviderFileStrategy('google')).toBe('files-api')
+    expect(getProviderFileStrategy('anthropic')).toBe('remote-url')
+    expect(getProviderFileStrategy('groq')).toBe('remote-url')
+    expect(getProviderFileStrategy('bedrock')).toBe('inline')
+    expect(getProviderFileStrategy('azure-openai')).toBe('inline')
+    expect(getProviderFileStrategy('vertex')).toBe('inline')
+
+    expect(getProviderAttachmentMaxBytes('openai')).toBeGreaterThan(
+      INLINE_ATTACHMENT_THRESHOLD_BYTES
+    )
+    expect(getProviderAttachmentMaxBytes('bedrock')).toBe(INLINE_ATTACHMENT_THRESHOLD_BYTES)
+    expect(getProviderAttachmentMaxBytes('azure-openai')).toBe(INLINE_ATTACHMENT_THRESHOLD_BYTES)
+  })
+
+  it('routes only oversized files on capable providers to the large-file path', () => {
+    const small = { ...imageFile, size: 1024 }
+    const large = { ...imageFile, size: INLINE_ATTACHMENT_THRESHOLD_BYTES + 1 }
+    expect(shouldUseLargeFilePath(small, 'openai')).toBe(false)
+    expect(shouldUseLargeFilePath(large, 'openai')).toBe(true)
+    expect(shouldUseLargeFilePath(large, 'bedrock')).toBe(false)
+  })
+
+  it('references uploaded OpenAI files by file_id instead of inlining base64', () => {
+    const content = buildOpenAIMessageContent(
+      'Analyze',
+      [
+        { ...imageFile, base64: undefined, providerFileId: 'file-img' },
+        { ...pdfFile, base64: undefined, providerFileId: 'file-doc' },
+      ],
+      'openai'
+    )
+    expect(content).toEqual([
+      { type: 'input_text', text: 'Analyze' },
+      { type: 'input_image', file_id: 'file-img', detail: 'auto' },
+      { type: 'input_file', file_id: 'file-doc' },
+    ])
+  })
+
+  it('references large Anthropic files via url content-block sources', () => {
+    const content = buildAnthropicMessageContent(
+      'Analyze',
+      [
+        { ...imageFile, base64: undefined, remoteUrl: 'https://signed/img.png' },
+        { ...pdfFile, base64: undefined, remoteUrl: 'https://signed/doc.pdf' },
+      ],
+      'anthropic'
+    )
+    expect(content).toEqual([
+      { type: 'text', text: 'Analyze' },
+      { type: 'image', source: { type: 'url', url: 'https://signed/img.png' } },
+      {
+        type: 'document',
+        source: { type: 'url', url: 'https://signed/doc.pdf' },
+        title: 'example.pdf',
+      },
+    ])
+  })
+
+  it('references uploaded Gemini files via fileData uri', () => {
+    const parts = buildGeminiMessageParts(
+      'Analyze',
+      [{ ...imageFile, base64: undefined, providerFileUri: 'https://files/abc' }],
+      'google'
+    )
+    expect(parts).toEqual([
+      { text: 'Analyze' },
+      { fileData: { fileUri: 'https://files/abc', mimeType: 'image/png' } },
+    ])
+  })
+
+  it('passes a remote url to OpenAI-compatible providers instead of a data url', () => {
+    const content = buildOpenAICompatibleChatContent(
+      'Analyze',
+      [{ ...imageFile, base64: undefined, remoteUrl: 'https://signed/img.png' }],
+      'groq'
+    )
+    expect(content).toEqual([
+      { type: 'text', text: 'Analyze' },
+      { type: 'image_url', image_url: { url: 'https://signed/img.png' } },
+    ])
+  })
+
+  it('rejects oversized non-PDF text documents on Anthropic (url source supports PDFs/images only)', () => {
+    expect(() =>
+      buildAnthropicMessageContent(
+        'Analyze',
+        [
+          {
+            ...markdownFile,
+            type: 'text/csv',
+            name: 'data.csv',
+            base64: undefined,
+            remoteUrl: 'https://signed/data.csv',
+          },
+        ],
+        'anthropic'
+      )
+    ).toThrow('Only PDFs and images are supported')
+  })
+
+  it('references large Anthropic PDFs via a url document source', () => {
+    const content = buildAnthropicMessageContent(
+      'Analyze',
+      [{ ...pdfFile, base64: undefined, remoteUrl: 'https://signed/doc.pdf' }],
+      'anthropic'
+    )
+    expect(content).toEqual([
+      { type: 'text', text: 'Analyze' },
+      {
+        type: 'document',
+        source: { type: 'url', url: 'https://signed/doc.pdf' },
+        title: 'example.pdf',
+      },
+    ])
+  })
+
+  it('rejects files above the provider ceiling', () => {
+    const huge = {
+      ...imageFile,
+      size: getProviderAttachmentMaxBytes('openai') + 1,
+      base64: undefined,
+      providerFileId: 'file-img',
+    }
+    expect(() => buildOpenAIMessageContent('Analyze', [huge], 'openai')).toThrow('exceeds the')
   })
 })

--- a/apps/sim/providers/attachments.ts
+++ b/apps/sim/providers/attachments.ts
@@ -11,6 +11,11 @@ import {
   MODEL_SUPPORTED_IMAGE_MIME_TYPES,
 } from '@/lib/uploads/utils/file-utils'
 import type { UserFile } from '@/executor/types'
+import {
+  getProviderFileAttachment,
+  INLINE_ATTACHMENT_MAX_BYTES,
+  type ProviderFileAttachmentStrategy,
+} from '@/providers/models'
 import type { ProviderId } from '@/providers/types'
 
 export type AttachmentProvider =
@@ -36,11 +41,19 @@ export interface PreparedProviderAttachment {
   filename: string
   mimeType: string
   providerMimeType: string
-  base64: string
-  dataUrl: string
+  /** Base64 payload — present only for inlined files (≤ inline threshold). Absent for large uploaded files. */
+  base64?: string
+  /** `data:` URL — present only for inlined files. Absent for large uploaded files. */
+  dataUrl?: string
   text?: string
   extension: string
   contentType: 'image' | 'document' | 'audio' | 'video'
+  /** Provider Files API id (OpenAI/Anthropic) when the file was uploaded instead of inlined. */
+  providerFileId?: string
+  /** Provider File API uri (Gemini) when the file was uploaded instead of inlined. */
+  providerFileUri?: string
+  /** Short-lived signed HTTPS URL for providers that fetch attachments by remote URL. */
+  remoteUrl?: string
 }
 
 type ProviderMessageInput = {
@@ -56,7 +69,29 @@ type ProviderFormattedMessage = {
   [key: string]: unknown
 }
 
-export const AGENT_ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024
+/**
+ * Files at or below this size are inlined as base64, exactly as before. Larger files take
+ * the provider's large-file path. Keeping the threshold at the legacy 10 MB cap guarantees
+ * identical behaviour for existing attachments.
+ */
+export const INLINE_ATTACHMENT_THRESHOLD_BYTES = INLINE_ATTACHMENT_MAX_BYTES
+
+export type ProviderFileStrategy = ProviderFileAttachmentStrategy
+
+/** Large-file delivery strategy for a provider, sourced from its `models.ts` definition. */
+export function getProviderFileStrategy(providerId: ProviderId | string): ProviderFileStrategy {
+  return getProviderFileAttachment(providerId).strategy
+}
+
+/** True when a file exceeds the inline threshold and the provider has a large-file path. */
+export function shouldUseLargeFilePath(
+  file: Pick<UserFile, 'size'>,
+  providerId: ProviderId | string
+): boolean {
+  if (getProviderFileAttachment(providerId).strategy === 'inline') return false
+  return Number.isFinite(file.size) && file.size > INLINE_ATTACHMENT_THRESHOLD_BYTES
+}
+
 const PDF_MIME_TYPE = 'application/pdf'
 
 const DOCUMENT_MIME_TYPES = new Set(
@@ -129,8 +164,13 @@ export function supportsFileAttachments(providerId: ProviderId | string): boolea
   return Boolean(provider && !UNSUPPORTED_FILE_PROVIDERS.has(provider))
 }
 
-export function getProviderAttachmentMaxBytes(_providerId: ProviderId | string): number {
-  return AGENT_ATTACHMENT_MAX_BYTES
+/**
+ * Real maximum attachment size for a provider — its native ceiling when it has a large-file
+ * path, else the inline base64 threshold. Used for UI limits and validation, never as the
+ * base64 hydration cap (which stays at {@link INLINE_ATTACHMENT_THRESHOLD_BYTES}).
+ */
+export function getProviderAttachmentMaxBytes(providerId: ProviderId | string): number {
+  return getProviderFileAttachment(providerId).maxBytes
 }
 
 export function inferAttachmentMimeType(file: UserFile): string {
@@ -315,20 +355,27 @@ export function prepareProviderAttachments(
       )
     }
 
-    if (Number.isFinite(file.size) && file.size > AGENT_ATTACHMENT_MAX_BYTES) {
+    const maxBytes = getProviderAttachmentMaxBytes(providerId)
+    if (Number.isFinite(file.size) && file.size > maxBytes) {
       const sizeMB = (file.size / (1024 * 1024)).toFixed(2)
-      const maxMB = (AGENT_ATTACHMENT_MAX_BYTES / (1024 * 1024)).toFixed(0)
+      const maxMB = (maxBytes / (1024 * 1024)).toFixed(0)
       throw new Error(
         `File "${file.name}" (${sizeMB}MB) exceeds the ${maxMB}MB agent attachment limit for provider "${providerId}"`
       )
     }
 
-    if (!file.base64) {
+    const providerFileId = file.providerFileId
+    const providerFileUri = file.providerFileUri
+    const remoteUrl = file.remoteUrl
+    const hasHandle = Boolean(providerFileId || providerFileUri || remoteUrl)
+
+    if (!file.base64 && !hasHandle) {
       throw new Error(`File "${file.name}" could not be read for provider "${providerId}"`)
     }
 
-    const sniffedImageMimeType = contentType === 'image' ? sniffImageMimeType(file.base64) : ''
-    if (contentType === 'image' && !sniffedImageMimeType) {
+    const sniffedImageMimeType =
+      contentType === 'image' && file.base64 ? sniffImageMimeType(file.base64) : ''
+    if (contentType === 'image' && file.base64 && !sniffedImageMimeType) {
       throw new Error(
         `Image bytes in "${file.name}" are not a supported model image format (declared MIME type "${declaredMimeType}"). Supported image formats: image/jpeg, image/png, image/gif, image/webp.`
       )
@@ -351,10 +398,14 @@ export function prepareProviderAttachments(
     return {
       ...attachment,
       providerMimeType,
-      dataUrl: toDataUrl(providerMimeType, file.base64),
-      ...(isTextDocumentMimeType(mimeType) && {
-        text: decodeBase64Text(file.base64, file.name),
-      }),
+      providerFileId,
+      providerFileUri,
+      remoteUrl,
+      ...(file.base64 && { dataUrl: toDataUrl(providerMimeType, file.base64) }),
+      ...(file.base64 &&
+        isTextDocumentMimeType(mimeType) && {
+          text: decodeBase64Text(file.base64, file.name),
+        }),
     }
   })
 }
@@ -378,17 +429,32 @@ export function buildOpenAIMessageContent(
 
   for (const attachment of attachments) {
     if (attachment.contentType === 'image') {
-      parts.push({
-        type: 'input_image',
-        image_url: attachment.dataUrl,
-        detail: 'auto',
-      } satisfies OpenAI.Responses.ResponseInputImage)
+      parts.push(
+        attachment.providerFileId
+          ? ({
+              type: 'input_image',
+              file_id: attachment.providerFileId,
+              detail: 'auto',
+            } satisfies OpenAI.Responses.ResponseInputImage)
+          : ({
+              type: 'input_image',
+              image_url: attachment.dataUrl,
+              detail: 'auto',
+            } satisfies OpenAI.Responses.ResponseInputImage)
+      )
     } else {
-      parts.push({
-        type: 'input_file',
-        filename: attachment.filename,
-        file_data: attachment.dataUrl,
-      } satisfies OpenAI.Responses.ResponseInputFile)
+      parts.push(
+        attachment.providerFileId
+          ? ({
+              type: 'input_file',
+              file_id: attachment.providerFileId,
+            } satisfies OpenAI.Responses.ResponseInputFile)
+          : ({
+              type: 'input_file',
+              filename: attachment.filename,
+              file_data: attachment.dataUrl,
+            } satisfies OpenAI.Responses.ResponseInputFile)
+      )
     }
   }
 
@@ -409,12 +475,25 @@ export function buildAnthropicMessageContent(
     if (attachment.contentType === 'image') {
       parts.push({
         type: 'image',
-        source: {
-          type: 'base64',
-          media_type: attachment.providerMimeType as AnthropicImageMediaType,
-          data: attachment.base64,
-        },
+        source: attachment.remoteUrl
+          ? ({ type: 'url', url: attachment.remoteUrl } satisfies Anthropic.Messages.URLImageSource)
+          : ({
+              type: 'base64',
+              media_type: attachment.providerMimeType as AnthropicImageMediaType,
+              data: attachment.base64 ?? '',
+            } satisfies Anthropic.Messages.Base64ImageSource),
       } satisfies Anthropic.Messages.ImageBlockParam)
+    } else if (attachment.remoteUrl) {
+      if (attachment.mimeType !== PDF_MIME_TYPE) {
+        throw new Error(
+          `Document "${attachment.filename}" (${attachment.mimeType}) is too large to send to provider "${providerId}". Only PDFs and images are supported above the inline limit — convert it to PDF or reduce its size.`
+        )
+      }
+      parts.push({
+        type: 'document',
+        source: { type: 'url', url: attachment.remoteUrl },
+        title: attachment.filename,
+      } satisfies Anthropic.Messages.DocumentBlockParam)
     } else if (attachment.text) {
       parts.push({
         type: 'document',
@@ -431,7 +510,7 @@ export function buildAnthropicMessageContent(
         source: {
           type: 'base64',
           media_type: 'application/pdf',
-          data: attachment.base64,
+          data: attachment.base64 ?? '',
         },
         title: attachment.filename,
       } satisfies Anthropic.Messages.DocumentBlockParam)
@@ -452,12 +531,21 @@ export function buildGeminiMessageParts(
   }
 
   for (const attachment of prepareProviderAttachments(files, providerId)) {
-    parts.push({
-      inlineData: {
-        mimeType: attachment.providerMimeType,
-        data: attachment.base64,
-      },
-    } satisfies Part)
+    parts.push(
+      attachment.providerFileUri
+        ? ({
+            fileData: {
+              fileUri: attachment.providerFileUri,
+              mimeType: attachment.providerMimeType,
+            },
+          } satisfies Part)
+        : ({
+            inlineData: {
+              mimeType: attachment.providerMimeType,
+              data: attachment.base64 ?? '',
+            },
+          } satisfies Part)
+    )
   }
 
   return parts
@@ -483,7 +571,7 @@ export function buildOpenAICompatibleChatContent(
     parts.push({
       type: 'image_url',
       image_url: {
-        url: attachment.dataUrl,
+        url: attachment.remoteUrl ?? attachment.dataUrl ?? '',
       },
     } satisfies OpenAI.Chat.Completions.ChatCompletionContentPartImage)
   }
@@ -511,14 +599,14 @@ export function buildOpenRouterMessageContent(
     if (attachment.contentType === 'image') {
       parts.push({
         type: 'image_url',
-        image_url: { url: attachment.dataUrl },
+        image_url: { url: attachment.remoteUrl ?? attachment.dataUrl ?? '' },
       } satisfies OpenAI.Chat.Completions.ChatCompletionContentPartImage)
     } else {
       parts.push({
         type: 'file',
         file: {
           filename: attachment.filename,
-          file_data: attachment.dataUrl,
+          file_data: attachment.remoteUrl ?? attachment.dataUrl ?? '',
         },
       } satisfies OpenAI.Chat.Completions.ChatCompletionContentPart.File)
     }
@@ -554,7 +642,7 @@ export function buildBedrockMessageContent(
   }
 
   for (const attachment of prepareProviderAttachments(files, providerId)) {
-    const bytes = Buffer.from(attachment.base64, 'base64')
+    const bytes = Buffer.from(attachment.base64 ?? '', 'base64')
     if (attachment.contentType === 'image') {
       parts.push({
         image: {

--- a/apps/sim/providers/azure-anthropic/index.test.ts
+++ b/apps/sim/providers/azure-anthropic/index.test.ts
@@ -44,6 +44,10 @@ vi.mock('@/providers/anthropic/core', () => ({
   executeAnthropicProviderRequest: mockExecuteAnthropic,
 }))
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getProviderModels: vi.fn(() => []),
   getProviderDefaultModel: vi.fn(() => 'azure-anthropic/claude'),
 }))

--- a/apps/sim/providers/azure-openai/index.test.ts
+++ b/apps/sim/providers/azure-openai/index.test.ts
@@ -62,6 +62,10 @@ vi.mock('@/providers/azure-openai/utils', () => ({
   checkForForcedToolUsage: vi.fn(() => ({ hasUsedForcedTool: false, usedForcedTools: [] })),
 }))
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getProviderModels: vi.fn(() => []),
   getProviderDefaultModel: vi.fn(() => 'azure/gpt-4o'),
 }))

--- a/apps/sim/providers/azure-openai/index.ts
+++ b/apps/sim/providers/azure-openai/index.ts
@@ -113,7 +113,7 @@ async function executeChatCompletionsRequest(
       const parts: ChatCompletionContentPart[] = []
       if (message.content) parts.push({ type: 'text', text: message.content })
       for (const a of attachments) {
-        parts.push({ type: 'image_url', image_url: { url: a.dataUrl } })
+        parts.push({ type: 'image_url', image_url: { url: a.remoteUrl ?? a.dataUrl ?? '' } })
       }
       const { files: _files, ...rest } = message
       allMessages.push({ ...rest, content: parts } as ChatCompletionMessageParam)

--- a/apps/sim/providers/baseten/index.test.ts
+++ b/apps/sim/providers/baseten/index.test.ts
@@ -26,6 +26,10 @@ vi.mock('openai', () => ({
 vi.mock('@/providers', () => ({ MAX_TOOL_ITERATIONS: 5 }))
 
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getProviderModels: vi.fn().mockReturnValue([]),
   getProviderDefaultModel: vi.fn().mockReturnValue('openai/gpt-oss-120b'),
 }))

--- a/apps/sim/providers/bedrock/index.test.ts
+++ b/apps/sim/providers/bedrock/index.test.ts
@@ -25,6 +25,10 @@ vi.mock('@/providers/bedrock/utils', () => ({
 }))
 
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getProviderModels: vi.fn().mockReturnValue([]),
   getProviderDefaultModel: vi.fn().mockReturnValue('us.anthropic.claude-3-5-sonnet-20241022-v2:0'),
 }))

--- a/apps/sim/providers/file-attachments.server.ts
+++ b/apps/sim/providers/file-attachments.server.ts
@@ -1,0 +1,255 @@
+import { FileState, GoogleGenAI } from '@google/genai'
+import { createLogger } from '@sim/logger'
+import { getErrorMessage } from '@sim/utils/errors'
+import { sleep } from '@sim/utils/helpers'
+import type { StorageContext } from '@/lib/uploads'
+import { StorageService } from '@/lib/uploads'
+import { inferContextFromKey } from '@/lib/uploads/utils/file-utils'
+import { downloadFileFromStorage } from '@/lib/uploads/utils/file-utils.server'
+import { verifyFileAccess } from '@/app/api/files/authorization'
+import type { UserFile } from '@/executor/types'
+import {
+  getProviderAttachmentMaxBytes,
+  getProviderFileStrategy,
+  inferAttachmentMimeType,
+  shouldUseLargeFilePath,
+} from '@/providers/attachments'
+import type { Message, ProviderId, ProviderRequest } from '@/providers/types'
+
+const logger = createLogger('ProviderFileAttachments')
+
+const OPENAI_FILES_ENDPOINT = 'https://api.openai.com/v1/files'
+const PRESIGNED_URL_EXPIRY_SECONDS = 60 * 60
+/** OpenAI auto-deletes uploaded files after this window — see the "rely on provider expiry" lifecycle. */
+const OPENAI_FILE_EXPIRY_SECONDS = 60 * 60
+const GEMINI_POLL_INTERVAL_MS = 1000
+const GEMINI_PROCESSING_TIMEOUT_MS = 5 * 60_000
+
+function* iterateRequestFiles(messages: Message[] | undefined): Generator<UserFile> {
+  for (const message of messages ?? []) {
+    for (const file of message.files ?? []) {
+      yield file
+    }
+  }
+}
+
+/**
+ * Resolves every attachment that exceeds the inline threshold on a large-file-capable
+ * provider to a short-lived signed URL on `file.remoteUrl`. `remote-url` providers send it
+ * to the model directly; for `files-api` providers it marks the file for upload (the bytes
+ * are read from storage at upload time). Requires cloud storage — a large file (already past
+ * the inline base64 cap) cannot be sent without it, so the request fails with a clear error.
+ *
+ * Runs for every request in {@link executeProviderRequest} (after the API key resolves), so
+ * the server-only handle fields are first cleared on every file for every provider — a forged
+ * handle on an untrusted request body can never survive to a builder or trigger a fetch.
+ */
+export async function attachLargeFileRemoteUrls(
+  request: ProviderRequest,
+  providerId: ProviderId | string
+): Promise<void> {
+  for (const file of iterateRequestFiles(request.messages)) {
+    file.providerFileId = undefined
+    file.providerFileUri = undefined
+    file.remoteUrl = undefined
+  }
+
+  if (getProviderFileStrategy(providerId) === 'inline') return
+
+  const requestId = request.workflowId ?? 'provider-request'
+  const maxBytes = getProviderAttachmentMaxBytes(providerId)
+
+  for (const file of iterateRequestFiles(request.messages)) {
+    if (!file.key || !shouldUseLargeFilePath(file, providerId)) continue
+
+    if (Number.isFinite(file.size) && file.size > maxBytes) {
+      const sizeMB = (file.size / (1024 * 1024)).toFixed(2)
+      const maxMB = (maxBytes / (1024 * 1024)).toFixed(0)
+      throw new Error(
+        `File "${file.name}" (${sizeMB}MB) exceeds the ${maxMB}MB agent attachment limit for provider "${providerId}"`
+      )
+    }
+
+    if (!StorageService.hasCloudStorage()) {
+      logger.warn(
+        `[${requestId}] "${file.name}" exceeds the inline limit for "${providerId}" but cloud storage is unavailable`
+      )
+      throw new Error(
+        `File "${file.name}" exceeds the inline attachment limit and requires cloud file storage, which is not configured`
+      )
+    }
+
+    if (!request.userId) {
+      throw new Error(
+        `File "${file.name}" requires an authenticated user for provider "${providerId}"`
+      )
+    }
+
+    const context = (file.context as StorageContext) || inferContextFromKey(file.key)
+    const hasAccess = await verifyFileAccess(file.key, request.userId, undefined, context, false)
+    if (!hasAccess) {
+      throw new Error(`File "${file.name}" is not accessible for provider "${providerId}"`)
+    }
+
+    file.remoteUrl = await StorageService.generatePresignedDownloadUrl(
+      file.key,
+      context,
+      PRESIGNED_URL_EXPIRY_SECONDS
+    )
+  }
+}
+
+/**
+ * For `files-api` providers, uploads each large attachment (already carrying a signed
+ * `remoteUrl` from {@link attachLargeFileRemoteUrls}) to the provider Files API and records
+ * the returned handle on the file. Runs after the request's API key is resolved so hosted
+ * and BYOK keys both work.
+ */
+export async function uploadLargeFilesToProvider(
+  request: ProviderRequest,
+  providerId: ProviderId | string
+): Promise<void> {
+  if (getProviderFileStrategy(providerId) !== 'files-api') return
+
+  const groups = groupUploadableFiles(request.messages)
+  if (groups.length === 0) return
+
+  const maxBytes = getProviderAttachmentMaxBytes(providerId)
+  const ai = providerId === 'google' ? new GoogleGenAI({ apiKey: request.apiKey }) : null
+
+  for (const group of groups) {
+    const [representative] = group
+    await assertFileAccessForUpload(representative, request.userId)
+    if (providerId === 'openai') {
+      await uploadOpenAIFile(representative, request.apiKey, maxBytes, request.abortSignal)
+    } else if (ai) {
+      await uploadGeminiFile(representative, ai, maxBytes, request.abortSignal)
+    }
+    for (const file of group) {
+      file.providerFileId = representative.providerFileId
+      file.providerFileUri = representative.providerFileUri
+    }
+  }
+}
+
+/**
+ * Verifies the caller may read this file before its bytes are uploaded to a provider. Enforced
+ * for every caller of {@link uploadLargeFilesToProvider} (not just the agent path), so a forged
+ * storage key in a passthrough request cannot exfiltrate another user's file.
+ */
+async function assertFileAccessForUpload(
+  file: UserFile,
+  userId: string | undefined
+): Promise<void> {
+  if (!file.key) {
+    throw new Error(`File "${file.name}" has no storage key`)
+  }
+  if (!userId) {
+    throw new Error(`File "${file.name}" requires an authenticated user to upload`)
+  }
+  const context = (file.context as StorageContext) || inferContextFromKey(file.key)
+  const hasAccess = await verifyFileAccess(file.key, userId, undefined, context, false)
+  if (!hasAccess) {
+    throw new Error(`File "${file.name}" is not accessible`)
+  }
+}
+
+/**
+ * Groups large files needing a Files API upload by storage key so a file referenced across
+ * multiple messages uploads once; the resulting handle is then applied to every occurrence.
+ */
+function groupUploadableFiles(messages: Message[] | undefined): UserFile[][] {
+  const groups = new Map<string, UserFile[]>()
+  for (const message of messages ?? []) {
+    for (const file of message.files ?? []) {
+      if (!file.remoteUrl || file.providerFileId || file.providerFileUri) continue
+      const dedupeKey = file.key || file.remoteUrl
+      const group = groups.get(dedupeKey)
+      if (group) group.push(file)
+      else groups.set(dedupeKey, [file])
+    }
+  }
+  return [...groups.values()]
+}
+
+/**
+ * Reads the file bytes straight from storage via the storage SDK (not by HTTP-fetching the
+ * signed URL), so there is no server-side URL fetch to be an SSRF vector and internal
+ * object storage works. Bounded by the provider's attachment ceiling.
+ */
+async function downloadFileForUpload(file: UserFile, maxBytes: number): Promise<Blob> {
+  const buffer = await downloadFileFromStorage(file, 'provider-file-upload', logger, { maxBytes })
+  return new Blob([new Uint8Array(buffer)], { type: file.type || inferAttachmentMimeType(file) })
+}
+
+/**
+ * Uploads to `POST /v1/files` via multipart directly (not the SDK), because the installed
+ * `openai` SDK does not type `expires_after`; the bracketed form fields are the documented
+ * multipart encoding for the nested object and give the file an auto-expiry.
+ */
+async function uploadOpenAIFile(
+  file: UserFile,
+  apiKey: string | undefined,
+  maxBytes: number,
+  signal?: AbortSignal
+): Promise<void> {
+  const mimeType = inferAttachmentMimeType(file)
+  const blob = await downloadFileForUpload(file, maxBytes)
+
+  const form = new FormData()
+  form.append('purpose', mimeType.startsWith('image/') ? 'vision' : 'user_data')
+  form.append('expires_after[anchor]', 'created_at')
+  form.append('expires_after[seconds]', String(OPENAI_FILE_EXPIRY_SECONDS))
+  form.append('file', blob, file.name)
+
+  const response = await fetch(OPENAI_FILES_ENDPOINT, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
+    signal,
+  })
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '')
+    throw new Error(`OpenAI file upload failed for "${file.name}" (${response.status}): ${detail}`)
+  }
+
+  const uploaded = (await response.json()) as { id?: string }
+  if (!uploaded.id) {
+    throw new Error(`OpenAI file upload for "${file.name}" returned no id`)
+  }
+  file.providerFileId = uploaded.id
+  logger.info(`Uploaded "${file.name}" to OpenAI Files API`, { fileId: uploaded.id })
+}
+
+async function uploadGeminiFile(
+  file: UserFile,
+  ai: GoogleGenAI,
+  maxBytes: number,
+  signal?: AbortSignal
+): Promise<void> {
+  const mimeType = inferAttachmentMimeType(file)
+  const blob = await downloadFileForUpload(file, maxBytes)
+
+  let uploaded = await ai.files.upload({ file: blob, config: { mimeType, abortSignal: signal } })
+  if (!uploaded.name) {
+    throw new Error(`Gemini upload for "${file.name}" returned no file name`)
+  }
+  const uploadedName = uploaded.name
+
+  const deadline = Date.now() + GEMINI_PROCESSING_TIMEOUT_MS
+  while (uploaded.state === FileState.PROCESSING) {
+    if (Date.now() > deadline) {
+      throw new Error(`Gemini file processing timed out for "${file.name}"`)
+    }
+    await sleep(GEMINI_POLL_INTERVAL_MS)
+    uploaded = await ai.files.get({ name: uploadedName })
+  }
+
+  if (uploaded.state === FileState.FAILED || !uploaded.uri) {
+    throw new Error(
+      `Gemini file processing failed for "${file.name}": ${getErrorMessage(uploaded.error, 'unknown error')}`
+    )
+  }
+  file.providerFileUri = uploaded.uri
+  logger.info(`Uploaded "${file.name}" to Gemini File API`, { fileUri: uploaded.uri })
+}

--- a/apps/sim/providers/fireworks/index.test.ts
+++ b/apps/sim/providers/fireworks/index.test.ts
@@ -26,6 +26,10 @@ vi.mock('openai', () => ({
 vi.mock('@/providers', () => ({ MAX_TOOL_ITERATIONS: 5 }))
 
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getProviderModels: vi.fn().mockReturnValue([]),
   getProviderDefaultModel: vi.fn().mockReturnValue('llama-v3p1-70b-instruct'),
 }))

--- a/apps/sim/providers/index.ts
+++ b/apps/sim/providers/index.ts
@@ -3,6 +3,10 @@ import { toError } from '@sim/utils/errors'
 import { getApiKeyWithBYOK } from '@/lib/api-key/byok'
 import { getCostMultiplier } from '@/lib/core/config/env-flags'
 import type { StreamingExecution } from '@/executor/types'
+import {
+  attachLargeFileRemoteUrls,
+  uploadLargeFilesToProvider,
+} from '@/providers/file-attachments.server'
 import { getProviderExecutor } from '@/providers/registry'
 import type { ProviderId, ProviderRequest, ProviderResponse } from '@/providers/types'
 import {
@@ -189,6 +193,9 @@ export async function executeProviderRequest(
       }
     }
   }
+
+  await attachLargeFileRemoteUrls(sanitizedRequest, providerId)
+  await uploadLargeFilesToProvider(sanitizedRequest, providerId)
 
   const response = await provider.executeRequest(sanitizedRequest)
 

--- a/apps/sim/providers/litellm/index.test.ts
+++ b/apps/sim/providers/litellm/index.test.ts
@@ -29,6 +29,10 @@ vi.mock('@/stores/providers', () => ({
 }))
 
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getProviderModels: () => [],
   getProviderDefaultModel: () => '',
 }))

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -195,7 +195,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   vllm: {
     id: 'vllm',
-    fileAttachment: { maxBytes: 50 * 1024 * 1024, strategy: 'remote-url' },
+    fileAttachment: { maxBytes: 25 * 1024 * 1024, strategy: 'remote-url' },
     name: 'vLLM',
     icon: VllmIcon,
     description: 'Self-hosted vLLM with an OpenAI-compatible API',
@@ -1319,7 +1319,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   google: {
     id: 'google',
-    fileAttachment: { maxBytes: 100 * 1024 * 1024, strategy: 'files-api' },
+    fileAttachment: { maxBytes: 50 * 1024 * 1024, strategy: 'files-api' },
     name: 'Google',
     description: "Google's Gemini models",
     defaultModel: 'gemini-2.5-pro',

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -81,6 +81,34 @@ export interface ProviderDefinition {
   isReseller?: boolean
   capabilities?: ModelCapabilities
   contextInformationAvailable?: boolean
+  /** Agent-block file attachment limit and large-file delivery for this provider. */
+  fileAttachment?: ProviderFileAttachment
+}
+
+/**
+ * How a provider accepts agent-block attachments larger than the inline base64 threshold:
+ * `files-api` uploads to the provider Files API, `remote-url` passes a signed URL the
+ * provider fetches itself, `inline` means base64-only (no large-file path).
+ */
+export type ProviderFileAttachmentStrategy = 'inline' | 'files-api' | 'remote-url'
+
+export interface ProviderFileAttachment {
+  /** Maximum attachment size the provider accepts, in bytes. */
+  maxBytes: number
+  strategy: ProviderFileAttachmentStrategy
+}
+
+/** Inline base64 attachment cap, also the fallback limit for providers without a large-file path. */
+export const INLINE_ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024
+
+const DEFAULT_FILE_ATTACHMENT: ProviderFileAttachment = {
+  maxBytes: INLINE_ATTACHMENT_MAX_BYTES,
+  strategy: 'inline',
+}
+
+/** Provider-level attachment limit + strategy, keyed on the granular provider id. */
+export function getProviderFileAttachment(providerId: string): ProviderFileAttachment {
+  return PROVIDER_DEFINITIONS[providerId]?.fileAttachment ?? DEFAULT_FILE_ATTACHMENT
 }
 
 export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
@@ -102,6 +130,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   together: {
     id: 'together',
+    fileAttachment: { maxBytes: 50 * 1024 * 1024, strategy: 'remote-url' },
     name: 'Together AI',
     description: 'Fast inference for open-source models via Together AI',
     defaultModel: '',
@@ -118,6 +147,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   baseten: {
     id: 'baseten',
+    fileAttachment: { maxBytes: 25 * 1024 * 1024, strategy: 'remote-url' },
     name: 'Baseten',
     description: 'Fast inference for open-source models via Baseten Model APIs',
     defaultModel: '',
@@ -134,6 +164,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   openrouter: {
     id: 'openrouter',
+    fileAttachment: { maxBytes: 50 * 1024 * 1024, strategy: 'remote-url' },
     name: 'OpenRouter',
     description: 'Unified access to many models via OpenRouter',
     defaultModel: '',
@@ -164,6 +195,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   vllm: {
     id: 'vllm',
+    fileAttachment: { maxBytes: 50 * 1024 * 1024, strategy: 'remote-url' },
     name: 'vLLM',
     icon: VllmIcon,
     description: 'Self-hosted vLLM with an OpenAI-compatible API',
@@ -191,6 +223,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   openai: {
     id: 'openai',
+    fileAttachment: { maxBytes: 50 * 1024 * 1024, strategy: 'files-api' },
     name: 'OpenAI',
     description: "OpenAI's models",
     defaultModel: 'gpt-4.1',
@@ -624,6 +657,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   anthropic: {
     id: 'anthropic',
+    fileAttachment: { maxBytes: 50 * 1024 * 1024, strategy: 'remote-url' },
     name: 'Anthropic',
     description: "Anthropic's Claude models",
     defaultModel: 'claude-sonnet-4-6',
@@ -1285,6 +1319,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   google: {
     id: 'google',
+    fileAttachment: { maxBytes: 100 * 1024 * 1024, strategy: 'files-api' },
     name: 'Google',
     description: "Google's Gemini models",
     defaultModel: 'gemini-2.5-pro',
@@ -1741,6 +1776,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   xai: {
     id: 'xai',
+    fileAttachment: { maxBytes: 20 * 1024 * 1024, strategy: 'remote-url' },
     name: 'xAI',
     description: "xAI's Grok models",
     defaultModel: 'grok-4.3',
@@ -2013,6 +2049,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   },
   groq: {
     id: 'groq',
+    fileAttachment: { maxBytes: 20 * 1024 * 1024, strategy: 'remote-url' },
     name: 'Groq',
     description: "Groq's LLM models with high-performance inference",
     defaultModel: 'groq/llama-3.3-70b-versatile',

--- a/apps/sim/providers/ollama-cloud/index.test.ts
+++ b/apps/sim/providers/ollama-cloud/index.test.ts
@@ -45,6 +45,10 @@ vi.mock('openai', () => {
 
 vi.mock('@/providers', () => ({ MAX_TOOL_ITERATIONS: 20 }))
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getProviderModels: vi.fn().mockReturnValue([]),
   getProviderDefaultModel: vi.fn().mockReturnValue(''),
 }))

--- a/apps/sim/providers/openrouter/index.test.ts
+++ b/apps/sim/providers/openrouter/index.test.ts
@@ -37,6 +37,10 @@ vi.mock('@/providers', () => ({ MAX_TOOL_ITERATIONS: 10 }))
 vi.mock('@/tools', () => ({ executeTool: mockExecuteTool }))
 
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getProviderModels: vi.fn().mockReturnValue([]),
   getProviderDefaultModel: vi.fn().mockReturnValue(''),
 }))

--- a/apps/sim/providers/together/index.test.ts
+++ b/apps/sim/providers/together/index.test.ts
@@ -26,6 +26,10 @@ vi.mock('openai', () => ({
 vi.mock('@/providers', () => ({ MAX_TOOL_ITERATIONS: 5 }))
 
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getProviderModels: vi.fn().mockReturnValue([]),
   getProviderDefaultModel: vi.fn().mockReturnValue('moonshotai/Kimi-K2-Instruct'),
 }))

--- a/apps/sim/providers/vllm/index.test.ts
+++ b/apps/sim/providers/vllm/index.test.ts
@@ -51,6 +51,10 @@ vi.mock('@/lib/core/security/input-validation.server', () => ({
 }))
 vi.mock('@/providers', () => ({ MAX_TOOL_ITERATIONS: 20 }))
 vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
   getProviderModels: vi.fn(() => []),
   getProviderDefaultModel: vi.fn(() => 'vllm/generic'),
 }))


### PR DESCRIPTION
- **fix(chat): keep autoscroll pinned when the virtualizer re-scrolls during streaming (#5093)**
- **feat(providers): support large agent-block attachments via Files APIs and remote URLs (#5092)**
- **fix(chat): autoscroll follow-ups — re-engage threshold + keep end-of-turn options in view (#5094)**
- **fix(kb): canonicalize knowledge-base upload keys (#5096)**
