### PR TITLE
feat(fathom): add list meeting types tool and missing list-meetings filters

### DIFF
--- a/apps/docs/content/docs/en/integrations/fathom.mdx
+++ b/apps/docs/content/docs/en/integrations/fathom.mdx
@@ -62,20 +62,69 @@ List recent meetings recorded by the user or shared to their team.
 | --------- | ---- | ----------- |
 | `meetings` | array | List of meetings |
 |   ↳ `title` | string | Meeting title |
+|   ↳ `meeting_title` | string | Calendar event title |
 |   ↳ `meeting_type` | string | Meeting type name |
 |   ↳ `recording_id` | number | Unique recording ID |
 |   ↳ `url` | string | URL to view the meeting |
 |   ↳ `meeting_url` | string | URL of the underlying video call \(Zoom, Meet, Teams, etc.\) |
 |   ↳ `share_url` | string | Shareable URL |
 |   ↳ `created_at` | string | Creation timestamp |
+|   ↳ `scheduled_start_time` | string | Scheduled start time |
+|   ↳ `scheduled_end_time` | string | Scheduled end time |
+|   ↳ `recording_start_time` | string | Recording start time |
+|   ↳ `recording_end_time` | string | Recording end time |
 |   ↳ `transcript_language` | string | Transcript language |
+|   ↳ `calendar_invitees_domains_type` | string | Invitee domain type: only_internal or one_or_more_external |
 |   ↳ `shared_with` | string | Sharing scope: no_teams, single_team, multiple_teams, or all_teams |
+|   ↳ `recorded_by` | object | Recorder details |
+|     ↳ `name` | string | Name of the recorder |
+|     ↳ `email` | string | Email of the recorder |
+|     ↳ `email_domain` | string | Email domain of the recorder |
+|     ↳ `team` | string | Recorder team name |
+|   ↳ `calendar_invitees` | array | Calendar invitees for the meeting |
+|     ↳ `name` | string | Invitee name |
+|     ↳ `email` | string | Invitee email |
+|     ↳ `email_domain` | string | Invitee email domain |
+|     ↳ `is_external` | boolean | Whether the invitee is external |
+|     ↳ `matched_speaker_display_name` | string | Matched transcript speaker display name |
+|   ↳ `default_summary` | object | Meeting summary |
+|     ↳ `template_name` | string | Summary template name |
+|     ↳ `markdown_formatted` | string | Markdown-formatted summary |
+|   ↳ `transcript` | array | Transcript entries with speaker, text, and timestamp |
+|     ↳ `speaker` | object | Speaker information |
+|       ↳ `display_name` | string | Speaker display name |
+|       ↳ `matched_calendar_invitee_email` | string | Matched calendar invitee email |
+|     ↳ `text` | string | Transcript text |
+|     ↳ `timestamp` | string | Timestamp \(HH:MM:SS\) |
+|   ↳ `action_items` | array | Action items extracted from the meeting |
+|     ↳ `description` | string | Action item description |
+|     ↳ `user_generated` | boolean | Whether the action item was user-generated |
+|     ↳ `completed` | boolean | Whether the action item is completed |
+|     ↳ `recording_timestamp` | string | Timestamp in the recording \(HH:MM:SS\) |
+|     ↳ `recording_playback_url` | string | Playback URL for the action item moment |
+|     ↳ `assignee` | object | Assignee details |
+|       ↳ `name` | string | Assignee name |
+|       ↳ `email` | string | Assignee email |
+|       ↳ `team` | string | Assignee team |
 |   ↳ `highlights` | array | Meeting highlights with type, summary, text, and start/end time |
 |     ↳ `type` | string | Highlight type |
 |     ↳ `summary` | string | Highlight summary |
 |     ↳ `text` | string | Highlight text |
 |     ↳ `start_time` | number | Start time in seconds |
 |     ↳ `end_time` | number | End time in seconds |
+|   ↳ `crm_matches` | object | Matched CRM contacts, companies, and deals |
+|     ↳ `contacts` | array | Matched CRM contacts |
+|       ↳ `name` | string | Contact name |
+|       ↳ `email` | string | Contact email |
+|       ↳ `record_url` | string | CRM record URL |
+|     ↳ `companies` | array | Matched CRM companies |
+|       ↳ `name` | string | Company name |
+|       ↳ `record_url` | string | CRM record URL |
+|     ↳ `deals` | array | Matched CRM deals |
+|       ↳ `name` | string | Deal name |
+|       ↳ `amount` | number | Deal amount |
+|       ↳ `record_url` | string | CRM record URL |
+|     ↳ `error` | string | CRM match error, if any |
 | `next_cursor` | string | Pagination cursor for next page |
 
 ### `fathom_list_meeting_types`

--- a/apps/docs/content/docs/en/integrations/fathom.mdx
+++ b/apps/docs/content/docs/en/integrations/fathom.mdx
@@ -46,10 +46,14 @@ List recent meetings recorded by the user or shared to their team.
 | `includeTranscript` | string | No | Include meeting transcript \(true/false\) |
 | `includeActionItems` | string | No | Include action items \(true/false\) |
 | `includeCrmMatches` | string | No | Include linked CRM matches \(true/false\) |
+| `includeHighlights` | string | No | Include meeting highlights \(true/false\) |
 | `createdAfter` | string | No | Filter meetings created after this ISO 8601 timestamp |
 | `createdBefore` | string | No | Filter meetings created before this ISO 8601 timestamp |
 | `recordedBy` | string | No | Filter by recorder email address |
 | `teams` | string | No | Filter by team name |
+| `meetingType` | string | No | Filter by meeting type name |
+| `calendarInviteesDomains` | string | No | Filter by calendar invitee company domain \(exact match\) |
+| `calendarInviteesDomainsType` | string | No | Filter by invitee domain type: all, only_internal, or one_or_more_external |
 | `cursor` | string | No | Pagination cursor from a previous response |
 
 #### Output
@@ -58,11 +62,34 @@ List recent meetings recorded by the user or shared to their team.
 | --------- | ---- | ----------- |
 | `meetings` | array | List of meetings |
 |   ↳ `title` | string | Meeting title |
+|   ↳ `meeting_type` | string | Meeting type name |
 |   ↳ `recording_id` | number | Unique recording ID |
 |   ↳ `url` | string | URL to view the meeting |
 |   ↳ `share_url` | string | Shareable URL |
 |   ↳ `created_at` | string | Creation timestamp |
 |   ↳ `transcript_language` | string | Transcript language |
+|   ↳ `shared_with` | string | Sharing scope: no_teams, single_team, multiple_teams, or all_teams |
+| `next_cursor` | string | Pagination cursor for next page |
+
+### `fathom_list_meeting_types`
+
+List meeting types configured in your Fathom organization.
+
+#### Input
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `apiKey` | string | Yes | Fathom API Key |
+| `cursor` | string | No | Pagination cursor from a previous response |
+
+#### Output
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `meetingTypes` | array | List of meeting types |
+|   ↳ `name` | string | Meeting type name |
+|   ↳ `status` | string | Meeting type status: active or inactive |
+|   ↳ `created_at` | string | Date the meeting type was created |
 | `next_cursor` | string | Pagination cursor for next page |
 
 ### `fathom_get_summary`

--- a/apps/docs/content/docs/en/integrations/fathom.mdx
+++ b/apps/docs/content/docs/en/integrations/fathom.mdx
@@ -65,10 +65,17 @@ List recent meetings recorded by the user or shared to their team.
 |   ↳ `meeting_type` | string | Meeting type name |
 |   ↳ `recording_id` | number | Unique recording ID |
 |   ↳ `url` | string | URL to view the meeting |
+|   ↳ `meeting_url` | string | URL of the underlying video call \(Zoom, Meet, Teams, etc.\) |
 |   ↳ `share_url` | string | Shareable URL |
 |   ↳ `created_at` | string | Creation timestamp |
 |   ↳ `transcript_language` | string | Transcript language |
 |   ↳ `shared_with` | string | Sharing scope: no_teams, single_team, multiple_teams, or all_teams |
+|   ↳ `highlights` | array | Meeting highlights with type, summary, text, and start/end time |
+|     ↳ `type` | string | Highlight type |
+|     ↳ `summary` | string | Highlight summary |
+|     ↳ `text` | string | Highlight text |
+|     ↳ `start_time` | number | Start time in seconds |
+|     ↳ `end_time` | number | End time in seconds |
 | `next_cursor` | string | Pagination cursor for next page |
 
 ### `fathom_list_meeting_types`

--- a/apps/sim/blocks/blocks/fathom.ts
+++ b/apps/sim/blocks/blocks/fathom.ts
@@ -165,7 +165,6 @@ export const FathomBlock: BlockConfig<FathomResponse> = {
         { label: 'Only Internal', id: 'only_internal' },
         { label: 'One or More External', id: 'one_or_more_external' },
       ],
-      value: () => 'all',
       condition: { field: 'operation', value: 'fathom_list_meetings' },
       mode: 'advanced',
     },

--- a/apps/sim/blocks/blocks/fathom.ts
+++ b/apps/sim/blocks/blocks/fathom.ts
@@ -24,6 +24,7 @@ export const FathomBlock: BlockConfig<FathomResponse> = {
       type: 'dropdown',
       options: [
         { label: 'List Meetings', id: 'fathom_list_meetings' },
+        { label: 'List Meeting Types', id: 'fathom_list_meeting_types' },
         { label: 'Get Summary', id: 'fathom_get_summary' },
         { label: 'Get Transcript', id: 'fathom_get_transcript' },
         { label: 'List Team Members', id: 'fathom_list_team_members' },
@@ -84,6 +85,17 @@ export const FathomBlock: BlockConfig<FathomResponse> = {
       condition: { field: 'operation', value: 'fathom_list_meetings' },
     },
     {
+      id: 'includeHighlights',
+      title: 'Include Highlights',
+      type: 'dropdown',
+      options: [
+        { label: 'No', id: 'false' },
+        { label: 'Yes', id: 'true' },
+      ],
+      value: () => 'false',
+      condition: { field: 'operation', value: 'fathom_list_meetings' },
+    },
+    {
       id: 'createdAfter',
       title: 'Created After',
       type: 'short-input',
@@ -129,13 +141,47 @@ export const FathomBlock: BlockConfig<FathomResponse> = {
       mode: 'advanced',
     },
     {
+      id: 'meetingType',
+      title: 'Meeting Type',
+      type: 'short-input',
+      placeholder: 'Filter by meeting type name',
+      condition: { field: 'operation', value: 'fathom_list_meetings' },
+      mode: 'advanced',
+    },
+    {
+      id: 'calendarInviteesDomains',
+      title: 'Invitee Domain',
+      type: 'short-input',
+      placeholder: 'Filter by calendar invitee company domain',
+      condition: { field: 'operation', value: 'fathom_list_meetings' },
+      mode: 'advanced',
+    },
+    {
+      id: 'calendarInviteesDomainsType',
+      title: 'Invitee Domain Type',
+      type: 'dropdown',
+      options: [
+        { label: 'All', id: 'all' },
+        { label: 'Only Internal', id: 'only_internal' },
+        { label: 'One or More External', id: 'one_or_more_external' },
+      ],
+      value: () => 'all',
+      condition: { field: 'operation', value: 'fathom_list_meetings' },
+      mode: 'advanced',
+    },
+    {
       id: 'cursor',
       title: 'Pagination Cursor',
       type: 'short-input',
       placeholder: 'Cursor from a previous response',
       condition: {
         field: 'operation',
-        value: ['fathom_list_meetings', 'fathom_list_team_members', 'fathom_list_teams'],
+        value: [
+          'fathom_list_meetings',
+          'fathom_list_meeting_types',
+          'fathom_list_team_members',
+          'fathom_list_teams',
+        ],
       },
       mode: 'advanced',
     },
@@ -162,6 +208,7 @@ export const FathomBlock: BlockConfig<FathomResponse> = {
   tools: {
     access: [
       'fathom_list_meetings',
+      'fathom_list_meeting_types',
       'fathom_get_summary',
       'fathom_get_transcript',
       'fathom_list_team_members',
@@ -187,6 +234,10 @@ export const FathomBlock: BlockConfig<FathomResponse> = {
       type: 'string',
       description: 'Include linked CRM matches in meetings response',
     },
+    includeHighlights: {
+      type: 'string',
+      description: 'Include highlights in meetings response',
+    },
     createdAfter: { type: 'string', description: 'Filter meetings created after this timestamp' },
     createdBefore: {
       type: 'string',
@@ -194,10 +245,20 @@ export const FathomBlock: BlockConfig<FathomResponse> = {
     },
     recordedBy: { type: 'string', description: 'Filter by recorder email' },
     teams: { type: 'string', description: 'Filter by team name' },
+    meetingType: { type: 'string', description: 'Filter by meeting type name' },
+    calendarInviteesDomains: {
+      type: 'string',
+      description: 'Filter by calendar invitee company domain',
+    },
+    calendarInviteesDomainsType: {
+      type: 'string',
+      description: 'Filter by invitee domain type',
+    },
     cursor: { type: 'string', description: 'Pagination cursor for next page' },
   },
   outputs: {
     meetings: { type: 'json', description: 'List of meetings' },
+    meetingTypes: { type: 'json', description: 'List of meeting types' },
     template_name: { type: 'string', description: 'Summary template name' },
     markdown_formatted: { type: 'string', description: 'Markdown-formatted summary' },
     transcript: { type: 'json', description: 'Meeting transcript entries' },

--- a/apps/sim/lib/integrations/integrations.json
+++ b/apps/sim/lib/integrations/integrations.json
@@ -5087,6 +5087,10 @@
           "description": "List recent meetings recorded by the user or shared to their team."
         },
         {
+          "name": "List Meeting Types",
+          "description": "List meeting types configured in your Fathom organization."
+        },
+        {
           "name": "Get Summary",
           "description": "Get the call summary for a specific meeting recording."
         },
@@ -5103,7 +5107,7 @@
           "description": "List teams in your Fathom organization."
         }
       ],
-      "operationCount": 5,
+      "operationCount": 6,
       "triggers": [
         {
           "id": "fathom_new_meeting",

--- a/apps/sim/tools/fathom/index.ts
+++ b/apps/sim/tools/fathom/index.ts
@@ -1,5 +1,6 @@
 import { getSummaryTool } from '@/tools/fathom/get_summary'
 import { getTranscriptTool } from '@/tools/fathom/get_transcript'
+import { listMeetingTypesTool } from '@/tools/fathom/list_meeting_types'
 import { listMeetingsTool } from '@/tools/fathom/list_meetings'
 import { listTeamMembersTool } from '@/tools/fathom/list_team_members'
 import { listTeamsTool } from '@/tools/fathom/list_teams'
@@ -7,6 +8,7 @@ import { listTeamsTool } from '@/tools/fathom/list_teams'
 export const fathomGetSummaryTool = getSummaryTool
 export const fathomGetTranscriptTool = getTranscriptTool
 export const fathomListMeetingsTool = listMeetingsTool
+export const fathomListMeetingTypesTool = listMeetingTypesTool
 export const fathomListTeamMembersTool = listTeamMembersTool
 export const fathomListTeamsTool = listTeamsTool
 

--- a/apps/sim/tools/fathom/list_meeting_types.ts
+++ b/apps/sim/tools/fathom/list_meeting_types.ts
@@ -1,0 +1,96 @@
+import type {
+  FathomListMeetingTypesParams,
+  FathomListMeetingTypesResponse,
+} from '@/tools/fathom/types'
+import type { ToolConfig } from '@/tools/types'
+
+export const listMeetingTypesTool: ToolConfig<
+  FathomListMeetingTypesParams,
+  FathomListMeetingTypesResponse
+> = {
+  id: 'fathom_list_meeting_types',
+  name: 'Fathom List Meeting Types',
+  description: 'List meeting types configured in your Fathom organization.',
+  version: '1.0.0',
+
+  params: {
+    apiKey: {
+      type: 'string',
+      required: true,
+      visibility: 'user-only',
+      description: 'Fathom API Key',
+    },
+    cursor: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Pagination cursor from a previous response',
+    },
+  },
+
+  request: {
+    url: (params) => {
+      const url = new URL('https://api.fathom.ai/external/v1/meeting_types')
+      if (params.cursor) url.searchParams.append('cursor', params.cursor)
+      return url.toString()
+    },
+    method: 'GET',
+    headers: (params) => ({
+      'X-Api-Key': params.apiKey,
+      'Content-Type': 'application/json',
+    }),
+  },
+
+  transformResponse: async (response: Response) => {
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      return {
+        success: false,
+        error:
+          (errorData as Record<string, string>).message ||
+          `Fathom API error: ${response.status} ${response.statusText}`,
+        output: {
+          meetingTypes: [],
+          next_cursor: null,
+        },
+      }
+    }
+
+    const data = await response.json()
+    const meetingTypes = (data.items ?? []).map(
+      (meetingType: { name?: string; status?: string; created_at?: string }) => ({
+        name: meetingType.name ?? '',
+        status: meetingType.status ?? '',
+        created_at: meetingType.created_at ?? '',
+      })
+    )
+
+    return {
+      success: true,
+      output: {
+        meetingTypes,
+        next_cursor: data.next_cursor ?? null,
+      },
+    }
+  },
+
+  outputs: {
+    meetingTypes: {
+      type: 'array',
+      description: 'List of meeting types',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'Meeting type name' },
+          status: { type: 'string', description: 'Meeting type status: active or inactive' },
+          created_at: { type: 'string', description: 'Date the meeting type was created' },
+        },
+      },
+    },
+    next_cursor: {
+      type: 'string',
+      description: 'Pagination cursor for next page',
+      optional: true,
+    },
+  },
+}

--- a/apps/sim/tools/fathom/list_meetings.ts
+++ b/apps/sim/tools/fathom/list_meetings.ts
@@ -197,6 +197,11 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
           meeting_type: { type: 'string', description: 'Meeting type name', optional: true },
           recording_id: { type: 'number', description: 'Unique recording ID' },
           url: { type: 'string', description: 'URL to view the meeting' },
+          meeting_url: {
+            type: 'string',
+            description: 'URL of the underlying video call (Zoom, Meet, Teams, etc.)',
+            optional: true,
+          },
           share_url: { type: 'string', description: 'Shareable URL' },
           created_at: { type: 'string', description: 'Creation timestamp' },
           transcript_language: { type: 'string', description: 'Transcript language' },
@@ -204,6 +209,21 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
             type: 'string',
             description: 'Sharing scope: no_teams, single_team, multiple_teams, or all_teams',
             optional: true,
+          },
+          highlights: {
+            type: 'array',
+            description: 'Meeting highlights with type, summary, text, and start/end time',
+            optional: true,
+            items: {
+              type: 'object',
+              properties: {
+                type: { type: 'string', description: 'Highlight type' },
+                summary: { type: 'string', description: 'Highlight summary', optional: true },
+                text: { type: 'string', description: 'Highlight text' },
+                start_time: { type: 'number', description: 'Start time in seconds' },
+                end_time: { type: 'number', description: 'End time in seconds' },
+              },
+            },
           },
         },
       },

--- a/apps/sim/tools/fathom/list_meetings.ts
+++ b/apps/sim/tools/fathom/list_meetings.ts
@@ -111,7 +111,7 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
       if (params.meetingType) url.searchParams.append('meeting_type', params.meetingType)
       if (params.calendarInviteesDomains)
         url.searchParams.append('calendar_invitees_domains[]', params.calendarInviteesDomains)
-      if (params.calendarInviteesDomainsType)
+      if (params.calendarInviteesDomainsType && params.calendarInviteesDomainsType !== 'all')
         url.searchParams.append(
           'calendar_invitees_domains_type',
           params.calendarInviteesDomainsType

--- a/apps/sim/tools/fathom/list_meetings.ts
+++ b/apps/sim/tools/fathom/list_meetings.ts
@@ -194,6 +194,7 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
         type: 'object',
         properties: {
           title: { type: 'string', description: 'Meeting title' },
+          meeting_title: { type: 'string', description: 'Calendar event title', optional: true },
           meeting_type: { type: 'string', description: 'Meeting type name', optional: true },
           recording_id: { type: 'number', description: 'Unique recording ID' },
           url: { type: 'string', description: 'URL to view the meeting' },
@@ -204,11 +205,143 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
           },
           share_url: { type: 'string', description: 'Shareable URL' },
           created_at: { type: 'string', description: 'Creation timestamp' },
+          scheduled_start_time: {
+            type: 'string',
+            description: 'Scheduled start time',
+            optional: true,
+          },
+          scheduled_end_time: {
+            type: 'string',
+            description: 'Scheduled end time',
+            optional: true,
+          },
+          recording_start_time: {
+            type: 'string',
+            description: 'Recording start time',
+            optional: true,
+          },
+          recording_end_time: {
+            type: 'string',
+            description: 'Recording end time',
+            optional: true,
+          },
           transcript_language: { type: 'string', description: 'Transcript language' },
+          calendar_invitees_domains_type: {
+            type: 'string',
+            description: 'Invitee domain type: only_internal or one_or_more_external',
+            optional: true,
+          },
           shared_with: {
             type: 'string',
             description: 'Sharing scope: no_teams, single_team, multiple_teams, or all_teams',
             optional: true,
+          },
+          recorded_by: {
+            type: 'object',
+            description: 'Recorder details',
+            optional: true,
+            properties: {
+              name: { type: 'string', description: 'Name of the recorder' },
+              email: { type: 'string', description: 'Email of the recorder' },
+              email_domain: { type: 'string', description: 'Email domain of the recorder' },
+              team: { type: 'string', description: 'Recorder team name', optional: true },
+            },
+          },
+          calendar_invitees: {
+            type: 'array',
+            description: 'Calendar invitees for the meeting',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string', description: 'Invitee name', optional: true },
+                email: { type: 'string', description: 'Invitee email' },
+                email_domain: {
+                  type: 'string',
+                  description: 'Invitee email domain',
+                  optional: true,
+                },
+                is_external: { type: 'boolean', description: 'Whether the invitee is external' },
+                matched_speaker_display_name: {
+                  type: 'string',
+                  description: 'Matched transcript speaker display name',
+                  optional: true,
+                },
+              },
+            },
+          },
+          default_summary: {
+            type: 'object',
+            description: 'Meeting summary',
+            optional: true,
+            properties: {
+              template_name: {
+                type: 'string',
+                description: 'Summary template name',
+                optional: true,
+              },
+              markdown_formatted: {
+                type: 'string',
+                description: 'Markdown-formatted summary',
+                optional: true,
+              },
+            },
+          },
+          transcript: {
+            type: 'array',
+            description: 'Transcript entries with speaker, text, and timestamp',
+            optional: true,
+            items: {
+              type: 'object',
+              properties: {
+                speaker: {
+                  type: 'object',
+                  description: 'Speaker information',
+                  properties: {
+                    display_name: { type: 'string', description: 'Speaker display name' },
+                    matched_calendar_invitee_email: {
+                      type: 'string',
+                      description: 'Matched calendar invitee email',
+                      optional: true,
+                    },
+                  },
+                },
+                text: { type: 'string', description: 'Transcript text' },
+                timestamp: { type: 'string', description: 'Timestamp (HH:MM:SS)' },
+              },
+            },
+          },
+          action_items: {
+            type: 'array',
+            description: 'Action items extracted from the meeting',
+            optional: true,
+            items: {
+              type: 'object',
+              properties: {
+                description: { type: 'string', description: 'Action item description' },
+                user_generated: {
+                  type: 'boolean',
+                  description: 'Whether the action item was user-generated',
+                },
+                completed: { type: 'boolean', description: 'Whether the action item is completed' },
+                recording_timestamp: {
+                  type: 'string',
+                  description: 'Timestamp in the recording (HH:MM:SS)',
+                },
+                recording_playback_url: {
+                  type: 'string',
+                  description: 'Playback URL for the action item moment',
+                },
+                assignee: {
+                  type: 'object',
+                  description: 'Assignee details',
+                  properties: {
+                    name: { type: 'string', description: 'Assignee name', optional: true },
+                    email: { type: 'string', description: 'Assignee email', optional: true },
+                    team: { type: 'string', description: 'Assignee team', optional: true },
+                  },
+                },
+              },
+            },
           },
           highlights: {
             type: 'array',
@@ -223,6 +356,49 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
                 start_time: { type: 'number', description: 'Start time in seconds' },
                 end_time: { type: 'number', description: 'End time in seconds' },
               },
+            },
+          },
+          crm_matches: {
+            type: 'object',
+            description: 'Matched CRM contacts, companies, and deals',
+            optional: true,
+            properties: {
+              contacts: {
+                type: 'array',
+                description: 'Matched CRM contacts',
+                items: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string', description: 'Contact name' },
+                    email: { type: 'string', description: 'Contact email' },
+                    record_url: { type: 'string', description: 'CRM record URL' },
+                  },
+                },
+              },
+              companies: {
+                type: 'array',
+                description: 'Matched CRM companies',
+                items: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string', description: 'Company name' },
+                    record_url: { type: 'string', description: 'CRM record URL' },
+                  },
+                },
+              },
+              deals: {
+                type: 'array',
+                description: 'Matched CRM deals',
+                items: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string', description: 'Deal name' },
+                    amount: { type: 'number', description: 'Deal amount' },
+                    record_url: { type: 'string', description: 'CRM record URL' },
+                  },
+                },
+              },
+              error: { type: 'string', description: 'CRM match error, if any', optional: true },
             },
           },
         },

--- a/apps/sim/tools/fathom/list_meetings.ts
+++ b/apps/sim/tools/fathom/list_meetings.ts
@@ -38,6 +38,12 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
       visibility: 'user-or-llm',
       description: 'Include linked CRM matches (true/false)',
     },
+    includeHighlights: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Include meeting highlights (true/false)',
+    },
     createdAfter: {
       type: 'string',
       required: false,
@@ -62,6 +68,24 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
       visibility: 'user-or-llm',
       description: 'Filter by team name',
     },
+    meetingType: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Filter by meeting type name',
+    },
+    calendarInviteesDomains: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Filter by calendar invitee company domain (exact match)',
+    },
+    calendarInviteesDomainsType: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Filter by invitee domain type: all, only_internal, or one_or_more_external',
+    },
     cursor: {
       type: 'string',
       required: false,
@@ -79,10 +103,19 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
         url.searchParams.append('include_action_items', 'true')
       if (params.includeCrmMatches === 'true')
         url.searchParams.append('include_crm_matches', 'true')
+      if (params.includeHighlights === 'true') url.searchParams.append('include_highlights', 'true')
       if (params.createdAfter) url.searchParams.append('created_after', params.createdAfter)
       if (params.createdBefore) url.searchParams.append('created_before', params.createdBefore)
       if (params.recordedBy) url.searchParams.append('recorded_by[]', params.recordedBy)
       if (params.teams) url.searchParams.append('teams[]', params.teams)
+      if (params.meetingType) url.searchParams.append('meeting_type', params.meetingType)
+      if (params.calendarInviteesDomains)
+        url.searchParams.append('calendar_invitees_domains[]', params.calendarInviteesDomains)
+      if (params.calendarInviteesDomainsType)
+        url.searchParams.append(
+          'calendar_invitees_domains_type',
+          params.calendarInviteesDomainsType
+        )
       if (params.cursor) url.searchParams.append('cursor', params.cursor)
       return url.toString()
     },
@@ -114,8 +147,10 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
       (meeting: Record<string, unknown> & { recorded_by?: Record<string, unknown> }) => ({
         title: meeting.title ?? '',
         meeting_title: meeting.meeting_title ?? null,
+        meeting_type: meeting.meeting_type ?? null,
         recording_id: meeting.recording_id ?? null,
         url: meeting.url ?? '',
+        meeting_url: meeting.meeting_url ?? null,
         share_url: meeting.share_url ?? '',
         created_at: meeting.created_at ?? '',
         scheduled_start_time: meeting.scheduled_start_time ?? null,
@@ -124,6 +159,7 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
         recording_end_time: meeting.recording_end_time ?? null,
         transcript_language: meeting.transcript_language ?? '',
         calendar_invitees_domains_type: meeting.calendar_invitees_domains_type ?? null,
+        shared_with: meeting.shared_with ?? null,
         recorded_by: meeting.recorded_by
           ? {
               name: meeting.recorded_by.name ?? '',
@@ -136,6 +172,7 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
         default_summary: meeting.default_summary ?? null,
         transcript: meeting.transcript ?? null,
         action_items: meeting.action_items ?? null,
+        highlights: meeting.highlights ?? null,
         crm_matches: meeting.crm_matches ?? null,
       })
     )
@@ -157,11 +194,17 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
         type: 'object',
         properties: {
           title: { type: 'string', description: 'Meeting title' },
+          meeting_type: { type: 'string', description: 'Meeting type name', optional: true },
           recording_id: { type: 'number', description: 'Unique recording ID' },
           url: { type: 'string', description: 'URL to view the meeting' },
           share_url: { type: 'string', description: 'Shareable URL' },
           created_at: { type: 'string', description: 'Creation timestamp' },
           transcript_language: { type: 'string', description: 'Transcript language' },
+          shared_with: {
+            type: 'string',
+            description: 'Sharing scope: no_teams, single_team, multiple_teams, or all_teams',
+            optional: true,
+          },
         },
       },
     },

--- a/apps/sim/tools/fathom/list_meetings.ts
+++ b/apps/sim/tools/fathom/list_meetings.ts
@@ -254,7 +254,7 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
               type: 'object',
               properties: {
                 name: { type: 'string', description: 'Invitee name', optional: true },
-                email: { type: 'string', description: 'Invitee email' },
+                email: { type: 'string', description: 'Invitee email', optional: true },
                 email_domain: {
                   type: 'string',
                   description: 'Invitee email domain',

--- a/apps/sim/tools/fathom/list_meetings.ts
+++ b/apps/sim/tools/fathom/list_meetings.ts
@@ -196,7 +196,7 @@ export const listMeetingsTool: ToolConfig<FathomListMeetingsParams, FathomListMe
           title: { type: 'string', description: 'Meeting title' },
           meeting_title: { type: 'string', description: 'Calendar event title', optional: true },
           meeting_type: { type: 'string', description: 'Meeting type name', optional: true },
-          recording_id: { type: 'number', description: 'Unique recording ID' },
+          recording_id: { type: 'number', description: 'Unique recording ID', optional: true },
           url: { type: 'string', description: 'URL to view the meeting' },
           meeting_url: {
             type: 'string',

--- a/apps/sim/tools/fathom/types.ts
+++ b/apps/sim/tools/fathom/types.ts
@@ -9,10 +9,14 @@ export interface FathomListMeetingsParams extends FathomBaseParams {
   includeTranscript?: string
   includeActionItems?: string
   includeCrmMatches?: string
+  includeHighlights?: string
   createdAfter?: string
   createdBefore?: string
   recordedBy?: string
   teams?: string
+  meetingType?: string
+  calendarInviteesDomains?: string
+  calendarInviteesDomainsType?: string
   cursor?: string
 }
 
@@ -21,8 +25,10 @@ export interface FathomListMeetingsResponse extends ToolResponse {
     meetings: Array<{
       title: string
       meeting_title: string | null
+      meeting_type: string | null
       recording_id: number | null
       url: string
+      meeting_url: string | null
       share_url: string
       created_at: string
       scheduled_start_time: string | null
@@ -31,6 +37,7 @@ export interface FathomListMeetingsResponse extends ToolResponse {
       recording_end_time: string | null
       transcript_language: string
       calendar_invitees_domains_type: string | null
+      shared_with: string | null
       recorded_by: { name: string; email: string; email_domain: string; team: string | null } | null
       calendar_invitees: Array<{
         name: string | null
@@ -52,6 +59,13 @@ export interface FathomListMeetingsResponse extends ToolResponse {
         recording_timestamp: string
         recording_playback_url: string
         assignee: { name: string | null; email: string | null; team: string | null }
+      }> | null
+      highlights: Array<{
+        type: string
+        summary: string | null
+        text: string
+        start_time: number
+        end_time: number
       }> | null
       crm_matches: {
         contacts: Array<{ name: string; email: string; record_url: string }>
@@ -119,9 +133,25 @@ export interface FathomListTeamsResponse extends ToolResponse {
   }
 }
 
+export interface FathomListMeetingTypesParams extends FathomBaseParams {
+  cursor?: string
+}
+
+export interface FathomListMeetingTypesResponse extends ToolResponse {
+  output: {
+    meetingTypes: Array<{
+      name: string
+      status: string
+      created_at: string
+    }>
+    next_cursor: string | null
+  }
+}
+
 export type FathomResponse =
   | FathomListMeetingsResponse
   | FathomGetSummaryResponse
   | FathomGetTranscriptResponse
   | FathomListTeamMembersResponse
   | FathomListTeamsResponse
+  | FathomListMeetingTypesResponse

--- a/apps/sim/tools/registry.ts
+++ b/apps/sim/tools/registry.ts
@@ -893,6 +893,7 @@ import {
   fathomGetSummaryTool,
   fathomGetTranscriptTool,
   fathomListMeetingsTool,
+  fathomListMeetingTypesTool,
   fathomListTeamMembersTool,
   fathomListTeamsTool,
 } from '@/tools/fathom'
@@ -6890,6 +6891,7 @@ export const tools: Record<string, ToolConfig> = {
   elevenlabs_speech_to_speech: elevenLabsSpeechToSpeechTool,
   elevenlabs_audio_isolation: elevenLabsAudioIsolationTool,
   fathom_list_meetings: fathomListMeetingsTool,
+  fathom_list_meeting_types: fathomListMeetingTypesTool,
   fathom_get_summary: fathomGetSummaryTool,
   fathom_get_transcript: fathomGetTranscriptTool,
   fathom_list_team_members: fathomListTeamMembersTool,


### PR DESCRIPTION
## Summary
- Ran /validate-integration on Fathom against the live API docs (developers.fathom.ai)
- Added a new `fathom_list_meeting_types` tool — Fathom's `GET /meeting_types` endpoint had no coverage
- Added missing `list_meetings` filters: `includeHighlights`, `meetingType`, `calendarInviteesDomains`, `calendarInviteesDomainsType`
- Added missing fields to the meeting response shape: `meeting_type`, `meeting_url`, `shared_with`, `highlights`
- Wired the new operation and filters into the Fathom block (subblocks, tools.access, inputs/outputs)
- Regenerated integration docs

## Type of Change
- [x] New feature / integration completeness fix

## Testing
- `bun run type-check` clean
- `bunx biome check` clean on all touched files
- Cross-referenced every endpoint, param, and response field against developers.fathom.ai

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)