### PR TITLE
fix(webhooks): run inactive deployment-version cleanup inline on deploy

### DIFF
--- a/apps/sim/lib/workflows/deployment-outbox.ts
+++ b/apps/sim/lib/workflows/deployment-outbox.ts
@@ -207,9 +207,10 @@ const syncActiveSideEffects = async (rawPayload: unknown): Promise<void> => {
     return
   }
 
-  await enqueueWorkflowInactiveDeploymentCleanup(db, {
+  await syncInactiveDeploymentCleanup({
     workflowId: payload.workflowId,
     activeDeploymentVersionId: payload.deploymentVersionId,
+    workflow: workflowData,
     userId: payload.userId,
     requestId,
   })
@@ -276,6 +277,40 @@ const cleanupUndeployedSideEffects = async (rawPayload: unknown): Promise<void> 
   })
 
   await removeMcpToolsIfStillUndeployed(payload.workflowId, requestId)
+}
+
+/**
+ * Run inactive-version cleanup synchronously as part of the active-version sync, right
+ * after the active version's webhooks/schedules are registered.
+ *
+ * {@link cleanupInactiveDeploymentVersions} re-checks that each version is still inactive
+ * before tearing anything down, so it can never touch the now-active version. Running it
+ * inline — rather than only enqueueing it — closes the window where a lost
+ * `CLEANUP_INACTIVE` outbox event leaves superseded webhooks behind as live-but-never-polled
+ * `is_active` orphans. The deferred event is kept as a fallback so cleanup still retries if
+ * the inline pass throws, without failing the already-succeeded registration.
+ */
+async function syncInactiveDeploymentCleanup(params: {
+  workflowId: string
+  activeDeploymentVersionId: string
+  workflow: Record<string, unknown>
+  userId: string
+  requestId: string
+}): Promise<void> {
+  try {
+    await cleanupInactiveDeploymentVersions(params)
+  } catch (cleanupError) {
+    logger.warn(
+      `[${params.requestId}] Inline inactive-deployment cleanup failed; deferring to outbox retry`,
+      cleanupError
+    )
+    await enqueueWorkflowInactiveDeploymentCleanup(db, {
+      workflowId: params.workflowId,
+      activeDeploymentVersionId: params.activeDeploymentVersionId,
+      userId: params.userId,
+      requestId: params.requestId,
+    })
+  }
 }
 
 async function cleanupInactiveDeploymentVersions(params: {


### PR DESCRIPTION
## Summary
- When a deploy activates a new version, the superseded versions' webhooks are removed by a separate, best-effort `CLEANUP_INACTIVE` outbox event. When that event is lost / dead-letters silently, old-version webhooks linger as `is_active=true` orphans that `fetchActiveWebhooks` skips (deployment-version mismatch) — so they **silently stop polling**. In prod this stranded ~515 webhooks across ~130 workflows.
- Fix: run the existing `cleanupInactiveDeploymentVersions` **synchronously** in the `SYNC_ACTIVE` handler, right after the active version's webhooks/schedules are registered — falling back to the deferred outbox event only if the inline pass throws.
- This **reuses the existing guarded cleanup** rather than introducing new deletion logic. That cleanup already re-checks each version is still inactive (`isDeploymentVersionActive`) before tearing anything down, and re-enqueues side-effects if a version became active — so it can never touch the active version.

## Why this layer (addressing the first review round)
An earlier revision folded stale-webhook deletion into `saveTriggerWebhooksForDeploy`. Review correctly flagged two problems with that approach, both avoided here:
- **Strict cleanup blocking registration (P1):** the outbox path uses `strictExternalCleanup: true`, so tearing down a stale/missing external subscription *before* registration could abort the deploy and leave the active version unregistered. Here cleanup runs strictly *after* registration, and a failure is caught and deferred — it can never block registration.
- **Active-version race (P2):** deleting by snapshot could tear down a version that concurrently became active. The reused `cleanupInactiveDeploymentVersions` re-checks active-ness before each delete (the existing `shouldDeleteWebhook` guard), so it's race-safe.

## Scope
Closes the leak going forward. Backfilling the ~515 already-stranded rows remains a separate ops pass (the "fully dead" subset needs external OAuth/polling subscriptions recreated via deploy side-effects).

## Type of Change
- [x] Bug fix

## Testing
- `tsc` + biome clean. Full webhooks suite green.
- No new unit test: the change reuses the already-exercised `cleanupInactiveDeploymentVersions` unchanged; the only new code is an inline-with-deferred-fallback wrapper. An isolated test would require brittle deep-mocking of the cleanup's internal db-query ordering and would assert little, so it was deliberately omitted rather than added as a checkbox.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)