### PR TITLE
fix(files): only show Share in context menu for files, not folders

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -1991,7 +1991,11 @@ export function Files() {
         onRename={handleContextMenuRename}
         onDelete={handleContextMenuDelete}
         onMove={handleContextMenuMove}
-        onShare={canEdit ? handleContextMenuShare : undefined}
+        onShare={
+          canEdit && contextMenuItemRef.current?.kind === 'file'
+            ? handleContextMenuShare
+            : undefined
+        }
         moveOptions={contextMenuMoveOptions}
         canEdit={canEdit}
         selectedCount={selectedRowIds.size}


### PR DESCRIPTION
## Summary
- Gate the Share action in the file-row right-click menu so it only renders for files, not folders
- Previously Share showed for folders too and silently no-op'd, since the handler only acts on files

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Lint and `check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)