### PR TITLE
fix(prism): load prismjs core before language components

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -3,6 +3,9 @@
 import { type ComponentPropsWithoutRef, memo, useEffect, useMemo, useRef } from 'react'
 import { Streamdown } from 'streamdown'
 import 'streamdown/styles.css'
+// prismjs core must load before its language components — they register on the
+// global `Prism` it installs (on `window`/`global`); fixes SSR + client order.
+import 'prismjs'
 import 'prismjs/components/prism-typescript'
 import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-css'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/code/code.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/code/code.tsx
@@ -1,8 +1,5 @@
 import type { ReactElement } from 'react'
 import { memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
-import { Check, Wand2 } from 'lucide-react'
-import { useParams } from 'next/navigation'
-import 'prismjs/components/prism-python'
 import {
   CODE_LINE_HEIGHT_PX,
   Code as CodeEditor,
@@ -14,6 +11,8 @@ import {
   languages,
 } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
+import { Check, Wand2 } from 'lucide-react'
+import { useParams } from 'next/navigation'
 import Editor from 'react-simple-code-editor'
 import { Button } from '@/components/ui/button'
 import { CodeLanguage } from '@/lib/execution/languages'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/starter/input-format.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/starter/input-format.tsx
@@ -1,7 +1,4 @@
 import { useCallback, useRef } from 'react'
-import { Trash } from '@sim/emcn/icons'
-import { Plus } from 'lucide-react'
-import 'prismjs/components/prism-json'
 import {
   Badge,
   Button,
@@ -19,6 +16,8 @@ import {
   Label,
   languages,
 } from '@sim/emcn'
+import { Trash } from '@sim/emcn/icons'
+import { Plus } from 'lucide-react'
 import Editor from 'react-simple-code-editor'
 import { createDefaultInputFormatField } from '@/lib/workflows/input-format'
 import { formatDisplayText } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/formatted-text'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/components/code-editor/code-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/components/code-editor/code-editor.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react'
 import { useEffect, useRef, useState } from 'react'
-import 'prismjs/components/prism-json'
 import {
   CODE_LINE_HEIGHT_PX,
   Code,


### PR DESCRIPTION
## Summary
Fixes `Prism is not defined` on the home (Chat) and workflow-editor pages after the `@sim/emcn` extraction.

prismjs language components (`prismjs/components/prism-*`) register on the global `Prism` that prismjs **core** installs. Importing a component before core throws `Prism is not defined` — in SSR and the client. The extraction changed bundling so core no longer loaded eagerly first, exposing a latent bad import order.

- **`chat-content.tsx`**: import prismjs core first (it needs ts/bash/css/markup, which emcn does not register).
- **`code-editor.tsx`, `input-format.tsx`, `code.tsx`**: drop the redundant `prism-json`/`prism-python` imports — these highlight via emcn's `languages`, which already registers js/json/python in the correct order.

Follow-up to #5261 (the `sideEffects` change was necessary but not sufficient — the real cause was import order).

## Type of Change
- [x] Bug fix

## Testing
- Verified on a running build: `Prism is not defined` is gone on Chat, Logs, and the workflow editor.
- Comprehensive sweep confirms every source file importing a prismjs language component now loads core first; the three editor files no longer import them at all.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)