### PR TITLE
fix(careers): remove /careers redirect so the in-app page is reachable

### DIFF
--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -307,11 +307,6 @@ const nextConfig: NextConfig = {
         source: '/team',
         destination: 'https://cal.com/emirkarabeg/sim-team',
         permanent: false,
-      },
-      {
-        source: '/careers',
-        destination: 'https://jobs.ashbyhq.com/sim',
-        permanent: true,
       }
     )
 


### PR DESCRIPTION
## Summary
- A pre-existing permanent (301) redirect `/careers → https://jobs.ashbyhq.com/sim` in `next.config.ts` shadowed the new first-party careers page shipped in #5316 — visitors hitting `/careers` were sent straight to the Ashby board and never saw the in-app page.
- Removed that redirect so `/careers` now serves the in-app careers page (which itself pulls roles from the Ashby job board).

## Type of Change
- [x] Bug fix

## Testing
Verified on the deployed site that `/careers` 301-redirected to `jobs.ashbyhq.com/sim` (`<title>Sim Jobs</title>`) instead of rendering the in-app page; removing the rule resolves it. Biome clean.

> Note: the old rule was `permanent: true` (301), which browsers cache aggressively — a hard refresh / cleared cache may be needed to see the in-app page on clients that previously hit the redirect.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)