### PR TITLE
feat(db): resolve DATABASE_URL per role (DATABASE_URL_<ROLE> with fallback)

### DIFF
--- a/apps/realtime/package.json
+++ b/apps/realtime/package.json
@@ -9,8 +9,8 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "dev": "DB_APP_NAME=sim-realtime bun --watch src/index.ts",
-    "start": "DB_APP_NAME=sim-realtime bun src/index.ts",
+    "dev": "SIM_DB_ROLE=realtime DB_APP_NAME=sim-realtime bun --watch src/index.ts",
+    "start": "SIM_DB_ROLE=realtime DB_APP_NAME=sim-realtime bun src/index.ts",
     "type-check": "tsc --noEmit",
     "lint": "biome check --write --unsafe .",
     "lint:check": "biome check .",

--- a/apps/realtime/src/bootstrap.ts
+++ b/apps/realtime/src/bootstrap.ts
@@ -7,10 +7,14 @@ import { loadRuntimeSecrets } from '@sim/runtime-secrets'
 
 await loadRuntimeSecrets()
 /**
- * Label every Postgres connection this process opens as `sim-realtime` — both
- * the realtime `socketDb` pool and the shared `@sim/db` client used by handlers,
- * preflight, and permissions. Set before importing `@/index` so it lands before
- * `@sim/db` reads it at module-eval time. `??=` respects an explicit override.
+ * Pin this process to the `realtime` DB role — covering both the realtime
+ * `socketDb` pool and the shared `@sim/db` client used by handlers, preflight,
+ * and permissions. The role drives the pool-size profile, `application_name`,
+ * and the role-keyed connection URL, so every realtime connection resolves
+ * consistently (without it the shared client would default to `web`). Set
+ * before importing `@/index` so it lands before `@sim/db` reads it at
+ * module-eval time; `??=` respects an explicit override.
  */
+process.env.SIM_DB_ROLE ??= 'realtime'
 process.env.DB_APP_NAME ??= 'sim-realtime'
 await import('@/index')

--- a/apps/realtime/src/database/operations.ts
+++ b/apps/realtime/src/database/operations.ts
@@ -2,6 +2,7 @@ import { AuditAction, AuditResourceType, recordAudit } from '@sim/audit'
 import * as schema from '@sim/db'
 import {
   instrumentPoolClient,
+  resolveDbUrl,
   workflow,
   workflowBlocks,
   workflowEdges,
@@ -31,7 +32,10 @@ import { env } from '@/env'
 
 const logger = createLogger('SocketDatabase')
 
-const connectionString = env.DATABASE_URL
+// Both realtime pools (this socketDb + the shared @sim/db pool) resolve the
+// realtime-keyed URL when set, falling back to the shared DATABASE_URL.
+const connectionString =
+  resolveDbUrl('DATABASE_URL', process.env.SIM_DB_ROLE ?? 'realtime') ?? env.DATABASE_URL
 // Realtime process footprint = this socketDb pool + the shared @sim/db pool.
 const socketDb = drizzle(
   instrumentPoolClient(

--- a/apps/realtime/src/env.ts
+++ b/apps/realtime/src/env.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 const EnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   DATABASE_URL: z.string().url(),
+  DATABASE_URL_REALTIME: z.string().url().optional(),
+  DATABASE_REPLICA_URL_REALTIME: z.string().url().optional(),
   REDIS_URL: z.preprocess(
     (value) => (typeof value === 'string' && value.trim() === '' ? undefined : value),
     z.string().url().optional()

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -22,6 +22,12 @@ export const env = createEnv({
     DATABASE_REPLICA_URL:                  z.string().url().optional(),            // Read-replica connection string; opt-in reads fall back to the primary when unset
     DB_APP_NAME:                           z.string().optional(),                  // Postgres application_name for query attribution (sim-app/sim-trigger/sim-realtime)
     SIM_DB_ROLE:                           z.enum(['web', 'trigger', 'realtime']).optional(), // Per-process pool profile selector (read directly by @sim/db)
+    DATABASE_URL_WEB:                      z.string().url().optional(),            // Per-role primary URL override; @sim/db falls back to DATABASE_URL
+    DATABASE_URL_TRIGGER:                  z.string().url().optional(),            // Per-role primary URL override (trigger)
+    DATABASE_URL_REALTIME:                 z.string().url().optional(),            // Per-role primary URL override (realtime)
+    DATABASE_REPLICA_URL_WEB:              z.string().url().optional(),            // Per-role replica URL override; falls back to DATABASE_REPLICA_URL
+    DATABASE_REPLICA_URL_TRIGGER:          z.string().url().optional(),            // Per-role replica URL override (trigger)
+    DATABASE_REPLICA_URL_REALTIME:         z.string().url().optional(),            // Per-role replica URL override (realtime)
     BETTER_AUTH_URL:                       z.string().url(),                       // Base URL for Better Auth service
     BETTER_AUTH_SECRET:                    z.string().min(32),                     // Secret key for Better Auth JWT signing
     DISABLE_REGISTRATION:                  z.boolean().optional(),                 // Flag to disable new user registration

--- a/packages/db/connection-url.test.ts
+++ b/packages/db/connection-url.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveDbUrl } from './connection-url'
+
+describe('resolveDbUrl', () => {
+  const KEYS = [
+    'DATABASE_URL',
+    'DATABASE_URL_WEB',
+    'DATABASE_URL_TRIGGER',
+    'DATABASE_REPLICA_URL',
+    'DATABASE_REPLICA_URL_TRIGGER',
+  ] as const
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of KEYS) {
+      saved[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of KEYS) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  })
+
+  it('prefers the role-keyed primary URL over the base', () => {
+    process.env.DATABASE_URL = 'postgres://base/db'
+    process.env.DATABASE_URL_TRIGGER = 'postgres://trigger/db'
+    expect(resolveDbUrl('DATABASE_URL', 'trigger')).toBe('postgres://trigger/db')
+  })
+
+  it('falls back to the base URL when the keyed var is unset', () => {
+    process.env.DATABASE_URL = 'postgres://base/db'
+    expect(resolveDbUrl('DATABASE_URL', 'web')).toBe('postgres://base/db')
+  })
+
+  it('returns undefined when neither keyed nor base is set', () => {
+    expect(resolveDbUrl('DATABASE_URL', 'realtime')).toBeUndefined()
+  })
+
+  it('resolves the replica variant independently of the primary', () => {
+    process.env.DATABASE_REPLICA_URL = 'postgres://replica/db'
+    process.env.DATABASE_REPLICA_URL_TRIGGER = 'postgres://trigger-replica/db'
+    expect(resolveDbUrl('DATABASE_REPLICA_URL', 'trigger')).toBe('postgres://trigger-replica/db')
+    expect(resolveDbUrl('DATABASE_REPLICA_URL', 'web')).toBe('postgres://replica/db')
+  })
+
+  it('uppercases the role to build the keyed var name', () => {
+    process.env.DATABASE_URL_WEB = 'postgres://web/db'
+    expect(resolveDbUrl('DATABASE_URL', 'web')).toBe('postgres://web/db')
+  })
+})

--- a/packages/db/connection-url.ts
+++ b/packages/db/connection-url.ts
@@ -1,0 +1,12 @@
+/**
+ * Resolve a connection URL for the active DB role, preferring the role-keyed
+ * variant (e.g. `DATABASE_URL_TRIGGER`) and falling back to the shared base.
+ * Lets each deploy point its surface at its own Postgres user + PgBouncer via
+ * env alone; unset keyed vars preserve the prior single-URL behavior.
+ */
+export function resolveDbUrl(
+  base: 'DATABASE_URL' | 'DATABASE_REPLICA_URL',
+  role: string
+): string | undefined {
+  return process.env[`${base}_${role.toUpperCase()}`] ?? process.env[base]
+}

--- a/packages/db/db.ts
+++ b/packages/db/db.ts
@@ -1,12 +1,8 @@
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
+import { resolveDbUrl } from './connection-url'
 import * as schema from './schema'
 import { instrumentPoolClient } from './tx-tripwire'
-
-const connectionString = process.env.DATABASE_URL!
-if (!connectionString) {
-  throw new Error('Missing DATABASE_URL environment variable')
-}
 
 /**
  * Per-role pool profiles. Starting numbers — validate against real per-role
@@ -28,7 +24,13 @@ if (roleEnv && !Object.hasOwn(DB_POOL_PROFILES, roleEnv)) {
     `Invalid SIM_DB_ROLE '${roleEnv}' — expected one of ${Object.keys(DB_POOL_PROFILES).join(', ')} (or unset for web)`
   )
 }
-const profile = DB_POOL_PROFILES[(roleEnv as DbRole) || 'web']
+const role = (roleEnv as DbRole) || 'web'
+const profile = DB_POOL_PROFILES[role]
+
+const connectionString = resolveDbUrl('DATABASE_URL', role)
+if (!connectionString) {
+  throw new Error('Missing DATABASE_URL environment variable')
+}
 
 const poolOptions = {
   prepare: false,
@@ -51,7 +53,7 @@ export const db = drizzle(postgresClient, { schema })
  * for auth, workflow state, or billing enforcement. Falls back to the primary
  * when `DATABASE_REPLICA_URL` is unset, so call sites never branch.
  */
-const replicaUrl = process.env.DATABASE_REPLICA_URL
+const replicaUrl = resolveDbUrl('DATABASE_REPLICA_URL', role)
 if (replicaUrl && !/^postgres(ql)?:\/\//.test(replicaUrl)) {
   throw new Error(
     'DATABASE_REPLICA_URL is set but is not a postgres:// DSN — fix the URL or unset the variable'

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,3 +1,4 @@
+export * from './connection-url'
 export * from './db'
 export * from './schema'
 export * from './triggers'


### PR DESCRIPTION
## Summary
- `@sim/db` now resolves its connection URL per runtime role: `DATABASE_URL_<ROLE>` (e.g. `DATABASE_URL_TRIGGER`) when set, **falling back to the existing `DATABASE_URL`** — same for the replica (`DATABASE_REPLICA_URL_<ROLE>`).
- **No-op until the keyed vars are populated** — with none set, behavior is identical to today. This is the inert, reversible switch for the in-progress connection-pool-isolation work (separate Postgres users + dedicated PgBouncers per surface).
- New shared helper `resolveDbUrl(base, role)` in `packages/db/connection-url.ts`, consumed by both `packages/db/db.ts` (primary + replica) and the realtime `socketDb` (`apps/realtime/.../operations.ts`) — so **both** realtime pools land on the realtime URL when set.
- Role is the existing `SIM_DB_ROLE` selector (already merged), so the URL and the pool-size profile always agree.
- Declared the new optional env vars in the app + realtime env schemas (typing/docs; `@sim/db` reads `process.env` directly).

## How the cutover works
Provision the users + bouncers (inert), ship this (no-op), then flip one surface at a time by populating its keyed var + restart; roll back by clearing it (falls back to `DATABASE_URL` / the old pooler). Trigger reads `DATABASE_URL_TRIGGER` from its trigger.dev env.

## Type of Change
- [x] New feature (infra plumbing; inert until configured)

## Testing
Tested manually. New `packages/db` unit tests for `resolveDbUrl` (keyed-preferred, base-fallback, undefined-when-unset, replica variant, role uppercasing). `bun run lint`, `check:api-validation:strict`, `@sim/db` vitest (24/24), and `packages/db` + `@sim/realtime` typechecks all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)