### PR TITLE
fix(copilot): gate post-tool output writes behind write permission

### DIFF
--- a/apps/sim/lib/copilot/request/tools/files.test.ts
+++ b/apps/sim/lib/copilot/request/tools/files.test.ts
@@ -1,13 +1,33 @@
 /**
  * @vitest-environment node
  */
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockWriteWorkspaceFileByPath } = vi.hoisted(() => ({
+  mockWriteWorkspaceFileByPath: vi.fn(),
+}))
+
+vi.mock('@/lib/copilot/vfs/resource-writer', () => ({
+  writeWorkspaceFileByPath: mockWriteWorkspaceFileByPath,
+}))
+
+vi.mock('@/lib/copilot/request/otel', () => ({
+  withCopilotSpan: (
+    _name: string,
+    _attrs: Record<string, unknown> | undefined,
+    fn: (span: unknown) => Promise<unknown>
+  ) => fn({ setAttribute: vi.fn(), setAttributes: vi.fn(), addEvent: vi.fn() }),
+}))
+
+import { FunctionExecute } from '@/lib/copilot/generated/tool-catalog-v1'
 import {
   extractTabularData,
+  maybeWriteOutputToFile,
   normalizeOutputWorkspaceFileName,
   serializeOutputForFile,
   unwrapFunctionExecuteOutput,
 } from '@/lib/copilot/request/tools/files'
+import type { ExecutionContext } from '@/lib/copilot/request/types'
 
 describe('unwrapFunctionExecuteOutput', () => {
   it('unwraps the function_execute envelope { result, stdout }', () => {
@@ -84,6 +104,53 @@ describe('normalizeOutputWorkspaceFileName', () => {
 
   it('still handles normal workspace file output paths', () => {
     expect(normalizeOutputWorkspaceFileName('files/Reports/output.csv')).toBe('output.csv')
+  })
+})
+
+describe('maybeWriteOutputToFile', () => {
+  function buildContext(overrides: Partial<ExecutionContext> = {}): ExecutionContext {
+    return {
+      userId: 'user-1',
+      workflowId: 'wf-1',
+      workspaceId: 'workspace-1',
+      userPermission: 'write',
+      ...overrides,
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWriteWorkspaceFileByPath.mockResolvedValue({
+      id: 'file-1',
+      name: 'report.csv',
+      vfsPath: 'files/report.csv',
+      mode: 'overwrite',
+    })
+  })
+
+  it('denies a read-only principal without writing the file', async () => {
+    const result = await maybeWriteOutputToFile(
+      FunctionExecute.id,
+      { outputs: { files: [{ path: 'files/report.csv', mode: 'overwrite' }] } },
+      { success: true, output: { result: 'name,age\nAlice,30', stdout: '' } },
+      buildContext({ userPermission: 'read' })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('requires write access')
+    expect(mockWriteWorkspaceFileByPath).not.toHaveBeenCalled()
+  })
+
+  it('writes the output file for a write principal', async () => {
+    const result = await maybeWriteOutputToFile(
+      FunctionExecute.id,
+      { outputs: { files: [{ path: 'files/report.csv', mode: 'overwrite' }] } },
+      { success: true, output: { result: 'name,age\nAlice,30', stdout: '' } },
+      buildContext()
+    )
+
+    expect(result.success).toBe(true)
+    expect(mockWriteWorkspaceFileByPath).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/sim/lib/copilot/request/tools/files.test.ts
+++ b/apps/sim/lib/copilot/request/tools/files.test.ts
@@ -141,6 +141,18 @@ describe('maybeWriteOutputToFile', () => {
     expect(mockWriteWorkspaceFileByPath).not.toHaveBeenCalled()
   })
 
+  it('does not deny a read-only principal when no workspace write occurs (sandbox export active)', async () => {
+    const result = await maybeWriteOutputToFile(
+      FunctionExecute.id,
+      { outputs: { files: [{ path: 'files/report.csv', mode: 'overwrite' }] } },
+      { success: true, output: { result: { files: [{ path: 'report.csv' }] }, stdout: '' } },
+      buildContext({ userPermission: 'read' })
+    )
+
+    expect(result.success).toBe(true)
+    expect(mockWriteWorkspaceFileByPath).not.toHaveBeenCalled()
+  })
+
   it('writes the output file for a write principal', async () => {
     const result = await maybeWriteOutputToFile(
       FunctionExecute.id,

--- a/apps/sim/lib/copilot/request/tools/files.ts
+++ b/apps/sim/lib/copilot/request/tools/files.ts
@@ -6,6 +6,7 @@ import { TraceAttr } from '@/lib/copilot/generated/trace-attributes-v1'
 import { TraceEvent } from '@/lib/copilot/generated/trace-events-v1'
 import { TraceSpan } from '@/lib/copilot/generated/trace-spans-v1'
 import { withCopilotSpan } from '@/lib/copilot/request/otel'
+import { denyOutputWriteWithoutWritePermission } from '@/lib/copilot/request/tools/permissions'
 import type { ExecutionContext, ToolCallResult } from '@/lib/copilot/request/types'
 import { decodeVfsPathSegments } from '@/lib/copilot/vfs/path-utils'
 import { writeWorkspaceFileByPath } from '@/lib/copilot/vfs/resource-writer'
@@ -209,6 +210,9 @@ export async function maybeWriteOutputToFile(
 
   const outputFiles = getOutputFileDeclarations(params).filter((file) => !file.sandboxPath)
   if (outputFiles.length === 0) return result
+
+  const denied = denyOutputWriteWithoutWritePermission(context)
+  if (denied) return denied
 
   const outputObject =
     result.output && typeof result.output === 'object' && !Array.isArray(result.output)

--- a/apps/sim/lib/copilot/request/tools/files.ts
+++ b/apps/sim/lib/copilot/request/tools/files.ts
@@ -211,9 +211,6 @@ export async function maybeWriteOutputToFile(
   const outputFiles = getOutputFileDeclarations(params).filter((file) => !file.sandboxPath)
   if (outputFiles.length === 0) return result
 
-  const denied = denyOutputWriteWithoutWritePermission(context)
-  if (denied) return denied
-
   const outputObject =
     result.output && typeof result.output === 'object' && !Array.isArray(result.output)
       ? (result.output as Record<string, unknown>)
@@ -231,6 +228,9 @@ export async function maybeWriteOutputToFile(
     })
     return result
   }
+
+  const denied = denyOutputWriteWithoutWritePermission(context)
+  if (denied) return denied
 
   // Only span the actual write path (where we upload to storage). Fast
   // no-op returns above don't need a span — they'd just pad the trace

--- a/apps/sim/lib/copilot/request/tools/permissions.ts
+++ b/apps/sim/lib/copilot/request/tools/permissions.ts
@@ -1,0 +1,28 @@
+import { type PermissionType, permissionSatisfies } from '@sim/platform-authz/workspace'
+import type { ExecutionContext, ToolCallResult } from '@/lib/copilot/request/types'
+
+/**
+ * Guards a post-tool output-redirection sink against read-only principals.
+ *
+ * `function_execute`, `user_table`, and `read` are read-allowed for execution
+ * (they don't mutate the workspace themselves), so the router's `WRITE_ACTIONS`
+ * gate in `tools/server/router.ts` lets read-only collaborators run them. But
+ * their output-redirection declarations (`outputs.files`, `outputTable`)
+ * durably persist to the workspace — creating/overwriting files and table rows.
+ * Those writes must satisfy the same write gate as the dedicated mutation tools.
+ *
+ * Returns a denial `ToolCallResult` when the caller lacks write access (so the
+ * agent surfaces the same `Permission denied` outcome it gets from `create_file`
+ * / `user_table` writes), or `null` when the write may proceed.
+ */
+export function denyOutputWriteWithoutWritePermission(
+  context: ExecutionContext
+): ToolCallResult | null {
+  if (permissionSatisfies(context.userPermission as PermissionType | undefined, 'write')) {
+    return null
+  }
+  return {
+    success: false,
+    error: `Permission denied: writing tool output to the workspace requires write access. You have '${context.userPermission ?? 'none'}' permission.`,
+  }
+}

--- a/apps/sim/lib/copilot/request/tools/tables.test.ts
+++ b/apps/sim/lib/copilot/request/tools/tables.test.ts
@@ -61,6 +61,7 @@ function buildContext(overrides: Partial<ExecutionContext> = {}): ExecutionConte
     userId: 'user-1',
     workflowId: 'wf-1',
     workspaceId: 'workspace-1',
+    userPermission: 'write',
     ...overrides,
   }
 }
@@ -83,6 +84,20 @@ describe('maybeWriteOutputToTable', () => {
     )
 
     expect(result).toEqual({ success: false, error: 'Table "tbl_1" not found' })
+    expect(mockReplaceTableRows).not.toHaveBeenCalled()
+  })
+
+  it('denies a read-only principal without touching the table', async () => {
+    const result = await maybeWriteOutputToTable(
+      FunctionExecute.id,
+      { outputTable: 'tbl_1' },
+      { success: true, output: { result: [{ name: 'Alice' }] } },
+      buildContext({ userPermission: 'read' })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('requires write access')
+    expect(mockGetTableById).not.toHaveBeenCalled()
     expect(mockReplaceTableRows).not.toHaveBeenCalled()
   })
 
@@ -176,6 +191,20 @@ describe('maybeWriteReadCsvToTable', () => {
     )
 
     expect(result).toEqual({ success: false, error: 'Table "tbl_1" not found' })
+    expect(mockReplaceTableRows).not.toHaveBeenCalled()
+  })
+
+  it('denies a read-only principal without touching the table', async () => {
+    const result = await maybeWriteReadCsvToTable(
+      ReadTool.id,
+      { outputTable: 'tbl_1', path: 'files/people.csv' },
+      { success: true, output: { content: 'name,age\nAlice,30' } },
+      buildContext({ userPermission: 'read' })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('requires write access')
+    expect(mockGetTableById).not.toHaveBeenCalled()
     expect(mockReplaceTableRows).not.toHaveBeenCalled()
   })
 

--- a/apps/sim/lib/copilot/request/tools/tables.ts
+++ b/apps/sim/lib/copilot/request/tools/tables.ts
@@ -8,6 +8,7 @@ import { TraceAttr } from '@/lib/copilot/generated/trace-attributes-v1'
 import { TraceEvent } from '@/lib/copilot/generated/trace-events-v1'
 import { TraceSpan } from '@/lib/copilot/generated/trace-spans-v1'
 import { withCopilotSpan } from '@/lib/copilot/request/otel'
+import { denyOutputWriteWithoutWritePermission } from '@/lib/copilot/request/tools/permissions'
 import type { ExecutionContext, ToolCallResult } from '@/lib/copilot/request/types'
 import type { RowData, TableDefinition } from '@/lib/table'
 import { buildIdByName, rowDataNameToId } from '@/lib/table/column-keys'
@@ -62,6 +63,9 @@ export async function maybeWriteOutputToTable(
 
   const outputTable = params?.outputTable as string | undefined
   if (!outputTable) return result
+
+  const denied = denyOutputWriteWithoutWritePermission(context)
+  if (denied) return denied
 
   return withCopilotSpan(
     TraceSpan.CopilotToolsWriteOutputTable,
@@ -177,6 +181,9 @@ export async function maybeWriteReadCsvToTable(
 
   const outputTable = params?.outputTable as string | undefined
   if (!outputTable) return result
+
+  const denied = denyOutputWriteWithoutWritePermission(context)
+  if (denied) return denied
 
   return withCopilotSpan(
     TraceSpan.CopilotToolsWriteCsvToTable,


### PR DESCRIPTION
## Summary
- Read-only workspace members could durably create/overwrite workspace files and insert/overwrite user-table rows by driving the Copilot/Mothership agent to run `function_execute`/`user_table`/`read` with output declarations (`outputs.files`, `outputTable`). Those tools are read-allowed for execution (not in `WRITE_ACTIONS`), but their three post-tool output-redirection sinks persisted to the workspace gated only on identity (`workspaceId` + `userId`), never on `userPermission` — a function-level authorization bypass (CWE-862) that the dedicated `create_file`/`user_table` write tools correctly reject.
- Add a shared `denyOutputWriteWithoutWritePermission(context)` guard (built on the canonical `permissionSatisfies` predicate) and apply it in all three sinks (`maybeWriteOutputToFile`, `maybeWriteOutputToTable`, `maybeWriteReadCsvToTable`) once a write is actually intended, so read-only principals get the same `Permission denied` outcome as the dedicated mutation tools.
- The check is synchronous and short-circuits before any DB lookup, CSV parsing, serialization, or tracing span.

## Type of Change
- [x] Bug fix (security)

## Testing
- Added read-only denial tests for all three sinks (assert nothing is written and the table is never fetched) plus a write happy-path for the file sink.
- `vitest` copilot `request/tools` + `lifecycle/run` (38 pass), `tsc` clean, `biome` clean, `check:api-validation` passed.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)