### PR TITLE
fix(blocks): render SubBlockConfig.tooltip in sub-block label

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
@@ -7,6 +7,7 @@ import {
   Check,
   Clipboard,
   ExternalLink,
+  Info,
 } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { Button, Input, Label, Tooltip } from '@/components/emcn/components'
@@ -252,6 +253,18 @@ const renderLabel = (
       <Label className='flex items-baseline gap-1.5 whitespace-nowrap'>
         {config.title}
         {required && <span className='ml-0.5'>*</span>}
+        {config.tooltip && (
+          <Tooltip.Root>
+            <Tooltip.Trigger asChild>
+              <span className='inline-flex'>
+                <Info className='size-3 flex-shrink-0 cursor-pointer text-muted-foreground' />
+              </span>
+            </Tooltip.Trigger>
+            <Tooltip.Content side='top'>
+              <p>{config.tooltip}</p>
+            </Tooltip.Content>
+          </Tooltip.Root>
+        )}
         {labelSuffix}
         {config.type === 'code' &&
           config.language === 'json' &&


### PR DESCRIPTION
## Summary
`SubBlockConfig.tooltip` is defined in `apps/sim/blocks/types.ts` (`tooltip?: string // Tooltip text displayed via info icon next to the title`) but was never rendered. `renderLabel` in `sub-block.tsx` reads `config.title` and `config.required` but ignored `config.tooltip`, so block configs that set it — e.g. `pi.ts` and `textract.ts` — showed no help text in the editor.

This wires up the field: when `config.tooltip` is set, an `Info` icon is rendered next to the field title, and hovering it shows the tooltip text. It reuses the `Tooltip.Root/Trigger/Content` pattern already used a few lines below in the same `renderLabel` for the invalid-JSON warning, and matches its icon styling (`size-3`, `flex-shrink-0`, `text-muted-foreground`).

Fixes #4071

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
- `bunx @biomejs/biome check` on the changed file passes with no fixes/warnings.
- Verified the existing block configs that already set `tooltip` (`pi.ts`, `textract.ts`) now surface an info icon with their help text next to the corresponding field label; fields without a `tooltip` are unchanged.
- This is a small, presentational addition that mirrors an existing rendering branch in the same function; there is no existing unit-test harness around `renderLabel`, so no test was added.

Reviewers: the only behavioral change is the new conditional block inside `renderLabel`; everything else (required asterisk, label suffix, invalid-JSON warning, copy/wand/toggle controls) is untouched.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
With a sub-block that sets `tooltip` (e.g. the PI block's "Personal access token" field), an info icon now appears immediately after the field title; hovering it shows the configured text. Fields with no `tooltip` render exactly as before.
