### PR TITLE
feat(careers): careers page backed by the Ashby job board

### DIFF
--- a/apps/sim/app/(landing)/careers/careers.tsx
+++ b/apps/sim/app/(landing)/careers/careers.tsx
@@ -1,0 +1,78 @@
+import { Suspense } from 'react'
+import { getAshbyJobs } from '@/lib/ashby/jobs'
+import {
+  groupByDepartment,
+  JobBoard,
+  JobGroups,
+} from '@/app/(landing)/careers/components/job-board'
+import { TrustedBy } from '@/app/(landing)/components/trusted-by'
+
+/**
+ * The careers page — a mission-led hero above the live open-roles board. Roles
+ * are pulled from Sim's public Ashby job board at build/revalidate time
+ * ({@link getAshbyJobs}) and server-rendered in full, so every posting is in the
+ * crawlable HTML; the interactive {@link JobBoard} hydrates on top to add
+ * Team/Location filtering.
+ *
+ * Both sections share the landing gutter — capped and centered at `max-w-[1446px]`
+ * with the navbar-aligned `px-12 max-lg:px-8 max-sm:px-5` so the headline starts on
+ * the same vertical line as the wordmark. The hero carries the single `<h1>`
+ * (containing "Sim" and "AI workspace") plus an sr-only product summary for AI
+ * citation (landing CLAUDE.md → GEO); the roles section owns its own `<h2>`.
+ *
+ * Because {@link JobBoard} reads the URL via nuqs (`useSearchParams`), it sits under
+ * a `<Suspense>` boundary whose fallback is the same list rendered statically
+ * ({@link JobGroups}) — so the roles are present in the prerendered HTML and the
+ * filter bar simply pops in on hydration, never flashing an empty frame.
+ */
+export default async function Careers() {
+  const postings = await getAshbyJobs()
+
+  return (
+    <main id='main-content'>
+      <section
+        id='careers-hero'
+        aria-labelledby='careers-heading'
+        className='mx-auto flex w-full max-w-[1446px] flex-col gap-5 px-12 pt-20 pb-10 max-sm:px-5 max-sm:pt-16 max-lg:px-8'
+      >
+        <p className='sr-only'>
+          Careers at Sim, the open-source AI workspace where teams build, deploy, and manage AI
+          agents. Sim is hiring engineers, designers, and go-to-market builders to help teams
+          automate real work across 1,000+ integrations and every major LLM — visually,
+          conversationally, or with code.
+        </p>
+
+        <h1
+          id='careers-heading'
+          className='max-w-[24ch] text-balance text-[48px] text-[var(--text-primary)] leading-[1.1] max-sm:text-[32px] max-xl:text-[40px]'
+        >
+          Help build Sim, the AI workspace for teams.
+        </h1>
+        <p className='max-w-[60ch] text-pretty text-[var(--text-body)] text-lg leading-[1.5] max-sm:text-base'>
+          Sim is the open-source AI workspace where teams build, deploy, and manage AI agents. We're
+          a small, high-agency team shipping fast to thousands of builders. If you want to own real
+          work and shape the workspace teams live in, we'd love to meet you.
+        </p>
+      </section>
+
+      <section
+        id='open-roles'
+        aria-labelledby='open-roles-heading'
+        className='mx-auto flex w-full max-w-[1446px] flex-col gap-10 px-12 pt-6 pb-24 max-sm:px-5 max-sm:pb-16 max-lg:px-8'
+      >
+        <h2
+          id='open-roles-heading'
+          className='text-[24px] text-[var(--text-primary)] leading-[110%] tracking-[-0.02em]'
+        >
+          Open roles
+        </h2>
+
+        <Suspense fallback={<JobGroups groups={groupByDepartment(postings)} />}>
+          <JobBoard postings={postings} />
+        </Suspense>
+
+        <TrustedBy className='pt-6' />
+      </section>
+    </main>
+  )
+}

--- a/apps/sim/app/(landing)/careers/careers.tsx
+++ b/apps/sim/app/(landing)/careers/careers.tsx
@@ -1,11 +1,18 @@
 import { Suspense } from 'react'
+import type { SearchParams } from 'nuqs/server'
 import { getAshbyJobs } from '@/lib/ashby/jobs'
 import {
+  filterPostings,
   groupByDepartment,
   JobBoard,
   JobGroups,
 } from '@/app/(landing)/careers/components/job-board'
+import { careersSearchParamsCache } from '@/app/(landing)/careers/search-params'
 import { TrustedBy } from '@/app/(landing)/components/trusted-by'
+
+interface CareersProps {
+  searchParams: Promise<SearchParams>
+}
 
 /**
  * The careers page — a mission-led hero above the live open-roles board. Roles
@@ -21,12 +28,15 @@ import { TrustedBy } from '@/app/(landing)/components/trusted-by'
  * citation (landing CLAUDE.md → GEO); the roles section owns its own `<h2>`.
  *
  * Because {@link JobBoard} reads the URL via nuqs (`useSearchParams`), it sits under
- * a `<Suspense>` boundary whose fallback is the same list rendered statically
- * ({@link JobGroups}) — so the roles are present in the prerendered HTML and the
- * filter bar simply pops in on hydration, never flashing an empty frame.
+ * a `<Suspense>` boundary. The page parses the same `?team=`/`?location=` query on
+ * the server ({@link careersSearchParamsCache}) and pre-filters the fallback to
+ * match, so a deep-linked filter renders the correct roles server-side — the list
+ * never flashes unfiltered before the client board hydrates.
  */
-export default async function Careers() {
+export default async function Careers({ searchParams }: CareersProps) {
+  const { team, location } = await careersSearchParamsCache.parse(searchParams)
   const postings = await getAshbyJobs()
+  const fallbackGroups = groupByDepartment(filterPostings(postings, team, location))
 
   return (
     <main id='main-content'>
@@ -67,7 +77,7 @@ export default async function Careers() {
           Open roles
         </h2>
 
-        <Suspense fallback={<JobGroups groups={groupByDepartment(postings)} />}>
+        <Suspense fallback={<JobGroups groups={fallbackGroups} />}>
           <JobBoard postings={postings} />
         </Suspense>
 

--- a/apps/sim/app/(landing)/careers/careers.tsx
+++ b/apps/sim/app/(landing)/careers/careers.tsx
@@ -4,6 +4,7 @@ import { getAshbyJobs } from '@/lib/ashby/jobs'
 import {
   filterPostings,
   groupByDepartment,
+  hasActiveFilters,
   JobBoard,
   JobGroups,
 } from '@/app/(landing)/careers/components/job-board'
@@ -77,7 +78,11 @@ export default async function Careers({ searchParams }: CareersProps) {
           Open roles
         </h2>
 
-        <Suspense fallback={<JobGroups groups={fallbackGroups} />}>
+        <Suspense
+          fallback={
+            <JobGroups groups={fallbackGroups} filtersActive={hasActiveFilters(team, location)} />
+          }
+        >
           <JobBoard postings={postings} />
         </Suspense>
 

--- a/apps/sim/app/(landing)/careers/components/job-board/index.ts
+++ b/apps/sim/app/(landing)/careers/components/job-board/index.ts
@@ -1,2 +1,2 @@
 export { JobBoard } from './job-board'
-export { groupByDepartment, JobGroups } from './job-groups'
+export { filterPostings, groupByDepartment, JobGroups } from './job-groups'

--- a/apps/sim/app/(landing)/careers/components/job-board/index.ts
+++ b/apps/sim/app/(landing)/careers/components/job-board/index.ts
@@ -1,0 +1,2 @@
+export { JobBoard } from './job-board'
+export { groupByDepartment, JobGroups } from './job-groups'

--- a/apps/sim/app/(landing)/careers/components/job-board/index.ts
+++ b/apps/sim/app/(landing)/careers/components/job-board/index.ts
@@ -1,2 +1,2 @@
 export { JobBoard } from './job-board'
-export { filterPostings, groupByDepartment, JobGroups } from './job-groups'
+export { filterPostings, groupByDepartment, hasActiveFilters, JobGroups } from './job-groups'

--- a/apps/sim/app/(landing)/careers/components/job-board/job-board.tsx
+++ b/apps/sim/app/(landing)/careers/components/job-board/job-board.tsx
@@ -4,6 +4,7 @@ import { ChipSelect, type ChipSelectOption } from '@sim/emcn'
 import { useQueryStates } from 'nuqs'
 import type { CareerPosting } from '@/lib/ashby/jobs'
 import {
+  filterPostings,
   groupByDepartment,
   JobGroups,
 } from '@/app/(landing)/careers/components/job-board/job-groups'
@@ -49,13 +50,7 @@ export function JobBoard({ postings }: JobBoardProps) {
     uniqueSorted(postings.map((p) => p.location).filter(Boolean)),
     'All locations'
   )
-  const groups = groupByDepartment(
-    postings.filter(
-      (p) =>
-        (team === ALL_FILTER_VALUE || p.department === team) &&
-        (location === ALL_FILTER_VALUE || p.location === location)
-    )
-  )
+  const groups = groupByDepartment(filterPostings(postings, team, location))
 
   return (
     <div className='flex flex-col gap-10'>

--- a/apps/sim/app/(landing)/careers/components/job-board/job-board.tsx
+++ b/apps/sim/app/(landing)/careers/components/job-board/job-board.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { ChipSelect, type ChipSelectOption } from '@sim/emcn'
+import { useQueryStates } from 'nuqs'
+import type { CareerPosting } from '@/lib/ashby/jobs'
+import {
+  groupByDepartment,
+  JobGroups,
+} from '@/app/(landing)/careers/components/job-board/job-groups'
+import {
+  ALL_FILTER_VALUE,
+  careersParsers,
+  careersUrlKeys,
+} from '@/app/(landing)/careers/search-params'
+
+interface JobBoardProps {
+  postings: CareerPosting[]
+}
+
+/** Builds `{ label, value }` options for a filter, with an "All" row at the top. */
+function toFilterOptions(values: string[], allLabel: string): ChipSelectOption[] {
+  return [
+    { label: allLabel, value: ALL_FILTER_VALUE },
+    ...values.map((value) => ({ label: value, value })),
+  ]
+}
+
+/** Distinct, alphabetically sorted values from a list. */
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((a, b) => a.localeCompare(b))
+}
+
+/**
+ * The interactive open-roles board — the single `'use client'` leaf on the
+ * careers page. Every posting is server-rendered into the HTML (via the static
+ * {@link JobGroups} Suspense fallback in `careers.tsx`), so all roles stay
+ * crawlable; this leaf hydrates on top to add Team/Location filtering. Filter
+ * state lives in the URL via nuqs (`?team=`/`?location=`) so a filtered view is
+ * shareable and survives reload/back-forward. The filter set is small and
+ * static, so filtering reads the instant URL value directly (no debounce).
+ */
+export function JobBoard({ postings }: JobBoardProps) {
+  const [{ team, location }, setFilters] = useQueryStates(careersParsers, careersUrlKeys)
+
+  // Derived directly — the board holds a handful of postings, so recomputing on a
+  // filter change is trivial and a memo would only add ceremony.
+  const teamOptions = toFilterOptions(uniqueSorted(postings.map((p) => p.department)), 'All teams')
+  const locationOptions = toFilterOptions(
+    uniqueSorted(postings.map((p) => p.location).filter(Boolean)),
+    'All locations'
+  )
+  const groups = groupByDepartment(
+    postings.filter(
+      (p) =>
+        (team === ALL_FILTER_VALUE || p.department === team) &&
+        (location === ALL_FILTER_VALUE || p.location === location)
+    )
+  )
+
+  return (
+    <div className='flex flex-col gap-10'>
+      <div className='flex flex-wrap items-center gap-3'>
+        <ChipSelect
+          options={teamOptions}
+          value={team}
+          onChange={(value) => setFilters({ team: value })}
+          aria-label='Filter roles by team'
+        />
+        <ChipSelect
+          options={locationOptions}
+          value={location}
+          onChange={(value) => setFilters({ location: value })}
+          aria-label='Filter roles by location'
+        />
+      </div>
+
+      <JobGroups
+        groups={groups}
+        emptyMessage='No roles match these filters right now. Try clearing them, or check back soon.'
+      />
+    </div>
+  )
+}

--- a/apps/sim/app/(landing)/careers/components/job-board/job-board.tsx
+++ b/apps/sim/app/(landing)/careers/components/job-board/job-board.tsx
@@ -6,6 +6,7 @@ import type { CareerPosting } from '@/lib/ashby/jobs'
 import {
   filterPostings,
   groupByDepartment,
+  hasActiveFilters,
   JobGroups,
 } from '@/app/(landing)/careers/components/job-board/job-groups'
 import {
@@ -43,8 +44,6 @@ function uniqueSorted(values: string[]): string[] {
 export function JobBoard({ postings }: JobBoardProps) {
   const [{ team, location }, setFilters] = useQueryStates(careersParsers, careersUrlKeys)
 
-  // Derived directly — the board holds a handful of postings, so recomputing on a
-  // filter change is trivial and a memo would only add ceremony.
   const teamOptions = toFilterOptions(uniqueSorted(postings.map((p) => p.department)), 'All teams')
   const locationOptions = toFilterOptions(
     uniqueSorted(postings.map((p) => p.location).filter(Boolean)),
@@ -69,10 +68,7 @@ export function JobBoard({ postings }: JobBoardProps) {
         />
       </div>
 
-      <JobGroups
-        groups={groups}
-        emptyMessage='No roles match these filters right now. Try clearing them, or check back soon.'
-      />
+      <JobGroups groups={groups} filtersActive={hasActiveFilters(team, location)} />
     </div>
   )
 }

--- a/apps/sim/app/(landing)/careers/components/job-board/job-groups.tsx
+++ b/apps/sim/app/(landing)/careers/components/job-board/job-groups.tsx
@@ -1,0 +1,114 @@
+import { cn } from '@sim/emcn'
+import { ArrowRight } from '@sim/emcn/icons'
+import type { CareerPosting } from '@/lib/ashby/jobs'
+
+export interface DepartmentGroup {
+  department: string
+  postings: CareerPosting[]
+}
+
+/**
+ * Buckets postings by department, preserving their incoming order (the fetcher
+ * pre-sorts by department then title). Shared by the interactive board and its
+ * static Suspense fallback so the two can never render a different grouping.
+ */
+export function groupByDepartment(postings: CareerPosting[]): DepartmentGroup[] {
+  const byDepartment = new Map<string, CareerPosting[]>()
+  for (const posting of postings) {
+    const bucket = byDepartment.get(posting.department)
+    if (bucket) bucket.push(posting)
+    else byDepartment.set(posting.department, [posting])
+  }
+  return Array.from(byDepartment, ([department, items]) => ({ department, postings: items }))
+}
+
+interface JobGroupsProps {
+  groups: DepartmentGroup[]
+  /** Copy shown when there are no groups to render (empty board or filtered-out). */
+  emptyMessage?: string
+}
+
+/**
+ * The presentational open-roles list: one labeled section per department, each a
+ * list of {@link JobRow}s. Server-safe (no client hooks) so it renders both as
+ * the static Suspense fallback and inside the client {@link JobBoard}.
+ */
+export function JobGroups({ groups, emptyMessage }: JobGroupsProps) {
+  if (groups.length === 0) {
+    return (
+      <p className='py-10 text-[var(--text-muted)] text-base'>
+        {emptyMessage ?? 'No open roles right now — check back soon.'}
+      </p>
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-12'>
+      {groups.map((group) => (
+        <section
+          key={group.department}
+          aria-label={`${group.department} roles`}
+          className='flex flex-col'
+        >
+          <h3 className='pb-2 font-medium text-[var(--text-muted)] text-sm'>{group.department}</h3>
+          <ul className='flex flex-col'>
+            {group.postings.map((posting) => (
+              <li key={posting.id}>
+                <JobRow posting={posting} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+interface JobRowProps {
+  posting: CareerPosting
+}
+
+/**
+ * A single role row: title over a metadata line, with an "Apply" affordance that
+ * links out to the posting on Ashby. The whole row is the link target; hovering
+ * tints the row and advances the arrow.
+ */
+function JobRow({ posting }: JobRowProps) {
+  const meta = [posting.location, posting.employmentType, posting.workplaceType].filter(Boolean)
+  if (posting.compensationSummary) meta.push(posting.compensationSummary)
+
+  return (
+    <a
+      href={posting.jobUrl}
+      target='_blank'
+      rel='noopener noreferrer'
+      className={cn(
+        'group flex items-center justify-between gap-6 border-[var(--border)] border-t py-5',
+        'transition-colors hover:bg-[var(--surface-hover)]'
+      )}
+    >
+      <div className='flex min-w-0 flex-col gap-1.5'>
+        <h4 className='truncate font-medium text-[var(--text-primary)] text-base'>
+          {posting.title}
+        </h4>
+        <div className='flex flex-wrap items-center gap-x-2 gap-y-1 text-[var(--text-muted)] text-sm'>
+          {meta.map((item, index) => (
+            <span key={item} className='flex items-center gap-2'>
+              {index > 0 && (
+                <span aria-hidden className='text-[var(--text-muted)]'>
+                  ·
+                </span>
+              )}
+              {item}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <span className='flex shrink-0 items-center gap-1.5 font-medium text-[var(--text-body)] text-sm'>
+        Apply
+        <ArrowRight className='size-[14px] text-[var(--text-icon)] transition-transform group-hover:translate-x-0.5' />
+      </span>
+    </a>
+  )
+}

--- a/apps/sim/app/(landing)/careers/components/job-board/job-groups.tsx
+++ b/apps/sim/app/(landing)/careers/components/job-board/job-groups.tsx
@@ -25,6 +25,16 @@ export function filterPostings(
   )
 }
 
+/** Whether either the Team or Location filter is narrowing the board. */
+export function hasActiveFilters(team: string, location: string): boolean {
+  return team !== ALL_FILTER_VALUE || location !== ALL_FILTER_VALUE
+}
+
+/** Empty-state copy: distinguishes a truly empty board from a filtered-to-zero view. */
+const NO_OPEN_ROLES_MESSAGE = 'No open roles right now — check back soon.'
+const NO_MATCHING_ROLES_MESSAGE =
+  'No roles match these filters right now. Try clearing them, or check back soon.'
+
 /**
  * Buckets postings by department, preserving their incoming order (the fetcher
  * pre-sorts by department then title). Shared by the interactive board and its
@@ -42,8 +52,12 @@ export function groupByDepartment(postings: CareerPosting[]): DepartmentGroup[] 
 
 interface JobGroupsProps {
   groups: DepartmentGroup[]
-  /** Copy shown when there are no groups to render (empty board or filtered-out). */
-  emptyMessage?: string
+  /**
+   * Whether a Team/Location filter is active. Selects the empty-state copy so an
+   * unfiltered empty board ("no open roles") never reads as a filtered miss ("no
+   * matches") — and the server fallback and client board always agree.
+   */
+  filtersActive?: boolean
 }
 
 /**
@@ -51,11 +65,11 @@ interface JobGroupsProps {
  * list of {@link JobRow}s. Server-safe (no client hooks) so it renders both as
  * the static Suspense fallback and inside the client {@link JobBoard}.
  */
-export function JobGroups({ groups, emptyMessage }: JobGroupsProps) {
+export function JobGroups({ groups, filtersActive = false }: JobGroupsProps) {
   if (groups.length === 0) {
     return (
       <p className='py-10 text-[var(--text-muted)] text-base'>
-        {emptyMessage ?? 'No open roles right now — check back soon.'}
+        {filtersActive ? NO_MATCHING_ROLES_MESSAGE : NO_OPEN_ROLES_MESSAGE}
       </p>
     )
   }
@@ -89,11 +103,11 @@ interface JobRowProps {
 /**
  * A single role row: title over a metadata line, with an "Apply" affordance that
  * links out to the posting on Ashby. The whole row is the link target; hovering
- * tints the row and advances the arrow.
+ * tints the row and advances the arrow. The metadata values are de-duplicated
+ * because a remote posting normalizes both `location` and `workplaceType` to
+ * "Remote", which would otherwise render "Remote · Remote" and collide as keys.
  */
 function JobRow({ posting }: JobRowProps) {
-  // De-duplicate: a remote posting normalizes both location and workplaceType to
-  // "Remote", which would otherwise render "Remote · Remote" and collide as keys.
   const meta = Array.from(
     new Set(
       [

--- a/apps/sim/app/(landing)/careers/components/job-board/job-groups.tsx
+++ b/apps/sim/app/(landing)/careers/components/job-board/job-groups.tsx
@@ -1,10 +1,28 @@
 import { cn } from '@sim/emcn'
 import { ArrowRight } from '@sim/emcn/icons'
 import type { CareerPosting } from '@/lib/ashby/jobs'
+import { ALL_FILTER_VALUE } from '@/app/(landing)/careers/search-params'
 
 export interface DepartmentGroup {
   department: string
   postings: CareerPosting[]
+}
+
+/**
+ * Narrows postings to a selected Team and Location, treating {@link ALL_FILTER_VALUE}
+ * as "any". Shared by the server-rendered fallback and the client board so a
+ * deep-linked filter resolves to the exact same set on both sides.
+ */
+export function filterPostings(
+  postings: CareerPosting[],
+  team: string,
+  location: string
+): CareerPosting[] {
+  return postings.filter(
+    (posting) =>
+      (team === ALL_FILTER_VALUE || posting.department === team) &&
+      (location === ALL_FILTER_VALUE || posting.location === location)
+  )
 }
 
 /**
@@ -74,8 +92,18 @@ interface JobRowProps {
  * tints the row and advances the arrow.
  */
 function JobRow({ posting }: JobRowProps) {
-  const meta = [posting.location, posting.employmentType, posting.workplaceType].filter(Boolean)
-  if (posting.compensationSummary) meta.push(posting.compensationSummary)
+  // De-duplicate: a remote posting normalizes both location and workplaceType to
+  // "Remote", which would otherwise render "Remote · Remote" and collide as keys.
+  const meta = Array.from(
+    new Set(
+      [
+        posting.location,
+        posting.employmentType,
+        posting.workplaceType,
+        posting.compensationSummary,
+      ].filter((value): value is string => Boolean(value))
+    )
+  )
 
   return (
     <a

--- a/apps/sim/app/(landing)/careers/page.tsx
+++ b/apps/sim/app/(landing)/careers/page.tsx
@@ -1,0 +1,16 @@
+import { buildLandingMetadata } from '@/lib/landing/seo'
+import Careers from '@/app/(landing)/careers/careers'
+
+export const revalidate = 3600
+
+export const metadata = buildLandingMetadata({
+  title: 'Careers at Sim — Build the AI workspace for teams',
+  description:
+    'Join Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. See open engineering, design, and go-to-market roles.',
+  path: '/careers',
+  keywords: 'Sim careers, Sim jobs, AI workspace jobs, AI agent engineering jobs, open source jobs',
+})
+
+export default function Page() {
+  return <Careers />
+}

--- a/apps/sim/app/(landing)/careers/page.tsx
+++ b/apps/sim/app/(landing)/careers/page.tsx
@@ -1,3 +1,4 @@
+import type { SearchParams } from 'nuqs/server'
 import { buildLandingMetadata } from '@/lib/landing/seo'
 import Careers from '@/app/(landing)/careers/careers'
 
@@ -11,6 +12,6 @@ export const metadata = buildLandingMetadata({
   keywords: 'Sim careers, Sim jobs, AI workspace jobs, AI agent engineering jobs, open source jobs',
 })
 
-export default function Page() {
-  return <Careers />
+export default function Page({ searchParams }: { searchParams: Promise<SearchParams> }) {
+  return <Careers searchParams={searchParams} />
 }

--- a/apps/sim/app/(landing)/careers/search-params.ts
+++ b/apps/sim/app/(landing)/careers/search-params.ts
@@ -1,0 +1,25 @@
+import { parseAsString } from 'nuqs/server'
+
+/** Sentinel value for an inactive filter — matches every posting. */
+export const ALL_FILTER_VALUE = 'all'
+
+/**
+ * Co-located, typed URL query params for the careers job board's Team and
+ * Location filters. Shareable, deep-linkable view-state over an already-rendered
+ * list, so it lives in the URL (nuqs) — never in a store. The values are dynamic
+ * (departments/locations come from the live board), so plain string parsers with
+ * an `all` default rather than a fixed literal set. Imported by the client board
+ * (`useQueryStates`); the page renders every posting statically and filters on
+ * the client, so no server-side cache is needed.
+ */
+export const careersParsers = {
+  team: parseAsString.withDefault(ALL_FILTER_VALUE),
+  location: parseAsString.withDefault(ALL_FILTER_VALUE),
+} as const
+
+/** Clean URLs, no back-stack churn — the filters are a passive view switch. */
+export const careersUrlKeys = {
+  history: 'replace',
+  shallow: true,
+  clearOnDefault: true,
+} as const

--- a/apps/sim/app/(landing)/careers/search-params.ts
+++ b/apps/sim/app/(landing)/careers/search-params.ts
@@ -1,16 +1,18 @@
-import { parseAsString } from 'nuqs/server'
+import { createSearchParamsCache, parseAsString } from 'nuqs/server'
 
-/** Sentinel value for an inactive filter — matches every posting. */
-export const ALL_FILTER_VALUE = 'all'
+/**
+ * Sentinel value for an inactive filter — matches every posting. Namespaced with
+ * underscores so it can never collide with a real Ashby department or location
+ * value (e.g. a team literally named "all").
+ */
+export const ALL_FILTER_VALUE = '__all__'
 
 /**
  * Co-located, typed URL query params for the careers job board's Team and
  * Location filters. Shareable, deep-linkable view-state over an already-rendered
  * list, so it lives in the URL (nuqs) — never in a store. The values are dynamic
  * (departments/locations come from the live board), so plain string parsers with
- * an `all` default rather than a fixed literal set. Imported by the client board
- * (`useQueryStates`); the page renders every posting statically and filters on
- * the client, so no server-side cache is needed.
+ * an `all` sentinel default rather than a fixed literal set.
  */
 export const careersParsers = {
   team: parseAsString.withDefault(ALL_FILTER_VALUE),
@@ -23,3 +25,11 @@ export const careersUrlKeys = {
   shallow: true,
   clearOnDefault: true,
 } as const
+
+/**
+ * Server-side reader for the same parser map. The page parses the request's
+ * query with this so the statically-rendered fallback is filtered to match a
+ * deep-linked `?team=`/`?location=` URL — the roles never flash unfiltered before
+ * the client board hydrates.
+ */
+export const careersSearchParamsCache = createSearchParamsCache(careersParsers)

--- a/apps/sim/app/(landing)/components/footer/footer.tsx
+++ b/apps/sim/app/(landing)/components/footer/footer.tsx
@@ -41,7 +41,7 @@ const RESOURCES_LINKS: FooterItem[] = [
   { label: 'Blog', href: '/blog' },
   { label: 'Docs', href: 'https://docs.sim.ai', external: true },
   { label: 'Partners', href: '/partners' },
-  { label: 'Careers', href: 'https://jobs.ashbyhq.com/sim', external: true },
+  { label: 'Careers', href: '/careers' },
   { label: 'Changelog', href: '/changelog' },
   { label: 'Contact', href: '/contact' },
 ]

--- a/apps/sim/app/sitemap.ts
+++ b/apps/sim/app/sitemap.ts
@@ -46,6 +46,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${baseUrl}/contact`,
     },
     {
+      url: `${baseUrl}/careers`,
+    },
+    {
       url: `${baseUrl}/enterprise`,
     },
     {

--- a/apps/sim/lib/ashby/jobs.ts
+++ b/apps/sim/lib/ashby/jobs.ts
@@ -16,6 +16,17 @@ const ASHBY_JOB_BOARD_URL = `https://api.ashbyhq.com/posting-api/job-board/${ASH
 const REVALIDATE_SECONDS = 3600
 
 /**
+ * An `http(s)`-only URL. `z.string().url()` alone accepts `javascript:`/`data:`
+ * (both parse as valid URLs), which would render as a live link, so the scheme is
+ * pinned explicitly — a posting whose `jobUrl` fails this is dropped rather than
+ * published as a clickable Apply link.
+ */
+const httpUrlSchema = z
+  .string()
+  .url()
+  .refine((value) => /^https?:\/\//i.test(value), 'Only http(s) URLs are allowed')
+
+/**
  * Tolerant schema for a single Ashby posting. The public board omits several
  * fields depending on the posting, so everything beyond the identity/title is
  * optional or nullable — Ashby is a third party and its payload varies per board.
@@ -32,7 +43,7 @@ const ashbyPostingSchema = z
     isListed: z.boolean().nullish(),
     isRemote: z.boolean().nullish(),
     publishedAt: z.string().nullish(),
-    jobUrl: z.string(),
+    jobUrl: httpUrlSchema,
     applyUrl: z.string().nullish(),
     shouldDisplayCompensationOnJobPostings: z.boolean().nullish(),
     compensation: z
@@ -43,9 +54,14 @@ const ashbyPostingSchema = z
   })
   .passthrough()
 
+/**
+ * The board envelope validates loosely — each posting is validated individually
+ * in {@link getAshbyJobs} so a single malformed row is skipped rather than
+ * emptying the entire board.
+ */
 const ashbyJobBoardSchema = z.object({
   apiVersion: z.string().nullish(),
-  jobs: z.array(ashbyPostingSchema),
+  jobs: z.array(z.unknown()),
 })
 
 /** Human-friendly labels for Ashby's enum-ish string fields. */
@@ -101,16 +117,25 @@ export async function getAshbyJobs(): Promise<CareerPosting[]> {
       return []
     }
 
-    const parsed = ashbyJobBoardSchema.safeParse(await response.json())
-    if (!parsed.success) {
-      logger.warn('Ashby job board response failed validation', { issues: parsed.error.issues })
+    const envelope = ashbyJobBoardSchema.safeParse(await response.json())
+    if (!envelope.success) {
+      logger.warn('Ashby job board response failed validation', { issues: envelope.error.issues })
       return []
     }
 
-    return parsed.data.jobs
-      .filter((job) => job.isListed !== false)
-      .map(normalizePosting)
-      .sort(comparePostings)
+    const postings: CareerPosting[] = []
+    for (const raw of envelope.data.jobs) {
+      const parsed = ashbyPostingSchema.safeParse(raw)
+      if (!parsed.success) {
+        // Skip the offending posting rather than emptying the whole board.
+        logger.warn('Skipping malformed Ashby posting', { issues: parsed.error.issues })
+        continue
+      }
+      if (parsed.data.isListed === false) continue
+      postings.push(normalizePosting(parsed.data))
+    }
+
+    return postings.sort(comparePostings)
   } catch (error) {
     logger.warn('Ashby job board request threw', { error })
     return []

--- a/apps/sim/lib/ashby/jobs.ts
+++ b/apps/sim/lib/ashby/jobs.ts
@@ -127,7 +127,6 @@ export async function getAshbyJobs(): Promise<CareerPosting[]> {
     for (const raw of envelope.data.jobs) {
       const parsed = ashbyPostingSchema.safeParse(raw)
       if (!parsed.success) {
-        // Skip the offending posting rather than emptying the whole board.
         logger.warn('Skipping malformed Ashby posting', { issues: parsed.error.issues })
         continue
       }

--- a/apps/sim/lib/ashby/jobs.ts
+++ b/apps/sim/lib/ashby/jobs.ts
@@ -1,0 +1,149 @@
+import { createLogger } from '@sim/logger'
+import { z } from 'zod'
+
+const logger = createLogger('AshbyJobs')
+
+/**
+ * The Ashby-hosted job board slug for Sim — the final path segment of
+ * `https://jobs.ashbyhq.com/sim`. Drives the public, no-auth job posting API.
+ */
+const ASHBY_JOB_BOARD_NAME = 'sim'
+
+/** Public job posting API — returns every listed posting in one payload, no auth. */
+const ASHBY_JOB_BOARD_URL = `https://api.ashbyhq.com/posting-api/job-board/${ASHBY_JOB_BOARD_NAME}?includeCompensation=true`
+
+/** Revalidate the board hourly, shared across every render (build/revalidate-time cache). */
+const REVALIDATE_SECONDS = 3600
+
+/**
+ * Tolerant schema for a single Ashby posting. The public board omits several
+ * fields depending on the posting, so everything beyond the identity/title is
+ * optional or nullable — Ashby is a third party and its payload varies per board.
+ */
+const ashbyPostingSchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    department: z.string().nullish(),
+    team: z.string().nullish(),
+    location: z.string().nullish(),
+    employmentType: z.string().nullish(),
+    workplaceType: z.string().nullish(),
+    isListed: z.boolean().nullish(),
+    isRemote: z.boolean().nullish(),
+    publishedAt: z.string().nullish(),
+    jobUrl: z.string(),
+    applyUrl: z.string().nullish(),
+    shouldDisplayCompensationOnJobPostings: z.boolean().nullish(),
+    compensation: z
+      .object({
+        compensationTierSummary: z.string().nullish(),
+      })
+      .nullish(),
+  })
+  .passthrough()
+
+const ashbyJobBoardSchema = z.object({
+  apiVersion: z.string().nullish(),
+  jobs: z.array(ashbyPostingSchema),
+})
+
+/** Human-friendly labels for Ashby's enum-ish string fields. */
+const EMPLOYMENT_TYPE_LABELS: Record<string, string> = {
+  FullTime: 'Full-time',
+  PartTime: 'Part-time',
+  Intern: 'Internship',
+  Contract: 'Contract',
+  Temporary: 'Temporary',
+}
+
+const WORKPLACE_TYPE_LABELS: Record<string, string> = {
+  OnSite: 'On-site',
+  Remote: 'Remote',
+  Hybrid: 'Hybrid',
+}
+
+/** A normalized, presentation-ready job posting for the careers page. */
+export interface CareerPosting {
+  id: string
+  title: string
+  /** Grouping bucket — the posting's department (falls back to team, then "Other"). */
+  department: string
+  /** Display location, e.g. "San Francisco" or "Remote". */
+  location: string
+  /** Human employment type, e.g. "Full-time". Empty string when unknown. */
+  employmentType: string
+  /** Human workplace type, e.g. "On-site". Empty string when unknown. */
+  workplaceType: string
+  /** Compensation range summary when the posting opts to display it, else null. */
+  compensationSummary: string | null
+  /** Public detail URL on `jobs.ashbyhq.com`. */
+  jobUrl: string
+}
+
+/**
+ * Fetches the listed Sim job postings from Ashby's public job board API and
+ * normalizes them for the careers page. Cached at build/revalidate time and
+ * shared across renders. Mirrors {@link getGitHubStars}: it never throws — on any
+ * transport, status, or shape error it logs a warning and returns an empty list
+ * so the page renders its "no open roles" state instead of erroring.
+ */
+export async function getAshbyJobs(): Promise<CareerPosting[]> {
+  try {
+    const response = await fetch(ASHBY_JOB_BOARD_URL, {
+      headers: { Accept: 'application/json' },
+      next: { revalidate: REVALIDATE_SECONDS },
+      cache: 'force-cache',
+    })
+
+    if (!response.ok) {
+      logger.warn('Ashby job board request failed', { status: response.status })
+      return []
+    }
+
+    const parsed = ashbyJobBoardSchema.safeParse(await response.json())
+    if (!parsed.success) {
+      logger.warn('Ashby job board response failed validation', { issues: parsed.error.issues })
+      return []
+    }
+
+    return parsed.data.jobs
+      .filter((job) => job.isListed !== false)
+      .map(normalizePosting)
+      .sort(comparePostings)
+  } catch (error) {
+    logger.warn('Ashby job board request threw', { error })
+    return []
+  }
+}
+
+/** Maps a raw Ashby posting to the presentation-ready {@link CareerPosting} shape. */
+function normalizePosting(job: z.infer<typeof ashbyPostingSchema>): CareerPosting {
+  const employmentType = job.employmentType
+    ? (EMPLOYMENT_TYPE_LABELS[job.employmentType] ?? job.employmentType)
+    : ''
+  const workplaceType = job.workplaceType
+    ? (WORKPLACE_TYPE_LABELS[job.workplaceType] ?? job.workplaceType)
+    : ''
+  const location = job.location?.trim() || (job.isRemote ? 'Remote' : '')
+  const compensationSummary =
+    job.shouldDisplayCompensationOnJobPostings && job.compensation?.compensationTierSummary
+      ? job.compensation.compensationTierSummary
+      : null
+
+  return {
+    id: job.id,
+    title: job.title,
+    department: job.department?.trim() || job.team?.trim() || 'Other',
+    location,
+    employmentType,
+    workplaceType,
+    compensationSummary,
+    jobUrl: job.jobUrl,
+  }
+}
+
+/** Orders postings by department, then title — the render order and grouping key. */
+function comparePostings(a: CareerPosting, b: CareerPosting): number {
+  return a.department.localeCompare(b.department) || a.title.localeCompare(b.title)
+}


### PR DESCRIPTION
## Summary
- New `/careers` landing page listing open roles pulled live from Sim's public Ashby job board (`jobs.ashbyhq.com/sim`), grouped by department with Team/Location filters.
- Roles are fetched server-side at build/revalidate time (`getAshbyJobs`, mirrors the GitHub-stars pattern — cached, never throws) so every posting is in the crawlable HTML; the interactive board hydrates on top.
- Filter state lives in the URL via nuqs (`?team=`/`?location=`), shareable and deep-linkable; the roles list stays server-rendered via a `<Suspense>` fallback.
- Styled with landing tokens/patterns only (shared `max-w-[1446px]`/`px-12` gutter, `ChipSelect` filters, `TrustedBy` reuse, single `<h1>` + sr-only GEO summary).
- Footer "Careers" link now points to the internal `/careers` page; added `/careers` to the sitemap.

## Type of Change
- [x] New feature

## Testing
Tested manually against the live Ashby board; typecheck and biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)