### PR TITLE
fix(brex): surface isPproEnabled in transfer block outputs

### DIFF
--- a/apps/sim/blocks/blocks/brex.ts
+++ b/apps/sim/blocks/blocks/brex.ts
@@ -591,6 +591,10 @@ export const BrexBlock: BlockConfig<BrexResponse> = {
     createdAt: { type: 'string', description: 'Creation timestamp of the transfer' },
     displayName: { type: 'string', description: 'Display name of the transfer' },
     externalMemo: { type: 'string', description: 'External memo of the transfer' },
+    isPproEnabled: {
+      type: 'boolean',
+      description: 'Whether Principal Protection (PPRO) is enabled for the transfer',
+    },
   },
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to #5362: the final confirmatory /validate-integration pass found that `get_transfer`/`list_transfers` tool outputs already include `isPproEnabled`/`is_ppro_enabled`, but the block's declared `outputs` map was missing it — making it unreachable from the workflow UI
- Adds `isPproEnabled` to the block outputs alongside the other transfer fields

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run lint` and `bun run type-check` pass clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)