### PR TITLE
fix(workspace): add granular error boundaries to 7 more workspace segments

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/chat/[chatId]/error.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/chat/[chatId]/error.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { type ErrorBoundaryProps, ErrorState } from '@/app/workspace/[workspaceId]/components'
+
+export default function ChatError({ error, reset }: ErrorBoundaryProps) {
+  return (
+    <ErrorState
+      error={error}
+      reset={reset}
+      title='Failed to load chat'
+      description='Something went wrong while loading this chat. Please try again.'
+      loggerName='ChatError'
+    />
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/home/error.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/error.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { type ErrorBoundaryProps, ErrorState } from '@/app/workspace/[workspaceId]/components'
+
+export default function HomeError({ error, reset }: ErrorBoundaryProps) {
+  return (
+    <ErrorState
+      error={error}
+      reset={reset}
+      title='Failed to load home'
+      description='Something went wrong while loading your workspace home. Please try again.'
+      loggerName='HomeError'
+    />
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/integrations/error.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/error.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { type ErrorBoundaryProps, ErrorState } from '@/app/workspace/[workspaceId]/components'
+
+export default function IntegrationsError({ error, reset }: ErrorBoundaryProps) {
+  return (
+    <ErrorState
+      error={error}
+      reset={reset}
+      title='Failed to load integrations'
+      description='Something went wrong while loading your integrations. Please try again.'
+      loggerName='IntegrationsError'
+    />
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/error.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/error.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { type ErrorBoundaryProps, ErrorState } from '@/app/workspace/[workspaceId]/components'
+
+export default function KnowledgeBaseError({ error, reset }: ErrorBoundaryProps) {
+  return (
+    <ErrorState
+      error={error}
+      reset={reset}
+      title='Failed to load knowledge base'
+      description='Something went wrong while loading this knowledge base. Please try again.'
+      loggerName='KnowledgeBaseError'
+    />
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/error.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/error.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { type ErrorBoundaryProps, ErrorState } from '@/app/workspace/[workspaceId]/components'
+
+export default function ScheduledTasksError({ error, reset }: ErrorBoundaryProps) {
+  return (
+    <ErrorState
+      error={error}
+      reset={reset}
+      title='Failed to load scheduled tasks'
+      description='Something went wrong while loading your scheduled tasks. Please try again.'
+      loggerName='ScheduledTasksError'
+    />
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/settings/error.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/error.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { type ErrorBoundaryProps, ErrorState } from '@/app/workspace/[workspaceId]/components'
+
+export default function SettingsError({ error, reset }: ErrorBoundaryProps) {
+  return (
+    <ErrorState
+      error={error}
+      reset={reset}
+      title='Failed to load settings'
+      description='Something went wrong while loading your settings. Please try again.'
+      loggerName='SettingsError'
+    />
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/skills/error.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/skills/error.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { type ErrorBoundaryProps, ErrorState } from '@/app/workspace/[workspaceId]/components'
+
+export default function SkillsError({ error, reset }: ErrorBoundaryProps) {
+  return (
+    <ErrorState
+      error={error}
+      reset={reset}
+      title='Failed to load skills'
+      description='Something went wrong while loading your skills. Please try again.'
+      loggerName='SkillsError'
+    />
+  )
+}


### PR DESCRIPTION
## Summary
Adds `error.tsx` to 7 more high-traffic workspace segments — **home, integrations, knowledge/[id], skills, settings, scheduled-tasks, chat/[chatId]** — so a crash in any of these panels stays scoped to the panel (with a retry) instead of bubbling to the generic workspace-level boundary.

Each reuses the shared `ErrorState` component, so they are **structurally identical** to the existing boundaries (tables/logs/files/knowledge) — same icon + description + "Refresh" button layout — differing only in title/description/loggerName. Purely additive: only narrows where errors are caught; the workspace-level fallback stays intact.

## Type of Change
- [x] Improvement (resilience / UX)

## Testing
- tsc 0 errors; Biome clean. Each file is a verbatim copy of the canonical `tables/error.tsx` pattern.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)