### PR TITLE
perf(trigger): cap concurrency on background DB tasks

### DIFF
--- a/apps/sim/background/async-execution-correlation.test.ts
+++ b/apps/sim/background/async-execution-correlation.test.ts
@@ -56,7 +56,7 @@ describe('async execution correlation fallbacks', () => {
     expect(scheduleExecutionTaskOptions).toMatchObject({
       queue: {
         name: 'schedule-execution',
-        concurrencyLimit: 50,
+        concurrencyLimit: 30,
       },
     })
   })

--- a/apps/sim/background/concurrency-limits.ts
+++ b/apps/sim/background/concurrency-limits.ts
@@ -1,0 +1,21 @@
+import { env, envNumber } from '@/lib/core/config/env'
+
+/** Per-task Trigger.dev concurrency caps. Bound heavy DB tasks so unbounded fan-out can't saturate the pool. */
+
+export const WORKFLOW_EXECUTION_CONCURRENCY_LIMIT = envNumber(
+  env.WORKFLOW_EXECUTION_CONCURRENCY_LIMIT,
+  75,
+  { min: 1, integer: true }
+)
+
+export const WEBHOOK_EXECUTION_CONCURRENCY_LIMIT = envNumber(
+  env.WEBHOOK_EXECUTION_CONCURRENCY_LIMIT,
+  75,
+  { min: 1, integer: true }
+)
+
+export const RESUME_EXECUTION_CONCURRENCY_LIMIT = envNumber(
+  env.RESUME_EXECUTION_CONCURRENCY_LIMIT,
+  50,
+  { min: 1, integer: true }
+)

--- a/apps/sim/background/resume-execution.ts
+++ b/apps/sim/background/resume-execution.ts
@@ -6,6 +6,7 @@ import { withCascadeLock } from '@/lib/table/cascade-lock'
 import { isExecCancelled } from '@/lib/table/deps'
 import type { RowData, RowExecutionMetadata } from '@/lib/table/types'
 import { PauseResumeManager } from '@/lib/workflows/executor/human-in-the-loop-manager'
+import { RESUME_EXECUTION_CONCURRENCY_LIMIT } from '@/background/concurrency-limits'
 
 const logger = createLogger('TriggerResumeExecution')
 
@@ -350,6 +351,9 @@ export const resumeExecutionTask = task({
   machine: 'medium-1x',
   retry: {
     maxAttempts: 1,
+  },
+  queue: {
+    concurrencyLimit: RESUME_EXECUTION_CONCURRENCY_LIMIT,
   },
   run: executeResumeJob,
 })

--- a/apps/sim/background/webhook-execution.ts
+++ b/apps/sim/background/webhook-execution.ts
@@ -26,6 +26,7 @@ import {
 import { handlePostExecutionPauseState } from '@/lib/workflows/executor/pause-persistence'
 import { loadDeployedWorkflowState } from '@/lib/workflows/persistence/utils'
 import { resolveOAuthAccountId } from '@/app/api/auth/oauth/utils'
+import { WEBHOOK_EXECUTION_CONCURRENCY_LIMIT } from '@/background/concurrency-limits'
 import { getBlock } from '@/blocks'
 import { ExecutionSnapshot } from '@/executor/execution/snapshot'
 import type { ExecutionMetadata } from '@/executor/execution/types'
@@ -682,6 +683,9 @@ export const webhookExecution = task({
   machine: 'medium-1x',
   retry: {
     maxAttempts: 1,
+  },
+  queue: {
+    concurrencyLimit: WEBHOOK_EXECUTION_CONCURRENCY_LIMIT,
   },
   run: async (payload: WebhookExecutionPayload) => executeWebhookJob(payload),
 })

--- a/apps/sim/background/workflow-execution.ts
+++ b/apps/sim/background/workflow-execution.ts
@@ -13,6 +13,7 @@ import {
   wasExecutionFinalizedByCore,
 } from '@/lib/workflows/executor/execution-core'
 import { handlePostExecutionPauseState } from '@/lib/workflows/executor/pause-persistence'
+import { WORKFLOW_EXECUTION_CONCURRENCY_LIMIT } from '@/background/concurrency-limits'
 import { ExecutionSnapshot } from '@/executor/execution/snapshot'
 import type { ExecutionMetadata } from '@/executor/execution/types'
 import { hasExecutionResult } from '@/executor/utils/errors'
@@ -206,5 +207,8 @@ export async function executeWorkflowJob(payload: WorkflowExecutionPayload) {
 export const workflowExecutionTask = task({
   id: 'workflow-execution',
   machine: 'medium-1x',
+  queue: {
+    concurrencyLimit: WORKFLOW_EXECUTION_CONCURRENCY_LIMIT,
+  },
   run: executeWorkflowJob,
 })

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -206,7 +206,10 @@ export const env = createEnv({
     TRIGGER_DEV_ENABLED:                   z.boolean().optional(),                 // Toggle to enable/disable Trigger.dev for async jobs
     CRON_SECRET:                           z.string().optional(),                  // Secret for authenticating cron job requests
     JOB_RETENTION_DAYS:                    z.string().optional().default('1'),     // Days to retain job logs/data
-    SCHEDULE_EXECUTION_CONCURRENCY_LIMIT:  z.string().optional().default('50'),
+    SCHEDULE_EXECUTION_CONCURRENCY_LIMIT:  z.string().optional().default('30'),
+    WORKFLOW_EXECUTION_CONCURRENCY_LIMIT:  z.string().optional().default('75'),
+    WEBHOOK_EXECUTION_CONCURRENCY_LIMIT:   z.string().optional().default('75'),
+    RESUME_EXECUTION_CONCURRENCY_LIMIT:    z.string().optional().default('50'),
     SCHEDULE_ENQUEUE_BUDGET_MULTIPLIER:    z.string().optional().default('2'),
     SCHEDULE_JITTER_MAX_MS:                z.string().optional().default('30000'),
     SCHEDULE_INFRA_RETRY_BASE_MS:          z.string().optional().default('60000'),

--- a/apps/sim/lib/workflows/schedules/execution-limits.ts
+++ b/apps/sim/lib/workflows/schedules/execution-limits.ts
@@ -4,7 +4,7 @@ export const SCHEDULE_EXECUTION_QUEUE_NAME = 'schedule-execution'
 
 export const SCHEDULE_EXECUTION_CONCURRENCY_LIMIT = envNumber(
   env.SCHEDULE_EXECUTION_CONCURRENCY_LIMIT,
-  50,
+  30,
   { min: 1, integer: true }
 )
 


### PR DESCRIPTION
## Summary
- Cap per-task Trigger.dev concurrency on the heavy DB-bound background tasks to mitigate the Postgres pool-exhaustion incident — unbounded fan-out spawned many machines that collectively saturated the pool.
- New `apps/sim/background/concurrency-limits.ts` defines env-overridable caps via the existing `envNumber` pattern: `workflow-execution` **75** (`WORKFLOW_EXECUTION_CONCURRENCY_LIMIT`), `webhook-execution` **75** (`WEBHOOK_EXECUTION_CONCURRENCY_LIMIT`), `resume-execution` **50** (`RESUME_EXECUTION_CONCURRENCY_LIMIT`).
- Lower the schedule cap default **50 → 30** (`SCHEDULE_EXECUTION_CONCURRENCY_LIMIT`).
- Register the three new env vars in `env.ts`.

This is a strict reduction in peak concurrency — the three tasks were previously unbounded.

### Validated against 30d of prod run data
- workflow/webhook/resume caps sit well above real load (typical distinct concurrency ~2–25, max ~11 workflow runs/min, ~261 webhook runs/min in worst burst).
- schedule at 30 intentionally bites cron-boundary bursts (p95 ~30, p99 ~64 runs/min). Schedule already queues at 50; 30 adds some latency at peak by design. Note `SCHEDULE_WORKFLOW_ENQUEUE_LIMIT = LIMIT × 2` drops 100→60 in tandem.

## Type of Change
- [x] Performance / reliability

## Testing
Tested manually — `bun run lint` (biome) clean, `bun run check:api-validation:strict` passes, `tsc --noEmit` clean on changed files. No API boundaries touched.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)