### PR TITLE
fix(emcn): keep Prism grammar registrations in bundle, never throw on missing grammar

### DIFF
--- a/packages/emcn/src/components/code/prism.ts
+++ b/packages/emcn/src/components/code/prism.ts
@@ -1,4 +1,4 @@
-import { highlight, languages } from 'prismjs'
+import { type Grammar, languages, highlight as prismHighlight } from 'prismjs'
 import 'prismjs/components/prism-javascript'
 import 'prismjs/components/prism-python'
 import 'prismjs/components/prism-json'
@@ -10,10 +10,32 @@ import 'prismjs/components/prism-json'
  * shared `Prism.languages` registry), which marks any module that statically
  * imports them as having side effects and therefore non-tree-shakeable. Keeping
  * them here — rather than in `code.tsx` — ensures Prism only enters bundles that
- * actually import `highlight`/`languages`, instead of every consumer of the
- * shared `@sim/emcn` barrel (which re-exports `Code`).
+ * actually import these utilities, instead of every consumer of the shared
+ * `@sim/emcn` barrel (which re-exports `Code`).
  *
  * `code.tsx` itself never imports this module statically; it loads it lazily via
  * dynamic `import()` on first highlight.
+ *
+ * `highlight` is a local wrapper rather than a re-export of Prism's `highlight`.
+ * A bare re-export lets bundlers resolve the binding straight from `prismjs` and
+ * skip this module's body, dropping the grammar registrations above so
+ * `languages.json` (etc.) become `undefined` at runtime. Owning the function
+ * keeps the registrations in the dependency graph and lets us degrade to escaped
+ * plaintext when a grammar is missing instead of throwing.
  */
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/**
+ * Highlights `code` with the given Prism `grammar`, returning HTML markup.
+ * Falls back to escaped plaintext when `grammar` is undefined so a missing or
+ * unregistered language never throws `The language "<x>" has no grammar.`.
+ */
+function highlight(code: string, grammar: Grammar | undefined, language: string): string {
+  if (!grammar) return escapeHtml(code)
+  return prismHighlight(code, grammar, language)
+}
+
 export { highlight, languages }


### PR DESCRIPTION
## Summary
- Selecting files in the start block's input format (`file[]` field) crashed immediately with `The language "json" has no grammar.` — and the same crash was latent in every other workflow-editor code highlighter (subflow editor, condition input, code blocks, tool-input editor, variables JSON editor).
- Root cause: consumers import `{ highlight, languages }` from the `@sim/emcn` barrel, which re-exported Prism's `highlight` straight from `prismjs`. Bundlers resolved that passthrough directly from `prismjs` and skipped `prism.ts`'s module body — dropping the side-effect grammar registrations, so `languages.json` (etc.) were `undefined` at runtime and Prism threw.
- Fix is centralized at the source: `prism.ts` now owns `highlight` as a local wrapper, so the grammar registrations stay in the dependency graph, and the wrapper degrades to escaped plaintext when a grammar is missing instead of throwing.
- No per-file imports or inline guards — one change covers all consumers.

## Type of Change
- [x] Bug fix

## Testing
Tested manually — start-block `file[]` field and other workflow-editor editors no longer crash; `tsc` clean across `@sim/emcn` and `apps/sim`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)