### PR TITLE
improvement(knowledge): make KB modals toast-only for errors

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/create-base-modal/create-base-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/create-base-modal/create-base-modal.tsx
@@ -142,14 +142,11 @@ export const CreateBaseModal = memo(function CreateBaseModal({
     onOpenChange(open)
   }
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    watch,
-    setValue,
-    formState: { errors },
-  } = useForm<FormInputValues, unknown, FormValues>({
+  const { register, handleSubmit, reset, watch, setValue } = useForm<
+    FormInputValues,
+    unknown,
+    FormValues
+  >({
     resolver: zodResolver(FormSchema),
     defaultValues: {
       name: '',
@@ -228,7 +225,7 @@ export const CreateBaseModal = memo(function CreateBaseModal({
       (fieldError) => typeof fieldError?.message === 'string'
     )?.message
     toast.error(
-      typeof firstMessage === 'string' ? firstMessage : 'Please fix the highlighted fields'
+      typeof firstMessage === 'string' ? firstMessage : 'Please fix the errors and try again'
     )
   }
 
@@ -312,7 +309,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
             <ChipInput
               placeholder='Enter knowledge base name'
               {...register('name')}
-              error={Boolean(errors.name)}
               autoComplete='off'
               autoCorrect='off'
               autoCapitalize='off'
@@ -326,7 +322,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
               placeholder='Describe this knowledge base (optional)'
               rows={4}
               {...register('description')}
-              error={Boolean(errors.description)}
             />
           </ChipModalField>
 
@@ -339,7 +334,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
                 step={1}
                 placeholder='100'
                 {...register('minChunkSize', { valueAsNumber: true })}
-                error={Boolean(errors.minChunkSize)}
                 autoComplete='off'
                 data-form-type='other'
               />
@@ -353,7 +347,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
                 step={1}
                 placeholder='1024'
                 {...register('maxChunkSize', { valueAsNumber: true })}
-                error={Boolean(errors.maxChunkSize)}
                 autoComplete='off'
                 data-form-type='other'
               />
@@ -372,7 +365,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
               step={1}
               placeholder='200'
               {...register('overlapSize', { valueAsNumber: true })}
-              error={Boolean(errors.overlapSize)}
               autoComplete='off'
               data-form-type='other'
             />
@@ -402,7 +394,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
                 <ChipInput
                   placeholder='e.g. \\n\\n or (?<=\\})\\s*(?=\\{)'
                   {...register('regexPattern')}
-                  error={Boolean(errors.regexPattern)}
                   autoComplete='off'
                   data-form-type='other'
                 />

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/create-base-modal/create-base-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/create-base-modal/create-base-modal.tsx
@@ -22,7 +22,7 @@ import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
 import { X } from 'lucide-react'
 import { useParams } from 'next/navigation'
-import { type FieldErrors, useForm } from 'react-hook-form'
+import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import type { StrategyOptions } from '@/lib/chunkers/types'
 import { KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH } from '@/lib/knowledge/constants'
@@ -142,11 +142,14 @@ export const CreateBaseModal = memo(function CreateBaseModal({
     onOpenChange(open)
   }
 
-  const { register, handleSubmit, reset, watch, setValue } = useForm<
-    FormInputValues,
-    unknown,
-    FormValues
-  >({
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<FormInputValues, unknown, FormValues>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
       name: '',
@@ -220,15 +223,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
   const isSubmitting =
     createKnowledgeBaseMutation.isPending || deleteKnowledgeBaseMutation.isPending || isUploading
 
-  const onInvalid = (formErrors: FieldErrors<FormInputValues>) => {
-    const firstMessage = Object.values(formErrors).find(
-      (fieldError) => typeof fieldError?.message === 'string'
-    )?.message
-    toast.error(
-      typeof firstMessage === 'string' ? firstMessage : 'Please fix the errors and try again'
-    )
-  }
-
   const onSubmit = async (data: FormValues) => {
     try {
       const strategyOptions: StrategyOptions | undefined =
@@ -293,7 +287,7 @@ export const CreateBaseModal = memo(function CreateBaseModal({
     <ChipModal open={open} onOpenChange={handleClose} srTitle='Create Knowledge Base' size='lg'>
       <ChipModalHeader onClose={() => handleClose(false)}>Create Knowledge Base</ChipModalHeader>
 
-      <form onSubmit={handleSubmit(onSubmit, onInvalid)} className='flex min-h-0 flex-1 flex-col'>
+      <form onSubmit={handleSubmit(onSubmit)} className='flex min-h-0 flex-1 flex-col'>
         <button type='submit' hidden disabled={isSubmitting || !nameValue?.trim()} />
         <ChipModalBody>
           <input
@@ -305,10 +299,11 @@ export const CreateBaseModal = memo(function CreateBaseModal({
             readOnly
           />
 
-          <ChipModalField type='custom' title='Name'>
+          <ChipModalField type='custom' title='Name' error={errors.name?.message}>
             <ChipInput
               placeholder='Enter knowledge base name'
               {...register('name')}
+              error={Boolean(errors.name)}
               autoComplete='off'
               autoCorrect='off'
               autoCapitalize='off'
@@ -317,16 +312,22 @@ export const CreateBaseModal = memo(function CreateBaseModal({
             />
           </ChipModalField>
 
-          <ChipModalField type='custom' title='Description'>
+          <ChipModalField type='custom' title='Description' error={errors.description?.message}>
             <ChipTextarea
               placeholder='Describe this knowledge base (optional)'
               rows={4}
               {...register('description')}
+              error={Boolean(errors.description)}
             />
           </ChipModalField>
 
           <div className='flex gap-3'>
-            <ChipModalField type='custom' title='Min Chunk Size (characters)' className='flex-1'>
+            <ChipModalField
+              type='custom'
+              title='Min Chunk Size (characters)'
+              className='flex-1'
+              error={errors.minChunkSize?.message}
+            >
               <ChipInput
                 type='number'
                 min={1}
@@ -334,12 +335,18 @@ export const CreateBaseModal = memo(function CreateBaseModal({
                 step={1}
                 placeholder='100'
                 {...register('minChunkSize', { valueAsNumber: true })}
+                error={Boolean(errors.minChunkSize)}
                 autoComplete='off'
                 data-form-type='other'
               />
             </ChipModalField>
 
-            <ChipModalField type='custom' title='Max Chunk Size (tokens)' className='flex-1'>
+            <ChipModalField
+              type='custom'
+              title='Max Chunk Size (tokens)'
+              className='flex-1'
+              error={errors.maxChunkSize?.message}
+            >
               <ChipInput
                 type='number'
                 min={100}
@@ -347,6 +354,7 @@ export const CreateBaseModal = memo(function CreateBaseModal({
                 step={1}
                 placeholder='1024'
                 {...register('maxChunkSize', { valueAsNumber: true })}
+                error={Boolean(errors.maxChunkSize)}
                 autoComplete='off'
                 data-form-type='other'
               />
@@ -357,6 +365,7 @@ export const CreateBaseModal = memo(function CreateBaseModal({
             type='custom'
             title='Overlap (tokens)'
             hint='1 token ≈ 4 characters. Max chunk size and overlap are in tokens.'
+            error={errors.overlapSize?.message}
           >
             <ChipInput
               type='number'
@@ -365,6 +374,7 @@ export const CreateBaseModal = memo(function CreateBaseModal({
               step={1}
               placeholder='200'
               {...register('overlapSize', { valueAsNumber: true })}
+              error={Boolean(errors.overlapSize)}
               autoComplete='off'
               data-form-type='other'
             />
@@ -390,10 +400,12 @@ export const CreateBaseModal = memo(function CreateBaseModal({
                 type='custom'
                 title='Regex Pattern'
                 hint='Text will be split at each match of this regex pattern.'
+                error={errors.regexPattern?.message}
               >
                 <ChipInput
                   placeholder='e.g. \\n\\n or (?<=\\})\\s*(?=\\{)'
                   {...register('regexPattern')}
+                  error={Boolean(errors.regexPattern)}
                   autoComplete='off'
                   data-form-type='other'
                 />
@@ -512,7 +524,7 @@ export const CreateBaseModal = memo(function CreateBaseModal({
                     : 'Creating...'
                 : 'Creating...'
               : 'Create',
-            onClick: handleSubmit(onSubmit, onInvalid),
+            onClick: handleSubmit(onSubmit),
             disabled: isSubmitting || !nameValue?.trim(),
           }}
         />

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/create-base-modal/create-base-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/create-base-modal/create-base-modal.tsx
@@ -9,7 +9,6 @@ import {
   ChipInput,
   ChipModal,
   ChipModalBody,
-  ChipModalError,
   ChipModalField,
   ChipModalFooter,
   ChipModalHeader,
@@ -119,11 +118,6 @@ const FormSchema = z
 type FormInputValues = z.input<typeof FormSchema>
 type FormValues = z.output<typeof FormSchema>
 
-interface SubmitStatus {
-  type: 'success' | 'error'
-  message: string
-}
-
 export const CreateBaseModal = memo(function CreateBaseModal({
   open,
   onOpenChange,
@@ -134,11 +128,10 @@ export const CreateBaseModal = memo(function CreateBaseModal({
   const createKnowledgeBaseMutation = useCreateKnowledgeBase(workspaceId)
   const deleteKnowledgeBaseMutation = useDeleteKnowledgeBase(workspaceId)
 
-  const [submitStatus, setSubmitStatus] = useState<SubmitStatus | null>(null)
   const [files, setFiles] = useState<File[]>([])
   const [fileError, setFileError] = useState<string | null>(null)
 
-  const { uploadFiles, isUploading, uploadProgress, uploadError, clearError } = useKnowledgeUpload({
+  const { uploadFiles, isUploading, uploadProgress, clearError } = useKnowledgeUpload({
     workspaceId,
   })
 
@@ -178,7 +171,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
 
   useEffect(() => {
     if (open) {
-      setSubmitStatus(null)
       setFileError(null)
       setFiles([])
       reset({
@@ -241,8 +233,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
   }
 
   const onSubmit = async (data: FormValues) => {
-    setSubmitStatus(null)
-
     try {
       const strategyOptions: StrategyOptions | undefined =
         data.strategy === 'regex' && data.regexPattern
@@ -289,7 +279,8 @@ export const CreateBaseModal = memo(function CreateBaseModal({
           } catch (deleteError) {
             logger.error('Failed to delete orphaned knowledge base:', deleteError)
           }
-          throw uploadError
+          toast.error(getErrorMessage(uploadError, 'Failed to upload files'))
+          return
         }
       }
 
@@ -298,10 +289,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
       handleClose(false)
     } catch (error) {
       logger.error('Error creating knowledge base:', error)
-      setSubmitStatus({
-        type: 'error',
-        message: getErrorMessage(error, 'An unknown error occurred'),
-      })
     }
   }
 
@@ -334,7 +321,7 @@ export const CreateBaseModal = memo(function CreateBaseModal({
             />
           </ChipModalField>
 
-          <ChipModalField type='custom' title='Description' error={errors.description?.message}>
+          <ChipModalField type='custom' title='Description'>
             <ChipTextarea
               placeholder='Describe this knowledge base (optional)'
               rows={4}
@@ -410,7 +397,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
               <ChipModalField
                 type='custom'
                 title='Regex Pattern'
-                error={errors.regexPattern?.message}
                 hint='Text will be split at each match of this regex pattern.'
               >
                 <ChipInput
@@ -520,8 +506,6 @@ export const CreateBaseModal = memo(function CreateBaseModal({
               </div>
             </ChipModalField>
           )}
-
-          <ChipModalError>{uploadError?.message || submitStatus?.message}</ChipModalError>
         </ChipModalBody>
 
         <ChipModalFooter

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/edit-knowledge-base-modal/edit-knowledge-base-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/edit-knowledge-base-modal/edit-knowledge-base-modal.tsx
@@ -7,7 +7,6 @@ import {
   ChipModalField,
   ChipModalFooter,
   ChipModalHeader,
-  toast,
 } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
 import { KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH } from '@/lib/knowledge/constants'
@@ -39,6 +38,8 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
 }: EditKnowledgeBaseModalProps) {
   const [name, setName] = useState(initialName)
   const [description, setDescription] = useState(initialDescription)
+  const [nameError, setNameError] = useState<string | null>(null)
+  const [descriptionError, setDescriptionError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   /**
@@ -51,24 +52,38 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
     if (open) {
       setName(initialName)
       setDescription(initialDescription)
+      setNameError(null)
+      setDescriptionError(null)
     }
   }
 
-  const validate = (): string | null => {
-    if (!name.trim()) return 'Name is required'
-    if (name.trim().length > 100) return 'Name must be less than 100 characters'
-    if (description.length > KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH) {
-      return `Description must be ${KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH} characters or less`
+  const validate = (): boolean => {
+    let valid = true
+
+    if (!name.trim()) {
+      setNameError('Name is required')
+      valid = false
+    } else if (name.trim().length > 100) {
+      setNameError('Name must be less than 100 characters')
+      valid = false
+    } else {
+      setNameError(null)
     }
-    return null
+
+    if (description.length > KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH) {
+      setDescriptionError(
+        `Description must be ${KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH} characters or less`
+      )
+      valid = false
+    } else {
+      setDescriptionError(null)
+    }
+
+    return valid
   }
 
   const handleSubmit = async () => {
-    const validationError = validate()
-    if (validationError) {
-      toast.error(validationError)
-      return
-    }
+    if (!validate()) return
 
     setIsSubmitting(true)
 
@@ -96,6 +111,7 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
           onChange={setName}
           placeholder='Enter knowledge base name'
           required
+          error={nameError ?? undefined}
           autoComplete='off'
         />
         <ChipModalField
@@ -105,6 +121,7 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
           onChange={setDescription}
           placeholder='Describe this knowledge base (optional)'
           rows={4}
+          error={descriptionError ?? undefined}
         />
         {chunkingConfig && (
           <ChipModalField type='custom' title='Chunking Configuration'>

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/edit-knowledge-base-modal/edit-knowledge-base-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/edit-knowledge-base-modal/edit-knowledge-base-modal.tsx
@@ -4,14 +4,12 @@ import { memo, useRef, useState } from 'react'
 import {
   ChipModal,
   ChipModalBody,
-  ChipModalError,
   ChipModalField,
   ChipModalFooter,
   ChipModalHeader,
   toast,
 } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
-import { getErrorMessage } from '@sim/utils/errors'
 import { KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH } from '@/lib/knowledge/constants'
 import type { ChunkingConfig } from '@/lib/knowledge/types'
 
@@ -41,10 +39,7 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
 }: EditKnowledgeBaseModalProps) {
   const [name, setName] = useState(initialName)
   const [description, setDescription] = useState(initialDescription)
-  const [nameError, setNameError] = useState<string | null>(null)
-  const [descriptionError, setDescriptionError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
   /**
    * Seed the fields only on the closed → open transition (render-phase reset),
@@ -56,34 +51,16 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
     if (open) {
       setName(initialName)
       setDescription(initialDescription)
-      setNameError(null)
-      setDescriptionError(null)
-      setError(null)
     }
   }
 
   const validate = (): string | null => {
-    let firstError: string | null = null
-
-    if (!name.trim()) {
-      setNameError('Name is required')
-      firstError ??= 'Name is required'
-    } else if (name.trim().length > 100) {
-      setNameError('Name must be less than 100 characters')
-      firstError ??= 'Name must be less than 100 characters'
-    } else {
-      setNameError(null)
-    }
-
+    if (!name.trim()) return 'Name is required'
+    if (name.trim().length > 100) return 'Name must be less than 100 characters'
     if (description.length > KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH) {
-      const message = `Description must be ${KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH} characters or less`
-      setDescriptionError(message)
-      firstError ??= message
-    } else {
-      setDescriptionError(null)
+      return `Description must be ${KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH} characters or less`
     }
-
-    return firstError
+    return null
   }
 
   const handleSubmit = async () => {
@@ -94,14 +71,12 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
     }
 
     setIsSubmitting(true)
-    setError(null)
 
     try {
       await onSave(knowledgeBaseId, name.trim(), description.trim())
       onOpenChange(false)
     } catch (err) {
       logger.error('Error updating knowledge base:', err)
-      setError(getErrorMessage(err, 'Failed to update knowledge base'))
     } finally {
       setIsSubmitting(false)
     }
@@ -121,7 +96,6 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
           onChange={setName}
           placeholder='Enter knowledge base name'
           required
-          error={nameError ?? undefined}
           autoComplete='off'
         />
         <ChipModalField
@@ -131,7 +105,6 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
           onChange={setDescription}
           placeholder='Describe this knowledge base (optional)'
           rows={4}
-          error={descriptionError ?? undefined}
         />
         {chunkingConfig && (
           <ChipModalField type='custom' title='Chunking Configuration'>
@@ -166,7 +139,6 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
             </div>
           </ChipModalField>
         )}
-        <ChipModalError>{error}</ChipModalError>
       </ChipModalBody>
       <ChipModalFooter
         onCancel={() => onOpenChange(false)}

--- a/apps/sim/hooks/queries/kb/knowledge.ts
+++ b/apps/sim/hooks/queries/kb/knowledge.ts
@@ -619,6 +619,9 @@ export function useCreateKnowledgeBase(workspaceId?: string) {
 
   return useMutation({
     mutationFn: createKnowledgeBase,
+    onError: (error) => {
+      toast.error(error.message, { duration: 5000 })
+    },
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: knowledgeKeys.lists(),


### PR DESCRIPTION
## Summary
- Follow-up to #5347. Standardize both KB modals on a single error-surfacing mechanism: toast.
- Create modal: validation errors already toast via `onInvalid`; removed the inline description/`regexPattern` field messages and the `submitStatus` state + `<ChipModalError>` block. Upload failures now toast in the catch.
- Add `onError: toast.error` to `useCreateKnowledgeBase` (matching `useUpdateKnowledgeBase`) so server errors surface from the hook — the create modal no longer hand-rolls server-error handling.
- Edit modal: dropped the redundant inline `nameError`/`descriptionError`/`error` state and `<ChipModalError>` (server errors already toast via the update hook's `onError`); validation now toasts.

## Type of Change
- [x] Improvement

## Testing
Tested manually. `bun run lint`, `bun run check:api-validation:strict`, and `tsc --noEmit` all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)