### PR TITLE
fix(trigger): mark cpu-features external to fix deploy build

### DIFF
--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
   dirs: ['./background'],
   ...(grafanaTelemetry ? { telemetry: grafanaTelemetry } : {}),
   build: {
-    external: ['isolated-vm', '@earendil-works/pi-coding-agent'],
+    external: ['isolated-vm', '@earendil-works/pi-coding-agent', 'cpu-features'],
     extensions: [
       additionalFiles({
         files: [


### PR DESCRIPTION
## Summary
- Trigger.dev deploy build was failing: `Could not resolve "../build/Release/cpufeatures.node"` from `cpu-features/lib/index.js`.
- Root cause: `ssh2` became reachable from the trigger background bundle via the Pi local SSH backend (#5178 wired `executor/handlers/pi/ssh-tools.ts` → `app/api/tools/ssh/utils` → `ssh2`). `ssh2` was previously only used in API routes, which the trigger build never bundles.
- esbuild then tried to bundle `ssh2`'s optional native dep `cpu-features` and choked on the missing compiled `.node` binary.
- Fix: add `cpu-features` to `build.external` in `trigger.config.ts`. `ssh2` requires it inside a `try/catch` purely as a crypto-acceleration optimization, so externalizing it has no runtime impact.

## Type of Change
- [x] Bug fix

## Testing
- Verified locally with `trigger.dev deploy --dry-run --local-build` → "Successfully built code" (build failed on the same step without the change).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)