### PR TITLE
fix(deps): bump echarts to 6.1.0 to patch XSS vulnerability

### DIFF
--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -140,7 +140,7 @@
     "docx": "^9.6.1",
     "docx-preview": "^0.3.7",
     "drizzle-orm": "^0.45.2",
-    "echarts": "6.0.0",
+    "echarts": "6.1.0",
     "es-toolkit": "1.45.1",
     "ffmpeg-static": "5.3.0",
     "fluent-ffmpeg": "2.1.3",

--- a/bun.lock
+++ b/bun.lock
@@ -208,7 +208,7 @@
         "docx": "^9.6.1",
         "docx-preview": "^0.3.7",
         "drizzle-orm": "^0.45.2",
-        "echarts": "6.0.0",
+        "echarts": "6.1.0",
         "es-toolkit": "1.45.1",
         "ffmpeg-static": "5.3.0",
         "fluent-ffmpeg": "2.1.3",
@@ -2439,7 +2439,7 @@
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
-    "echarts": ["echarts@6.0.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.0.0" } }, "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ=="],
+    "echarts": ["echarts@6.1.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.1.0" } }, "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
@@ -4043,7 +4043,7 @@
 
     "zod-validation-error": ["zod-validation-error@1.5.0", "", { "peerDependencies": { "zod": "^3.18.0" } }, "sha512-/7eFkAI4qV0tcxMBB/3+d2c1P6jzzZYdYSlBuAklzMuCrJu5bzJfHS0yVAS87dRHVlhftd6RFJDIvv03JgkSbw=="],
 
-    "zrender": ["zrender@6.0.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg=="],
+    "zrender": ["zrender@6.1.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ=="],
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 


### PR DESCRIPTION
## Summary
- Bumps `echarts` from 6.0.0 to 6.1.0, patching a medium-severity XSS in the Lines series tooltip renderer (GHSA-fgmj-fm8m-jvvx / CVE-2026-45249)
- Prior to 6.1.0, `series.data[i].name` could be rendered as raw HTML into the tooltip via `innerHTML` when no custom `tooltip.formatter` is set
- Lockfile updated accordingly (pulls in `zrender@6.1.0`)

## Type of Change
- [x] Bug fix (dependency security patch)

## Testing
Ran `bun run type-check` and `bun run lint` — both clean, no code changes required beyond the version bump.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)