### PR TITLE
chore(ci): bump API contract boundary route-count baseline to 884

### DIFF
--- a/scripts/check-api-validation-contracts.ts
+++ b/scripts/check-api-validation-contracts.ts
@@ -9,8 +9,8 @@ const QUERY_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/queries')
 const SELECTOR_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/selectors')
 
 const BASELINE = {
-  totalRoutes: 883,
-  zodRoutes: 883,
+  totalRoutes: 884,
+  zodRoutes: 884,
   nonZodRoutes: 0,
 } as const
 


### PR DESCRIPTION
## Summary
- \`check:api-validation:strict\` was failing on staging HEAD itself (confirmed on commit a8f27094f9) because the pinned \`BASELINE.totalRoutes\`/\`zodRoutes\` (883) went stale — a legitimate new Zod-contract-compliant route merged without the required ratchet-bump step
- Actual count is 884 total routes, 884 Zod-compliant, 0 non-Zod — pure headcount update, no policy violation, no route bypassed the contract boundary
- Verified `bun audit` ("Security audit" step) is explicitly `continue-on-error: true` with a comment marking the advisory backlog as accepted tech debt pending separate triage — it was never actually blocking this or any other PR, despite showing up as a red X in the job's step list

## Type of Change
- [x] CI/build fix

## Testing
- \`bun run check:api-validation:strict\` passes locally against origin/staging
- \`bun run apps/sim/scripts/check-block-registry.ts origin/staging\` passes
- \`bun run scripts/check-migrations-safety.ts origin/staging\` passes
- lint clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)