### PR TITLE
fix: add parseInt radix, return 403 on unauthorized log export

### DIFF
--- a/apps/sim/app/api/logs/export/route.ts
+++ b/apps/sim/app/api/logs/export/route.ts
@@ -75,13 +75,8 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
 
     const access = await checkWorkspaceAccess(params.workspaceId, userId)
     if (!access.hasAccess) {
-      return new NextResponse(`${header}\n`, {
-        status: 200,
-        headers: {
-          'Content-Type': 'text/csv; charset=utf-8',
-          'Content-Disposition': 'attachment; filename="logs-export.csv"',
-          'Cache-Control': 'no-cache',
-        },
+      return new NextResponse('Forbidden', {
+        status: 403,
       })
     }
 

--- a/apps/sim/blocks/blocks/firecrawl.ts
+++ b/apps/sim/blocks/blocks/firecrawl.ts
@@ -660,7 +660,7 @@ Example 2 - Product Data:
             }
             if (onlyMainContent != null) result.onlyMainContent = onlyMainContent
             if (params.maxConcurrency != null && params.maxConcurrency !== '') {
-              result.maxConcurrency = Number.parseInt(String(params.maxConcurrency))
+              result.maxConcurrency = Number.parseInt(String(params.maxConcurrency), 10)
             }
             if (params.ignoreInvalidURLs != null) {
               result.ignoreInvalidURLs = params.ignoreInvalidURLs

--- a/apps/sim/providers/bedrock/index.ts
+++ b/apps/sim/providers/bedrock/index.ts
@@ -344,7 +344,7 @@ export const bedrockProvider: ProviderConfig = {
       temperature: Number.parseFloat(String(request.temperature ?? 0.7)),
     }
     if (request.maxTokens != null) {
-      inferenceConfig.maxTokens = Number.parseInt(String(request.maxTokens))
+      inferenceConfig.maxTokens = Number.parseInt(String(request.maxTokens), 10)
     }
 
     const shouldStreamToolCalls = request.streamToolCalls ?? false


### PR DESCRIPTION
Two small things:

- the bedrock provider and firecrawl block were calling \`Number.parseInt()\` without a radix parameter. while modern engines default to base-10, strings with leading zeros can still cause surprises. added explicit radix 10 to both calls.

- the logs export route was returning HTTP 200 with just the CSV header row when workspace access was denied. this makes it hard for clients and monitoring to tell the difference between "no logs" and "not authorized". changed to return a proper 403.