### PR TITLE
ci(companion-check): run on PRs targeting dev

### DIFF
--- a/.github/workflows/companion-pr-check.yml
+++ b/.github/workflows/companion-pr-check.yml
@@ -1,6 +1,6 @@
 name: companion-pr-check
 
-# Soft, NON-BLOCKING warning: when a PR targeting staging/main declares a
+# Soft, NON-BLOCKING warning: when a PR targeting dev/staging/main declares a
 # cross-repo "Companion:" PR, surface whether that companion is merged yet, so
 # copilot and sim stay in lockstep (a change in one often needs the other).
 #
@@ -19,7 +19,7 @@ on:
   # re-edit the PR (or run this workflow manually via the Actions tab).
   pull_request:
     types: [opened, edited, reopened, synchronize]
-    branches: [staging, main]
+    branches: [dev, staging, main]
   workflow_dispatch: {}
 
 permissions:
@@ -199,8 +199,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               await checkPR(context.payload.pull_request);
             } else {
-              // workflow_dispatch only: manual full re-scan of open staging/main PRs.
-              for (const b of ['staging', 'main']) {
+              // workflow_dispatch only: manual full re-scan of open dev/staging/main PRs.
+              for (const b of ['dev', 'staging', 'main']) {
                 const prs = await github.paginate(github.rest.pulls.list, { owner, repo, base: b, state: 'open', per_page: 100 });
                 for (const pr of prs) await checkPR(pr);
               }


### PR DESCRIPTION
## Summary
Adds `dev` to the branch filters of the `companion-pr-check` workflow. Feature PRs now target `dev` on both simstudioai repos, so the cross-repo companion lockstep warning must fire there too — previously the check only ran for PRs targeting `staging`/`main`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: CI workflow config

## Testing
Self-validating: this PR targets `dev`, and the `companion` check ran and passed on it (GitHub evaluates `pull_request` workflows from the PR merge ref, so the updated filter applies to this PR itself). Cross-linked with the mothership companion below, which shows the same green check.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing — n/a, CI config only
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Companion PR

Companion: https://github.com/simstudioai/mothership/pull/339
