### PR TITLE
fix(azure): use Azure icon for Azure DevOps connector and remove AzureDevOpsIcon

### DIFF
--- a/apps/sim/components/icons.tsx
+++ b/apps/sim/components/icons.tsx
@@ -3396,36 +3396,6 @@ export function AzureIcon(props: SVGProps<SVGSVGElement>) {
   )
 }
 
-export function AzureDevOpsIcon(props: SVGProps<SVGSVGElement>) {
-  const id = useId()
-  const gradientId = `azure_devops_gradient_${id}`
-  return (
-    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128' {...props}>
-      <defs>
-        <linearGradient
-          id={gradientId}
-          gradientUnits='userSpaceOnUse'
-          x1='9'
-          y1='16.97'
-          x2='9'
-          y2='1.03'
-          gradientTransform='scale(7.11111)'
-        >
-          <stop offset='0' stopColor='#0078d4' />
-          <stop offset='.16' stopColor='#1380da' />
-          <stop offset='.53' stopColor='#3c91e5' />
-          <stop offset='.82' stopColor='#559cec' />
-          <stop offset='1' stopColor='#5ea0ef' />
-        </linearGradient>
-      </defs>
-      <path
-        fill={`url(#${gradientId})`}
-        d='M120.89 28.445v69.262l-28.445 23.324-44.09-16.07v15.93L23.395 88.25l72.746 5.688V31.574ZM96.64 31.93 55.82 7.11v16.285L18.348 34.418 7.109 48.852v32.785l16.075 7.11V46.718Zm0 0'
-      />
-    </svg>
-  )
-}
-
 export const GroqIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     {...props}

--- a/apps/sim/connectors/azure-devops/meta.ts
+++ b/apps/sim/connectors/azure-devops/meta.ts
@@ -1,4 +1,4 @@
-import { AzureDevOpsIcon } from '@/components/icons'
+import { AzureIcon } from '@/components/icons'
 import type { ConnectorMeta } from '@/connectors/types'
 
 export const azureDevopsConnectorMeta: ConnectorMeta = {
@@ -7,7 +7,7 @@ export const azureDevopsConnectorMeta: ConnectorMeta = {
   description:
     'Sync wiki pages, work items, and repository files from an Azure DevOps project into your knowledge base',
   version: '1.1.0',
-  icon: AzureDevOpsIcon,
+  icon: AzureIcon,
 
   auth: {
     mode: 'apiKey',

--- a/apps/sim/connectors/utils.test.ts
+++ b/apps/sim/connectors/utils.test.ts
@@ -18,12 +18,12 @@ vi.mock('@/components/icons', () => ({
   JiraServiceManagementIcon: () => null,
   S3Icon: () => null,
   GoogleFormsIcon: () => null,
-  AzureDevOpsIcon: () => null,
   xIcon: () => null,
   GranolaIcon: () => null,
   GreenhouseIcon: () => null,
   FathomIcon: () => null,
   RootlyIcon: () => null,
+  AzureIcon: () => null,
 }))
 vi.mock('@/lib/knowledge/documents/utils', () => ({
   fetchWithRetry: vi.fn(),

--- a/apps/sim/triggers/azure_devops/build_failed.ts
+++ b/apps/sim/triggers/azure_devops/build_failed.ts
@@ -1,4 +1,4 @@
-import { AzureDevOpsIcon } from '@/components/icons'
+import { AzureIcon } from '@/components/icons'
 import { buildTriggerSubBlocks } from '@/triggers'
 import {
   azureDevOpsTriggerOptions,
@@ -14,7 +14,7 @@ export const azureDevOpsBuildFailedTrigger: TriggerConfig = {
   description:
     'Trigger workflow when an Azure DevOps build fails, is canceled, or partially succeeds',
   version: '1.0.0',
-  icon: AzureDevOpsIcon,
+  icon: AzureIcon,
 
   subBlocks: buildTriggerSubBlocks({
     triggerId: 'azure_devops_build_failed',

--- a/apps/sim/triggers/azure_devops/webhook.ts
+++ b/apps/sim/triggers/azure_devops/webhook.ts
@@ -1,4 +1,4 @@
-import { AzureDevOpsIcon } from '@/components/icons'
+import { AzureIcon } from '@/components/icons'
 import { buildTriggerSubBlocks } from '@/triggers'
 import {
   azureDevOpsTriggerOptions,
@@ -18,7 +18,7 @@ export const azureDevOpsWebhookTrigger: TriggerConfig = {
   description:
     'Trigger on whichever service hook event types you configure in Azure DevOps. Sim does not filter deliveries for this trigger.',
   version: '1.0.0',
-  icon: AzureDevOpsIcon,
+  icon: AzureIcon,
 
   subBlocks: buildTriggerSubBlocks({
     triggerId: 'azure_devops_webhook',

--- a/apps/sim/triggers/azure_devops/work_item_created.ts
+++ b/apps/sim/triggers/azure_devops/work_item_created.ts
@@ -1,4 +1,4 @@
-import { AzureDevOpsIcon } from '@/components/icons'
+import { AzureIcon } from '@/components/icons'
 import { buildTriggerSubBlocks } from '@/triggers'
 import {
   azureDevOpsTriggerOptions,
@@ -13,7 +13,7 @@ export const azureDevOpsWorkItemCreatedTrigger: TriggerConfig = {
   provider: 'azure_devops',
   description: 'Trigger workflow when a work item is created in Azure DevOps',
   version: '1.0.0',
-  icon: AzureDevOpsIcon,
+  icon: AzureIcon,
 
   subBlocks: buildTriggerSubBlocks({
     triggerId: 'azure_devops_work_item_created',


### PR DESCRIPTION
## Summary
- Replaced the Azure DevOps icon with the Azure icon on the Azure DevOps knowledge base connector
- Removed `AzureDevOpsIcon` entirely; repointed the three Azure DevOps triggers to `AzureIcon`
- Updated the icon mock in `connectors/utils.test.ts`

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)