### PR TITLE
fix(workflows): allow larger parallel batch sizes

### DIFF
--- a/apps/sim/executor/constants.ts
+++ b/apps/sim/executor/constants.ts
@@ -174,7 +174,7 @@ export const DEFAULTS = {
   BLOCK_TITLE: 'Untitled Block',
   WORKFLOW_NAME: 'Workflow',
   DEFAULT_LOOP_ITERATIONS: 1000,
-  MAX_PARALLEL_BRANCHES: 20,
+  MAX_PARALLEL_BRANCHES: 100,
   MAX_NESTING_DEPTH: 10,
   /** Maximum child workflow depth for propagating SSE callbacks (block:started, block:completed). */
   MAX_SSE_CHILD_DEPTH: 3,

--- a/apps/sim/executor/orchestrators/parallel.test.ts
+++ b/apps/sim/executor/orchestrators/parallel.test.ts
@@ -253,14 +253,15 @@ describe('ParallelOrchestrator', () => {
       'parallel-1'
     )
 
+    expect(oversizedBatchScope.batchSize).toBe(50)
     expect(oversizedBatchScope.currentBatchSize).toBe(9)
   })
 
   it.each([
     ['oversized numeric batch size', 999, DEFAULTS.MAX_PARALLEL_BRANCHES],
     ['negative batch size', -1, 1],
-    ['undefined batch size', undefined, DEFAULTS.MAX_PARALLEL_BRANCHES],
-    ['nonnumeric batch size', 'not-a-number', DEFAULTS.MAX_PARALLEL_BRANCHES],
+    ['undefined batch size', undefined, 20],
+    ['nonnumeric batch size', 'not-a-number', 20],
   ])('normalizes %s', async (_name, batchSize, expectedBatchSize) => {
     const dag = createDag()
     const parallelConfig = dag.parallelConfigs.get('parallel-1')!

--- a/apps/sim/executor/orchestrators/parallel.test.ts
+++ b/apps/sim/executor/orchestrators/parallel.test.ts
@@ -260,8 +260,8 @@ describe('ParallelOrchestrator', () => {
   it.each([
     ['oversized numeric batch size', 999, DEFAULTS.MAX_PARALLEL_BRANCHES],
     ['negative batch size', -1, 1],
-    ['undefined batch size', undefined, 20],
-    ['nonnumeric batch size', 'not-a-number', 20],
+    ['undefined batch size', undefined, DEFAULT_PARALLEL_BATCH_SIZE],
+    ['nonnumeric batch size', 'not-a-number', DEFAULT_PARALLEL_BATCH_SIZE],
   ])('normalizes %s', async (_name, batchSize, expectedBatchSize) => {
     const dag = createDag()
     const parallelConfig = dag.parallelConfigs.get('parallel-1')!

--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -1906,7 +1906,7 @@ export function useCollaborativeWorkflow() {
       const currentCount = currentBlock.data?.count || 5
       const currentDistribution = currentBlock.data?.collection || ''
       const currentParallelType = currentBlock.data?.parallelType || 'count'
-      const clampedBatchSize = Math.max(1, Math.min(100, batchSize))
+      const clampedBatchSize = Math.max(1, Math.min(DEFAULTS.MAX_PARALLEL_BRANCHES, batchSize))
 
       const config = {
         id: parallelId,

--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -1906,7 +1906,7 @@ export function useCollaborativeWorkflow() {
       const currentCount = currentBlock.data?.count || 5
       const currentDistribution = currentBlock.data?.collection || ''
       const currentParallelType = currentBlock.data?.parallelType || 'count'
-      const clampedBatchSize = Math.max(1, Math.min(20, batchSize))
+      const clampedBatchSize = Math.max(1, Math.min(100, batchSize))
 
       const config = {
         id: parallelId,

--- a/apps/sim/lib/workflows/search-replace/replacements.test.ts
+++ b/apps/sim/lib/workflows/search-replace/replacements.test.ts
@@ -1658,14 +1658,14 @@ describe('buildWorkflowSearchReplacePlan', () => {
       blocks: workflow.blocks,
       matches,
       selectedMatchIds: new Set(matches.map((match) => match.id)),
-      defaultReplacement: '25',
+      defaultReplacement: '101',
     })
 
     expect(plan.subflowUpdates).toEqual([])
     expect(plan.conflicts).toEqual([
       {
         matchId: 'subflow-text:parallel-1:subflowBatchSize:0:0',
-        reason: 'Parallel batch size must be between 1 and 20',
+        reason: 'Parallel batch size must be between 1 and 100',
       },
     ])
   })

--- a/apps/sim/lib/workflows/search-replace/subflow-fields.ts
+++ b/apps/sim/lib/workflows/search-replace/subflow-fields.ts
@@ -169,7 +169,7 @@ export function parseWorkflowSearchSubflowReplacement({
   }
 
   const count = Number.parseInt(trimmed, 10)
-  const maxBatchSize = 20
+  const maxBatchSize = 100
   if (
     count < 1 ||
     (fieldId === WORKFLOW_SEARCH_SUBFLOW_FIELD_IDS.batchSize && count > maxBatchSize)

--- a/apps/sim/stores/workflows/workflow/store.test.ts
+++ b/apps/sim/stores/workflows/workflow/store.test.ts
@@ -603,7 +603,7 @@ describe('workflow store', () => {
       expect(state.blocks.parallel1?.data?.count).toBe(1)
     })
 
-    it('should clamp parallel batch size between 1 and 20', () => {
+    it('should clamp parallel batch size between 1 and 100', () => {
       const { updateParallelBatchSize } = useWorkflowStore.getState()
 
       addBlock(
@@ -625,7 +625,13 @@ describe('workflow store', () => {
 
       updateParallelBatchSize('parallel1', 50)
       state = useWorkflowStore.getState()
-      expect(state.blocks.parallel1?.data?.batchSize).toBe(20)
+      expect(state.blocks.parallel1?.data?.batchSize).toBe(50)
+      expect(state.parallels.parallel1.batchSize).toBe(50)
+
+      updateParallelBatchSize('parallel1', 101)
+      state = useWorkflowStore.getState()
+      expect(state.blocks.parallel1?.data?.batchSize).toBe(100)
+      expect(state.parallels.parallel1.batchSize).toBe(100)
 
       updateParallelBatchSize('parallel1', 0)
       state = useWorkflowStore.getState()

--- a/apps/sim/stores/workflows/workflow/utils.ts
+++ b/apps/sim/stores/workflows/workflow/utils.ts
@@ -7,7 +7,7 @@ import type { BlockState, Loop, Parallel } from '@/stores/workflows/workflow/typ
 
 const DEFAULT_LOOP_ITERATIONS = 5
 const DEFAULT_PARALLEL_BATCH_SIZE = 20
-const MAX_PARALLEL_BATCH_SIZE = 20
+const MAX_PARALLEL_BATCH_SIZE = 100
 
 export function clampParallelBatchSize(batchSize: unknown): number {
   const parsed = typeof batchSize === 'number' ? batchSize : Number.parseInt(String(batchSize), 10)

--- a/packages/workflow-persistence/src/subflow-helpers.ts
+++ b/packages/workflow-persistence/src/subflow-helpers.ts
@@ -2,7 +2,7 @@ import type { BlockState, Loop, Parallel } from '@sim/workflow-types/workflow'
 
 const DEFAULT_LOOP_ITERATIONS = 5
 const DEFAULT_PARALLEL_BATCH_SIZE = 20
-const MAX_PARALLEL_BATCH_SIZE = 20
+const MAX_PARALLEL_BATCH_SIZE = 100
 
 export function clampParallelBatchSize(batchSize: unknown): number {
   const parsed = typeof batchSize === 'number' ? batchSize : Number.parseInt(String(batchSize), 10)


### PR DESCRIPTION
## Summary
- raise the configurable Parallel Block batch-size cap from 20 to 100
- keep the default batch size at 20 so existing workflows keep their current behavior
- update persistence, client store, collaboration sync, search/replace validation, and executor normalization consistently
- update focused tests for the new cap and default behavior

## Tests
- `bun --filter sim test stores/workflows/workflow/store.test.ts`
- `bun --filter sim test executor/orchestrators/parallel.test.ts`
- `bun --filter sim test lib/workflows/search-replace/replacements.test.ts`
- `bunx biome check apps/sim/executor/constants.ts apps/sim/executor/orchestrators/parallel.test.ts apps/sim/hooks/use-collaborative-workflow.ts apps/sim/lib/workflows/search-replace/replacements.test.ts apps/sim/lib/workflows/search-replace/subflow-fields.ts apps/sim/stores/workflows/workflow/store.test.ts apps/sim/stores/workflows/workflow/utils.ts packages/workflow-persistence/src/subflow-helpers.ts`

Fixes #4903