### PR TITLE
fix(connectors): harden Zendesk connector against SSRF

### DIFF
--- a/apps/sim/connectors/zendesk/zendesk.test.ts
+++ b/apps/sim/connectors/zendesk/zendesk.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { buildBaseUrl } from '@/connectors/zendesk/zendesk'
+
+describe('buildBaseUrl', () => {
+  it.concurrent('builds the base URL for a valid subdomain', () => {
+    expect(buildBaseUrl('acme')).toBe('https://acme.zendesk.com')
+  })
+
+  it.concurrent('allows hyphens and digits within the label', () => {
+    expect(buildBaseUrl('acme-support-1')).toBe('https://acme-support-1.zendesk.com')
+  })
+
+  it.concurrent('allows a single-character subdomain', () => {
+    expect(buildBaseUrl('a')).toBe('https://a.zendesk.com')
+  })
+
+  it.concurrent('allows the maximum 63-character label', () => {
+    const label = `a${'b'.repeat(61)}c`
+    expect(label).toHaveLength(63)
+    expect(buildBaseUrl(label)).toBe(`https://${label}.zendesk.com`)
+  })
+
+  it.concurrent('trims surrounding whitespace', () => {
+    expect(buildBaseUrl('  acme  ')).toBe('https://acme.zendesk.com')
+  })
+
+  it.concurrent('normalizes uppercase to lowercase (DNS is case-insensitive)', () => {
+    expect(buildBaseUrl('MyCompany')).toBe('https://mycompany.zendesk.com')
+  })
+
+  describe('rejects SSRF payloads', () => {
+    const ssrfPayloads: Array<[string, string]> = [
+      ['fragment truncation', 'webhook.site/abc#'],
+      ['fragment with path', 'evil.com/path#'],
+      ['embedded path', 'acme/api/v2'],
+      ['scheme injection', 'http://evil.com'],
+      ['userinfo', 'user@evil.com'],
+      ['port', 'acme:8080'],
+      ['open-redirect host', 'httpbin.org/redirect-to?url=http://169.254.169.254'],
+      ['loopback', '127.0.0.1'],
+      ['link-local literal', '169.254.169.254'],
+      ['whitespace injection', 'acme evil'],
+      ['leading hyphen', '-acme'],
+      ['trailing hyphen', 'acme-'],
+      ['leading dot', '.acme'],
+      ['trailing dot', 'acme.'],
+      ['empty string', ''],
+      ['whitespace only', '   '],
+      ['over-length label', 'a'.repeat(64)],
+      ['unicode', 'acmé'],
+    ]
+
+    it.concurrent.each(ssrfPayloads)('rejects %s', (_label, payload) => {
+      expect(() => buildBaseUrl(payload)).toThrow('Invalid Zendesk subdomain')
+    })
+  })
+})

--- a/apps/sim/connectors/zendesk/zendesk.ts
+++ b/apps/sim/connectors/zendesk/zendesk.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
-import { fetchWithRetry, VALIDATE_RETRY_OPTIONS } from '@/lib/knowledge/documents/utils'
+import { secureFetchWithRetry } from '@/lib/knowledge/documents/secure-fetch.server'
+import { VALIDATE_RETRY_OPTIONS } from '@/lib/knowledge/documents/utils'
 import type { ConnectorConfig, ExternalDocument, ExternalDocumentList } from '@/connectors/types'
 import { htmlToPlainText, joinTagArray, parseTagDate } from '@/connectors/utils'
 import { DEFAULT_MAX_TICKETS, zendeskConnectorMeta } from '@/connectors/zendesk/meta'
@@ -51,10 +52,31 @@ interface ZendeskComment {
 }
 
 /**
- * Builds the base URL for a Zendesk subdomain.
+ * Strict Zendesk subdomain label: a single DNS label of lowercase letters,
+ * digits, and hyphens (not leading/trailing). Rejects anything that could
+ * smuggle a scheme, host, path, port, or fragment into the base URL.
  */
-function buildBaseUrl(subdomain: string): string {
-  return `https://${subdomain}.zendesk.com`
+const SUBDOMAIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+
+/**
+ * Validates and normalizes a Zendesk subdomain.
+ *
+ * @throws {Error} when the subdomain is missing or not a valid DNS label.
+ */
+function normalizeSubdomain(subdomain: string): string {
+  const normalized = subdomain.trim().toLowerCase()
+  if (!SUBDOMAIN_PATTERN.test(normalized)) {
+    throw new Error('Invalid Zendesk subdomain')
+  }
+  return normalized
+}
+
+/**
+ * Builds the base URL for a Zendesk subdomain. The subdomain is validated to a
+ * strict DNS label so it cannot be used to forge requests to arbitrary hosts.
+ */
+export function buildBaseUrl(subdomain: string): string {
+  return `https://${normalizeSubdomain(subdomain)}.zendesk.com`
 }
 
 /**
@@ -65,11 +87,11 @@ async function zendeskApiGet(
   url: string,
   accessToken: string,
   sourceConfig: Record<string, unknown>,
-  retryOptions?: Parameters<typeof fetchWithRetry>[2]
+  retryOptions?: Parameters<typeof secureFetchWithRetry>[2]
 ): Promise<Record<string, unknown>> {
   const email = sourceConfig.email as string
 
-  const response = await fetchWithRetry(
+  const response = await secureFetchWithRetry(
     url,
     {
       method: 'GET',

--- a/apps/sim/lib/knowledge/documents/utils.test.ts
+++ b/apps/sim/lib/knowledge/documents/utils.test.ts
@@ -132,6 +132,10 @@ describe('isRetryableError', () => {
     it.concurrent('returns true for "service unavailable" in message', () => {
       expect(isRetryableError(new Error('The service unavailable right now'))).toBe(true)
     })
+
+    it.concurrent('returns true for a transient DNS resolution failure', () => {
+      expect(isRetryableError(new Error('url hostname could not be resolved'))).toBe(true)
+    })
   })
 
   describe('case insensitivity', () => {
@@ -177,6 +181,10 @@ describe('isRetryableError', () => {
 
     it.concurrent('returns false for plain object with non-retryable status and no message', () => {
       expect(isRetryableError({ status: 500 })).toBe(false)
+    })
+
+    it.concurrent('returns false for the deterministic blocked-IP SSRF rejection', () => {
+      expect(isRetryableError(new Error('url resolves to a blocked IP address'))).toBe(false)
     })
   })
 })

--- a/apps/sim/lib/knowledge/documents/utils.ts
+++ b/apps/sim/lib/knowledge/documents/utils.ts
@@ -67,6 +67,10 @@ export function isRetryableError(error: unknown): boolean {
     'enetunreach',
     'socket hang up',
     'network error',
+    // Transient DNS resolution failure surfaced by secureFetchWithValidation
+    // before the request is made. The deterministic "resolves to a blocked IP
+    // address" security rejection is a distinct message and stays non-retryable.
+    'could not be resolved',
   ]
 
   if (networkKeywords.some((keyword) => lowerMessage.includes(keyword))) {


### PR DESCRIPTION
## Summary
- The Zendesk knowledge connector built its base URL from a fully user-controlled `subdomain` and fetched it with the plain `fetchWithRetry` wrapper, which performs no SSRF validation and follows redirects by default. An authenticated user could coerce the backend into issuing arbitrary outbound requests (and chain an open redirect toward internal/link-local targets).
- Routed the connector through the existing SSRF-safe `secureFetchWithRetry` (DNS-resolve + IP-pin + per-redirect revalidation), matching the GitLab/Sentry/Obsidian/S3 connectors.
- Added strict subdomain validation: `subdomain` is normalized and checked against a single DNS-label pattern before interpolation, so it can't smuggle a scheme, host, path, port, or fragment into the base URL.
- Added unit tests covering both legitimate subdomains and rejected SSRF payloads.

## Type of Change
- [x] Bug fix (security)

## Testing
- `bunx vitest run connectors/zendesk/zendesk.test.ts` — 24 passing (7 legitimate-request cases, 17 SSRF-payload rejections)
- Typecheck and biome clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)