### PR TITLE
fix(state): align server/client state with best practices (query-key bugs, persist hygiene, useState)

### DIFF
--- a/.claude/rules/sim-hooks.md
+++ b/.claude/rules/sim-hooks.md
@@ -48,3 +48,19 @@ export function useFeature({ id, onSelect }: UseFeatureProps) {
 4. Wrap returned functions in useCallback
 5. Server data goes through React Query (`hooks/queries/`), never `useState` + `fetch`
 6. Keep only UI/orchestration state in these hooks
+
+## State shape
+
+Never mirror a prop into state with `useState(prop)` + a syncing `useEffect` — a prop change clobbers in-progress local edits. Use the prop directly, reset via a remount `key`, or — when you must seed local state from a prop only on a transition (e.g. a modal opening) — reset during render with the `prevX` ref idiom:
+
+```typescript
+const prevOpenRef = useRef(open)
+if (prevOpenRef.current !== open) {
+  prevOpenRef.current = open
+  if (open) setName(initialName) // closed → open only
+}
+```
+
+Model mutually-exclusive flags as ONE `status` enum, not several contradictory booleans. `isLoading`/`isVerified`/`isInvalidOtp` describing one machine collapse to `status: 'idle' | 'verifying' | 'verified' | 'error'` (+ `errorMessage`); derive any boolean a consumer still needs (`status === 'error'`).
+
+Derive busy/success from the mutation object — never duplicate `mutation.isPending`/`mutation.isSuccess` into local `useState`. Read them directly (`mutation.isSuccess`) and reset with `mutation.reset()`.

--- a/.claude/rules/sim-hooks.md
+++ b/.claude/rules/sim-hooks.md
@@ -63,4 +63,4 @@ if (prevOpenRef.current !== open) {
 
 Model mutually-exclusive flags as ONE `status` enum, not several contradictory booleans. `isLoading`/`isVerified`/`isInvalidOtp` describing one machine collapse to `status: 'idle' | 'verifying' | 'verified' | 'error'` (+ `errorMessage`); derive any boolean a consumer still needs (`status === 'error'`).
 
-Derive busy/success from the mutation object — never duplicate `mutation.isPending`/`mutation.isSuccess` into local `useState`. Read them directly (`mutation.isSuccess`) and reset with `mutation.reset()`.
+Derive busy/success from the mutation object — never duplicate `mutation.isPending`/`mutation.isSuccess` into local `useState`. Read them directly (`mutation.isSuccess`) and reset with `mutation.reset()`. A distinct phase the mutation doesn't cover — e.g. a pre-submit captcha/Turnstile gate that runs before `mutate()` — is not a duplicate; keep that flag.

--- a/.claude/rules/sim-queries.md
+++ b/.claude/rules/sim-queries.md
@@ -25,6 +25,8 @@ export const entityKeys = {
 
 Never use inline query keys — always use the factory.
 
+**Every identifier the `queryFn` uses MUST appear in the `queryKey`.** If the fetch is scoped by `workspaceId`, `cursor`, `limit`, an org id, etc., those values must be part of the key — otherwise distinct fetch args share one cache entry (a cross-tenant / per-param cache collision). The lone exception is a globally-unique id used as the key while a second fetch arg is only an authz scope that cannot collide; annotate those with `// rq-lint-allow: <reason>`. Enforced by the `key-fetch-arg-drift` check in `scripts/check-react-query-patterns.ts`.
+
 ## File Structure
 
 ```typescript
@@ -142,4 +144,4 @@ const handler = useCallback(() => {
 
 ## Enforcement
 
-`scripts/check-react-query-patterns.ts` (`bun run check:react-query`, run in CI) statically enforces these conventions: every `useQuery`/`useInfiniteQuery`/`useSuspenseQuery` declares an explicit `staleTime`, inline `queryFn`s destructure `signal`, `queryKey`s reference a colocated factory rather than an inline literal, and every `*Keys` factory in `hooks/queries/**` exposes an `all` root key. `hooks/queries/**` is a zero-tolerance zone; the rest of `apps/sim/**` is ratcheted against `scripts/check-react-query-patterns.baseline.json`. For a genuine exception, put `// rq-lint-allow: <reason>` on the line directly above the flagged construct.
+`scripts/check-react-query-patterns.ts` (`bun run check:react-query`, run in CI) statically enforces these conventions: every `useQuery`/`useInfiniteQuery`/`useSuspenseQuery` declares an explicit `staleTime`, inline `queryFn`s destructure `signal`, `queryKey`s reference a colocated factory rather than an inline literal, every `*Keys` factory in `hooks/queries/**` exposes an `all` root key, and every identifier the `queryFn` forwards into the fetch also appears in the `queryKey` (`key-fetch-arg-drift`). `hooks/queries/**` is a zero-tolerance zone; the rest of `apps/sim/**` is ratcheted against `scripts/check-react-query-patterns.baseline.json`. For a genuine exception, put `// rq-lint-allow: <reason>` on the line directly above the flagged construct.

--- a/.claude/rules/sim-queries.md
+++ b/.claude/rules/sim-queries.md
@@ -25,7 +25,7 @@ export const entityKeys = {
 
 Never use inline query keys — always use the factory.
 
-**Every identifier the `queryFn` uses MUST appear in the `queryKey`.** If the fetch is scoped by `workspaceId`, `cursor`, `limit`, an org id, etc., those values must be part of the key — otherwise distinct fetch args share one cache entry (a cross-tenant / per-param cache collision). The lone exception is a globally-unique id used as the key while a second fetch arg is only an authz scope that cannot collide; annotate those with `// rq-lint-allow: <reason>`. Enforced by the `key-fetch-arg-drift` check in `scripts/check-react-query-patterns.ts`.
+**Every identifier the `queryFn` forwards into the fetch MUST appear in the `queryKey`.** (Query-machinery identifiers — `signal`, `pageParam` — are exempt; they aren't fetch-scoping args.) If the fetch is scoped by `workspaceId`, `cursor`, `limit`, an org id, etc., those values must be part of the key — otherwise distinct fetch args share one cache entry (a cross-tenant / per-param cache collision). The lone exception is a globally-unique id used as the key while a second fetch arg is only an authz scope that cannot collide; annotate those with `// rq-lint-allow: <reason>`. Enforced by the `key-fetch-arg-drift` check in `scripts/check-react-query-patterns.ts`.
 
 ## File Structure
 

--- a/.claude/rules/sim-stores.md
+++ b/.claude/rules/sim-stores.md
@@ -57,7 +57,7 @@ export const useFeatureStore = create<FeatureState>()(
 
 1. Use `devtools` middleware (named stores)
 2. Use `persist` only when data should survive reload
-3. `persist` MUST use `partialize` with an explicit whitelist of the durable fields. NEVER persist transient flags (`isResizing`, drag/hover state) or `_hasHydrated`, and never spread the whole state (`{ ...state }`) — it leaks actions and transient state into storage
+3. `persist` MUST use `partialize` with an explicit whitelist of the durable fields. Exclude transient flags (`isResizing`, drag/hover state) and `_hasHydrated` from the whitelist, and never spread the whole state (`{ ...state }`) — it leaks actions and transient state into storage
 4. `_hasHydrated` pattern for persisted stores needing hydration tracking
 5. Immutable updates only
 6. `set((state) => ...)` when depending on previous state

--- a/.claude/rules/sim-stores.md
+++ b/.claude/rules/sim-stores.md
@@ -57,7 +57,7 @@ export const useFeatureStore = create<FeatureState>()(
 
 1. Use `devtools` middleware (named stores)
 2. Use `persist` only when data should survive reload
-3. `partialize` to persist only necessary state
+3. `persist` MUST use `partialize` with an explicit whitelist of the durable fields. NEVER persist transient flags (`isResizing`, drag/hover state) or `_hasHydrated`, and never spread the whole state (`{ ...state }`) — it leaks actions and transient state into storage
 4. `_hasHydrated` pattern for persisted stores needing hydration tracking
 5. Immutable updates only
 6. `set((state) => ...)` when depending on previous state

--- a/apps/sim/app/(auth)/verify/use-verification.ts
+++ b/apps/sim/app/(auth)/verify/use-verification.ts
@@ -9,6 +9,15 @@ import { validateCallbackUrl } from '@/lib/core/security/input-validation'
 
 const logger = createLogger('useVerification')
 
+/**
+ * Mutually-exclusive phases of the email-OTP verification machine.
+ * - `idle`: awaiting input
+ * - `verifying`: a verify request is in flight
+ * - `verified`: code accepted, redirecting
+ * - `error`: last verify attempt failed (paired with `errorMessage`)
+ */
+type VerificationStatus = 'idle' | 'verifying' | 'verified' | 'error'
+
 interface UseVerificationParams {
   hasEmailService: boolean
   isProduction: boolean
@@ -18,9 +27,8 @@ interface UseVerificationParams {
 interface UseVerificationReturn {
   otp: string
   email: string
-  isLoading: boolean
-  isVerified: boolean
-  isInvalidOtp: boolean
+  status: VerificationStatus
+  isResending: boolean
   errorMessage: string
   isOtpComplete: boolean
   hasEmailService: boolean
@@ -41,10 +49,9 @@ export function useVerification({
   const { refetch: refetchSession } = useSession()
   const [otp, setOtp] = useState('')
   const [email, setEmail] = useState('')
-  const [isLoading, setIsLoading] = useState(false)
-  const [isVerified, setIsVerified] = useState(false)
+  const [status, setStatus] = useState<VerificationStatus>('idle')
+  const [isResending, setIsResending] = useState(false)
   const [isSendingInitialOtp, setIsSendingInitialOtp] = useState(false)
-  const [isInvalidOtp, setIsInvalidOtp] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
   const [redirectUrl, setRedirectUrl] = useState<string | null>(null)
   const [isInviteFlow, setIsInviteFlow] = useState(false)
@@ -96,8 +103,7 @@ export function useVerification({
   async function verifyCode() {
     if (!isOtpComplete || !email) return
 
-    setIsLoading(true)
-    setIsInvalidOtp(false)
+    setStatus('verifying')
     setErrorMessage('')
 
     try {
@@ -108,7 +114,7 @@ export function useVerification({
       })
 
       if (response && !response.error) {
-        setIsVerified(true)
+        setStatus('verified')
 
         try {
           await refetchSession()
@@ -135,12 +141,9 @@ export function useVerification({
       } else {
         logger.info('Setting invalid OTP state - API error response')
         const message = 'Invalid verification code. Please check and try again.'
-        setIsInvalidOtp(true)
+        setStatus('error')
         setErrorMessage(message)
-        logger.info('Error state after API error:', {
-          isInvalidOtp: true,
-          errorMessage: message,
-        })
+        logger.info('Error state after API error:', { errorMessage: message })
         setOtp('')
       }
     } catch (error: any) {
@@ -155,23 +158,18 @@ export function useVerification({
         message = 'Too many failed attempts. Please request a new code.'
       }
 
-      setIsInvalidOtp(true)
+      setStatus('error')
       setErrorMessage(message)
-      logger.info('Error state after caught error:', {
-        isInvalidOtp: true,
-        errorMessage: message,
-      })
+      logger.info('Error state after caught error:', { errorMessage: message })
 
       setOtp('')
-    } finally {
-      setIsLoading(false)
     }
   }
 
   function resendCode() {
     if (!email || !hasEmailService || !isEmailVerificationEnabled) return
 
-    setIsLoading(true)
+    setIsResending(true)
     setErrorMessage('')
 
     const normalizedEmail = normalizeEmail(email)
@@ -185,32 +183,32 @@ export function useVerification({
         setErrorMessage('Failed to resend verification code. Please try again later.')
       })
       .finally(() => {
-        setIsLoading(false)
+        setIsResending(false)
       })
   }
 
   function handleOtpChange(value: string) {
-    if (value.length === 6) {
-      setIsInvalidOtp(false)
+    if (value.length === 6 && status === 'error') {
+      setStatus('idle')
       setErrorMessage('')
     }
     setOtp(value)
   }
 
   useEffect(() => {
-    if (otp.length === 6 && email && !isLoading && !isVerified) {
+    if (otp.length === 6 && email && status !== 'verifying' && status !== 'verified') {
       const timeoutId = setTimeout(() => {
         verifyCode()
       }, 300)
 
       return () => clearTimeout(timeoutId)
     }
-  }, [otp, email, isLoading, isVerified])
+  }, [otp, email, status])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       if (!isEmailVerificationEnabled) {
-        setIsVerified(true)
+        setStatus('verified')
 
         const handleRedirect = async () => {
           try {
@@ -234,9 +232,8 @@ export function useVerification({
   return {
     otp,
     email,
-    isLoading,
-    isVerified,
-    isInvalidOtp,
+    status,
+    isResending,
     errorMessage,
     isOtpComplete,
     hasEmailService,

--- a/apps/sim/app/(auth)/verify/use-verification.ts
+++ b/apps/sim/app/(auth)/verify/use-verification.ts
@@ -187,9 +187,14 @@ export function useVerification({
       })
   }
 
+  /**
+   * On a complete (6-char) code, clear any lingering message — including a
+   * resend failure (which sets `errorMessage` while `status` stays `idle`) — and
+   * exit the error state, matching the prior unconditional reset on a full OTP.
+   */
   function handleOtpChange(value: string) {
-    if (value.length === 6 && status === 'error') {
-      setStatus('idle')
+    if (value.length === 6) {
+      if (status === 'error') setStatus('idle')
       setErrorMessage('')
     }
     setOtp(value)

--- a/apps/sim/app/(auth)/verify/use-verification.ts
+++ b/apps/sim/app/(auth)/verify/use-verification.ts
@@ -201,14 +201,20 @@ export function useVerification({
   }
 
   useEffect(() => {
-    if (otp.length === 6 && email && status !== 'verifying' && status !== 'verified') {
+    if (
+      otp.length === 6 &&
+      email &&
+      status !== 'verifying' &&
+      status !== 'verified' &&
+      !isResending
+    ) {
       const timeoutId = setTimeout(() => {
         verifyCode()
       }, 300)
 
       return () => clearTimeout(timeoutId)
     }
-  }, [otp, email, status])
+  }, [otp, email, status, isResending])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {

--- a/apps/sim/app/(auth)/verify/verify-content.tsx
+++ b/apps/sim/app/(auth)/verify/verify-content.tsx
@@ -25,15 +25,18 @@ function VerificationForm({
   const {
     otp,
     email,
-    isLoading,
-    isVerified,
-    isInvalidOtp,
+    status,
+    isResending,
     errorMessage,
     isOtpComplete,
     verifyCode,
     resendCode,
     handleOtpChange,
   } = useVerification({ hasEmailService, isProduction, isEmailVerificationEnabled })
+
+  const isVerified = status === 'verified'
+  const isInvalidOtp = status === 'error'
+  const isBusy = status === 'verifying' || isResending
 
   const [countdown, setCountdown] = useState(0)
   const [isResendDisabled, setIsResendDisabled] = useState(false)
@@ -88,7 +91,7 @@ function VerificationForm({
                 maxLength={6}
                 value={otp}
                 onChange={handleOtpChange}
-                disabled={isLoading}
+                disabled={isBusy}
                 className={cn('gap-2', isInvalidOtp && 'otp-error')}
               >
                 <InputOTPGroup>
@@ -112,10 +115,10 @@ function VerificationForm({
 
           <button
             onClick={verifyCode}
-            disabled={!isOtpComplete || isLoading}
+            disabled={!isOtpComplete || isBusy}
             className={AUTH_SUBMIT_BTN}
           >
-            {isLoading ? (
+            {isBusy ? (
               <span className='flex items-center gap-2'>
                 <Loader className='size-4' animate />
                 Verifying…
@@ -138,7 +141,7 @@ function VerificationForm({
                   <button
                     className='font-medium text-[var(--landing-text)] underline-offset-4 transition hover:text-white hover:underline'
                     onClick={handleResend}
-                    disabled={isLoading || isResendDisabled}
+                    disabled={isBusy || isResendDisabled}
                   >
                     Resend
                   </button>

--- a/apps/sim/app/(landing)/components/contact/contact-form.tsx
+++ b/apps/sim/app/(landing)/components/contact/contact-form.tsx
@@ -69,7 +69,6 @@ export function ContactForm() {
       captureClientEvent('landing_contact_submitted', { topic: variables.topic })
       setForm(INITIAL_FORM_STATE)
       setErrors({})
-      setSubmitSuccess(true)
     },
     onError: () => {
       turnstileRef.current?.reset()
@@ -78,7 +77,6 @@ export function ContactForm() {
 
   const [form, setForm] = useState<ContactFormState>(INITIAL_FORM_STATE)
   const [errors, setErrors] = useState<ContactErrors>({})
-  const [submitSuccess, setSubmitSuccess] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [website, setWebsite] = useState('')
   const [widgetReady, setWidgetReady] = useState(false)
@@ -141,6 +139,7 @@ export function ContactForm() {
   }
 
   const isBusy = contactMutation.isPending || isSubmitting
+  const submitSuccess = contactMutation.isSuccess
 
   const submitError = contactMutation.isError
     ? toError(contactMutation.error).message || 'Failed to send message. Please try again.'
@@ -161,7 +160,7 @@ export function ContactForm() {
         </p>
         <button
           type='button'
-          onClick={() => setSubmitSuccess(false)}
+          onClick={() => contactMutation.reset()}
           className='mt-6 font-season text-[13px] text-[var(--landing-text)] underline underline-offset-2 transition-opacity hover:opacity-80'
         >
           Send another message

--- a/apps/sim/app/(landing)/components/demo-request/demo-request-modal.tsx
+++ b/apps/sim/app/(landing)/components/demo-request/demo-request-modal.tsx
@@ -69,7 +69,6 @@ export function DemoRequestModal({ children, theme = 'dark' }: DemoRequestModalP
   const [open, setOpen] = useState(false)
   const [form, setForm] = useState<DemoRequestFormState>(INITIAL_FORM_STATE)
   const [errors, setErrors] = useState<DemoRequestErrors>({})
-  const [submitSuccess, setSubmitSuccess] = useState(false)
 
   const demoMutation = useMutation({
     mutationFn: submitDemoRequest,
@@ -77,14 +76,14 @@ export function DemoRequestModal({ children, theme = 'dark' }: DemoRequestModalP
       captureClientEvent('landing_demo_request_submitted', {
         company_size: variables.companySize,
       })
-      setSubmitSuccess(true)
     },
   })
+
+  const submitSuccess = demoMutation.isSuccess
 
   function resetForm() {
     setForm(INITIAL_FORM_STATE)
     setErrors({})
-    setSubmitSuccess(false)
     demoMutation.reset()
   }
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry/resource-registry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry/resource-registry.tsx
@@ -255,9 +255,9 @@ const RESOURCE_INVALIDATORS: Record<
   scheduledtask: (qc, wId) => {
     qc.invalidateQueries({ queryKey: scheduleKeys.list(wId) })
   },
-  log: (qc, _wId, id) => {
+  log: (qc, wId, id) => {
     qc.invalidateQueries({ queryKey: logKeys.details() })
-    qc.invalidateQueries({ queryKey: logKeys.detail(id) })
+    qc.invalidateQueries({ queryKey: logKeys.detail(wId, id) })
   },
   /**
    * Integrations are sourced from the static integration catalog

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/edit-knowledge-base-modal/edit-knowledge-base-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/edit-knowledge-base-modal/edit-knowledge-base-modal.tsx
@@ -44,7 +44,10 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  // Reset form fields when the modal opens (open transitions false → true).
+  /**
+   * Seed the fields only on the closed → open transition (render-phase reset),
+   * so a prop change while the modal is open never clobbers in-progress edits.
+   */
   const prevOpenRef = useRef(open)
   if (prevOpenRef.current !== open) {
     prevOpenRef.current = open

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/edit-knowledge-base-modal/edit-knowledge-base-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/edit-knowledge-base-modal/edit-knowledge-base-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { memo, useEffect, useState } from 'react'
+import { memo, useRef, useState } from 'react'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
 import {
@@ -44,7 +44,10 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
+  // Reset form fields when the modal opens (open transitions false → true).
+  const prevOpenRef = useRef(open)
+  if (prevOpenRef.current !== open) {
+    prevOpenRef.current = open
     if (open) {
       setName(initialName)
       setDescription(initialDescription)
@@ -52,7 +55,7 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
       setDescriptionError(null)
       setError(null)
     }
-  }, [open, initialName, initialDescription])
+  }
 
   const validate = (): boolean => {
     let valid = true

--- a/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
@@ -525,7 +525,7 @@ export default function Logs() {
 
       try {
         const detailLog = await queryClient.fetchQuery({
-          queryKey: logKeys.detail(logId),
+          queryKey: logKeys.detail(workspaceId, logId),
           queryFn: ({ signal }) => fetchLogDetail(logId, workspaceId, signal),
           staleTime: 30 * 1000,
         })

--- a/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
@@ -505,7 +505,7 @@ export default function Logs() {
     }
   }, [contextMenuLog])
 
-  const cancelExecution = useCancelExecution()
+  const cancelExecution = useCancelExecution(workspaceId)
   const retryExecution = useRetryExecution()
 
   const handleCancelExecution = useCallback(() => {

--- a/apps/sim/hooks/queries/a2a/agents.ts
+++ b/apps/sim/hooks/queries/a2a/agents.ts
@@ -101,13 +101,19 @@ export function useCreateA2AAgent() {
 
   return useMutation({
     mutationFn: createA2AAgent,
-    onSettled: () => {
+    onSettled: (data) => {
       queryClient.invalidateQueries({
         queryKey: a2aAgentKeys.lists(),
       })
-      queryClient.invalidateQueries({
-        queryKey: a2aAgentKeys.byWorkflows(),
-      })
+      if (data) {
+        queryClient.invalidateQueries({
+          queryKey: a2aAgentKeys.byWorkflow(data.workspaceId, data.workflowId),
+        })
+      } else {
+        queryClient.invalidateQueries({
+          queryKey: a2aAgentKeys.byWorkflows(),
+        })
+      }
     },
   })
 }
@@ -136,16 +142,22 @@ export function useUpdateA2AAgent() {
 
   return useMutation({
     mutationFn: updateA2AAgent,
-    onSettled: (_data, _error, variables) => {
+    onSettled: (data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: a2aAgentKeys.lists(),
       })
       queryClient.invalidateQueries({
         queryKey: a2aAgentKeys.detail(variables.agentId),
       })
-      queryClient.invalidateQueries({
-        queryKey: a2aAgentKeys.byWorkflows(),
-      })
+      if (data) {
+        queryClient.invalidateQueries({
+          queryKey: a2aAgentKeys.byWorkflow(data.workspaceId, data.workflowId),
+        })
+      } else {
+        queryClient.invalidateQueries({
+          queryKey: a2aAgentKeys.byWorkflows(),
+        })
+      }
     },
   })
 }

--- a/apps/sim/hooks/queries/inbox.ts
+++ b/apps/sim/hooks/queries/inbox.ts
@@ -26,8 +26,8 @@ export const inboxKeys = {
   senders: () => [...inboxKeys.all, 'sender'] as const,
   senderList: (workspaceId: string) => [...inboxKeys.senders(), workspaceId] as const,
   tasks: () => [...inboxKeys.all, 'task'] as const,
-  taskList: (workspaceId: string, status?: string) =>
-    [...inboxKeys.tasks(), workspaceId, status ?? 'all'] as const,
+  taskList: (workspaceId: string, status?: string, cursor?: string, limit?: number) =>
+    [...inboxKeys.tasks(), workspaceId, status ?? 'all', cursor ?? '', limit ?? ''] as const,
 }
 
 type InboxTaskStatusFilter = InboxTaskStatus
@@ -88,7 +88,7 @@ export function useInboxTasks(
   opts: { status?: InboxTaskStatusFilter; cursor?: string; limit?: number } = {}
 ) {
   return useQuery({
-    queryKey: inboxKeys.taskList(workspaceId, opts.status),
+    queryKey: inboxKeys.taskList(workspaceId, opts.status, opts.cursor, opts.limit),
     queryFn: ({ signal }) => fetchInboxTasks(workspaceId, opts, signal),
     enabled: Boolean(workspaceId),
     staleTime: 15 * 1000,

--- a/apps/sim/hooks/queries/logs.ts
+++ b/apps/sim/hooks/queries/logs.ts
@@ -37,7 +37,8 @@ export const logKeys = {
   list: (workspaceId: string | undefined, filters: LogFilters) =>
     [...logKeys.lists(), workspaceId ?? '', filters] as const,
   details: () => [...logKeys.all, 'detail'] as const,
-  detail: (logId: string | undefined) => [...logKeys.details(), logId ?? ''] as const,
+  detail: (workspaceId: string | undefined, logId: string | undefined) =>
+    [...logKeys.details(), workspaceId ?? '', logId ?? ''] as const,
   byExecutionAll: () => [...logKeys.all, 'byExecution'] as const,
   byExecution: (workspaceId: string | undefined, executionId: string | undefined) =>
     [...logKeys.byExecutionAll(), workspaceId ?? '', executionId ?? ''] as const,
@@ -189,7 +190,7 @@ export function useLogDetail(
   options?: UseLogDetailOptions
 ) {
   return useQuery({
-    queryKey: logKeys.detail(logId),
+    queryKey: logKeys.detail(workspaceId, logId),
     queryFn: ({ signal }) => fetchLogDetail(logId as string, workspaceId as string, signal),
     enabled: Boolean(logId) && Boolean(workspaceId) && (options?.enabled ?? true),
     refetchInterval: options?.refetchInterval ?? false,
@@ -212,7 +213,7 @@ export function useLogByExecutionId(
         query: { workspaceId: workspaceId as string },
         signal,
       })
-      queryClient.setQueryData(logKeys.detail(data.id), data)
+      queryClient.setQueryData(logKeys.detail(workspaceId, data.id), data)
       return data
     },
     enabled: Boolean(workspaceId) && Boolean(executionId),
@@ -222,7 +223,7 @@ export function useLogByExecutionId(
 
 export function prefetchLogDetail(queryClient: QueryClient, logId: string, workspaceId: string) {
   queryClient.prefetchQuery({
-    queryKey: logKeys.detail(logId),
+    queryKey: logKeys.detail(workspaceId, logId),
     queryFn: ({ signal }) => fetchLogDetail(logId, workspaceId, signal),
     staleTime: 30 * 1000,
   })
@@ -315,6 +316,7 @@ export function useCancelExecution() {
       })
 
       let affectedLogId: string | null = null
+      let affectedWorkspaceId: string | undefined
       queryClient.setQueriesData<InfiniteData<LogsPage>>({ queryKey: logKeys.lists() }, (old) => {
         if (!old) return old
         return {
@@ -324,6 +326,7 @@ export function useCancelExecution() {
             logs: page.logs.map((log) => {
               if (log.executionId !== executionId) return log
               affectedLogId = log.id
+              affectedWorkspaceId = log.workflow?.workspaceId ?? undefined
               return { ...log, status: 'cancelling' }
             }),
           })),
@@ -332,23 +335,31 @@ export function useCancelExecution() {
 
       let previousDetail: WorkflowLogDetail | undefined
       if (affectedLogId) {
-        previousDetail = queryClient.getQueryData<WorkflowLogDetail>(logKeys.detail(affectedLogId))
+        previousDetail = queryClient.getQueryData<WorkflowLogDetail>(
+          logKeys.detail(affectedWorkspaceId, affectedLogId)
+        )
         if (previousDetail) {
-          queryClient.setQueryData<WorkflowLogDetail>(logKeys.detail(affectedLogId), {
-            ...previousDetail,
-            status: 'cancelling',
-          })
+          queryClient.setQueryData<WorkflowLogDetail>(
+            logKeys.detail(affectedWorkspaceId, affectedLogId),
+            {
+              ...previousDetail,
+              status: 'cancelling',
+            }
+          )
         }
       }
 
-      return { previousQueries, affectedLogId, previousDetail }
+      return { previousQueries, affectedLogId, affectedWorkspaceId, previousDetail }
     },
     onError: (_err, _variables, context) => {
       for (const [queryKey, data] of context?.previousQueries ?? []) {
         queryClient.setQueryData(queryKey, data)
       }
       if (context?.affectedLogId && context.previousDetail !== undefined) {
-        queryClient.setQueryData(logKeys.detail(context.affectedLogId), context.previousDetail)
+        queryClient.setQueryData(
+          logKeys.detail(context.affectedWorkspaceId, context.affectedLogId),
+          context.previousDetail
+        )
       }
     },
     onSettled: () => {

--- a/apps/sim/hooks/queries/logs.ts
+++ b/apps/sim/hooks/queries/logs.ts
@@ -292,7 +292,7 @@ export function useExecutionSnapshot(executionId: string | undefined) {
   })
 }
 
-export function useCancelExecution() {
+export function useCancelExecution(workspaceId: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async ({
@@ -316,7 +316,6 @@ export function useCancelExecution() {
       })
 
       let affectedLogId: string | null = null
-      let affectedWorkspaceId: string | undefined
       queryClient.setQueriesData<InfiniteData<LogsPage>>({ queryKey: logKeys.lists() }, (old) => {
         if (!old) return old
         return {
@@ -326,7 +325,6 @@ export function useCancelExecution() {
             logs: page.logs.map((log) => {
               if (log.executionId !== executionId) return log
               affectedLogId = log.id
-              affectedWorkspaceId = log.workflow?.workspaceId ?? undefined
               return { ...log, status: 'cancelling' }
             }),
           })),
@@ -336,20 +334,17 @@ export function useCancelExecution() {
       let previousDetail: WorkflowLogDetail | undefined
       if (affectedLogId) {
         previousDetail = queryClient.getQueryData<WorkflowLogDetail>(
-          logKeys.detail(affectedWorkspaceId, affectedLogId)
+          logKeys.detail(workspaceId, affectedLogId)
         )
         if (previousDetail) {
-          queryClient.setQueryData<WorkflowLogDetail>(
-            logKeys.detail(affectedWorkspaceId, affectedLogId),
-            {
-              ...previousDetail,
-              status: 'cancelling',
-            }
-          )
+          queryClient.setQueryData<WorkflowLogDetail>(logKeys.detail(workspaceId, affectedLogId), {
+            ...previousDetail,
+            status: 'cancelling',
+          })
         }
       }
 
-      return { previousQueries, affectedLogId, affectedWorkspaceId, previousDetail }
+      return { previousQueries, affectedLogId, previousDetail }
     },
     onError: (_err, _variables, context) => {
       for (const [queryKey, data] of context?.previousQueries ?? []) {
@@ -357,7 +352,7 @@ export function useCancelExecution() {
       }
       if (context?.affectedLogId && context.previousDetail !== undefined) {
         queryClient.setQueryData(
-          logKeys.detail(context.affectedWorkspaceId, context.affectedLogId),
+          logKeys.detail(workspaceId, context.affectedLogId),
           context.previousDetail
         )
       }

--- a/apps/sim/hooks/queries/organization.ts
+++ b/apps/sim/hooks/queries/organization.ts
@@ -174,10 +174,18 @@ export function useOrganizations() {
 }
 
 /**
- * Fetch a specific organization by ID
+ * Fetch a specific organization by ID.
+ *
+ * `getFullOrganization` defaults to the active organization when no
+ * `organizationId` is supplied; passing `orgId` through scopes the result to the
+ * requested org so it is cached under the correct `organizationKeys.detail(orgId)`
+ * (no cross-org cache collision). The active-org caller passes the active org's
+ * id, so its behavior is unchanged.
  */
-async function fetchOrganization(_signal?: AbortSignal) {
-  const response = await client.organization.getFullOrganization()
+async function fetchOrganization(orgId: string, _signal?: AbortSignal) {
+  const response = await client.organization.getFullOrganization({
+    query: { organizationId: orgId },
+  })
   return response.data
 }
 
@@ -187,7 +195,7 @@ async function fetchOrganization(_signal?: AbortSignal) {
 export function useOrganization(orgId: string) {
   return useQuery({
     queryKey: organizationKeys.detail(orgId),
-    queryFn: ({ signal }) => fetchOrganization(signal),
+    queryFn: ({ signal }) => fetchOrganization(orgId, signal),
     enabled: !!orgId,
     staleTime: 30 * 1000,
     placeholderData: keepPreviousData,

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -265,6 +265,7 @@ export function useTablesList(
  * Fetch a single table by id.
  */
 export function useTable(workspaceId: string | undefined, tableId: string | undefined) {
+  // rq-lint-allow: tableId is a globally-unique id; workspaceId is only an authz scope on the fetch and cannot collide across workspaces
   return useQuery({
     queryKey: tableKeys.detail(tableId ?? ''),
     queryFn: ({ signal }) => fetchTable(workspaceId as string, tableId as string, signal),

--- a/apps/sim/stores/chat/store.ts
+++ b/apps/sim/stores/chat/store.ts
@@ -254,8 +254,20 @@ export const useChatStore = create<ChatState>()(
       }),
       {
         name: 'chat-store',
+        /**
+         * Persist only the durable chat state — message history (with transient
+         * blob `previewUrl`s stripped since they are not valid across reloads),
+         * per-workflow output selections and conversation ids, and the floating
+         * chat's open state, position, and dimensions. Actions and any transient
+         * UI flags are intentionally excluded.
+         */
         partialize: (state) => ({
-          ...state,
+          isChatOpen: state.isChatOpen,
+          chatPosition: state.chatPosition,
+          chatWidth: state.chatWidth,
+          chatHeight: state.chatHeight,
+          selectedWorkflowOutputs: state.selectedWorkflowOutputs,
+          conversationIds: state.conversationIds,
           messages: state.messages.map((msg) => ({
             ...msg,
             attachments: msg.attachments?.map((att) => ({

--- a/apps/sim/stores/panel/store.ts
+++ b/apps/sim/stores/panel/store.ts
@@ -40,6 +40,17 @@ export const usePanelStore = create<PanelState>()(
     }),
     {
       name: 'panel-state',
+      /**
+       * Persist only the durable panel preferences. `activeTab` MUST be kept:
+       * the blocking script in `app/layout.tsx` reads it from this persisted
+       * `panel-state` entry to set `data-panel-active-tab` before hydration,
+       * preventing a tab flash. The transient `isResizing` drag flag and the
+       * `_hasHydrated` hydration marker are excluded.
+       */
+      partialize: (state) => ({
+        panelWidth: state.panelWidth,
+        activeTab: state.activeTab,
+      }),
       onRehydrateStorage: () => (state) => {
         // Sync CSS variables with stored state after rehydration
         if (state && typeof window !== 'undefined') {

--- a/apps/sim/stores/terminal/store.ts
+++ b/apps/sim/stores/terminal/store.ts
@@ -94,6 +94,19 @@ export const useTerminalStore = create<TerminalState>()(
     {
       name: 'terminal-state',
       /**
+       * Persist only the durable terminal UI preferences. The transient
+       * `isResizing` drag flag and the `_hasHydrated` hydration marker are
+       * excluded so they always start fresh on load.
+       */
+      partialize: (state) => ({
+        terminalHeight: state.terminalHeight,
+        lastExpandedHeight: state.lastExpandedHeight,
+        outputPanelWidth: state.outputPanelWidth,
+        openOnRun: state.openOnRun,
+        wrapText: state.wrapText,
+        structuredView: state.structuredView,
+      }),
+      /**
        * Synchronizes the `--terminal-height` CSS custom property with the
        * persisted store value after client-side rehydration.
        */

--- a/scripts/check-react-query-patterns.ts
+++ b/scripts/check-react-query-patterns.ts
@@ -10,6 +10,12 @@
  *   2. queryfn-no-signal    — an inline `queryFn` that takes no args (cannot forward the AbortSignal)
  *   3. inline-query-key     — `queryKey: ['literal', ...]` instead of a colocated key factory
  *   4. key-factory-no-root  — a `*Keys` factory in hooks/queries/** without an `all` root key
+ *   5. key-fetch-arg-drift  — an identifier the queryFn forwards into the fetch (e.g. `workspaceId`)
+ *                             that is absent from the queryKey, so distinct fetch args collide on one
+ *                             cache entry. Conservative: only bare camelCase identifiers (never the
+ *                             requestJson contract arg, PascalCase/SCREAMING constants, or signal/
+ *                             pageParam machinery) are checked, and only when both a queryKey and an
+ *                             inline-arrow queryFn with a recognizable call are present.
  *
  * Enforcement model (mirrors check-api-validation-contracts.ts):
  *   - STRICT ZONE (apps/sim/hooks/queries/**): zero tolerance — any violation fails.
@@ -41,6 +47,7 @@ type Category =
   | 'queryfn-no-signal'
   | 'inline-query-key'
   | 'key-factory-no-root'
+  | 'key-fetch-arg-drift'
 
 interface Violation {
   file: string
@@ -59,6 +66,9 @@ const SUGGESTION: Record<Category, string> = {
     'use a colocated hierarchical key factory (entityKeys.list(id)) instead of an inline literal key',
   'key-factory-no-root':
     'every *Keys factory in hooks/queries/** must expose an `all` root key for prefix invalidation',
+  'key-fetch-arg-drift':
+    'every identifier the queryFn passes to fetch/requestJson must also appear in the queryKey — ' +
+    'otherwise distinct fetch args collide on one cache entry (cross-tenant/param cache collision)',
 }
 
 async function walk(dir: string, out: string[] = []): Promise<string[]> {
@@ -127,6 +137,124 @@ const QUERYFN_PRESENT = /queryFn\s*:/
 const INLINE_KEY = /queryKey\s*:\s*\[\s*[`'"]/
 const KEYS_FACTORY = /\b(?:export\s+)?const\s+\w*[kK]eys\s*[:=][^=]*?=?\s*\{/g
 
+/**
+ * Identifiers that are part of the queryFn machinery (not fetch params) and
+ * must never be flagged as drift even though they appear in the call.
+ */
+const QUERYFN_NOISE = new Set([
+  'signal',
+  'pageParam',
+  'meta',
+  'queryKey',
+  'direction',
+  'client',
+  'true',
+  'false',
+  'null',
+  'undefined',
+])
+
+/**
+ * Extracts the value slice of `key: ...` from an options object, reading up to
+ * the property-terminating top-level comma. Nested brackets (arrays, calls, and
+ * arrow-function bodies including their own param parens) are skipped via depth
+ * tracking, so this correctly returns the whole `({ signal }) => fetchX(...)`
+ * arrow for `queryFn`, not just its parameter list.
+ */
+function extractOptionValue(obj: string, key: string): string | null {
+  const re = new RegExp(`\\b${key}\\s*:`, 'g')
+  const m = re.exec(obj)
+  if (!m) return null
+  let i = m.index + m[0].length
+  while (i < obj.length && /\s/.test(obj[i])) i++
+  let depth = 0
+  let inStr: string | null = null
+  let j = i
+  for (; j < obj.length; j++) {
+    const c = obj[j]
+    const prev = obj[j - 1]
+    if (inStr) {
+      if (c === inStr && prev !== '\\') inStr = null
+      continue
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      inStr = c
+      continue
+    }
+    if (c === '(' || c === '[' || c === '{') depth++
+    else if (c === ')' || c === ']' || c === '}') {
+      if (depth === 0) break
+      depth--
+    } else if (c === ',' && depth === 0) break
+  }
+  return obj.slice(i, j)
+}
+
+/**
+ * "key/fetch-arg drift": an identifier the queryFn forwards into the fetch
+ * (the args of the first call expression inside the queryFn body) that does NOT
+ * textually appear in the queryKey. Conservative — only fires when both the
+ * queryKey and an inline-arrow queryFn with a recognizable call are present, and
+ * only for bare identifiers (optionally `x as T` / `x!`), never member access,
+ * literals, or queryFn machinery (signal/pageParam/etc.).
+ */
+function findKeyFetchArgDrift(obj: string): string[] {
+  const keyExpr = extractOptionValue(obj, 'queryKey')
+  const fnExpr = extractOptionValue(obj, 'queryFn')
+  if (!keyExpr || !fnExpr) return []
+
+  // Drop the arrow prefix (`async`, `(params) =>`, optional `{ return`) so the
+  // search begins at the queryFn body, then locate the first call expression and
+  // balance its argument list.
+  const bodyStart = /=>\s*(?:\{\s*(?:return\s+)?)?/.exec(fnExpr)
+  const body = bodyStart ? fnExpr.slice(bodyStart.index + bodyStart[0].length) : fnExpr
+  const call = /(?:await\s+)?([A-Za-z_$][\w$.]*)\s*\(/.exec(body)
+  if (!call) return []
+  const callee = call[1]
+  const openParen = call.index + call[0].length - 1
+  const argList = matchBalanced(body, openParen, '(', ')')
+
+  // Split top-level args.
+  const args: string[] = []
+  let depth = 0
+  let cur = ''
+  for (let i = 1; i < argList.length - 1; i++) {
+    const c = argList[i]
+    if (c === '(' || c === '[' || c === '{') depth++
+    else if (c === ')' || c === ']' || c === '}') depth--
+    if (c === ',' && depth === 0) {
+      args.push(cur)
+      cur = ''
+    } else cur += c
+  }
+  if (cur.trim()) args.push(cur)
+
+  // `requestJson(contract, ...)` / `ensureQueryData(contract, ...)` etc. take the
+  // contract constant as their first arg — that is module-level config, never a
+  // per-hook identifier, so drop it before checking.
+  const dropsFirstArg = /(?:^|\.)(requestJson|requestText|ensureQueryData|fetchQuery)$/.test(callee)
+  const checkArgs = dropsFirstArg ? args.slice(1) : args
+
+  const drifted: string[] = []
+  for (const raw of checkArgs) {
+    const id = raw
+      .trim()
+      .replace(/\s+as\s+[\w$.<>[\]| ]+$/, '')
+      .replace(/!+$/, '')
+      .trim()
+    // Only bare identifiers; skip member access, calls, literals, destructures, spreads.
+    if (!/^[A-Za-z_$][\w$]*$/.test(id)) continue
+    if (QUERYFN_NOISE.has(id)) continue
+    // Skip module-level constants (contracts/config), which are camelCase config
+    // ending in `Contract`, PascalCase, or SCREAMING_SNAKE — never hook params.
+    if (/Contract$/.test(id) || /^[A-Z]/.test(id) || /^[A-Z0-9_]+$/.test(id)) continue
+    // Present in the key (as a whole word) → no drift.
+    const inKey = new RegExp(`\\b${id}\\b`).test(keyExpr)
+    if (!inKey && !drifted.includes(id)) drifted.push(id)
+  }
+  return drifted
+}
+
 function scanFile(rel: string, content: string): Violation[] {
   const lines = content.split('\n')
   const violations: Violation[] = []
@@ -152,6 +280,13 @@ function scanFile(rel: string, content: string): Violation[] {
     }
     if (QUERYFN_PRESENT.test(obj) && QUERYFN_NOARG.test(obj)) {
       add(m.index, 'queryfn-no-signal', `${m[1]} queryFn takes no args`)
+    }
+    for (const id of findKeyFetchArgDrift(obj)) {
+      add(
+        m.index,
+        'key-fetch-arg-drift',
+        `${m[1]}: '${id}' passed to fetch but absent from queryKey`
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

Aligns server/client state management with canonical best practices (React Query owns server state; Zustand/`useState` own client state). Three real bug fixes + hygiene, each validated against the code and audited — plus a CI guard so the main bug class can't recur. No behavior changes beyond the fixes.

## Fixes

**1. React Query key / fetch-arg drift (cache-collision bugs)**
- `useOrganization(orgId)` ignored `orgId` (always fetched the *active* org, cached under the requested id) → now threads `orgId` to `getFullOrganization`.
- `useLogDetail` key omitted `workspaceId`; `useInboxTasks` key omitted `cursor`/`limit` → distinct requests collided on one cache entry. Added to the key factories.
- `a2a` agent mutations narrowed to `byWorkflow(...)` where the response carries `workflowId`.
- **Harness:** `scripts/check-react-query-patterns.ts` now flags any identifier used in a `queryFn` that's missing from the `queryKey` (`bun run check:react-query`).

**2. Zustand `persist` hygiene**
- `chat` store: replaced `partialize: {...state}` (persisted actions + transient UI) with an explicit durable whitelist.
- `terminal` / `panel` stores: added `partialize` (were persisting transient `isResizing` + `_hasHydrated`). `panel` keeps `activeTab`/`panelWidth` (read by the SSR flash-prevention script). No `version`/`migrate` needed — old localStorage blobs rehydrate benignly.

**3. Component `useState` correctness**
- `edit-knowledge-base-modal`: prop-into-state-via-effect (clobbered in-progress edits) → render-phase `prevOpenRef` idiom.
- `verify/use-verification`: contradictory booleans → single `status` enum.
- landing `contact-form`/`demo-request-modal`: derive success from the mutation (kept the Turnstile-phase `isSubmitting`, which is not a mutation duplicate).

**Harness docs:** `sim-queries.md`, `sim-stores.md`, `sim-hooks.md` updated with the rules above.

## Deliberately not changed (validated as unsafe / not violations)
- `providers` store — a justified isomorphic sync bridge (server/executor readers; `getQueryClient()` is empty server-side).
- `registry.loadWorkflowState` and `SessionProvider` — central paths where the "clean" swap would change behavior (full-envelope shape / `disableCookieCache`); deferred with plans.

## Verification
`tsc` 0 errors · Biome clean · `check:api-validation` · `check:react-query` all pass. Each commit independently audited line-by-line for backwards-compat + regressions.
