### PR TITLE
fix(webhooks): cast json provider_config for atomic jsonb merge

### DIFF
--- a/apps/sim/lib/webhooks/polling/utils.test.ts
+++ b/apps/sim/lib/webhooks/polling/utils.test.ts
@@ -7,7 +7,7 @@ const { mockUpdate, mockSet, mockWhere, sqlCalls } = vi.hoisted(() => ({
   mockUpdate: vi.fn(),
   mockSet: vi.fn(),
   mockWhere: vi.fn(),
-  sqlCalls: [] as Array<{ values: unknown[] }>,
+  sqlCalls: [] as Array<{ strings: readonly string[]; values: unknown[] }>,
 }))
 
 vi.mock('@sim/db', () => ({ db: { update: mockUpdate } }))
@@ -23,8 +23,8 @@ vi.mock('@sim/db/schema', () => ({
   workflowDeploymentVersion: {},
 }))
 vi.mock('drizzle-orm', () => ({
-  sql: (_strings: readonly string[], ...values: unknown[]) => {
-    const node = { values }
+  sql: (strings: readonly string[], ...values: unknown[]) => {
+    const node = { strings, values }
     sqlCalls.push(node)
     return node
   },
@@ -48,6 +48,10 @@ const logger = { error: vi.fn() } as never
 
 function allInterpolatedValues(): unknown[] {
   return sqlCalls.flatMap((c) => c.values)
+}
+
+function allSqlText(): string {
+  return sqlCalls.map((c) => c.strings.join('')).join(' ')
 }
 
 describe('updateWebhookProviderConfig (atomic jsonb merge)', () => {
@@ -76,5 +80,15 @@ describe('updateWebhookProviderConfig (atomic jsonb merge)', () => {
 
     expect(allInterpolatedValues()).toContain(JSON.stringify({ historyId: 'h1' }))
     expect(allInterpolatedValues().some((v) => Array.isArray(v))).toBe(false)
+  })
+
+  it('casts the json column to jsonb for the merge and back to json for storage', async () => {
+    await updateWebhookProviderConfig('wh-1', { historyId: 'h1', cleared: undefined }, logger)
+
+    const sqlText = allSqlText()
+    // Column (interpolated as a value) is cast to jsonb: `COALESCE(<col>::jsonb, ...)`
+    expect(sqlText).toContain('COALESCE(::jsonb')
+    // Merge runs in jsonb space, result cast back to the json column: `(<expr>)::json`
+    expect(sqlText).toContain(')::json')
   })
 })

--- a/apps/sim/lib/webhooks/polling/utils.ts
+++ b/apps/sim/lib/webhooks/polling/utils.ts
@@ -148,8 +148,13 @@ export async function runWithConcurrency(
 }
 
 /**
- * Read-merge-write pattern for updating provider-specific config fields.
+ * Atomically merge provider-specific config fields into `webhook.provider_config`.
  * Each provider passes its specific state updates (historyId, lastSeenGuids, etc.).
+ *
+ * The column is `json` (not `jsonb`), which has no merge operators, so the existing
+ * value is cast to `jsonb` for the `||`/`-` merge and the result cast back to `json`
+ * for storage. Casting is required — a bare `jsonb` expression cannot be assigned to
+ * the `json` column.
  */
 export async function updateWebhookProviderConfig(
   webhookId: string,
@@ -164,12 +169,13 @@ export async function updateWebhookProviderConfig(
       else defined[key] = value
     }
 
-    const merged = sql`COALESCE(${webhook.providerConfig}, '{}'::jsonb) || ${JSON.stringify(defined)}::jsonb`
+    const merged = sql`COALESCE(${webhook.providerConfig}::jsonb, '{}'::jsonb) || ${JSON.stringify(defined)}::jsonb`
+    const nextConfig = removedKeys.length > 0 ? sql`(${merged}) - ${removedKeys}::text[]` : merged
 
     await db
       .update(webhook)
       .set({
-        providerConfig: removedKeys.length > 0 ? sql`(${merged}) - ${removedKeys}::text[]` : merged,
+        providerConfig: sql`(${nextConfig})::json`,
         updatedAt: new Date(),
       })
       .where(eq(webhook.id, webhookId))


### PR DESCRIPTION
## Summary
- `updateWebhookProviderConfig` built a DB-side merge with jsonb operators (`COALESCE(provider_config, '{}'::jsonb) || $1::jsonb`), but `webhook.provider_config` is a `json` column, not `jsonb`. Postgres can't apply jsonb merge operators to a `json` column, so **every** polling state write failed with `could not convert type jsonb to json` (42846).
- The error was caught and swallowed, so it was silent (`failed_count` stayed 0) — but it broke `historyId` / `lastCheckedTimestamp` / `pageToken` / `lastSeenGuids` persistence for **all** polling webhooks (Gmail, RSS, Google Sheets/Drive, Outlook, IMAP) since the atomic-merge change landed.
- Fix: cast the column to `jsonb` for the `||` / `-` merge, then cast the result back to `json` for storage. Matches the existing pattern already used for `subscription.metadata` (`subscription.ts:82`).
- Verified no other `json`-column-vs-`jsonb`-operator misalignments exist in the codebase — every other jsonb-operator write targets a true `jsonb` column.

## Type of Change
- [x] Bug fix

## Testing
- Added a regression test asserting the column is cast `json`→`jsonb`→`json`.
- Reproduced the original failure and validated the corrected merge expression directly against the production schema.
- `vitest` (3/3 pass), biome, and tsc all clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)