### PR TITLE
ci(dev): auto-deploy Trigger.dev tasks + fail dev db:push on TTY prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Deploy to Trigger.dev
         working-directory: ./apps/sim
         env:
-          TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
+          TRIGGER_ACCESS_TOKEN: ${{ secrets.DEV_TRIGGER_ACCESS_TOKEN }}
           TRIGGER_PROJECT_ID: ${{ secrets.TRIGGER_PROJECT_ID }}
         run: |
           if [ -z "$TRIGGER_ACCESS_TOKEN" ] || [ -z "$TRIGGER_PROJECT_ID" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,44 @@ jobs:
           provenance: false
           sbom: false
 
+  # Dev: deploy Trigger.dev background tasks to the preview "dev-sim" branch.
+  # Gated after migrate-dev for the same reason as build-dev — the new task
+  # code runs against the dev DB, so the schema must be pushed first.
+  deploy-trigger-dev:
+    name: Deploy Trigger.dev (Dev)
+    needs: [migrate-dev]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+            **/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Deploy to Trigger.dev
+        working-directory: ./apps/sim
+        env:
+          TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
+          TRIGGER_PROJECT_ID: proj_kufttkwzywcydwtccqhx
+        run: bunx trigger.dev@4.4.3 deploy --env preview --branch dev-sim
+
   # Main/staging: build AMD64 images and push to ECR + GHCR
   build-amd64:
     name: Build AMD64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,12 @@ jobs:
         env:
           TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
           TRIGGER_PROJECT_ID: ${{ secrets.TRIGGER_PROJECT_ID }}
-        run: bunx trigger.dev@4.4.3 deploy --env preview --branch dev-sim
+        run: |
+          if [ -z "$TRIGGER_ACCESS_TOKEN" ] || [ -z "$TRIGGER_PROJECT_ID" ]; then
+            echo "ERROR: TRIGGER_ACCESS_TOKEN and TRIGGER_PROJECT_ID repo secrets must both be set" >&2
+            exit 1
+          fi
+          bunx trigger.dev@4.4.3 deploy --env preview --branch dev-sim
 
   # Main/staging: build AMD64 images and push to ECR + GHCR
   build-amd64:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           TRIGGER_PROJECT_ID: ${{ secrets.TRIGGER_PROJECT_ID }}
         run: |
           if [ -z "$TRIGGER_ACCESS_TOKEN" ] || [ -z "$TRIGGER_PROJECT_ID" ]; then
-            echo "ERROR: TRIGGER_ACCESS_TOKEN and TRIGGER_PROJECT_ID repo secrets must both be set" >&2
+            echo "ERROR: DEV_TRIGGER_ACCESS_TOKEN and TRIGGER_PROJECT_ID repo secrets must both be set" >&2
             exit 1
           fi
           bunx trigger.dev@4.4.3 deploy --env preview --branch dev-sim
@@ -402,7 +402,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          fetch-depth: 2  # Need at least 2 commits to detect changes
+          fetch-depth: 2 # Need at least 2 commits to detect changes
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
         working-directory: ./apps/sim
         env:
           TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
-          TRIGGER_PROJECT_ID: proj_kufttkwzywcydwtccqhx
+          TRIGGER_PROJECT_ID: ${{ secrets.TRIGGER_PROJECT_ID }}
         run: bunx trigger.dev@4.4.3 deploy --env preview --branch dev-sim
 
   # Main/staging: build AMD64 images and push to ECR + GHCR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
             ecr_repo_secret: ECR_PII
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -69,18 +69,14 @@ jobs:
 
           if [ "${ENVIRONMENT}" = "dev" ]; then
             echo "Dev environment — pushing schema directly (db:push)"
-            # drizzle-kit push prompts interactively for ambiguous renames (which
-            # --force does NOT cover). With no TTY the prompt reads EOF and drizzle
-            # can still exit 0 without applying — a false green. Close stdin, then
-            # reject prompt markers and require a success marker so an unresolved
-            # rename or failed statement fails the job instead of passing.
+            # drizzle-kit push needs a TTY to resolve ambiguous renames (--force only
+            # covers data-loss). In CI it throws "Interactive prompts require a TTY
+            # terminal" but still exits 0, so the job goes green without applying the
+            # change. tee keeps the output live in the log; we then fail on drizzle's
+            # own TTY error. A genuine non-zero exit already fails via `set -e`.
             bun run db:push --force < /dev/null 2>&1 | tee /tmp/db-push.log
-            if grep -qE "created or renamed|Do you want" /tmp/db-push.log; then
-              echo "ERROR: db:push hit an interactive rename prompt; resolve it with a versioned migration, not push." >&2
-              exit 1
-            fi
-            if ! grep -qE "Changes applied|No changes detected|No schema changes" /tmp/db-push.log; then
-              echo "ERROR: db:push did not confirm success (aborted prompt or failed statement)." >&2
+            if grep -q "Interactive prompts require a TTY terminal" /tmp/db-push.log; then
+              echo "ERROR: db:push needs an interactive rename decision; land it as a versioned migration instead of relying on push." >&2
               exit 1
             fi
           else

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -69,7 +69,20 @@ jobs:
 
           if [ "${ENVIRONMENT}" = "dev" ]; then
             echo "Dev environment — pushing schema directly (db:push)"
-            bun run db:push --force
+            # drizzle-kit push prompts interactively for ambiguous renames (which
+            # --force does NOT cover). With no TTY the prompt reads EOF and drizzle
+            # can still exit 0 without applying — a false green. Close stdin, then
+            # reject prompt markers and require a success marker so an unresolved
+            # rename or failed statement fails the job instead of passing.
+            bun run db:push --force < /dev/null 2>&1 | tee /tmp/db-push.log
+            if grep -qE "created or renamed|Do you want" /tmp/db-push.log; then
+              echo "ERROR: db:push hit an interactive rename prompt; resolve it with a versioned migration, not push." >&2
+              exit 1
+            fi
+            if ! grep -qE "Changes applied|No changes detected|No schema changes" /tmp/db-push.log; then
+              echo "ERROR: db:push did not confirm success (aborted prompt or failed statement)." >&2
+              exit 1
+            fi
           else
             echo "Applying versioned migrations (db:migrate)"
             bun run ./scripts/migrate.ts


### PR DESCRIPTION
## What

Two dev-CI fixes:

1. **Automate the Trigger.dev task deploy** that was being run by hand.
2. **Stop the dev `db:push` step from false-greening** when drizzle-kit needs an interactive prompt.

## 1. Trigger.dev deploy job

Replaces the manual command:

```
TRIGGER_PROJECT_ID=… bunx trigger.dev@4.4.3 deploy --env preview --branch dev-sim
```

New `deploy-trigger-dev` job:

- **Trigger:** push to `dev` only.
- **Ordering:** `needs: [migrate-dev]` — the deployed task code runs against the dev DB, so the schema push lands first (same rationale as `build-dev`).
- **Remote build:** no `--local-build`, so the runner needs no Docker/buildx — Trigger.dev builds server-side.
- **Auth/config:** `TRIGGER_ACCESS_TOKEN` and `TRIGGER_PROJECT_ID` from repo secrets, with a fail-fast guard so a missing secret exits with a clear message instead of a cryptic CLI error.

## 2. Dev `db:push` false-green fix (`migrations.yml`)

`drizzle-kit push` needs a TTY to resolve ambiguous renames (`--force` only covers data-loss). In CI it throws `Interactive prompts require a TTY terminal` **but still exits 0**, so the job went green while silently skipping the schema change — e.g. run [28415609570](https://github.com/simstudioai/sim/actions/runs/28415609570), which threw that error and still passed.

Fix: `tee` the output (kept live in the log) and fail on drizzle-kit's own dedicated TTY error. A genuine non-zero exit is still caught by `set -e`. Staging/prod are untouched — they use versioned `migrate.ts`.

## Required before the trigger job runs

Set both repo secrets:

```
gh secret set TRIGGER_ACCESS_TOKEN --repo simstudioai/sim   # tr_pat_… PAT
gh secret set TRIGGER_PROJECT_ID   --repo simstudioai/sim   # proj_…
```

## Notes

- No `GRAFANA_OTLP_*` vars are set in the trigger job, so telemetry stays inert and dev tasks deploy without exporting traces. (Separate, unresolved issue: prod Trigger.dev telemetry has been dark since ~06-30 — tracked outside this PR.)
- The inbox debounce / admin `useCallback` / teammates review comments are on already-merged commits (#5324, #5321) that only appear here because this PR brings `dev` up to date — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
