### PR TITLE
fix(providers): drop deprecated temperature capability from claude-sonnet-5

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -678,7 +678,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
           updatedAt: '2026-06-30',
         },
         capabilities: {
-          temperature: { min: 0, max: 1 },
           nativeStructuredOutputs: true,
           maxOutputTokens: 128000,
           thinking: {

--- a/apps/sim/providers/utils.test.ts
+++ b/apps/sim/providers/utils.test.ts
@@ -214,6 +214,7 @@ describe('Model Capabilities', () => {
     it.concurrent('should return false for models that do not support temperature', () => {
       const unsupportedModels = [
         'unsupported-model',
+        'claude-sonnet-5',
         'cerebras/llama-3.3-70b',
         'o1',
         'o3',


### PR DESCRIPTION
## Summary
- Claude Sonnet 5 rejects the `temperature` parameter with a **400** (`` `temperature` is deprecated for this model ``) — verified against the live Anthropic API.
- The `claude-sonnet-5` model entry exposed `temperature: { min: 0, max: 1 }`, so `supportsTemperature()` returned `true` and the Anthropic request builder sent `temperature` whenever thinking was disabled — breaking those runs.
- Remove the capability (matching Opus 4.7/4.8, which omit it for the same deprecation) so `temperature` is never sent for Sonnet 5.
- Add a `supportsTemperature` regression assertion for `claude-sonnet-5`.

## Verification (live Anthropic API)
| Request | Result |
|---|---|
| Sonnet 5 **with** `temperature` | 400 — "temperature is deprecated for this model" |
| Sonnet 5 **without** `temperature` | 200 |
| Provider shape (adaptive thinking + `effort:high`, no temp) | 200 |
| Structured outputs (`output_format` json_schema) | 200 |

## Type of Change
- [x] Bug fix

## Testing
- 156 provider tests pass (`providers/utils.test.ts`, `providers/models.test.ts`)
- Live API verified (table above)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)