### PR TITLE
fix(mcp,tools): correct fetchFn fallback order and Drive size-check hardening

### DIFF
--- a/apps/sim/app/api/tools/google_drive/download/route.test.ts
+++ b/apps/sim/app/api/tools/google_drive/download/route.test.ts
@@ -133,6 +133,30 @@ describe('POST /api/tools/google_drive/download', () => {
     expect(data.success).toBe(false)
   })
 
+  it('proceeds to the streamed download when metadata size is malformed', async () => {
+    mockSecureFetchWithPinnedIP
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'file-abc',
+          name: 'report.pdf',
+          mimeType: 'application/pdf',
+          size: 'not-a-number',
+          capabilities: { canReadRevisions: false },
+        })
+      )
+      .mockResolvedValueOnce(fileResponse(1024))
+
+    const response = await POST(createMockRequest('POST', baseBody))
+    expect(response.status).toBe(200)
+    const data = (await response.json()) as { success: boolean; output: { file: { size: number } } }
+    expect(data.success).toBe(true)
+    expect(data.output.file.size).toBe(1024)
+
+    // The early size check should be skipped, but the streaming cap must still apply.
+    const downloadCall = mockSecureFetchWithPinnedIP.mock.calls[1]
+    expect(downloadCall[2]).toMatchObject({ maxResponseBytes: MAX_FILE_SIZE })
+  })
+
   it('does not require a metadata size for Google Workspace exports', async () => {
     mockSecureFetchWithPinnedIP
       .mockResolvedValueOnce(

--- a/apps/sim/app/api/tools/google_drive/download/route.ts
+++ b/apps/sim/app/api/tools/google_drive/download/route.ts
@@ -188,11 +188,10 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       logger.info(`[${requestId}] Downloading regular file`, { fileId, mimeType: fileMimeType })
 
       if (metadata.size) {
-        assertKnownSizeWithinLimit(
-          Number.parseInt(metadata.size, 10),
-          MAX_FILE_SIZE,
-          `Google Drive file ${fileId}`
-        )
+        const parsedSize = Number.parseInt(metadata.size, 10)
+        if (Number.isFinite(parsedSize)) {
+          assertKnownSizeWithinLimit(parsedSize, MAX_FILE_SIZE, `Google Drive file ${fileId}`)
+        }
       }
 
       const downloadUrl = `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media&supportsAllDrives=true`

--- a/apps/sim/lib/mcp/oauth/auth.test.ts
+++ b/apps/sim/lib/mcp/oauth/auth.test.ts
@@ -51,4 +51,17 @@ describe('mcpAuthGuarded', () => {
       fetchFn: overrideFetch,
     })
   })
+
+  it('falls back to the SSRF-guarded fetch when fetchFn is explicitly undefined', async () => {
+    await mcpAuthGuarded(provider, {
+      serverUrl: 'https://mcp.example.com/mcp',
+      fetchFn: undefined,
+    })
+
+    expect(mockCreateSsrfGuardedMcpFetch).toHaveBeenCalledTimes(1)
+    expect(mockAuth).toHaveBeenCalledWith(provider, {
+      serverUrl: 'https://mcp.example.com/mcp',
+      fetchFn: mockGuardedFetch,
+    })
+  })
 })

--- a/apps/sim/lib/mcp/oauth/auth.ts
+++ b/apps/sim/lib/mcp/oauth/auth.ts
@@ -15,5 +15,5 @@ export function mcpAuthGuarded(
   provider: OAuthClientProvider,
   options: McpAuthOptions
 ): ReturnType<typeof auth> {
-  return auth(provider, { fetchFn: createSsrfGuardedMcpFetch(), ...options })
+  return auth(provider, { ...options, fetchFn: options.fetchFn ?? createSsrfGuardedMcpFetch() })
 }


### PR DESCRIPTION
## Summary
- `mcpAuthGuarded`: fix spread order so the SSRF-guarded fetch is only overridden by a genuine caller-supplied `fetchFn`, not silently disabled when `options` merely contains the key (e.g. `fetchFn: undefined`)
- Google Drive download route: guard the early pre-download size check against a malformed/non-numeric `metadata.size` string so it's skipped explicitly rather than relying on an incidental `NaN` no-op; the streaming cap on the actual download still enforces the limit either way

## Type of Change
- [x] Bug fix

## Testing
- Added a test confirming `mcpAuthGuarded` falls back to the guarded fetch when `fetchFn: undefined` is passed explicitly (in addition to existing default/override coverage)
- Added a test confirming a malformed `metadata.size` doesn't crash and the download proceeds to the (separately tested) streaming cap
- `bun vitest run` on both touched test files, `tsc --noEmit`, `biome check`, and `bun run check:api-validation` all pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)