### PR TITLE
improvement(auth): make Microsoft emailVerified derivation total

### DIFF
--- a/apps/sim/lib/oauth/microsoft.test.ts
+++ b/apps/sim/lib/oauth/microsoft.test.ts
@@ -64,6 +64,11 @@ describe('deriveMicrosoftEmailVerified', () => {
     )
     expect(deriveMicrosoftEmailVerified({ verified_primary_email: null }, EMAIL)).toBe(false)
   })
+
+  it('does not treat a string claim equal to the email as verified (guards the old unsafe cast)', () => {
+    expect(deriveMicrosoftEmailVerified({ verified_primary_email: EMAIL }, EMAIL)).toBe(false)
+    expect(deriveMicrosoftEmailVerified({ verified_secondary_email: EMAIL }, EMAIL)).toBe(false)
+  })
 })
 
 describe('isMicrosoftProvider', () => {

--- a/apps/sim/lib/oauth/microsoft.test.ts
+++ b/apps/sim/lib/oauth/microsoft.test.ts
@@ -54,10 +54,15 @@ describe('deriveMicrosoftEmailVerified', () => {
     expect(deriveMicrosoftEmailVerified({ email_verified: 'true' }, EMAIL)).toBe(true)
   })
 
-  it('treats a malformed verified-email claim as unverified', () => {
+  it('treats malformed (non-array) verified-email claims as unverified without throwing', () => {
     expect(deriveMicrosoftEmailVerified({ verified_primary_email: 'not-an-array' }, EMAIL)).toBe(
       false
     )
+    expect(deriveMicrosoftEmailVerified({ verified_primary_email: 123 }, EMAIL)).toBe(false)
+    expect(deriveMicrosoftEmailVerified({ verified_secondary_email: { foo: 'bar' } }, EMAIL)).toBe(
+      false
+    )
+    expect(deriveMicrosoftEmailVerified({ verified_primary_email: null }, EMAIL)).toBe(false)
   })
 })
 

--- a/apps/sim/lib/oauth/microsoft.ts
+++ b/apps/sim/lib/oauth/microsoft.ts
@@ -36,7 +36,10 @@ export function deriveMicrosoftEmailVerified(
   if (claims.email_verified !== undefined) {
     return Boolean(claims.email_verified)
   }
-  const verifiedPrimaryEmail = claims.verified_primary_email as string[] | undefined
-  const verifiedSecondaryEmail = claims.verified_secondary_email as string[] | undefined
-  return Boolean(verifiedPrimaryEmail?.includes(email) || verifiedSecondaryEmail?.includes(email))
+  const { verified_primary_email: verifiedPrimary, verified_secondary_email: verifiedSecondary } =
+    claims
+  return (
+    (Array.isArray(verifiedPrimary) && verifiedPrimary.includes(email)) ||
+    (Array.isArray(verifiedSecondary) && verifiedSecondary.includes(email))
+  )
 }


### PR DESCRIPTION
## Summary
- Follow-up hardening to the nOAuth account-linking fix (#5156, already merged).
- `deriveMicrosoftEmailVerified` cast the verified-email claims to `string[]` and called `.includes` via optional chaining, which only guards `null`/`undefined`. If a claim ever arrived as a non-array, non-string value (e.g. a number or object), `.includes` would throw and fail the OAuth `getUserInfo` flow.
- Replaced the unchecked `as string[]` cast with proper `Array.isArray` guards, so any claim shape resolves to unverified instead of throwing. No behavior change for real Microsoft tokens — purely defensive robustness on a security-relevant helper.

## Type of Change
- [x] Improvement

## Testing
- Extended `microsoft.test.ts` with non-array claim shapes (string, number, object, null) asserting no throw + unverified.
- `bunx vitest run lib/oauth/microsoft.test.ts` — 11 passing.
- `bunx tsc --noEmit` — 0 errors. `bun run lint` — clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)