### PR TITLE
fix(integrations): resolve Server Components crash on the integration detail page (digest 783665031)

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/integrations/[block]/integration-block-detail-fallback.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/[block]/integration-block-detail-fallback.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { ChipLink } from '@sim/emcn'
+import { ArrowLeft } from 'lucide-react'
+
+interface IntegrationBlockDetailFallbackProps {
+  workspaceId: string
+}
+
+/**
+ * Suspense fallback for the integration detail page — the back-link chrome
+ * shown while {@link IntegrationBlockDetail} hydrates.
+ *
+ * This MUST be a client component. The lucide `ArrowLeft` passed as `ChipLink`'s
+ * `leftIcon` is a function, and functions cannot cross the server→client
+ * boundary as props. Rendering the fallback from the server `page.tsx` directly
+ * threw a React Server Components error ("Functions cannot be passed directly to
+ * Client Components") that surfaced as the integrations error boundary. Keeping
+ * the icon inside a client component avoids the boundary crossing entirely.
+ */
+export function IntegrationBlockDetailFallback({
+  workspaceId,
+}: IntegrationBlockDetailFallbackProps) {
+  return (
+    <div className='flex h-full flex-col bg-[var(--bg)]'>
+      <div className='flex flex-shrink-0 items-center bg-[var(--bg)] px-[16px] pt-[8.5px] pb-[8.5px]'>
+        <ChipLink href={`/workspace/${workspaceId}/integrations`} leftIcon={ArrowLeft}>
+          Integrations
+        </ChipLink>
+      </div>
+    </div>
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/integrations/[block]/page.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/[block]/page.tsx
@@ -1,10 +1,9 @@
 import { Suspense } from 'react'
-import { ChipLink } from '@sim/emcn'
-import { ArrowLeft } from 'lucide-react'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { INTEGRATIONS } from '@/lib/integrations'
 import { IntegrationBlockDetail } from '@/app/workspace/[workspaceId]/integrations/[block]/integration-block-detail'
+import { IntegrationBlockDetailFallback } from '@/app/workspace/[workspaceId]/integrations/[block]/integration-block-detail-fallback'
 
 export async function generateMetadata({
   params,
@@ -28,17 +27,7 @@ export default async function IntegrationBlockPage({
   if (!integration) notFound()
 
   return (
-    <Suspense
-      fallback={
-        <div className='flex h-full flex-col bg-[var(--bg)]'>
-          <div className='flex flex-shrink-0 items-center bg-[var(--bg)] px-[16px] pt-[8.5px] pb-[8.5px]'>
-            <ChipLink href={`/workspace/${workspaceId}/integrations`} leftIcon={ArrowLeft}>
-              Integrations
-            </ChipLink>
-          </div>
-        </div>
-      }
-    >
+    <Suspense fallback={<IntegrationBlockDetailFallback workspaceId={workspaceId} />}>
       <IntegrationBlockDetail integration={integration} workspaceId={workspaceId} />
     </Suspense>
   )


### PR DESCRIPTION
## Summary
- **Root cause (confirmed via staging server logs — digest `783665031`):** the integration detail route `[block]/page.tsx` is a **server component**, and its Suspense `fallback` rendered `<ChipLink leftIcon={ArrowLeft}>`. That passes the lucide `ArrowLeft` (a **function**) across the server→client boundary, which React Server Components rejects: *"Functions cannot be passed directly to Client Components."* It surfaced as the integrations error boundary ("Failed to load integrations") on soft navigation to a detail page — while a hard refresh papered over it, matching the reported "fails on nav, works on refresh" behavior.
- **Fix:** move the fallback into a small `'use client'` component (`IntegrationBlockDetailFallback`) that receives only `workspaceId` (a string). The icon now lives entirely client-side and never crosses the boundary.
- Audited every server route entry (`page`/`layout`/`template`/`default`) — this was the only occurrence of the anti-pattern.

## Type of Change
- [x] Bug fix

## Testing
Root cause identified directly from the staging CloudWatch app logs (the `digest: '783665031'` line = "Functions cannot be passed directly to Client Components"). Fix compiles clean (biome + tsc); the server component no longer imports `ChipLink`/`ArrowLeft`, so no function prop crosses the RSC boundary.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)