### PR TITLE
feat(db): attribute Postgres connections by runtime via application_name

### DIFF
--- a/apps/realtime/package.json
+++ b/apps/realtime/package.json
@@ -9,8 +9,8 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "dev": "bun --watch src/index.ts",
-    "start": "bun src/index.ts",
+    "dev": "DB_APP_NAME=sim-realtime bun --watch src/index.ts",
+    "start": "DB_APP_NAME=sim-realtime bun src/index.ts",
     "type-check": "tsc --noEmit",
     "lint": "biome check --write --unsafe .",
     "lint:check": "biome check .",

--- a/apps/realtime/src/bootstrap.ts
+++ b/apps/realtime/src/bootstrap.ts
@@ -6,4 +6,11 @@
 import { loadRuntimeSecrets } from '@sim/runtime-secrets'
 
 await loadRuntimeSecrets()
+/**
+ * Label every Postgres connection this process opens as `sim-realtime` — both
+ * the realtime `socketDb` pool and the shared `@sim/db` client used by handlers,
+ * preflight, and permissions. Set before importing `@/index` so it lands before
+ * `@sim/db` reads it at module-eval time. `??=` respects an explicit override.
+ */
+process.env.DB_APP_NAME ??= 'sim-realtime'
 await import('@/index')

--- a/apps/realtime/src/database/operations.ts
+++ b/apps/realtime/src/database/operations.ts
@@ -40,6 +40,7 @@ const socketDb = drizzle(
       connect_timeout: 20,
       max: 15,
       onnotice: () => {},
+      connection: { application_name: process.env.DB_APP_NAME ?? 'sim-realtime' },
     }),
     'socketDb'
   ),

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -20,7 +20,7 @@ export const env = createEnv({
     // Core Database & Authentication
     DATABASE_URL:                          z.string().url(),                       // Primary database connection string
     DATABASE_REPLICA_URL:                  z.string().url().optional(),            // Read-replica connection string; opt-in reads fall back to the primary when unset
-    DB_APP_NAME:                           z.string().optional(),                  // Postgres application_name for query attribution (sim-app/sim-trigger/sim-realtime); read directly from process.env in @sim/db, documented here for discoverability
+    DB_APP_NAME:                           z.string().optional(),                  // Postgres application_name for query attribution (sim-app/sim-trigger/sim-realtime)
     BETTER_AUTH_URL:                       z.string().url(),                       // Base URL for Better Auth service
     BETTER_AUTH_SECRET:                    z.string().min(32),                     // Secret key for Better Auth JWT signing
     DISABLE_REGISTRATION:                  z.boolean().optional(),                 // Flag to disable new user registration

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -20,6 +20,7 @@ export const env = createEnv({
     // Core Database & Authentication
     DATABASE_URL:                          z.string().url(),                       // Primary database connection string
     DATABASE_REPLICA_URL:                  z.string().url().optional(),            // Read-replica connection string; opt-in reads fall back to the primary when unset
+    DB_APP_NAME:                           z.string().optional(),                  // Postgres application_name for query attribution (sim-app/sim-trigger/sim-realtime); read directly from process.env in @sim/db, documented here for discoverability
     BETTER_AUTH_URL:                       z.string().url(),                       // Base URL for Better Auth service
     BETTER_AUTH_SECRET:                    z.string().min(32),                     // Secret key for Better Auth JWT signing
     DISABLE_REGISTRATION:                  z.boolean().optional(),                 // Flag to disable new user registration

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -2,7 +2,11 @@ import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { resourceFromAttributes } from '@opentelemetry/resources'
-import { additionalFiles, additionalPackages } from '@trigger.dev/build/extensions/core'
+import {
+  additionalFiles,
+  additionalPackages,
+  syncEnvVars,
+} from '@trigger.dev/build/extensions/core'
 import { defineConfig } from '@trigger.dev/sdk'
 import { env } from './lib/core/config/env'
 import { parseOtlpHeaders } from './lib/monitoring/otlp'
@@ -58,6 +62,7 @@ export default defineConfig({
   build: {
     external: ['isolated-vm', '@earendil-works/pi-coding-agent', 'cpu-features'],
     extensions: [
+      syncEnvVars(() => [{ name: 'DB_APP_NAME', value: 'sim-trigger' }]),
       additionalFiles({
         files: [
           './lib/execution/isolated-vm-worker.cjs',

--- a/packages/db/db.ts
+++ b/packages/db/db.ts
@@ -13,6 +13,7 @@ const poolOptions = {
   idle_timeout: 20,
   connect_timeout: 30,
   onnotice: () => {},
+  connection: { application_name: process.env.DB_APP_NAME ?? 'sim-app' },
 }
 
 const postgresClient = instrumentPoolClient(

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -45,7 +45,12 @@ const hasDirectMigrationUrl = Boolean(process.env.MIGRATION_DATABASE_URL)
  * default recycles the connection after 30–60 min, silently dropping the
  * session advisory lock and `SET`s.
  */
-const client = postgres(url, { max: 1, connect_timeout: 10, max_lifetime: null })
+const client = postgres(url, {
+  max: 1,
+  connect_timeout: 10,
+  max_lifetime: null,
+  connection: { application_name: 'sim-migrate' },
+})
 
 /**
  * Cross-process migration lock. drizzle's `migrate()` has no built-in lock, so


### PR DESCRIPTION
## Summary
- Set Postgres `application_name` per runtime so DB activity is attributable: `sim-app` (Next.js), `sim-trigger` (trigger.dev workers), `sim-realtime` (socket server). Previously every connection reported the `postgres.js` library default, making it impossible to tell whether lock spikes / advisory-lock contention / statement timeouts come from a request-path query or a background task.
- `packages/db/db.ts` + `apps/realtime/src/database/operations.ts`: add `connection: { application_name }` from `DB_APP_NAME` (defaults `sim-app` / `sim-realtime`).
- `apps/sim/trigger.config.ts`: declare `DB_APP_NAME=sim-trigger` in code via the `syncEnvVars` build extension — the worker's separate deploy scope gets the label without a manual dashboard step or sniffing trigger internals (the obvious `TRIGGER_*` vars are present in the web app too).
- `apps/sim/lib/core/config/env.ts`: document `DB_APP_NAME`.

Validated against prod (`sim-studio-production`): `application_name` propagates through PlanetScale's pooler to the backend, and a `pg_locks ⋈ pg_stat_activity` join attributes locks by app on the existing `pg_read_all_data` role (no `pg_monitor` needed). Finer-grained per-request/run comment tags, lock-victim logging, and a Grafana Alloy lock-by-app metric are deferred follow-ups.

## Type of Change
- [x] New feature (observability)

## Testing
Tested manually. `bun run lint`, `bun run check:api-validation:strict`, and the `@sim/db` vitest suite (19/19) pass. Live verification post-deploy via `SELECT application_name, count(*) FROM pg_stat_activity GROUP BY 1`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)