### PR TITLE
fix(resource): left-align table filter/sort when there's no search bar

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
@@ -84,10 +84,11 @@ interface ResourceOptionsProps {
   filterTags?: FilterTag[]
   /**
    * Lightweight control rendered immediately to the LEFT of the filter/sort
-   * cluster; the two form one right-aligned group, with or without a search —
-   * e.g. the knowledge view's connected-source badge or the table editor's
-   * embedded run/stop control. Keep it to badges/status widgets; primary actions
-   * belong in the header's `actions`.
+   * cluster, forming one group with it — e.g. the knowledge view's
+   * connected-source badge or the table editor's embedded run/stop control. With
+   * a search the group is pushed right (opposite the search); without one it
+   * stays left-aligned (the embedded table editor). Keep it to badges/status
+   * widgets; primary actions belong in the header's `actions`.
    */
   aside?: ReactNode
 }
@@ -117,7 +118,7 @@ export const ResourceOptions = memo(function ResourceOptions({
     <div className={cn('border-[var(--border)] border-b py-2.5', search ? 'px-6' : 'px-4')}>
       <div className='flex items-center'>
         {search && <SearchSection search={search} />}
-        <div className='ml-auto flex shrink-0 items-center gap-1.5'>
+        <div className={cn('flex shrink-0 items-center gap-1.5', search && 'ml-auto')}>
           {aside}
           <div className='flex items-center'>
             {filterTags?.map((tag) => (


### PR DESCRIPTION
## Summary
- #5117 wrapped the options-bar \`aside + filter/sort\` cluster in an unconditional \`ml-auto\`, which right-aligned the embedded table editor's filter/sort — that view has no search bar, so the controls used to sit left-aligned.
- Only push the group right when a search occupies the left edge; without a search it stays left-aligned (the embedded table editor). All list pages (knowledge/tables/logs/files) have a search, so they're unchanged.
- Updated the \`aside\` doc comment to match.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. \`bun run lint\` and \`bun run check:api-validation:strict\` clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)