### PR TITLE
fix(icypeas): surface submit-time validationErrors as a descriptive error

### DIFF
--- a/apps/sim/tools/icypeas-hosting.test.ts
+++ b/apps/sim/tools/icypeas-hosting.test.ts
@@ -147,6 +147,71 @@ describe('Icypeas transformResponse validation errors', () => {
       } as any)
     ).rejects.toThrow(/item _id/)
   })
+
+  it('verify-email throws on a bare success:false body without validationErrors', async () => {
+    const response = new Response(JSON.stringify({ success: false }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    await expect(
+      icypeasVerifyEmailTool.transformResponse!(response, {
+        apiKey: 'test-key',
+        email: 'jane@example.com',
+      } as any)
+    ).rejects.toThrow(/item _id/)
+  })
+})
+
+describe('Icypeas postProcess on BAD_INPUT', () => {
+  it('verify-email returns the BAD_INPUT verdict without polling or throwing', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await icypeasVerifyEmailTool.postProcess!(
+      {
+        success: true as const,
+        output: {
+          searchId: null,
+          status: 'BAD_INPUT',
+          email: 'support@stripe.com',
+          valid: false,
+          item: {},
+        },
+      } as any,
+      { apiKey: 'test-key', email: 'support@stripe.com' } as any,
+      vi.fn()
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.success).toBe(true)
+    expect((result.output as any).status).toBe('BAD_INPUT')
+  })
+
+  it('find-email returns the BAD_INPUT verdict without polling or throwing', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await icypeasFindEmailTool.postProcess!(
+      {
+        success: true as const,
+        output: {
+          searchId: null,
+          status: 'BAD_INPUT',
+          email: null,
+          firstname: null,
+          lastname: null,
+          item: {},
+        },
+      } as any,
+      { apiKey: 'test-key', domainOrCompany: 'stripe.com' } as any,
+      vi.fn()
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.success).toBe(true)
+    expect((result.output as any).status).toBe('BAD_INPUT')
+  })
 })
 
 describe('Icypeas find-email postProcess poll', () => {

--- a/apps/sim/tools/icypeas-hosting.test.ts
+++ b/apps/sim/tools/icypeas-hosting.test.ts
@@ -84,54 +84,60 @@ describe('Icypeas verify-email pricing', () => {
 })
 
 describe('Icypeas transformResponse validation errors', () => {
-  it('verify-email maps a 200 validationErrors body to a BAD_INPUT verdict', async () => {
-    const response = new Response(
-      JSON.stringify({
-        success: false,
-        validationErrors: [
-          { expected: 'email', type: 'required', field: 'email', message: 'validation_required' },
-        ],
-      }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    )
-
-    const result = await icypeasVerifyEmailTool.transformResponse!(response, {
-      apiKey: 'test-key',
-      email: 'support@stripe.com',
-    } as any)
-
-    expect(result.success).toBe(true)
-    expect((result.output as any).status).toBe('BAD_INPUT')
-    expect((result.output as any).valid).toBe(false)
-    expect((result.output as any).email).toBe('support@stripe.com')
-    expect((result.output as any).searchId).toBeNull()
-  })
-
-  it('find-email maps a 200 validationErrors body to a BAD_INPUT verdict', async () => {
+  it('verify-email throws the human-readable reason on a 200 validationErrors body', async () => {
     const response = new Response(
       JSON.stringify({
         success: false,
         validationErrors: [
           {
-            expected: 'string',
-            type: 'required',
-            field: 'domainOrCompany',
-            message: 'validation_required',
+            field: 'type',
+            message: 'insufficient_credits',
+            humanReadableMessage: 'Insufficient credits to run the search',
+            type: 'InsufficientCredits',
           },
         ],
       }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }
     )
 
-    const result = await icypeasFindEmailTool.transformResponse!(response, {
-      apiKey: 'test-key',
-      domainOrCompany: 'stripe.com',
-    } as any)
+    await expect(icypeasVerifyEmailTool.transformResponse!(response)).rejects.toThrow(
+      /Insufficient credits to run the search/
+    )
+  })
 
-    expect(result.success).toBe(true)
-    expect((result.output as any).status).toBe('BAD_INPUT')
-    expect((result.output as any).email).toBeNull()
-    expect((result.output as any).searchId).toBeNull()
+  it('find-email throws the human-readable reason on a 200 validationErrors body', async () => {
+    const response = new Response(
+      JSON.stringify({
+        success: false,
+        validationErrors: [
+          {
+            field: 'type',
+            message: 'insufficient_credits',
+            humanReadableMessage: 'Insufficient credits to run the search',
+            type: 'InsufficientCredits',
+          },
+        ],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+
+    await expect(icypeasFindEmailTool.transformResponse!(response)).rejects.toThrow(
+      /Insufficient credits to run the search/
+    )
+  })
+
+  it('verify-email falls back to message when humanReadableMessage is absent', async () => {
+    const response = new Response(
+      JSON.stringify({
+        success: false,
+        validationErrors: [{ field: 'email', message: 'validation_required' }],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+
+    await expect(icypeasVerifyEmailTool.transformResponse!(response)).rejects.toThrow(
+      /validation_required/
+    )
   })
 
   it('verify-email still throws when a success body has no item _id', async () => {
@@ -140,77 +146,7 @@ describe('Icypeas transformResponse validation errors', () => {
       headers: { 'Content-Type': 'application/json' },
     })
 
-    await expect(
-      icypeasVerifyEmailTool.transformResponse!(response, {
-        apiKey: 'test-key',
-        email: 'jane@example.com',
-      } as any)
-    ).rejects.toThrow(/item _id/)
-  })
-
-  it('verify-email throws on a bare success:false body without validationErrors', async () => {
-    const response = new Response(JSON.stringify({ success: false }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    })
-
-    await expect(
-      icypeasVerifyEmailTool.transformResponse!(response, {
-        apiKey: 'test-key',
-        email: 'jane@example.com',
-      } as any)
-    ).rejects.toThrow(/item _id/)
-  })
-})
-
-describe('Icypeas postProcess on BAD_INPUT', () => {
-  it('verify-email returns the BAD_INPUT verdict without polling or throwing', async () => {
-    const fetchMock = vi.fn()
-    vi.stubGlobal('fetch', fetchMock)
-
-    const result = await icypeasVerifyEmailTool.postProcess!(
-      {
-        success: true as const,
-        output: {
-          searchId: null,
-          status: 'BAD_INPUT',
-          email: 'support@stripe.com',
-          valid: false,
-          item: {},
-        },
-      } as any,
-      { apiKey: 'test-key', email: 'support@stripe.com' } as any,
-      vi.fn()
-    )
-
-    expect(fetchMock).not.toHaveBeenCalled()
-    expect(result.success).toBe(true)
-    expect((result.output as any).status).toBe('BAD_INPUT')
-  })
-
-  it('find-email returns the BAD_INPUT verdict without polling or throwing', async () => {
-    const fetchMock = vi.fn()
-    vi.stubGlobal('fetch', fetchMock)
-
-    const result = await icypeasFindEmailTool.postProcess!(
-      {
-        success: true as const,
-        output: {
-          searchId: null,
-          status: 'BAD_INPUT',
-          email: null,
-          firstname: null,
-          lastname: null,
-          item: {},
-        },
-      } as any,
-      { apiKey: 'test-key', domainOrCompany: 'stripe.com' } as any,
-      vi.fn()
-    )
-
-    expect(fetchMock).not.toHaveBeenCalled()
-    expect(result.success).toBe(true)
-    expect((result.output as any).status).toBe('BAD_INPUT')
+    await expect(icypeasVerifyEmailTool.transformResponse!(response)).rejects.toThrow(/item _id/)
   })
 })
 

--- a/apps/sim/tools/icypeas-hosting.test.ts
+++ b/apps/sim/tools/icypeas-hosting.test.ts
@@ -83,6 +83,72 @@ describe('Icypeas verify-email pricing', () => {
   })
 })
 
+describe('Icypeas transformResponse validation errors', () => {
+  it('verify-email maps a 200 validationErrors body to a BAD_INPUT verdict', async () => {
+    const response = new Response(
+      JSON.stringify({
+        success: false,
+        validationErrors: [
+          { expected: 'email', type: 'required', field: 'email', message: 'validation_required' },
+        ],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+
+    const result = await icypeasVerifyEmailTool.transformResponse!(response, {
+      apiKey: 'test-key',
+      email: 'support@stripe.com',
+    } as any)
+
+    expect(result.success).toBe(true)
+    expect((result.output as any).status).toBe('BAD_INPUT')
+    expect((result.output as any).valid).toBe(false)
+    expect((result.output as any).email).toBe('support@stripe.com')
+    expect((result.output as any).searchId).toBeNull()
+  })
+
+  it('find-email maps a 200 validationErrors body to a BAD_INPUT verdict', async () => {
+    const response = new Response(
+      JSON.stringify({
+        success: false,
+        validationErrors: [
+          {
+            expected: 'string',
+            type: 'required',
+            field: 'domainOrCompany',
+            message: 'validation_required',
+          },
+        ],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+
+    const result = await icypeasFindEmailTool.transformResponse!(response, {
+      apiKey: 'test-key',
+      domainOrCompany: 'stripe.com',
+    } as any)
+
+    expect(result.success).toBe(true)
+    expect((result.output as any).status).toBe('BAD_INPUT')
+    expect((result.output as any).email).toBeNull()
+    expect((result.output as any).searchId).toBeNull()
+  })
+
+  it('verify-email still throws when a success body has no item _id', async () => {
+    const response = new Response(JSON.stringify({ success: true, item: {} }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    await expect(
+      icypeasVerifyEmailTool.transformResponse!(response, {
+        apiKey: 'test-key',
+        email: 'jane@example.com',
+      } as any)
+    ).rejects.toThrow(/item _id/)
+  })
+})
+
 describe('Icypeas find-email postProcess poll', () => {
   it('polls the results endpoint until terminal status and returns the email', async () => {
     vi.useFakeTimers()

--- a/apps/sim/tools/icypeas/find_email.ts
+++ b/apps/sim/tools/icypeas/find_email.ts
@@ -112,25 +112,18 @@ export const icypeasFindEmailTool: ToolConfig<IcypeasFindEmailParams, IcypeasFin
       throw new Error(`Icypeas API error: ${response.status} - ${errorText}`)
     }
     const json = (await response.json()) as Record<string, unknown>
-    // Icypeas returns HTTP 200 with { success: false, validationErrors: [...] } when
-    // it rejects the input up front (missing/invalid name or domain). There is no item
-    // to poll — this is a BAD_INPUT verdict, not a transport error. Surface it as a
-    // successful run with a null email so the enrichment cascade records the verdict
-    // instead of inflating the runner's error count. Key on a non-empty validationErrors
-    // array specifically: a bare { success: false } is an unexpected failure shape that
-    // should fall through and throw, not be masked as BAD_INPUT.
-    if (Array.isArray(json.validationErrors) && json.validationErrors.length > 0) {
-      return {
-        success: true,
-        output: {
-          searchId: null,
-          status: 'BAD_INPUT',
-          email: null,
-          firstname: null,
-          lastname: null,
-          item: json,
-        },
-      }
+    // Icypeas signals submit-time failures as HTTP 200 { success: false, validationErrors: [...] }
+    // — malformed input, insufficient credits, rate limits, etc. None of these are a
+    // search verdict (those only come from polling), so fail fast with the human-readable
+    // reason rather than a cryptic missing-_id error or a fabricated empty result.
+    const validationErrors = json.validationErrors
+    if (Array.isArray(validationErrors) && validationErrors.length > 0) {
+      const first = validationErrors[0] as Record<string, unknown> | undefined
+      const reason =
+        (first?.humanReadableMessage as string | undefined) ??
+        (first?.message as string | undefined) ??
+        'validation error'
+      throw new Error(`Icypeas email-search rejected the request: ${reason}`)
     }
     // Submit response: { success: true, item: { _id: '...', status: 'NONE', ... } }
     const item = (json.item as Record<string, unknown> | undefined) ?? {}
@@ -147,15 +140,14 @@ export const icypeasFindEmailTool: ToolConfig<IcypeasFindEmailParams, IcypeasFin
   postProcess: async (result, params) => {
     if (!result.success) return result
 
-    // If already terminal, return immediately — a BAD_INPUT verdict has no searchId
-    // to poll, so this must run before the searchId guard.
-    if (result.output.status && TERMINAL_STATUSES.has(result.output.status)) {
-      return result
-    }
-
     const searchId = result.output.searchId
     if (!searchId) {
       throw new Error('Icypeas find-email result is missing a searchId')
+    }
+
+    // If already terminal (unlikely on submit but defensive), return immediately.
+    if (result.output.status && TERMINAL_STATUSES.has(result.output.status)) {
+      return result
     }
 
     let elapsed = 0

--- a/apps/sim/tools/icypeas/find_email.ts
+++ b/apps/sim/tools/icypeas/find_email.ts
@@ -112,6 +112,24 @@ export const icypeasFindEmailTool: ToolConfig<IcypeasFindEmailParams, IcypeasFin
       throw new Error(`Icypeas API error: ${response.status} - ${errorText}`)
     }
     const json = (await response.json()) as Record<string, unknown>
+    // Icypeas returns HTTP 200 with { success: false, validationErrors: [...] } when
+    // it rejects the input up front (missing/invalid name or domain). There is no item
+    // to poll — this is a BAD_INPUT verdict, not a transport error. Surface it as a
+    // successful run with a null email so the enrichment cascade records the verdict
+    // instead of inflating the runner's error count.
+    if (json.success === false || Array.isArray(json.validationErrors)) {
+      return {
+        success: true,
+        output: {
+          searchId: null,
+          status: 'BAD_INPUT',
+          email: null,
+          firstname: null,
+          lastname: null,
+          item: json,
+        },
+      }
+    }
     // Submit response: { success: true, item: { _id: '...', status: 'NONE', ... } }
     const item = (json.item as Record<string, unknown> | undefined) ?? {}
     const searchId = (item._id as string | undefined) ?? null

--- a/apps/sim/tools/icypeas/find_email.ts
+++ b/apps/sim/tools/icypeas/find_email.ts
@@ -116,8 +116,10 @@ export const icypeasFindEmailTool: ToolConfig<IcypeasFindEmailParams, IcypeasFin
     // it rejects the input up front (missing/invalid name or domain). There is no item
     // to poll — this is a BAD_INPUT verdict, not a transport error. Surface it as a
     // successful run with a null email so the enrichment cascade records the verdict
-    // instead of inflating the runner's error count.
-    if (json.success === false || Array.isArray(json.validationErrors)) {
+    // instead of inflating the runner's error count. Key on a non-empty validationErrors
+    // array specifically: a bare { success: false } is an unexpected failure shape that
+    // should fall through and throw, not be masked as BAD_INPUT.
+    if (Array.isArray(json.validationErrors) && json.validationErrors.length > 0) {
       return {
         success: true,
         output: {
@@ -145,14 +147,15 @@ export const icypeasFindEmailTool: ToolConfig<IcypeasFindEmailParams, IcypeasFin
   postProcess: async (result, params) => {
     if (!result.success) return result
 
+    // If already terminal, return immediately — a BAD_INPUT verdict has no searchId
+    // to poll, so this must run before the searchId guard.
+    if (result.output.status && TERMINAL_STATUSES.has(result.output.status)) {
+      return result
+    }
+
     const searchId = result.output.searchId
     if (!searchId) {
       throw new Error('Icypeas find-email result is missing a searchId')
-    }
-
-    // If already terminal (unlikely on submit but defensive), return immediately.
-    if (result.output.status && TERMINAL_STATUSES.has(result.output.status)) {
-      return result
     }
 
     let elapsed = 0

--- a/apps/sim/tools/icypeas/verify_email.ts
+++ b/apps/sim/tools/icypeas/verify_email.ts
@@ -99,12 +99,29 @@ export const icypeasVerifyEmailTool: ToolConfig<
     }),
   },
 
-  transformResponse: async (response: Response) => {
+  transformResponse: async (response: Response, params?: IcypeasVerifyEmailParams) => {
     if (!response.ok) {
       const errorText = await response.text()
       throw new Error(`Icypeas API error: ${response.status} - ${errorText}`)
     }
     const json = (await response.json()) as Record<string, unknown>
+    // Icypeas returns HTTP 200 with { success: false, validationErrors: [...] } when
+    // it rejects the input up front (bad format, role-based address, etc.). There is
+    // no item to poll — this is a BAD_INPUT verdict, not a transport error. Surface it
+    // as a successful run with valid=false so the enrichment cascade records the
+    // verdict instead of inflating the runner's error count.
+    if (json.success === false || Array.isArray(json.validationErrors)) {
+      return {
+        success: true,
+        output: {
+          searchId: null,
+          status: 'BAD_INPUT',
+          email: params?.email ?? null,
+          valid: false,
+          item: json,
+        },
+      }
+    }
     // Submit response: { success: true, item: { _id: '...', status: 'NONE', ... } }
     const item = (json.item as Record<string, unknown> | undefined) ?? {}
     const searchId = (item._id as string | undefined) ?? null

--- a/apps/sim/tools/icypeas/verify_email.ts
+++ b/apps/sim/tools/icypeas/verify_email.ts
@@ -99,30 +99,25 @@ export const icypeasVerifyEmailTool: ToolConfig<
     }),
   },
 
-  transformResponse: async (response: Response, params?: IcypeasVerifyEmailParams) => {
+  transformResponse: async (response: Response) => {
     if (!response.ok) {
       const errorText = await response.text()
       throw new Error(`Icypeas API error: ${response.status} - ${errorText}`)
     }
     const json = (await response.json()) as Record<string, unknown>
-    // Icypeas returns HTTP 200 with { success: false, validationErrors: [...] } when
-    // it rejects the input up front (bad format, role-based address, etc.). There is
-    // no item to poll — this is a BAD_INPUT verdict, not a transport error. Surface it
-    // as a successful run with valid=false so the enrichment cascade records the
-    // verdict instead of inflating the runner's error count. Key on a non-empty
-    // validationErrors array specifically: a bare { success: false } is an unexpected
-    // failure shape that should fall through and throw, not be masked as BAD_INPUT.
-    if (Array.isArray(json.validationErrors) && json.validationErrors.length > 0) {
-      return {
-        success: true,
-        output: {
-          searchId: null,
-          status: 'BAD_INPUT',
-          email: params?.email ?? null,
-          valid: false,
-          item: json,
-        },
-      }
+    // Icypeas signals submit-time failures as HTTP 200 { success: false, validationErrors: [...] }
+    // — malformed input, insufficient credits, rate limits, etc. None of these are a
+    // deliverability verdict (those only come from polling), so fail fast with the
+    // human-readable reason rather than a cryptic missing-_id error or a fabricated
+    // valid=false result.
+    const validationErrors = json.validationErrors
+    if (Array.isArray(validationErrors) && validationErrors.length > 0) {
+      const first = validationErrors[0] as Record<string, unknown> | undefined
+      const reason =
+        (first?.humanReadableMessage as string | undefined) ??
+        (first?.message as string | undefined) ??
+        'validation error'
+      throw new Error(`Icypeas email-verification rejected the request: ${reason}`)
     }
     // Submit response: { success: true, item: { _id: '...', status: 'NONE', ... } }
     const item = (json.item as Record<string, unknown> | undefined) ?? {}
@@ -139,15 +134,14 @@ export const icypeasVerifyEmailTool: ToolConfig<
   postProcess: async (result, params) => {
     if (!result.success) return result
 
-    // If already terminal, return immediately — a BAD_INPUT verdict has no searchId
-    // to poll, so this must run before the searchId guard.
-    if (result.output.status && TERMINAL_STATUSES.has(result.output.status)) {
-      return result
-    }
-
     const searchId = result.output.searchId
     if (!searchId) {
       throw new Error('Icypeas verify-email result is missing a searchId')
+    }
+
+    // If already terminal, return immediately.
+    if (result.output.status && TERMINAL_STATUSES.has(result.output.status)) {
+      return result
     }
 
     let elapsed = 0

--- a/apps/sim/tools/icypeas/verify_email.ts
+++ b/apps/sim/tools/icypeas/verify_email.ts
@@ -109,8 +109,10 @@ export const icypeasVerifyEmailTool: ToolConfig<
     // it rejects the input up front (bad format, role-based address, etc.). There is
     // no item to poll — this is a BAD_INPUT verdict, not a transport error. Surface it
     // as a successful run with valid=false so the enrichment cascade records the
-    // verdict instead of inflating the runner's error count.
-    if (json.success === false || Array.isArray(json.validationErrors)) {
+    // verdict instead of inflating the runner's error count. Key on a non-empty
+    // validationErrors array specifically: a bare { success: false } is an unexpected
+    // failure shape that should fall through and throw, not be masked as BAD_INPUT.
+    if (Array.isArray(json.validationErrors) && json.validationErrors.length > 0) {
       return {
         success: true,
         output: {
@@ -137,14 +139,15 @@ export const icypeasVerifyEmailTool: ToolConfig<
   postProcess: async (result, params) => {
     if (!result.success) return result
 
+    // If already terminal, return immediately — a BAD_INPUT verdict has no searchId
+    // to poll, so this must run before the searchId guard.
+    if (result.output.status && TERMINAL_STATUSES.has(result.output.status)) {
+      return result
+    }
+
     const searchId = result.output.searchId
     if (!searchId) {
       throw new Error('Icypeas verify-email result is missing a searchId')
-    }
-
-    // If already terminal, return immediately.
-    if (result.output.status && TERMINAL_STATUSES.has(result.output.status)) {
-      return result
     }
 
     let elapsed = 0


### PR DESCRIPTION
## Summary
- The canary failure (`Icypeas email-verification did not return an item _id` on `support@stripe.com`) was misdiagnosed at first. Reproducing the live call shows Icypeas returns **HTTP 200 `{ success: false, validationErrors: [{ message: "insufficient_credits", humanReadableMessage: "Insufficient credits to run the search", ... }] }`** — the hosted account is **out of credits**, not an invalid/role-based email.
- `transformResponse` only handled the `{ success: true, item: { _id } }` shape, so any submit-time `validationErrors` body threw the cryptic missing-`_id` error.
- Now both `verify_email.ts` and `find_email.ts` detect a non-empty `validationErrors` array and **throw the human-readable reason** (`Icypeas ... rejected the request: Insufficient credits to run the search`). A submit rejection is never a deliverability verdict, so it surfaces as a real, legible error instead of a fabricated `valid: false` / empty result.

## ⚠️ Operational follow-up (not fixed by this PR)
- The underlying canary break is that the hosted `ICYPEAS_API_KEY` account has **no credits**. Top it up — code only makes the failure legible.

## Type of Change
- [x] Bug fix

## Testing
- Reproduced the live `support@stripe.com` submit response to confirm the exact `validationErrors` shape.
- Added/updated tests: throws the human-readable reason (incl. `insufficient_credits`), falls back to `message`, still throws on a `success: true` body missing `_id`. 16/16 pass.
- `bun run lint:check`, `bun run check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)