### PR TITLE
refactor(uploads): hoist execution permission check, dedupe permission-gate tests

### DIFF
--- a/apps/sim/app/api/files/upload/route.test.ts
+++ b/apps/sim/app/api/files/upload/route.test.ts
@@ -562,6 +562,19 @@ describe('File Upload Security Tests', () => {
       return formData
     }
 
+    const postExecutionUpload = async (workspaceId: string | null = 'test-workspace-id') => {
+      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
+      const formData = createExecutionFormData(file, workspaceId)
+
+      const req = new Request('http://localhost/api/files/upload', {
+        method: 'POST',
+        headers: { 'content-length': '1024' },
+        body: formData,
+      })
+
+      return POST(req as unknown as NextRequest)
+    }
+
     beforeEach(() => {
       setupFileApiMocks({
         cloudEnabled: false,
@@ -570,16 +583,7 @@ describe('File Upload Security Tests', () => {
     })
 
     it('rejects execution uploads without workspaceId', async () => {
-      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
-      const formData = createExecutionFormData(file, null)
-
-      const req = new Request('http://localhost/api/files/upload', {
-        method: 'POST',
-        headers: { 'content-length': '1024' },
-        body: formData,
-      })
-
-      const response = await POST(req as unknown as NextRequest)
+      const response = await postExecutionUpload(null)
 
       expect(response.status).toBe(400)
       const data = await response.json()
@@ -590,16 +594,7 @@ describe('File Upload Security Tests', () => {
     it('rejects execution uploads for a read-only workspace member', async () => {
       permissionsMockFns.mockGetUserEntityPermissions.mockResolvedValue('read')
 
-      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
-      const formData = createExecutionFormData(file)
-
-      const req = new Request('http://localhost/api/files/upload', {
-        method: 'POST',
-        headers: { 'content-length': '1024' },
-        body: formData,
-      })
-
-      const response = await POST(req as unknown as NextRequest)
+      const response = await postExecutionUpload()
 
       expect(response.status).toBe(403)
       const data = await response.json()
@@ -610,16 +605,7 @@ describe('File Upload Security Tests', () => {
     it('rejects execution uploads for a member with no workspace permission', async () => {
       permissionsMockFns.mockGetUserEntityPermissions.mockResolvedValue(null)
 
-      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
-      const formData = createExecutionFormData(file)
-
-      const req = new Request('http://localhost/api/files/upload', {
-        method: 'POST',
-        headers: { 'content-length': '1024' },
-        body: formData,
-      })
-
-      const response = await POST(req as unknown as NextRequest)
+      const response = await postExecutionUpload()
 
       expect(response.status).toBe(403)
       expect(mocks.mockUploadExecutionFile).not.toHaveBeenCalled()
@@ -628,16 +614,7 @@ describe('File Upload Security Tests', () => {
     it('allows execution uploads for a write-permission workspace member', async () => {
       permissionsMockFns.mockGetUserEntityPermissions.mockResolvedValue('write')
 
-      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
-      const formData = createExecutionFormData(file)
-
-      const req = new Request('http://localhost/api/files/upload', {
-        method: 'POST',
-        headers: { 'content-length': '1024' },
-        body: formData,
-      })
-
-      const response = await POST(req as unknown as NextRequest)
+      const response = await postExecutionUpload()
 
       expect(response.status).toBe(200)
       expect(mocks.mockUploadExecutionFile).toHaveBeenCalledWith(
@@ -656,16 +633,7 @@ describe('File Upload Security Tests', () => {
     it('allows execution uploads for an admin-permission workspace member', async () => {
       permissionsMockFns.mockGetUserEntityPermissions.mockResolvedValue('admin')
 
-      const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
-      const formData = createExecutionFormData(file)
-
-      const req = new Request('http://localhost/api/files/upload', {
-        method: 'POST',
-        headers: { 'content-length': '1024' },
-        body: formData,
-      })
-
-      const response = await POST(req as unknown as NextRequest)
+      const response = await postExecutionUpload()
 
       expect(response.status).toBe(200)
       expect(mocks.mockUploadExecutionFile).toHaveBeenCalled()

--- a/apps/sim/app/api/files/upload/route.ts
+++ b/apps/sim/app/api/files/upload/route.ts
@@ -92,6 +92,29 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     const usingCloudStorage = storageService.hasCloudStorage()
     logger.info(`Using storage mode: ${usingCloudStorage ? 'Cloud' : 'Local'} for file upload`)
 
+    // Execution context requires a workspace write/admin permission check. Resolve it once per
+    // request (not per file) since workspaceId is invariant across all files in the upload.
+    let executionUploadContext:
+      | { workspaceId: string; workflowId: string; executionId: string }
+      | undefined
+    if (context === 'execution') {
+      if (!workflowId || !executionId || !workspaceId) {
+        throw new InvalidRequestError(
+          'Execution context requires workflowId, executionId, and workspaceId parameters'
+        )
+      }
+
+      const permission = await getUserEntityPermissions(session.user.id, 'workspace', workspaceId)
+      if (permission !== 'write' && permission !== 'admin') {
+        return NextResponse.json(
+          { error: 'Write or Admin access required for execution uploads' },
+          { status: 403 }
+        )
+      }
+
+      executionUploadContext = { workspaceId, workflowId, executionId }
+    }
+
     const uploadResults = []
 
     for (const file of files) {
@@ -110,28 +133,10 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       })
 
       // Handle execution context
-      if (context === 'execution') {
-        if (!workflowId || !executionId || !workspaceId) {
-          throw new InvalidRequestError(
-            'Execution context requires workflowId, executionId, and workspaceId parameters'
-          )
-        }
-
-        const permission = await getUserEntityPermissions(session.user.id, 'workspace', workspaceId)
-        if (permission !== 'write' && permission !== 'admin') {
-          return NextResponse.json(
-            { error: 'Write or Admin access required for execution uploads' },
-            { status: 403 }
-          )
-        }
-
+      if (context === 'execution' && executionUploadContext) {
         const { uploadExecutionFile } = await import('@/lib/uploads/contexts/execution')
         const userFile = await uploadExecutionFile(
-          {
-            workspaceId,
-            workflowId,
-            executionId,
-          },
+          executionUploadContext,
           buffer,
           originalName,
           file.type,


### PR DESCRIPTION
## Summary
Follow-up to #5404 (already merged) — applying an explicit `/cleanup` + `/simplify` final gate on that diff surfaced two small, real, low-risk quality issues that this PR fixes:

- `apps/sim/app/api/files/upload/route.ts`: the new execution-context workspace permission check (`getUserEntityPermissions`) was re-run once per uploaded file inside the upload loop, even though `workspaceId` (and thus the permission result) is invariant for the whole request. Hoisted the workflowId/executionId/workspaceId validation + permission check above the loop so it runs once per request instead of once per file.
- `apps/sim/app/api/files/upload/route.test.ts`: the 5 new "Execution Context Permission Gate" tests repeated identical request-construction boilerplate. Extracted a shared `postExecutionUpload()` helper.

No behavior change — same validation order, same error messages/status codes, same mocked call assertions. `/cleanup`'s other 6 sub-passes (effects/memo/callbacks/state/react-query/emcn/url-state) had nothing to flag since this diff is backend-only (no React/UI code). A `/simplify` "reuse" suggestion to swap the permission check for a different existing helper (`verifyExecutionFileAccess`) was deliberately **not** applied — it would make the execution branch inconsistent with the 4 other context branches in the same file that use the identical `getUserEntityPermissions` + 403 pattern; an altitude-focused review agent independently confirmed the current pattern is the correct, consistent one for this file.

## Test plan
- [x] `bun vitest run apps/sim/app/api/files/upload/route.test.ts` — 19/19 pass
- [x] `apps/sim` type-check clean (`bun run type-check` in apps/sim)
- [x] `bunx biome check` clean on both touched files
- [x] `bun run check:api-validation` — audit passed