### PR TITLE
fix(mcp): pass SSRF-guarded fetch into OAuth callback token exchange

### DIFF
--- a/apps/sim/app/api/mcp/oauth/callback/route.test.ts
+++ b/apps/sim/app/api/mcp/oauth/callback/route.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment node
+ */
+import {
+  authMockFns,
+  dbChainMock,
+  dbChainMockFns,
+  mcpOauthMock,
+  mcpOauthMockFns,
+  resetDbChainMock,
+  schemaMock,
+} from '@sim/testing'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockMcpAuth, mockCreateSsrfGuardedMcpFetch, mockGuardedFetch, mockDiscoverServerTools } =
+  vi.hoisted(() => ({
+    mockMcpAuth: vi.fn(),
+    mockCreateSsrfGuardedMcpFetch: vi.fn(),
+    mockGuardedFetch: vi.fn(),
+    mockDiscoverServerTools: vi.fn(),
+  }))
+
+vi.mock('@sim/db', () => dbChainMock)
+vi.mock('@sim/db/schema', () => schemaMock)
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  isNull: vi.fn(),
+}))
+vi.mock('@modelcontextprotocol/sdk/client/auth.js', () => ({
+  auth: mockMcpAuth,
+}))
+vi.mock('@/lib/mcp/oauth', () => mcpOauthMock)
+vi.mock('@/lib/mcp/pinned-fetch', () => ({
+  createSsrfGuardedMcpFetch: mockCreateSsrfGuardedMcpFetch,
+}))
+vi.mock('@/lib/mcp/service', () => ({
+  mcpService: { discoverServerTools: mockDiscoverServerTools },
+}))
+
+import { GET } from './route'
+
+describe('MCP OAuth callback route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDbChainMock()
+    mockCreateSsrfGuardedMcpFetch.mockReturnValue(mockGuardedFetch)
+    authMockFns.mockGetSession.mockResolvedValue({ user: { id: 'user-1' } })
+    mcpOauthMockFns.mockLoadOauthRowByState.mockResolvedValue({
+      id: 'oauth-row-1',
+      mcpServerId: 'server-1',
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    })
+    dbChainMockFns.limit.mockResolvedValue([
+      {
+        id: 'server-1',
+        url: 'https://mcp.example.com/mcp',
+        workspaceId: 'workspace-1',
+      },
+    ])
+    mcpOauthMockFns.mockLoadPreregisteredClient.mockResolvedValue(undefined)
+    mockMcpAuth.mockResolvedValue('AUTHORIZED')
+    mockDiscoverServerTools.mockResolvedValue(undefined)
+  })
+
+  it('performs the token exchange through the SSRF-guarded fetch', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/mcp/oauth/callback?state=state-1&code=auth-code-1'
+    )
+
+    await GET(request)
+
+    expect(mockCreateSsrfGuardedMcpFetch).toHaveBeenCalledTimes(1)
+    expect(mockMcpAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        serverUrl: 'https://mcp.example.com/mcp',
+        authorizationCode: 'auth-code-1',
+        fetchFn: mockGuardedFetch,
+      })
+    )
+  })
+})

--- a/apps/sim/app/api/mcp/oauth/callback/route.ts
+++ b/apps/sim/app/api/mcp/oauth/callback/route.ts
@@ -19,6 +19,7 @@ import {
   type McpOauthCallbackReason,
   SimMcpOauthProvider,
 } from '@/lib/mcp/oauth'
+import { createSsrfGuardedMcpFetch } from '@/lib/mcp/pinned-fetch'
 import { mcpService } from '@/lib/mcp/service'
 
 const logger = createLogger('McpOauthCallbackAPI')
@@ -149,6 +150,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       result = await mcpAuth(provider, {
         serverUrl: server.url,
         authorizationCode: code,
+        fetchFn: createSsrfGuardedMcpFetch(),
       })
     } catch (e) {
       logger.error('Token exchange failed during MCP OAuth callback', e)


### PR DESCRIPTION
## Summary
- The OAuth callback route's token exchange (`mcpAuth(...)`) was calling the MCP SDK's `auth()` without a `fetchFn`, so it defaulted to the global `fetch` for the token-endpoint request.
- Sibling files `apps/sim/lib/mcp/oauth/probe.ts` and `apps/sim/lib/mcp/oauth/revoke.ts` already wire `createSsrfGuardedMcpFetch()` into their outbound requests — this route was just missing the same guard.
- Passed `fetchFn: createSsrfGuardedMcpFetch()` alongside the existing `serverUrl`/`authorizationCode` options, matching the established pattern exactly.

## Type of Change
- [x] Bug fix

## Testing
- Added `apps/sim/app/api/mcp/oauth/callback/route.test.ts` covering that the token exchange call passes the guarded fetch instance through to `mcpAuth`, alongside the existing `serverUrl`/`authorizationCode` args.
- `bun vitest run` on the new test file and the sibling `start/route.test.ts` — both pass.
- `bun run check:api-validation`, `bun run type-check`, and `bunx biome check` all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)