### PR TITLE
improvement(tables): make max row size env-configurable and raise default to 400KB

### DIFF
--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -94,6 +94,7 @@ export const env = createEnv({
     TEAM_TABLE_ROWS_LIMIT:                 z.number().optional(),                  // Max rows per table on team tier (default: 500000)
     ENTERPRISE_TABLES_LIMIT:               z.number().optional(),                  // Max user tables per workspace on enterprise tier (default: 10000)
     ENTERPRISE_TABLE_ROWS_LIMIT:           z.number().optional(),                  // Max rows per table on enterprise tier (default: 1000000)
+    TABLE_MAX_ROW_SIZE_BYTES:              z.number().optional(),                  // Max serialized size in bytes of a single user-table row (default: 409600)
 
     // Credit-tier Stripe prices (monthly)
     STRIPE_PRICE_TIER_25_MO:               z.string().min(1).optional(),           // Pro: $25/mo (6,000 credits)

--- a/apps/sim/lib/table/constants.ts
+++ b/apps/sim/lib/table/constants.ts
@@ -8,7 +8,7 @@ import { env, envNumber } from '@/lib/core/config/env'
 export const TABLE_LIMITS = {
   MAX_TABLES_PER_WORKSPACE: 100,
   MAX_ROWS_PER_TABLE: 10000,
-  MAX_ROW_SIZE_BYTES: 100 * 1024, // 100KB
+  MAX_ROW_SIZE_BYTES: 400 * 1024, // 400KB
   MAX_COLUMNS_PER_TABLE: 50,
   MAX_TABLE_NAME_LENGTH: 128,
   MAX_COLUMN_NAME_LENGTH: 50,
@@ -60,6 +60,18 @@ export const DEFAULT_TABLE_PLAN_LIMITS = {
     maxRowsPerTable: 1000000,
   },
 } as const
+
+/**
+ * Maximum serialized size in bytes of a single row. Defaults to
+ * `TABLE_LIMITS.MAX_ROW_SIZE_BYTES`; overridable via the
+ * `TABLE_MAX_ROW_SIZE_BYTES` env var (server-only, read at call time).
+ */
+export function getMaxRowSizeBytes(): number {
+  return envNumber(env.TABLE_MAX_ROW_SIZE_BYTES, TABLE_LIMITS.MAX_ROW_SIZE_BYTES, {
+    min: 1,
+    integer: true,
+  })
+}
 
 export type PlanName = keyof typeof DEFAULT_TABLE_PLAN_LIMITS
 

--- a/apps/sim/lib/table/validation.ts
+++ b/apps/sim/lib/table/validation.ts
@@ -7,7 +7,7 @@ import { userTableRows } from '@sim/db/schema'
 import { and, eq, or, type SQL, sql } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { getColumnId } from '@/lib/table/column-keys'
-import { COLUMN_TYPES, NAME_PATTERN, TABLE_LIMITS } from '@/lib/table/constants'
+import { COLUMN_TYPES, getMaxRowSizeBytes, NAME_PATTERN, TABLE_LIMITS } from '@/lib/table/constants'
 import { withSeqscanOff } from '@/lib/table/planner'
 import type {
   ColumnDefinition,
@@ -356,11 +356,12 @@ export function coerceRowToSchema(data: RowData, schema: TableSchema): Validatio
 
 /** Validates row data size is within limits. */
 export function validateRowSize(data: RowData): ValidationResult {
+  const maxRowSizeBytes = getMaxRowSizeBytes()
   const size = JSON.stringify(data).length
-  if (size > TABLE_LIMITS.MAX_ROW_SIZE_BYTES) {
+  if (size > maxRowSizeBytes) {
     return {
       valid: false,
-      errors: [`Row size exceeds limit (${size} bytes > ${TABLE_LIMITS.MAX_ROW_SIZE_BYTES} bytes)`],
+      errors: [`Row size exceeds limit (${size} bytes > ${maxRowSizeBytes} bytes)`],
     }
   }
   return { valid: true, errors: [] }


### PR DESCRIPTION
## Summary
- raise the table row size limit default from 100KB to 400KB
- make it overridable via a new `TABLE_MAX_ROW_SIZE_BYTES` env var (read at call time in `validateRowSize`, same pattern as the plan-limit overrides)
- error message now reports the effective limit instead of the hardcoded constant

## Type of Change
- [x] Improvement

## Testing
Table validation tests pass (54/54). `bun run lint` and `bun run check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)