### PR TITLE
fix(landing): inset careers row hover, drop trusted-by section, gate contact submit

### DIFF
--- a/apps/sim/app/(landing)/careers/careers.tsx
+++ b/apps/sim/app/(landing)/careers/careers.tsx
@@ -9,7 +9,6 @@ import {
   JobGroups,
 } from '@/app/(landing)/careers/components/job-board'
 import { careersSearchParamsCache } from '@/app/(landing)/careers/search-params'
-import { TrustedBy } from '@/app/(landing)/components/trusted-by'
 
 interface CareersProps {
   searchParams: Promise<SearchParams>
@@ -87,8 +86,6 @@ export default async function Careers({ searchParams }: CareersProps) {
         >
           <JobBoard postings={postings} />
         </Suspense>
-
-        <TrustedBy className='pt-6' />
       </section>
     </main>
   )

--- a/apps/sim/app/(landing)/careers/components/job-board/job-groups.tsx
+++ b/apps/sim/app/(landing)/careers/components/job-board/job-groups.tsx
@@ -83,8 +83,8 @@ function JobRow({ posting }: JobRowProps) {
       target='_blank'
       rel='noopener noreferrer'
       className={cn(
-        'group flex items-center justify-between gap-6 border-[var(--border)] border-t py-5',
-        'transition-colors hover:bg-[var(--surface-hover)]'
+        '-mx-3 group flex items-center justify-between gap-6 rounded-lg border-[var(--border)]',
+        'border-t px-3 py-5 transition-colors hover:bg-[var(--surface-hover)]'
       )}
     >
       <div className='flex min-w-0 flex-col gap-1.5'>

--- a/apps/sim/app/(landing)/contact/components/contact-form/contact-form.tsx
+++ b/apps/sim/app/(landing)/contact/components/contact-form/contact-form.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/lib/api/contracts/contact'
 import { flattenFieldErrors } from '@/lib/api/contracts/primitives'
 import { getEnv } from '@/lib/core/config/env'
+import { quickValidateEmail } from '@/lib/messaging/email/validation'
 import { captureClientEvent } from '@/lib/posthog/client'
 import { useSubmitContact } from '@/hooks/queries/contact'
 
@@ -175,6 +176,13 @@ export function ContactForm() {
     )
   }
 
+  const canSubmit =
+    quickValidateEmail(form.email.trim()).isValid &&
+    form.name.trim().length > 0 &&
+    form.topic.length > 0 &&
+    form.subject.trim().length > 0 &&
+    form.message.trim().length > 0
+
   const isBusy = contactMutation.isPending || isSubmitting
 
   const submitError = contactMutation.isError
@@ -336,7 +344,7 @@ export function ContactForm() {
           variant='primary'
           flush
           fullWidth
-          disabled={isBusy}
+          disabled={isBusy || !canSubmit}
           className='mt-1 justify-center [&>span]:flex-none'
         >
           {isBusy ? 'Sending…' : 'Send message'}


### PR DESCRIPTION
## Summary
- Careers job row hover now insets text/highlight slightly from the row edges instead of running flush to the container
- Removed the "Trusted by technical teams at" logo section from the careers page
- Contact form submit button now stays disabled until all required fields (name, valid email, topic, subject, message) are filled, matching the demo form's pattern

## Type of Change
- [x] Bug fix

## Testing
Tested manually — verified hover spacing on careers job rows, confirmed the trusted-by section no longer renders on /careers, and confirmed the contact submit button is disabled on an empty form and enables once all required fields are valid.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)