### PR TITLE
fix(enrichment): stop PDL billing on no-match via required-field gating

### DIFF
--- a/apps/sim/enrichments/company-domain/company-domain.test.ts
+++ b/apps/sim/enrichments/company-domain/company-domain.test.ts
@@ -22,7 +22,7 @@ describe('company-domain enrichment cascade', () => {
     const p = provider('pdl')
     it('matches by name and normalizes the returned website', () => {
       expect(p.toolId).toBe('pdl_company_enrich')
-      expect(p.buildParams(nameInput)).toEqual({ name: 'Acme Inc' })
+      expect(p.buildParams(nameInput)).toEqual({ name: 'Acme Inc', required: 'website' })
       expect(p.buildParams({ companyName: '' })).toBeNull()
       expect(p.mapOutput({ company: { website: 'https://www.acme.com' } })).toEqual({
         domain: 'acme.com',

--- a/apps/sim/enrichments/company-domain/company-domain.ts
+++ b/apps/sim/enrichments/company-domain/company-domain.ts
@@ -21,7 +21,9 @@ export const companyDomainEnrichment: EnrichmentConfig = {
       buildParams: (inputs) => {
         const name = str(inputs.companyName)
         if (!name) return null
-        return { name }
+        // `required` makes PDL 404 (free) when the match has no website,
+        // instead of charging a credit for a match we'd discard as a no-match.
+        return { name, required: 'website' }
       },
       mapOutput: (output) => {
         const company = output.company as Record<string, unknown> | undefined

--- a/apps/sim/enrichments/company-info/company-info.ts
+++ b/apps/sim/enrichments/company-info/company-info.ts
@@ -45,7 +45,9 @@ export const companyInfoEnrichment: EnrichmentConfig = {
       buildParams: (inputs) => {
         const website = normalizeDomain(inputs.domain)
         if (!website) return null
-        return { website }
+        // `required` makes PDL 404 (free) when neither field we extract is
+        // present, instead of charging a credit for a match we'd discard.
+        return { website, required: 'employee_count OR summary' }
       },
       mapOutput: (output) => {
         const company = output.company as Record<string, unknown> | undefined

--- a/apps/sim/enrichments/phone-number/phone-number.ts
+++ b/apps/sim/enrichments/phone-number/phone-number.ts
@@ -31,10 +31,13 @@ export const phoneNumberEnrichment: EnrichmentConfig = {
       buildParams: (inputs) => {
         const name = str(inputs.fullName)
         if (!name) return null
+        // `required` makes PDL 404 (free) when the profile has no phone,
+        // instead of charging a credit for a match we'd discard as a no-match.
         return filterUndefined({
           name,
           company: normalizeDomain(inputs.companyDomain) || undefined,
           min_likelihood: 6,
+          required: 'phone_numbers OR mobile_phone',
         })
       },
       mapOutput: (output) => {

--- a/apps/sim/enrichments/work-email/work-email.ts
+++ b/apps/sim/enrichments/work-email/work-email.ts
@@ -122,10 +122,13 @@ export const workEmailEnrichment: EnrichmentConfig = {
       buildParams: (inputs) => {
         const name = str(inputs.fullName)
         if (!name) return null
+        // `required` makes PDL 404 (free) when the profile has no work email,
+        // instead of charging a credit for a match we'd discard as a no-match.
         return filterUndefined({
           name,
           company: normalizeDomain(inputs.companyDomain) || undefined,
           min_likelihood: 6,
+          required: 'work_email',
         })
       },
       mapOutput: (output) => {


### PR DESCRIPTION
## Summary
- People Data Labs bills per matched *profile*, but each enrichment cascade only counts a hit when `mapOutput` yields a *specific field*. A confident profile (likelihood ≥ 6) lacking that field was billed \$0.28 yet recorded as `no_match` — surfacing as "charged on no match" in the enrichment sidebar.
- Pass PDL's `required` param in all four cascades so PDL returns a free 404 when the extracted field is absent, aligning PDL's billing unit with the cascade's success unit. `min_likelihood: 6` unchanged.
  - work-email → `required: 'work_email'`
  - phone-number → `required: 'phone_numbers OR mobile_phone'`
  - company-info → `required: 'employee_count OR summary'`
  - company-domain → `required: 'website'`
- In each case the required field is not also a search/input param (PDL ignores `required` otherwise).

## Type of Change
- [x] Bug fix

## Testing
Tested manually. 35/35 enrichment tests pass, `tsc --noEmit` clean, `bun run lint` and `bun run check:api-validation:strict` pass. `required`-param billing behavior verified against PDL docs.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)