### PR TITLE
fix(emcn): stop calendar content bleeding through the modal backdrop

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-delete-dialog/task-delete-dialog.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-delete-dialog/task-delete-dialog.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import {
-  Calendar,
   ChipConfirmModal,
   ChipModal,
   ChipModalBody,
   ChipModalFooter,
   ChipModalHeader,
 } from '@sim/emcn'
+import { Calendar } from '@sim/emcn/icons'
 import type { ScheduledTask } from '@/app/workspace/[workspaceId]/scheduled-tasks/utils/schedule-events'
 
 interface TaskDeleteDialogProps {

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-details-modal/task-details-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-details-modal/task-details-modal.tsx
@@ -1,6 +1,5 @@
 'use client'
 import {
-  Calendar,
   ChipModal,
   ChipModalBody,
   ChipModalField,
@@ -9,6 +8,7 @@ import {
   chipFieldSurfaceClass,
   cn,
 } from '@sim/emcn'
+import { Calendar } from '@sim/emcn/icons'
 import { format } from 'date-fns'
 import { useParams } from 'next/navigation'
 import {

--- a/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/scheduled-tasks/components/task-modal/task-modal.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useState } from 'react'
 import {
-  Calendar,
   ChipDatePicker,
   ChipModal,
   ChipModalFooter,
@@ -11,6 +10,7 @@ import {
   ChipModalPromptBody,
   ChipTimePicker,
 } from '@sim/emcn'
+import { Calendar } from '@sim/emcn/icons'
 import { format } from 'date-fns'
 import { useParams } from 'next/navigation'
 import { wallClockNow, zonedWallClockToUtc } from '@/lib/core/utils/timezone'

--- a/packages/emcn/src/components/modal/modal.tsx
+++ b/packages/emcn/src/components/modal/modal.tsx
@@ -122,6 +122,14 @@ const ModalClose = DialogPrimitive.Close
  * Modal overlay component with fade transition.
  * Outside interactions are handled by the dialog content so nested poppers can
  * close without also dismissing the modal.
+ *
+ * `[transform:translateZ(0)]` forces the overlay onto its own compositing layer.
+ * A `backdrop-blur` overlay does not reliably paint above page content the
+ * browser has already GPU-promoted — `position: sticky` headers and `z-index`ed
+ * absolutes inside a scroll container (e.g. the scheduled-tasks calendar) can
+ * sort ABOVE it despite its higher `z-index`, bleeding through. Promoting the
+ * overlay (and the content wrapper below, so the panel occludes too) makes the
+ * compositor honor stacking order.
  */
 const ModalOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -131,7 +139,7 @@ const ModalOverlay = React.forwardRef<
     <DialogPrimitive.Overlay
       ref={ref}
       className={cn(
-        'fixed inset-0 z-[var(--z-modal)] bg-black/10 backdrop-blur-[2px]',
+        'fixed inset-0 z-[var(--z-modal)] bg-black/10 backdrop-blur-[2px] [transform:translateZ(0)]',
         ANIMATION_CLASSES,
         className
       )}
@@ -229,7 +237,7 @@ const ModalContent = React.forwardRef<
       <ModalPortal>
         <ModalOverlay />
         <div
-          className='pointer-events-none fixed inset-0 z-[var(--z-modal)] flex items-center justify-center'
+          className='pointer-events-none fixed inset-0 z-[var(--z-modal)] flex items-center justify-center [transform:translateZ(0)]'
           style={
             size === 'full'
               ? undefined

--- a/packages/emcn/src/components/modal/modal.tsx
+++ b/packages/emcn/src/components/modal/modal.tsx
@@ -122,14 +122,6 @@ const ModalClose = DialogPrimitive.Close
  * Modal overlay component with fade transition.
  * Outside interactions are handled by the dialog content so nested poppers can
  * close without also dismissing the modal.
- *
- * `[transform:translateZ(0)]` forces the overlay onto its own compositing layer.
- * A `backdrop-blur` overlay does not reliably paint above page content the
- * browser has already GPU-promoted — `position: sticky` headers and `z-index`ed
- * absolutes inside a scroll container (e.g. the scheduled-tasks calendar) can
- * sort ABOVE it despite its higher `z-index`, bleeding through. Promoting the
- * overlay (and the content wrapper below, so the panel occludes too) makes the
- * compositor honor stacking order.
  */
 const ModalOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -139,7 +131,7 @@ const ModalOverlay = React.forwardRef<
     <DialogPrimitive.Overlay
       ref={ref}
       className={cn(
-        'fixed inset-0 z-[var(--z-modal)] bg-black/10 backdrop-blur-[2px] [transform:translateZ(0)]',
+        'fixed inset-0 z-[var(--z-modal)] bg-black/10 backdrop-blur-[2px]',
         ANIMATION_CLASSES,
         className
       )}
@@ -237,7 +229,7 @@ const ModalContent = React.forwardRef<
       <ModalPortal>
         <ModalOverlay />
         <div
-          className='pointer-events-none fixed inset-0 z-[var(--z-modal)] flex items-center justify-center [transform:translateZ(0)]'
+          className='pointer-events-none fixed inset-0 z-[var(--z-modal)] flex items-center justify-center'
           style={
             size === 'full'
               ? undefined


### PR DESCRIPTION
## Summary
- The shared modal's `backdrop-blur` overlay did not reliably paint above page content the browser had GPU-promoted — `position: sticky` headers and `z-index`ed absolutes inside a scroll container (e.g. the scheduled-tasks calendar's sticky day headers, toolbar chevrons, and event chips). Those composited layers sorted *above* the overlay despite its higher `z-index`, bleeding through the backdrop and over the modal panel.
- Fix: promote both the overlay and the content wrapper to their own compositing layers via `[transform:translateZ(0)]`, so the GPU compositor honors stacking order. Compositing hint only — no layout, spacing, z-index, focus, or event-handling change.
- Not a regression: every ingredient (the blur overlay + the calendar's sticky/z layers) has coexisted since the calendar first shipped (#4979). The emcn extraction touched these files import-only; `modal.tsx` is byte-identical pre/post-move.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Note: this is a GPU-compositor behavior that is hard to reproduce deterministically headless — verified the reasoning via git archaeology and the isolated repro; needs a real-Mac eyeball that (1) the bleed is gone and (2) modal text stays crisp across a couple of modals.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)