### PR TITLE
fix(custom-tool): restore modal body scroll so Save stays reachable

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/components/custom-tool-modal/custom-tool-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/components/custom-tool-modal/custom-tool-modal.tsx
@@ -834,9 +834,10 @@ try {
         {/*
           The body is the scroll region so tall schema/code content stays inside
           the modal and the footer (Next/Save) is always reachable. The EnvVar,
-          Tag, and schema-param autocompletes anchor to the textarea caret and
-          render in portaled popovers, so they aren't clipped by this scroll
-          boundary — see the `inputRef` wiring below.
+          Tag, and schema-param autocompletes render their menus in portaled
+          popovers (never clipped by this scroll boundary) and anchor to a
+          caret-positioned element inside the editor wrapper, so the menus track
+          the caret as the body scrolls.
         */}
         <ChipModalBody className='gap-2 px-4'>
           <ChipModalTabs
@@ -1046,10 +1047,11 @@ try {
                       setShowEnvVars(false)
                       setSearchTerm('')
                     }}
-                    inputRef={{
-                      current: codeEditorRef.current?.querySelector(
-                        'textarea'
-                      ) as HTMLTextAreaElement,
+                    className='w-64'
+                    style={{
+                      position: 'absolute',
+                      top: `${dropdownPosition.top}px`,
+                      left: `${dropdownPosition.left}px`,
                     }}
                   />
                 )}
@@ -1066,10 +1068,11 @@ try {
                       setShowTags(false)
                       setActiveSourceBlockId(null)
                     }}
-                    inputRef={{
-                      current: codeEditorRef.current?.querySelector(
-                        'textarea'
-                      ) as HTMLTextAreaElement,
+                    className='w-64'
+                    style={{
+                      position: 'absolute',
+                      top: `${dropdownPosition.top}px`,
+                      left: `${dropdownPosition.left}px`,
                     }}
                   />
                 )}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/components/custom-tool-modal/custom-tool-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/components/custom-tool-modal/custom-tool-modal.tsx
@@ -832,12 +832,13 @@ try {
         </ChipModalHeader>
 
         {/*
-          flex-none + overflow-visible opt this body out of the chrome's
-          scroll container: the caret-anchored EnvVar/Tag autocomplete
-          dropdowns are absolute-positioned inside it and must spill past
-          the body's bounds rather than clip against a scroll boundary.
+          The body is the scroll region so tall schema/code content stays inside
+          the modal and the footer (Next/Save) is always reachable. The EnvVar,
+          Tag, and schema-param autocompletes anchor to the textarea caret and
+          render in portaled popovers, so they aren't clipped by this scroll
+          boundary — see the `inputRef` wiring below.
         */}
-        <ChipModalBody className='flex-none gap-2 overflow-visible px-4'>
+        <ChipModalBody className='gap-2 px-4'>
           <ChipModalTabs
             tabs={[
               { value: 'schema', label: 'Schema' },
@@ -1045,11 +1046,10 @@ try {
                       setShowEnvVars(false)
                       setSearchTerm('')
                     }}
-                    className='w-64'
-                    style={{
-                      position: 'absolute',
-                      top: `${dropdownPosition.top}px`,
-                      left: `${dropdownPosition.left}px`,
+                    inputRef={{
+                      current: codeEditorRef.current?.querySelector(
+                        'textarea'
+                      ) as HTMLTextAreaElement,
                     }}
                   />
                 )}
@@ -1066,11 +1066,10 @@ try {
                       setShowTags(false)
                       setActiveSourceBlockId(null)
                     }}
-                    className='w-64'
-                    style={{
-                      position: 'absolute',
-                      top: `${dropdownPosition.top}px`,
-                      left: `${dropdownPosition.left}px`,
+                    inputRef={{
+                      current: codeEditorRef.current?.querySelector(
+                        'textarea'
+                      ) as HTMLTextAreaElement,
                     }}
                   />
                 )}


### PR DESCRIPTION
## Summary
- The Edit/Create Agent Tool modal clipped its footer (Save/Update) and could not scroll when a tool had long code or a long schema.
- Root cause: #4354 migrated this modal to `ChipModal` and changed the body from a scroll region (`flex-1 overflow-y-auto`) to `flex-none overflow-visible` so the hand-positioned EnvVar/Tag autocompletes could spill past it. That removed the scroll region, so tall content grew the body past the modal's `max-h-[84vh]` cap and the `overflow-hidden` surface clipped the footer.
- Restore `ChipModalBody` as the scroll region (its documented behavior — header/footer stay pinned), and switch the EnvVar/Tag dropdowns to portaled `inputRef` caret-anchoring, matching the canonical Function-block editor (`code.tsx`), so they anchor to the caret in a portal and are never clipped by the scroll boundary.
- No editor height caps, no magic numbers — removes the workaround rather than layering another on top. Net −1 line, one file.

## Type of Change
- [x] Bug fix

## Testing
Tested manually; `tsc`, biome, and the tool-input test suite (47 tests) pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)