### PR TITLE
improvement(clickhouse): expand block templates and skills, normalize tool versions

### DIFF
--- a/apps/sim/blocks/blocks/clickhouse.ts
+++ b/apps/sim/blocks/blocks/clickhouse.ts
@@ -528,7 +528,7 @@ export const ClickHouseBlockMeta = {
       icon: Trash,
       title: 'Partition retention cleanup',
       prompt:
-        'Build a scheduled workflow that lists the partitions of my ClickHouse events table and drops partitions older than the retention window to keep storage under control.',
+        'Build a scheduled workflow that enforces a retention policy on my ClickHouse events table: take an explicit cutoff date as input, list the table partitions, select only the partitions on that exact table whose range ends strictly before the cutoff, and drop just those. Never infer the cutoff and never drop a partition that is not clearly past it.',
       modules: ['scheduled', 'agent', 'workflows'],
       category: 'engineering',
       tags: ['data-warehouse', 'maintenance'],
@@ -537,7 +537,7 @@ export const ClickHouseBlockMeta = {
       icon: Bell,
       title: 'Alert on long-running queries',
       prompt:
-        'Create a scheduled workflow that checks ClickHouse for running queries, and if any has been running too long, posts an alert to Slack and optionally kills the query.',
+        'Create a scheduled workflow that lists ClickHouse running queries and alerts Slack about any whose elapsed time exceeds an explicit threshold I set. Alert only by default; only kill a query when it is clearly past the threshold, is not a write or system/replication job, and a human has confirmed the specific query_id.',
       modules: ['scheduled', 'agent', 'workflows'],
       category: 'engineering',
       tags: ['monitoring', 'data-warehouse'],
@@ -597,7 +597,7 @@ export const ClickHouseBlockMeta = {
       description:
         'Keep ClickHouse tables healthy by inspecting parts, optimizing tables, and dropping stale partitions. Use for scheduled maintenance or when storage or part counts grow.',
       content:
-        '# Maintain Tables\n\nRun routine ClickHouse table maintenance.\n\n## Steps\n1. Use Table Stats and List Partitions to see size on disk, part counts, and per-partition rows.\n2. For tables with many small parts, run Optimize Table (optionally with Force Final Merge) to consolidate them.\n3. For time-partitioned tables past their retention window, use Drop Partition on the oldest partitions.\n4. Re-check Table Stats to confirm the part count and size dropped.\n\n## Output\nReport what was optimized or dropped, the before/after part count and size on disk, and any partitions intentionally retained. Never drop a partition unless it is clearly outside the retention window.',
+        "# Maintain Tables\n\nRun routine ClickHouse table maintenance. Optimize is safe; dropping partitions is destructive and irreversible, so treat it with care.\n\n## Steps\n1. Use Table Stats and List Partitions to see size on disk, part counts, and per-partition rows.\n2. For tables with many small parts, run Optimize Table (optionally with Force Final Merge) to consolidate them.\n3. Dropping partitions requires an explicit retention cutoff supplied by the caller — never infer or guess one. List the partitions of the intended table, select only those whose range ends strictly before that cutoff, and confirm each target's table and partition id before acting. Drop them one at a time with Drop Partition.\n4. Re-check Table Stats to confirm the part count and size dropped.\n\n## Output\nReport what was optimized or dropped, the before/after part count and size on disk, and any partitions intentionally retained. If no explicit cutoff was given, do not drop anything — optimize and report only. Never drop a partition unless it is clearly older than the cutoff and on the intended table.",
     },
   ],
 } as const satisfies BlockMeta

--- a/apps/sim/blocks/blocks/clickhouse.ts
+++ b/apps/sim/blocks/blocks/clickhouse.ts
@@ -537,7 +537,7 @@ export const ClickHouseBlockMeta = {
       icon: Bell,
       title: 'Alert on long-running queries',
       prompt:
-        'Create a scheduled workflow that lists ClickHouse running queries and alerts Slack about any whose elapsed time exceeds an explicit threshold I set. Alert only by default; only kill a query when it is clearly past the threshold, is not a write or system/replication job, and a human has confirmed the specific query_id.',
+        'Create a scheduled workflow that lists ClickHouse running queries and posts a Slack alert for any whose elapsed time exceeds an explicit threshold I set, including the query_id, user, and elapsed time so a human can investigate and decide whether to intervene.',
       modules: ['scheduled', 'agent', 'workflows'],
       category: 'engineering',
       tags: ['monitoring', 'data-warehouse'],

--- a/apps/sim/blocks/blocks/clickhouse.ts
+++ b/apps/sim/blocks/blocks/clickhouse.ts
@@ -1,5 +1,14 @@
 import { getErrorMessage } from '@sim/utils/errors'
-import { ClipboardList, File } from '@/components/emcn/icons'
+import {
+  Bell,
+  ClipboardList,
+  Database,
+  File,
+  Search,
+  Server,
+  Trash,
+  Wrench,
+} from '@/components/emcn/icons'
 import { ClickHouseIcon } from '@/components/icons'
 import type { BlockConfig, BlockMeta } from '@/blocks/types'
 import { IntegrationType } from '@/blocks/types'
@@ -497,6 +506,62 @@ export const ClickHouseBlockMeta = {
       category: 'engineering',
       tags: ['data-analytics', 'data-warehouse'],
     },
+    {
+      icon: Search,
+      title: 'Document a ClickHouse schema',
+      prompt:
+        'Build a workflow that introspects my ClickHouse database schema, then has an agent write clear documentation describing each table, its columns, types, and engine.',
+      modules: ['agent', 'workflows'],
+      category: 'engineering',
+      tags: ['data-warehouse', 'documentation'],
+    },
+    {
+      icon: Wrench,
+      title: 'Scheduled table maintenance',
+      prompt:
+        'Create a scheduled workflow that runs OPTIMIZE TABLE on my high-write ClickHouse tables each night to merge parts, then reports the resulting part counts and storage size.',
+      modules: ['scheduled', 'workflows'],
+      category: 'engineering',
+      tags: ['data-warehouse', 'maintenance'],
+    },
+    {
+      icon: Trash,
+      title: 'Partition retention cleanup',
+      prompt:
+        'Build a scheduled workflow that lists the partitions of my ClickHouse events table and drops partitions older than the retention window to keep storage under control.',
+      modules: ['scheduled', 'agent', 'workflows'],
+      category: 'engineering',
+      tags: ['data-warehouse', 'maintenance'],
+    },
+    {
+      icon: Bell,
+      title: 'Alert on long-running queries',
+      prompt:
+        'Create a scheduled workflow that checks ClickHouse for running queries, and if any has been running too long, posts an alert to Slack and optionally kills the query.',
+      modules: ['scheduled', 'agent', 'workflows'],
+      category: 'engineering',
+      tags: ['monitoring', 'data-warehouse'],
+      alsoIntegrations: ['slack'],
+    },
+    {
+      icon: Database,
+      title: 'Provision a ClickHouse table from a spec',
+      prompt:
+        'Build a workflow where I describe the table I need in plain English, an agent designs the columns, engine, and ORDER BY key, and the workflow creates the ClickHouse table.',
+      modules: ['agent', 'workflows'],
+      category: 'engineering',
+      tags: ['data-warehouse', 'schema'],
+    },
+    {
+      icon: Server,
+      title: 'Weekly storage growth report',
+      prompt:
+        'Create a scheduled workflow that collects ClickHouse table stats (rows and size on disk) each week, has an agent summarize the largest tables and fastest growth, and posts the report to Slack.',
+      modules: ['scheduled', 'agent', 'workflows'],
+      category: 'engineering',
+      tags: ['monitoring', 'reporting'],
+      alsoIntegrations: ['slack'],
+    },
   ],
   skills: [
     {
@@ -519,6 +584,20 @@ export const ClickHouseBlockMeta = {
         'Insert a batch of rows into a ClickHouse table after mapping them to the right columns. Use to ingest event or record payloads into ClickHouse.',
       content:
         '# Bulk Insert Events\n\nLoad a batch of records into a ClickHouse table.\n\n## Steps\n1. Use Describe Table to confirm the target column names and types.\n2. Map each incoming payload to those columns, coercing types (e.g. timestamps to DateTime format, numbers to the right width).\n3. Build a JSON array of row objects with consistent keys, then use Insert Rows (Bulk) against the table.\n4. Verify with Count Rows or a small SELECT.\n\n## Output\nReturn the number of rows inserted and any rows that were skipped or failed validation, with the reason. Confirm the new total row count so the caller knows ingestion succeeded.',
+    },
+    {
+      name: 'document-schema',
+      description:
+        'Introspect a ClickHouse database and produce readable documentation of its tables, columns, and engines. Use when onboarding to an unfamiliar ClickHouse instance or refreshing schema docs.',
+      content:
+        '# Document Schema\n\nInspect a ClickHouse database and describe its structure.\n\n## Steps\n1. Use Introspect Schema to pull every table with its columns, types, and engine in one call. For a single table, use Describe Table or Show Create Table instead.\n2. Group columns by table and note primary/sorting key membership and defaults.\n3. Summarize each table: what it appears to store, its engine, key columns, and approximate row count.\n\n## Output\nReturn a per-table summary (name, engine, key columns, row count) followed by a column reference. Keep it concise and skimmable; call out anything unusual such as missing ORDER BY keys or very wide tables.',
+    },
+    {
+      name: 'maintain-tables',
+      description:
+        'Keep ClickHouse tables healthy by inspecting parts, optimizing tables, and dropping stale partitions. Use for scheduled maintenance or when storage or part counts grow.',
+      content:
+        '# Maintain Tables\n\nRun routine ClickHouse table maintenance.\n\n## Steps\n1. Use Table Stats and List Partitions to see size on disk, part counts, and per-partition rows.\n2. For tables with many small parts, run Optimize Table (optionally with Force Final Merge) to consolidate them.\n3. For time-partitioned tables past their retention window, use Drop Partition on the oldest partitions.\n4. Re-check Table Stats to confirm the part count and size dropped.\n\n## Output\nReport what was optimized or dropped, the before/after part count and size on disk, and any partitions intentionally retained. Never drop a partition unless it is clearly outside the retention window.',
     },
   ],
 } as const satisfies BlockMeta

--- a/apps/sim/tools/clickhouse/count-rows.ts
+++ b/apps/sim/tools/clickhouse/count-rows.ts
@@ -5,7 +5,7 @@ export const countRowsTool: ToolConfig<ClickHouseCountRowsParams, ClickHouseCoun
   id: 'clickhouse_count_rows',
   name: 'ClickHouse Count Rows',
   description: 'Count rows in a ClickHouse table, optionally filtered',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/create-database.ts
+++ b/apps/sim/tools/clickhouse/create-database.ts
@@ -11,7 +11,7 @@ export const createDatabaseTool: ToolConfig<
   id: 'clickhouse_create_database',
   name: 'ClickHouse Create Database',
   description: 'Create a new database on a ClickHouse server',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/create-table.ts
+++ b/apps/sim/tools/clickhouse/create-table.ts
@@ -8,7 +8,7 @@ export const createTableTool: ToolConfig<ClickHouseCreateTableParams, ClickHouse
   id: 'clickhouse_create_table',
   name: 'ClickHouse Create Table',
   description: 'Create a new MergeTree-family table in ClickHouse',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/delete.ts
+++ b/apps/sim/tools/clickhouse/delete.ts
@@ -5,7 +5,7 @@ export const deleteTool: ToolConfig<ClickHouseDeleteParams, ClickHouseDeleteResp
   id: 'clickhouse_delete',
   name: 'ClickHouse Delete',
   description: 'Delete rows from a ClickHouse table via an ALTER TABLE ... DELETE mutation',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/describe-table.ts
+++ b/apps/sim/tools/clickhouse/describe-table.ts
@@ -9,7 +9,7 @@ export const describeTableTool: ToolConfig<ClickHouseDescribeTableParams, ClickH
     id: 'clickhouse_describe_table',
     name: 'ClickHouse Describe Table',
     description: 'Describe the columns of a ClickHouse table',
-    version: '1.0',
+    version: '1.0.0',
 
     params: {
       host: {

--- a/apps/sim/tools/clickhouse/drop-database.ts
+++ b/apps/sim/tools/clickhouse/drop-database.ts
@@ -9,7 +9,7 @@ export const dropDatabaseTool: ToolConfig<ClickHouseDropDatabaseParams, ClickHou
     id: 'clickhouse_drop_database',
     name: 'ClickHouse Drop Database',
     description: 'Drop a database from a ClickHouse server',
-    version: '1.0',
+    version: '1.0.0',
 
     params: {
       host: {

--- a/apps/sim/tools/clickhouse/drop-partition.ts
+++ b/apps/sim/tools/clickhouse/drop-partition.ts
@@ -11,7 +11,7 @@ export const dropPartitionTool: ToolConfig<
   id: 'clickhouse_drop_partition',
   name: 'ClickHouse Drop Partition',
   description: 'Drop a partition from a ClickHouse table',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/drop-table.ts
+++ b/apps/sim/tools/clickhouse/drop-table.ts
@@ -5,7 +5,7 @@ export const dropTableTool: ToolConfig<ClickHouseDropTableParams, ClickHouseMess
   id: 'clickhouse_drop_table',
   name: 'ClickHouse Drop Table',
   description: 'Drop a table from a ClickHouse database',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/execute.ts
+++ b/apps/sim/tools/clickhouse/execute.ts
@@ -5,7 +5,7 @@ export const executeTool: ToolConfig<ClickHouseExecuteParams, ClickHouseExecuteR
   id: 'clickhouse_execute',
   name: 'ClickHouse Execute',
   description: 'Execute raw SQL (DDL, mutations, or queries) on a ClickHouse database',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/insert-rows.ts
+++ b/apps/sim/tools/clickhouse/insert-rows.ts
@@ -5,7 +5,7 @@ export const insertRowsTool: ToolConfig<ClickHouseInsertRowsParams, ClickHouseRo
   id: 'clickhouse_insert_rows',
   name: 'ClickHouse Insert Rows',
   description: 'Insert multiple rows into a ClickHouse table',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/insert.ts
+++ b/apps/sim/tools/clickhouse/insert.ts
@@ -5,7 +5,7 @@ export const insertTool: ToolConfig<ClickHouseInsertParams, ClickHouseInsertResp
   id: 'clickhouse_insert',
   name: 'ClickHouse Insert',
   description: 'Insert a row into a ClickHouse table',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/introspect.ts
+++ b/apps/sim/tools/clickhouse/introspect.ts
@@ -11,7 +11,7 @@ export const introspectTool: ToolConfig<ClickHouseIntrospectParams, ClickHouseIn
     name: 'ClickHouse Introspect',
     description:
       'Introspect a ClickHouse database to retrieve table structures, columns, and engines',
-    version: '1.0',
+    version: '1.0.0',
 
     params: {
       host: {

--- a/apps/sim/tools/clickhouse/kill-query.ts
+++ b/apps/sim/tools/clickhouse/kill-query.ts
@@ -5,7 +5,7 @@ export const killQueryTool: ToolConfig<ClickHouseKillQueryParams, ClickHouseRows
   id: 'clickhouse_kill_query',
   name: 'ClickHouse Kill Query',
   description: 'Kill a running query by its query ID',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/list-clusters.ts
+++ b/apps/sim/tools/clickhouse/list-clusters.ts
@@ -5,7 +5,7 @@ export const listClustersTool: ToolConfig<ClickHouseListClustersParams, ClickHou
   id: 'clickhouse_list_clusters',
   name: 'ClickHouse List Clusters',
   description: 'List configured clusters, shards, and replicas',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/list-databases.ts
+++ b/apps/sim/tools/clickhouse/list-databases.ts
@@ -9,7 +9,7 @@ export const listDatabasesTool: ToolConfig<ClickHouseListDatabasesParams, ClickH
     id: 'clickhouse_list_databases',
     name: 'ClickHouse List Databases',
     description: 'List all databases on a ClickHouse server',
-    version: '1.0',
+    version: '1.0.0',
 
     params: {
       host: {

--- a/apps/sim/tools/clickhouse/list-mutations.ts
+++ b/apps/sim/tools/clickhouse/list-mutations.ts
@@ -9,7 +9,7 @@ export const listMutationsTool: ToolConfig<ClickHouseListMutationsParams, ClickH
     id: 'clickhouse_list_mutations',
     name: 'ClickHouse List Mutations',
     description: 'List mutations (async ALTER UPDATE/DELETE) for the connected database',
-    version: '1.0',
+    version: '1.0.0',
 
     params: {
       host: {

--- a/apps/sim/tools/clickhouse/list-partitions.ts
+++ b/apps/sim/tools/clickhouse/list-partitions.ts
@@ -11,7 +11,7 @@ export const listPartitionsTool: ToolConfig<
   id: 'clickhouse_list_partitions',
   name: 'ClickHouse List Partitions',
   description: 'List active partitions for a ClickHouse table',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/list-running-queries.ts
+++ b/apps/sim/tools/clickhouse/list-running-queries.ts
@@ -11,7 +11,7 @@ export const listRunningQueriesTool: ToolConfig<
   id: 'clickhouse_list_running_queries',
   name: 'ClickHouse List Running Queries',
   description: 'List currently running queries on a ClickHouse server',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/list-tables.ts
+++ b/apps/sim/tools/clickhouse/list-tables.ts
@@ -5,7 +5,7 @@ export const listTablesTool: ToolConfig<ClickHouseListTablesParams, ClickHouseRo
   id: 'clickhouse_list_tables',
   name: 'ClickHouse List Tables',
   description: 'List tables in the connected ClickHouse database',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/optimize-table.ts
+++ b/apps/sim/tools/clickhouse/optimize-table.ts
@@ -11,7 +11,7 @@ export const optimizeTableTool: ToolConfig<
   id: 'clickhouse_optimize_table',
   name: 'ClickHouse Optimize Table',
   description: 'Trigger a merge of table parts via OPTIMIZE TABLE',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/query.ts
+++ b/apps/sim/tools/clickhouse/query.ts
@@ -5,7 +5,7 @@ export const queryTool: ToolConfig<ClickHouseQueryParams, ClickHouseQueryRespons
   id: 'clickhouse_query',
   name: 'ClickHouse Query',
   description: 'Execute a SELECT query on a ClickHouse database',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/rename-table.ts
+++ b/apps/sim/tools/clickhouse/rename-table.ts
@@ -8,7 +8,7 @@ export const renameTableTool: ToolConfig<ClickHouseRenameTableParams, ClickHouse
   id: 'clickhouse_rename_table',
   name: 'ClickHouse Rename Table',
   description: 'Rename a ClickHouse table',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/show-create-table.ts
+++ b/apps/sim/tools/clickhouse/show-create-table.ts
@@ -11,7 +11,7 @@ export const showCreateTableTool: ToolConfig<
   id: 'clickhouse_show_create_table',
   name: 'ClickHouse Show Create Table',
   description: 'Get the CREATE TABLE statement (DDL) for a ClickHouse table',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/table-stats.ts
+++ b/apps/sim/tools/clickhouse/table-stats.ts
@@ -5,7 +5,7 @@ export const tableStatsTool: ToolConfig<ClickHouseTableStatsParams, ClickHouseRo
   id: 'clickhouse_table_stats',
   name: 'ClickHouse Table Stats',
   description: 'Get row counts and on-disk size for tables in the connected database',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/truncate-table.ts
+++ b/apps/sim/tools/clickhouse/truncate-table.ts
@@ -11,7 +11,7 @@ export const truncateTableTool: ToolConfig<
   id: 'clickhouse_truncate_table',
   name: 'ClickHouse Truncate Table',
   description: 'Remove all rows from a ClickHouse table',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {

--- a/apps/sim/tools/clickhouse/update.ts
+++ b/apps/sim/tools/clickhouse/update.ts
@@ -5,7 +5,7 @@ export const updateTool: ToolConfig<ClickHouseUpdateParams, ClickHouseUpdateResp
   id: 'clickhouse_update',
   name: 'ClickHouse Update',
   description: 'Update rows in a ClickHouse table via an ALTER TABLE ... UPDATE mutation',
-  version: '1.0',
+  version: '1.0.0',
 
   params: {
     host: {


### PR DESCRIPTION
## Summary
- Validated the full ClickHouse integration (26 tools, block, 26 internal proxy routes, contracts) against ClickHouse's official API/docs and Sim conventions — all SQL statements and system-table columns confirmed, tool↔route↔contract shapes aligned, SQL-injection defenses verified
- Expanded `ClickHouseBlockMeta` templates from 3 to 9 (schema docs, scheduled table maintenance, partition retention cleanup, long-running-query alerts, table provisioning, weekly storage growth report)
- Added `document-schema` and `maintain-tables` skills (now 5 total, each grounded in `tools.access` and verified against real, attested ClickHouse use cases)
- Normalized tool `version` from `'1.0'` to `'1.0.0'` across all 26 tools for repo consistency

## Type of Change
- [x] Improvement

## Testing
- `bun run lint` clean
- ClickHouse utils tests pass (6/6)
- TypeScript compiles clean (no new errors)
- `bun run check:api-validation` passes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)