### PR TITLE
fix(realtime): debounce the reconnecting toast to stop transient-blip flashes

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/providers/workspace-permissions-provider.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/workspace-permissions-provider.tsx
@@ -12,10 +12,22 @@ import {
   type WorkspacePermissions,
   workspaceKeys,
 } from '@/hooks/queries/workspace'
+import { useStableFlag } from '@/hooks/use-stable-flag'
 import { useUserPermissions, type WorkspaceUserPermissions } from '@/hooks/use-user-permissions'
 import { useOperationQueueStore } from '@/stores/operation-queue/store'
 
 const logger = createLogger('WorkspacePermissionsProvider')
+
+/**
+ * Anti-flicker timing for the "Reconnecting..." toast. Socket.IO flips
+ * `isReconnecting` on any disconnect — including sub-second transport hiccups
+ * that recover on the first retry — so we delay surfacing the toast until the
+ * drop has lasted long enough to matter, then hold it on screen long enough to
+ * read. Together these suppress both flicker modes (flash-on and flash-off)
+ * while still alerting on real outages.
+ */
+const RECONNECTING_TOAST_DELAY_MS = 2000
+const RECONNECTING_TOAST_MIN_VISIBLE_MS = 1500
 
 interface PersistentToastOptions {
   description?: string
@@ -115,9 +127,13 @@ export function WorkspacePermissionsProvider({ children }: WorkspacePermissionsP
 
   const isOfflineMode = hasOperationError
   const isJoinBlocked = Boolean(blockedJoinWorkflowId) && blockedJoinWorkflowId === urlWorkflowId
+  const showReconnecting = useStableFlag(isReconnecting, {
+    delayMs: RECONNECTING_TOAST_DELAY_MS,
+    minVisibleMs: RECONNECTING_TOAST_MIN_VISIBLE_MS,
+  })
   const realtimeStatusMessage = isOfflineMode
     ? null
-    : isReconnecting
+    : showReconnecting
       ? 'Reconnecting...'
       : isRetryingWorkflowJoin
         ? 'Joining workflow...'

--- a/apps/sim/hooks/use-stable-flag.test.ts
+++ b/apps/sim/hooks/use-stable-flag.test.ts
@@ -1,0 +1,163 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the `createStableFlagController` state machine behind `useStableFlag`.
+ * The controller is framework-agnostic so the anti-flicker timing can be driven
+ * with fake timers and no DOM; the thin React wrapper is covered by manual QA.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStableFlagController } from '@/hooks/use-stable-flag'
+
+const DELAY_MS = 2000
+const MIN_VISIBLE_MS = 1500
+
+function setup(options = { delayMs: DELAY_MS, minVisibleMs: MIN_VISIBLE_MS }) {
+  const states: boolean[] = []
+  let active = false
+  const controller = createStableFlagController((next) => {
+    active = next
+    states.push(next)
+  }, options)
+  return {
+    controller,
+    states,
+    get active() {
+      return active
+    },
+  }
+}
+
+describe('createStableFlagController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('suppresses a blip that heals before the delay (flash-on)', () => {
+    const { controller, states, active } = setup()
+
+    controller.setValue(true)
+    vi.advanceTimersByTime(DELAY_MS - 1)
+    controller.setValue(false)
+    vi.advanceTimersByTime(10_000)
+
+    expect(states).toEqual([])
+    expect(active).toBe(false)
+  })
+
+  it('does not turn on one tick before the delay boundary', () => {
+    const probe = setup()
+
+    probe.controller.setValue(true)
+    vi.advanceTimersByTime(DELAY_MS - 1)
+
+    expect(probe.active).toBe(false)
+    expect(probe.states).toEqual([])
+  })
+
+  it('turns on exactly at the delay boundary', () => {
+    const probe = setup()
+
+    probe.controller.setValue(true)
+    vi.advanceTimersByTime(DELAY_MS)
+
+    expect(probe.states).toEqual([true])
+    expect(probe.active).toBe(true)
+  })
+
+  it('holds the flag on for the minimum-visible window (flash-off)', () => {
+    const probe = setup()
+
+    probe.controller.setValue(true)
+    vi.advanceTimersByTime(DELAY_MS) // shown
+    expect(probe.active).toBe(true)
+
+    // Value clears almost immediately after showing.
+    vi.advanceTimersByTime(100)
+    probe.controller.setValue(false)
+    expect(probe.active).toBe(true) // still held
+
+    vi.advanceTimersByTime(MIN_VISIBLE_MS - 100 - 1)
+    expect(probe.active).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    expect(probe.active).toBe(false)
+    expect(probe.states).toEqual([true, false])
+  })
+
+  it('clears immediately when the value has already been visible past the minimum', () => {
+    const probe = setup()
+
+    probe.controller.setValue(true)
+    vi.advanceTimersByTime(DELAY_MS)
+    vi.advanceTimersByTime(MIN_VISIBLE_MS + 500) // well past the floor
+    probe.controller.setValue(false)
+
+    expect(probe.active).toBe(false)
+    expect(probe.states).toEqual([true, false])
+  })
+
+  it('keeps the flag on through a flap while held, without re-delaying', () => {
+    const probe = setup()
+
+    probe.controller.setValue(true)
+    vi.advanceTimersByTime(DELAY_MS) // shown
+    probe.controller.setValue(false) // schedules hide
+    vi.advanceTimersByTime(500)
+    probe.controller.setValue(true) // reconnect flaps back before hide fires
+
+    vi.advanceTimersByTime(10_000)
+    expect(probe.active).toBe(true)
+    expect(probe.states).toEqual([true])
+  })
+
+  it('is idempotent on repeated setValue(true) — schedules a single show', () => {
+    const probe = setup()
+
+    probe.controller.setValue(true)
+    vi.advanceTimersByTime(500)
+    probe.controller.setValue(true)
+    probe.controller.setValue(true)
+
+    vi.advanceTimersByTime(DELAY_MS - 500)
+    expect(probe.states).toEqual([true]) // exactly one transition, fired at the original deadline
+  })
+
+  it('dispose cancels a pending show', () => {
+    const probe = setup()
+
+    probe.controller.setValue(true)
+    probe.controller.dispose()
+    vi.advanceTimersByTime(10_000)
+
+    expect(probe.states).toEqual([])
+  })
+
+  it('dispose cancels a pending hide', () => {
+    const probe = setup()
+
+    probe.controller.setValue(true)
+    vi.advanceTimersByTime(DELAY_MS)
+    probe.controller.setValue(false) // schedules hide within min-visible window
+    probe.controller.dispose()
+    vi.advanceTimersByTime(10_000)
+
+    expect(probe.states).toEqual([true]) // hide never fired
+  })
+
+  it('with zero options, mirrors the value on the next tick', () => {
+    const probe = setup({ delayMs: 0, minVisibleMs: 0 })
+
+    probe.controller.setValue(true)
+    vi.advanceTimersByTime(0)
+    expect(probe.active).toBe(true)
+
+    probe.controller.setValue(false)
+    expect(probe.active).toBe(false)
+    expect(probe.states).toEqual([true, false])
+  })
+})

--- a/apps/sim/hooks/use-stable-flag.test.ts
+++ b/apps/sim/hooks/use-stable-flag.test.ts
@@ -38,15 +38,15 @@ describe('createStableFlagController', () => {
   })
 
   it('suppresses a blip that heals before the delay (flash-on)', () => {
-    const { controller, states, active } = setup()
+    const probe = setup()
 
-    controller.setValue(true)
+    probe.controller.setValue(true)
     vi.advanceTimersByTime(DELAY_MS - 1)
-    controller.setValue(false)
+    probe.controller.setValue(false)
     vi.advanceTimersByTime(10_000)
 
-    expect(states).toEqual([])
-    expect(active).toBe(false)
+    expect(probe.states).toEqual([])
+    expect(probe.active).toBe(false)
   })
 
   it('does not turn on one tick before the delay boundary', () => {

--- a/apps/sim/hooks/use-stable-flag.ts
+++ b/apps/sim/hooks/use-stable-flag.ts
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react'
+
+export interface StableFlagOptions {
+  /**
+   * Time `value` must stay continuously true before the flag turns on. Suppresses
+   * brief flashes for blips that heal within the window. Defaults to `0` (no delay).
+   */
+  delayMs?: number
+  /**
+   * Minimum time the flag stays on once shown, even if `value` clears immediately
+   * after. Prevents a flash-and-vanish when `value` is true just past `delayMs`.
+   * Defaults to `0` (clears as soon as `value` does).
+   */
+  minVisibleMs?: number
+}
+
+/**
+ * Framework-agnostic state machine behind {@link useStableFlag}. Extracted so the
+ * anti-flicker timing can be unit-tested with fake timers without a DOM. Relies on
+ * the ambient `setTimeout`/`clearTimeout`/`Date.now`, which fake timers replace.
+ *
+ * `onChange` fires whenever the smoothed flag flips. `setValue` is idempotent — it
+ * is safe to feed it the same value repeatedly (e.g. from React effect re-runs).
+ */
+export function createStableFlagController(
+  onChange: (active: boolean) => void,
+  { delayMs = 0, minVisibleMs = 0 }: StableFlagOptions = {}
+) {
+  let active = false
+  let shownAt: number | null = null
+  let showTimer: ReturnType<typeof setTimeout> | null = null
+  let hideTimer: ReturnType<typeof setTimeout> | null = null
+
+  const clearShow = () => {
+    if (showTimer !== null) {
+      clearTimeout(showTimer)
+      showTimer = null
+    }
+  }
+  const clearHide = () => {
+    if (hideTimer !== null) {
+      clearTimeout(hideTimer)
+      hideTimer = null
+    }
+  }
+
+  const show = () => {
+    showTimer = null
+    shownAt = Date.now()
+    active = true
+    onChange(true)
+  }
+  const hide = () => {
+    hideTimer = null
+    shownAt = null
+    active = false
+    onChange(false)
+  }
+
+  return {
+    setValue(value: boolean) {
+      if (value) {
+        clearHide()
+        if (active || showTimer !== null) {
+          return
+        }
+        showTimer = setTimeout(show, delayMs)
+        return
+      }
+
+      clearShow()
+      if (!active || hideTimer !== null) {
+        return
+      }
+
+      const elapsed = shownAt === null ? minVisibleMs : Date.now() - shownAt
+      const remaining = minVisibleMs - elapsed
+      if (remaining <= 0) {
+        hide()
+        return
+      }
+      hideTimer = setTimeout(hide, remaining)
+    },
+    dispose() {
+      clearShow()
+      clearHide()
+    },
+  }
+}
+
+/**
+ * Anti-flicker boolean. Mirrors `value` but smooths both edges so transient
+ * toggles never produce a visible flash:
+ *
+ * - Rising edge — `value` must hold true for `delayMs` before the flag turns on.
+ * - Falling edge — once on, the flag stays on for at least `minVisibleMs`.
+ *
+ * With both options at `0` it returns `value` unchanged (after a tick). Useful for
+ * connection/loading indicators that would otherwise flicker on sub-second changes.
+ */
+export function useStableFlag(value: boolean, options: StableFlagOptions = {}): boolean {
+  const [active, setActive] = useState(false)
+  const { delayMs = 0, minVisibleMs = 0 } = options
+  const valueRef = useRef(value)
+  valueRef.current = value
+  const controllerRef = useRef<ReturnType<typeof createStableFlagController> | null>(null)
+
+  useEffect(() => {
+    const controller = createStableFlagController(setActive, { delayMs, minVisibleMs })
+    controllerRef.current = controller
+    controller.setValue(valueRef.current)
+    return () => {
+      controller.dispose()
+      controllerRef.current = null
+    }
+  }, [delayMs, minVisibleMs])
+
+  useEffect(() => {
+    controllerRef.current?.setValue(value)
+  }, [value])
+
+  return active
+}

--- a/apps/sim/hooks/use-stable-flag.ts
+++ b/apps/sim/hooks/use-stable-flag.ts
@@ -106,6 +106,12 @@ export function useStableFlag(value: boolean, options: StableFlagOptions = {}): 
   const controllerRef = useRef<ReturnType<typeof createStableFlagController> | null>(null)
 
   useEffect(() => {
+    // Reset to the fresh controller's baseline. Without this, recreating the
+    // controller on an options change while `active` is true and `value` is
+    // already false would strand the React state at true — the new controller
+    // starts internally false, so its `setValue(false)` early-returns and never
+    // emits `onChange(false)`.
+    setActive(false)
     const controller = createStableFlagController(setActive, { delayMs, minVisibleMs })
     controllerRef.current = controller
     controller.setValue(valueRef.current)


### PR DESCRIPTION
## Summary
- The "Reconnecting..." persistent toast fired the **instant** `isReconnecting` flipped true. Socket.IO flips that flag on *any* disconnect — including sub-second transport hiccups that recover on the very first retry (`reconnectionDelay: 1000`) — so a momentary blip flashed a scary alert that vanished a beat later.
- Adds `useStableFlag`, an anti-flicker boolean that smooths **both** edges:
  - **Rising edge** — `value` must stay true for `delayMs` (2000ms) before the flag turns on, so blips that self-heal within the window never surface.
  - **Falling edge** — once shown, the flag holds for at least `minVisibleMs` (1500ms), so a drop that lasts just past the delay doesn't flash-and-vanish.
- The socket flag itself stays accurate; only the user-facing alarm is smoothed (the correct layer for the grace period).
- State machine extracted into a framework-agnostic controller (`createStableFlagController`) and covered by 10 unit tests: both flicker modes, genuine outage, mid-hold flap (reconnect bouncing during the hold window), idempotent re-feeds, and dispose cancellation.

## Why this is the canonical pattern (not a hack)
This is the textbook **anti-flicker** fix for connection indicators, confirmed from two angles:
- **Socket.IO's own model treats transient drops as transparent** — the client "will automatically try to reconnect after a small delay," and `socket.active` exists precisely to distinguish *temporary* (self-healing) from *terminal* failures. Delaying the UI aligns with that intent rather than papering over it. → https://socket.io/docs/v4/tutorial/handling-disconnections
- **The entry-delay + minimum-visible-duration pairing** is the established anti-flicker indicator pattern (delay before show kills flash-on; minimum on-screen time kills flash-off). → https://github.com/frysztak/use-debounced-loader

Complementary / out of scope (noted for reviewers): Socket.IO **connection state recovery** addresses *data* continuity across drops (missed events), not the UI alarm — a separate concern from this change. → https://socket.io/docs/v4/connection-state-recovery

## Type of Change
- [x] Bug fix

## Testing
- 10 unit tests on the `createStableFlagController` state machine (fake timers, no DOM) covering both flicker modes, genuine outage, mid-hold flap, idempotency, and dispose — all passing.
- Manually exercised in a real browser (forged session + Chrome network throttling): a sub-second blip surfaced **no** toast (correct).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
