### PR TITLE
fix:shortcut for changing hand and cursor mode

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
@@ -96,12 +96,12 @@ export const COMMAND_DEFINITIONS: Record<CommandId, CommandDefinition> = {
   },
   'set-canvas-mode-pointer': {
     id: 'set-canvas-mode-pointer',
-    shortcut: 'Shift+P',
+    shortcut: 'P',
     allowInEditable: false,
   },
   'set-canvas-mode-mover': {
     id: 'set-canvas-mode-mover',
-    shortcut: 'Shift+M',
+    shortcut: 'M',
     allowInEditable: false,
   },
 }

--- a/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
@@ -17,6 +17,8 @@ export type CommandId =
   | 'clear-terminal-console'
   | 'focus-toolbar-search'
   | 'fit-to-view'
+  | 'set-canvas-mode-pointer'
+  | 'set-canvas-mode-mover'
 
 /**
  * Static metadata for a global command.
@@ -90,6 +92,16 @@ export const COMMAND_DEFINITIONS: Record<CommandId, CommandDefinition> = {
   'fit-to-view': {
     id: 'fit-to-view',
     shortcut: 'Mod+Shift+F',
+    allowInEditable: false,
+  },
+  'set-canvas-mode-pointer': {
+    id: 'set-canvas-mode-pointer',
+    shortcut: 'Shift+P',
+    allowInEditable: false,
+  },
+  'set-canvas-mode-mover': {
+    id: 'set-canvas-mode-mover',
+    shortcut: 'Shift+M',
     allowInEditable: false,
   },
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-controls/workflow-controls.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-controls/workflow-controls.tsx
@@ -61,6 +61,14 @@ export const WorkflowControls = memo(function WorkflowControls() {
       id: 'fit-to-view',
       handler: handleFitToView,
     }),
+    createCommand({
+      id: 'set-canvas-mode-pointer',
+      handler: () => setMode('cursor'),
+    }),
+    createCommand({
+      id: 'set-canvas-mode-mover',
+      handler: () => setMode('hand'),
+    }),
   ])
 
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
@@ -118,7 +126,11 @@ export const WorkflowControls = memo(function WorkflowControls() {
                 </Button>
               </div>
             </PopoverTrigger>
-            <Tooltip.Content side='top'>{mode === 'hand' ? 'Mover' : 'Pointer'}</Tooltip.Content>
+            <Tooltip.Content side='top'>
+              <Tooltip.Shortcut keys={mode === 'hand' ? 'M' : 'P'}>
+                {mode === 'hand' ? 'Mover' : 'Pointer'}
+              </Tooltip.Shortcut>
+            </Tooltip.Content>
           </Tooltip.Root>
           <PopoverContent side='top' sideOffset={8} maxWidth={100} minWidth={100}>
             <PopoverItem
@@ -128,7 +140,10 @@ export const WorkflowControls = memo(function WorkflowControls() {
               }}
             >
               <Hand className='size-3' />
-              <span>Mover</span>
+              <div className='flex items-center gap-2 '>
+                <span>Mover</span>
+                <span className='opacity-70'>M</span>
+              </div>
             </PopoverItem>
             <PopoverItem
               onClick={() => {
@@ -137,7 +152,10 @@ export const WorkflowControls = memo(function WorkflowControls() {
               }}
             >
               <Cursor className='size-3' />
-              <span>Pointer</span>
+              <div className=' flex items-center gap-2 '>
+                <span>Pointer</span>
+                <span className='opacity-70'>P</span>
+              </div>
             </PopoverItem>
           </PopoverContent>
         </Popover>


### PR DESCRIPTION
Adds keyboard shortcuts for switching canvas modes and updates the matching UI labels.

- `P` → switch to Pointer (cursor)  mode
- `M` → switch to Mover (hand) mode

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ______

## Testing
- Verified the new commands are registered in `COMMAND_DEFINITIONS`.
- Confirmed `workflow-controls.tsx` calls `setMode('cursor')` / `setMode('hand')` from the handlers.
- Shortcuts are set with `allowInEditable: false`, so they won't fire while typing in inputs/textareas.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](/CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
before :
https://github.com/user-attachments/assets/dc64c564-56ad-49d8-b3bc-43757b3ae633

after : 

https://github.com/user-attachments/assets/c31ac5ee-4e06-4d4e-a4a7-6cda72e504a3

