### PR TITLE
fix(pii): listen on 5001 to avoid app :3000 collision (awsvpc)

### DIFF
--- a/docker/pii.Dockerfile
+++ b/docker/pii.Dockerfile
@@ -38,15 +38,13 @@ RUN groupadd -g 1001 pii && \
     chown -R pii:pii /app
 USER pii
 
-# Bind a configurable port via $PORT. In the ECS task all containers share one
-# network namespace (awsvpc), so this must NOT collide with the app on 3000 —
-# default to 5001 and let the taskdef override via PORT.
-ENV PORT=5001
+# Listen on 5001. In the ECS task all containers share one network namespace
+# (awsvpc) and the app owns 3000, so this sidecar must not use 3000.
 EXPOSE 5001
 
 # start-period is generous: five large spaCy models load at import before
 # /health responds. Tune against measured cold-start once built.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
-    CMD curl -fsS "http://localhost:${PORT}/health" || exit 1
+    CMD curl -fsS http://localhost:5001/health || exit 1
 
-CMD ["sh", "-c", "exec uvicorn server:app --host 0.0.0.0 --port ${PORT}"]
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "5001"]

--- a/docker/pii.Dockerfile
+++ b/docker/pii.Dockerfile
@@ -38,11 +38,15 @@ RUN groupadd -g 1001 pii && \
     chown -R pii:pii /app
 USER pii
 
-EXPOSE 3000
+# Bind a configurable port via $PORT. In the ECS task all containers share one
+# network namespace (awsvpc), so this must NOT collide with the app on 3000 —
+# default to 5001 and let the taskdef override via PORT.
+ENV PORT=5001
+EXPOSE 5001
 
 # start-period is generous: five large spaCy models load at import before
 # /health responds. Tune against measured cold-start once built.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
-    CMD curl -fsS http://localhost:3000/health || exit 1
+    CMD curl -fsS "http://localhost:${PORT}/health" || exit 1
 
-CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "3000"]
+CMD ["sh", "-c", "exec uvicorn server:app --host 0.0.0.0 --port ${PORT}"]


### PR DESCRIPTION
## Summary
- The `sim/pii` image hardcoded `uvicorn --port 3000`, so it always bound 3000.
- In the app ECS task (awsvpc), all containers share one network namespace and the **app owns 3000** — a `sim/pii` sidecar on 3000 collides with it and breaks the task. (The stock `mcr` presidio images ran on 5002/5001, which is why they coexisted with the app.)
- Fix: the sidecar now **listens on 5001** — exec-form `CMD` on 5001, `EXPOSE 5001`, healthcheck on 5001.

## Why hardcode 5001 (not a configurable `$PORT`)
An earlier revision made the port configurable via `$PORT`, but `EXPOSE` can't be parameterized in a Dockerfile, so it always showed 5001 regardless of the runtime port (Greptile P2). We own both the image and the taskdef and only ever need one port, so hardcoding 5001 keeps `EXPOSE`/healthcheck/CMD consistent and avoids the mismatch. (Implication: the taskdef just needs `containerPort: 5001`; a `PORT` env on the sidecar is a no-op.)

## Deploy ordering
Must be in ECR **before** the infra taskdef points the sidecar at `sim/pii` — otherwise the taskdef would run the old 3000-binding image and collide with the app. Independent of the app-rewire PR (which deploys *after* the taskdef). Sequence: **this → infra taskdef (`containerPort 5001`, `PII_URL=http://localhost:5001`) → app-rewire**.

## Testing
Built locally and verified the service binds 5001 and `/analyze` returns spans on that port. The hardcoded build produces an identical runtime process (`uvicorn server:app --host 0.0.0.0 --port 5001`) to the verified revision; CI rebuilds the image on merge.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)