### PR TITLE
fix(emcn): Calendar icon collision + prism side-effect registration

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/loading.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/loading.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Calendar, Plus } from '@sim/emcn'
+import { Calendar, Plus } from '@sim/emcn/icons'
 import {
   type ChromeActionSpec,
   ResourceChromeFallback,

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/scheduled-tasks.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useMemo, useState } from 'react'
-import { Calendar, Plus } from '@sim/emcn'
+import { Calendar, Plus } from '@sim/emcn/icons'
 import { useParams } from 'next/navigation'
 import type { ResourceAction } from '@/app/workspace/[workspaceId]/components'
 import { Resource } from '@/app/workspace/[workspaceId]/components'

--- a/packages/emcn/package.json
+++ b/packages/emcn/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "sideEffects": [
-    "**/*.css"
+    "**/*.css",
+    "**/components/code/prism.ts"
   ],
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Two regressions surfaced after the `@sim/emcn` extraction (#5257):

- **Calendar icon rendered a date picker** (e.g. the Scheduled Tasks header). The barrel resolves the `Calendar` name-collision to the date-picker **component** (symmetric with `Table`). Scheduled-tasks imported `Calendar` from the barrel but used it as an **icon**, so it rendered the picker. Routed the icon consumers (`scheduled-tasks.tsx`, `loading.tsx`) to `@sim/emcn/icons`, matching the "icons come from the `/icons` subpath" convention. Added a barrel note so the component re-export isn't re-introduced.
- **`Prism is not defined`** on page load. The package's new `sideEffects: ["**/*.css"]` marked `code/prism.ts` as side-effect-free, but it registers prismjs languages on the global `Prism` (a real JS side effect). The bundler could drop/reorder its core init. Added `code/prism.ts` to `sideEffects`.

## Type of Change
- [x] Bug fix

## Testing
- **Calendar fix:** `apps/sim` typecheck clean (0 errors); a comprehensive sweep confirms no remaining collision-named icon (`Calendar`/`Table`) is imported from the barrel as an icon. High confidence.
- **`sideEffects` fix:** config-correct (`prism.ts` genuinely has JS side effects), but it's a bundler-level change that typecheck/static analysis cannot confirm — **needs a runtime check on a real build** to verify `Prism is not defined` is gone.

## Not in scope (verified NOT emcn-caused)
- Malformed `<path> d` SVG warnings live in `apps/sim/components/icons.tsx` (block icons), which the emcn move never touched — pre-existing on `main`.
- React #418 is a hydration mismatch, not something a mechanical component move introduces.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)