### PR TITLE
fix(copilot): strip hosted apiKey on type-less edit ops + guard hosting.enabled

### DIFF
--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
@@ -630,6 +630,59 @@ describe('preValidateCredentialInputs (hosted-tool blocks)', () => {
     expect(result.errors[0]).toMatchObject({ blockId: 'video-child', field: 'apiKey' })
   })
 
+  it('strips a key set before a later op makes the block hosted (reverse batch order)', async () => {
+    // op1 sets apiKey while the block is still non-hosted (runway); op2 later flips it to falai.
+    // Deciding against final state must still strip op1's key.
+    const operations = [
+      {
+        operation_type: 'edit' as const,
+        block_id: 'video-1',
+        params: { inputs: { apiKey: '{{FAL_API_KEY}}' } },
+      },
+      {
+        operation_type: 'edit' as const,
+        block_id: 'video-1',
+        params: { inputs: { provider: 'falai' } },
+      },
+    ]
+    const workflowState = {
+      blocks: {
+        'video-1': { type: 'video_generator_v3', subBlocks: { provider: { value: 'runway' } } },
+      },
+    }
+
+    const result = await preValidateCredentialInputs(operations, ctx, workflowState)
+
+    expect(result.filteredOperations[0]?.params?.inputs?.apiKey).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({ blockId: 'video-1', field: 'apiKey' })
+  })
+
+  it('does not let a bogus type on an earlier op block stripping on a later edit', async () => {
+    const operations = [
+      {
+        operation_type: 'edit' as const,
+        block_id: 'video-1',
+        params: { type: '', inputs: { prompt: 'x' } },
+      },
+      {
+        operation_type: 'edit' as const,
+        block_id: 'video-1',
+        params: { inputs: { apiKey: '{{FAL_API_KEY}}' } },
+      },
+    ]
+    const workflowState = {
+      blocks: {
+        'video-1': { type: 'video_generator_v3', subBlocks: { provider: { value: 'falai' } } },
+      },
+    }
+
+    const result = await preValidateCredentialInputs(operations, ctx, workflowState)
+
+    expect(result.filteredOperations[1]?.params?.inputs?.apiKey).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
+  })
+
   it('uses same-batch state: a type-less apiKey edit after an earlier op makes the block hosted', async () => {
     // op1 switches provider to falai (hosted); op2 (type-less) sets apiKey. op2 must see op1's
     // provider, not the stale snapshot (runway), and strip the key.

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
@@ -561,6 +561,41 @@ describe('preValidateCredentialInputs (hosted-tool blocks)', () => {
     expect(result.errors[0]).toMatchObject({ blockId: 'custom-1', field: 'serviceKey' })
   })
 
+  it('strips apiKey on a grandchild block nested two levels deep (loop in loop)', async () => {
+    const operations = [
+      {
+        operation_type: 'add' as const,
+        block_id: 'outer-loop',
+        params: {
+          type: 'loop',
+          inputs: {},
+          nestedNodes: {
+            'inner-loop': {
+              type: 'loop',
+              inputs: {},
+              nestedNodes: {
+                'video-child': {
+                  type: 'video_generator_v3',
+                  inputs: { provider: 'falai', apiKey: '{{FAL_API_KEY}}' },
+                },
+              },
+            },
+          },
+        },
+      },
+    ]
+
+    const result = await preValidateCredentialInputs(operations, ctx)
+
+    const innerInputs = (
+      (result.filteredOperations[0]?.params?.nestedNodes as Record<string, any>)?.['inner-loop']
+        ?.nestedNodes as Record<string, { inputs?: Record<string, unknown> }>
+    )?.['video-child']?.inputs
+    expect(innerInputs?.apiKey).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({ blockId: 'video-child', field: 'apiKey' })
+  })
+
   it('uses same-batch state for nested children (provider set earlier, apiKey set later)', async () => {
     const operations = [
       {

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
@@ -114,6 +114,15 @@ const imageBlockConfig = {
   tools: { access: ['image_generate'], config: { tool: () => 'image_generate' } },
 }
 
+// Tool whose hosting.enabled predicate throws — used to assert fail-toward-strip behavior.
+const throwGateBlockConfig = {
+  type: 'throw_gate_block',
+  name: 'Throw Gate Block',
+  outputs: {},
+  subBlocks: [{ id: 'provider', type: 'dropdown' }],
+  tools: { access: ['throw_gate_tool'], config: { tool: () => 'throw_gate_tool' } },
+}
+
 // Tool registry stand-in for the hosted-tool tests.
 const toolsByIdMock: Record<string, unknown> = {
   video_falai: { id: 'video_falai', hosting: { apiKeyParam: 'apiKey' } },
@@ -124,6 +133,15 @@ const toolsByIdMock: Record<string, unknown> = {
     hosting: {
       apiKeyParam: 'apiKey',
       enabled: (p: Record<string, unknown>) => p.provider === 'falai',
+    },
+  },
+  throw_gate_tool: {
+    id: 'throw_gate_tool',
+    hosting: {
+      apiKeyParam: 'apiKey',
+      enabled: () => {
+        throw new Error('boom')
+      },
     },
   },
 }
@@ -150,7 +168,9 @@ vi.mock('@/blocks/registry', () => ({
                       ? customKeyBlockConfig
                       : type === 'image_generator_v2'
                         ? imageBlockConfig
-                        : undefined,
+                        : type === 'throw_gate_block'
+                          ? throwGateBlockConfig
+                          : undefined,
 }))
 
 vi.mock('@/blocks/utils', () => ({
@@ -539,6 +559,55 @@ describe('preValidateCredentialInputs (hosted-tool blocks)', () => {
     expect(result.filteredOperations[0]?.params?.inputs?.serviceKey).toBeUndefined()
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0]).toMatchObject({ blockId: 'custom-1', field: 'serviceKey' })
+  })
+
+  it('uses same-batch state: a type-less apiKey edit after an earlier op makes the block hosted', async () => {
+    // op1 switches provider to falai (hosted); op2 (type-less) sets apiKey. op2 must see op1's
+    // provider, not the stale snapshot (runway), and strip the key.
+    const operations = [
+      {
+        operation_type: 'edit' as const,
+        block_id: 'video-1',
+        params: { inputs: { provider: 'falai' } },
+      },
+      {
+        operation_type: 'edit' as const,
+        block_id: 'video-1',
+        params: { inputs: { apiKey: 'test-api-key-12345' } },
+      },
+    ]
+    const workflowState = {
+      blocks: {
+        'video-1': {
+          type: 'video_generator_v3',
+          subBlocks: { provider: { value: 'runway' } },
+        },
+      },
+    }
+
+    const result = await preValidateCredentialInputs(operations, ctx, workflowState)
+
+    expect(result.filteredOperations[1]?.params?.inputs?.apiKey).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({ blockId: 'video-1', field: 'apiKey' })
+  })
+
+  it('strips apiKey when a tool hosting enabled predicate throws (fail toward stripping)', async () => {
+    const operations = [
+      {
+        operation_type: 'add' as const,
+        block_id: 'gate-1',
+        params: {
+          type: 'throw_gate_block',
+          inputs: { provider: 'whatever', apiKey: 'user-key' },
+        },
+      },
+    ]
+
+    const result = await preValidateCredentialInputs(operations, ctx)
+
+    expect(result.filteredOperations[0]?.params?.inputs?.apiKey).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
   })
 
   it('preserves apiKey on self-hosted deployments (isHosted false)', async () => {

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
@@ -123,6 +123,22 @@ const throwGateBlockConfig = {
   tools: { access: ['throw_gate_tool'], config: { tool: () => 'throw_gate_tool' } },
 }
 
+// Block whose tool selector throws — should fall back to scanning access tools (video_falai).
+const throwSelectorBlockConfig = {
+  type: 'throw_selector_block',
+  name: 'Throw Selector Block',
+  outputs: {},
+  subBlocks: [{ id: 'provider', type: 'dropdown' }],
+  tools: {
+    access: ['video_falai'],
+    config: {
+      tool: () => {
+        throw new Error('selector boom')
+      },
+    },
+  },
+}
+
 // Tool registry stand-in for the hosted-tool tests.
 const toolsByIdMock: Record<string, unknown> = {
   video_falai: { id: 'video_falai', hosting: { apiKeyParam: 'apiKey' } },
@@ -170,7 +186,9 @@ vi.mock('@/blocks/registry', () => ({
                         ? imageBlockConfig
                         : type === 'throw_gate_block'
                           ? throwGateBlockConfig
-                          : undefined,
+                          : type === 'throw_selector_block'
+                            ? throwSelectorBlockConfig
+                            : undefined,
 }))
 
 vi.mock('@/blocks/utils', () => ({
@@ -712,6 +730,24 @@ describe('preValidateCredentialInputs (hosted-tool blocks)', () => {
     expect(result.filteredOperations[1]?.params?.inputs?.apiKey).toBeUndefined()
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0]).toMatchObject({ blockId: 'video-1', field: 'apiKey' })
+  })
+
+  it('strips apiKey when the tool selector throws (falls back to access tools)', async () => {
+    const operations = [
+      {
+        operation_type: 'add' as const,
+        block_id: 'sel-1',
+        params: {
+          type: 'throw_selector_block',
+          inputs: { provider: 'falai', apiKey: 'user-key' },
+        },
+      },
+    ]
+
+    const result = await preValidateCredentialInputs(operations, ctx)
+
+    expect(result.filteredOperations[0]?.params?.inputs?.apiKey).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
   })
 
   it('strips apiKey when a tool hosting enabled predicate throws (fail toward stripping)', async () => {

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
@@ -676,30 +676,33 @@ describe('preValidateCredentialInputs (hosted-tool blocks)', () => {
     expect(result.errors[0]).toMatchObject({ blockId: 'video-1', field: 'apiKey' })
   })
 
-  it('does not let a bogus type on an earlier op block stripping on a later edit', async () => {
-    const operations = [
-      {
-        operation_type: 'edit' as const,
-        block_id: 'video-1',
-        params: { type: '', inputs: { prompt: 'x' } },
-      },
-      {
-        operation_type: 'edit' as const,
-        block_id: 'video-1',
-        params: { inputs: { apiKey: '{{FAL_API_KEY}}' } },
-      },
-    ]
-    const workflowState = {
-      blocks: {
-        'video-1': { type: 'video_generator_v3', subBlocks: { provider: { value: 'falai' } } },
-      },
+  it.each([{ type: '' }, { type: 'totally_unknown_type' }])(
+    'does not let an invalid type (%o) on an earlier op block stripping on a later edit',
+    async ({ type }) => {
+      const operations = [
+        {
+          operation_type: 'edit' as const,
+          block_id: 'video-1',
+          params: { type, inputs: { prompt: 'x' } },
+        },
+        {
+          operation_type: 'edit' as const,
+          block_id: 'video-1',
+          params: { inputs: { apiKey: '{{FAL_API_KEY}}' } },
+        },
+      ]
+      const workflowState = {
+        blocks: {
+          'video-1': { type: 'video_generator_v3', subBlocks: { provider: { value: 'falai' } } },
+        },
+      }
+
+      const result = await preValidateCredentialInputs(operations, ctx, workflowState)
+
+      expect(result.filteredOperations[1]?.params?.inputs?.apiKey).toBeUndefined()
+      expect(result.errors).toHaveLength(1)
     }
-
-    const result = await preValidateCredentialInputs(operations, ctx, workflowState)
-
-    expect(result.filteredOperations[1]?.params?.inputs?.apiKey).toBeUndefined()
-    expect(result.errors).toHaveLength(1)
-  })
+  )
 
   it('uses same-batch state: a type-less apiKey edit after an earlier op makes the block hosted', async () => {
     // op1 switches provider to falai (hosted); op2 (type-less) sets apiKey. op2 must see op1's

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
@@ -561,6 +561,40 @@ describe('preValidateCredentialInputs (hosted-tool blocks)', () => {
     expect(result.errors[0]).toMatchObject({ blockId: 'custom-1', field: 'serviceKey' })
   })
 
+  it('uses same-batch state for nested children (provider set earlier, apiKey set later)', async () => {
+    const operations = [
+      {
+        operation_type: 'add' as const,
+        block_id: 'loop-1',
+        params: {
+          type: 'loop',
+          inputs: {},
+          nestedNodes: {
+            'video-child': { type: 'video_generator_v3', inputs: { provider: 'falai' } },
+          },
+        },
+      },
+      {
+        operation_type: 'edit' as const,
+        block_id: 'loop-1',
+        params: {
+          nestedNodes: {
+            'video-child': { type: 'video_generator_v3', inputs: { apiKey: 'test-key' } },
+          },
+        },
+      },
+    ]
+
+    const result = await preValidateCredentialInputs(operations, ctx)
+
+    const nested = result.filteredOperations[1]?.params?.nestedNodes as
+      | Record<string, { inputs?: Record<string, unknown> }>
+      | undefined
+    expect(nested?.['video-child']?.inputs?.apiKey).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({ blockId: 'video-child', field: 'apiKey' })
+  })
+
   it('uses same-batch state: a type-less apiKey edit after an earlier op makes the block hosted', async () => {
     // op1 switches provider to falai (hosted); op2 (type-less) sets apiKey. op2 must see op1's
     // provider, not the stale snapshot (runway), and strip the key.

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
@@ -469,6 +469,31 @@ describe('preValidateCredentialInputs (hosted-tool blocks)', () => {
     expect(result.errors).toHaveLength(1)
   })
 
+  it('strips apiKey on a type-less edit op, resolving block type + provider from workflow state', async () => {
+    // Mirrors the real failure: agent edits only { apiKey } with no `type` restated.
+    const operations = [
+      {
+        operation_type: 'edit' as const,
+        block_id: 'video-1',
+        params: { inputs: { apiKey: 'test-api-key-12345' } },
+      },
+    ]
+    const workflowState = {
+      blocks: {
+        'video-1': {
+          type: 'video_generator_v3',
+          subBlocks: { provider: { value: 'falai' } },
+        },
+      },
+    }
+
+    const result = await preValidateCredentialInputs(operations, ctx, workflowState)
+
+    expect(result.filteredOperations[0]?.params?.inputs?.apiKey).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({ blockId: 'video-1', field: 'apiKey' })
+  })
+
   it('strips apiKey on a hosted-tool block nested inside a loop', async () => {
     const operations = [
       {

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
@@ -1392,6 +1392,22 @@ export async function preValidateCredentialInputs(
     value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined
   const snapshotBlock = (blockId: string) => asRecord(asRecord(workflowState?.blocks)?.[blockId])
 
+  // nestedNodes can nest recursively (a loop/parallel child can itself contain nestedNodes), and
+  // the apply path processes them recursively — so find a descendant's inputs at any depth.
+  const findNestedInputs = (
+    nodes: unknown,
+    targetId: string
+  ): Record<string, unknown> | undefined => {
+    const map = asRecord(nodes)
+    if (!map) return undefined
+    for (const [id, node] of Object.entries(map)) {
+      if (id === targetId) return asRecord(asRecord(node)?.inputs)
+      const found = findNestedInputs(asRecord(node)?.nestedNodes, targetId)
+      if (found) return found
+    }
+    return undefined
+  }
+
   // Track each block's effective state across ops in this batch (seeded from the snapshot, then
   // updated per op), so a later type-less edit sees type/provider changed by an earlier op in the
   // same request rather than the stale snapshot — otherwise a key could survive on a block an
@@ -1449,6 +1465,26 @@ export async function preValidateCredentialInputs(
     }
   }
 
+  // Walk a nestedNodes tree (loop/parallel children, recursively) running the collectors on each
+  // descendant. Keyed by each node's own id so deeper children get the same batch/snapshot
+  // resolution as top-level blocks and can't bypass stripping.
+  const walkNested = (opIndex: number, opBlockId: string, nodes: unknown) => {
+    const map = asRecord(nodes)
+    if (!map) return
+    for (const [childId, childBlock] of Object.entries(map)) {
+      const child = asRecord(childBlock)
+      collectForBlock(
+        opIndex,
+        childId,
+        opBlockId,
+        child?.type as string | undefined,
+        asRecord(child?.inputs),
+        childId
+      )
+      walkNested(opIndex, opBlockId, child?.nestedNodes)
+    }
+  }
+
   operations.forEach((op, opIndex) => {
     collectForBlock(
       opIndex,
@@ -1457,24 +1493,7 @@ export async function preValidateCredentialInputs(
       op.params?.type as string | undefined,
       asRecord(op.params?.inputs)
     )
-
-    // Nested nodes (blocks inside loop/parallel containers) — keyed by their own child id so they
-    // get the same batch/snapshot resolution as top-level blocks.
-    const nestedNodes = op.params?.nestedNodes as
-      | Record<string, Record<string, unknown>>
-      | undefined
-    if (nestedNodes) {
-      Object.entries(nestedNodes).forEach(([childId, childBlock]) => {
-        collectForBlock(
-          opIndex,
-          childId,
-          op.block_id,
-          childBlock.type as string | undefined,
-          asRecord(childBlock.inputs),
-          childId
-        )
-      })
-    }
+    walkNested(opIndex, op.block_id, op.params?.nestedNodes)
   })
 
   const hasCredentialsToValidate = credentialInputs.length > 0
@@ -1502,11 +1521,7 @@ export async function preValidateCredentialInputs(
 
       // Handle nested block apiKey filtering
       if (apiKeyInput.nestedBlockId) {
-        const nestedNodes = op.params?.nestedNodes as
-          | Record<string, Record<string, unknown>>
-          | undefined
-        const nestedBlock = nestedNodes?.[apiKeyInput.nestedBlockId]
-        const nestedInputs = nestedBlock?.inputs as Record<string, unknown> | undefined
+        const nestedInputs = findNestedInputs(op.params?.nestedNodes, apiKeyInput.nestedBlockId)
         if (nestedInputs?.[field]) {
           nestedInputs[field] = undefined
           logger.debug('Filtered platform-managed apiKey in nested block', {
@@ -1565,11 +1580,7 @@ export async function preValidateCredentialInputs(
 
         // Handle nested block credential removal
         if (credInput.nestedBlockId) {
-          const nestedNodes = op.params?.nestedNodes as
-            | Record<string, Record<string, unknown>>
-            | undefined
-          const nestedBlock = nestedNodes?.[credInput.nestedBlockId]
-          const nestedInputs = nestedBlock?.inputs as Record<string, unknown> | undefined
+          const nestedInputs = findNestedInputs(op.params?.nestedNodes, credInput.nestedBlockId)
           if (nestedInputs?.[credInput.fieldName]) {
             delete nestedInputs[credInput.fieldName]
             logger.info('Removed invalid credential from nested block', {

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
@@ -1463,7 +1463,11 @@ export async function preValidateCredentialInputs(
       const priorType = finalType.has(stateKey)
         ? finalType.get(stateKey)
         : (snapshotBlock(stateKey)?.type as string | undefined)
-      const resolved = validType(rawType) ?? priorType
+      // Only advance the type to one apply will honor: a registry-known type. An unknown type
+      // (apply skips the change and keeps the existing block) must not poison the fallback, or a
+      // later type-less apiKey edit would be judged against a block config that never applies.
+      const candidate = validType(rawType)
+      const resolved = (candidate && getBlock(candidate) ? candidate : undefined) ?? priorType
       if (resolved) finalType.set(stateKey, resolved)
       if (isHosted) {
         const priorValues =

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
@@ -1349,7 +1349,15 @@ export async function preValidateCredentialInputs(
     for (const toolId of candidateToolIds) {
       const tool = getTool(toolId)
       if (!tool?.hosting) continue
-      if (tool.hosting.enabled && !tool.hosting.enabled(toolParams)) continue
+      // The enabled predicate is tool-defined; guard it like the selector so a throw can't
+      // break edit_workflow for the request.
+      if (tool.hosting.enabled) {
+        try {
+          if (!tool.hosting.enabled(toolParams)) continue
+        } catch {
+          continue
+        }
+      }
       managedFieldIds.add(tool.hosting.apiKeyParam)
     }
 
@@ -1378,9 +1386,20 @@ export async function preValidateCredentialInputs(
   }
 
   operations.forEach((op, opIndex) => {
+    // Resolve the block type. Edit ops often omit `type` (they only carry the changed inputs),
+    // so fall back to the existing block's type from workflowState — otherwise an apiKey-only
+    // edit would skip credential/apiKey stripping entirely.
+    const opBlockType =
+      (op.params?.type as string | undefined) ??
+      ((
+        (workflowState?.blocks as Record<string, unknown>)?.[op.block_id] as
+          | Record<string, unknown>
+          | undefined
+      )?.type as string | undefined)
+
     // Process main block inputs
-    if (op.params?.inputs && op.params?.type) {
-      const blockConfig = getBlock(op.params.type)
+    if (op.params?.inputs && opBlockType) {
+      const blockConfig = getBlock(opBlockType)
       if (blockConfig) {
         // Collect credentials from main block
         collectCredentialInputs(
@@ -1388,7 +1407,7 @@ export async function preValidateCredentialInputs(
           op.params.inputs as Record<string, unknown>,
           opIndex,
           op.block_id,
-          op.params.type
+          opBlockType
         )
 
         // Check for apiKey inputs on hosted models
@@ -1416,7 +1435,7 @@ export async function preValidateCredentialInputs(
           modelValue,
           opIndex,
           op.block_id,
-          op.params.type
+          opBlockType
         )
 
         // The active tool depends on inputs (e.g. provider). On edit ops that don't restate
@@ -1441,7 +1460,7 @@ export async function preValidateCredentialInputs(
           toolParams,
           opIndex,
           op.block_id,
-          op.params.type
+          opBlockType
         )
       }
     }

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
@@ -1399,80 +1399,78 @@ export async function preValidateCredentialInputs(
   const batchBlockType = new Map<string, string | undefined>()
   const batchBlockValues = new Map<string, Record<string, unknown>>()
 
-  operations.forEach((op, opIndex) => {
-    const inputs = asRecord(op.params?.inputs)
-
-    // Effective block type: this op's type, else the type left by an earlier batch op, else the
+  // Resolve a single block (top-level or nested) against batch + snapshot state and run the
+  // collectors. `stateKey` keys the batch/snapshot lookup (the block's own id, including nested
+  // children); `reportBlockId`/`nestedBlockId` are how the strip surfaces it to the agent. Both
+  // paths route through here so they can't drift (the source of the earlier nested-vs-main gap).
+  const collectForBlock = (
+    opIndex: number,
+    stateKey: string,
+    reportBlockId: string,
+    rawType: string | undefined,
+    inputs: Record<string, unknown> | undefined,
+    nestedBlockId?: string
+  ) => {
+    // Effective type: this op's type, else the type left by an earlier batch op, else the
     // snapshot. Edit ops omit `type`, so without this an apiKey-only edit would skip stripping.
-    const priorType = batchBlockType.has(op.block_id)
-      ? batchBlockType.get(op.block_id)
-      : (snapshotBlock(op.block_id)?.type as string | undefined)
-    const opBlockType = (op.params?.type as string | undefined) ?? priorType
-    batchBlockType.set(op.block_id, opBlockType)
+    const priorType = batchBlockType.has(stateKey)
+      ? batchBlockType.get(stateKey)
+      : (snapshotBlock(stateKey)?.type as string | undefined)
+    const blockType = rawType ?? priorType
+    batchBlockType.set(stateKey, blockType)
 
-    // Process main block inputs
-    if (inputs && opBlockType) {
-      const blockConfig = getBlock(opBlockType)
-      if (blockConfig) {
-        collectCredentialInputs(blockConfig, inputs, opIndex, op.block_id, opBlockType)
+    if (!inputs || !blockType) return
+    const blockConfig = getBlock(blockType)
+    if (!blockConfig) return
 
-        // Both hosted collectors no-op off hosted Sim, so only reconstruct the effective inputs
-        // (prior batch/snapshot values overlaid with this op's delta) when it can matter.
-        if (isHosted) {
-          const priorValues =
-            batchBlockValues.get(op.block_id) ??
-            buildSubBlockValues(
-              (snapshotBlock(op.block_id)?.subBlocks as Record<string, { value?: unknown }>) ?? {}
-            )
-          const toolParams = { ...priorValues, ...inputs }
-          batchBlockValues.set(op.block_id, toolParams)
-          const modelValue = toolParams.model as string | undefined
-          collectHostedApiKeyInput(inputs, modelValue, opIndex, op.block_id, opBlockType)
-          collectHostedToolApiKeyInput(
-            blockConfig,
-            inputs,
-            toolParams,
-            opIndex,
-            op.block_id,
-            opBlockType
-          )
-        }
-      }
+    collectCredentialInputs(blockConfig, inputs, opIndex, reportBlockId, blockType, nestedBlockId)
+
+    // Both hosted collectors no-op off hosted Sim, so only reconstruct the effective inputs
+    // (prior batch/snapshot values overlaid with this op's delta) when it can matter.
+    if (isHosted) {
+      const priorValues =
+        batchBlockValues.get(stateKey) ??
+        buildSubBlockValues(
+          (snapshotBlock(stateKey)?.subBlocks as Record<string, { value?: unknown }>) ?? {}
+        )
+      const toolParams = { ...priorValues, ...inputs }
+      batchBlockValues.set(stateKey, toolParams)
+      const modelValue = toolParams.model as string | undefined
+      collectHostedApiKeyInput(inputs, modelValue, opIndex, reportBlockId, blockType, nestedBlockId)
+      collectHostedToolApiKeyInput(
+        blockConfig,
+        inputs,
+        toolParams,
+        opIndex,
+        reportBlockId,
+        blockType,
+        nestedBlockId
+      )
     }
+  }
 
-    // Process nested nodes (blocks inside loop/parallel containers)
+  operations.forEach((op, opIndex) => {
+    collectForBlock(
+      opIndex,
+      op.block_id,
+      op.block_id,
+      op.params?.type as string | undefined,
+      asRecord(op.params?.inputs)
+    )
+
+    // Nested nodes (blocks inside loop/parallel containers) — keyed by their own child id so they
+    // get the same batch/snapshot resolution as top-level blocks.
     const nestedNodes = op.params?.nestedNodes as
       | Record<string, Record<string, unknown>>
       | undefined
     if (nestedNodes) {
       Object.entries(nestedNodes).forEach(([childId, childBlock]) => {
-        const childType = childBlock.type as string | undefined
-        const childInputs = childBlock.inputs as Record<string, unknown> | undefined
-        if (!childType || !childInputs) return
-
-        const childBlockConfig = getBlock(childType)
-        if (!childBlockConfig) return
-
-        // Collect credentials from nested block
-        collectCredentialInputs(
-          childBlockConfig,
-          childInputs,
+        collectForBlock(
           opIndex,
+          childId,
           op.block_id,
-          childType,
-          childId
-        )
-
-        // Check for apiKey inputs on hosted models in nested block
-        const modelValue = childInputs.model as string | undefined
-        collectHostedApiKeyInput(childInputs, modelValue, opIndex, op.block_id, childType, childId)
-        collectHostedToolApiKeyInput(
-          childBlockConfig,
-          childInputs,
-          childInputs,
-          opIndex,
-          op.block_id,
-          childType,
+          childBlock.type as string | undefined,
+          asRecord(childBlock.inputs),
           childId
         )
       })

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
@@ -1349,14 +1349,17 @@ export async function preValidateCredentialInputs(
     for (const toolId of candidateToolIds) {
       const tool = getTool(toolId)
       if (!tool?.hosting) continue
-      // The enabled predicate is tool-defined; guard it like the selector so a throw can't
-      // break edit_workflow for the request.
+      // The enabled predicate is tool-defined; guard it so a throw can't break edit_workflow. On
+      // a throw the hosting state is unknown, so fail toward treating the key as managed (strip)
+      // rather than preserving a key that may actually be platform-managed.
       if (tool.hosting.enabled) {
+        let isManaged: boolean
         try {
-          if (!tool.hosting.enabled(toolParams)) continue
+          isManaged = tool.hosting.enabled(toolParams)
         } catch {
-          continue
+          isManaged = true
         }
+        if (!isManaged) continue
       }
       managedFieldIds.add(tool.hosting.apiKeyParam)
     }
@@ -1387,18 +1390,25 @@ export async function preValidateCredentialInputs(
 
   const asRecord = (value: unknown): Record<string, unknown> | undefined =>
     value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined
+  const snapshotBlock = (blockId: string) => asRecord(asRecord(workflowState?.blocks)?.[blockId])
+
+  // Track each block's effective state across ops in this batch (seeded from the snapshot, then
+  // updated per op), so a later type-less edit sees type/provider changed by an earlier op in the
+  // same request rather than the stale snapshot — otherwise a key could survive on a block an
+  // earlier op just made hosted.
+  const batchBlockType = new Map<string, string | undefined>()
+  const batchBlockValues = new Map<string, Record<string, unknown>>()
 
   operations.forEach((op, opIndex) => {
-    // Edit ops carry only the changed inputs, so reconstruct the block from workflowState: its
-    // type when not restated, and its existing subblock values so the tool selector and
-    // hosted-model checks see provider/model even when the edit omits them.
-    const existingBlock =
-      op.operation_type === 'edit'
-        ? asRecord(asRecord(workflowState?.blocks)?.[op.block_id])
-        : undefined
-    const opBlockType =
-      (op.params?.type as string | undefined) ?? (existingBlock?.type as string | undefined)
     const inputs = asRecord(op.params?.inputs)
+
+    // Effective block type: this op's type, else the type left by an earlier batch op, else the
+    // snapshot. Edit ops omit `type`, so without this an apiKey-only edit would skip stripping.
+    const priorType = batchBlockType.has(op.block_id)
+      ? batchBlockType.get(op.block_id)
+      : (snapshotBlock(op.block_id)?.type as string | undefined)
+    const opBlockType = (op.params?.type as string | undefined) ?? priorType
+    batchBlockType.set(op.block_id, opBlockType)
 
     // Process main block inputs
     if (inputs && opBlockType) {
@@ -1407,12 +1417,15 @@ export async function preValidateCredentialInputs(
         collectCredentialInputs(blockConfig, inputs, opIndex, op.block_id, opBlockType)
 
         // Both hosted collectors no-op off hosted Sim, so only reconstruct the effective inputs
-        // (existing subblock values overlaid with this op's delta) when it can matter.
+        // (prior batch/snapshot values overlaid with this op's delta) when it can matter.
         if (isHosted) {
-          const existingValues = buildSubBlockValues(
-            (existingBlock?.subBlocks as Record<string, { value?: unknown }>) ?? {}
-          )
-          const toolParams = { ...existingValues, ...inputs }
+          const priorValues =
+            batchBlockValues.get(op.block_id) ??
+            buildSubBlockValues(
+              (snapshotBlock(op.block_id)?.subBlocks as Record<string, { value?: unknown }>) ?? {}
+            )
+          const toolParams = { ...priorValues, ...inputs }
+          batchBlockValues.set(op.block_id, toolParams)
           const modelValue = toolParams.model as string | undefined
           collectHostedApiKeyInput(inputs, modelValue, opIndex, op.block_id, opBlockType)
           collectHostedToolApiKeyInput(

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
@@ -1408,93 +1408,107 @@ export async function preValidateCredentialInputs(
     return undefined
   }
 
-  // Track each block's effective state across ops in this batch (seeded from the snapshot, then
-  // updated per op), so a later type-less edit sees type/provider changed by an earlier op in the
-  // same request rather than the stale snapshot — otherwise a key could survive on a block an
-  // earlier op just made hosted.
-  const batchBlockType = new Map<string, string | undefined>()
-  const batchBlockValues = new Map<string, Record<string, unknown>>()
+  const validType = (type: unknown): string | undefined =>
+    typeof type === 'string' && type.trim() ? type : undefined
 
-  // Resolve a single block (top-level or nested) against batch + snapshot state and run the
-  // collectors. `stateKey` keys the batch/snapshot lookup (the block's own id, including nested
-  // children); `reportBlockId`/`nestedBlockId` are how the strip surfaces it to the agent. Both
-  // paths route through here so they can't drift (the source of the earlier nested-vs-main gap).
-  const collectForBlock = (
+  // Visit every block an op touches — its main block and each nestedNodes descendant (recursively,
+  // since loop/parallel children can themselves contain nestedNodes) — keyed by the block's own id.
+  const visitOpBlocks = (
+    op: EditWorkflowOperation,
     opIndex: number,
-    stateKey: string,
-    reportBlockId: string,
-    rawType: string | undefined,
-    inputs: Record<string, unknown> | undefined,
-    nestedBlockId?: string
+    visit: (b: {
+      opIndex: number
+      stateKey: string
+      reportBlockId: string
+      rawType: string | undefined
+      inputs: Record<string, unknown> | undefined
+      nestedBlockId?: string
+    }) => void
   ) => {
-    // Effective type: this op's type, else the type left by an earlier batch op, else the
-    // snapshot. Edit ops omit `type`, so without this an apiKey-only edit would skip stripping.
-    const priorType = batchBlockType.has(stateKey)
-      ? batchBlockType.get(stateKey)
-      : (snapshotBlock(stateKey)?.type as string | undefined)
-    const blockType = rawType ?? priorType
-    batchBlockType.set(stateKey, blockType)
-
-    if (!inputs || !blockType) return
-    const blockConfig = getBlock(blockType)
-    if (!blockConfig) return
-
-    collectCredentialInputs(blockConfig, inputs, opIndex, reportBlockId, blockType, nestedBlockId)
-
-    // Both hosted collectors no-op off hosted Sim, so only reconstruct the effective inputs
-    // (prior batch/snapshot values overlaid with this op's delta) when it can matter.
-    if (isHosted) {
-      const priorValues =
-        batchBlockValues.get(stateKey) ??
-        buildSubBlockValues(
-          (snapshotBlock(stateKey)?.subBlocks as Record<string, { value?: unknown }>) ?? {}
-        )
-      const toolParams = { ...priorValues, ...inputs }
-      batchBlockValues.set(stateKey, toolParams)
-      const modelValue = toolParams.model as string | undefined
-      collectHostedApiKeyInput(inputs, modelValue, opIndex, reportBlockId, blockType, nestedBlockId)
-      collectHostedToolApiKeyInput(
-        blockConfig,
-        inputs,
-        toolParams,
-        opIndex,
-        reportBlockId,
-        blockType,
-        nestedBlockId
-      )
-    }
-  }
-
-  // Walk a nestedNodes tree (loop/parallel children, recursively) running the collectors on each
-  // descendant. Keyed by each node's own id so deeper children get the same batch/snapshot
-  // resolution as top-level blocks and can't bypass stripping.
-  const walkNested = (opIndex: number, opBlockId: string, nodes: unknown) => {
-    const map = asRecord(nodes)
-    if (!map) return
-    for (const [childId, childBlock] of Object.entries(map)) {
-      const child = asRecord(childBlock)
-      collectForBlock(
-        opIndex,
-        childId,
-        opBlockId,
-        child?.type as string | undefined,
-        asRecord(child?.inputs),
-        childId
-      )
-      walkNested(opIndex, opBlockId, child?.nestedNodes)
-    }
-  }
-
-  operations.forEach((op, opIndex) => {
-    collectForBlock(
+    visit({
       opIndex,
-      op.block_id,
-      op.block_id,
-      op.params?.type as string | undefined,
-      asRecord(op.params?.inputs)
-    )
-    walkNested(opIndex, op.block_id, op.params?.nestedNodes)
-  })
+      stateKey: op.block_id,
+      reportBlockId: op.block_id,
+      rawType: op.params?.type as string | undefined,
+      inputs: asRecord(op.params?.inputs),
+    })
+    const walk = (nodes: unknown, parentBlockId: string) => {
+      const map = asRecord(nodes)
+      if (!map) return
+      for (const [childId, childBlock] of Object.entries(map)) {
+        const child = asRecord(childBlock)
+        visit({
+          opIndex,
+          stateKey: childId,
+          reportBlockId: parentBlockId,
+          rawType: child?.type as string | undefined,
+          inputs: asRecord(child?.inputs),
+          nestedBlockId: childId,
+        })
+        walk(child?.nestedNodes, parentBlockId)
+      }
+    }
+    walk(op.params?.nestedNodes, op.block_id)
+  }
+
+  // Pass 1: fold every op into each block's FINAL effective state (type + values) for the batch,
+  // seeded from the snapshot. Deciding strips against the final state (not a forward prefix) makes
+  // order irrelevant — a key set before a later op makes the block hosted is still caught.
+  const finalType = new Map<string, string | undefined>()
+  const finalValues = new Map<string, Record<string, unknown>>()
+  for (const [opIndex, op] of operations.entries()) {
+    visitOpBlocks(op, opIndex, ({ stateKey, rawType, inputs }) => {
+      const priorType = finalType.has(stateKey)
+        ? finalType.get(stateKey)
+        : (snapshotBlock(stateKey)?.type as string | undefined)
+      const resolved = validType(rawType) ?? priorType
+      if (resolved) finalType.set(stateKey, resolved)
+      if (isHosted) {
+        const priorValues =
+          finalValues.get(stateKey) ??
+          buildSubBlockValues(
+            (snapshotBlock(stateKey)?.subBlocks as Record<string, { value?: unknown }>) ?? {}
+          )
+        finalValues.set(stateKey, { ...priorValues, ...(inputs ?? {}) })
+      }
+    })
+  }
+
+  // Pass 2: for each op, strip the managed fields it actually sets, judged against the block's
+  // final state. Both top-level and nested blocks route through the same visit so they can't drift.
+  for (const [opIndex, op] of operations.entries()) {
+    visitOpBlocks(op, opIndex, ({ stateKey, reportBlockId, inputs, nestedBlockId }) => {
+      const blockType = finalType.get(stateKey)
+      if (!inputs || !blockType) return
+      const blockConfig = getBlock(blockType)
+      if (!blockConfig) return
+
+      collectCredentialInputs(blockConfig, inputs, opIndex, reportBlockId, blockType, nestedBlockId)
+
+      // Hosted collectors no-op off hosted Sim, so only resolve the effective state when it matters.
+      if (isHosted) {
+        const toolParams = finalValues.get(stateKey) ?? inputs
+        const modelValue = toolParams.model as string | undefined
+        collectHostedApiKeyInput(
+          inputs,
+          modelValue,
+          opIndex,
+          reportBlockId,
+          blockType,
+          nestedBlockId
+        )
+        collectHostedToolApiKeyInput(
+          blockConfig,
+          inputs,
+          toolParams,
+          opIndex,
+          reportBlockId,
+          blockType,
+          nestedBlockId
+        )
+      }
+    })
+  }
 
   const hasCredentialsToValidate = credentialInputs.length > 0
   const hasHostedApiKeysToFilter = hostedApiKeyInputs.length > 0

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
@@ -1385,83 +1385,45 @@ export async function preValidateCredentialInputs(
     }
   }
 
+  const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+    value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined
+
   operations.forEach((op, opIndex) => {
-    // Resolve the block type. Edit ops often omit `type` (they only carry the changed inputs),
-    // so fall back to the existing block's type from workflowState — otherwise an apiKey-only
-    // edit would skip credential/apiKey stripping entirely.
+    // Edit ops carry only the changed inputs, so reconstruct the block from workflowState: its
+    // type when not restated, and its existing subblock values so the tool selector and
+    // hosted-model checks see provider/model even when the edit omits them.
+    const existingBlock =
+      op.operation_type === 'edit'
+        ? asRecord(asRecord(workflowState?.blocks)?.[op.block_id])
+        : undefined
     const opBlockType =
-      (op.params?.type as string | undefined) ??
-      ((
-        (workflowState?.blocks as Record<string, unknown>)?.[op.block_id] as
-          | Record<string, unknown>
-          | undefined
-      )?.type as string | undefined)
+      (op.params?.type as string | undefined) ?? (existingBlock?.type as string | undefined)
+    const inputs = asRecord(op.params?.inputs)
 
     // Process main block inputs
-    if (op.params?.inputs && opBlockType) {
+    if (inputs && opBlockType) {
       const blockConfig = getBlock(opBlockType)
       if (blockConfig) {
-        // Collect credentials from main block
-        collectCredentialInputs(
-          blockConfig,
-          op.params.inputs as Record<string, unknown>,
-          opIndex,
-          op.block_id,
-          opBlockType
-        )
+        collectCredentialInputs(blockConfig, inputs, opIndex, op.block_id, opBlockType)
 
-        // Check for apiKey inputs on hosted models
-        let modelValue = (op.params.inputs as Record<string, unknown>).model as string | undefined
-
-        // For edit operations, if model is not being changed, check existing block's model
-        if (
-          !modelValue &&
-          op.operation_type === 'edit' &&
-          (op.params.inputs as Record<string, unknown>).apiKey &&
-          workflowState
-        ) {
-          const existingBlock = (workflowState.blocks as Record<string, unknown>)?.[op.block_id] as
-            | Record<string, unknown>
-            | undefined
-          const existingSubBlocks = existingBlock?.subBlocks as Record<string, unknown> | undefined
-          const existingModelSubBlock = existingSubBlocks?.model as
-            | Record<string, unknown>
-            | undefined
-          modelValue = existingModelSubBlock?.value as string | undefined
+        // Both hosted collectors no-op off hosted Sim, so only reconstruct the effective inputs
+        // (existing subblock values overlaid with this op's delta) when it can matter.
+        if (isHosted) {
+          const existingValues = buildSubBlockValues(
+            (existingBlock?.subBlocks as Record<string, { value?: unknown }>) ?? {}
+          )
+          const toolParams = { ...existingValues, ...inputs }
+          const modelValue = toolParams.model as string | undefined
+          collectHostedApiKeyInput(inputs, modelValue, opIndex, op.block_id, opBlockType)
+          collectHostedToolApiKeyInput(
+            blockConfig,
+            inputs,
+            toolParams,
+            opIndex,
+            op.block_id,
+            opBlockType
+          )
         }
-
-        collectHostedApiKeyInput(
-          op.params.inputs as Record<string, unknown>,
-          modelValue,
-          opIndex,
-          op.block_id,
-          opBlockType
-        )
-
-        // The active tool depends on inputs (e.g. provider). On edit ops that don't restate
-        // provider, merge the existing block's subblock values so the tool selector and its
-        // `enabled` gate resolve correctly.
-        let toolParams = op.params.inputs as Record<string, unknown>
-        if (op.operation_type === 'edit' && workflowState) {
-          const existingBlock = (workflowState.blocks as Record<string, unknown>)?.[op.block_id] as
-            | Record<string, unknown>
-            | undefined
-          const existingSubBlocks = existingBlock?.subBlocks as
-            | Record<string, { value?: unknown } | null | undefined>
-            | undefined
-          if (existingSubBlocks) {
-            toolParams = { ...buildSubBlockValues(existingSubBlocks), ...toolParams }
-          }
-        }
-
-        collectHostedToolApiKeyInput(
-          blockConfig,
-          op.params.inputs as Record<string, unknown>,
-          toolParams,
-          opIndex,
-          op.block_id,
-          opBlockType
-        )
       }
     }
 

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
@@ -1332,17 +1332,19 @@ export async function preValidateCredentialInputs(
     if (!isHosted || !blockConfig?.tools) return
 
     // Resolve which tool(s) the current inputs select. With a selector there is exactly one active
-    // tool; without one, every accessible tool is a candidate.
+    // tool; without one (or if the selector throws on partial params), every accessible tool is a
+    // candidate — failing toward considering all hosted params so a key can't slip through.
+    const accessToolIds = blockConfig.tools.access ?? []
     let candidateToolIds: string[]
     const toolSelector = blockConfig.tools.config?.tool
     if (toolSelector) {
       try {
         candidateToolIds = [toolSelector(toolParams)]
       } catch {
-        return
+        candidateToolIds = accessToolIds
       }
     } else {
-      candidateToolIds = blockConfig.tools.access ?? []
+      candidateToolIds = accessToolIds
     }
 
     const managedFieldIds = new Set<string>()


### PR DESCRIPTION
## Summary
Follow-up to #5217. That PR stripped copilot-authored platform-managed `apiKey` on hosted-tool blocks, but only for ops that restate `type` — so a **type-less `edit` op** slipped through.

Verified live on staging via [trace `84d38867…`]: prompted with "directly set apiKey for the makeVideo block", the agent issued `{ params: { inputs: { apiKey: "test-api-key-12345" } }, operation_type: "edit" }` (no `type`). `preValidateCredentialInputs` gates the whole strip path (both the model and tool paths) on `op.params.type`, so the op was skipped and the key persisted — re-disabling hosted-key injection.

- Resolve the block type from `workflowState` when the op omits `type`, so type-less edits run through the strip (also closes the same latent gap in the original hosted-LLM-model strip).
- Guard `tool.hosting.enabled()` in try/catch, matching the existing guard on the tool selector, so a throwing predicate can't break `edit_workflow`.
- Regression test mirroring the observed failure (edit op with only `apiKey`; type + provider resolved from workflow state).

Known remaining gap (lower-likelihood, not addressed here): **nested** edit ops inside a loop/parallel don't get workflow-state enrichment, so a nested type/provider-less edit could still slip through.

## Type of Change
- [x] Bug fix

## Testing
- `vitest` on `validation.test.ts`: 57 passed (added type-less-edit regression case)
- `bun run lint:check`: clean
- `bun run check:api-validation:strict`: passed
- `tsc --noEmit`: clean
- Runtime wiring confirmed: `edit-workflow/index.ts` passes `workflowState` to `preValidateCredentialInputs`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)