### PR TITLE
improvement(brex): fill validate-integration gaps against live API docs

### DIFF
--- a/apps/sim/blocks/blocks/brex.ts
+++ b/apps/sim/blocks/blocks/brex.ts
@@ -215,6 +215,12 @@ export const BrexBlock: BlockConfig<BrexResponse> = {
       placeholder: 'Comma-separated user IDs to filter by',
       mode: 'advanced',
       condition: { field: 'operation', value: ['list_expenses', 'list_card_transactions'] },
+      wandConfig: {
+        enabled: true,
+        prompt:
+          'Generate a comma-separated list of Brex user IDs to filter by based on the description.\n\nReturn ONLY the comma-separated user IDs - no explanations, no extra text.',
+        placeholder: 'Describe which users to include...',
+      },
     },
     {
       id: 'statuses',
@@ -223,6 +229,12 @@ export const BrexBlock: BlockConfig<BrexResponse> = {
       placeholder: 'e.g., APPROVED, SETTLED (comma-separated)',
       mode: 'advanced',
       condition: { field: 'operation', value: 'list_expenses' },
+      wandConfig: {
+        enabled: true,
+        prompt:
+          'Generate a comma-separated list of Brex expense statuses to filter by.\n\nValid statuses: DRAFT, SUBMITTED, APPROVED, OUT_OF_POLICY, VOID, CANCELED, SPLIT, SETTLED\n\nExamples:\n- "only settled expenses" -> SETTLED\n- "approved or settled" -> APPROVED,SETTLED\n- "expenses awaiting review" -> DRAFT,SUBMITTED\n\nReturn ONLY the comma-separated status values - no explanations, no extra text.',
+        placeholder: 'Describe which expense statuses to include...',
+      },
     },
     {
       id: 'paymentStatuses',
@@ -231,6 +243,12 @@ export const BrexBlock: BlockConfig<BrexResponse> = {
       placeholder: 'e.g., CLEARED, REFUNDED (comma-separated)',
       mode: 'advanced',
       condition: { field: 'operation', value: 'list_expenses' },
+      wandConfig: {
+        enabled: true,
+        prompt:
+          'Generate a comma-separated list of Brex expense payment statuses to filter by.\n\nValid statuses: NOT_STARTED, PROCESSING, CANCELED, DECLINED, CLEARED, REFUNDING, REFUNDED, CASH_ADVANCE, CREDITED, AWAITING_PAYMENT, SCHEDULED\n\nExamples:\n- "only cleared payments" -> CLEARED\n- "refunded or refunding" -> REFUNDED,REFUNDING\n\nReturn ONLY the comma-separated status values - no explanations, no extra text.',
+        placeholder: 'Describe which payment statuses to include...',
+      },
     },
     {
       id: 'purchasedAtStart',
@@ -284,6 +302,12 @@ export const BrexBlock: BlockConfig<BrexResponse> = {
       placeholder: 'Comma-separated user IDs to filter spend limits by member',
       mode: 'advanced',
       condition: { field: 'operation', value: 'list_spend_limits' },
+      wandConfig: {
+        enabled: true,
+        prompt:
+          'Generate a comma-separated list of Brex user IDs to filter spend limits by member based on the description.\n\nReturn ONLY the comma-separated user IDs - no explanations, no extra text.',
+        placeholder: 'Describe which spend limit members to include...',
+      },
     },
     {
       id: 'cursor',

--- a/apps/sim/tools/brex/get_transfer.ts
+++ b/apps/sim/tools/brex/get_transfer.ts
@@ -50,6 +50,7 @@ export const brexGetTransferTool: ToolConfig<BrexGetTransferParams, BrexGetTrans
         createdAt: data.created_at ?? null,
         displayName: data.display_name ?? null,
         externalMemo: data.external_memo ?? null,
+        isPproEnabled: data.is_ppro_enabled ?? null,
       },
     }
   },
@@ -97,5 +98,10 @@ export const brexGetTransferTool: ToolConfig<BrexGetTransferParams, BrexGetTrans
     createdAt: { type: 'string', description: 'Creation timestamp', optional: true },
     displayName: { type: 'string', description: 'Transfer display name', optional: true },
     externalMemo: { type: 'string', description: 'External memo', optional: true },
+    isPproEnabled: {
+      type: 'boolean',
+      description: 'Whether Principal Protection (PPRO) is enabled',
+      optional: true,
+    },
   },
 }

--- a/apps/sim/tools/brex/list_spend_limits.ts
+++ b/apps/sim/tools/brex/list_spend_limits.ts
@@ -88,6 +88,8 @@ export const brexListSpendLimitsTool: ToolConfig<
             description: 'Period recurrence (PER_WEEK, PER_MONTH, PER_QUARTER, PER_YEAR, ONE_TIME)',
           },
           spend_type: { type: 'string', description: 'Spend type of the limit' },
+          start_date: { type: 'string', description: 'Spend limit start date', optional: true },
+          end_date: { type: 'string', description: 'Spend limit end date', optional: true },
           owner_user_ids: { type: 'array', description: 'User IDs of the spend limit owners' },
           member_user_ids: { type: 'array', description: 'User IDs of the spend limit members' },
           current_period_balance: {
@@ -95,6 +97,12 @@ export const brexListSpendLimitsTool: ToolConfig<
             description: 'Spend and rollover amounts for the current period',
             optional: true,
             properties: BREX_SPEND_LIMIT_PERIOD_BALANCE_PROPERTIES,
+          },
+          authorization_settings: {
+            type: 'json',
+            description:
+              'Authorization settings (base limit, authorization type, rollover refresh)',
+            optional: true,
           },
         },
       },

--- a/apps/sim/tools/brex/list_transfers.ts
+++ b/apps/sim/tools/brex/list_transfers.ts
@@ -115,6 +115,11 @@ export const brexListTransfersTool: ToolConfig<BrexPaginationParams, BrexListTra
           created_at: { type: 'string', description: 'Creation timestamp', optional: true },
           display_name: { type: 'string', description: 'Transfer display name', optional: true },
           external_memo: { type: 'string', description: 'External memo', optional: true },
+          is_ppro_enabled: {
+            type: 'boolean',
+            description: 'Whether Principal Protection (PPRO) is enabled',
+            optional: true,
+          },
         },
       },
     },

--- a/apps/sim/tools/brex/types.ts
+++ b/apps/sim/tools/brex/types.ts
@@ -143,9 +143,12 @@ export interface BrexSpendLimit {
   status: string
   period_recurrence_type: string
   spend_type: string
+  start_date: string | null
+  end_date: string | null
   owner_user_ids: string[]
   member_user_ids: string[]
   current_period_balance: BrexSpendLimitPeriodBalance | null
+  authorization_settings: Record<string, unknown> | null
 }
 
 export interface BrexVendor {
@@ -171,6 +174,7 @@ export interface BrexTransfer {
   created_at: string | null
   display_name: string | null
   external_memo: string | null
+  is_ppro_enabled: boolean | null
 }
 
 export interface BrexCard {
@@ -551,6 +555,7 @@ export interface BrexGetTransferResponse extends ToolResponse {
     createdAt: string | null
     displayName: string | null
     externalMemo: string | null
+    isPproEnabled: boolean | null
   }
 }
 


### PR DESCRIPTION
## Summary
- Ran a full /validate-integration audit on the Brex integration (28 tools + block) against Brex's live REST v2 API docs
- Added AI-autofill (wandConfig) to the expense/spend-limit advanced-mode filter subBlocks (user IDs, statuses, payment statuses)
- Surfaced `is_ppro_enabled` on the get/list transfer tools — confirmed present in Brex's live Transfer schema but previously missing from our output
- Surfaced `start_date`/`end_date`/`authorization_settings` on `list_spend_limits` to match what `get_spend_limit` already exposes for the same resource
- Confirmed via 6 parallel adversarial re-validation passes: endpoints, methods, params, response mappings, pagination, and block/tool wiring are all correct; no fields removed, fully backwards compatible

## Type of Change
- [x] Improvement

## Testing
Tested manually. `bun run lint` and `bun run type-check` pass clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)