### PR TITLE
feat(providers): add Claude Fable 5 model

### DIFF
--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -84,6 +84,7 @@ const THINKING_BUDGET_TOKENS: Record<string, number> = {
 
 /**
  * Checks if a model supports adaptive thinking (thinking.type: "adaptive").
+ * Fable 5 supports ONLY adaptive thinking (always on; type: "disabled" is rejected).
  * Sonnet 5 supports ONLY adaptive thinking (manual budget_tokens returns a 400 error).
  * Opus 4.8 and Opus 4.7 support ONLY adaptive thinking (no extended thinking / budget_tokens).
  * Opus 4.6 and Sonnet 4.6 support both extended and adaptive thinking — use adaptive.
@@ -92,6 +93,7 @@ const THINKING_BUDGET_TOKENS: Record<string, number> = {
 function supportsAdaptiveThinking(modelId: string): boolean {
   const normalizedModel = modelId.toLowerCase()
   return (
+    normalizedModel.includes('fable-5') ||
     normalizedModel.includes('sonnet-5') ||
     normalizedModel.includes('opus-4-8') ||
     normalizedModel.includes('opus-4.8') ||
@@ -107,7 +109,7 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 /**
  * Builds the thinking configuration for the Anthropic API based on model capabilities and level.
  *
- * - Sonnet 5, Opus 4.8, Opus 4.7: Uses adaptive thinking only (no extended thinking support)
+ * - Fable 5, Sonnet 5, Opus 4.8, Opus 4.7: Uses adaptive thinking only (no extended thinking support)
  * - Opus 4.6, Sonnet 4.6: Uses adaptive thinking with effort parameter
  * - Other models: Uses budget_tokens-based extended thinking
  *

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -670,6 +670,25 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     },
     models: [
       {
+        id: 'claude-fable-5',
+        pricing: {
+          input: 10.0,
+          cachedInput: 1.0,
+          output: 50.0,
+          updatedAt: '2026-07-01',
+        },
+        capabilities: {
+          nativeStructuredOutputs: true,
+          maxOutputTokens: 128000,
+          thinking: {
+            levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+            default: 'high',
+          },
+        },
+        contextWindow: 1000000,
+        releaseDate: '2026-06-09',
+      },
+      {
         id: 'claude-sonnet-5',
         pricing: {
           input: 2.0,


### PR DESCRIPTION
## Summary
- Re-add `claude-fable-5` (Anthropic's most capable widely released model), **not** marked recommended — matching the prior entry (added in #4921, removed in #5020).
- Routed through adaptive thinking in `anthropic/core.ts` (Fable 5 is adaptive-thinking-only, always on — manual `budget_tokens`/`temperature` are rejected with 400).

## Verified against live Anthropic API + docs
| Field | Value |
|---|---|
| Pricing | $10 input / $50 output per MTok, $1 cached-input (cache read) |
| Context / Max output | 1M / 128k |
| Thinking | adaptive only; effort `low`/`medium`/`high`/`xhigh`/`max` (default `high`) |
| Structured outputs | supported — live `output_format` json_schema call returned 200 |
| Temperature | omitted — live API returns 400 "deprecated for this model" |
| Release date | 2026-06-09 (GA) |

Note: the prior #4921 entry omitted `nativeStructuredOutputs`; I've included it since the live API + docs confirm support and it matches the same-generation siblings (Sonnet 5, Opus 4.8).

## Type of Change
- [x] New feature

## Testing
- 156 provider tests + landing models catalog + providers index tests pass
- biome + tsc clean
- Live API verified (table above)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)