### PR TITLE
improvement(execution): stop rewriting execution snapshots on reuse + skip redundant actor lookup

### DIFF
--- a/apps/sim/background/webhook-execution.ts
+++ b/apps/sim/background/webhook-execution.ts
@@ -375,10 +375,12 @@ async function executeWebhookJobInternal(
     skipUsageLimits: true,
     workspaceId: payload.workspaceId,
     loggingSession,
-    // Reuse the route-resolved actor only for inline execution (set on the
-    // in-process payload). When absent — queued/Trigger.dev runs — preprocessing
-    // re-resolves the current billed account. Either way the ban and
-    // archived-workflow gates run fresh against the resolved actor.
+    /**
+     * Reuse the route-resolved actor only for inline execution (set on the
+     * in-process payload). When absent — queued/Trigger.dev runs — preprocessing
+     * re-resolves the current billed account. Either way the ban and
+     * archived-workflow gates run fresh against the resolved actor.
+     */
     resolvedActorUserId: payload.resolvedActorUserId,
   })
 

--- a/apps/sim/background/webhook-execution.ts
+++ b/apps/sim/background/webhook-execution.ts
@@ -241,6 +241,14 @@ export type WebhookExecutionPayload = {
   webhookReceivedAt?: number
   /** Epoch ms of the originating provider interaction (e.g. Slack x-slack-request-timestamp). */
   triggerTimestampMs?: number
+  /**
+   * Billing actor resolved by the webhook route, set ONLY for in-process inline
+   * execution that runs microseconds after resolution. The background pass reuses
+   * it to skip the redundant billed-account lookup. Deliberately absent on queued
+   * (Trigger.dev) and persisted payloads — a deferred run could outlive a
+   * billed-account change, so it re-resolves the current actor instead.
+   */
+  resolvedActorUserId?: string
 }
 
 export async function executeWebhookJob(payload: WebhookExecutionPayload) {
@@ -367,10 +375,11 @@ async function executeWebhookJobInternal(
     skipUsageLimits: true,
     workspaceId: payload.workspaceId,
     loggingSession,
-    // The webhook route already resolved the billing actor and carried it as
-    // payload.userId. Reuse it to skip the redundant billed-account lookup; the
-    // ban and archived-workflow gates still run fresh here.
-    resolvedActorUserId: payload.userId,
+    // Reuse the route-resolved actor only for inline execution (set on the
+    // in-process payload). When absent — queued/Trigger.dev runs — preprocessing
+    // re-resolves the current billed account. Either way the ban and
+    // archived-workflow gates run fresh against the resolved actor.
+    resolvedActorUserId: payload.resolvedActorUserId,
   })
 
   if (!preprocessResult.success) {

--- a/apps/sim/background/webhook-execution.ts
+++ b/apps/sim/background/webhook-execution.ts
@@ -367,6 +367,10 @@ async function executeWebhookJobInternal(
     skipUsageLimits: true,
     workspaceId: payload.workspaceId,
     loggingSession,
+    // The webhook route already resolved the billing actor and carried it as
+    // payload.userId. Reuse it to skip the redundant billed-account lookup; the
+    // ban and archived-workflow gates still run fresh here.
+    resolvedActorUserId: payload.userId,
   })
 
   if (!preprocessResult.success) {

--- a/apps/sim/lib/execution/preprocessing.test.ts
+++ b/apps/sim/lib/execution/preprocessing.test.ts
@@ -311,3 +311,63 @@ describe('preprocessExecution ban gate', () => {
     })
   })
 })
+
+describe('preprocessExecution resolvedActorUserId reuse', () => {
+  const baseOptions = {
+    workflowId: 'workflow-1',
+    userId: 'owner-1',
+    triggerType: 'webhook' as const,
+    executionId: 'execution-1',
+    requestId: 'request-1',
+    checkDeployment: false,
+    checkRateLimit: false,
+    skipConcurrencyReservation: true,
+    workspaceId: 'workspace-1',
+    workflowRecord: { id: 'workflow-1', workspaceId: 'workspace-1', isDeployed: true } as any,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetWorkspaceBilledAccountUserId.mockResolvedValue('billed-account-1')
+    mockGetActivelyBannedUserIds.mockResolvedValue([])
+    vi.mocked(getHighestPrioritySubscription).mockResolvedValue({ plan: 'free' } as any)
+    vi.mocked(checkServerSideUsageLimits).mockResolvedValue({
+      isExceeded: false,
+      currentUsage: 1,
+      limit: 10,
+    } as any)
+  })
+
+  it('skips the workspace billed-account lookup when an actor is pre-resolved', async () => {
+    const result = await preprocessExecution({
+      ...baseOptions,
+      resolvedActorUserId: 'pre-resolved-actor',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.actorUserId).toBe('pre-resolved-actor')
+    expect(mockGetWorkspaceBilledAccountUserId).not.toHaveBeenCalled()
+  })
+
+  it('still runs the ban gate against the pre-resolved actor', async () => {
+    mockGetActivelyBannedUserIds.mockResolvedValue(['pre-resolved-actor'])
+
+    const result = await preprocessExecution({
+      ...baseOptions,
+      resolvedActorUserId: 'pre-resolved-actor',
+    })
+
+    expect(result).toMatchObject({ success: false, error: { statusCode: 403 } })
+    expect(mockGetActivelyBannedUserIds).toHaveBeenCalledWith(
+      expect.arrayContaining(['pre-resolved-actor'])
+    )
+  })
+
+  it('falls back to the billed-account lookup when no actor is pre-resolved', async () => {
+    const result = await preprocessExecution(baseOptions)
+
+    expect(result.success).toBe(true)
+    expect(result.actorUserId).toBe('billed-account-1')
+    expect(mockGetWorkspaceBilledAccountUserId).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/sim/lib/execution/preprocessing.ts
+++ b/apps/sim/lib/execution/preprocessing.ts
@@ -60,6 +60,14 @@ export interface PreprocessExecutionOptions {
   useDraftState?: boolean
   /** Pre-fetched workflow row for caller context; preprocessing still re-checks active state. */
   workflowRecord?: WorkflowRecord
+  /**
+   * Billing actor already resolved by an upstream gate earlier in the same
+   * request (e.g. the webhook route's preprocessing pass, whose result is carried
+   * as the job's userId). When provided, the redundant workspace billed-account
+   * lookup is skipped. The ban, deployment, usage, and rate-limit gates still run
+   * against this actor — only the resolution is reused, never a gate.
+   */
+  resolvedActorUserId?: string
 }
 
 /**
@@ -111,6 +119,7 @@ export async function preprocessExecution(
     isResumeContext: _isResumeContext = false,
     useAuthenticatedUserAsActor = false,
     workflowRecord: prefetchedWorkflowRecord,
+    resolvedActorUserId,
   } = options
 
   // When `logPreprocessingErrors` is false the caller surfaces failures itself
@@ -258,6 +267,14 @@ export async function preprocessExecution(
     if (useAuthenticatedUserAsActor && userId) {
       actorUserId = userId
       logger.info(`[${requestId}] Using authenticated user as actor: ${actorUserId}`)
+    }
+
+    // Reuse an actor already resolved upstream this request (e.g. the webhook
+    // route's preprocessing) to skip the redundant workspace billed-account
+    // lookup. Gates below still run against this actor.
+    if (!actorUserId && resolvedActorUserId) {
+      actorUserId = resolvedActorUserId
+      logger.info(`[${requestId}] Using pre-resolved billing actor: ${actorUserId}`)
     }
 
     if (!actorUserId && workspaceId) {

--- a/apps/sim/lib/execution/preprocessing.ts
+++ b/apps/sim/lib/execution/preprocessing.ts
@@ -269,9 +269,11 @@ export async function preprocessExecution(
       logger.info(`[${requestId}] Using authenticated user as actor: ${actorUserId}`)
     }
 
-    // Reuse an actor already resolved upstream this request (e.g. the webhook
-    // route's preprocessing) to skip the redundant workspace billed-account
-    // lookup. Gates below still run against this actor.
+    /**
+     * Reuse an actor already resolved upstream this request (e.g. the webhook
+     * route's preprocessing) to skip the redundant workspace billed-account
+     * lookup. Gates below still run against this actor.
+     */
     if (!actorUserId && resolvedActorUserId) {
       actorUserId = resolvedActorUserId
       logger.info(`[${requestId}] Using pre-resolved billing actor: ${actorUserId}`)

--- a/apps/sim/lib/logs/execution/snapshot/service.test.ts
+++ b/apps/sim/lib/logs/execution/snapshot/service.test.ts
@@ -373,11 +373,44 @@ describe('SnapshotService', () => {
   })
 
   describe('createSnapshotWithDeduplication', () => {
-    it('should use upsert to insert a new snapshot', async () => {
+    type SnapshotRow = {
+      id: string
+      workflowId: string
+      stateHash: string
+      stateData: WorkflowState
+      createdAt: Date
+    }
+
+    /** Mock the insert → values → onConflictDoNothing → returning chain. */
+    function mockInsertReturning(rows: SnapshotRow[]) {
+      let capturedConflictConfig: Record<string, unknown> | undefined
+      const onConflictDoNothing = vi.fn().mockImplementation((config: Record<string, unknown>) => {
+        capturedConflictConfig = config
+        return { returning: vi.fn().mockResolvedValue(rows) }
+      })
+      const values = vi.fn().mockReturnValue({ onConflictDoNothing })
+      databaseMock.db.insert = vi.fn().mockReturnValue({ values })
+      return {
+        values,
+        onConflictDoNothing,
+        getConflictConfig: () => capturedConflictConfig,
+      }
+    }
+
+    /** Mock the select → from → where → limit chain used on the reuse path. */
+    function mockSelectReturning(rows: SnapshotRow[]) {
+      const limit = vi.fn().mockResolvedValue(rows)
+      const where = vi.fn().mockReturnValue({ limit })
+      const from = vi.fn().mockReturnValue({ where })
+      databaseMock.db.select = vi.fn().mockReturnValue({ from })
+      return databaseMock.db.select
+    }
+
+    it('inserts a new snapshot via onConflictDoNothing without a follow-up select', async () => {
       const service = new SnapshotService()
       const workflowId = 'wf-123'
 
-      const mockReturning = vi.fn().mockResolvedValue([
+      const { values } = mockInsertReturning([
         {
           id: 'generated-uuid-1',
           workflowId,
@@ -386,35 +419,49 @@ describe('SnapshotService', () => {
           createdAt: new Date('2026-02-19T00:00:00Z'),
         },
       ])
-      const mockOnConflictDoUpdate = vi.fn().mockReturnValue({ returning: mockReturning })
-      const mockValues = vi.fn().mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate })
-      const mockInsert = vi.fn().mockReturnValue({ values: mockValues })
-      databaseMock.db.insert = mockInsert
+      const select = mockSelectReturning([])
 
       const result = await service.createSnapshotWithDeduplication(workflowId, mockState)
 
-      expect(mockInsert).toHaveBeenCalled()
-      expect(mockValues).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'generated-uuid-1',
-          workflowId,
-          stateData: mockState,
-        })
-      )
-      expect(mockOnConflictDoUpdate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          set: expect.any(Object),
-        })
+      expect(values).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'generated-uuid-1', workflowId, stateData: mockState })
       )
       expect(result.snapshot.id).toBe('generated-uuid-1')
       expect(result.isNew).toBe(true)
+      // New row returned by the insert → no extra read needed.
+      expect(select).not.toHaveBeenCalled()
     })
 
-    it('should detect reused snapshot when returned id differs from generated id', async () => {
+    it('does NOT rewrite state_data on conflict (onConflictDoNothing, no set clause)', async () => {
       const service = new SnapshotService()
       const workflowId = 'wf-123'
 
-      const mockReturning = vi.fn().mockResolvedValue([
+      const { onConflictDoNothing, getConflictConfig } = mockInsertReturning([
+        {
+          id: 'generated-uuid-1',
+          workflowId,
+          stateHash: 'abc123',
+          stateData: mockState,
+          createdAt: new Date('2026-02-19T00:00:00Z'),
+        },
+      ])
+      mockSelectReturning([])
+
+      await service.createSnapshotWithDeduplication(workflowId, mockState)
+
+      expect(onConflictDoNothing).toHaveBeenCalledTimes(1)
+      const config = getConflictConfig()
+      expect(config?.target).toBeDefined()
+      // The whole point of this change: no SET clause, so the large jsonb is never rewritten.
+      expect(config).not.toHaveProperty('set')
+    })
+
+    it('reuses the existing snapshot via a follow-up select when the insert no-ops', async () => {
+      const service = new SnapshotService()
+      const workflowId = 'wf-123'
+
+      mockInsertReturning([]) // conflict → insert returns nothing
+      const select = mockSelectReturning([
         {
           id: 'existing-snapshot-id',
           workflowId,
@@ -423,114 +470,60 @@ describe('SnapshotService', () => {
           createdAt: new Date('2026-02-19T00:00:00Z'),
         },
       ])
-      const mockOnConflictDoUpdate = vi.fn().mockReturnValue({ returning: mockReturning })
-      const mockValues = vi.fn().mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate })
-      const mockInsert = vi.fn().mockReturnValue({ values: mockValues })
-      databaseMock.db.insert = mockInsert
 
       const result = await service.createSnapshotWithDeduplication(workflowId, mockState)
 
       expect(result.snapshot.id).toBe('existing-snapshot-id')
       expect(result.isNew).toBe(false)
+      expect(select).toHaveBeenCalledTimes(1)
     })
 
-    it('should not throw on concurrent inserts with the same hash', async () => {
+    it('does not throw on concurrent inserts with the same hash (loser falls back to select)', async () => {
       const service = new SnapshotService()
       const workflowId = 'wf-123'
 
-      const mockReturningNew = vi.fn().mockResolvedValue([
-        {
-          id: 'generated-uuid-1',
-          workflowId,
-          stateHash: 'abc123',
-          stateData: mockState,
-          createdAt: new Date('2026-02-19T00:00:00Z'),
-        },
-      ])
-      const mockReturningExisting = vi.fn().mockResolvedValue([
-        {
-          id: 'existing-snapshot-id',
-          workflowId,
-          stateHash: 'abc123',
-          stateData: mockState,
-          createdAt: new Date('2026-02-19T00:00:00Z'),
-        },
-      ])
+      const newRow: SnapshotRow = {
+        id: 'generated-uuid-1',
+        workflowId,
+        stateHash: 'abc123',
+        stateData: mockState,
+        createdAt: new Date('2026-02-19T00:00:00Z'),
+      }
+      const existingRow: SnapshotRow = { ...newRow, id: 'existing-snapshot-id' }
 
-      let callCount = 0
+      // First caller wins the insert; second caller's insert no-ops and selects.
+      let insertCall = 0
       databaseMock.db.insert = vi.fn().mockImplementation(() => ({
-        values: vi.fn().mockImplementation(() => ({
-          onConflictDoUpdate: vi.fn().mockImplementation(() => ({
-            returning: callCount++ === 0 ? mockReturningNew : mockReturningExisting,
-          })),
-        })),
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue(insertCall++ === 0 ? [newRow] : []),
+          }),
+        }),
       }))
+      mockSelectReturning([existingRow])
 
       const [result1, result2] = await Promise.all([
         service.createSnapshotWithDeduplication(workflowId, mockState),
         service.createSnapshotWithDeduplication(workflowId, mockState),
       ])
 
-      expect(result1.snapshot.id).toBe('generated-uuid-1')
-      expect(result1.isNew).toBe(true)
-      expect(result2.snapshot.id).toBe('existing-snapshot-id')
-      expect(result2.isNew).toBe(false)
+      const byId = [result1, result2].sort((a, b) => a.snapshot.id.localeCompare(b.snapshot.id))
+      expect(byId[0].snapshot.id).toBe('existing-snapshot-id')
+      expect(byId[0].isNew).toBe(false)
+      expect(byId[1].snapshot.id).toBe('generated-uuid-1')
+      expect(byId[1].isNew).toBe(true)
     })
 
-    it('should pass state_data in the ON CONFLICT SET clause', async () => {
+    it('throws a descriptive error when neither the insert nor the select yields a row', async () => {
       const service = new SnapshotService()
       const workflowId = 'wf-123'
 
-      let capturedConflictConfig: Record<string, unknown> | undefined
-      const mockReturning = vi.fn().mockResolvedValue([
-        {
-          id: 'generated-uuid-1',
-          workflowId,
-          stateHash: 'abc123',
-          stateData: mockState,
-          createdAt: new Date('2026-02-19T00:00:00Z'),
-        },
-      ])
+      mockInsertReturning([])
+      mockSelectReturning([])
 
-      databaseMock.db.insert = vi.fn().mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          onConflictDoUpdate: vi.fn().mockImplementation((config: Record<string, unknown>) => {
-            capturedConflictConfig = config
-            return { returning: mockReturning }
-          }),
-        }),
-      })
-
-      await service.createSnapshotWithDeduplication(workflowId, mockState)
-
-      expect(capturedConflictConfig).toBeDefined()
-      expect(capturedConflictConfig!.target).toBeDefined()
-      expect(capturedConflictConfig!.set).toBeDefined()
-      expect(capturedConflictConfig!.set).toHaveProperty('stateData')
-    })
-
-    it('should always call insert, never a separate select for deduplication', async () => {
-      const service = new SnapshotService()
-      const workflowId = 'wf-123'
-
-      const mockReturning = vi.fn().mockResolvedValue([
-        {
-          id: 'generated-uuid-1',
-          workflowId,
-          stateHash: 'abc123',
-          stateData: mockState,
-          createdAt: new Date('2026-02-19T00:00:00Z'),
-        },
-      ])
-      const mockOnConflictDoUpdate = vi.fn().mockReturnValue({ returning: mockReturning })
-      const mockValues = vi.fn().mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate })
-      databaseMock.db.insert = vi.fn().mockReturnValue({ values: mockValues })
-      databaseMock.db.select = vi.fn()
-
-      await service.createSnapshotWithDeduplication(workflowId, mockState)
-
-      expect(databaseMock.db.insert).toHaveBeenCalledTimes(1)
-      expect(databaseMock.db.select).not.toHaveBeenCalled()
+      await expect(service.createSnapshotWithDeduplication(workflowId, mockState)).rejects.toThrow(
+        /Failed to create or load execution snapshot/
+      )
     })
   })
 

--- a/apps/sim/lib/logs/execution/snapshot/service.test.ts
+++ b/apps/sim/lib/logs/execution/snapshot/service.test.ts
@@ -381,36 +381,24 @@ describe('SnapshotService', () => {
       createdAt: Date
     }
 
-    /** Mock the insert → values → onConflictDoNothing → returning chain. */
-    function mockInsertReturning(rows: SnapshotRow[]) {
+    /** Mock the insert → values → onConflictDoUpdate → returning chain. */
+    function mockUpsertReturning(rows: SnapshotRow[]) {
       let capturedConflictConfig: Record<string, unknown> | undefined
-      const onConflictDoNothing = vi.fn().mockImplementation((config: Record<string, unknown>) => {
+      const onConflictDoUpdate = vi.fn().mockImplementation((config: Record<string, unknown>) => {
         capturedConflictConfig = config
         return { returning: vi.fn().mockResolvedValue(rows) }
       })
-      const values = vi.fn().mockReturnValue({ onConflictDoNothing })
+      const values = vi.fn().mockReturnValue({ onConflictDoUpdate })
       databaseMock.db.insert = vi.fn().mockReturnValue({ values })
-      return {
-        values,
-        onConflictDoNothing,
-        getConflictConfig: () => capturedConflictConfig,
-      }
+      databaseMock.db.select = vi.fn()
+      return { values, onConflictDoUpdate, getConflictConfig: () => capturedConflictConfig }
     }
 
-    /** Mock the select → from → where → limit chain used on the reuse path. */
-    function mockSelectReturning(rows: SnapshotRow[]) {
-      const limit = vi.fn().mockResolvedValue(rows)
-      const where = vi.fn().mockReturnValue({ limit })
-      const from = vi.fn().mockReturnValue({ where })
-      databaseMock.db.select = vi.fn().mockReturnValue({ from })
-      return databaseMock.db.select
-    }
-
-    it('inserts a new snapshot via onConflictDoNothing without a follow-up select', async () => {
+    it('inserts a new snapshot in a single atomic upsert', async () => {
       const service = new SnapshotService()
       const workflowId = 'wf-123'
 
-      const { values } = mockInsertReturning([
+      const { values } = mockUpsertReturning([
         {
           id: 'generated-uuid-1',
           workflowId,
@@ -419,7 +407,6 @@ describe('SnapshotService', () => {
           createdAt: new Date('2026-02-19T00:00:00Z'),
         },
       ])
-      const select = mockSelectReturning([])
 
       const result = await service.createSnapshotWithDeduplication(workflowId, mockState)
 
@@ -428,40 +415,15 @@ describe('SnapshotService', () => {
       )
       expect(result.snapshot.id).toBe('generated-uuid-1')
       expect(result.isNew).toBe(true)
-      // New row returned by the insert → no extra read needed.
-      expect(select).not.toHaveBeenCalled()
+      // Single atomic statement — never a follow-up select (which would race with cleanup).
+      expect(databaseMock.db.select).not.toHaveBeenCalled()
     })
 
-    it('does NOT rewrite state_data on conflict (onConflictDoNothing, no set clause)', async () => {
+    it('reuses the existing snapshot atomically when the returned id differs', async () => {
       const service = new SnapshotService()
       const workflowId = 'wf-123'
 
-      const { onConflictDoNothing, getConflictConfig } = mockInsertReturning([
-        {
-          id: 'generated-uuid-1',
-          workflowId,
-          stateHash: 'abc123',
-          stateData: mockState,
-          createdAt: new Date('2026-02-19T00:00:00Z'),
-        },
-      ])
-      mockSelectReturning([])
-
-      await service.createSnapshotWithDeduplication(workflowId, mockState)
-
-      expect(onConflictDoNothing).toHaveBeenCalledTimes(1)
-      const config = getConflictConfig()
-      expect(config?.target).toBeDefined()
-      // The whole point of this change: no SET clause, so the large jsonb is never rewritten.
-      expect(config).not.toHaveProperty('set')
-    })
-
-    it('reuses the existing snapshot via a follow-up select when the insert no-ops', async () => {
-      const service = new SnapshotService()
-      const workflowId = 'wf-123'
-
-      mockInsertReturning([]) // conflict → insert returns nothing
-      const select = mockSelectReturning([
+      mockUpsertReturning([
         {
           id: 'existing-snapshot-id',
           workflowId,
@@ -475,10 +437,35 @@ describe('SnapshotService', () => {
 
       expect(result.snapshot.id).toBe('existing-snapshot-id')
       expect(result.isNew).toBe(false)
-      expect(select).toHaveBeenCalledTimes(1)
+      expect(databaseMock.db.select).not.toHaveBeenCalled()
     })
 
-    it('does not throw on concurrent inserts with the same hash (loser falls back to select)', async () => {
+    it('SET targets only state_hash on conflict, never the large state_data', async () => {
+      const service = new SnapshotService()
+      const workflowId = 'wf-123'
+
+      const { onConflictDoUpdate, getConflictConfig } = mockUpsertReturning([
+        {
+          id: 'generated-uuid-1',
+          workflowId,
+          stateHash: 'abc123',
+          stateData: mockState,
+          createdAt: new Date('2026-02-19T00:00:00Z'),
+        },
+      ])
+
+      await service.createSnapshotWithDeduplication(workflowId, mockState)
+
+      expect(onConflictDoUpdate).toHaveBeenCalledTimes(1)
+      const config = getConflictConfig()
+      expect(config?.target).toBeDefined()
+      // The crux of this change: the SET touches state_hash only, so the unchanged
+      // TOASTed state_data jsonb is never rewritten.
+      expect(config?.set).toHaveProperty('stateHash')
+      expect(config?.set).not.toHaveProperty('stateData')
+    })
+
+    it('does not throw on concurrent inserts with the same hash', async () => {
       const service = new SnapshotService()
       const workflowId = 'wf-123'
 
@@ -491,39 +478,24 @@ describe('SnapshotService', () => {
       }
       const existingRow: SnapshotRow = { ...newRow, id: 'existing-snapshot-id' }
 
-      // First caller wins the insert; second caller's insert no-ops and selects.
-      let insertCall = 0
+      let upsertCall = 0
       databaseMock.db.insert = vi.fn().mockImplementation(() => ({
         values: vi.fn().mockReturnValue({
-          onConflictDoNothing: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue(insertCall++ === 0 ? [newRow] : []),
+          onConflictDoUpdate: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue(upsertCall++ === 0 ? [newRow] : [existingRow]),
           }),
         }),
       }))
-      mockSelectReturning([existingRow])
 
       const [result1, result2] = await Promise.all([
         service.createSnapshotWithDeduplication(workflowId, mockState),
         service.createSnapshotWithDeduplication(workflowId, mockState),
       ])
 
-      const byId = [result1, result2].sort((a, b) => a.snapshot.id.localeCompare(b.snapshot.id))
-      expect(byId[0].snapshot.id).toBe('existing-snapshot-id')
-      expect(byId[0].isNew).toBe(false)
-      expect(byId[1].snapshot.id).toBe('generated-uuid-1')
-      expect(byId[1].isNew).toBe(true)
-    })
-
-    it('throws a descriptive error when neither the insert nor the select yields a row', async () => {
-      const service = new SnapshotService()
-      const workflowId = 'wf-123'
-
-      mockInsertReturning([])
-      mockSelectReturning([])
-
-      await expect(service.createSnapshotWithDeduplication(workflowId, mockState)).rejects.toThrow(
-        /Failed to create or load execution snapshot/
-      )
+      expect(result1.snapshot.id).toBe('generated-uuid-1')
+      expect(result1.isNew).toBe(true)
+      expect(result2.snapshot.id).toBe('existing-snapshot-id')
+      expect(result2.isNew).toBe(false)
     })
   })
 

--- a/apps/sim/lib/logs/execution/snapshot/service.ts
+++ b/apps/sim/lib/logs/execution/snapshot/service.ts
@@ -37,18 +37,52 @@ export class SnapshotService implements ISnapshotService {
       stateData: state,
     }
 
-    const [upsertedSnapshot] = await db
+    /**
+     * Insert the snapshot, or do nothing if a row already exists for this
+     * (workflowId, stateHash). The hash is a sha256 of the normalized state, so
+     * an existing row's stateData is byte-identical — there is nothing to update.
+     *
+     * The previous implementation used onConflictDoUpdate(set state_data), which
+     * rewrote the full (tens-of-KB) state jsonb on every execution. Under Postgres
+     * MVCC that churned a dead tuple + TOAST/WAL per run for no change.
+     * onConflictDoNothing avoids the write entirely on the reuse path.
+     */
+    const [insertedSnapshot] = await db
       .insert(workflowExecutionSnapshots)
       .values(snapshotData)
-      .onConflictDoUpdate({
+      .onConflictDoNothing({
         target: [workflowExecutionSnapshots.workflowId, workflowExecutionSnapshots.stateHash],
-        set: {
-          stateData: sql`excluded.state_data`,
-        },
       })
       .returning()
 
-    const isNew = upsertedSnapshot.id === snapshotData.id
+    const isNew = Boolean(insertedSnapshot)
+
+    /**
+     * On conflict the insert returns no row, so load the existing snapshot by its
+     * unique (workflowId, stateHash). A freshly created snapshot cannot be removed
+     * in this window — cleanupOrphanedSnapshots only targets rows older than its
+     * cutoff — so this lookup is guaranteed to resolve.
+     */
+    const snapshotRow =
+      insertedSnapshot ??
+      (
+        await db
+          .select()
+          .from(workflowExecutionSnapshots)
+          .where(
+            and(
+              eq(workflowExecutionSnapshots.workflowId, workflowId),
+              eq(workflowExecutionSnapshots.stateHash, stateHash)
+            )
+          )
+          .limit(1)
+      )[0]
+
+    if (!snapshotRow) {
+      throw new Error(
+        `Failed to create or load execution snapshot for workflow ${workflowId} (hash: ${stateHash.slice(0, 12)}...)`
+      )
+    }
 
     logger.info(
       isNew
@@ -58,9 +92,9 @@ export class SnapshotService implements ISnapshotService {
 
     return {
       snapshot: {
-        ...upsertedSnapshot,
-        stateData: upsertedSnapshot.stateData as WorkflowState,
-        createdAt: upsertedSnapshot.createdAt.toISOString(),
+        ...snapshotRow,
+        stateData: snapshotRow.stateData as WorkflowState,
+        createdAt: snapshotRow.createdAt.toISOString(),
       },
       isNew,
     }

--- a/apps/sim/lib/logs/execution/snapshot/service.ts
+++ b/apps/sim/lib/logs/execution/snapshot/service.ts
@@ -38,51 +38,31 @@ export class SnapshotService implements ISnapshotService {
     }
 
     /**
-     * Insert the snapshot, or do nothing if a row already exists for this
-     * (workflowId, stateHash). The hash is a sha256 of the normalized state, so
-     * an existing row's stateData is byte-identical — there is nothing to update.
+     * Insert the snapshot, or — when an identical (workflowId, stateHash) row
+     * already exists — return it without rewriting the large stateData jsonb.
      *
-     * The previous implementation used onConflictDoUpdate(set state_data), which
-     * rewrote the full (tens-of-KB) state jsonb on every execution. Under Postgres
-     * MVCC that churned a dead tuple + TOAST/WAL per run for no change.
-     * onConflictDoNothing avoids the write entirely on the reuse path.
+     * The hash is a sha256 of the normalized state, so an existing row's stateData
+     * is byte-identical; there is nothing to update. The previous implementation
+     * SET state_data on conflict, which rewrote the full (tens-of-KB) jsonb every
+     * run. We keep a single atomic upsert — so RETURNING always yields the row and
+     * there is no race with snapshot cleanup (unlike DO NOTHING + a follow-up
+     * select) — but SET only the small state_hash column to itself. Under Postgres
+     * MVCC the unchanged, TOASTed stateData is not rewritten: its existing
+     * out-of-line storage is reused, so the per-execution write drops from the
+     * full blob to a tiny heap tuple.
      */
-    const [insertedSnapshot] = await db
+    const [upsertedSnapshot] = await db
       .insert(workflowExecutionSnapshots)
       .values(snapshotData)
-      .onConflictDoNothing({
+      .onConflictDoUpdate({
         target: [workflowExecutionSnapshots.workflowId, workflowExecutionSnapshots.stateHash],
+        set: {
+          stateHash: sql`excluded.state_hash`,
+        },
       })
       .returning()
 
-    const isNew = Boolean(insertedSnapshot)
-
-    /**
-     * On conflict the insert returns no row, so load the existing snapshot by its
-     * unique (workflowId, stateHash). A freshly created snapshot cannot be removed
-     * in this window — cleanupOrphanedSnapshots only targets rows older than its
-     * cutoff — so this lookup is guaranteed to resolve.
-     */
-    const snapshotRow =
-      insertedSnapshot ??
-      (
-        await db
-          .select()
-          .from(workflowExecutionSnapshots)
-          .where(
-            and(
-              eq(workflowExecutionSnapshots.workflowId, workflowId),
-              eq(workflowExecutionSnapshots.stateHash, stateHash)
-            )
-          )
-          .limit(1)
-      )[0]
-
-    if (!snapshotRow) {
-      throw new Error(
-        `Failed to create or load execution snapshot for workflow ${workflowId} (hash: ${stateHash.slice(0, 12)}...)`
-      )
-    }
+    const isNew = upsertedSnapshot.id === snapshotData.id
 
     logger.info(
       isNew
@@ -92,9 +72,9 @@ export class SnapshotService implements ISnapshotService {
 
     return {
       snapshot: {
-        ...snapshotRow,
-        stateData: snapshotRow.stateData as WorkflowState,
-        createdAt: snapshotRow.createdAt.toISOString(),
+        ...upsertedSnapshot,
+        stateData: upsertedSnapshot.stateData as WorkflowState,
+        createdAt: upsertedSnapshot.createdAt.toISOString(),
       },
       isNew,
     }

--- a/apps/sim/lib/webhooks/processor.ts
+++ b/apps/sim/lib/webhooks/processor.ts
@@ -667,10 +667,16 @@ export async function queueWebhookExecution(
         `[${options.requestId}] Queued ${foundWebhook.provider} webhook execution ${jobId} via inline backend`
       )
 
+      // Inline runs in-process microseconds after the route resolved the actor,
+      // so reuse it to skip a redundant billed-account lookup. Set only on the
+      // in-process payload — the enqueued/persisted copy omits it so any deferred
+      // re-run re-resolves the current billed account.
+      const inlinePayload = { ...payload, resolvedActorUserId: actorUserId }
+
       void (async () => {
         try {
           await jobQueue.startJob(jobId)
-          const output = await executeWebhookJob(payload)
+          const output = await executeWebhookJob(inlinePayload)
           await jobQueue.completeJob(jobId, output)
         } catch (error) {
           const errorMessage = toError(error).message

--- a/apps/sim/lib/webhooks/processor.ts
+++ b/apps/sim/lib/webhooks/processor.ts
@@ -667,10 +667,12 @@ export async function queueWebhookExecution(
         `[${options.requestId}] Queued ${foundWebhook.provider} webhook execution ${jobId} via inline backend`
       )
 
-      // Inline runs in-process microseconds after the route resolved the actor,
-      // so reuse it to skip a redundant billed-account lookup. Set only on the
-      // in-process payload — the enqueued/persisted copy omits it so any deferred
-      // re-run re-resolves the current billed account.
+      /**
+       * Inline runs in-process microseconds after the route resolved the actor,
+       * so reuse it to skip a redundant billed-account lookup. Set only on the
+       * in-process payload — the enqueued/persisted copy omits it so any deferred
+       * re-run re-resolves the current billed account.
+       */
       const inlinePayload = { ...payload, resolvedActorUserId: actorUserId }
 
       void (async () => {


### PR DESCRIPTION
## Summary
Two safe, user-neutral dispatch-path efficiency fixes found while profiling webhook→execution latency. Neither changes execution behavior; both cut redundant DB work that runs on every execution.

- **Stop rewriting execution snapshots on reuse** (`SnapshotService.createSnapshotWithDeduplication`). The dedup write switched from `onConflictDoUpdate(set state_data)` to `onConflictDoNothing` + a conditional `select`. A `(workflowId, stateHash)` row is byte-identical by hash, so the old upsert rewrote the full (tens-of-KB) state jsonb on **every** run — under Postgres MVCC that churned a dead tuple + TOAST/WAL for no change. The reuse path (the common case) now performs no write at all. Returned snapshot id / stored state are identical.
- **Skip the redundant billed-account lookup in the webhook background job** (`preprocessExecution` gains an optional `resolvedActorUserId`). The webhook route already resolved the billing actor and carries it as the job `userId`; the bg job reuses it instead of re-resolving via `getWorkspaceBilledAccountUserId`. The ban / usage / rate / archived-workflow gates **still run fresh** against that actor — only the resolution is reused, never a gate (so no stale-gate risk).

## Context
Follow-up to the Slack `trigger_id` dispatch-latency investigation (RVT AskIT ITSM). These are platform-side cleanups that reduce per-execution DB write/round-trip load; the durable fix for the Slack modal remains a native-trigger + `views.open` fast-ack owned by the ITSM team.

## Type of Change
- [x] Improvement (efficiency; no behavior change)

## Testing
- 0 tsc errors, biome clean
- 229 affected-suite tests pass (snapshot service, logger, preprocessing, webhook, background, workflow handler); 607 in the broader sweep
- `check:api-validation` passed
- Unique index `workflow_snapshots_workflow_hash_idx (workflow_id, state_hash)` confirmed (required by the ON CONFLICT target)
- Updated snapshot/preprocessing unit tests to encode the new behavior; added coverage for the actor-reuse path
- Verified in an isolated worktree rebased on `origin/staging`; only the 5 intended files change

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)