### PR TITLE
fix(mcp): pass SSRF-guarded fetch into OAuth start flow, matching probe/revoke

### DIFF
--- a/apps/sim/app/api/mcp/oauth/start/route.test.ts
+++ b/apps/sim/app/api/mcp/oauth/start/route.test.ts
@@ -17,8 +17,10 @@ import {
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockMcpAuth } = vi.hoisted(() => ({
+const { mockMcpAuth, mockCreateSsrfGuardedMcpFetch, mockGuardedFetch } = vi.hoisted(() => ({
   mockMcpAuth: vi.fn(),
+  mockCreateSsrfGuardedMcpFetch: vi.fn(),
+  mockGuardedFetch: vi.fn(),
 }))
 
 vi.mock('@sim/db', () => dbChainMock)
@@ -30,6 +32,9 @@ vi.mock('drizzle-orm', () => ({
 }))
 vi.mock('@modelcontextprotocol/sdk/client/auth.js', () => ({
   auth: mockMcpAuth,
+}))
+vi.mock('@/lib/mcp/pinned-fetch', () => ({
+  createSsrfGuardedMcpFetch: mockCreateSsrfGuardedMcpFetch,
 }))
 vi.mock('@/lib/auth/hybrid', () => hybridAuthMock)
 vi.mock('@/lib/workspaces/permissions/utils', () => permissionsMock)
@@ -73,6 +78,21 @@ describe('MCP OAuth start route', () => {
     })
     mcpOauthMockFns.mockLoadPreregisteredClient.mockResolvedValue(undefined)
     mockMcpAuth.mockRejectedValue(new McpOauthRedirectRequiredMock('https://mcp.exa.ai/authorize'))
+    mockCreateSsrfGuardedMcpFetch.mockReturnValue(mockGuardedFetch)
+  })
+
+  it('routes OAuth discovery through the SSRF-guarded fetch', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/mcp/oauth/start?workspaceId=workspace-1&serverId=server-1'
+    )
+
+    await GET(request)
+
+    expect(mockCreateSsrfGuardedMcpFetch).toHaveBeenCalledTimes(1)
+    expect(mockMcpAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ serverUrl: 'https://mcp.exa.ai/mcp', fetchFn: mockGuardedFetch })
+    )
   })
 
   it('requires workspace write permission via MCP auth middleware', async () => {

--- a/apps/sim/app/api/mcp/oauth/start/route.ts
+++ b/apps/sim/app/api/mcp/oauth/start/route.ts
@@ -20,6 +20,7 @@ import {
   SimMcpOauthProvider,
   setOauthRowUser,
 } from '@/lib/mcp/oauth'
+import { createSsrfGuardedMcpFetch } from '@/lib/mcp/pinned-fetch'
 import { createMcpErrorResponse } from '@/lib/mcp/utils'
 
 const logger = createLogger('McpOauthStartAPI')
@@ -129,7 +130,10 @@ export const GET = withRouteHandler(
       const provider = new SimMcpOauthProvider({ row, preregistered })
 
       try {
-        const result = await mcpAuth(provider, { serverUrl: server.url })
+        const result = await mcpAuth(provider, {
+          serverUrl: server.url,
+          fetchFn: createSsrfGuardedMcpFetch(),
+        })
         if (result === 'AUTHORIZED') {
           return NextResponse.json({ status: 'already_authorized' })
         }


### PR DESCRIPTION
## Summary
- MCP OAuth start route was calling `mcpAuth()` without a `fetchFn`, so discovery/registration requests used the default global fetch
- Sibling files `probe.ts` and `revoke.ts` already pass `createSsrfGuardedMcpFetch()` into their equivalent calls — this brings the start route in line with the same pattern
- Added a test asserting the route wires the guarded fetch into `mcpAuth`

## Type of Change
- [x] Bug fix

## Testing
- Added/ran unit tests for `apps/sim/app/api/mcp/oauth/start/route.test.ts` (all passing)
- `bun run check:api-validation` passes
- Typecheck and biome clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)