### PR TITLE
fix(rich-md-editor): stop the editor flashing during an agent rewrite

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -158,6 +158,14 @@ export function LoadedRichMarkdownEditor({
   const [initialContent] = useState<JSONContent | string>(() =>
     streamingAtMountRef.current ? '' : parseMarkdownToDoc(splitFrontmatter(content).body)
   )
+  /**
+   * The body currently shown in the editor: seeded from a settled mount, updated on local edits (via
+   * onUpdate) and on each streamed sync. The streaming tick reveals a chunk only when it extends this,
+   * so an agent rewrite holds the current content instead of collapsing to a partial result.
+   */
+  const lastSyncedBodyRef = useRef<string | null>(
+    streamingAtMountRef.current ? null : splitFrontmatter(content).body
+  )
   const onChangeRef = useRef(onChange)
   onChangeRef.current = onChange
   const onSaveShortcutRef = useRef(onSaveShortcut)
@@ -263,12 +271,11 @@ export function LoadedRichMarkdownEditor({
     },
     onUpdate: ({ editor }) => {
       const md = postProcessSerializedMarkdown(editor.getMarkdown())
+      lastSyncedBodyRef.current = md
       onChangeRef.current(applyFrontmatter(settledRef.current?.frontmatter ?? '', md))
     },
   })
   editorInstanceRef.current = editor
-
-  const lastSyncedBodyRef = useRef<string | null>(null)
 
   const wasStreamingRef = useRef(streamingAtMountRef.current)
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -291,6 +291,12 @@ export function LoadedRichMarkdownEditor({
           streamRafRef.current = null
           return
         }
+        const shownBody = lastSyncedBodyRef.current
+        const extendsShown = shownBody === null || pending.startsWith(shownBody)
+        if (!extendsShown) {
+          streamRafRef.current = null
+          return
+        }
         if (
           pending.length > STREAM_REPARSE_THROTTLE_THRESHOLD &&
           performance.now() - lastStreamParseAtRef.current < STREAM_REPARSE_THROTTLE_MS
@@ -303,7 +309,7 @@ export function LoadedRichMarkdownEditor({
         lastStreamParseAtRef.current = performance.now()
         const el = containerRef.current
         const pinnedToBottom = el ? el.scrollHeight - el.scrollTop - el.clientHeight < 80 : false
-        editor.setEditable(false)
+        if (editor.isEditable) editor.setEditable(false)
         editor.commands.setContent(parseMarkdownToDoc(pending), {
           contentType: 'json',
           emitUpdate: false,


### PR DESCRIPTION
## Summary
- When an agent **rewrites/edits** an existing markdown file (e.g. removing text the user appended), the streamed chunks replaced the doc with each partial result, collapsing the content to a few characters and re-growing on every chunk — visible flashing.
- Fix: the stream-sync tick now reveals a chunk **only when it extends what's already shown**. A divergent chunk (a rewrite/edit) holds the current content in place; the final result is applied once on settle. Fresh writes and appends still reveal live.

## Empirical validation (e2e harness)
- **Rewrite/remove:** content length stays at the settled value across mid-stream chunks (no collapse), then settles to the corrected result.
- **Fresh write:** reveals live, growing monotonically.
- **Append-to-existing:** holds at the existing length until the stream passes it, then reveals the new tail — never collapses.
- New regression test added (`an agent rewrite does not collapse the editor mid-stream`). Full e2e harness (568) + file-viewer vitest (142) + typecheck all green.

## Type of Change
- [x] Bug fix

## Testing
Validated empirically via the rich-markdown-editor e2e harness (streaming lifecycle), plus the full suite.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)