### PR TITLE
fix(emcn): repair unstyled UI after package extraction

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -2,6 +2,7 @@
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 @import "fumadocs-openapi/css/preset.css";
+@source "../../../packages/emcn/src";
 
 /* Prevent overscroll bounce effect on the page */
 html,

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -133,7 +133,6 @@ const nextConfig: NextConfig = {
     optimizeCss: true,
     preloadEntriesOnStart: false,
     optimizePackageImports: [
-      '@sim/emcn',
       'lodash',
       'framer-motion',
       'reactflow',

--- a/apps/sim/tailwind.config.ts
+++ b/apps/sim/tailwind.config.ts
@@ -6,6 +6,7 @@ export default {
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
+    '../../packages/emcn/src/**/*.{js,ts,jsx,tsx}',
     '!./app/node_modules/**',
     '!**/node_modules/**',
   ],


### PR DESCRIPTION
## Summary
Two runtime regressions from the `@sim/emcn` extraction (#5257), both invisible to typecheck:

- **App-wide crash on every workspace route** (logs, chat, workflows, …). `optimizePackageImports: ['@sim/emcn']` rewrites barrel imports to direct subpaths and, for this barrel, duplicates the toast module — so `<ToastProvider>` (workspace layout) and `useToast()` (workspace permissions provider, rendered on every route) ended up with **different `ToastContext` objects**. `useToast` then threw `must be used within <ToastProvider>`, which the route `error.tsx` boundaries caught ("Failed to load …"). The simple Button-only error fallback still rendered, which is why the error UI showed. **Fix:** removed `@sim/emcn` from `optimizePackageImports` (normal bundling already tree-shakes it; the optimizer is incompatible with the barrel's collision re-exports).
- **emcn components rendered unstyled** (e.g. oversized buttons). After moving emcn out of `apps/sim/components`, its source fell outside apps/sim's Tailwind `content` globs and docs' Tailwind v4 auto-content scope (which excludes node_modules), so utility classes used only inside emcn stopped being generated. **Fix:** added `packages/emcn/src` to apps/sim's Tailwind `content` and a `@source` to docs' global CSS.

## Type of Change
- [x] Bug fix

## Testing
- Root causes verified by code analysis (the `useToast` null-context throw + the optimizer/module-duplication mechanism). Config-only changes; typecheck unaffected. Verified live against the running app.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)