### PR TITLE
fix(mcp): pin public IP-literal server URLs to block SSRF redirect bypass

### DIFF
--- a/apps/sim/lib/mcp/domain-check.test.ts
+++ b/apps/sim/lib/mcp/domain-check.test.ts
@@ -375,6 +375,20 @@ describe('validateMcpServerSsrf', () => {
     )
   })
 
+  it('returns the literal IP for a public IPv4 literal so the caller pins it', async () => {
+    await expect(validateMcpServerSsrf('http://93.184.216.34:8080/mcp')).resolves.toBe(
+      '93.184.216.34'
+    )
+    expect(mockDnsLookup).not.toHaveBeenCalled()
+  })
+
+  it('returns the literal IP for a public IPv6 literal (brackets stripped)', async () => {
+    await expect(
+      validateMcpServerSsrf('http://[2606:2800:220:1:248:1893:25c8:1946]/mcp')
+    ).resolves.toBe('2606:2800:220:1:248:1893:25c8:1946')
+    expect(mockDnsLookup).not.toHaveBeenCalled()
+  })
+
   it('throws McpSsrfError for cloud metadata IP literal', async () => {
     await expect(validateMcpServerSsrf('http://169.254.169.254/latest/meta-data/')).rejects.toThrow(
       McpSsrfError
@@ -445,6 +459,11 @@ describe('validateMcpServerSsrf', () => {
     it('returns resolved IP for public IP resolutions on hosted', async () => {
       mockDnsLookup.mockResolvedValue({ address: '93.184.216.34' })
       await expect(validateMcpServerSsrf('https://example.com/mcp')).resolves.toBe('93.184.216.34')
+    })
+
+    it('pins public IP literals on hosted so redirects cannot escape', async () => {
+      await expect(validateMcpServerSsrf('http://93.184.216.34/mcp')).resolves.toBe('93.184.216.34')
+      expect(mockDnsLookup).not.toHaveBeenCalled()
     })
 
     it('skips loopback check on hosted when allowlist is configured', async () => {

--- a/apps/sim/lib/mcp/domain-check.ts
+++ b/apps/sim/lib/mcp/domain-check.ts
@@ -139,12 +139,14 @@ function isLocalhostHostname(hostname: string): boolean {
  * URLs with env var references in the hostname are skipped — they will be
  * validated after resolution at execution time.
  *
- * Returns the resolved IP address when DNS resolution was performed (so the
- * caller can pin subsequent connections to that IP and prevent DNS-rebinding
- * TOCTOU attacks). Returns null in cases where pinning is unnecessary or
+ * Returns the IP address to pin subsequent connections to (the resolved IP for
+ * hostnames, or the literal itself for public IP-literal URLs) so the caller can
+ * prevent DNS-rebinding TOCTOU attacks and stop redirects from escaping to
+ * internal hosts. Pinning matters for IP literals too: without it the transport
+ * uses the default fetch, which follows an attacker-controlled 3xx redirect to a
+ * private/metadata address. Returns null only when pinning is unnecessary or
  * impossible: no URL, allowlist-only mode, env-var hostnames (validated later),
- * IP literals (no DNS to rebind), and localhost on self-hosted (no rebinding
- * risk against a fixed loopback).
+ * and localhost on self-hosted (no rebinding risk against a fixed loopback).
  *
  * @throws McpSsrfError if the URL resolves to a blocked IP address
  */
@@ -174,7 +176,11 @@ export async function validateMcpServerSsrf(url: string | undefined): Promise<st
     if (isPrivateOrReservedIP(cleanHostname)) {
       throw new McpSsrfError('MCP server URL cannot point to a private or reserved IP address')
     }
-    return null
+    // Public IP literal: pin to this exact address so the caller's pinned fetch
+    // (createPinnedFetch) keeps every redirect hop on it. Returning null here
+    // would fall back to the default fetch, which follows a 3xx redirect to a
+    // private/metadata host and escapes SSRF controls.
+    return cleanHostname
   }
 
   let address: string


### PR DESCRIPTION
## Summary
- Fix an SSRF bypass in the MCP transport: a public **IP-literal** server URL passed validation but returned no pinned IP, so the StreamableHTTP transport used the default global fetch and followed an attacker-controlled 3xx redirect to internal/cloud-metadata hosts (`169.254.169.254`, etc.).
- `validateMcpServerSsrf` now returns the validated literal IP for public IP-literal URLs (instead of `null`), so every consumer pins the connection via `createPinnedFetch`. The pinned lookup ignores redirect hostnames and always dials the validated IP — redirects can no longer escape to internal targets. This makes the IP-literal path identical to the already-safe hostname path.

## Type of Change
- [x] Bug fix (security)

## Testing
- Added IPv4 + IPv6 public-literal pinning tests (default + hosted blocks)
- Full mcp suite green (305/305), tsc + biome clean
- Private/reserved/loopback literals still throw; localhost-on-self-hosted still returns null (no regression)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)