### PR TITLE
fix(mothership): block subflow re-parenting in embedded workflow view

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -3142,6 +3142,14 @@ const WorkflowContent = React.memo(
           updateContainerDimensionsDuringMove(node.id, node.position)
         }
 
+        // Embedded (mship panel) canvases allow repositioning but never
+        // re-parenting: skip container-intersection detection so a drag over a
+        // subflow neither highlights it nor arms potentialParentId. Both drag-stop
+        // paths bail when potentialParentId still equals the drag-start parent, so
+        // positions persist but a block can never be inserted into (or pulled out
+        // of) a loop/parallel from the embedded view.
+        if (embedded) return
+
         // Check if this is a starter block - starter blocks should never be in containers
         const isStarterBlock = node.data?.type === 'starter'
         if (isStarterBlock) {
@@ -3257,6 +3265,7 @@ const WorkflowContent = React.memo(
         getNodes,
         potentialParentId,
         blocks,
+        embedded,
         getNodeAbsolutePosition,
         getNodeDepth,
         isDescendantOf,
@@ -4109,7 +4118,9 @@ const WorkflowContent = React.memo(
                   edgesUpdatable={!embedded && effectivePermissions.canEdit}
                   className={`workflow-container h-full bg-[var(--bg)] transition-opacity duration-150 ${reactFlowStyles} ${canvasOpacityClass} ${isHandMode ? 'canvas-mode-hand' : 'canvas-mode-cursor'}`}
                   onNodeDrag={effectivePermissions.canEdit ? onNodeDrag : undefined}
-                  onNodeDragStop={effectivePermissions.canEdit ? onNodeDragStop : undefined}
+                  onNodeDragStop={
+                    !embedded && effectivePermissions.canEdit ? onNodeDragStop : undefined
+                  }
                   onSelectionDragStart={
                     effectivePermissions.canEdit ? onSelectionDragStart : undefined
                   }
@@ -4117,7 +4128,9 @@ const WorkflowContent = React.memo(
                   onSelectionDragStop={
                     effectivePermissions.canEdit ? onSelectionDragStop : undefined
                   }
-                  onNodeDragStart={effectivePermissions.canEdit ? onNodeDragStart : undefined}
+                  onNodeDragStart={
+                    !embedded && effectivePermissions.canEdit ? onNodeDragStart : undefined
+                  }
                   snapToGrid={snapToGrid}
                   snapGrid={snapGrid}
                   elevateEdgesOnSelect={false}


### PR DESCRIPTION
## Summary
- In the mship chat panel's embedded workflow view, dragging a block over a loop/parallel highlighted it and dropped the block INTO the subflow as a persistent collaborative op — with no way to undo it from the panel. Dragging itself is fine; the insertion is the bug.
- Fix: in embedded mode, `onNodeDrag` skips container-intersection detection entirely, so a drag over a subflow never highlights it and never arms `potentialParentId`. Both drag-stop paths already bail when `potentialParentId` equals the drag-start parent, so block positions still move normally but a block can never be inserted into (or pulled out of) a subflow from the embedded view.
- Standalone editor untouched (the skip is embedded-only).

## Type of Change
- [x] Bug fix

## Testing
Tested manually in the embedded panel with a loop workflow: dragging a block still works, dragging it directly onto the loop shows no drop-target highlight, and after dropping on the loop the block's parentId is unchanged (verified via API). Standalone editor drag/reparent behavior unchanged. `bun run lint`, `bun run check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
