### PR TITLE
feat(landing): reintroduce /contact page styled like /demo

### DIFF
--- a/apps/sim/app/(landing)/components/footer/footer.tsx
+++ b/apps/sim/app/(landing)/components/footer/footer.tsx
@@ -43,6 +43,7 @@ const RESOURCES_LINKS: FooterItem[] = [
   { label: 'Partners', href: '/partners' },
   { label: 'Careers', href: 'https://jobs.ashbyhq.com/sim', external: true },
   { label: 'Changelog', href: '/changelog' },
+  { label: 'Contact', href: '/contact' },
 ]
 
 /** Top model providers, sourced from the catalog so labels/hrefs never drift. */

--- a/apps/sim/app/(landing)/contact/components/contact-form/contact-form.tsx
+++ b/apps/sim/app/(landing)/contact/components/contact-form/contact-form.tsx
@@ -144,10 +144,6 @@ export function ContactForm() {
       return
     }
 
-    // Best-effort Turnstile execution: re-run the (invisible) widget on every
-    // submit, including after an expiry, since reset + execute yields a fresh
-    // token. If the widget never loaded or execution fails, the token is omitted
-    // and the server applies its stricter no-captcha rate limit.
     let captchaToken: string | undefined
     const widget = turnstileRef.current
 
@@ -172,9 +168,6 @@ export function ContactForm() {
         onError: () => {
           turnstileRef.current?.reset()
         },
-        // Reset the pre-submit gate only once the mutation settles, so `isBusy`
-        // stays true continuously (the captcha window then `isPending`) and a
-        // second click can never slip through to fire a duplicate request.
         onSettled: () => {
           setIsSubmitting(false)
         },
@@ -224,7 +217,6 @@ export function ContactForm() {
         className='relative mt-5 flex flex-col gap-4'
         noValidate
       >
-        {/* Honeypot */}
         <div
           aria-hidden='true'
           className='pointer-events-none absolute left-[-9999px] h-px w-px overflow-hidden opacity-0'
@@ -333,10 +325,6 @@ export function ContactForm() {
           </p>
         ) : null}
 
-        {/*
-          `Chip` gives its label span `flex-1`; under `fullWidth` that left-aligns the
-          label, so center it with `justify-center` + a `flex-none` span override.
-        */}
         <Chip
           type='submit'
           variant='primary'

--- a/apps/sim/app/(landing)/contact/components/contact-form/contact-form.tsx
+++ b/apps/sim/app/(landing)/contact/components/contact-form/contact-form.tsx
@@ -23,6 +23,9 @@ import { useSubmitContact } from '@/hooks/queries/contact'
  */
 const FIELD_HEIGHT = 'h-[34px]'
 
+/** Build-time-inlined Turnstile site key; absent when captcha isn't configured. */
+const TURNSTILE_SITE_KEY = getEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY')
+
 type ContactField = keyof ContactRequestPayload
 type ContactErrors = Partial<Record<ContactField, string>>
 
@@ -105,8 +108,7 @@ export function ContactForm() {
   const [errors, setErrors] = useState<ContactErrors>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [website, setWebsite] = useState('')
-  const [widgetReady, setWidgetReady] = useState(false)
-  const [turnstileSiteKey] = useState(() => getEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY'))
+  const [widgetLoaded, setWidgetLoaded] = useState(false)
 
   function updateField<TField extends keyof ContactFormState>(
     field: TField,
@@ -142,26 +144,25 @@ export function ContactForm() {
       return
     }
 
+    // Best-effort Turnstile execution: re-run the (invisible) widget on every
+    // submit, including after an expiry, since reset + execute yields a fresh
+    // token. If the widget never loaded or execution fails, the token is omitted
+    // and the server applies its stricter no-captcha rate limit.
     let captchaToken: string | undefined
-    let captchaUnavailable: boolean | undefined
     const widget = turnstileRef.current
 
-    if (turnstileSiteKey) {
-      if (widgetReady && widget) {
-        try {
-          widget.reset()
-          widget.execute()
-          captchaToken = await widget.getResponsePromise(30_000)
-        } catch {
-          captchaUnavailable = true
-        }
-      } else {
-        captchaUnavailable = true
+    if (TURNSTILE_SITE_KEY && widgetLoaded && widget) {
+      try {
+        widget.reset()
+        widget.execute()
+        captchaToken = await widget.getResponsePromise(30_000)
+      } catch {
+        captchaToken = undefined
       }
     }
 
     contactMutation.mutate(
-      { ...parsed.data, website, captchaToken, captchaUnavailable },
+      { ...parsed.data, website, captchaToken },
       {
         onSuccess: () => {
           captureClientEvent('landing_contact_submitted', { topic: parsed.data.topic })
@@ -171,9 +172,14 @@ export function ContactForm() {
         onError: () => {
           turnstileRef.current?.reset()
         },
+        // Reset the pre-submit gate only once the mutation settles, so `isBusy`
+        // stays true continuously (the captcha window then `isPending`) and a
+        // second click can never slip through to fire a duplicate request.
+        onSettled: () => {
+          setIsSubmitting(false)
+        },
       }
     )
-    setIsSubmitting(false)
   }
 
   const isBusy = contactMutation.isPending || isSubmitting
@@ -190,8 +196,7 @@ export function ContactForm() {
         </div>
         <h2 className='mt-5 text-[var(--text-primary)] text-xl leading-[1.2]'>Message received</h2>
         <p className='mt-2 max-w-sm text-[var(--text-muted)] text-sm leading-[1.6]'>
-          Thanks for reaching out. We've sent a confirmation to your inbox and will get back to you
-          shortly.
+          Thanks for reaching out. Our team will get back to you shortly.
         </p>
         <button
           type='button'
@@ -311,15 +316,14 @@ export function ContactForm() {
           />
         </ContactField>
 
-        {turnstileSiteKey ? (
+        {TURNSTILE_SITE_KEY ? (
           <Turnstile
             ref={turnstileRef}
-            siteKey={turnstileSiteKey}
+            siteKey={TURNSTILE_SITE_KEY}
             options={{ execution: 'execute', appearance: 'execute', size: 'invisible' }}
-            onWidgetLoad={() => setWidgetReady(true)}
-            onExpire={() => setWidgetReady(false)}
-            onError={() => setWidgetReady(false)}
-            onUnsupported={() => setWidgetReady(false)}
+            onWidgetLoad={() => setWidgetLoaded(true)}
+            onError={() => setWidgetLoaded(false)}
+            onUnsupported={() => setWidgetLoaded(false)}
           />
         ) : null}
 

--- a/apps/sim/app/(landing)/contact/components/contact-form/contact-form.tsx
+++ b/apps/sim/app/(landing)/contact/components/contact-form/contact-form.tsx
@@ -1,0 +1,349 @@
+'use client'
+
+import { type ReactNode, useId, useRef, useState } from 'react'
+import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
+import { Chip, ChipDropdown, ChipInput, ChipTextarea, Label } from '@sim/emcn'
+import { Check } from '@sim/emcn/icons'
+import { toError } from '@sim/utils/errors'
+import {
+  CONTACT_TOPIC_OPTIONS,
+  type ContactRequestPayload,
+  contactRequestSchema,
+} from '@/lib/api/contracts/contact'
+import { flattenFieldErrors } from '@/lib/api/contracts/primitives'
+import { getEnv } from '@/lib/core/config/env'
+import { captureClientEvent } from '@/lib/posthog/client'
+import { useSubmitContact } from '@/hooks/queries/contact'
+
+/**
+ * Field control height — slightly taller than the 30px in-app chip default and
+ * just under the 36px auth field, so the form reads as a roomy landing surface.
+ * Applied to each control's `className`, the sanctioned way to own only a chip
+ * field's height (mirrors the demo form).
+ */
+const FIELD_HEIGHT = 'h-[34px]'
+
+type ContactField = keyof ContactRequestPayload
+type ContactErrors = Partial<Record<ContactField, string>>
+
+interface ContactFormState {
+  name: string
+  email: string
+  company: string
+  topic: ContactRequestPayload['topic'] | ''
+  subject: string
+  message: string
+}
+
+const INITIAL_STATE: ContactFormState = {
+  name: '',
+  email: '',
+  company: '',
+  topic: '',
+  subject: '',
+  message: '',
+}
+
+interface ContactFieldProps {
+  label: string
+  /** Set for native controls (inputs/textarea) to associate the label by `id`. */
+  htmlFor?: string
+  required?: boolean
+  error?: string
+  /** The control. Dropdowns (no `htmlFor`) are wrapped in a labeled group. */
+  children: ReactNode
+}
+
+/**
+ * A labeled field row matching the chip field rhythm (`gap-[9px]`, muted label,
+ * caption-sized error). Native controls associate via `htmlFor`/`id`; controls
+ * that can't take a label `id` (the dropdown) become a `role='group'` named by
+ * the label instead, so every field has an accessible name.
+ */
+function ContactField({ label, htmlFor, required, error, children }: ContactFieldProps) {
+  const labelId = useId()
+  const isGroup = htmlFor === undefined
+  return (
+    <div
+      className='flex flex-col gap-[9px]'
+      role={isGroup ? 'group' : undefined}
+      aria-labelledby={isGroup ? labelId : undefined}
+    >
+      <Label id={labelId} htmlFor={htmlFor} className='pl-0.5 font-normal text-[var(--text-muted)]'>
+        {label}
+        {required ? (
+          <span aria-hidden className='ml-0.5 text-[var(--text-error)]'>
+            *
+          </span>
+        ) : null}
+      </Label>
+      {children}
+      {error ? <p className='pl-0.5 text-[var(--text-error)] text-caption'>{error}</p> : null}
+    </div>
+  )
+}
+
+/**
+ * The `/contact` form — rendered inside the card chrome owned by the page, so it
+ * returns just its heading and fields. Fields are hand-composed at the slightly
+ * taller {@link FIELD_HEIGHT}, stacked at the platform `gap-4` rhythm with no
+ * divider lines, mirroring the demo booking form.
+ *
+ * On submit it validates against the shared {@link contactRequestSchema}, runs an
+ * invisible Turnstile challenge (falling back gracefully when the widget is
+ * unavailable), and posts through {@link useSubmitContact}, which emails the help
+ * inbox and sends the visitor a confirmation. A honeypot `website` field and the
+ * captcha token ride along on the payload. A successful submit swaps the card to a
+ * confirmation state.
+ */
+export function ContactForm() {
+  const turnstileRef = useRef<TurnstileInstance>(null)
+
+  const contactMutation = useSubmitContact()
+
+  const [form, setForm] = useState<ContactFormState>(INITIAL_STATE)
+  const [errors, setErrors] = useState<ContactErrors>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [website, setWebsite] = useState('')
+  const [widgetReady, setWidgetReady] = useState(false)
+  const [turnstileSiteKey] = useState(() => getEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY'))
+
+  function updateField<TField extends keyof ContactFormState>(
+    field: TField,
+    value: ContactFormState[TField]
+  ) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    setErrors((prev) => {
+      if (!prev[field as ContactField]) {
+        return prev
+      }
+      const nextErrors = { ...prev }
+      delete nextErrors[field as ContactField]
+      return nextErrors
+    })
+    if (contactMutation.isError) {
+      contactMutation.reset()
+    }
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (contactMutation.isPending || isSubmitting) return
+    setIsSubmitting(true)
+
+    const parsed = contactRequestSchema.safeParse({
+      ...form,
+      company: form.company || undefined,
+    })
+
+    if (!parsed.success) {
+      setErrors(flattenFieldErrors<ContactField>(parsed.error))
+      setIsSubmitting(false)
+      return
+    }
+
+    let captchaToken: string | undefined
+    let captchaUnavailable: boolean | undefined
+    const widget = turnstileRef.current
+
+    if (turnstileSiteKey) {
+      if (widgetReady && widget) {
+        try {
+          widget.reset()
+          widget.execute()
+          captchaToken = await widget.getResponsePromise(30_000)
+        } catch {
+          captchaUnavailable = true
+        }
+      } else {
+        captchaUnavailable = true
+      }
+    }
+
+    contactMutation.mutate(
+      { ...parsed.data, website, captchaToken, captchaUnavailable },
+      {
+        onSuccess: () => {
+          captureClientEvent('landing_contact_submitted', { topic: parsed.data.topic })
+          setForm(INITIAL_STATE)
+          setErrors({})
+        },
+        onError: () => {
+          turnstileRef.current?.reset()
+        },
+      }
+    )
+    setIsSubmitting(false)
+  }
+
+  const isBusy = contactMutation.isPending || isSubmitting
+
+  const submitError = contactMutation.isError
+    ? toError(contactMutation.error).message || 'Failed to send message. Please try again.'
+    : null
+
+  if (contactMutation.isSuccess) {
+    return (
+      <div className='flex flex-col items-center px-4 py-12 text-center'>
+        <div className='flex size-14 items-center justify-center rounded-full border border-[var(--border-1)] bg-[var(--surface-1)] text-[var(--text-primary)]'>
+          <Check className='size-7' />
+        </div>
+        <h2 className='mt-5 text-[var(--text-primary)] text-xl leading-[1.2]'>Message received</h2>
+        <p className='mt-2 max-w-sm text-[var(--text-muted)] text-sm leading-[1.6]'>
+          Thanks for reaching out. We've sent a confirmation to your inbox and will get back to you
+          shortly.
+        </p>
+        <button
+          type='button'
+          onClick={() => contactMutation.reset()}
+          className='mt-5 text-[var(--text-primary)] text-small underline underline-offset-2 transition-opacity hover:opacity-80'
+        >
+          Send another message
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <h2 id='contact-form-heading' className='text-[var(--text-primary)] text-xl leading-[1.2]'>
+        Send us a message
+      </h2>
+      <p className='mt-1.5 text-[var(--text-muted)] text-sm'>
+        Ask a question, request an integration, or get help — we'll get back to you shortly.
+      </p>
+
+      <form
+        onSubmit={handleSubmit}
+        aria-labelledby='contact-form-heading'
+        className='relative mt-5 flex flex-col gap-4'
+        noValidate
+      >
+        {/* Honeypot */}
+        <div
+          aria-hidden='true'
+          className='pointer-events-none absolute left-[-9999px] h-px w-px overflow-hidden opacity-0'
+        >
+          <label htmlFor='contact-website'>Website</label>
+          <input
+            id='contact-website'
+            name='website'
+            type='text'
+            tabIndex={-1}
+            autoComplete='off'
+            value={website}
+            onChange={(event) => setWebsite(event.target.value)}
+            data-lpignore='true'
+            data-1p-ignore='true'
+          />
+        </div>
+
+        <div className='grid grid-cols-2 gap-3 max-sm:grid-cols-1'>
+          <ContactField label='Name' htmlFor='contact-name' required error={errors.name}>
+            <ChipInput
+              id='contact-name'
+              className={FIELD_HEIGHT}
+              value={form.name}
+              onChange={(event) => updateField('name', event.target.value)}
+              error={Boolean(errors.name)}
+              placeholder='Jane Doe'
+              autoComplete='name'
+            />
+          </ContactField>
+          <ContactField label='Email' htmlFor='contact-email' required error={errors.email}>
+            <ChipInput
+              id='contact-email'
+              type='email'
+              className={FIELD_HEIGHT}
+              value={form.email}
+              onChange={(event) => updateField('email', event.target.value)}
+              error={Boolean(errors.email)}
+              placeholder='jane@acme.co'
+              autoComplete='email'
+            />
+          </ContactField>
+        </div>
+
+        <div className='grid grid-cols-2 gap-3 max-sm:grid-cols-1'>
+          <ContactField label='Company (optional)' htmlFor='contact-company' error={errors.company}>
+            <ChipInput
+              id='contact-company'
+              className={FIELD_HEIGHT}
+              value={form.company}
+              onChange={(event) => updateField('company', event.target.value)}
+              error={Boolean(errors.company)}
+              placeholder='Acme Inc.'
+              autoComplete='organization'
+            />
+          </ContactField>
+          <ContactField label='Topic' required error={errors.topic}>
+            <ChipDropdown
+              fullWidth
+              flush
+              className={FIELD_HEIGHT}
+              value={form.topic || undefined}
+              onChange={(value) => updateField('topic', value as ContactRequestPayload['topic'])}
+              options={CONTACT_TOPIC_OPTIONS}
+              placeholder='Select a topic'
+            />
+          </ContactField>
+        </div>
+
+        <ContactField label='Subject' htmlFor='contact-subject' required error={errors.subject}>
+          <ChipInput
+            id='contact-subject'
+            className={FIELD_HEIGHT}
+            value={form.subject}
+            onChange={(event) => updateField('subject', event.target.value)}
+            error={Boolean(errors.subject)}
+            placeholder='How can we help?'
+          />
+        </ContactField>
+
+        <ContactField label='Message' htmlFor='contact-message' required error={errors.message}>
+          <ChipTextarea
+            id='contact-message'
+            value={form.message}
+            onChange={(event) => updateField('message', event.target.value)}
+            error={Boolean(errors.message)}
+            placeholder='Share details so we can help as quickly as possible.'
+            rows={4}
+          />
+        </ContactField>
+
+        {turnstileSiteKey ? (
+          <Turnstile
+            ref={turnstileRef}
+            siteKey={turnstileSiteKey}
+            options={{ execution: 'execute', appearance: 'execute', size: 'invisible' }}
+            onWidgetLoad={() => setWidgetReady(true)}
+            onExpire={() => setWidgetReady(false)}
+            onError={() => setWidgetReady(false)}
+            onUnsupported={() => setWidgetReady(false)}
+          />
+        ) : null}
+
+        {submitError ? (
+          <p role='alert' className='text-[var(--text-error)] text-caption'>
+            {submitError}
+          </p>
+        ) : null}
+
+        {/*
+          `Chip` gives its label span `flex-1`; under `fullWidth` that left-aligns the
+          label, so center it with `justify-center` + a `flex-none` span override.
+        */}
+        <Chip
+          type='submit'
+          variant='primary'
+          flush
+          fullWidth
+          disabled={isBusy}
+          className='mt-1 justify-center [&>span]:flex-none'
+        >
+          {isBusy ? 'Sending…' : 'Send message'}
+        </Chip>
+      </form>
+    </>
+  )
+}

--- a/apps/sim/app/(landing)/contact/components/contact-form/index.ts
+++ b/apps/sim/app/(landing)/contact/components/contact-form/index.ts
@@ -1,0 +1,1 @@
+export { ContactForm } from './contact-form'

--- a/apps/sim/app/(landing)/contact/contact.tsx
+++ b/apps/sim/app/(landing)/contact/contact.tsx
@@ -1,0 +1,75 @@
+import { chipBorderShadowRing, cn } from '@sim/emcn'
+import { TrustedBy } from '@/app/(landing)/components/trusted-by'
+import { ContactForm } from '@/app/(landing)/contact/components/contact-form'
+
+/**
+ * Contact page — mirrors the demo page's two-column split: value proposition and
+ * customer proof on the left, the message form in a content-height card on the
+ * right.
+ *
+ * The section is a two-column CSS grid capped and centered at the shared
+ * `max-w-[1446px]` with the navbar-aligned `px-12` gutter, so the headline starts
+ * on the same vertical line as the wordmark. The desktop split is `xl:grid-cols-2`
+ * with `xl:gap-x-0` — the columns split at the exact horizontal center, so the
+ * right card occupies the same rectangle as the hero's right panel. The card is
+ * inset from the section's top and bottom by 32px (`xl:pt-8`/`xl:pb-8`), spans both
+ * rows (`xl:row-span-2`), and its content drives the column height — the left
+ * column stretches to match, bottom-anchoring the logos to the card's lower edge.
+ *
+ * Three grid children, ordered in the DOM as headline → form → logos so the
+ * COLLAPSE below `xl` (single column) yields the best mobile reading order: value
+ * proposition first, the form immediately after it, then the customer logos as
+ * reinforcing social proof. On desktop the headline cell adds `xl:pt-[80px]` so its
+ * text sits on the hero's line, while the card top stays on the higher `top-8`
+ * line. The customer proof reuses the shared {@link TrustedBy} block,
+ * bottom-anchored (`xl:row-start-2 xl:self-end`). The gutter follows the navbar
+ * convention (`px-12 max-lg:px-8 max-sm:px-5`), and `max-sm` drops to the smallest
+ * type scale.
+ *
+ * Carries an sr-only product summary for AI citation (landing CLAUDE.md → GEO).
+ */
+export default function Contact() {
+  return (
+    <main id='main-content'>
+      <section
+        id='contact'
+        aria-labelledby='contact-heading'
+        className='mx-auto grid w-full max-w-[1446px] grid-cols-1 gap-y-10 px-12 pt-20 pb-24 max-sm:gap-y-8 max-sm:px-5 max-sm:pt-16 max-sm:pb-16 max-lg:px-8 xl:grid-cols-2 xl:grid-rows-[auto_1fr] xl:gap-x-0 xl:pt-8 xl:pb-8'
+      >
+        <div className='flex flex-col gap-5 xl:col-start-1 xl:row-start-1 xl:self-start xl:pt-[80px]'>
+          <p className='sr-only'>
+            Get in touch with Sim, the open-source AI workspace where teams build, deploy, and
+            manage AI agents and workflows. Ask a question, request an integration, or get help from
+            the team — send a message and we'll get back to you shortly.
+          </p>
+
+          <h1
+            id='contact-heading'
+            className='text-balance text-[48px] text-[var(--text-primary)] leading-[1.1] max-sm:text-[32px] max-xl:text-wrap max-xl:text-[40px] [&>br]:max-xl:hidden'
+          >
+            Get in touch with Sim, <br />
+            the AI agent workspace.
+          </h1>
+          <p className='max-w-[46ch] text-pretty text-[var(--text-body)] text-lg leading-[1.5] max-sm:text-base'>
+            Ask a question, request an integration, or get help from the team. Tell us what you need
+            and we'll get back to you shortly.
+          </p>
+        </div>
+
+        <div
+          className={cn(
+            'relative min-w-0 overflow-hidden rounded-lg bg-[var(--surface-2)]',
+            chipBorderShadowRing,
+            'xl:col-start-2 xl:row-span-2 xl:row-start-1'
+          )}
+        >
+          <div className='p-6 max-sm:p-5'>
+            <ContactForm />
+          </div>
+        </div>
+
+        <TrustedBy className='xl:col-start-1 xl:row-start-2 xl:self-end' />
+      </section>
+    </main>
+  )
+}

--- a/apps/sim/app/(landing)/contact/page.tsx
+++ b/apps/sim/app/(landing)/contact/page.tsx
@@ -1,0 +1,18 @@
+import { buildLandingMetadata } from '@/lib/landing/seo'
+import Contact from '@/app/(landing)/contact/contact'
+
+export const revalidate = 3600
+
+const TITLE = 'Contact Us | Sim, the AI Workspace'
+const DESCRIPTION =
+  'Get in touch with Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Ask a question, request an integration, or get help from the team.'
+
+export const metadata = buildLandingMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: '/contact',
+})
+
+export default function Page() {
+  return <Contact />
+}

--- a/apps/sim/app/api/contact/route.ts
+++ b/apps/sim/app/api/contact/route.ts
@@ -34,6 +34,7 @@ const CAPTCHA_UNAVAILABLE_RATE_LIMIT: TokenBucketConfig = {
 }
 
 const SUCCESS_RESPONSE = { success: true, message: "Thanks — we'll be in touch soon." }
+const TOO_MANY_REQUESTS_RESPONSE = { error: 'Too many requests. Please try again later.' }
 
 export const POST = withRouteHandler(async (req: NextRequest) => {
   const requestId = generateRequestId()
@@ -49,13 +50,10 @@ export const POST = withRouteHandler(async (req: NextRequest) => {
 
     if (!allowed) {
       logger.warn(`[${requestId}] Rate limit exceeded for IP ${ip}`, { remaining, resetAt })
-      return NextResponse.json(
-        { error: 'Too many requests. Please try again later.' },
-        {
-          status: 429,
-          headers: { 'Retry-After': String(Math.ceil((resetAt.getTime() - Date.now()) / 1000)) },
-        }
-      )
+      return NextResponse.json(TOO_MANY_REQUESTS_RESPONSE, {
+        status: 429,
+        headers: { 'Retry-After': String(Math.ceil((resetAt.getTime() - Date.now()) / 1000)) },
+      })
     }
 
     const parsed = await parseRequest(submitContactContract, req, {})
@@ -72,56 +70,51 @@ export const POST = withRouteHandler(async (req: NextRequest) => {
       return NextResponse.json(SUCCESS_RESPONSE, { status: 201 })
     }
 
-    const captchaUnavailable = parsed.data.body.captchaUnavailable === true
+    // Captcha is server-authoritative: a valid Turnstile token is the only way to
+    // skip the stricter fallback bucket. A missing token (widget could not load) or
+    // a Cloudflare transport error falls back to the tighter no-captcha rate limit
+    // rather than a free pass, so callers cannot opt out of the challenge. An
+    // outright invalid token is rejected.
+    if (isTurnstileConfigured()) {
+      let captchaVerified = false
+      const token =
+        typeof captchaToken === 'string' && captchaToken.length > 0 ? captchaToken : null
 
-    if (captchaUnavailable) {
-      const nocaptchaKey = `public:contact:nocaptcha:${ip}`
-      const { allowed: nocaptchaAllowed } = await rateLimiter.checkRateLimitDirect(
-        nocaptchaKey,
-        CAPTCHA_UNAVAILABLE_RATE_LIMIT
-      )
-      if (!nocaptchaAllowed) {
-        logger.warn(`[${requestId}] Rate limit exceeded (no-captcha) for IP ${ip}`)
-        return NextResponse.json(
-          { error: 'Too many requests. Please try again later.' },
-          { status: 429 }
-        )
+      if (token) {
+        const verification = await verifyTurnstileToken({
+          token,
+          remoteIp: ip,
+          expectedHostname: SITE_HOSTNAME,
+        })
+        if (verification.success) {
+          captchaVerified = true
+        } else if (!verification.transportError) {
+          logger.warn(`[${requestId}] Captcha verification failed`, {
+            ip,
+            errorCodes: verification.errorCodes,
+          })
+          return NextResponse.json(
+            { error: 'Captcha verification failed. Please try again.' },
+            { status: 400 }
+          )
+        } else {
+          logger.warn(
+            `[${requestId}] Captcha transport error, falling back to no-captcha rate limit`,
+            { ip }
+          )
+        }
       }
-    }
 
-    if (isTurnstileConfigured() && !captchaUnavailable) {
-      const token = typeof captchaToken === 'string' ? captchaToken : null
-      const verification = await verifyTurnstileToken({
-        token,
-        remoteIp: ip,
-        expectedHostname: SITE_HOSTNAME,
-      })
-      if (!verification.success && verification.transportError) {
-        logger.warn(
-          `[${requestId}] Captcha transport error, falling back to no-captcha rate limit`,
-          { ip }
-        )
+      if (!captchaVerified) {
         const nocaptchaKey = `public:contact:nocaptcha:${ip}`
         const { allowed: nocaptchaAllowed } = await rateLimiter.checkRateLimitDirect(
           nocaptchaKey,
           CAPTCHA_UNAVAILABLE_RATE_LIMIT
         )
         if (!nocaptchaAllowed) {
-          logger.warn(`[${requestId}] Rate limit exceeded (transport-error fallback) for IP ${ip}`)
-          return NextResponse.json(
-            { error: 'Too many requests. Please try again later.' },
-            { status: 429 }
-          )
+          logger.warn(`[${requestId}] Rate limit exceeded (no-captcha) for IP ${ip}`)
+          return NextResponse.json(TOO_MANY_REQUESTS_RESPONSE, { status: 429 })
         }
-      } else if (!verification.success) {
-        logger.warn(`[${requestId}] Captcha verification failed`, {
-          ip,
-          errorCodes: verification.errorCodes,
-        })
-        return NextResponse.json(
-          { error: 'Captcha verification failed. Please try again.' },
-          { status: 400 }
-        )
       }
     }
 

--- a/apps/sim/app/api/contact/route.ts
+++ b/apps/sim/app/api/contact/route.ts
@@ -35,6 +35,20 @@ const CAPTCHA_UNAVAILABLE_RATE_LIMIT: TokenBucketConfig = {
 const SUCCESS_RESPONSE = { success: true, message: "Thanks — we'll be in touch soon." }
 const TOO_MANY_REQUESTS_RESPONSE = { error: 'Too many requests. Please try again later.' }
 
+/**
+ * Public contact-form endpoint: per-IP rate limit, honeypot drop, captcha, then a
+ * help-inbox notification plus a best-effort visitor confirmation.
+ *
+ * Captcha is server-authoritative — a valid Turnstile token is the only way past
+ * the stricter fallback bucket, so a caller cannot opt out of the challenge. A
+ * missing token (widget could not load) or a Cloudflare transport error falls
+ * back to the tighter no-captcha bucket rather than a free pass; an outright
+ * invalid token is rejected. That backstop is enforced `failClosed`, so an
+ * unavailable limiter rejects token-less submits instead of admitting them. No
+ * `expectedHostname` is pinned: the site key is already domain-bound in
+ * Cloudflare, and a single-host pin would reject valid self-hosted/preview/apex
+ * tokens.
+ */
 export const POST = withRouteHandler(async (req: NextRequest) => {
   const requestId = generateRequestId()
 
@@ -69,20 +83,12 @@ export const POST = withRouteHandler(async (req: NextRequest) => {
       return NextResponse.json(SUCCESS_RESPONSE, { status: 201 })
     }
 
-    // Captcha is server-authoritative: a valid Turnstile token is the only way to
-    // skip the stricter fallback bucket. A missing token (widget could not load) or
-    // a Cloudflare transport error falls back to the tighter no-captcha rate limit
-    // rather than a free pass, so callers cannot opt out of the challenge. An
-    // outright invalid token is rejected.
     if (isTurnstileConfigured()) {
       let captchaVerified = false
       const token =
         typeof captchaToken === 'string' && captchaToken.length > 0 ? captchaToken : null
 
       if (token) {
-        // No expectedHostname: the Turnstile site key is already domain-bound in
-        // Cloudflare, and pinning a single hostname here would reject valid tokens
-        // from self-hosted, preview, and apex-vs-www deployments.
         const verification = await verifyTurnstileToken({ token, remoteIp: ip })
         if (verification.success) {
           captchaVerified = true
@@ -104,9 +110,6 @@ export const POST = withRouteHandler(async (req: NextRequest) => {
       }
 
       if (!captchaVerified) {
-        // Fail closed: this bucket is the only throttle on token-less submits, so
-        // if the limiter storage is unavailable we reject rather than admit an
-        // uncaptcha'd request to the email path.
         const nocaptchaKey = `public:contact:nocaptcha:${ip}`
         const { allowed: nocaptchaAllowed } = await rateLimiter.checkRateLimitDirect(
           nocaptchaKey,

--- a/apps/sim/app/api/contact/route.ts
+++ b/apps/sim/app/api/contact/route.ts
@@ -104,13 +104,17 @@ export const POST = withRouteHandler(async (req: NextRequest) => {
       }
 
       if (!captchaVerified) {
+        // Fail closed: this bucket is the only throttle on token-less submits, so
+        // if the limiter storage is unavailable we reject rather than admit an
+        // uncaptcha'd request to the email path.
         const nocaptchaKey = `public:contact:nocaptcha:${ip}`
         const { allowed: nocaptchaAllowed } = await rateLimiter.checkRateLimitDirect(
           nocaptchaKey,
-          CAPTCHA_UNAVAILABLE_RATE_LIMIT
+          CAPTCHA_UNAVAILABLE_RATE_LIMIT,
+          { failClosed: true }
         )
         if (!nocaptchaAllowed) {
-          logger.warn(`[${requestId}] Rate limit exceeded (no-captcha) for IP ${ip}`)
+          logger.warn(`[${requestId}] Rate limit rejected (no-captcha) for IP ${ip}`)
           return NextResponse.json(TOO_MANY_REQUESTS_RESPONSE, { status: 429 })
         }
       }

--- a/apps/sim/app/api/contact/route.ts
+++ b/apps/sim/app/api/contact/route.ts
@@ -12,14 +12,13 @@ import type { TokenBucketConfig } from '@/lib/core/rate-limiter'
 import { RateLimiter } from '@/lib/core/rate-limiter'
 import { isTurnstileConfigured, verifyTurnstileToken } from '@/lib/core/security/turnstile'
 import { generateRequestId, getClientIp } from '@/lib/core/utils/request'
-import { getEmailDomain, SITE_URL } from '@/lib/core/utils/urls'
+import { getEmailDomain } from '@/lib/core/utils/urls'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { sendEmail } from '@/lib/messaging/email/mailer'
 import { getFromEmailAddress } from '@/lib/messaging/email/utils'
 
 const logger = createLogger('ContactAPI')
 const rateLimiter = new RateLimiter()
-const SITE_HOSTNAME = new URL(SITE_URL).hostname
 
 const PUBLIC_ENDPOINT_RATE_LIMIT: TokenBucketConfig = {
   maxTokens: 10,
@@ -81,11 +80,10 @@ export const POST = withRouteHandler(async (req: NextRequest) => {
         typeof captchaToken === 'string' && captchaToken.length > 0 ? captchaToken : null
 
       if (token) {
-        const verification = await verifyTurnstileToken({
-          token,
-          remoteIp: ip,
-          expectedHostname: SITE_HOSTNAME,
-        })
+        // No expectedHostname: the Turnstile site key is already domain-bound in
+        // Cloudflare, and pinning a single hostname here would reject valid tokens
+        // from self-hosted, preview, and apex-vs-www deployments.
+        const verification = await verifyTurnstileToken({ token, remoteIp: ip })
         if (verification.success) {
           captchaVerified = true
         } else if (!verification.transportError) {

--- a/apps/sim/app/api/contact/route.ts
+++ b/apps/sim/app/api/contact/route.ts
@@ -1,0 +1,193 @@
+import { createLogger } from '@sim/logger'
+import { type NextRequest, NextResponse } from 'next/server'
+import { renderHelpConfirmationEmail } from '@/components/emails'
+import {
+  getContactTopicLabel,
+  mapContactTopicToHelpType,
+  submitContactContract,
+} from '@/lib/api/contracts/contact'
+import { parseRequest } from '@/lib/api/server'
+import { env } from '@/lib/core/config/env'
+import type { TokenBucketConfig } from '@/lib/core/rate-limiter'
+import { RateLimiter } from '@/lib/core/rate-limiter'
+import { isTurnstileConfigured, verifyTurnstileToken } from '@/lib/core/security/turnstile'
+import { generateRequestId, getClientIp } from '@/lib/core/utils/request'
+import { getEmailDomain, SITE_URL } from '@/lib/core/utils/urls'
+import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { sendEmail } from '@/lib/messaging/email/mailer'
+import { getFromEmailAddress } from '@/lib/messaging/email/utils'
+
+const logger = createLogger('ContactAPI')
+const rateLimiter = new RateLimiter()
+const SITE_HOSTNAME = new URL(SITE_URL).hostname
+
+const PUBLIC_ENDPOINT_RATE_LIMIT: TokenBucketConfig = {
+  maxTokens: 10,
+  refillRate: 5,
+  refillIntervalMs: 60_000,
+}
+
+const CAPTCHA_UNAVAILABLE_RATE_LIMIT: TokenBucketConfig = {
+  maxTokens: 3,
+  refillRate: 1,
+  refillIntervalMs: 60_000,
+}
+
+const SUCCESS_RESPONSE = { success: true, message: "Thanks — we'll be in touch soon." }
+
+export const POST = withRouteHandler(async (req: NextRequest) => {
+  const requestId = generateRequestId()
+
+  try {
+    const ip = getClientIp(req)
+    const storageKey = `public:contact:${ip}`
+
+    const { allowed, remaining, resetAt } = await rateLimiter.checkRateLimitDirect(
+      storageKey,
+      PUBLIC_ENDPOINT_RATE_LIMIT
+    )
+
+    if (!allowed) {
+      logger.warn(`[${requestId}] Rate limit exceeded for IP ${ip}`, { remaining, resetAt })
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(Math.ceil((resetAt.getTime() - Date.now()) / 1000)) },
+        }
+      )
+    }
+
+    const parsed = await parseRequest(submitContactContract, req, {})
+    if (!parsed.success) {
+      logger.warn(`[${requestId}] Invalid contact request data`)
+      return parsed.response
+    }
+
+    const { name, email, company, topic, subject, message, website, captchaToken } =
+      parsed.data.body
+
+    if (typeof website === 'string' && website.trim().length > 0) {
+      logger.warn(`[${requestId}] Honeypot triggered, discarding`, { ip })
+      return NextResponse.json(SUCCESS_RESPONSE, { status: 201 })
+    }
+
+    const captchaUnavailable = parsed.data.body.captchaUnavailable === true
+
+    if (captchaUnavailable) {
+      const nocaptchaKey = `public:contact:nocaptcha:${ip}`
+      const { allowed: nocaptchaAllowed } = await rateLimiter.checkRateLimitDirect(
+        nocaptchaKey,
+        CAPTCHA_UNAVAILABLE_RATE_LIMIT
+      )
+      if (!nocaptchaAllowed) {
+        logger.warn(`[${requestId}] Rate limit exceeded (no-captcha) for IP ${ip}`)
+        return NextResponse.json(
+          { error: 'Too many requests. Please try again later.' },
+          { status: 429 }
+        )
+      }
+    }
+
+    if (isTurnstileConfigured() && !captchaUnavailable) {
+      const token = typeof captchaToken === 'string' ? captchaToken : null
+      const verification = await verifyTurnstileToken({
+        token,
+        remoteIp: ip,
+        expectedHostname: SITE_HOSTNAME,
+      })
+      if (!verification.success && verification.transportError) {
+        logger.warn(
+          `[${requestId}] Captcha transport error, falling back to no-captcha rate limit`,
+          { ip }
+        )
+        const nocaptchaKey = `public:contact:nocaptcha:${ip}`
+        const { allowed: nocaptchaAllowed } = await rateLimiter.checkRateLimitDirect(
+          nocaptchaKey,
+          CAPTCHA_UNAVAILABLE_RATE_LIMIT
+        )
+        if (!nocaptchaAllowed) {
+          logger.warn(`[${requestId}] Rate limit exceeded (transport-error fallback) for IP ${ip}`)
+          return NextResponse.json(
+            { error: 'Too many requests. Please try again later.' },
+            { status: 429 }
+          )
+        }
+      } else if (!verification.success) {
+        logger.warn(`[${requestId}] Captcha verification failed`, {
+          ip,
+          errorCodes: verification.errorCodes,
+        })
+        return NextResponse.json(
+          { error: 'Captcha verification failed. Please try again.' },
+          { status: 400 }
+        )
+      }
+    }
+
+    const topicLabel = getContactTopicLabel(topic)
+
+    logger.info(`[${requestId}] Processing contact request`, {
+      email: `${email.substring(0, 3)}***`,
+      topic,
+    })
+
+    const emailText = `Contact form submission
+Submitted: ${new Date().toISOString()}
+Topic: ${topicLabel}
+Name: ${name}
+Email: ${email}
+Company: ${company ?? 'Not provided'}
+
+Subject: ${subject}
+
+Message:
+${message}
+`
+
+    const helpInboxDomain = env.EMAIL_DOMAIN || getEmailDomain()
+    const emailResult = await sendEmail({
+      to: [`help@${helpInboxDomain}`],
+      subject: `[CONTACT:${topic.toUpperCase()}] ${subject}`,
+      text: emailText,
+      from: getFromEmailAddress(),
+      replyTo: email,
+      emailType: 'transactional',
+    })
+
+    if (!emailResult.success) {
+      logger.error(`[${requestId}] Error sending contact request email`, emailResult.message)
+      return NextResponse.json({ error: 'Failed to send message' }, { status: 500 })
+    }
+
+    logger.info(`[${requestId}] Contact request email sent successfully`)
+
+    try {
+      const confirmationHtml = await renderHelpConfirmationEmail(
+        mapContactTopicToHelpType(topic),
+        0
+      )
+
+      await sendEmail({
+        to: [email],
+        subject: `We've received your message: ${subject}`,
+        html: confirmationHtml,
+        from: getFromEmailAddress(),
+        replyTo: `help@${helpInboxDomain}`,
+        emailType: 'transactional',
+      })
+    } catch (err) {
+      logger.warn(`[${requestId}] Failed to send contact confirmation email`, err)
+    }
+
+    return NextResponse.json(SUCCESS_RESPONSE, { status: 201 })
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('not configured')) {
+      logger.error(`[${requestId}] Email service configuration error`, error)
+      return NextResponse.json({ error: 'Email service configuration error.' }, { status: 500 })
+    }
+
+    logger.error(`[${requestId}] Error processing contact request`, error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+})

--- a/apps/sim/app/sitemap.ts
+++ b/apps/sim/app/sitemap.ts
@@ -43,6 +43,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${baseUrl}/demo`,
     },
     {
+      url: `${baseUrl}/contact`,
+    },
+    {
       url: `${baseUrl}/enterprise`,
     },
     {

--- a/apps/sim/hooks/queries/contact.ts
+++ b/apps/sim/hooks/queries/contact.ts
@@ -1,0 +1,25 @@
+import { createLogger } from '@sim/logger'
+import { useMutation } from '@tanstack/react-query'
+import { requestJson } from '@/lib/api/client/request'
+import {
+  type SubmitContactBody,
+  type SubmitContactResult,
+  submitContactContract,
+} from '@/lib/api/contracts/contact'
+
+const logger = createLogger('ContactMutation')
+
+/**
+ * Submit an inbound contact request. The route emails the help inbox (replying to
+ * the visitor) and sends the visitor a confirmation. Used by the public `/contact`
+ * form; the honeypot and captcha fields ride along on the same payload.
+ */
+export function useSubmitContact() {
+  return useMutation({
+    mutationFn: (variables: SubmitContactBody): Promise<SubmitContactResult> =>
+      requestJson(submitContactContract, { body: variables }),
+    onError: (error) => {
+      logger.error('Failed to submit contact request:', error)
+    },
+  })
+}

--- a/apps/sim/lib/api/contracts/contact.ts
+++ b/apps/sim/lib/api/contracts/contact.ts
@@ -68,7 +68,6 @@ export type ContactRequestBody = z.input<typeof contactRequestSchema>
 export const submitContactBodySchema = contactRequestSchema.extend({
   website: z.string().optional(),
   captchaToken: z.string().optional(),
-  captchaUnavailable: z.boolean().optional(),
 })
 
 export function getContactTopicLabel(value: ContactRequestPayload['topic']): string {
@@ -77,17 +76,14 @@ export function getContactTopicLabel(value: ContactRequestPayload['topic']): str
 
 export type HelpEmailType = 'bug' | 'feedback' | 'feature_request' | 'other'
 
+/**
+ * Map a contact topic to the confirmation-email type. Only `feature_request` has
+ * a matching email label ("Feature Request"); every other topic — support, sales,
+ * billing, etc. — resolves to `other` ("General Inquiry") so the confirmation copy
+ * never mislabels the request (e.g. calling a support inquiry a "bug report").
+ */
 export function mapContactTopicToHelpType(topic: ContactRequestPayload['topic']): HelpEmailType {
-  switch (topic) {
-    case 'feature_request':
-      return 'feature_request'
-    case 'support':
-      return 'bug'
-    case 'integration':
-      return 'feedback'
-    default:
-      return 'other'
-  }
+  return topic === 'feature_request' ? 'feature_request' : 'other'
 }
 
 export const contactResponseSchema = z.object({

--- a/apps/sim/lib/api/contracts/contact.ts
+++ b/apps/sim/lib/api/contracts/contact.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod'
+import type { ContractBodyInput } from '@/lib/api/contracts/types'
+import { defineRouteContract } from '@/lib/api/contracts/types'
+import { NO_EMAIL_HEADER_CONTROL_CHARS_REGEX } from '@/lib/messaging/email/utils'
+import { quickValidateEmail } from '@/lib/messaging/email/validation'
+
+export const CONTACT_TOPIC_VALUES = [
+  'general',
+  'support',
+  'integration',
+  'feature_request',
+  'sales',
+  'partnership',
+  'billing',
+  'other',
+] as const
+
+export const CONTACT_TOPIC_OPTIONS = [
+  { value: 'general', label: 'General question' },
+  { value: 'support', label: 'Technical support' },
+  { value: 'integration', label: 'Integration request' },
+  { value: 'feature_request', label: 'Feature request' },
+  { value: 'sales', label: 'Sales & pricing' },
+  { value: 'partnership', label: 'Partnership' },
+  { value: 'billing', label: 'Billing' },
+  { value: 'other', label: 'Other' },
+] as const
+
+export const contactRequestSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Name is required')
+    .max(120, 'Name must be 120 characters or less')
+    .regex(NO_EMAIL_HEADER_CONTROL_CHARS_REGEX, 'Invalid characters'),
+  email: z
+    .string()
+    .trim()
+    .min(1, 'Email is required')
+    .max(320)
+    .transform((value) => value.toLowerCase())
+    .refine((value) => quickValidateEmail(value).isValid, 'Enter a valid email'),
+  company: z
+    .string()
+    .trim()
+    .max(120, 'Company must be 120 characters or less')
+    .optional()
+    .transform((value) => (value && value.length > 0 ? value : undefined)),
+  topic: z.enum(CONTACT_TOPIC_VALUES, {
+    error: 'Please select a topic',
+  }),
+  subject: z
+    .string()
+    .trim()
+    .min(1, 'Subject is required')
+    .max(200, 'Subject must be 200 characters or less')
+    .regex(NO_EMAIL_HEADER_CONTROL_CHARS_REGEX, 'Invalid characters'),
+  message: z
+    .string()
+    .trim()
+    .min(1, 'Message is required')
+    .max(5000, 'Message must be 5,000 characters or less'),
+})
+
+export type ContactRequestPayload = z.infer<typeof contactRequestSchema>
+export type ContactRequestBody = z.input<typeof contactRequestSchema>
+
+export const submitContactBodySchema = contactRequestSchema.extend({
+  website: z.string().optional(),
+  captchaToken: z.string().optional(),
+  captchaUnavailable: z.boolean().optional(),
+})
+
+export function getContactTopicLabel(value: ContactRequestPayload['topic']): string {
+  return CONTACT_TOPIC_OPTIONS.find((option) => option.value === value)?.label ?? value
+}
+
+export type HelpEmailType = 'bug' | 'feedback' | 'feature_request' | 'other'
+
+export function mapContactTopicToHelpType(topic: ContactRequestPayload['topic']): HelpEmailType {
+  switch (topic) {
+    case 'feature_request':
+      return 'feature_request'
+    case 'support':
+      return 'bug'
+    case 'integration':
+      return 'feedback'
+    default:
+      return 'other'
+  }
+}
+
+export const contactResponseSchema = z.object({
+  success: z.literal(true),
+  message: z.string(),
+})
+
+export type SubmitContactResult = z.output<typeof contactResponseSchema>
+
+export const submitContactContract = defineRouteContract({
+  method: 'POST',
+  path: '/api/contact',
+  body: submitContactBodySchema,
+  response: {
+    mode: 'json',
+    schema: contactResponseSchema,
+  },
+})
+
+export type SubmitContactBody = ContractBodyInput<typeof submitContactContract>

--- a/apps/sim/lib/core/rate-limiter/rate-limiter.test.ts
+++ b/apps/sim/lib/core/rate-limiter/rate-limiter.test.ts
@@ -266,6 +266,43 @@ describe('RateLimiter', () => {
     })
   })
 
+  describe('checkRateLimitDirect', () => {
+    const config = { maxTokens: 3, refillRate: 1, refillIntervalMs: 60_000 }
+
+    it('should reflect the storage decision when it succeeds', async () => {
+      mockAdapter.consumeTokens.mockResolvedValue({
+        allowed: true,
+        tokensRemaining: 2,
+        resetAt: new Date(),
+      })
+
+      const result = await rateLimiter.checkRateLimitDirect('public:contact:ip', config)
+
+      expect(result.allowed).toBe(true)
+      expect(result.remaining).toBe(2)
+    })
+
+    it('should fail open on storage error by default', async () => {
+      mockAdapter.consumeTokens.mockRejectedValue(new Error('Storage error'))
+
+      const result = await rateLimiter.checkRateLimitDirect('public:contact:ip', config)
+
+      expect(result.allowed).toBe(true)
+      expect(result.remaining).toBe(1)
+    })
+
+    it('should fail closed on storage error when failClosed is set', async () => {
+      mockAdapter.consumeTokens.mockRejectedValue(new Error('Storage error'))
+
+      const result = await rateLimiter.checkRateLimitDirect('public:contact:ip', config, {
+        failClosed: true,
+      })
+
+      expect(result.allowed).toBe(false)
+      expect(result.remaining).toBe(0)
+    })
+  })
+
   describe('subscription plan handling', () => {
     it('should use pro plan limits', async () => {
       const proSubscription = { plan: 'pro', referenceId: testUserId }

--- a/apps/sim/lib/core/rate-limiter/rate-limiter.ts
+++ b/apps/sim/lib/core/rate-limiter/rate-limiter.ts
@@ -165,9 +165,16 @@ export class RateLimiter {
     }
   }
 
+  /**
+   * Consume one token from a bucket. On storage failure the default is to fail
+   * open (allow the request) so a limiter outage never takes down normal traffic.
+   * Pass `failClosed: true` for security-critical checks — e.g. a captcha
+   * backstop — where an unenforceable limit must reject rather than admit.
+   */
   async checkRateLimitDirect(
     storageKey: string,
-    config: { maxTokens: number; refillRate: number; refillIntervalMs: number }
+    config: { maxTokens: number; refillRate: number; refillIntervalMs: number },
+    options?: { failClosed?: boolean }
   ): Promise<RateLimitResult> {
     try {
       const result = await this.storage.consumeTokens(storageKey, 1, config)
@@ -181,13 +188,17 @@ export class RateLimiter {
         retryAfterMs: result.retryAfterMs,
       }
     } catch (error) {
-      logger.error('Rate limit storage error - failing open (allowing request)', {
-        error: toError(error).message,
-        storageKey,
-      })
+      const failClosed = options?.failClosed === true
+      logger.error(
+        `Rate limit storage error - failing ${failClosed ? 'closed (rejecting request)' : 'open (allowing request)'}`,
+        {
+          error: toError(error).message,
+          storageKey,
+        }
+      )
       return {
-        allowed: true,
-        remaining: 1,
+        allowed: !failClosed,
+        remaining: failClosed ? 0 : 1,
         resetAt: new Date(Date.now() + RATE_LIMIT_WINDOW_MS),
       }
     }

--- a/scripts/check-api-validation-contracts.ts
+++ b/scripts/check-api-validation-contracts.ts
@@ -9,8 +9,8 @@ const QUERY_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/queries')
 const SELECTOR_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/selectors')
 
 const BASELINE = {
-  totalRoutes: 881,
-  zodRoutes: 881,
+  totalRoutes: 882,
+  zodRoutes: 882,
   nonZodRoutes: 0,
 } as const
 


### PR DESCRIPTION
## Summary
- Reintroduce the `/contact` page (removed in #5181) with a two-column layout mirroring `/demo`: value proposition + trusted-by logos on the left, a message-form card on the right
- Styled wholly on the platform light tokens and chip components — card chrome, field rhythm, and responsive tiers are identical to the demo booking card
- Restore the contact contract and `/api/contact` route (rate-limit, honeypot, Turnstile, help-inbox notification + visitor confirmation email), now fully contract-bound via `parseRequest`
- Add a `useSubmitContact` React Query mutation hook (contract-bound `requestJson`)
- Link Contact from the footer Resources column and add `/contact` to the sitemap

## Type of Change
- [x] New feature (reintroduction)

## Testing
Tested manually. `tsc`, biome, `check:api-validation:strict`, `check:react-query`, and `check:client-boundary` all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)