### PR TITLE
fix(workflow-renderer): validate dropbox host in note embed renderer

### DIFF
--- a/packages/workflow-renderer/src/note/note-block-view.tsx
+++ b/packages/workflow-renderer/src/note/note-block-view.tsx
@@ -17,6 +17,15 @@ function getTwitchParent(): string {
   return typeof window !== 'undefined' ? window.location.hostname : 'localhost'
 }
 
+/** Parse a URL's lowercased hostname, returning null for non-absolute/invalid URLs. */
+function parseHostname(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase()
+  } catch {
+    return null
+  }
+}
+
 /**
  * Get embed info for supported media platforms
  */
@@ -250,7 +259,12 @@ function getEmbedInfo(url: string): EmbedInfo | null {
     return { url: `https://drive.google.com/file/d/${googleDriveMatch[1]}/preview`, type: 'iframe' }
   }
 
-  if (url.includes('dropbox.com') && /\.(mp4|mov|webm)/.test(url)) {
+  const dropboxHost = parseHostname(url)
+  if (
+    dropboxHost &&
+    (dropboxHost === 'dropbox.com' || dropboxHost.endsWith('.dropbox.com')) &&
+    /\.(mp4|mov|webm)/.test(url)
+  ) {
     const directUrl = url
       .replace('www.dropbox.com', 'dl.dropboxusercontent.com')
       .replace('?dl=0', '')

--- a/packages/workflow-renderer/src/note/note-block-view.tsx
+++ b/packages/workflow-renderer/src/note/note-block-view.tsx
@@ -17,13 +17,32 @@ function getTwitchParent(): string {
   return typeof window !== 'undefined' ? window.location.hostname : 'localhost'
 }
 
-/** Parse a URL's lowercased hostname, returning null for non-absolute/invalid URLs. */
-function parseHostname(url: string): string | null {
-  try {
-    return new URL(url).hostname.toLowerCase()
-  } catch {
-    return null
+/** Parse a URL, tolerating scheme-less inputs (https is assumed). Returns null if unparseable. */
+function parseUrl(url: string): URL | null {
+  for (const candidate of [url, `https://${url}`]) {
+    try {
+      return new URL(candidate)
+    } catch {}
   }
+  return null
+}
+
+/**
+ * Resolve a Dropbox share link to a direct, embeddable video URL. Accepts only URLs
+ * whose host is `dropbox.com` or a `*.dropbox.com` subdomain (so attacker-controlled
+ * hosts like `dropbox.com.evil.com` are rejected), then rewrites the host to
+ * `dl.dropboxusercontent.com` so the file streams as media. Returns null for any
+ * non-Dropbox host or non-video path.
+ */
+function getDropboxDirectVideoUrl(url: string): string | null {
+  const parsed = parseUrl(url)
+  if (!parsed) return null
+  const host = parsed.hostname.toLowerCase()
+  if (host !== 'dropbox.com' && !host.endsWith('.dropbox.com')) return null
+  if (!/\.(mp4|mov|webm)$/i.test(parsed.pathname)) return null
+  parsed.hostname = 'dl.dropboxusercontent.com'
+  parsed.searchParams.delete('dl')
+  return parsed.toString()
 }
 
 /**
@@ -259,16 +278,9 @@ function getEmbedInfo(url: string): EmbedInfo | null {
     return { url: `https://drive.google.com/file/d/${googleDriveMatch[1]}/preview`, type: 'iframe' }
   }
 
-  const dropboxHost = parseHostname(url)
-  if (
-    dropboxHost &&
-    (dropboxHost === 'dropbox.com' || dropboxHost.endsWith('.dropbox.com')) &&
-    /\.(mp4|mov|webm)/.test(url)
-  ) {
-    const directUrl = url
-      .replace('www.dropbox.com', 'dl.dropboxusercontent.com')
-      .replace('?dl=0', '')
-    return { url: directUrl, type: 'video' }
+  const dropboxDirectVideoUrl = getDropboxDirectVideoUrl(url)
+  if (dropboxDirectVideoUrl) {
+    return { url: dropboxDirectVideoUrl, type: 'video' }
   }
 
   const tenorMatch = url.match(/tenor\.com\/view\/[^/]+-(\d+)/)


### PR DESCRIPTION
## Summary
- Replace the bare `url.includes('dropbox.com')` check in the note embed renderer with a parsed-hostname match (`dropbox.com` or `*.dropbox.com`)
- Add a small `parseHostname()` helper that safely parses the URL and lowercases the host
- Resolves CodeQL `js/incomplete-url-substring-sanitization` (alert #430): previously `https://dropbox.com.evil.com/x.mp4` or `https://evil.com/?dropbox.com/x.mp4` would be treated as a direct dropbox video and embedded from an attacker host

## Type of Change
- [x] Bug fix (security)

## Testing
Tested manually; `tsc --noEmit` on `packages/workflow-renderer` passes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)