### PR TITLE
fix(chat): fail-safe to noindex if the deployment lookup errors

### DIFF
--- a/apps/sim/app/(interfaces)/chat/[identifier]/page.tsx
+++ b/apps/sim/app/(interfaces)/chat/[identifier]/page.tsx
@@ -1,15 +1,26 @@
 import { db } from '@sim/db'
 import { chat } from '@sim/db/schema'
+import { createLogger } from '@sim/logger'
+import { getErrorMessage } from '@sim/utils/errors'
 import { and, eq, isNull } from 'drizzle-orm'
 import type { Metadata } from 'next'
 import ChatClient from '@/app/(interfaces)/chat/[identifier]/chat'
 import { OfficeEmbedInit } from '@/app/(interfaces)/chat/[identifier]/office-embed-init'
+
+const logger = createLogger('ChatMetadata')
 
 /**
  * Only fully public, active deployments are indexable. Auth-gated (password,
  * email, SSO) and inactive/nonexistent chats are noindexed at the page level
  * so Google never indexes an auth wall — narrower than blocking `/chat/`
  * entirely in robots.ts, which would also hide genuinely public deployments.
+ *
+ * Errors from the lookup fail toward noindex rather than throwing: unlike
+ * the identical query in app/api/chat/[identifier]/route.ts (which must
+ * surface failures to the caller), a metadata resolution error has no
+ * error.tsx boundary in this route to catch it — throwing here would take
+ * the whole page down instead of just skipping indexability, and "can't
+ * confirm this is safe to index" should default to not indexing it anyway.
  */
 export async function generateMetadata({
   params,
@@ -18,13 +29,21 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { identifier } = await params
 
-  const [deployment] = await db
-    .select({ authType: chat.authType, isActive: chat.isActive })
-    .from(chat)
-    .where(and(eq(chat.identifier, identifier), isNull(chat.archivedAt)))
-    .limit(1)
+  let isIndexable = false
+  try {
+    const [deployment] = await db
+      .select({ authType: chat.authType, isActive: chat.isActive })
+      .from(chat)
+      .where(and(eq(chat.identifier, identifier), isNull(chat.archivedAt)))
+      .limit(1)
 
-  const isIndexable = Boolean(deployment?.isActive && deployment.authType === 'public')
+    isIndexable = Boolean(deployment?.isActive && deployment.authType === 'public')
+  } catch (error) {
+    logger.error('Failed to resolve chat deployment for metadata', {
+      identifier,
+      error: getErrorMessage(error),
+    })
+  }
 
   return {
     title: 'Chat',


### PR DESCRIPTION
## Summary
- Cursor Bugbot flagged on #5388 (already merged): the chat page's `generateMetadata` DB lookup had no error handling, unlike the identical query in `api/chat/[identifier]/route.ts` which already wraps it in try/catch
- Verified this is real: there's no `error.tsx` under `app/(interfaces)/chat/`, and Next.js docs confirm `generateMetadata` resolves outside the rendered tree that route-segment error boundaries wrap — only the root `global-error.tsx` would catch a throw here, meaning a DB hiccup during this lookup would crash the whole page to a generic error page instead of degrading like the old static-metadata version did
- Fix: catch the error, log it, default `isIndexable = false`. This is also just the correct default independent of the bug — if we can't confirm a deployment is safely public, noindex is the right call, not a 500

## Type of Change
- [x] Bug fix

## Testing
Tested manually — live dev server, confirmed the success path (`noindex, nofollow` for a nonexistent identifier) is unchanged. Typecheck and Biome lint pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)