### PR TITLE
fix(404): use ChipLink for return-home CTA on root not-found page

### DIFF
--- a/apps/sim/app/not-found.tsx
+++ b/apps/sim/app/not-found.tsx
@@ -1,5 +1,5 @@
+import { ChipLink } from '@sim/emcn'
 import type { Metadata } from 'next'
-import Link from 'next/link'
 import { LogoShell } from '@/app/(landing)/components'
 
 export const metadata: Metadata = {
@@ -17,12 +17,9 @@ export default function NotFound() {
         <p className='text-[var(--text-muted)] text-lg'>
           The page you&apos;re looking for doesn&apos;t exist or has been moved.
         </p>
-        <Link
-          href='/'
-          className='mt-3 inline-flex h-[40px] items-center rounded-[5px] bg-[var(--surface-inverted)] px-5 text-sm text-white transition-colors hover:bg-[var(--surface-inverted-hover)]'
-        >
+        <ChipLink variant='primary' href='/' className='mt-3'>
           Return home
-        </Link>
+        </ChipLink>
       </div>
     </LogoShell>
   )


### PR DESCRIPTION
## Summary
- Root 404 page (`app/not-found.tsx`) hand-rolled a `<Link>` with raw Tailwind classes to mimic a primary chip button
- Replaced with `ChipLink variant='primary'` from `@sim/emcn`, matching the pattern already used by the sibling landing not-found pages (`models`, `integrations`, `comparison`)
- Note: this standardizes the CTA to the platform's canonical chip geometry (30px height, `rounded-lg`, `px-2`), which is more compact than the removed bespoke inline styles (40px height, `rounded-[5px]`, `px-5`). This is an intentional trade-off — matching the already-established convention on every sibling not-found page rather than preserving a one-off custom size

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)