### PR TITLE
fix(security): gate credential-set invitation listing to admins and drop token

### DIFF
--- a/apps/sim/app/api/credential-sets/[id]/invite/route.ts
+++ b/apps/sim/app/api/credential-sets/[id]/invite/route.ts
@@ -68,8 +68,20 @@ export const GET = withRouteHandler(
       return NextResponse.json({ error: 'Credential set not found' }, { status: 404 })
     }
 
+    if (result.role !== 'admin' && result.role !== 'owner') {
+      return NextResponse.json({ error: 'Admin or owner permissions required' }, { status: 403 })
+    }
+
     const invitations = await db
-      .select()
+      .select({
+        id: credentialSetInvitation.id,
+        credentialSetId: credentialSetInvitation.credentialSetId,
+        email: credentialSetInvitation.email,
+        status: credentialSetInvitation.status,
+        expiresAt: credentialSetInvitation.expiresAt,
+        createdAt: credentialSetInvitation.createdAt,
+        invitedBy: credentialSetInvitation.invitedBy,
+      })
       .from(credentialSetInvitation)
       .where(eq(credentialSetInvitation.credentialSetId, id))
 

--- a/apps/sim/hooks/queries/credential-sets.ts
+++ b/apps/sim/hooks/queries/credential-sets.ts
@@ -12,7 +12,7 @@ import {
   type CreateCredentialSetData,
   type CredentialSet,
   type CredentialSetInvitation,
-  type CredentialSetInvitationDetail,
+  type CredentialSetInvitationListItem,
   type CredentialSetMember,
   type CredentialSetMembership,
   cancelCredentialSetInvitationContract,
@@ -34,7 +34,7 @@ export type {
   CreateCredentialSetData,
   CredentialSet,
   CredentialSetInvitation,
-  CredentialSetInvitationDetail,
+  CredentialSetInvitationListItem,
   CredentialSetMember,
   CredentialSetMembership,
 }
@@ -251,7 +251,7 @@ export function useDeleteCredentialSet() {
 }
 
 export function useCredentialSetInvitationsDetail(credentialSetId?: string) {
-  return useQuery<CredentialSetInvitationDetail[]>({
+  return useQuery<CredentialSetInvitationListItem[]>({
     queryKey: credentialSetKeys.detailInvitations(credentialSetId),
     queryFn: async ({ signal }) => {
       if (!credentialSetId) return []

--- a/apps/sim/lib/api/contracts/credential-sets.ts
+++ b/apps/sim/lib/api/contracts/credential-sets.ts
@@ -63,6 +63,16 @@ export const credentialSetInvitationDetailSchema = z.object({
   invitedBy: z.string(),
 })
 
+/**
+ * Management-list view of an invitation. Omits the bearer `token` — the secret
+ * redeemed via the invite link — so listing a credential set's invitations never
+ * broadcasts it. Only the creating admin receives the token (and its `inviteUrl`)
+ * in the create response.
+ */
+export const credentialSetInvitationListItemSchema = credentialSetInvitationDetailSchema.omit({
+  token: true,
+})
+
 export const credentialSetInvitePreviewSchema = z.object({
   credentialSetName: z.string(),
   organizationName: z.string(),
@@ -92,6 +102,7 @@ export type CredentialSetMembership = z.output<typeof credentialSetMembershipSch
 export type CredentialSetInvitation = z.output<typeof credentialSetInvitationSchema>
 export type CredentialSetMember = z.output<typeof credentialSetMemberSchema>
 export type CredentialSetInvitationDetail = z.output<typeof credentialSetInvitationDetailSchema>
+export type CredentialSetInvitationListItem = z.output<typeof credentialSetInvitationListItemSchema>
 export type CredentialSetInvitePreview = z.output<typeof credentialSetInvitePreviewSchema>
 
 export const listCredentialSetsQuerySchema = z.object({
@@ -245,7 +256,7 @@ export const listCredentialSetInvitationDetailsContract = defineRouteContract({
   response: {
     mode: 'json',
     schema: z.object({
-      invitations: z.array(credentialSetInvitationDetailSchema).optional(),
+      invitations: z.array(credentialSetInvitationListItemSchema).optional(),
     }),
   },
 })


### PR DESCRIPTION
## Summary
- `GET /api/credential-sets/[id]/invite` listed **every** invitation row — including the secret bearer `token` — to **any** member of the owning org, regardless of role. Its sibling methods (`POST`/`DELETE` on the same route, `POST` resend) all enforce `admin`/`owner`; the `GET` was the only one missing the gate.
- This let a non-privileged member harvest a pending **null-email** invite token and self-join the credential set via `POST /api/credential-sets/invite/[token]` (the accept path skips the email-match check when `email` is null), durably inserting themselves as an `active` member. It also contradicted the self-scoped `/credential-sets/invitations` endpoint's documented invariant that open-link tokens "must never be listed."

## Fix
- Add the `admin`/`owner` role gate to `GET`, matching `POST`/`DELETE` on the same route.
- Project explicit columns and **drop `token`** from the list response (defense-in-depth / least-privilege) — the management UI only consumes `id`/`email`/`status`, and the creating admin still receives the token + `inviteUrl` via the create response. New `credentialSetInvitationListItemSchema` (= detail schema minus `token`) backs the list contract.

## Type of Change
- [x] Bug fix (security)

## Testing
- `bunx tsc --noEmit` clean (only the pre-existing unrelated `tailwind.config.ts` error)
- `bunx biome check` clean on all three changed files
- `bun run check:api-validation` passed
- Verified the only client consumer (`useCredentialSetInvitationsDetail` → `pendingInvitations`) reads only `id`/`email`/`status`; the `invitation.token` use elsewhere is the separate self-scoped `/invitations` hook, unaffected.
- No automated test added: this route family (incl. the sibling `POST`/`DELETE`) has no existing test harness, and the fix is authz parity with already-shipped siblings. Flagging for follow-up if a harness is desired.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
