### PR TITLE
fix(landing): avoid unpolyfilled ES2023 array methods (toSorted/toReversed) in client code

### DIFF
--- a/apps/sim/app/(landing)/components/landing-preview/components/landing-preview-logs/landing-preview-logs.tsx
+++ b/apps/sim/app/(landing)/components/landing-preview/components/landing-preview-logs/landing-preview-logs.tsx
@@ -141,7 +141,7 @@ export function LandingPreviewLogs() {
       : MOCK_LOGS
 
     if (!sortKey) return filtered
-    return filtered.toSorted((a, b) => {
+    return [...filtered].sort((a, b) => {
       const av = sortKey === 'cost' ? a.cost.replace(/\D/g, '') : a[sortKey]
       const bv = sortKey === 'cost' ? b.cost.replace(/\D/g, '') : b[sortKey]
       const cmp = av.localeCompare(bv, undefined, { numeric: true, sensitivity: 'base' })

--- a/apps/sim/app/(landing)/components/landing-preview/components/landing-preview-resource/landing-preview-resource.tsx
+++ b/apps/sim/app/(landing)/components/landing-preview/components/landing-preview-resource/landing-preview-resource.tsx
@@ -62,7 +62,7 @@ export function LandingPreviewResource({
       : rows
 
     if (!sortColId) return filtered
-    return filtered.toSorted((a, b) => {
+    return [...filtered].sort((a, b) => {
       const av = a.cells[sortColId]?.label ?? ''
       const bv = b.cells[sortColId]?.label ?? ''
       const cmp = av.localeCompare(bv, undefined, { numeric: true, sensitivity: 'base' })

--- a/apps/sim/app/(landing)/components/lifecycle/components/lifecycle-icons/lifecycle-icons.tsx
+++ b/apps/sim/app/(landing)/components/lifecycle/components/lifecycle-icons/lifecycle-icons.tsx
@@ -121,7 +121,7 @@ export function MonitorIcon(props: IconProps) {
   return (
     <IconFrame {...props}>
       {/* Far → near so nearer bars occlude the ones behind them. */}
-      {MONITOR_BARS.toReversed().map((bar) => (
+      {[...MONITOR_BARS].reverse().map((bar) => (
         <IsoBox key={bar.x} cx={bar.x} topY={bar.ground - bar.h} w={5} h={bar.h} />
       ))}
     </IconFrame>

--- a/apps/sim/app/(landing)/integrations/(shell)/[slug]/page.tsx
+++ b/apps/sim/app/(landing)/integrations/(shell)/[slug]/page.tsx
@@ -129,7 +129,7 @@ function escapeRegex(value: string): string {
  * names.
  */
 function mentionifyPromptForNames(prompt: string, names: readonly string[]): string {
-  const unique = Array.from(new Set(names.filter((n) => n.trim().length >= 2))).toSorted(
+  const unique = Array.from(new Set(names.filter((n) => n.trim().length >= 2))).sort(
     (a, b) => b.length - a.length
   )
   if (unique.length === 0) return prompt

--- a/apps/sim/app/(landing)/models/components/model-comparison-charts.tsx
+++ b/apps/sim/app/(landing)/models/components/model-comparison-charts.tsx
@@ -27,7 +27,7 @@ function selectComparisonModels(models: CatalogModel[]): CatalogModel[] {
   const seen = new Set<string>()
   const result: CatalogModel[] = []
 
-  const sorted = models.toSorted((a, b) => {
+  const sorted = [...models].sort((a, b) => {
     const score = (m: CatalogModel) => {
       const reseller = RESELLER_PROVIDERS.has(m.providerId) ? -50 : 0
       const reasoning = m.capabilities.reasoningEffort || m.capabilities.thinking ? 10 : 0

--- a/apps/sim/app/(landing)/models/utils.ts
+++ b/apps/sim/app/(landing)/models/utils.ts
@@ -513,7 +513,7 @@ const rawProviders = Object.values(PROVIDER_DEFINITIONS).map((provider) => {
     models.find((model) => model.id === provider.defaultModel)?.displayName ||
     (provider.defaultModel ? formatModelDisplayName(provider.id, provider.defaultModel) : 'Dynamic')
 
-  const featuredModels = models.toSorted(compareModelsByRelevance).slice(0, 6)
+  const featuredModels = [...models].sort(compareModelsByRelevance).slice(0, 6)
 
   return {
     id: provider.id,

--- a/apps/sim/tsconfig.json
+++ b/apps/sim/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@sim/tsconfig/nextjs.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "paths": {
       "@/*": ["./*"],
       "@/components/*": ["components/*"],


### PR DESCRIPTION
## Summary
- `Array.prototype.toSorted`/`toReversed` (ES2023) require **Safari 16+ / iOS 16+** and **Next.js/SWC does not polyfill prototype methods** ([vercel/next.js#58421](https://github.com/vercel/next.js/pull/58421) was closed unmerged per maintainer policy). So the react-doctor pass in #5326 introduced a runtime `TypeError: … toSorted is not a function` on Safari 15 / iOS 15 — breaking sorting on the models page and the landing preview (logs/resource) plus the lifecycle monitor icon.
- Reverts the 6 call sites to `[...arr].sort()` / `[...arr].reverse()` — immutable (copies first), universally supported, and matching the existing codebase idiom (8 other `[...x].sort()` sites).
- Drops the `"lib": ["ES2023", …]` override in `apps/sim/tsconfig.json` that only existed to type-check `toSorted`; back on the inherited ES2022 lib, these methods no longer type-check, restoring the guardrail against re-introduction.
- Swept the entire repo (apps + packages): these were the only `toSorted`/`toReversed`/`toSpliced` usages — the issue exists nowhere else.

## Type of Change
- [x] Bug fix

## Testing
`tsc --noEmit` clean on the ES2022 baseline (0 errors), `biome check` clean, `bun run lint` clean. Verified no remaining ES2023 array-method usages repo-wide. Browser support + Next.js no-polyfill behavior validated against caniuse and the Next.js issue/PR threads.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)