### PR TITLE
docs: Academy learning surface

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -38,3 +38,6 @@ next-env.d.ts
 # Fumadocs
 /.source/ 
 .plans/
+
+# fumadocs generates .source dirs anywhere a source.config sits
+**/.source/

--- a/apps/docs/app/[lang]/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/[[...slug]]/page.tsx
@@ -75,16 +75,23 @@ export default async function Page(props: { params: Promise<{ slug?: string[]; l
   }
   const isOpenAPI = '_openapi' in data && data._openapi != null
   const isApiReference = slug?.some((s) => s === 'api-reference') ?? false
+  // Academy lessons are video-first: drop the "On this page" TOC and go full
+  // width so the lesson hero/video gets the room (chapters live in-page instead).
+  const isAcademy = slug?.[0] === 'academy'
 
   const pageTreeRecord = source.pageTree as Record<string, Root>
   const pageTree = pageTreeRecord[lang] ?? pageTreeRecord.en ?? Object.values(pageTreeRecord)[0]
   const rawNeighbours = pageTree ? findNeighbour(pageTree, page.url) : null
-  const neighbours = isApiReference
+  // Academy and API Reference are self-contained sections; keep prev/next inside
+  // the section instead of spilling into the main documentation tree. Match both
+  // the section's pages (`/<slug>/...`) and its index (`/<slug>`).
+  const sectionSlug = isApiReference ? 'api-reference' : isAcademy ? 'academy' : null
+  const inSection = (url?: string) =>
+    url != null && (url.includes(`/${sectionSlug}/`) || url.endsWith(`/${sectionSlug}`))
+  const neighbours = sectionSlug
     ? {
-        previous: rawNeighbours?.previous?.url.includes('/api-reference/')
-          ? rawNeighbours.previous
-          : undefined,
-        next: rawNeighbours?.next?.url.includes('/api-reference/') ? rawNeighbours.next : undefined,
+        previous: inSection(rawNeighbours?.previous?.url) ? rawNeighbours?.previous : undefined,
+        next: inSection(rawNeighbours?.next?.url) ? rawNeighbours?.next : undefined,
       }
     : rawNeighbours
 
@@ -197,18 +204,18 @@ export default async function Page(props: { params: Promise<{ slug?: string[]; l
       />
       <DocsPage
         toc={data.toc}
-        full={data.full}
+        full={data.full || isAcademy}
         breadcrumb={{
           enabled: false,
         }}
         tableOfContent={{
           style: 'clerk',
-          enabled: true,
+          enabled: !isAcademy,
           single: false,
         }}
         tableOfContentPopover={{
           style: 'clerk',
-          enabled: true,
+          enabled: !isAcademy,
         }}
         footer={{
           enabled: true,

--- a/apps/docs/components/navbar/navbar.tsx
+++ b/apps/docs/components/navbar/navbar.tsx
@@ -13,7 +13,13 @@ const NAV_TABS = [
   {
     label: 'Documentation',
     href: '/introduction',
-    match: (p: string) => !p.includes('/api-reference'),
+    match: (p: string) => !p.includes('/api-reference') && !p.includes('/academy'),
+    external: false,
+  },
+  {
+    label: 'Academy',
+    href: '/academy',
+    match: (p: string) => p.includes('/academy'),
     external: false,
   },
   {

--- a/apps/docs/components/ui/video-chapters.tsx
+++ b/apps/docs/components/ui/video-chapters.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { CirclePlay } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/** Parse a chapter timestamp ("M:SS" or "H:MM:SS") into seconds. */
+function parseTime(time: string): number {
+  const parts = time.split(':').map(Number)
+  if (parts.some(Number.isNaN)) return 0
+  return parts.reduce((acc, n) => acc * 60 + n, 0)
+}
+
+interface Chapter {
+  /** Chapter label. */
+  title: string
+  /** Timestamp, e.g. "0:45". */
+  time?: string
+}
+
+interface VideoChaptersProps {
+  /** Panel heading. Defaults to "Chapters". */
+  title?: string
+  chapters: Chapter[]
+  className?: string
+}
+
+/**
+ * Right-rail panel listing the current video's chapters, styled to match the
+ * Academy's course panels. Rows are skip-to controls; they activate once the
+ * lesson's video is recorded.
+ */
+export function VideoChapters({ title = 'Chapters', chapters, className }: VideoChaptersProps) {
+  // Chapters only seek when a VideoPlaceholder with a real video is on the page.
+  // Handshake so the rows stay inert (not falsely clickable) on video-less lessons.
+  const [hasVideo, setHasVideo] = useState(false)
+  useEffect(() => {
+    const onReady = () => setHasVideo(true)
+    window.addEventListener('academy:video-ready', onReady)
+    window.dispatchEvent(new Event('academy:video-query'))
+    return () => window.removeEventListener('academy:video-ready', onReady)
+  }, [])
+
+  return (
+    <aside
+      className={cn('not-prose rounded-xl border border-fd-border bg-fd-card/40 p-5', className)}
+    >
+      <h2 className='mt-0 mb-3 font-semibold text-fd-foreground text-lg'>{title}</h2>
+      <ul className='m-0 flex list-none flex-col gap-0.5 p-0'>
+        {chapters.map((chapter) => (
+          <li key={chapter.title}>
+            <button
+              type='button'
+              disabled={!hasVideo || chapter.time == null}
+              onClick={() => {
+                if (chapter.time == null) return
+                window.dispatchEvent(
+                  new CustomEvent('academy:seek', { detail: { time: parseTime(chapter.time) } })
+                )
+              }}
+              className='flex w-full cursor-pointer items-start gap-2.5 rounded-lg px-2.5 py-2 text-left text-fd-muted-foreground text-sm transition-colors hover:bg-fd-accent/50 disabled:cursor-default disabled:hover:bg-transparent'
+            >
+              <CirclePlay className='mt-0.5 size-4 shrink-0' />
+              <span className='min-w-0 flex-1 break-words'>{chapter.title}</span>
+              {chapter.time && (
+                <span className='mt-0.5 shrink-0 text-fd-muted-foreground text-xs tabular-nums'>
+                  {chapter.time}
+                </span>
+              )}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  )
+}

--- a/apps/docs/components/ui/video-placeholder.tsx
+++ b/apps/docs/components/ui/video-placeholder.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { cn, getAssetUrl } from '@/lib/utils'
+
+interface VideoPlaceholderProps {
+  /** Large title shown on the hero. */
+  title?: string
+  /** Small italic eyebrow above the title, e.g. a module name. */
+  eyebrow?: string
+  /** Pill in the top-right corner. Defaults to "Coming soon" (shown only until a video is set). */
+  label?: string
+  /**
+   * Self-hosted video source. Accepts an absolute URL, a root-relative path
+   * (`/static/...`), or a bare asset name resolved through the Blob CDN. When
+   * set, the play button loads the video; otherwise the card is "coming soon".
+   */
+  src?: string
+  className?: string
+}
+
+/** Resolve a video source: pass absolute/root-relative through, send bare names to the Blob CDN. */
+function resolveVideoSrc(src: string): string {
+  if (/^https?:\/\//.test(src) || src.startsWith('/')) return src
+  return getAssetUrl(src)
+}
+
+/** The sim logotype, drawn with currentColor so the theme can tint it. */
+function SimWordmark({ className }: { className?: string }) {
+  return (
+    <svg viewBox='0 0 816 392' fill='currentColor' aria-label='Sim' className={className}>
+      <path d='M 0 297.507 L 54.609 297.507 C 54.609 312.642 60.07 324.71 70.992 333.709 C 81.914 342.299 96.679 346.594 115.287 346.594 C 135.512 346.594 151.086 342.707 162.008 334.936 C 172.93 326.754 178.391 315.915 178.391 302.415 C 178.391 292.598 175.357 284.417 169.289 277.871 C 163.627 271.326 153.109 266.009 137.737 261.918 L 85.555 249.646 C 59.261 243.102 39.642 233.08 26.698 219.581 C 14.158 206.082 7.888 188.287 7.888 166.198 C 7.888 147.79 12.54 131.837 21.844 118.338 C 31.552 104.838 44.699 94.408 61.284 87.045 C 78.274 79.682 97.69 76 119.534 76 C 141.378 76 160.187 79.886 175.964 87.658 C 192.144 95.43 204.684 106.271 213.584 120.179 C 222.888 134.086 227.742 150.654 228.146 169.88 L 173.536 169.88 C 173.132 154.335 168.076 142.267 158.368 133.678 C 148.659 125.087 135.108 120.792 117.714 120.792 C 99.915 120.792 86.162 124.678 76.453 132.451 C 66.745 140.223 61.891 150.858 61.891 164.357 C 61.891 184.402 76.453 198.105 105.579 205.468 L 157.76 218.354 C 182.841 224.08 201.651 233.489 214.191 246.579 C 226.73 259.26 233 276.644 233 298.734 C 233 317.55 227.943 334.118 217.831 348.435 C 207.718 362.343 193.762 373.183 175.964 380.955 C 158.57 388.318 137.939 392 114.073 392 C 79.285 392 51.576 383.409 30.945 366.229 C 10.315 349.048 0 326.141 0 297.507 Z' />
+      <path d='M 430.759 392 L 374 392 L 374 92 L 424.721 92 L 424.721 143.095 C 430.76 126.357 442.433 112.167 458.535 101.145 C 475.039 89.715 494.966 84 518.314 84 C 544.48 84 566.217 91.144 583.527 105.431 C 600.837 119.719 612.108 138.701 617.342 162.378 L 607.076 162.378 C 611.102 138.701 622.172 119.719 640.287 105.431 C 658.401 91.144 680.743 84 707.311 84 C 741.126 84 767.694 94.001 787.017 114.004 C 806.339 134.006 816 161.357 816 196.056 L 816 392 L 760.448 392 L 760.448 210.139 C 760.448 186.462 754.41 168.297 742.333 155.643 C 730.66 142.579 714.758 136.048 694.631 136.048 C 680.542 136.048 668.062 139.314 657.194 145.845 C 646.728 151.968 638.475 160.949 632.437 172.787 C 626.398 184.625 623.38 198.505 623.38 214.425 L 623.38 392 L 567.223 392 L 567.223 209.527 C 567.223 185.85 561.387 167.888 549.713 155.643 C 538.039 142.988 522.138 136.66 502.01 136.66 C 487.921 136.66 475.442 139.926 464.574 146.457 C 454.108 152.58 445.855 161.562 439.817 173.4 C 433.778 184.83 430.759 198.505 430.759 214.425 L 430.759 392 Z' />
+      <path d='M 342 38 C 342 58.987 324.987 76 304 76 C 283.013 76 266 58.987 266 38 C 266 17.013 283.013 0 304 0 C 324.987 0 342 17.013 342 38 Z' />
+      <path d='M 332 392 L 276 392 L 276 92 C 284.5 95.988 293.99 98.218 304 98.218 C 314.01 98.218 323.5 95.988 332 92 L 332 392 Z' />
+    </svg>
+  )
+}
+
+/**
+ * A 16:9 lesson hero used across the Academy. Always shows the design-system
+ * video card (title, blueprint grid, theme-aware dark/light). When a `src` is
+ * provided the play button loads the self-hosted video inline; otherwise the
+ * card reads "Coming soon" and the play button is muted.
+ */
+export function VideoPlaceholder({
+  title,
+  eyebrow,
+  label = 'Coming soon',
+  src,
+  className,
+}: VideoPlaceholderProps) {
+  const hasVideo = Boolean(src)
+  const [playing, setPlaying] = useState(false)
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const pendingSeek = useRef<number | null>(null)
+
+  // Chapter rows (VideoChapters) dispatch `academy:seek` with a time in seconds.
+  // Start the video if it isn't playing yet, then jump there. We also announce
+  // that a video exists (and answer a chapters-side query) so the chapter rows
+  // only become interactive when there's actually something to seek.
+  useEffect(() => {
+    if (!src) return
+    const onSeek = (e: Event) => {
+      const time = (e as CustomEvent<{ time: number }>).detail?.time
+      if (typeof time !== 'number') return
+      const video = videoRef.current
+      if (video) {
+        video.currentTime = time
+        void video.play()
+      } else {
+        pendingSeek.current = time
+        setPlaying(true)
+      }
+    }
+    const announce = () => window.dispatchEvent(new Event('academy:video-ready'))
+    window.addEventListener('academy:seek', onSeek)
+    window.addEventListener('academy:video-query', announce)
+    announce()
+    return () => {
+      window.removeEventListener('academy:seek', onSeek)
+      window.removeEventListener('academy:video-query', announce)
+    }
+  }, [src])
+
+  if (playing && src) {
+    return (
+      <div
+        className={cn(
+          'not-prose my-6 aspect-video w-full overflow-hidden rounded-[20px] bg-black',
+          className
+        )}
+      >
+        {/* biome-ignore lint/a11y/useMediaCaption: lesson videos have no caption track yet */}
+        <video
+          ref={videoRef}
+          src={resolveVideoSrc(src)}
+          title={title ?? 'Lesson video'}
+          controls
+          autoPlay
+          playsInline
+          onLoadedMetadata={() => {
+            if (pendingSeek.current != null && videoRef.current) {
+              videoRef.current.currentTime = pendingSeek.current
+              void videoRef.current.play()
+              pendingSeek.current = null
+            }
+          }}
+          className='h-full w-full border-0'
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'not-prose group relative my-6 aspect-video w-full select-none overflow-hidden rounded-[20px] font-season transition-transform duration-200 [container-type:inline-size]',
+        'shadow-[inset_0_0_0_1px_#E6E6E6] [background:radial-gradient(130%_130%_at_50%_14%,#ffffff_0%,#f6f6f6_55%,#ececec_100%)]',
+        'dark:shadow-none dark:[background:radial-gradient(130%_130%_at_50%_18%,#1c1c1c_0%,#121212_45%,#0a0a0a_100%)]',
+        className
+      )}
+    >
+      {/* Blueprint grid — faint, fading to atmosphere at the edges */}
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 [background-image:linear-gradient(rgba(18,18,18,0.05)_1px,transparent_1px),linear-gradient(90deg,rgba(18,18,18,0.05)_1px,transparent_1px)] [background-size:64px_64px] [mask-image:radial-gradient(120%_90%_at_50%_35%,#000_30%,transparent_100%)] dark:[background-image:linear-gradient(rgba(255,255,255,0.06)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.06)_1px,transparent_1px)]'
+      />
+
+      {/* Corner plus-marks, 20px inset */}
+      {['top-5 left-5', 'top-5 right-5', 'bottom-5 left-5', 'right-5 bottom-5'].map((pos) => (
+        <span
+          key={pos}
+          aria-hidden
+          className={cn(
+            'absolute font-mono text-[20px] text-[rgba(18,18,18,0.22)] leading-none dark:text-[rgba(255,255,255,0.28)]',
+            pos
+          )}
+        >
+          +
+        </span>
+      ))}
+
+      {/* Top-right status pill — only until a video is wired up */}
+      {!hasVideo && (
+        <span className='absolute top-6 right-6 z-10 inline-flex items-center gap-2 rounded-full border border-[#E6E6E6] bg-white px-4 py-2 font-medium text-[#5F5F5F] text-[12px] uppercase tracking-[0.14em] md:top-8 md:right-8 dark:border-white/12 dark:bg-[#1A1A1A] dark:text-[#E6E6E6]'>
+          <span className='size-1.5 rounded-full bg-[#1F8A5B]' />
+          {label}
+        </span>
+      )}
+
+      {/* Heading: eyebrow + title, bottom-left (design: left:40 bottom:40) */}
+      <div className='absolute bottom-10 left-10 z-10 max-w-[80%]'>
+        {eyebrow && (
+          <span className='mb-[14px] block font-normal text-[#5F5F5F] text-[clamp(15px,2cqi,22px)] italic tracking-[-0.01em] dark:text-[#B4B4B4]'>
+            {eyebrow}
+          </span>
+        )}
+        {title && (
+          <span className='block font-semibold text-[#121212] text-[clamp(2.5rem,9.5cqi,5.5rem)] leading-[0.96] tracking-[-0.035em] dark:text-[#F8F8F8]'>
+            {title}
+          </span>
+        )}
+      </div>
+
+      {/* Wordmark, bottom-right (design: right:40 bottom:40, svg height 22) */}
+      <span className='absolute right-10 bottom-10 z-10 text-[#121212] dark:text-white/90'>
+        <SimWordmark className='block h-[22px] w-auto' />
+      </span>
+
+      {/* Centered play button — active when a video is wired, muted otherwise */}
+      <div className='absolute inset-0 z-10 grid place-items-center'>
+        {hasVideo ? (
+          <button
+            type='button'
+            onClick={() => setPlaying(true)}
+            aria-label={title ? `Play ${title}` : 'Play video'}
+            className='grid h-12 w-16 cursor-pointer place-items-center rounded-[14px] bg-[rgba(255,255,255,0.78)] shadow-[0_1px_3px_rgba(18,18,18,0.12),inset_0_0_0_1px_#E6E6E6] backdrop-blur-[4px] transition-transform duration-200 hover:scale-105 active:scale-95 dark:bg-[rgba(10,10,10,0.72)] dark:shadow-none'
+          >
+            <svg
+              width='18'
+              height='20'
+              viewBox='0 0 18 20'
+              aria-hidden
+              className='translate-x-[1px] text-[#121212] dark:text-white'
+            >
+              <path d='M0 0l18 10L0 20z' fill='currentColor' />
+            </svg>
+          </button>
+        ) : (
+          <span className='grid h-12 w-16 place-items-center rounded-[14px] bg-[rgba(255,255,255,0.78)] opacity-60 shadow-[0_1px_3px_rgba(18,18,18,0.12),inset_0_0_0_1px_#E6E6E6] backdrop-blur-[4px] dark:bg-[rgba(10,10,10,0.72)] dark:shadow-none'>
+            <svg
+              width='18'
+              height='20'
+              viewBox='0 0 18 20'
+              aria-hidden
+              className='translate-x-[1px] text-[#121212] dark:text-white'
+            >
+              <path d='M0 0l18 10L0 20z' fill='currentColor' />
+            </svg>
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/docs/components/ui/what-you-will-learn.tsx
+++ b/apps/docs/components/ui/what-you-will-learn.tsx
@@ -1,0 +1,30 @@
+import { cn } from '@/lib/utils'
+
+interface LearnItem {
+  title: string
+  body: string
+}
+
+interface WhatYouWillLearnProps {
+  items: LearnItem[]
+  className?: string
+}
+
+/** A bordered "What you will learn" card listing lesson takeaways. */
+export function WhatYouWillLearn({ items, className }: WhatYouWillLearnProps) {
+  return (
+    <div
+      className={cn('not-prose rounded-xl border border-fd-border bg-fd-card/40 p-6', className)}
+    >
+      <h2 className='mt-0 mb-5 font-semibold text-fd-foreground text-xl'>What you will learn</h2>
+      <div className='flex flex-col gap-5'>
+        {items.map((item) => (
+          <div key={item.title}>
+            <p className='mb-1 font-semibold text-fd-foreground text-sm'>{item.title}</p>
+            <p className='m-0 text-fd-muted-foreground text-sm leading-relaxed'>{item.body}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/docs/content/docs/en/academy/agents/intro.mdx
+++ b/apps/docs/content/docs/en/academy/agents/intro.mdx
@@ -1,0 +1,88 @@
+---
+title: Agents
+description: An AI agent is a Sim workflow that uses Agent blocks — the reasoning engine you shape, parameterize, and compose into intelligent processes.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview, CLASSIFY_WORKFLOW } from '@/components/workflow-preview'
+
+<VideoPlaceholder eyebrow="Agents" title="Agents" src="https://nnjgp7vypgx4myuq.public.blob.vercel-storage.com/academy-preview/agents-intro-light-with-intro.mp4" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+In Sim, you build AI agents as **workflows that use the Agent block**. There's no separate "agent" object to learn — an AI agent *is* a workflow, and the Agent block is where it thinks.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'An agent is a workflow',
+      body: 'You build agents by composing workflows around one or more Agent blocks — the same blocks and connections you already know.',
+    },
+    {
+      title: 'The Agent block is the reasoning engine',
+      body: 'It is a model call you can shape: customize its messages, give it tools to act, and load skills for guidance.',
+    },
+    {
+      title: 'Composition is the design',
+      body: 'Wiring multiple agent calls together is how you compose and design an intelligent process.',
+    },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'Introduction', time: '0:00' },
+    { title: 'A rules-based workflow', time: '0:31' },
+    { title: 'Adding an Agent block', time: '0:41' },
+    { title: 'The agent responds', time: '0:49' },
+    { title: 'Composing with agents', time: '1:07' },
+    { title: 'Building a bigger system', time: '1:16' },
+    { title: 'Scaling up', time: '1:24' },
+  ]}
+/>
+
+</div>
+
+## An agent is a workflow
+
+This is the one idea to hold onto: **an AI agent is a workflow** — one built around the Agent block. Everything you learned about [workflows](/academy/workflows/intro) applies. You don't leave the model; you add reasoning to it.
+
+Here's the shape of it — a workflow built around an Agent block where it thinks:
+
+<WorkflowPreview workflow={CLASSIFY_WORKFLOW} />
+
+## Inside the Agent block
+
+The Agent block is **a chat with a model, spawned programmatically**. Picture a conversation in ChatGPT or Claude: the block's **Messages** parameter is exactly those messages, except you set them — you decide what instructions, context, and earlier outputs go in. The model reasons over that and returns a result the rest of the workflow can read.
+
+The Agent block is where it *thinks* — the reasoning engine of your agent. You design the blocks *around* it to shape how the agent processes data: what it reads before it reasons, what it does with the result after.
+
+## Tools and skills
+
+Two parameters extend the Agent block, and both fit the chat-box picture:
+
+- **Tools** are the functions and blocks the agent can decide to call while answering — search the web, send an email, run another workflow. They're the tool calls the model makes mid-response.
+- **Skills** are prompt modules the model loads on demand — like a manual it looks up only when a task calls for it, instead of stuffing everything into every prompt.
+
+## Make a workflow agentic
+
+The clearest way to see an agent isn't to build one from nothing — it's to take a **deterministic workflow and let an agent into it**. Replace a fixed rule with an agent that *decides* the path (routing), or *augment* a step with real reasoning — or both. Same workflow, now with judgment in it.
+
+## Composing intelligence
+
+Your ability to compose workflows that make **multiple agent calls** is central to designing intelligent processes. And every agentic workflow you build becomes a building block — your workspace's library of agents composes into larger AI systems.
+
+Start with one Agent block; the platform scales as your ambition does. The most sophisticated systems are just more of these, composed — more agent blocks swapping in, more reasoning, more reach, all from the same model you learned here.
+
+## Related documentation
+
+- [Agents overview](/agents)
+- [Choosing a model](/agents/choosing)
+- [Custom tools](/agents/custom-tools)
+- [MCP](/agents/mcp)
+- [Skills](/agents/skills)

--- a/apps/docs/content/docs/en/academy/files/intro.mdx
+++ b/apps/docs/content/docs/en/academy/files/intro.mdx
@@ -1,0 +1,75 @@
+---
+title: Files
+description: Sim natively supports files — store, reference, and pass around documents and media so workflows can read and produce real assets like PDFs, images, audio, and video.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview, FILE_SUMMARY_WORKFLOW } from '@/components/workflow-preview'
+
+<VideoPlaceholder eyebrow="Files" title="Files" src="https://nnjgp7vypgx4myuq.public.blob.vercel-storage.com/academy-preview/files-light-with-intro.mp4" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Sim has native support for **files** — a way to store, reference, and pass around documents, media, and generated outputs, so your workflows can read and produce real assets: PDFs, images, audio, video.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'Why files exist',
+      body: 'Many operations you already do involve files — attaching an image to an email, transcribing audio, processing an upload. Workflows routinely take files in and hand files out.',
+    },
+    {
+      title: 'Consume and produce',
+      body: 'A workflow can read a file as input and produce a new file as output, passing it between blocks like any other value.',
+    },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'Introduction', time: '0:00' },
+    { title: 'Working with files', time: '0:28' },
+    { title: 'Passing files between blocks', time: '0:34' },
+    { title: 'Running the workflow', time: '0:49' },
+    { title: 'What the agent receives', time: '0:59' },
+    { title: 'Producing a new file', time: '1:13' },
+    { title: 'Files in, files out', time: '1:24' },
+  ]}
+/>
+
+</div>
+
+## Why you need files
+
+Most of the work you'd want to automate touches files somewhere. You receive a PDF and need to extract from it. An email needs an image attached. Audio comes in and has to be transcribed. A user uploads a document to process. These aren't edge cases — workflows reference file types as inputs and outputs all the time, so files are a first-class thing in Sim rather than something you work around.
+
+Here's the shape of it — a workflow that takes a file in and produces a result from it:
+
+<WorkflowPreview workflow={FILE_SUMMARY_WORKFLOW} />
+
+## Files in and out
+
+Workflows **consume** files and **produce** them, and hand them between blocks like any other value. A file goes in, a block reads it; a block creates one, the next step uses it.
+
+## What you can build
+
+The point isn't a new concept to learn — it's recognizing that the file-based operations you already picture are supported here:
+
+- Attach a generated report to an email.
+- Transcribe an audio clip that came in through a trigger.
+- Read an uploaded image and describe it with a vision model.
+- Extract structured fields from a batch of PDFs.
+- Produce a rendered document, chart, or audio file as a workflow's output.
+
+If you're thinking "could I automate the thing that involves *that* document?" — the answer is almost always yes. Files are how Sim handles the real assets your processes already run on.
+
+## Related documentation
+
+- [Files overview](/files)
+- [Using files in workflows](/files/using-in-workflows)
+- [Generating files](/files/generating)

--- a/apps/docs/content/docs/en/academy/index.mdx
+++ b/apps/docs/content/docs/en/academy/index.mdx
@@ -1,0 +1,44 @@
+---
+title: What is Sim?
+description: Sim is a unified workspace for building and operating AI systems — data, workflows, and the integrations that connect them to the outside world.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+
+<VideoPlaceholder eyebrow="Get Started" title="What is Sim?" src="https://nnjgp7vypgx4myuq.public.blob.vercel-storage.com/academy-preview/what-is-sim-light-with-intro.mp4" className="mt-2" />
+
+Sim is a unified workspace for **building and operating AI systems**. Everything you make lives in one place, and everything connects.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'What a workspace is',
+      body: 'A workspace holds two things: resources — your data — and workflows — your processes. Both live together and reference each other.',
+    },
+    {
+      title: 'How the pieces relate',
+      body: 'Workflows are where work happens; resources are what they work on; integrations are how both reach the outside world.',
+    },
+  ]}
+/>
+
+## The workspace
+
+A **workspace** is a collection of shared resources and the workflows that use them.
+
+- **Resources** are your data: [tables](/academy/tables/intro) (structured records), [knowledge bases](/academy/knowledge-bases/intro) (searchable memory), and [files](/academy/files/intro) (documents and media).
+- **Workflows** are your processes — the agents and automations that read those resources, act, and write results back.
+
+Everything in a workspace can see everything else in it. A workflow reads a table, searches a knowledge base, produces a file — and the next workflow picks up where it left off.
+
+## Integrations connect you to the outside world
+
+**Integrations** are plugins. They let your resources and workflows reach services beyond Sim — send a Slack message, read a Gmail inbox, write a row to a CRM, call any API. You connect an account once, and any workflow can use it.
+
+So the whole picture is small: a workspace is **data + processes**, integrations plug it into **everything else**, and the rest of this course is just learning each piece and watching them compose.
+
+## Related documentation
+
+- [Introduction](/introduction)
+- [Getting started](/getting-started)

--- a/apps/docs/content/docs/en/academy/knowledge-bases/intro.mdx
+++ b/apps/docs/content/docs/en/academy/knowledge-bases/intro.mdx
@@ -1,0 +1,85 @@
+---
+title: Knowledge Bases
+description: Knowledge bases give your workflows searchable memory — large volumes of text an agent can search by meaning and use to ground its answers.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview, SUPPORT_KB_WORKFLOW } from '@/components/workflow-preview'
+
+<VideoPlaceholder eyebrow="Knowledge Bases" title="Knowledge Bases" src="https://nnjgp7vypgx4myuq.public.blob.vercel-storage.com/academy-preview/knowledge-bases-light-with-intro.mp4" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+A **knowledge base** gives your workflows searchable memory. You put in large volumes of text, and an agent retrieves just the parts that matter — by meaning, not keywords.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'The context problem',
+      body: 'You cannot stuff everything into a model\'s context. A knowledge base lets you search a large corpus and pass back only what is relevant.',
+    },
+    {
+      title: 'What is inside one',
+      body: 'Documents and connectors that sync them, automatically indexed into searchable chunks you can query by meaning.',
+    },
+    {
+      title: 'How it grounds an answer',
+      body: 'A search returns the most relevant chunks with similarity scores; feeding those into the model produces accurate, cited answers.',
+    },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'Introduction', time: '0:00' },
+    { title: 'The problem: scattered docs', time: '0:29' },
+    { title: 'Too much for one prompt', time: '0:35' },
+    { title: 'Enter the knowledge base', time: '0:44' },
+    { title: 'In your workspace', time: '0:51' },
+    { title: 'Multiple knowledge bases', time: '0:57' },
+    { title: 'Answering from your docs', time: '1:05' },
+    { title: 'Inside a knowledge base', time: '1:15' },
+    { title: 'Chunking into passages', time: '1:24' },
+    { title: 'Retrieving the closest passages', time: '1:36' },
+    { title: 'Adding to the context', time: '1:47' },
+    { title: 'Retrieval in the logs', time: '2:01' },
+    { title: 'Grounded in your docs', time: '2:10' },
+  ]}
+/>
+
+</div>
+
+## The context problem
+
+The naive way to give a model knowledge is to paste everything into its context. That breaks down fast — too much text, too much cost, too much noise. A knowledge base is the answer: store the corpus once, and at run time pull back only the passages that bear on the question.
+
+Here's the shape of it — a workflow that searches a knowledge base and grounds the answer in what comes back:
+
+<WorkflowPreview workflow={SUPPORT_KB_WORKFLOW} />
+
+## Inside a knowledge base
+
+A knowledge base is a resource that lives in your workspace — you can have several. Open one and it holds **documents**, plus **connectors** that bring in and keep documents in sync from outside sources.
+
+Sim automatically **indexes and embeds** every document into searchable **chunks**, so the contents become queryable by meaning — you don't manage any of that yourself.
+
+## Searching by meaning
+
+Use a Knowledge block with a query and it returns the most relevant chunks, each with a **similarity score** — how closely it matches the *meaning* of the query, not its words. So "refund timelines" can match a passage that says "we process returns within 14 days," even with no shared words.
+
+## Grounding an answer
+
+On its own, that's retrieval. The power comes one step later: feed those chunks into an [Agent](/academy/agents/intro) block's context, and the model answers from your actual documents — accurate, up to date, and able to **cite** where each fact came from. That's grounding plus retrieval.
+
+Knowledge bases power systems that need to give agents accurate, current context — and they're where you store what your systems learn over time.
+
+## Related documentation
+
+- [Knowledge Bases overview](/knowledgebase)
+- [Using a knowledge base in workflows](/knowledgebase/using-in-workflows)
+- [Connectors](/knowledgebase/connectors)

--- a/apps/docs/content/docs/en/academy/meta.json
+++ b/apps/docs/content/docs/en/academy/meta.json
@@ -1,0 +1,28 @@
+{
+  "title": "Academy",
+  "root": true,
+  "pages": [
+    "---Get Started---",
+    "index",
+    "---Workflows---",
+    "workflows/intro",
+    "workflows/logs",
+    "workflows/branching",
+    "workflows/loops",
+    "workflows/subworkflows",
+    "workflows/deployment",
+    "---Agents---",
+    "agents/intro",
+    "---Tables---",
+    "tables/intro",
+    "---Files---",
+    "files/intro",
+    "---Knowledge Bases---",
+    "knowledge-bases/intro",
+    "---Use Cases---",
+    "use-cases/slack-it-triage",
+    "use-cases/document-extraction",
+    "use-cases/monitoring-research",
+    "use-cases/sales-data-enrichment"
+  ]
+}

--- a/apps/docs/content/docs/en/academy/tables/intro.mdx
+++ b/apps/docs/content/docs/en/academy/tables/intro.mdx
@@ -1,0 +1,80 @@
+---
+title: Tables
+description: Tables store structured data — columns as types, rows as entries — a spreadsheet or lightweight database your workflows read, write, and operate on at scale.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview, TABLE_ENRICH_WORKFLOW } from '@/components/workflow-preview'
+
+<VideoPlaceholder eyebrow="Tables" title="Tables" src="https://nnjgp7vypgx4myuq.public.blob.vercel-storage.com/academy-preview/tables-light-with-intro.mp4" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+A **table** stores structured data: columns are the types, rows are the entries. Think of it as giving your workflows a spreadsheet — or a lightweight database — for tracking and maintaining records.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'The shape of a table',
+      body: 'Columns define types, rows hold entries — the same mental model as a spreadsheet your workflows can read and write.',
+    },
+    {
+      title: 'Work as operations over data',
+      body: 'Many business use cases are just a query, an update, or a combination with logic over structured records.',
+    },
+    {
+      title: 'Scale with workflow columns',
+      body: 'Workflow columns run an operation across every row in parallel, making a table a surface for automation at scale.',
+    },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'Introduction', time: '0:00' },
+    { title: 'What a table is', time: '0:26' },
+    { title: 'Rows and fields', time: '0:35' },
+    { title: 'Using it in a workflow', time: '0:42' },
+    { title: 'Reading rows', time: '0:51' },
+    { title: 'Writing rows', time: '1:01' },
+    { title: 'Seeing it in the logs', time: '1:12' },
+    { title: 'Tables as a queue', time: '1:21' },
+  ]}
+/>
+
+</div>
+
+## A familiar shape
+
+If you've used a spreadsheet, you already understand a table: columns with types, rows of entries. Your workflows read rows to work on, write rows they produce, and update rows in place.
+
+Here's the shape of it — a workflow that reads a table, operates on each record, and writes the result back:
+
+<WorkflowPreview workflow={TABLE_ENRICH_WORKFLOW} />
+
+## Operations over data
+
+A surprising amount of real business work decomposes into a few operations over structured records:
+
+- **A query** — "which leads are still unprocessed?"
+- **An update** — "mark these rows handled."
+- **A combination with logic** — "for each new signup, score it, then write the score back."
+
+Once you see a use case that way, building it in Sim is mostly wiring those operations together.
+
+## A surface for scale
+
+Tables aren't only storage — they're a working surface for your AI systems. **Workflow columns** let you run an operation across every row at once, in parallel, so a table becomes the place you launch and track work in bulk.
+
+That makes a table a powerful interface for automation — the place you manage and operate agentic processes at scale.
+
+## Related documentation
+
+- [Tables overview](/tables)
+- [Using tables in workflows](/tables/using-in-workflows)
+- [Workflow columns](/tables/workflow-columns)

--- a/apps/docs/content/docs/en/academy/use-cases/document-extraction.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/document-extraction.mdx
@@ -1,0 +1,43 @@
+---
+title: Document Intake & Extraction
+description: A pipeline that takes incoming documents, extracts the fields you care about, and writes structured rows you can act on.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+
+<VideoPlaceholder eyebrow="Use case" title="Document Intake & Extraction" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Turn a pile of unstructured documents — invoices, contracts, forms — into structured data. The workflow reads each file, extracts the fields that matter, and writes them as rows you can query and process.
+
+<WhatYouWillLearn
+  items={[
+    { title: 'Read real files', body: 'Take a PDF or image in and pull its contents into the workflow.' },
+    { title: 'Extract with an agent', body: 'Use a structured output so the agent returns clean, predictable fields.' },
+    { title: 'Persist the result', body: 'Write each extraction as a row in a table for downstream work.' },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'The problem', time: '0:00' },
+    { title: 'Bring a file in', time: '0:35' },
+    { title: 'Extract structured fields', time: '1:20' },
+    { title: 'Write rows to a table', time: '2:15' },
+    { title: 'Run it on a batch', time: '3:00' },
+  ]}
+/>
+
+</div>
+
+## What you'll build
+
+A **file** comes in, an **Agent** block extracts the fields into a [structured output](/academy/agents/intro) so the shape is predictable, and a **Table** block writes the row. Run it across a batch and a folder of documents becomes a queryable table.
+
+This composes [files](/academy/files/intro), [agents](/academy/agents/intro), and [tables](/academy/tables/intro).

--- a/apps/docs/content/docs/en/academy/use-cases/monitoring-research.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/monitoring-research.mdx
@@ -1,0 +1,43 @@
+---
+title: Monitoring & Automated Research
+description: A scheduled agent that watches sources you care about, researches what changed, and reports back — on its own.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+
+<VideoPlaceholder eyebrow="Use case" title="Monitoring & Automated Research" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Build a system that runs on a schedule, checks the sources you care about, researches what's new, and delivers a synthesized report — competitor moves, market signals, anything worth watching — without you asking each time.
+
+<WhatYouWillLearn
+  items={[
+    { title: 'Run on a schedule', body: 'Trigger a workflow on a timer so the work happens on its own.' },
+    { title: 'Research with tools', body: 'Let an agent search the web, read pages, and synthesize findings.' },
+    { title: 'Deliver the result', body: 'Post a summary to Slack or save a report file each run.' },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'The problem', time: '0:00' },
+    { title: 'Schedule trigger', time: '0:35' },
+    { title: 'Research with tools', time: '1:25' },
+    { title: 'Synthesize findings', time: '2:20' },
+    { title: 'Deliver the report', time: '3:10' },
+  ]}
+/>
+
+</div>
+
+## What you'll build
+
+A **Schedule trigger** kicks the workflow off. An **Agent** block with search tools gathers and reads sources, synthesizes what changed, and a final step delivers it — a Slack message, or a saved report [file](/academy/files/intro).
+
+This composes [workflows](/academy/workflows/intro), [agents](/academy/agents/intro), and [files](/academy/files/intro).

--- a/apps/docs/content/docs/en/academy/use-cases/sales-data-enrichment.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/sales-data-enrichment.mdx
@@ -1,0 +1,43 @@
+---
+title: Sales Data Management & Enrichment
+description: A table-backed system that takes thin lead records, enriches them in parallel, scores them, and writes the results back.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+
+<VideoPlaceholder eyebrow="Use case" title="Sales Data Management & Enrichment" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Run your sales pipeline as data. Start with thin lead records in a table, enrich each one — company info, fit signals — score it, and write the results back, all in parallel across the whole table.
+
+<WhatYouWillLearn
+  items={[
+    { title: 'Treat a table as the system', body: 'Hold leads as rows and operate over them in bulk.' },
+    { title: 'Enrich and score', body: 'Look up each lead, gather context, and let an agent score the fit.' },
+    { title: 'Run at scale', body: 'Use workflow columns to process every row in parallel.' },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'The problem', time: '0:00' },
+    { title: 'Leads as a table', time: '0:35' },
+    { title: 'Enrich each row', time: '1:20' },
+    { title: 'Score the fit', time: '2:10' },
+    { title: 'Run in parallel', time: '3:00' },
+  ]}
+/>
+
+</div>
+
+## What you'll build
+
+Leads live in a **table**. A **workflow column** runs per row: it enriches the record, an **Agent** block scores the fit, and the results are written straight back into the table. The table becomes both the queue and the record.
+
+This is [tables](/academy/tables/intro) and [agents](/academy/agents/intro) composed into a pipeline that operates at scale.

--- a/apps/docs/content/docs/en/academy/use-cases/slack-it-triage.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/slack-it-triage.mdx
@@ -1,0 +1,43 @@
+---
+title: Slack IT Triage Bot
+description: An agent that watches a Slack channel, classifies incoming IT requests, answers what it can from your docs, and routes the rest.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+
+<VideoPlaceholder eyebrow="Use case" title="Slack IT Triage Bot" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Build an agent that lives in a Slack channel: it reads each incoming IT request, decides what kind it is, answers the ones it can from your internal docs, and routes the rest to the right person.
+
+<WhatYouWillLearn
+  items={[
+    { title: 'Trigger on real events', body: 'Start a workflow from a Slack message and read its contents.' },
+    { title: 'Let an agent decide', body: 'Classify the request and route it — answer, escalate, or file a ticket.' },
+    { title: 'Ground the answer', body: 'Search a knowledge base of IT docs so replies are accurate and cited.' },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'The problem', time: '0:00' },
+    { title: 'Slack trigger', time: '0:30' },
+    { title: 'Classify and route', time: '1:10' },
+    { title: 'Answer from the docs', time: '2:00' },
+    { title: 'Escalate the rest', time: '2:50' },
+  ]}
+/>
+
+</div>
+
+## What you'll build
+
+A **Slack trigger** starts the workflow on each new message. An **Agent** block classifies the request and decides the path: a **knowledge-base search** drafts an answer for common questions, while anything it can't resolve is routed to a human or filed as a ticket. Every run is recorded in the [logs](/logs-debugging).
+
+This pulls together [workflows](/academy/workflows/intro), [agents](/academy/agents/intro), and [knowledge bases](/academy/knowledge-bases/intro) into one system — the foundations, composed.

--- a/apps/docs/content/docs/en/academy/workflows/branching.mdx
+++ b/apps/docs/content/docs/en/academy/workflows/branching.mdx
@@ -1,0 +1,76 @@
+---
+title: Branching
+description: Split a workflow into different paths based on the result of a step — the Condition block decides with a rule, the Router lets a model decide.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview, CONDITION_ROUTE_WORKFLOW } from '@/components/workflow-preview'
+
+<VideoPlaceholder eyebrow="Workflows" title="Branching" src="https://nnjgp7vypgx4myuq.public.blob.vercel-storage.com/academy-preview/workflows-branching-light-with-intro.mp4" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Branching is how a workflow **splits into different paths based on the result of a step**. Sim gives you two blocks for it — the **Condition** block, which decides with an explicit rule, and the **Router**, which lets a model decide from intent.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'Branching the flow',
+      body: 'After a step produces a result, branching sends the run down one path or another instead of straight through.',
+    },
+    {
+      title: 'Condition: decide with a rule',
+      body: 'The Condition block picks a branch from an explicit rule you write, a comparison over an earlier output.',
+    },
+    {
+      title: 'Router: let a model decide',
+      body: 'The Router reads the input and chooses a branch from natural-language intent, for when the rule is fuzzy.',
+    },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'Introduction', time: '0:00' },
+    { title: 'Branching the flow', time: '0:24' },
+    { title: 'The Condition block', time: '0:32' },
+    { title: 'If, else if, else', time: '0:46' },
+    { title: 'Switching to a Router', time: '0:55' },
+    { title: 'The Router block', time: '1:05' },
+    { title: 'Seeing it in the logs', time: '1:17' },
+    { title: 'Recap', time: '1:26' },
+  ]}
+/>
+
+</div>
+
+## A fork in the flow
+
+Most workflows you've seen run in a line. Branching adds a **fork**: at some point the run looks at the result of a step and takes one path or another. The paths can do completely different work.
+
+Here's the shape of a fork — one step decides, and the run takes one path or the other:
+
+<WorkflowPreview workflow={CONDITION_ROUTE_WORKFLOW} />
+
+## The Condition block — decide with a rule
+
+The **Condition** block branches on an **explicit rule** — a comparison over an earlier block's output, like priority equals "high". The matching branch runs; the others don't. It's deterministic and predictable.
+
+## The Router block — let a model decide
+
+Sometimes the rule is fuzzy: "send billing questions one way, everything else another." The **Router** block hands the decision to a **model** — it reads the input, picks the branch that matches the intent, and the run continues down it. Same fork, but the decider is reasoning instead of a fixed rule.
+
+## Still one workflow
+
+Whichever way it forks, it's **still one workflow**, and every run is recorded. Open the logs and you can see exactly which path a given run took, and why.
+
+## Related documentation
+
+- [How workflows run](/workflows/how-it-runs)
+- [Condition block](/workflows/blocks/condition)
+- [Router block](/workflows/blocks/router)

--- a/apps/docs/content/docs/en/academy/workflows/deployment.mdx
+++ b/apps/docs/content/docs/en/academy/workflows/deployment.mdx
@@ -1,0 +1,85 @@
+---
+title: Deployment
+description: Deploying gives a workflow an address so the outside world can run it — the same Start block answers calls as an API, a chat, or an MCP tool.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview, RESPONSE_API_WORKFLOW } from '@/components/workflow-preview'
+
+<VideoPlaceholder eyebrow="Workflows" title="Deployment" src="https://nnjgp7vypgx4myuq.public.blob.vercel-storage.com/academy-preview/workflows-deployments-light-with-intro.mp4" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Deploying publishes a workflow and gives it an **address**, so something other than the editor can run it. Nothing inside the workflow changes — the same blocks, the same Start block — but now an external request can reach it and start a run.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'Deploy gives it an address',
+      body: 'Publishing makes a workflow reachable from outside the editor at a stable, versioned address. The workflow itself does not change.',
+    },
+    {
+      title: 'Calls flow into Start',
+      body: 'An external request arrives at the same Start block you tested with, runs the chain, and the response goes back to the caller.',
+    },
+    {
+      title: 'Pick a surface',
+      body: 'Expose the one workflow as an API endpoint, a hosted chat page, or an MCP tool other AI systems can call.',
+    },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'Introduction', time: '0:00' },
+    { title: 'Start with a working workflow', time: '0:23' },
+    { title: 'Deploying it', time: '0:36' },
+    { title: 'Calling it as an API', time: '0:50' },
+    { title: 'The chat interface', time: '1:08' },
+    { title: 'Running in production', time: '1:33' },
+  ]}
+/>
+
+</div>
+
+## A working workflow
+
+Before deploying, you have a workflow that runs when *you* run it, in the editor. Deploying is the step that lets anything else run it too.
+
+Here's the shape of the workflow you'll deploy — a Start block, a chain, and a response back to the caller:
+
+<WorkflowPreview workflow={RESPONSE_API_WORKFLOW} />
+
+## Deploy gives it an address
+
+Deploying publishes the workflow and gives it an **address**. Nothing inside the chain changes — same blocks, same Start block, same logic. What's new is that the workflow is now **live** and reachable from outside, at a stable, versioned URL. A deployment is a snapshot, so you can promote new versions and roll back.
+
+## A call from outside
+
+An external request comes in, hits that address, and flows straight into the **Start block** — the same entry you tested with in the editor. From there the run is identical: the chain executes and the response goes back to whoever called it. An external call is just a run; the only difference is where it came from.
+
+## The same workflow, three surfaces
+
+The one deployed workflow can be reached three ways, and you choose which:
+
+- **API** — other systems POST to an endpoint and get the response back.
+- **Chat** — a hosted chat page anyone can open; each message becomes the workflow's input.
+- **MCP** — the workflow becomes a tool that other AI agents (like Cursor or Claude) can call.
+
+Same blocks underneath, same Start — just different doors in.
+
+## Runs when they run it
+
+Once deployed, the workflow runs on demand — whenever a caller hits it, with no one in the editor. The same process you built is now an operational system.
+
+## Related documentation
+
+- [Deployment overview](/workflows/deployment)
+- [Deploy as an API](/workflows/deployment/api)
+- [Deploy as a chat](/workflows/deployment/chat)
+- [Deploy as an MCP server](/workflows/deployment/mcp)

--- a/apps/docs/content/docs/en/academy/workflows/intro.mdx
+++ b/apps/docs/content/docs/en/academy/workflows/intro.mdx
@@ -1,0 +1,84 @@
+---
+title: Workflows
+description: A workflow is a visual program made of blocks — where you compose data, operations, integrations, and AI agents into a process.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview, CLASSIFY_REPLY_WORKFLOW } from '@/components/workflow-preview'
+
+<VideoPlaceholder eyebrow="Workflows" title="Workflows" src="https://nnjgp7vypgx4myuq.public.blob.vercel-storage.com/academy-preview/workflows-intro-light-with-intro.mp4" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+A **workflow** is a visual program made of blocks. It's where you compose everything else in Sim — data, operations, integrations, and AI agents — into a process, and bind it to a trigger so it runs.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'Read a workflow',
+      body: 'Blocks are steps, some blocks are triggers, and connections wire them into an order that runs.',
+    },
+    {
+      title: 'Follow the data',
+      body: 'Each block has parameters and produces an output. A later block reads an earlier output with a connection tag.',
+    },
+    {
+      title: 'See how it executes',
+      body: 'Independent blocks run at once; a block waits only for what it depends on. Every run is recorded in the logs.',
+    },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'Introduction', time: '0:00' },
+    { title: 'What a workflow is', time: '0:32' },
+    { title: 'Blocks and triggers', time: '0:41' },
+    { title: 'Parameters', time: '0:54' },
+    { title: 'Connection tags', time: '1:06' },
+    { title: 'Following the data', time: '1:23' },
+    { title: 'Running in parallel', time: '1:34' },
+    { title: 'Waiting for inputs', time: '1:45' },
+    { title: 'The whole model', time: '1:57' },
+    { title: 'Scaling up', time: '2:08' },
+  ]}
+/>
+
+</div>
+
+## The pieces
+
+- A workflow is a **visual program** — you build it by placing and wiring blocks, not by writing a script.
+- It's made of **blocks**, each one a step. Some blocks are **triggers** — they decide what starts the run and what it receives.
+- **Connections** link blocks together. They set the order: a block runs after the blocks wired into it finish.
+- Blocks have **parameters** that configure how they work. A Fetch Webpage block takes a URL; an Agent block takes a model and a prompt.
+- When a workflow runs, Sim records what each block produced. Any later block can read an earlier block's output through a **connection tag**, like `<fetch.content>`.
+- Everything that happened is saved in the **logs** — the trigger, every block, and each block's input and output — so you can see exactly where a value came from.
+
+Here's a small workflow you can read top to bottom — blocks wired in order, each one a step. The highlighted block reads an earlier block's output through a connection tag:
+
+<WorkflowPreview workflow={CLASSIFY_REPLY_WORKFLOW} highlightBlock="reply" />
+
+## How execution flows
+
+A block waits only for the blocks it depends on — nothing else.
+
+So if `A` feeds both `B` and `C`, then `B` and `C` start at the same moment `A` finishes; they don't wait for each other. And if `B` and `C` both feed `D`, then `D` waits for both before it runs. The shape of the connections *is* the execution plan.
+
+## Branches, loops, and parallel
+
+From those primitives you get expressive control flow: **branch** down one path or another with a Condition or Router, **loop** over a list, run work in **parallel** across many items. These are the expressive core of what you'll build — and they're all just blocks and connections.
+
+Everything complicated — an automated software factory, an autonomous triage system that takes action on its own — is built from these same simple primitives. You start with a few blocks; the platform scales to your ambition. As you get more comfortable, the workflows you compose get richer — more branches, more agents, more reach — without ever leaving the same model you learned here. We're glad you're on this journey: Sim is built of simple primitives that compose into anything you can imagine.
+
+## Related documentation
+
+- [Workflows overview](/workflows)
+- [How workflows run](/workflows/how-it-runs)
+- [Data flow](/workflows/data-flow)
+- [Connections](/workflows/connections)

--- a/apps/docs/content/docs/en/academy/workflows/logs.mdx
+++ b/apps/docs/content/docs/en/academy/workflows/logs.mdx
@@ -1,0 +1,76 @@
+---
+title: Logs
+description: A log is the complete record of one workflow run — and debugging is reading that record backwards, from a wrong value to the block that produced it.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview, ROUTER_TRIAGE_WORKFLOW } from '@/components/workflow-preview'
+
+<VideoPlaceholder eyebrow="Workflows" title="Logs" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Every time a workflow runs, Sim writes down exactly what happened: the trigger, every block in the order it ran, and for each block its input, its output, its timing, and any error. That record is a **log** — the ground truth for understanding and debugging a run.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'Every run is recorded',
+      body: 'You never turn logging on. Each run automatically writes a complete record: the trigger, every block in order, and what each one received, returned, and how long it took.',
+    },
+    {
+      title: 'The log is the ground truth',
+      body: 'To see what a run actually did — not what you think it did — you read its log: which blocks ran, in what order, and the real input and output of each.',
+    },
+    {
+      title: 'Debug by reading backwards',
+      body: 'Start from the wrong value and trace it back, block by block — which block produced it, what that block read — until you reach the source.',
+    },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'A run happens', time: '0:00' },
+    { title: 'The record', time: '0:11' },
+    { title: 'What it really did', time: '0:21' },
+    { title: 'Reading it backwards', time: '0:33' },
+    { title: 'Every run writes one', time: '0:53' },
+  ]}
+/>
+
+</div>
+
+## Every run leaves a record
+
+When a workflow runs, the run isn't a black box. Sim records the **trigger** that started it, every **block** in the order it executed, and for each block its **input**, its **output**, its **timing**, and an error message if it failed. Nothing about a run is a mystery — it all gets written down.
+
+Here's the kind of workflow whose runs you'll read — a trigger, an agent, and the branches it routes between:
+
+<WorkflowPreview workflow={ROUTER_TRIAGE_WORKFLOW} />
+
+## The record
+
+Open a run and the log lists every block in the order it ran, each with its **duration**. So when a run is slow, you can see exactly where the time went — which block took the seconds — instead of guessing.
+
+## What each block did
+
+Selecting a block shows everything it actually did: the **input** it received, the **output** it returned, and — for an agent — the **tool calls** it made and the **tokens** it used. From the outside a step can look instant; the log keeps everything that happened inside it.
+
+## Read it backwards
+
+The log also shows where every value came from. A block's input names the block that produced it — a connection tag like `<triage.content>`. So to debug, you start from the **wrong value** and step **backwards**: which block produced it, what that block read, and on back through the chain until you reach the source. Debugging a workflow is reading its log backward from the symptom.
+
+## Every run writes one
+
+You don't enable any of this — every run produces a log automatically. When a workflow does something you didn't expect, the log is the first place to look, because it's the one place that records what actually happened.
+
+## Related documentation
+
+- [Logs &amp; debugging overview](/logs-debugging)
+- [The Logs page](/logs-debugging/logging)

--- a/apps/docs/content/docs/en/academy/workflows/loops.mdx
+++ b/apps/docs/content/docs/en/academy/workflows/loops.mdx
@@ -1,0 +1,79 @@
+---
+title: Loops & Parallel
+description: Repeat the same steps over a collection — the Loop block runs them one item at a time, the Parallel block runs every item at once.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview, LOOP_WORKFLOW } from '@/components/workflow-preview'
+
+<VideoPlaceholder eyebrow="Workflows" title="Loops & Parallel" src="https://nnjgp7vypgx4myuq.public.blob.vercel-storage.com/academy-preview/workflows-loops-light-with-intro.mp4" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Repeating the same steps across a whole collection is one of the most fundamental ideas in programming. Sim gives you two blocks for it — the **Loop** block and the **Parallel** block. They do the same job and differ only in *how* they run.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'A container over a collection',
+      body: 'Drop blocks inside a Loop or Parallel and hand it a collection; it runs those blocks once for every item.',
+    },
+    {
+      title: 'Loop runs one at a time',
+      body: 'The Loop block iterates sequentially, item by item in order, when each step can depend on the last.',
+    },
+    {
+      title: 'Parallel runs all at once',
+      body: 'The Parallel block runs every item concurrently, far faster when the items are independent.',
+    },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'Introduction', time: '0:00' },
+    { title: 'The Loop block', time: '0:25' },
+    { title: 'What a loop iterates over', time: '0:36' },
+    { title: 'Running one at a time', time: '0:44' },
+    { title: 'Collecting the results', time: '0:58' },
+    { title: 'Switching to Parallel', time: '1:06' },
+    { title: 'Running all at once', time: '1:15' },
+    { title: 'Loop vs Parallel', time: '1:27' },
+  ]}
+/>
+
+</div>
+
+## A block that holds blocks
+
+A Loop (or Parallel) is a **container** — a block you drop other blocks inside. You hand it a collection, and it runs whatever's inside once for every item in that collection, turning a single step into many.
+
+Here's the shape of it — a container wrapping the blocks it repeats over the collection:
+
+<WorkflowPreview workflow={LOOP_WORKFLOW} />
+
+## What each run knows
+
+Inside the container, every iteration gets the **current item** to work on (and its index). That's how one lane of blocks becomes a run per lead, per row, or per file — the steps stay the same, the data changes each pass.
+
+## One at a time, or all at once
+
+This is the whole difference between the two blocks:
+
+- **Loop** runs the items **sequentially** — one finishes before the next begins. Reach for it when each step builds on the last, or when you need to respect order or rate limits.
+- **Parallel** runs them **all at once** — every item concurrently. Reach for it when the items are independent; it's dramatically faster across a large collection.
+
+## Swapping the container
+
+Because the two blocks share the same shape, you can **swap a Loop for a Parallel** (or back) without rewiring anything inside. Same logic, different execution — sequential or concurrent — chosen by which container you wrap it in.
+
+## Related documentation
+
+- [How workflows run](/workflows/how-it-runs)
+- [Loop block](/workflows/blocks/loop)
+- [Parallel block](/workflows/blocks/parallel)

--- a/apps/docs/content/docs/en/academy/workflows/subworkflows.mdx
+++ b/apps/docs/content/docs/en/academy/workflows/subworkflows.mdx
@@ -1,0 +1,74 @@
+---
+title: Subworkflows
+description: Call one workflow from another, the way you'd call a function in code — reuse logic and compose small workflows into larger systems.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview, WORKFLOW_CALL_WORKFLOW } from '@/components/workflow-preview'
+
+<VideoPlaceholder eyebrow="Workflows" title="Subworkflows" src="https://nnjgp7vypgx4myuq.public.blob.vercel-storage.com/academy-preview/workflows-subworkflows-light-with-intro.mp4" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Once you've built a workflow that does something well, you can **call it from another workflow** — the way you'd call a function in code. The Workflow block turns any workflow into a reusable step.
+
+<WhatYouWillLearn
+  items={[
+    {
+      title: 'A workflow becomes a block',
+      body: 'Any workflow can be invoked as a single block inside another, with an input in and its result out.',
+    },
+    {
+      title: 'Call, run, return',
+      body: 'The parent pauses at the call, the child workflow runs start to finish, and its output flows back into the parent.',
+    },
+    {
+      title: 'Reuse and compose',
+      body: 'Factor shared logic into one subworkflow instead of duplicating blocks; compose small workflows into big systems.',
+    },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'Introduction', time: '0:00' },
+    { title: 'Start with a workflow', time: '0:22' },
+    { title: 'Turning it into a block', time: '0:30' },
+    { title: 'Calling a subworkflow', time: '0:41' },
+    { title: 'Inside the subworkflow', time: '0:48' },
+    { title: 'Returning the result', time: '1:02' },
+    { title: 'Composing workflows', time: '1:12' },
+  ]}
+/>
+
+</div>
+
+## The workflow you already know
+
+Start with a workflow you've built and trust — say one that classifies a message. On its own it's a complete process you can run.
+
+Here's the shape of it — one workflow invoked as a single block inside another:
+
+<WorkflowPreview workflow={WORKFLOW_CALL_WORKFLOW} />
+
+## It becomes a block
+
+Any workflow can be used as a **block** inside another. You drop a **Workflow block**, point it at the workflow you want, and pass it an input — just like calling a function. You don't rebuild its logic; you reuse it.
+
+## Call, run, return
+
+When the parent run reaches the Workflow block, the **child workflow runs** start to finish — its own blocks, its own logic — and its **result comes back** into the parent, where the next block reads it. The parent doesn't need to know how the child works, only what it returns.
+
+## Workflows all the way up
+
+This is how big systems stay manageable: factor shared logic into focused subworkflows and **compose** them. Each workflow you build becomes a building block for the next — small, tested pieces assembling into larger processes, without turning into a mess.
+
+## Related documentation
+
+- [Workflow block](/workflows/blocks/workflow)
+- [Workflows overview](/workflows)

--- a/apps/docs/lib/utils.ts
+++ b/apps/docs/lib/utils.ts
@@ -14,6 +14,10 @@ export function cn(...inputs: ClassValue[]) {
  * - Otherwise falls back to local static assets served from root path
  */
 export function getAssetUrl(filename: string) {
+  // Absolute URLs (e.g. blob-hosted academy videos) are already complete.
+  if (/^https?:\/\//.test(filename)) {
+    return filename
+  }
   const cdnBaseUrl = process.env.NEXT_PUBLIC_BLOB_BASE_URL
   if (cdnBaseUrl) {
     return `${cdnBaseUrl}/${filename}`


### PR DESCRIPTION
Adds the Academy section to the docs: video-first lessons (self-hosted MP4 on Vercel Blob), organized into Workflows, Agents, Tables, Files, and Knowledge Bases, each linking back to the reference docs.

Docs only — no runtime or auth changes. The content may move to a separate CMS or its own site (academy.sim.ai) later; the docs are a starting point.

Replaces #5170 with a clean single-commit history (drops the committed preview MP4s and draft MDX).
