### PR TITLE
fix(compare): render two already-populated fact rows missing from the table

### DIFF
--- a/apps/sim/app/(landing)/comparison/comparison-sections.ts
+++ b/apps/sim/app/(landing)/comparison/comparison-sections.ts
@@ -67,6 +67,8 @@ export const COMPARISON_SECTIONS: ComparisonSectionDef[] = [
       { key: 'versionControlDepth', label: 'Version control' },
       { key: 'realtimeCollaboration', label: 'Realtime collaboration' },
       { key: 'nativeFileStorage', label: 'Native file storage' },
+      { key: 'dataTables', label: 'Native data tables' },
+      { key: 'richTextEditor', label: 'Rich-text document editor' },
       { key: 'subWorkflows', label: 'Sub-workflows (composition)' },
     ],
   }),


### PR DESCRIPTION
## Summary
- `dataTables` and `richTextEditor` are required fact fields already researched and filled in for Sim and every competitor, but neither key was ever added to the row list the comparison table actually renders.
- Adds both as rows in the Platform section.

## Type of Change
- [x] Bug fix

## Testing
- `tsc --noEmit` clean (confirms every profile already has both fields populated)
- `biome check` clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)