### PR TITLE
feat(file): include public share status in File read output

### DIFF
--- a/apps/sim/app/api/tools/file/manage/route.ts
+++ b/apps/sim/app/api/tools/file/manage/route.ts
@@ -423,11 +423,14 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
         // with no active public link reads as 'private' and exposes no link/config.
         // Picker/upload input files have no canonical id, so they read as private.
         const shares = await getSharesForResources('file', selectedFileIds)
+        const privateReadShare = () => ({
+          visibility: 'private' as const,
+          url: null,
+          allowedEmails: [] as string[],
+        })
         const toReadShare = (fileId: string) => {
           const share = shares.get(fileId)
-          if (!share || !share.isActive) {
-            return { visibility: 'private' as const, url: null, allowedEmails: [] as string[] }
-          }
+          if (!share || !share.isActive) return privateReadShare()
           return {
             visibility: share.authType,
             url: share.url,
@@ -440,7 +443,9 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
             Boolean(file)
           )
           .map((file) => ({ ...file, share: toReadShare(file.id) }))
-          .concat(selectedInputFiles.map((file) => ({ ...file, share: toReadShare(file.id) })))
+          // Picker/upload entries have only a synthetic id (storage key/URL), so they
+          // never carry a canonical share — mark them private without a lookup.
+          .concat(selectedInputFiles.map((file) => ({ ...file, share: privateReadShare() })))
 
         logger.info('Files retrieved', {
           count: userFiles.length,

--- a/apps/sim/app/api/tools/file/manage/route.ts
+++ b/apps/sim/app/api/tools/file/manage/route.ts
@@ -418,10 +418,6 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           )
         }
 
-        // Attach each workspace file's share status (batched to avoid N+1), using
-        // the same visibility vocabulary as the Manage Sharing operation. A file
-        // with no active public link reads as 'private' and exposes no link/config.
-        // Picker/upload input files have no canonical id, so they read as private.
         const shares = await getSharesForResources('file', selectedFileIds)
         const privateReadShare = () => ({
           visibility: 'private' as const,

--- a/apps/sim/app/api/tools/file/manage/route.ts
+++ b/apps/sim/app/api/tools/file/manage/route.ts
@@ -17,6 +17,7 @@ import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { isSupportedFileType, parseBuffer } from '@/lib/file-parsers'
 import {
   getShareForResource,
+  getSharesForResources,
   ShareValidationError,
   upsertFileShare,
 } from '@/lib/public-shares/share-manager'
@@ -417,12 +418,16 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           )
         }
 
+        // Attach each workspace file's public share status (batched to avoid N+1).
+        // Picker/upload input files have no canonical id, so they carry no share.
+        const shares = await getSharesForResources('file', selectedFileIds)
         const userFiles = files
           .map((file) => workspaceFileToUserFile(file))
           .filter((file): file is NonNullable<ReturnType<typeof workspaceFileToUserFile>> =>
             Boolean(file)
           )
-          .concat(selectedInputFiles)
+          .map((file) => ({ ...file, share: shares.get(file.id) ?? null }))
+          .concat(selectedInputFiles.map((file) => ({ ...file, share: null })))
 
         logger.info('Files retrieved', {
           count: userFiles.length,

--- a/apps/sim/app/api/tools/file/manage/route.ts
+++ b/apps/sim/app/api/tools/file/manage/route.ts
@@ -418,16 +418,29 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           )
         }
 
-        // Attach each workspace file's public share status (batched to avoid N+1).
-        // Picker/upload input files have no canonical id, so they carry no share.
+        // Attach each workspace file's share status (batched to avoid N+1), using
+        // the same visibility vocabulary as the Manage Sharing operation. A file
+        // with no active public link reads as 'private' and exposes no link/config.
+        // Picker/upload input files have no canonical id, so they read as private.
         const shares = await getSharesForResources('file', selectedFileIds)
+        const toReadShare = (fileId: string) => {
+          const share = shares.get(fileId)
+          if (!share || !share.isActive) {
+            return { visibility: 'private' as const, url: null, allowedEmails: [] as string[] }
+          }
+          return {
+            visibility: share.authType,
+            url: share.url,
+            allowedEmails: share.allowedEmails,
+          }
+        }
         const userFiles = files
           .map((file) => workspaceFileToUserFile(file))
           .filter((file): file is NonNullable<ReturnType<typeof workspaceFileToUserFile>> =>
             Boolean(file)
           )
-          .map((file) => ({ ...file, share: shares.get(file.id) ?? null }))
-          .concat(selectedInputFiles.map((file) => ({ ...file, share: null })))
+          .map((file) => ({ ...file, share: toReadShare(file.id) }))
+          .concat(selectedInputFiles.map((file) => ({ ...file, share: toReadShare(file.id) })))
 
         logger.info('Files retrieved', {
           count: userFiles.length,

--- a/apps/sim/blocks/blocks/file.ts
+++ b/apps/sim/blocks/blocks/file.ts
@@ -1361,7 +1361,7 @@ export const FileV5Block: BlockConfig<FileParserV3Output> = {
     files: {
       type: 'file[]',
       description:
-        'Workspace file objects (read), fetched file objects (fetch), the compressed archive (compress), or extracted files (decompress)',
+        'Workspace file objects (read; each includes a "share" field with its public share status, null when not shared), fetched file objects (fetch), the compressed archive (compress), or extracted files (decompress)',
     },
     contents: {
       type: 'array',

--- a/apps/sim/blocks/blocks/file.ts
+++ b/apps/sim/blocks/blocks/file.ts
@@ -1361,7 +1361,7 @@ export const FileV5Block: BlockConfig<FileParserV3Output> = {
     files: {
       type: 'file[]',
       description:
-        'Workspace file objects (read; each includes a "share" field — { visibility, url, allowedEmails }, where visibility is "private" when not shared or "public"/"password"/"email"/"sso" with the link in url), fetched file objects (fetch), the compressed archive (compress), or extracted files (decompress)',
+        'Workspace file objects with share status (read), fetched file objects (fetch), the compressed archive (compress), or extracted files (decompress)',
     },
     contents: {
       type: 'array',

--- a/apps/sim/blocks/blocks/file.ts
+++ b/apps/sim/blocks/blocks/file.ts
@@ -1361,7 +1361,7 @@ export const FileV5Block: BlockConfig<FileParserV3Output> = {
     files: {
       type: 'file[]',
       description:
-        'Workspace file objects (read; each includes a "share" field with its public share status, null when not shared), fetched file objects (fetch), the compressed archive (compress), or extracted files (decompress)',
+        'Workspace file objects (read; each includes a "share" field — { visibility, url, allowedEmails }, where visibility is "private" when not shared or "public"/"password"/"email"/"sso" with the link in url), fetched file objects (fetch), the compressed archive (compress), or extracted files (decompress)',
     },
     contents: {
       type: 'array',

--- a/apps/sim/tools/file/get.ts
+++ b/apps/sim/tools/file/get.ts
@@ -63,7 +63,7 @@ const createFileReadTool = (config: {
     files: {
       type: 'file[]',
       description:
-        'Workspace file objects, each with its public share status in a "share" field (null when the file is not shared)',
+        'Workspace file objects, each with a "share" field: { visibility, url, allowedEmails }. visibility is "private" when not publicly shared (url null), otherwise "public"/"password"/"email"/"sso" with the public link in url',
     },
   },
 })

--- a/apps/sim/tools/file/get.ts
+++ b/apps/sim/tools/file/get.ts
@@ -60,7 +60,11 @@ const createFileReadTool = (config: {
   },
 
   outputs: {
-    files: { type: 'file[]', description: 'Workspace file objects' },
+    files: {
+      type: 'file[]',
+      description:
+        'Workspace file objects, each with its public share status in a "share" field (null when the file is not shared)',
+    },
   },
 })
 

--- a/apps/sim/tools/file/get.ts
+++ b/apps/sim/tools/file/get.ts
@@ -60,11 +60,7 @@ const createFileReadTool = (config: {
   },
 
   outputs: {
-    files: {
-      type: 'file[]',
-      description:
-        'Workspace file objects, each with a "share" field: { visibility, url, allowedEmails }. visibility is "private" when not publicly shared (url null), otherwise "public"/"password"/"email"/"sso" with the public link in url',
-    },
+    files: { type: 'file[]', description: 'Workspace file objects' },
   },
 })
 


### PR DESCRIPTION
## Summary
- The File block's **Read** operation now returns each workspace file's public share status alongside the file object.
- Each returned file gains a `share` field — the public-safe share record (`isActive`, `url`, `authType`, `hasPassword`, `allowedEmails`, …) or `null` when the file isn't shared.
- Shares are batch-fetched with `getSharesForResources` (one query for all files, no N+1).
- Picker/upload input files have no canonical workspace id, so they carry `share: null`.

Follow-up to #5177 (Manage Sharing operation).

## Type of Change
- [x] New feature

## Testing
- `tsc --noEmit`, `bun run lint`, `bun run check:api-validation:strict`, and the File block test suite all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)