### PR TITLE
fix(uploads): gate execution-context uploads behind write/admin permission

### DIFF
--- a/apps/sim/app/api/files/upload/route.test.ts
+++ b/apps/sim/app/api/files/upload/route.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => {
   const mockGetStorageProvider = vi.fn()
   const mockIsUsingCloudStorage = vi.fn()
   const mockUploadFile = vi.fn()
+  const mockUploadExecutionFile = vi.fn()
 
   return {
     mockVerifyFileAccess,
@@ -33,6 +34,7 @@ const mocks = vi.hoisted(() => {
     mockGetStorageProvider,
     mockIsUsingCloudStorage,
     mockUploadFile,
+    mockUploadExecutionFile,
   }
 })
 
@@ -80,6 +82,10 @@ vi.mock('@/lib/workspaces/permissions/utils', () => permissionsMock)
 
 vi.mock('@/lib/uploads/contexts/workspace', () => ({
   uploadWorkspaceFile: mocks.mockUploadWorkspaceFile,
+}))
+
+vi.mock('@/lib/uploads/contexts/execution', () => ({
+  uploadExecutionFile: mocks.mockUploadExecutionFile,
 }))
 
 vi.mock('@/lib/uploads', () => ({
@@ -147,6 +153,17 @@ function setupFileApiMocks(
     size: 100,
     type: 'text/plain',
     key: 'workspace/test-workspace-id/1234567890-test.txt',
+    uploadedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  })
+
+  mocks.mockUploadExecutionFile.mockResolvedValue({
+    id: 'test-execution-file-id',
+    name: 'test.txt',
+    url: '/api/files/serve/execution/test-workspace-id/test-file.txt',
+    size: 100,
+    type: 'text/plain',
+    key: 'execution/test-workspace-id/1234567890-test.txt',
     uploadedAt: new Date().toISOString(),
     expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
   })
@@ -528,6 +545,130 @@ describe('File Upload Security Tests', () => {
       expect(response.status).toBe(400)
       const data = await response.json()
       expect(data.message).toContain("File type 'exe' is not allowed")
+    })
+  })
+
+  describe('Execution Context Permission Gate', () => {
+    const createExecutionFormData = (
+      file: File,
+      workspaceId: string | null = 'test-workspace-id'
+    ) => {
+      const formData = new FormData()
+      formData.append('file', file)
+      formData.append('context', 'execution')
+      formData.append('workflowId', 'test-workflow-id')
+      formData.append('executionId', 'test-execution-id')
+      if (workspaceId !== null) formData.append('workspaceId', workspaceId)
+      return formData
+    }
+
+    beforeEach(() => {
+      setupFileApiMocks({
+        cloudEnabled: false,
+        storageProvider: 'local',
+      })
+    })
+
+    it('rejects execution uploads without workspaceId', async () => {
+      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
+      const formData = createExecutionFormData(file, null)
+
+      const req = new Request('http://localhost/api/files/upload', {
+        method: 'POST',
+        headers: { 'content-length': '1024' },
+        body: formData,
+      })
+
+      const response = await POST(req as unknown as NextRequest)
+
+      expect(response.status).toBe(400)
+      const data = await response.json()
+      expect(data.message).toContain('workflowId, executionId, and workspaceId')
+      expect(mocks.mockUploadExecutionFile).not.toHaveBeenCalled()
+    })
+
+    it('rejects execution uploads for a read-only workspace member', async () => {
+      permissionsMockFns.mockGetUserEntityPermissions.mockResolvedValue('read')
+
+      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
+      const formData = createExecutionFormData(file)
+
+      const req = new Request('http://localhost/api/files/upload', {
+        method: 'POST',
+        headers: { 'content-length': '1024' },
+        body: formData,
+      })
+
+      const response = await POST(req as unknown as NextRequest)
+
+      expect(response.status).toBe(403)
+      const data = await response.json()
+      expect(data.error).toBe('Write or Admin access required for execution uploads')
+      expect(mocks.mockUploadExecutionFile).not.toHaveBeenCalled()
+    })
+
+    it('rejects execution uploads for a member with no workspace permission', async () => {
+      permissionsMockFns.mockGetUserEntityPermissions.mockResolvedValue(null)
+
+      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
+      const formData = createExecutionFormData(file)
+
+      const req = new Request('http://localhost/api/files/upload', {
+        method: 'POST',
+        headers: { 'content-length': '1024' },
+        body: formData,
+      })
+
+      const response = await POST(req as unknown as NextRequest)
+
+      expect(response.status).toBe(403)
+      expect(mocks.mockUploadExecutionFile).not.toHaveBeenCalled()
+    })
+
+    it('allows execution uploads for a write-permission workspace member', async () => {
+      permissionsMockFns.mockGetUserEntityPermissions.mockResolvedValue('write')
+
+      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
+      const formData = createExecutionFormData(file)
+
+      const req = new Request('http://localhost/api/files/upload', {
+        method: 'POST',
+        headers: { 'content-length': '1024' },
+        body: formData,
+      })
+
+      const response = await POST(req as unknown as NextRequest)
+
+      expect(response.status).toBe(200)
+      expect(mocks.mockUploadExecutionFile).toHaveBeenCalledWith(
+        {
+          workspaceId: 'test-workspace-id',
+          workflowId: 'test-workflow-id',
+          executionId: 'test-execution-id',
+        },
+        expect.anything(),
+        'test.pdf',
+        'application/pdf',
+        'test-user-id'
+      )
+    })
+
+    it('allows execution uploads for an admin-permission workspace member', async () => {
+      permissionsMockFns.mockGetUserEntityPermissions.mockResolvedValue('admin')
+
+      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
+      const formData = createExecutionFormData(file)
+
+      const req = new Request('http://localhost/api/files/upload', {
+        method: 'POST',
+        headers: { 'content-length': '1024' },
+        body: formData,
+      })
+
+      const response = await POST(req as unknown as NextRequest)
+
+      expect(response.status).toBe(200)
+      expect(mocks.mockUploadExecutionFile).toHaveBeenCalled()
     })
   })
 

--- a/apps/sim/app/api/files/upload/route.ts
+++ b/apps/sim/app/api/files/upload/route.ts
@@ -111,16 +111,24 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
       // Handle execution context
       if (context === 'execution') {
-        if (!workflowId || !executionId) {
+        if (!workflowId || !executionId || !workspaceId) {
           throw new InvalidRequestError(
-            'Execution context requires workflowId and executionId parameters'
+            'Execution context requires workflowId, executionId, and workspaceId parameters'
+          )
+        }
+
+        const permission = await getUserEntityPermissions(session.user.id, 'workspace', workspaceId)
+        if (permission !== 'write' && permission !== 'admin') {
+          return NextResponse.json(
+            { error: 'Write or Admin access required for execution uploads' },
+            { status: 403 }
           )
         }
 
         const { uploadExecutionFile } = await import('@/lib/uploads/contexts/execution')
         const userFile = await uploadExecutionFile(
           {
-            workspaceId: workspaceId || '',
+            workspaceId,
             workflowId,
             executionId,
           },


### PR DESCRIPTION
## Summary
- The multipart-upload fallback route (`/api/files/upload`) had no workspace-permission check for `execution`-context uploads, while the primary presigned-upload route (`/api/files/presigned`) already requires write/admin for the same upload type.
- Added the same `write`/`admin` gate to the fallback route's execution branch, and now require `workspaceId` (in addition to `workflowId`/`executionId`) before proceeding, matching the presigned route's validation.

Note: self-hosted deployments without cloud storage configured will now require write/admin workspace permission for execution-context uploads via this fallback path, matching the existing requirement on the primary presigned-upload path.

## Type of Change
- [x] Bug fix

## Testing
- Added 5 new tests covering: missing workspaceId, read-only member rejected, no-permission member rejected, write-permission member allowed, admin-permission member allowed.
- `bun run vitest run app/api/files/upload/route.test.ts` — 19/19 passing.
- `bun run check:api-validation` passes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

---
Supersedes #5403, whose source branch (`worktree-deepsec-fresh`) had a polluted commit history (~100 unrelated commits from a bad rebase/merge). Same code, clean single-commit branch off current staging.