### PR TITLE
fix(security): cap KB document download size to prevent memory-exhaustion DoS

### DIFF
--- a/apps/sim/lib/knowledge/documents/document-processor.ts
+++ b/apps/sim/lib/knowledge/documents/document-processor.ts
@@ -22,6 +22,7 @@ import { retryWithExponentialBackoff } from '@/lib/knowledge/documents/utils'
 import { StorageService } from '@/lib/uploads'
 import { isInternalFileUrl } from '@/lib/uploads/utils/file-utils'
 import { downloadFileFromUrl } from '@/lib/uploads/utils/file-utils.server'
+import { MAX_FILE_SIZE } from '@/lib/uploads/utils/validation'
 import { mistralParserTool } from '@/tools/mistral/parser'
 
 const logger = createLogger('DocumentProcessor')
@@ -380,8 +381,18 @@ async function handleFileForOCR(
   }
 }
 
+/**
+ * Downloads an ingestion source file, enforcing the {@link MAX_FILE_SIZE} document
+ * limit. `maxBytes` aborts the streaming read once the cap is exceeded (and rejects
+ * up front on an oversized `Content-Length`), so an attacker-controlled `fileUrl`
+ * pointing at an unbounded body cannot exhaust the processing worker's memory.
+ */
 async function downloadFileWithTimeout(fileUrl: string, userId?: string): Promise<Buffer> {
-  return downloadFileFromUrl(fileUrl, { timeoutMs: TIMEOUTS.FILE_DOWNLOAD, userId })
+  return downloadFileFromUrl(fileUrl, {
+    timeoutMs: TIMEOUTS.FILE_DOWNLOAD,
+    maxBytes: MAX_FILE_SIZE,
+    userId,
+  })
 }
 
 async function downloadFileForBase64(fileUrl: string, userId?: string): Promise<Buffer> {


### PR DESCRIPTION
## Summary
- Knowledge-base document ingestion downloaded an attacker-controlled external `fileUrl` server-side with no byte cap: `downloadFileWithTimeout` → `downloadFileFromUrl` was called without `maxBytes`, which defaults to `Number.MAX_SAFE_INTEGER`, so the entire response body was buffered into the processing worker's memory uncapped.
- Any authenticated user with a KB they own could OOM the worker by pointing `fileUrl` at a server that streams an unbounded body (memory-exhaustion DoS, CWE-400/CWE-770).
- Fix: wire the documented 100MB file-size limit (`MAX_FILE_SIZE`, the same constant the KB upload path enforces) into the single ingestion download helper. All four KB download call sites route through it. The existing stream limiter rejects up front on an oversized `Content-Length` and aborts the read mid-stream once the cap is exceeded, so the body is never fully buffered.

## Type of Change
- [x] Bug fix (security)

## Testing
- `tsc` clean (only pre-existing unrelated `tailwind.config.ts` error), biome clean, `bun run check:api-validation` passed.
- Reviewed all KB ingestion download paths (PDF page-count check, cloud-upload-for-OCR, base64-for-OCR, `parseHttpFile`) — all funnel through the capped helper.

## Notes
- Scoped to the reported KB ingestion vuln. The same DoS class exists in two executor callers (`lib/execution/files.ts` post-buffer check, `executor/utils/file-tool-processor.ts` no cap) plus the unbounded default in `downloadFileFromUrl` — tracked for a separate follow-up PR.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
