### PR TITLE
improvement(mistral): update OCR pricing to OCR 4 rate ($4/1,000 pages)

### DIFF
--- a/apps/sim/tools/mistral/parser.ts
+++ b/apps/sim/tools/mistral/parser.ts
@@ -15,11 +15,13 @@ const logger = createLogger('MistralParserTool')
 /**
  * Mistral OCR 4 standard pricing, in USD per page ($4 per 1,000 pages).
  *
- * This tool calls the synchronous `/v1/ocr` endpoint, so the standard (non-batch)
- * rate applies. Document AI / annotation pages are priced separately, but this tool
- * does not submit annotation requests.
+ * This tool calls the synchronous `/v1/ocr` endpoint with the `mistral-ocr-latest`
+ * alias, which Mistral repointed to OCR 4 (`mistral-ocr-4-0`) on 2026-06-23, so the
+ * standard (non-batch) OCR 4 rate applies. Document AI / annotation pages are priced
+ * separately, but this tool does not submit annotation requests.
  *
  * @see https://mistral.ai/news/ocr-4/
+ * @see https://docs.mistral.ai/getting-started/changelog
  */
 const MISTRAL_OCR_COST_PER_PAGE = 0.004
 

--- a/apps/sim/tools/mistral/parser.ts
+++ b/apps/sim/tools/mistral/parser.ts
@@ -12,6 +12,17 @@ import type { ToolConfig } from '@/tools/types'
 
 const logger = createLogger('MistralParserTool')
 
+/**
+ * Mistral OCR 4 standard pricing, in USD per page ($4 per 1,000 pages).
+ *
+ * This tool calls the synchronous `/v1/ocr` endpoint, so the standard (non-batch)
+ * rate applies. Document AI / annotation pages are priced separately, but this tool
+ * does not submit annotation requests.
+ *
+ * @see https://mistral.ai/news/ocr-4/
+ */
+const MISTRAL_OCR_COST_PER_PAGE = 0.004
+
 const MISTRAL_OCR_HOSTING = {
   envKeyPrefix: 'MISTRAL_API_KEY',
   apiKeyParam: 'apiKey',
@@ -19,9 +30,6 @@ const MISTRAL_OCR_HOSTING = {
   pricing: {
     type: 'custom' as const,
     getCost: (_params: unknown, output: Record<string, unknown>) => {
-      // Mistral OCR 3 standard pricing: $2 per 1,000 pages ($0.002/page).
-      // Annotated pages are priced separately at $3 per 1,000 annotated pages, but this tool does
-      // not submit annotation requests. Source: https://docs.mistral.ai/models/ocr-3-25-12
       const rawUsageInfo = output.usage_info as { pages_processed?: number } | undefined
       const transformedUsageInfo = (
         output.metadata as { usageInfo?: { pagesProcessed?: number } } | undefined
@@ -33,7 +41,7 @@ const MISTRAL_OCR_HOSTING = {
           'Mistral OCR response missing pages_processed in usage_info or metadata.usageInfo.pagesProcessed'
         )
       }
-      const cost = pagesProcessed * 0.002
+      const cost = pagesProcessed * MISTRAL_OCR_COST_PER_PAGE
       return { cost, metadata: { pagesProcessed } }
     },
   },


### PR DESCRIPTION
## Summary
- Mistral's `mistral-ocr-latest` alias (what we call) now resolves to OCR 4 (`mistral-ocr-4-0`), so the model is already current — no model-string change needed.
- The per-page cost constant was stale at OCR 3's rate ($0.002/page). OCR 4's synchronous `/v1/ocr` standard rate is $4/1,000 pages, so updated the cost to $0.004/page.
- Extracted the magic number into a documented `MISTRAL_OCR_COST_PER_PAGE` constant with TSDoc citing the source.

## Type of Change
- [x] Bug fix (cost-tracking accuracy)

## Testing
Tested manually — verified OCR 4 pricing against https://mistral.ai/news/ocr-4/ and https://mistral.ai/pricing.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)