### PR TITLE
improvement(knowledge): align connected-sources rows and move source chip left of filter/sort

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
@@ -114,63 +114,67 @@ export const ResourceOptions = memo(function ResourceOptions({
 
   return (
     <div className={cn('border-[var(--border)] border-b py-2.5', search ? 'px-6' : 'px-4')}>
-      <div className='flex items-center justify-between'>
+      <div className='flex items-center'>
         {search && <SearchSection search={search} />}
-        {aside && <div className='flex shrink-0 items-center gap-1.5'>{aside}</div>}
-        <div className='flex items-center'>
-          {filterTags?.map((tag) => (
-            <Chip key={tag.label} rightIcon={X} onClick={tag.onRemove}>
-              {tag.label}
-            </Chip>
-          ))}
-          {isToggleFilter && filter.mode === 'toggle' ? (
-            <Chip active={filter.active} leftIcon={ListFilter} onClick={filter.onToggle}>
-              Filter
-            </Chip>
-          ) : popoverFilter ? (
-            <PopoverPrimitive.Root
-              open={openMenu === 'filter'}
-              onOpenChange={(open) =>
-                setOpenMenu((current) => (open ? 'filter' : current === 'filter' ? null : current))
-              }
-            >
-              <PopoverPrimitive.Anchor asChild>
-                <div className='flex items-center'>
-                  <PopoverPrimitive.Trigger asChild>
-                    <Chip active={popoverFilter.active} leftIcon={ListFilter}>
-                      Filter
-                    </Chip>
-                  </PopoverPrimitive.Trigger>
-                  {sort && (
-                    <SortDropdown
-                      config={sort}
-                      open={openMenu === 'sort'}
-                      onOpenChange={(open) =>
-                        setOpenMenu((current) =>
-                          open ? 'sort' : current === 'sort' ? null : current
-                        )
-                      }
-                    />
-                  )}
-                </div>
-              </PopoverPrimitive.Anchor>
-              <PopoverPrimitive.Portal>
-                <PopoverPrimitive.Content
-                  align='end'
-                  alignOffset={RESOURCE_MENU_EDGE_OFFSET}
-                  collisionPadding={6}
-                  sideOffset={6}
-                  className={cn(
-                    POPOVER_ANIMATION_CLASSES,
-                    'z-50 w-fit origin-[--radix-popover-content-transform-origin] rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm'
-                  )}
-                >
-                  {popoverFilter.content}
-                </PopoverPrimitive.Content>
-              </PopoverPrimitive.Portal>
-            </PopoverPrimitive.Root>
-          ) : null}
-          {sort && (isToggleFilter || !popoverFilter) && <SortDropdown config={sort} />}
+        <div className='ml-auto flex shrink-0 items-center gap-1.5'>
+          {aside}
+          <div className='flex items-center'>
+            {filterTags?.map((tag) => (
+              <Chip key={tag.label} rightIcon={X} onClick={tag.onRemove}>
+                {tag.label}
+              </Chip>
+            ))}
+            {isToggleFilter && filter.mode === 'toggle' ? (
+              <Chip active={filter.active} leftIcon={ListFilter} onClick={filter.onToggle}>
+                Filter
+              </Chip>
+            ) : popoverFilter ? (
+              <PopoverPrimitive.Root
+                open={openMenu === 'filter'}
+                onOpenChange={(open) =>
+                  setOpenMenu((current) =>
+                    open ? 'filter' : current === 'filter' ? null : current
+                  )
+                }
+              >
+                <PopoverPrimitive.Anchor asChild>
+                  <div className='flex items-center'>
+                    <PopoverPrimitive.Trigger asChild>
+                      <Chip active={popoverFilter.active} leftIcon={ListFilter}>
+                        Filter
+                      </Chip>
+                    </PopoverPrimitive.Trigger>
+                    {sort && (
+                      <SortDropdown
+                        config={sort}
+                        open={openMenu === 'sort'}
+                        onOpenChange={(open) =>
+                          setOpenMenu((current) =>
+                            open ? 'sort' : current === 'sort' ? null : current
+                          )
+                        }
+                      />
+                    )}
+                  </div>
+                </PopoverPrimitive.Anchor>
+                <PopoverPrimitive.Portal>
+                  <PopoverPrimitive.Content
+                    align='end'
+                    alignOffset={RESOURCE_MENU_EDGE_OFFSET}
+                    collisionPadding={6}
+                    sideOffset={6}
+                    className={cn(
+                      POPOVER_ANIMATION_CLASSES,
+                      'z-50 w-fit origin-[--radix-popover-content-transform-origin] rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm'
+                    )}
+                  >
+                    {popoverFilter.content}
+                  </PopoverPrimitive.Content>
+                </PopoverPrimitive.Portal>
+              </PopoverPrimitive.Root>
+            ) : null}
+            {sort && (isToggleFilter || !popoverFilter) && <SortDropdown config={sort} />}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
@@ -83,11 +83,18 @@ interface ResourceOptionsProps {
   filter?: FilterConfig
   filterTags?: FilterTag[]
   /**
+   * Lightweight control rendered immediately to the LEFT of the filter/sort
+   * cluster (still right-aligned after the search) — e.g. the knowledge view's
+   * connected-source badge, which reads as part of the control row. Use this for
+   * controls that belong alongside filter/sort; use {@link aside} for status
+   * widgets that should sit at the far right edge.
+   */
+  leading?: ReactNode
+  /**
    * Supplementary right-aligned slot (pushed opposite the left-aligned
    * filter/sort via `justify-between`) for lightweight status content — e.g.
-   * the knowledge list's connector badges or the table editor's run/stop
-   * control in embedded mode. Keep it to badges/status widgets; primary
-   * actions belong in the header's `actions`, not here.
+   * the table editor's run/stop control in embedded mode. Keep it to
+   * badges/status widgets; primary actions belong in the header's `actions`.
    */
   aside?: ReactNode
 }
@@ -97,6 +104,7 @@ export const ResourceOptions = memo(function ResourceOptions({
   sort,
   filter,
   filterTags,
+  leading,
   aside,
 }: ResourceOptionsProps) {
   /**
@@ -110,13 +118,15 @@ export const ResourceOptions = memo(function ResourceOptions({
   const isToggleFilter = filter?.mode === 'toggle'
   const popoverFilter = filter && filter.mode !== 'toggle' ? filter : null
 
-  const hasContent = search || sort || filter || aside || (filterTags && filterTags.length > 0)
+  const hasContent =
+    search || sort || filter || leading || aside || (filterTags && filterTags.length > 0)
   if (!hasContent) return null
 
   return (
     <div className={cn('border-[var(--border)] border-b py-2.5', search ? 'px-6' : 'px-4')}>
       <div className='flex items-center justify-between'>
         {search && <SearchSection search={search} />}
+        {leading && <div className='flex shrink-0 items-center gap-1.5'>{leading}</div>}
         <div className='flex items-center'>
           {filterTags?.map((tag) => (
             <Chip key={tag.label} rightIcon={X} onClick={tag.onRemove}>

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
@@ -84,17 +84,9 @@ interface ResourceOptionsProps {
   filterTags?: FilterTag[]
   /**
    * Lightweight control rendered immediately to the LEFT of the filter/sort
-   * cluster (still right-aligned after the search) — e.g. the knowledge view's
-   * connected-source badge, which reads as part of the control row. Use this for
-   * controls that belong alongside filter/sort; use {@link aside} for status
-   * widgets that should sit at the far right edge.
-   */
-  leading?: ReactNode
-  /**
-   * Supplementary right-aligned slot (pushed opposite the left-aligned
-   * filter/sort via `justify-between`) for lightweight status content — e.g.
-   * the table editor's run/stop control in embedded mode. Keep it to
-   * badges/status widgets; primary actions belong in the header's `actions`.
+   * cluster (right-aligned after the search) — e.g. the knowledge view's
+   * connected-source badge or the table editor's embedded run/stop control. Keep
+   * it to badges/status widgets; primary actions belong in the header's `actions`.
    */
   aside?: ReactNode
 }
@@ -104,7 +96,6 @@ export const ResourceOptions = memo(function ResourceOptions({
   sort,
   filter,
   filterTags,
-  leading,
   aside,
 }: ResourceOptionsProps) {
   /**
@@ -118,15 +109,14 @@ export const ResourceOptions = memo(function ResourceOptions({
   const isToggleFilter = filter?.mode === 'toggle'
   const popoverFilter = filter && filter.mode !== 'toggle' ? filter : null
 
-  const hasContent =
-    search || sort || filter || leading || aside || (filterTags && filterTags.length > 0)
+  const hasContent = search || sort || filter || aside || (filterTags && filterTags.length > 0)
   if (!hasContent) return null
 
   return (
     <div className={cn('border-[var(--border)] border-b py-2.5', search ? 'px-6' : 'px-4')}>
       <div className='flex items-center justify-between'>
         {search && <SearchSection search={search} />}
-        {leading && <div className='flex shrink-0 items-center gap-1.5'>{leading}</div>}
+        {aside && <div className='flex shrink-0 items-center gap-1.5'>{aside}</div>}
         <div className='flex items-center'>
           {filterTags?.map((tag) => (
             <Chip key={tag.label} rightIcon={X} onClick={tag.onRemove}>
@@ -182,7 +172,6 @@ export const ResourceOptions = memo(function ResourceOptions({
           ) : null}
           {sort && (isToggleFilter || !popoverFilter) && <SortDropdown config={sort} />}
         </div>
-        {aside && <div className='flex shrink-0 items-center gap-1.5'>{aside}</div>}
       </div>
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
@@ -84,9 +84,10 @@ interface ResourceOptionsProps {
   filterTags?: FilterTag[]
   /**
    * Lightweight control rendered immediately to the LEFT of the filter/sort
-   * cluster (right-aligned after the search) — e.g. the knowledge view's
-   * connected-source badge or the table editor's embedded run/stop control. Keep
-   * it to badges/status widgets; primary actions belong in the header's `actions`.
+   * cluster; the two form one right-aligned group, with or without a search —
+   * e.g. the knowledge view's connected-source badge or the table editor's
+   * embedded run/stop control. Keep it to badges/status widgets; primary actions
+   * belong in the header's `actions`.
    */
   aside?: ReactNode
 }

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -1154,7 +1154,7 @@ export function KnowledgeBase({
           sort={sortConfig}
           filter={filterContent ? { content: filterContent } : undefined}
           filterTags={filterTags}
-          leading={connectorBadges}
+          aside={connectorBadges}
         />
         <Resource.Table
           columns={DOCUMENT_COLUMNS}

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -1154,7 +1154,7 @@ export function KnowledgeBase({
           sort={sortConfig}
           filter={filterContent ? { content: filterContent } : undefined}
           filterTags={filterTags}
-          aside={connectorBadges}
+          leading={connectorBadges}
         />
         <Resource.Table
           columns={DOCUMENT_COLUMNS}

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connectors-section/connectors-section.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connectors-section/connectors-section.tsx
@@ -202,7 +202,7 @@ export function ConnectorsSection({
           No connected sources yet. Connect an external source to automatically sync documents.
         </p>
       ) : (
-        <div className='-mx-2 mt-2 flex flex-col gap-0.5'>
+        <div className='mt-2 flex flex-col gap-0.5'>
           {connectors.map((connector) => (
             <ConnectorCard
               key={connector.id}

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/table.tsx
@@ -640,9 +640,9 @@ export function Table({
           }
         />
       )}
-      {/* Sort + filter render in both modes (left-aligned). In embedded (mothership)
-          mode there's no Resource.Header, so the run/stop control rides in the options
-          bar's right-aligned `aside` slot — opposite the left-aligned filter/sort. */}
+      {/* Sort + filter render in both modes. In embedded (mothership) mode there's no
+          Resource.Header, so the run/stop control rides in the options bar's `aside`
+          slot, just left of filter/sort. */}
       <Resource.Options
         sort={sortConfig}
         filter={filterConfig}


### PR DESCRIPTION
## Summary
- Drop the `-mx-2` on the connectors list so rows respect the `ChipModalBody` gutter — the connected-source row hover no longer bleeds to the modal edges, and row content lines up with the `px-4` header (matching the integrations row pattern).
- Add a `leading` slot to `ResourceOptions` (rendered left of the filter/sort cluster) and render the knowledge connected-source chip there instead of the far-right `aside`, so it reads as part of the control row. `aside` stays right-aligned for the table editor's run/stop control (which intentionally sits opposite filter/sort).

## Type of Change
- [x] Improvement

## Testing
Tested manually. `tsc` + `biome` clean. Token-level alignment verified against the integrations row/icon-tile patterns.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)