### PR TITLE
improvement(models): add DeepSeek V4 + Mistral Medium 3.5, fix Codestral context window

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -1719,6 +1719,32 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     },
     models: [
       {
+        id: 'deepseek-v4-pro',
+        pricing: {
+          input: 0.435,
+          cachedInput: 0.003625,
+          output: 0.87,
+          updatedAt: '2026-06-16',
+        },
+        capabilities: {},
+        contextWindow: 1000000,
+        releaseDate: '2026-04-24',
+      },
+      {
+        id: 'deepseek-v4-flash',
+        pricing: {
+          input: 0.14,
+          cachedInput: 0.0028,
+          output: 0.28,
+          updatedAt: '2026-06-16',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 2 },
+        },
+        contextWindow: 1000000,
+        releaseDate: '2026-04-24',
+      },
+      {
         id: 'deepseek-chat',
         pricing: {
           input: 0.14,
@@ -2325,6 +2351,19 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         releaseDate: '2025-08-12',
       },
       {
+        id: 'mistral-medium-2604',
+        pricing: {
+          input: 1.5,
+          output: 7.5,
+          updatedAt: '2026-06-16',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 1.5 },
+        },
+        contextWindow: 256000,
+        releaseDate: '2026-04-29',
+      },
+      {
         id: 'mistral-medium-2508',
         pricing: {
           input: 0.4,
@@ -2400,7 +2439,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         capabilities: {
           temperature: { min: 0, max: 1.5 },
         },
-        contextWindow: 128000,
+        contextWindow: 256000,
         releaseDate: '2025-07-30',
       },
       {
@@ -2413,7 +2452,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         capabilities: {
           temperature: { min: 0, max: 1.5 },
         },
-        contextWindow: 128000,
+        contextWindow: 256000,
         releaseDate: '2025-07-30',
       },
       {


### PR DESCRIPTION
## Summary
- Add `deepseek-v4-pro` and `deepseek-v4-flash` (1M context, verified against DeepSeek pricing docs)
- Add `mistral-medium-2604` (Mistral Medium 3.5, 256K context, \$1.50/\$7.50, verified against Mistral docs)
- Fix `codestral-latest` and `codestral-2508` context window 128K → 256K (verified: Codestral 25.08 is 256K)

All values verified against each provider's live docs — cross-checked models.dev but did not treat it as source of truth (it had stale data for `gpt-5-chat-latest`, Ministral, and several `-latest` aliases, which were left unchanged because ours were already correct).

## Type of Change
- [x] Improvement (data accuracy)

## Testing
Tested manually — `models.ts` parses cleanly and passes file-scoped typecheck.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)