### PR TITLE
fix(sso): keep an exit affordance in edit mode when clean

### DIFF
--- a/apps/sim/ee/sso/components/sso-settings.tsx
+++ b/apps/sim/ee/sso/components/sso-settings.tsx
@@ -6,6 +6,7 @@ import { getErrorMessage } from '@sim/utils/errors'
 import { Check, ChevronDown, Clipboard, Eye, EyeOff } from 'lucide-react'
 import {
   Button,
+  Chip,
   ChipCombobox,
   ChipInput,
   ChipSelect,
@@ -535,15 +536,22 @@ export function SSO() {
 
       <SettingsPanel
         actions={
-          <SaveDiscardActions
-            dirty={hasChanges}
-            saving={configureSSOMutation.isPending}
-            saveDisabled={hasAnyErrors(errors) || !isFormValid()}
-            saveLabel={isEditing ? 'Update' : 'Save'}
-            savingLabel={isEditing ? 'Updating...' : 'Saving...'}
-            onSave={() => void handleSubmit()}
-            onDiscard={handleDiscard}
-          />
+          <>
+            {isEditing && !hasChanges && (
+              <Chip onClick={handleDiscard} disabled={configureSSOMutation.isPending}>
+                Cancel
+              </Chip>
+            )}
+            <SaveDiscardActions
+              dirty={hasChanges}
+              saving={configureSSOMutation.isPending}
+              saveDisabled={hasAnyErrors(errors) || !isFormValid()}
+              saveLabel={isEditing ? 'Update' : 'Save'}
+              savingLabel={isEditing ? 'Updating...' : 'Saving...'}
+              onSave={() => void handleSubmit()}
+              onDiscard={handleDiscard}
+            />
+          </>
         }
       >
         <div className='flex flex-col gap-4.5'>


### PR DESCRIPTION
## Problem

After the settings save/discard consolidation, the SSO edit form's only header action is the shared `SaveDiscardActions`, which renders nothing when the form is clean. So after clicking **Edit** on an existing SSO provider (`isEditing=true`, no changes yet), there were **no** header actions — no way to leave edit mode back to the read-only summary without first changing a field (to summon Discard) or navigating away from the section. The pre-consolidation UI had an always-visible `Cancel` button in edit mode; the migration dropped it. (Flagged by Cursor on the v0.7.16 release PR #5245.)

## Fix

Render a `Cancel` chip when `isEditing && !hasChanges` — when there *are* changes, the dirty-gated `SaveDiscardActions` Discard already exits. The two are mutually exclusive, so exactly one exit affordance is always present in edit mode:

- edit + clean → **Cancel** (exits to summary)
- edit + dirty → **Discard** (exits) + **Update**
- create mode / read-only summary → unchanged

## Audit

Audited every `SaveDiscardActions` consumer for the same trap-class: the two detail sub-views (data-retention, access-control group-detail) keep an always-rendered back chip, and the top-level pages (whitelabeling, secrets) exit via the settings nav — none are trapped. tsc + biome clean.