### PR TITLE
refactor(react-query): hoist every staleTime into a named exported constant

### DIFF
--- a/.agents/skills/react-query-best-practices/SKILL.md
+++ b/.agents/skills/react-query-best-practices/SKILL.md
@@ -31,7 +31,7 @@ Read these before analyzing:
 
 ### Query hooks
 - Every `queryFn` must forward `signal` for request cancellation
-- Every query must have an explicit `staleTime` (default 0 is almost never correct)
+- Every query must have an explicit `staleTime` (default 0 is almost never correct), assigned from a named exported constant — never an inline numeric literal. A server-side prefetch hydrating the same query key must import and reuse that constant instead of restating the number
 - `keepPreviousData` / `placeholderData` only on variable-key queries (where params change), never on static keys
 - Use `enabled` to prevent queries from running without required params
 

--- a/.claude/commands/react-query-best-practices.md
+++ b/.claude/commands/react-query-best-practices.md
@@ -31,7 +31,7 @@ Read these before analyzing:
 
 ### Query hooks
 - Every `queryFn` must forward `signal` for request cancellation
-- Every query must have an explicit `staleTime` (default 0 is almost never correct)
+- Every query must have an explicit `staleTime` (default 0 is almost never correct), assigned from a named exported constant — never an inline numeric literal. A server-side prefetch hydrating the same query key must import and reuse that constant instead of restating the number
 - `keepPreviousData` / `placeholderData` only on variable-key queries (where params change), never on static keys
 - Use `enabled` to prevent queries from running without required params
 

--- a/.claude/rules/sim-queries.md
+++ b/.claude/rules/sim-queries.md
@@ -50,13 +50,15 @@ The `'use client'` hook module then imports these back for its hooks. **Never** 
 ## Query Hook
 
 - Every `queryFn` must destructure and forward `signal` for request cancellation
-- Every query must have an explicit `staleTime`
+- Every query must have an explicit `staleTime`, assigned from a named exported constant (`ENTITY_LIST_STALE_TIME`), never an inline numeric literal. A server-side prefetch (`prefetch.ts`) hydrating the same query key must import and reuse that constant, not restate the number — this is what keeps a prefetched cache entry from going stale out of sync with the client hook that reads it
 - Use `keepPreviousData` only on variable-key queries (where params change), never on static keys
 - Same-origin JSON calls must go through `requestJson(contract, ...)` from `@/lib/api/client/request` against the contract in `@/lib/api/contracts/**`
 
 ```typescript
 import { requestJson } from '@/lib/api/client/request'
 import { listEntitiesContract, type EntityList } from '@/lib/api/contracts/entities'
+
+export const ENTITY_LIST_STALE_TIME = 60 * 1000
 
 async function fetchEntities(workspaceId: string, signal?: AbortSignal): Promise<EntityList> {
   const data = await requestJson(listEntitiesContract, {
@@ -71,7 +73,7 @@ export function useEntityList(workspaceId?: string, options?: { enabled?: boolea
     queryKey: entityKeys.list(workspaceId),
     queryFn: ({ signal }) => fetchEntities(workspaceId as string, signal),
     enabled: Boolean(workspaceId) && (options?.enabled ?? true),
-    staleTime: 60 * 1000,
+    staleTime: ENTITY_LIST_STALE_TIME,
     placeholderData: keepPreviousData, // OK: workspaceId varies
   })
 }

--- a/.cursor/commands/react-query-best-practices.md
+++ b/.cursor/commands/react-query-best-practices.md
@@ -26,7 +26,7 @@ Read these before analyzing:
 
 ### Query hooks
 - Every `queryFn` must forward `signal` for request cancellation
-- Every query must have an explicit `staleTime` (default 0 is almost never correct)
+- Every query must have an explicit `staleTime` (default 0 is almost never correct), assigned from a named exported constant — never an inline numeric literal. A server-side prefetch hydrating the same query key must import and reuse that constant instead of restating the number
 - `keepPreviousData` / `placeholderData` only on variable-key queries (where params change), never on static keys
 - Use `enabled` to prevent queries from running without required params
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,8 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { requestJson } from '@/lib/api/client/request'
 import { listEntitiesContract, type EntityList } from '@/lib/api/contracts/entities'
 
+export const ENTITY_LIST_STALE_TIME = 60 * 1000
+
 async function fetchEntities(workspaceId: string, signal?: AbortSignal): Promise<EntityList> {
   const data = await requestJson(listEntitiesContract, {
     query: { workspaceId },
@@ -303,7 +305,7 @@ export function useEntityList(workspaceId?: string) {
     queryKey: entityKeys.list(workspaceId),
     queryFn: ({ signal }) => fetchEntities(workspaceId as string, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 60 * 1000,
+    staleTime: ENTITY_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -326,7 +328,7 @@ export const entityKeys = {
 ### Query Hooks
 
 - Every `queryFn` must forward `signal` for request cancellation
-- Every query must have an explicit `staleTime`
+- Every query must have an explicit `staleTime`, assigned from a named exported constant, never an inline numeric literal — a server-side prefetch hydrating the same query key must import and reuse that constant so the two never drift out of sync
 - Use `keepPreviousData` only on variable-key queries (where params change), never on static keys
 
 ```typescript
@@ -335,7 +337,7 @@ export function useEntityList(workspaceId?: string) {
     queryKey: entityKeys.list(workspaceId),
     queryFn: ({ signal }) => fetchEntities(workspaceId as string, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 60 * 1000,
+    staleTime: ENTITY_LIST_STALE_TIME,
     placeholderData: keepPreviousData, // OK: workspaceId varies
   })
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/prefetch.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/prefetch.ts
@@ -2,8 +2,14 @@ import type { QueryClient } from '@tanstack/react-query'
 import type { WorkspaceFileFolderApi } from '@/lib/api/contracts/workspace-file-folders'
 import type { ListWorkspaceFilesResponse } from '@/lib/api/contracts/workspace-files'
 import { prefetchInternalJson } from '@/app/workspace/[workspaceId]/lib/prefetch-internal-fetch'
-import { workspaceFileFolderKeys } from '@/hooks/queries/workspace-file-folders'
-import { workspaceFilesKeys } from '@/hooks/queries/workspace-files'
+import {
+  WORKSPACE_FILE_FOLDERS_STALE_TIME,
+  workspaceFileFolderKeys,
+} from '@/hooks/queries/workspace-file-folders'
+import {
+  WORKSPACE_FILES_LIST_STALE_TIME,
+  workspaceFilesKeys,
+} from '@/hooks/queries/workspace-files'
 
 /**
  * Prefetches the Files browser's two lists — workspace files and file folders —
@@ -27,7 +33,7 @@ export async function prefetchFilesBrowser(
         )
         return data.success ? data.files : []
       },
-      staleTime: 30 * 1000,
+      staleTime: WORKSPACE_FILES_LIST_STALE_TIME,
     }),
     queryClient.prefetchQuery({
       queryKey: workspaceFileFolderKeys.list(workspaceId, 'active'),
@@ -37,7 +43,7 @@ export async function prefetchFilesBrowser(
         )
         return data.folders ?? []
       },
-      staleTime: 30 * 1000,
+      staleTime: WORKSPACE_FILE_FOLDERS_STALE_TIME,
     }),
   ])
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/prefetch.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/prefetch.ts
@@ -4,7 +4,10 @@ import type { ListWorkspaceFilesResponse } from '@/lib/api/contracts/workspace-f
 import { prefetchInternalJson } from '@/app/workspace/[workspaceId]/lib/prefetch-internal-fetch'
 import { FOLDER_LIST_STALE_TIME, mapFolder } from '@/hooks/queries/folders'
 import { folderKeys } from '@/hooks/queries/utils/folder-keys'
-import { workspaceFilesKeys } from '@/hooks/queries/workspace-files'
+import {
+  WORKSPACE_FILES_LIST_STALE_TIME,
+  workspaceFilesKeys,
+} from '@/hooks/queries/workspace-files'
 
 /**
  * Prefetches the home page's secondary lists — folders and workspace files —
@@ -42,7 +45,7 @@ export async function prefetchHomeLists(
         )
         return data.success ? data.files : []
       },
-      staleTime: 30 * 1000,
+      staleTime: WORKSPACE_FILES_LIST_STALE_TIME,
     }),
   ])
 }

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/prefetch.ts
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/prefetch.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from '@tanstack/react-query'
 import type { KnowledgeBaseData } from '@/lib/api/contracts/knowledge'
 import { prefetchInternalJson } from '@/app/workspace/[workspaceId]/lib/prefetch-internal-fetch'
-import { knowledgeKeys } from '@/hooks/queries/kb/knowledge'
+import { KNOWLEDGE_BASE_LIST_STALE_TIME, knowledgeKeys } from '@/hooks/queries/kb/knowledge'
 
 /**
  * Prefetches the workspace's knowledge-bases list under the same query key the
@@ -23,6 +23,6 @@ export async function prefetchKnowledgeBases(
       )
       return result.data
     },
-    staleTime: 60 * 1000,
+    staleTime: KNOWLEDGE_BASE_LIST_STALE_TIME,
   })
 }

--- a/apps/sim/app/workspace/[workspaceId]/settings/[section]/prefetch.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/[section]/prefetch.ts
@@ -3,9 +3,17 @@ import { headers } from 'next/headers'
 import { getSession } from '@/lib/auth'
 import { getInternalApiBaseUrl } from '@/lib/core/utils/urls'
 import { getUserProfile, getUserSettings } from '@/lib/users/queries'
-import { generalSettingsKeys, mapGeneralSettingsResponse } from '@/hooks/queries/general-settings'
-import { subscriptionKeys } from '@/hooks/queries/subscription'
-import { mapUserProfileResponse, userProfileKeys } from '@/hooks/queries/user-profile'
+import {
+  GENERAL_SETTINGS_STALE_TIME,
+  generalSettingsKeys,
+  mapGeneralSettingsResponse,
+} from '@/hooks/queries/general-settings'
+import { SUBSCRIPTION_DATA_STALE_TIME, subscriptionKeys } from '@/hooks/queries/subscription'
+import {
+  mapUserProfileResponse,
+  USER_PROFILE_STALE_TIME,
+  userProfileKeys,
+} from '@/hooks/queries/user-profile'
 
 /**
  * Prefetch general settings server-side via the shared data layer.
@@ -20,7 +28,7 @@ export function prefetchGeneralSettings(queryClient: QueryClient) {
       const data = await getUserSettings(session?.user?.id ?? null)
       return mapGeneralSettingsResponse(data)
     },
-    staleTime: 60 * 60 * 1000,
+    staleTime: GENERAL_SETTINGS_STALE_TIME,
   })
 }
 
@@ -46,7 +54,7 @@ export function prefetchSubscriptionData(queryClient: QueryClient) {
       if (!response.ok) throw new Error(`Subscription prefetch failed: ${response.status}`)
       return response.json()
     },
-    staleTime: 5 * 60 * 1000,
+    staleTime: SUBSCRIPTION_DATA_STALE_TIME,
   })
 }
 
@@ -65,6 +73,6 @@ export function prefetchUserProfile(queryClient: QueryClient) {
       if (!user) throw new Error('User not found')
       return mapUserProfileResponse(user)
     },
-    staleTime: 5 * 60 * 1000,
+    staleTime: USER_PROFILE_STALE_TIME,
   })
 }

--- a/apps/sim/app/workspace/[workspaceId]/tables/prefetch.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/prefetch.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from '@tanstack/react-query'
 import type { TableDefinition } from '@/lib/table'
 import { prefetchInternalJson } from '@/app/workspace/[workspaceId]/lib/prefetch-internal-fetch'
-import { tableKeys } from '@/hooks/queries/utils/table-keys'
+import { TABLE_LIST_STALE_TIME, tableKeys } from '@/hooks/queries/utils/table-keys'
 
 /**
  * Prefetches the workspace's tables list under the same query key the client
@@ -21,6 +21,6 @@ export async function prefetchTables(queryClient: QueryClient, workspaceId: stri
       )
       return response.data.tables
     },
-    staleTime: 30 * 1000,
+    staleTime: TABLE_LIST_STALE_TIME,
   })
 }

--- a/apps/sim/hooks/queries/admin-users.ts
+++ b/apps/sim/hooks/queries/admin-users.ts
@@ -5,6 +5,8 @@ import { client } from '@/lib/auth/auth-client'
 
 const logger = createLogger('AdminUsersQuery')
 
+export const ADMIN_USER_LIST_STALE_TIME = 30 * 1000
+
 export const adminUserKeys = {
   all: ['adminUsers'] as const,
   lists: () => [...adminUserKeys.all, 'list'] as const,
@@ -84,7 +86,7 @@ export function useAdminUsers(offset: number, limit: number, searchQuery: string
     queryKey: adminUserKeys.list(offset, limit, searchQuery),
     queryFn: ({ signal }) => fetchAdminUsers(offset, limit, searchQuery, signal),
     enabled: searchQuery.length > 0,
-    staleTime: 30 * 1000,
+    staleTime: ADMIN_USER_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/allowed-providers.ts
+++ b/apps/sim/hooks/queries/allowed-providers.ts
@@ -13,6 +13,8 @@ export const allowedProvidersKeys = {
   blacklisted: () => [...allowedProvidersKeys.all, 'blacklisted'] as const,
 }
 
+export const BLACKLISTED_PROVIDERS_STALE_TIME = 5 * 60 * 1000
+
 type BlacklistedProvidersResponse = ContractJsonResponse<typeof getAllowedProvidersContract>
 
 async function fetchBlacklistedProviders(
@@ -32,7 +34,7 @@ export function useBlacklistedProviders({ enabled = true }: { enabled?: boolean 
   return useQuery({
     queryKey: allowedProvidersKeys.blacklisted(),
     queryFn: ({ signal }) => fetchBlacklistedProviders(signal),
-    staleTime: 5 * 60 * 1000,
+    staleTime: BLACKLISTED_PROVIDERS_STALE_TIME,
     enabled,
   })
 }

--- a/apps/sim/hooks/queries/api-keys.ts
+++ b/apps/sim/hooks/queries/api-keys.ts
@@ -27,6 +27,8 @@ export const apiKeysKeys = {
   combined: (workspaceId: string) => [...apiKeysKeys.combineds(), workspaceId] as const,
 }
 
+export const API_KEYS_COMBINED_STALE_TIME = 60 * 1000
+
 type CombinedApiKeysData = {
   workspaceKeys: ApiKey[]
   personalKeys: ApiKey[]
@@ -67,7 +69,7 @@ export function useApiKeys(workspaceId: string) {
     queryKey: apiKeysKeys.combined(workspaceId),
     queryFn: ({ signal }) => fetchApiKeys(workspaceId, signal),
     enabled: !!workspaceId,
-    staleTime: 60 * 1000,
+    staleTime: API_KEYS_COMBINED_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/background-work.ts
+++ b/apps/sim/hooks/queries/background-work.ts
@@ -11,6 +11,8 @@ export const backgroundWorkKeys = {
   list: (workspaceId?: string) => [...backgroundWorkKeys.lists(), workspaceId ?? ''] as const,
 }
 
+export const BACKGROUND_WORK_STALE_TIME = 5_000
+
 async function fetchWorkspaceBackgroundWork(
   workspaceId: string,
   signal?: AbortSignal
@@ -36,7 +38,7 @@ export function useWorkspaceBackgroundWork(workspaceId?: string) {
     queryKey: backgroundWorkKeys.list(workspaceId),
     queryFn: ({ signal }) => fetchWorkspaceBackgroundWork(workspaceId as string, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 5_000,
+    staleTime: BACKGROUND_WORK_STALE_TIME,
     refetchInterval: (query) => ((query.state.data ?? []).some(isActive) ? 5_000 : false),
     refetchOnWindowFocus: true,
   })

--- a/apps/sim/hooks/queries/byok-keys.ts
+++ b/apps/sim/hooks/queries/byok-keys.ts
@@ -20,6 +20,8 @@ export const byokKeysKeys = {
   list: (workspaceId?: string) => [...byokKeysKeys.lists(), workspaceId ?? ''] as const,
 }
 
+export const BYOK_KEY_LIST_STALE_TIME = 60 * 1000
+
 async function fetchBYOKKeys(workspaceId: string, signal?: AbortSignal): Promise<BYOKKeysResponse> {
   const data = await requestJson(listByokKeysContract, {
     params: { id: workspaceId },
@@ -35,7 +37,7 @@ export function useBYOKKeys(workspaceId: string) {
     queryKey: byokKeysKeys.list(workspaceId),
     queryFn: ({ signal }) => fetchBYOKKeys(workspaceId, signal),
     enabled: !!workspaceId,
-    staleTime: 60 * 1000,
+    staleTime: BYOK_KEY_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/chats.ts
+++ b/apps/sim/hooks/queries/chats.ts
@@ -34,6 +34,8 @@ export const chatKeys = {
   config: (identifier?: string) => [...chatKeys.configs(), identifier ?? ''] as const,
 }
 
+export const DEPLOYED_CHAT_CONFIG_STALE_TIME = 60 * 1000
+
 /**
  * Auth types for chat access control
  */
@@ -91,7 +93,7 @@ export function useDeployedChatConfig(identifier: string) {
     queryKey: chatKeys.config(identifier),
     queryFn: ({ signal }) => fetchDeployedChatConfig(identifier, signal),
     enabled: Boolean(identifier),
-    staleTime: 60 * 1000,
+    staleTime: DEPLOYED_CHAT_CONFIG_STALE_TIME,
     retry: false,
   })
 }

--- a/apps/sim/hooks/queries/copilot-chats.ts
+++ b/apps/sim/hooks/queries/copilot-chats.ts
@@ -11,6 +11,8 @@ export const copilotChatsKeys = {
   list: (workflowId?: string) => [...copilotChatsKeys.lists(), workflowId ?? ''] as const,
 }
 
+export const COPILOT_CHAT_LIST_STALE_TIME = 30 * 1000
+
 async function fetchCopilotChats(
   workflowId: string,
   signal?: AbortSignal
@@ -33,6 +35,6 @@ export function useCopilotChats(workflowId?: string) {
   return useQuery<CopilotChatListItem[]>({
     queryKey: copilotChatsKeys.list(workflowId),
     queryFn: workflowId ? ({ signal }) => fetchCopilotChats(workflowId, signal) : skipToken,
-    staleTime: 30 * 1000,
+    staleTime: COPILOT_CHAT_LIST_STALE_TIME,
   })
 }

--- a/apps/sim/hooks/queries/copilot-keys.ts
+++ b/apps/sim/hooks/queries/copilot-keys.ts
@@ -20,6 +20,8 @@ export const copilotKeysKeys = {
   keys: () => [...copilotKeysKeys.all, 'api-keys'] as const,
 }
 
+export const COPILOT_KEY_LIST_STALE_TIME = 30 * 1000
+
 /**
  * Copilot API key type (re-exported from the API contract).
  */
@@ -41,7 +43,7 @@ export function useCopilotKeys() {
     queryKey: copilotKeysKeys.keys(),
     queryFn: ({ signal }) => fetchCopilotKeys(signal),
     enabled: isHosted,
-    staleTime: 30 * 1000, // 30 seconds
+    staleTime: COPILOT_KEY_LIST_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/credential-sets.ts
+++ b/apps/sim/hooks/queries/credential-sets.ts
@@ -39,6 +39,13 @@ export type {
   CredentialSetMembership,
 }
 
+export const CREDENTIAL_SET_LIST_STALE_TIME = 60 * 1000
+export const CREDENTIAL_SET_DETAIL_STALE_TIME = 60 * 1000
+export const CREDENTIAL_SET_MEMBERSHIP_STALE_TIME = 60 * 1000
+export const CREDENTIAL_SET_INVITATION_LIST_STALE_TIME = 30 * 1000
+export const CREDENTIAL_SET_MEMBER_LIST_STALE_TIME = 30 * 1000
+export const CREDENTIAL_SET_INVITATION_DETAIL_STALE_TIME = 30 * 1000
+
 export const credentialSetKeys = {
   all: ['credentialSets'] as const,
   lists: () => [...credentialSetKeys.all, 'list'] as const,
@@ -71,7 +78,7 @@ export function useCredentialSets(organizationId?: string, enabled = true) {
     queryKey: credentialSetKeys.list(organizationId),
     queryFn: ({ signal }) => fetchCredentialSets(organizationId ?? '', signal),
     enabled: Boolean(organizationId) && enabled,
-    staleTime: 60 * 1000,
+    staleTime: CREDENTIAL_SET_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -81,7 +88,7 @@ export function useCredentialSetDetail(id?: string, enabled = true) {
     queryKey: credentialSetKeys.detail(id),
     queryFn: ({ signal }) => fetchCredentialSetById(id ?? '', signal),
     enabled: Boolean(id) && enabled,
-    staleTime: 60 * 1000,
+    staleTime: CREDENTIAL_SET_DETAIL_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -93,7 +100,7 @@ export function useCredentialSetMemberships() {
       const data = await requestJson(listCredentialSetMembershipsContract, { signal })
       return data.memberships ?? []
     },
-    staleTime: 60 * 1000,
+    staleTime: CREDENTIAL_SET_MEMBERSHIP_STALE_TIME,
   })
 }
 
@@ -104,7 +111,7 @@ export function useCredentialSetInvitations() {
       const data = await requestJson(listCredentialSetInvitationsContract, { signal })
       return data.invitations ?? []
     },
-    staleTime: 30 * 1000,
+    staleTime: CREDENTIAL_SET_INVITATION_LIST_STALE_TIME,
   })
 }
 
@@ -178,7 +185,7 @@ export function useCredentialSetMembers(credentialSetId?: string) {
       return data.members ?? []
     },
     enabled: Boolean(credentialSetId),
-    staleTime: 30 * 1000,
+    staleTime: CREDENTIAL_SET_MEMBER_LIST_STALE_TIME,
   })
 }
 
@@ -262,7 +269,7 @@ export function useCredentialSetInvitationsDetail(credentialSetId?: string) {
       return (data.invitations ?? []).filter((inv) => inv.status === 'pending')
     },
     enabled: Boolean(credentialSetId),
-    staleTime: 30 * 1000,
+    staleTime: CREDENTIAL_SET_INVITATION_DETAIL_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/credentials.ts
+++ b/apps/sim/hooks/queries/credentials.ts
@@ -29,6 +29,10 @@ import { fetchWorkspaceCredentialList } from '@/hooks/queries/utils/fetch-worksp
  */
 const OAUTH_CREDENTIALS_KEY = ['oauthCredentials'] as const
 
+export const WORKSPACE_CREDENTIAL_LIST_STALE_TIME = 60 * 1000
+export const WORKSPACE_CREDENTIAL_DETAIL_STALE_TIME = 60 * 1000
+export const WORKSPACE_CREDENTIAL_MEMBER_LIST_STALE_TIME = 30 * 1000
+
 export type {
   WorkspaceCredential,
   WorkspaceCredentialMember,
@@ -44,7 +48,7 @@ export function prefetchWorkspaceCredentials(queryClient: QueryClient, workspace
   queryClient.prefetchQuery({
     queryKey: workspaceCredentialKeys.list(workspaceId),
     queryFn: ({ signal }) => fetchWorkspaceCredentialList(workspaceId, signal),
-    staleTime: 60 * 1000,
+    staleTime: WORKSPACE_CREDENTIAL_LIST_STALE_TIME,
   })
 }
 
@@ -71,7 +75,7 @@ export function useWorkspaceCredentials(params: {
       return data.credentials ?? []
     },
     enabled: Boolean(workspaceId) && enabled,
-    staleTime: 60 * 1000,
+    staleTime: WORKSPACE_CREDENTIAL_LIST_STALE_TIME,
   })
 }
 
@@ -87,7 +91,7 @@ export function useWorkspaceCredential(credentialId?: string, enabled = true) {
       return data.credential ?? null
     },
     enabled: Boolean(credentialId) && enabled,
-    staleTime: 60 * 1000,
+    staleTime: WORKSPACE_CREDENTIAL_DETAIL_STALE_TIME,
   })
 }
 
@@ -216,7 +220,7 @@ export function useWorkspaceCredentialMembers(credentialId?: string) {
       return data.members ?? []
     },
     enabled: Boolean(credentialId),
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_CREDENTIAL_MEMBER_LIST_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/custom-blocks.ts
+++ b/apps/sim/hooks/queries/custom-blocks.ts
@@ -10,6 +10,8 @@ import {
   updateCustomBlockContract,
 } from '@/lib/api/contracts/custom-blocks'
 
+export const CUSTOM_BLOCK_LIST_STALE_TIME = 60 * 1000
+
 export const customBlockKeys = {
   all: ['custom-blocks'] as const,
   lists: () => [...customBlockKeys.all, 'list'] as const,
@@ -36,7 +38,7 @@ function useCustomBlocksQuery<T>(
     queryKey: customBlockKeys.list(workspaceId),
     queryFn: ({ signal }) => fetchCustomBlocks(workspaceId as string, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 60 * 1000,
+    staleTime: CUSTOM_BLOCK_LIST_STALE_TIME,
     select,
   })
 }

--- a/apps/sim/hooks/queries/custom-tools.ts
+++ b/apps/sim/hooks/queries/custom-tools.ts
@@ -11,6 +11,8 @@ import { customToolsKeys } from '@/hooks/queries/utils/custom-tool-keys'
 
 const logger = createLogger('CustomToolsQueries')
 
+export const CUSTOM_TOOL_LIST_STALE_TIME = 60 * 1000
+
 interface CustomToolSchema {
   [key: string]: unknown
   type: 'function'
@@ -170,7 +172,7 @@ export function useCustomTools(workspaceId: string) {
     queryKey: customToolsKeys.list(workspaceId),
     queryFn: ({ signal }) => fetchCustomTools(workspaceId, signal),
     enabled: !!workspaceId,
-    staleTime: 60 * 1000, // 1 minute - tools don't change frequently
+    staleTime: CUSTOM_TOOL_LIST_STALE_TIME, // 1 minute - tools don't change frequently
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/deployments.ts
+++ b/apps/sim/hooks/queries/deployments.ts
@@ -31,6 +31,12 @@ const logger = createLogger('DeploymentQueries')
 
 export type { ChatDetail, DeploymentVersionsResponse }
 
+export const DEPLOYMENT_INFO_STALE_TIME = 30 * 1000
+export const DEPLOYED_WORKFLOW_STATE_STALE_TIME = 30 * 1000
+export const DEPLOYMENT_VERSIONS_STALE_TIME = 30 * 1000
+export const CHAT_DEPLOYMENT_STATUS_STALE_TIME = 30 * 1000
+export const CHAT_DETAIL_STALE_TIME = 30 * 1000
+
 /**
  * Query key factory for deployment-related queries
  */
@@ -111,7 +117,7 @@ export function useDeploymentInfo(
     queryKey: deploymentKeys.info(workflowId),
     queryFn: ({ signal }) => fetchDeploymentInfo(workflowId!, signal),
     enabled: Boolean(workflowId) && (options?.enabled ?? true),
-    staleTime: 30 * 1000, // 30 seconds
+    staleTime: DEPLOYMENT_INFO_STALE_TIME,
     ...(options?.refetchOnMount !== undefined && { refetchOnMount: options.refetchOnMount }),
   })
 }
@@ -142,7 +148,7 @@ export function useDeployedWorkflowState(
     queryKey: deploymentKeys.deployedState(workflowId),
     queryFn: ({ signal }) => fetchDeployedWorkflowState(workflowId!, signal),
     enabled: Boolean(workflowId) && (options?.enabled ?? true),
-    staleTime: 30 * 1000,
+    staleTime: DEPLOYED_WORKFLOW_STATE_STALE_TIME,
   })
 }
 
@@ -171,7 +177,7 @@ export function useDeploymentVersions(workflowId: string | null, options?: { ena
     queryKey: deploymentKeys.versions(workflowId),
     queryFn: ({ signal }) => fetchDeploymentVersions(workflowId!, signal),
     enabled: Boolean(workflowId) && (options?.enabled ?? true),
-    staleTime: 30 * 1000, // 30 seconds
+    staleTime: DEPLOYMENT_VERSIONS_STALE_TIME,
   })
 }
 
@@ -204,7 +210,7 @@ export function useChatDeploymentStatus(
     queryKey: deploymentKeys.chatStatus(workflowId),
     queryFn: ({ signal }) => fetchChatDeploymentStatus(workflowId!, signal),
     enabled: Boolean(workflowId) && (options?.enabled ?? true),
-    staleTime: 30 * 1000, // 30 seconds
+    staleTime: CHAT_DEPLOYMENT_STATUS_STALE_TIME,
   })
 }
 
@@ -227,7 +233,7 @@ export function useChatDetail(chatId: string | null, options?: { enabled?: boole
     queryKey: deploymentKeys.chatDetail(chatId),
     queryFn: ({ signal }) => fetchChatDetail(chatId!, signal),
     enabled: Boolean(chatId) && (options?.enabled ?? true),
-    staleTime: 30 * 1000, // 30 seconds
+    staleTime: CHAT_DETAIL_STALE_TIME,
   })
 }
 
@@ -253,7 +259,7 @@ export function useChatDeploymentInfo(workflowId: string | null, options?: { ena
       await queryClient.fetchQuery({
         queryKey: deploymentKeys.chatDetail(nextChatId),
         queryFn: ({ signal }) => fetchChatDetail(nextChatId, signal),
-        staleTime: 30 * 1000,
+        staleTime: CHAT_DETAIL_STALE_TIME,
       })
     }
   }, [queryClient, statusQuery.refetch])

--- a/apps/sim/hooks/queries/environment.ts
+++ b/apps/sim/hooks/queries/environment.ts
@@ -15,6 +15,9 @@ const logger = createLogger('EnvironmentQueries')
 /**
  * Query key factories for environment variable queries
  */
+export const PERSONAL_ENVIRONMENT_STALE_TIME = 60 * 1000
+export const WORKSPACE_ENVIRONMENT_STALE_TIME = 60 * 1000
+
 export const environmentKeys = {
   all: ['environment'] as const,
   personal: () => [...environmentKeys.all, 'personal'] as const,
@@ -29,7 +32,7 @@ export function usePersonalEnvironment() {
   return useQuery({
     queryKey: environmentKeys.personal(),
     queryFn: ({ signal }) => fetchPersonalEnvironment(signal),
-    staleTime: 60 * 1000,
+    staleTime: PERSONAL_ENVIRONMENT_STALE_TIME,
   })
 }
 
@@ -44,7 +47,7 @@ export function useWorkspaceEnvironment<TData = WorkspaceEnvironmentData>(
     queryKey: environmentKeys.workspace(workspaceId),
     queryFn: ({ signal }) => fetchWorkspaceEnvironment(workspaceId, signal),
     enabled: !!workspaceId,
-    staleTime: 60 * 1000, // 1 minute
+    staleTime: WORKSPACE_ENVIRONMENT_STALE_TIME,
     placeholderData: keepPreviousData,
     ...options,
   })

--- a/apps/sim/hooks/queries/folders.ts
+++ b/apps/sim/hooks/queries/folders.ts
@@ -69,7 +69,7 @@ export function useFolders(workspaceId?: string, options?: { scope?: FolderQuery
     queryFn: ({ signal }) => fetchFolders(workspaceId as string, scope, signal),
     enabled: Boolean(workspaceId),
     placeholderData: keepPreviousData,
-    staleTime: 60 * 1000,
+    staleTime: FOLDER_LIST_STALE_TIME,
   })
 }
 
@@ -82,7 +82,7 @@ export function useFolderMap(workspaceId?: string) {
     queryFn: ({ signal }) => fetchFolders(workspaceId as string, 'active', signal),
     enabled: Boolean(workspaceId),
     placeholderData: keepPreviousData,
-    staleTime: 60 * 1000,
+    staleTime: FOLDER_LIST_STALE_TIME,
     select: selectFolderMap,
   })
 }

--- a/apps/sim/hooks/queries/general-settings.ts
+++ b/apps/sim/hooks/queries/general-settings.ts
@@ -21,6 +21,8 @@ export const generalSettingsKeys = {
   settings: () => [...generalSettingsKeys.all, 'settings'] as const,
 }
 
+export const GENERAL_SETTINGS_STALE_TIME = 60 * 60 * 1000
+
 /**
  * General settings type
  */
@@ -79,7 +81,7 @@ export function useGeneralSettings() {
       syncThemeToNextThemes(settings.theme)
       return settings
     },
-    staleTime: 60 * 60 * 1000,
+    staleTime: GENERAL_SETTINGS_STALE_TIME,
   })
 }
 
@@ -95,7 +97,7 @@ export function prefetchGeneralSettings(queryClient: QueryClient) {
       syncThemeToNextThemes(settings.theme)
       return settings
     },
-    staleTime: 60 * 60 * 1000,
+    staleTime: GENERAL_SETTINGS_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/github-stars.ts
+++ b/apps/sim/hooks/queries/github-stars.ts
@@ -16,6 +16,8 @@ export const githubStarsKeys = {
  */
 export const GITHUB_STARS_FALLBACK = '27.8k'
 
+export const GITHUB_STARS_STALE_TIME = 60 * 60 * 1000
+
 async function fetchGitHubStars(signal?: AbortSignal): Promise<string> {
   const data = await requestJson(getStarsContract, { signal })
   const value = data.stars
@@ -34,7 +36,7 @@ export function useGitHubStars() {
   return useQuery({
     queryKey: githubStarsKeys.count(),
     queryFn: ({ signal }) => fetchGitHubStars(signal),
-    staleTime: 60 * 60 * 1000,
+    staleTime: GITHUB_STARS_STALE_TIME,
     initialData: GITHUB_STARS_FALLBACK,
     initialDataUpdatedAt: 0,
   })

--- a/apps/sim/hooks/queries/inbox.ts
+++ b/apps/sim/hooks/queries/inbox.ts
@@ -19,6 +19,10 @@ export type { InboxConfig, InboxSendersResponseBody }
 export type InboxTaskItem = InboxTask
 export type InboxTasksResponse = InboxTasksResponseBody
 
+export const INBOX_CONFIG_STALE_TIME = 30 * 1000
+export const INBOX_SENDER_LIST_STALE_TIME = 60 * 1000
+export const INBOX_TASK_LIST_STALE_TIME = 15 * 1000
+
 export const inboxKeys = {
   all: ['inbox'] as const,
   configs: () => [...inboxKeys.all, 'config'] as const,
@@ -70,7 +74,7 @@ export function useInboxConfig(workspaceId: string) {
     queryKey: inboxKeys.config(workspaceId),
     queryFn: ({ signal }) => fetchInboxConfig(workspaceId, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 30 * 1000,
+    staleTime: INBOX_CONFIG_STALE_TIME,
   })
 }
 
@@ -79,7 +83,7 @@ export function useInboxSenders(workspaceId: string) {
     queryKey: inboxKeys.senderList(workspaceId),
     queryFn: ({ signal }) => fetchInboxSenders(workspaceId, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 60 * 1000,
+    staleTime: INBOX_SENDER_LIST_STALE_TIME,
   })
 }
 
@@ -91,7 +95,7 @@ export function useInboxTasks(
     queryKey: inboxKeys.taskList(workspaceId, opts.status, opts.cursor, opts.limit),
     queryFn: ({ signal }) => fetchInboxTasks(workspaceId, opts, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 15 * 1000,
+    staleTime: INBOX_TASK_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/invitations.ts
+++ b/apps/sim/hooks/queries/invitations.ts
@@ -21,6 +21,8 @@ export const invitationKeys = {
   list: (workspaceId: string) => [...invitationKeys.lists(), workspaceId] as const,
 }
 
+export const WORKSPACE_INVITATION_LIST_STALE_TIME = 30 * 1000
+
 export interface WorkspaceInvitation {
   email: string
   permissionType: 'admin' | 'write' | 'read'
@@ -61,7 +63,7 @@ export function usePendingInvitations(workspaceId: string | undefined) {
     queryKey: invitationKeys.list(workspaceId ?? ''),
     queryFn: ({ signal }) => fetchPendingInvitations(workspaceId as string, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_INVITATION_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/kb/connectors.ts
+++ b/apps/sim/hooks/queries/kb/connectors.ts
@@ -21,6 +21,10 @@ const logger = createLogger('KnowledgeConnectorQueries')
 
 export type { ConnectorData, ConnectorDetailData, SyncLogData }
 
+export const CONNECTOR_LIST_STALE_TIME = 30 * 1000
+export const CONNECTOR_DETAIL_STALE_TIME = 30 * 1000
+export const CONNECTOR_DOCUMENT_LIST_STALE_TIME = 30 * 1000
+
 export const connectorKeys = {
   all: (knowledgeBaseId?: string) =>
     [...knowledgeKeys.detail(knowledgeBaseId), 'connectors'] as const,
@@ -76,7 +80,7 @@ export function useConnectorList(knowledgeBaseId?: string) {
     queryKey: connectorKeys.list(knowledgeBaseId),
     queryFn: ({ signal }) => fetchConnectors(knowledgeBaseId as string, signal),
     enabled: Boolean(knowledgeBaseId),
-    staleTime: 30 * 1000,
+    staleTime: CONNECTOR_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
     refetchInterval: (query) => {
       const connectors = query.state.data
@@ -92,7 +96,7 @@ export function useConnectorDetail(knowledgeBaseId?: string, connectorId?: strin
     queryFn: ({ signal }) =>
       fetchConnectorDetail(knowledgeBaseId as string, connectorId as string, signal),
     enabled: Boolean(knowledgeBaseId && connectorId),
-    staleTime: 30 * 1000,
+    staleTime: CONNECTOR_DETAIL_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -263,7 +267,7 @@ export function useConnectorDocuments(
         signal
       ),
     enabled: Boolean(knowledgeBaseId && connectorId),
-    staleTime: 30 * 1000,
+    staleTime: CONNECTOR_DOCUMENT_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/kb/knowledge.ts
+++ b/apps/sim/hooks/queries/kb/knowledge.ts
@@ -61,6 +61,16 @@ export type {
   TagUsageData,
 }
 
+export const KNOWLEDGE_BASE_LIST_STALE_TIME = 60 * 1000
+export const KNOWLEDGE_BASE_DETAIL_STALE_TIME = 60 * 1000
+export const KNOWLEDGE_DOCUMENT_DETAIL_STALE_TIME = 60 * 1000
+export const KNOWLEDGE_DOCUMENT_LIST_STALE_TIME = 60 * 1000
+export const KNOWLEDGE_CHUNK_LIST_STALE_TIME = 60 * 1000
+export const KNOWLEDGE_CHUNK_SEARCH_STALE_TIME = 60 * 1000
+export const KNOWLEDGE_TAG_DEFINITION_LIST_STALE_TIME = 60 * 1000
+export const KNOWLEDGE_TAG_USAGE_STALE_TIME = 60 * 1000
+export const KNOWLEDGE_DOCUMENT_TAG_DEFINITION_LIST_STALE_TIME = 60 * 1000
+
 export const knowledgeKeys = {
   all: ['knowledge'] as const,
   lists: () => [...knowledgeKeys.all, 'list'] as const,
@@ -235,7 +245,7 @@ export function useKnowledgeBasesQuery(
     queryKey: knowledgeKeys.list(workspaceId, scope),
     queryFn: ({ signal }) => fetchKnowledgeBases(workspaceId, scope, signal),
     enabled: options?.enabled ?? true,
-    staleTime: 60 * 1000,
+    staleTime: KNOWLEDGE_BASE_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -245,7 +255,7 @@ export function useKnowledgeBaseQuery(knowledgeBaseId?: string) {
     queryKey: knowledgeKeys.detail(knowledgeBaseId),
     queryFn: ({ signal }) => fetchKnowledgeBase(knowledgeBaseId as string, signal),
     enabled: Boolean(knowledgeBaseId),
-    staleTime: 60 * 1000,
+    staleTime: KNOWLEDGE_BASE_DETAIL_STALE_TIME,
   })
 }
 
@@ -254,7 +264,7 @@ export function useDocumentQuery(knowledgeBaseId?: string, documentId?: string) 
     queryKey: knowledgeKeys.document(knowledgeBaseId ?? '', documentId ?? ''),
     queryFn: ({ signal }) => fetchDocument(knowledgeBaseId as string, documentId as string, signal),
     enabled: Boolean(knowledgeBaseId && documentId),
-    staleTime: 60 * 1000,
+    staleTime: KNOWLEDGE_DOCUMENT_DETAIL_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -285,7 +295,7 @@ export function useKnowledgeDocumentsQuery(
     queryKey: knowledgeKeys.documents(params.knowledgeBaseId, paramsKey),
     queryFn: ({ signal }) => fetchKnowledgeDocuments(params, signal),
     enabled: (options?.enabled ?? true) && Boolean(params.knowledgeBaseId),
-    staleTime: 60 * 1000,
+    staleTime: KNOWLEDGE_DOCUMENT_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
     refetchInterval: options?.refetchInterval ?? false,
   })
@@ -312,7 +322,7 @@ export function useKnowledgeChunksQuery(
     queryKey: knowledgeKeys.chunks(params.knowledgeBaseId, params.documentId, paramsKey),
     queryFn: ({ signal }) => fetchKnowledgeChunks(params, signal),
     enabled: (options?.enabled ?? true) && Boolean(params.knowledgeBaseId && params.documentId),
-    staleTime: 60 * 1000,
+    staleTime: KNOWLEDGE_CHUNK_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -371,7 +381,7 @@ export function useDocumentChunkSearchQuery(
     enabled:
       (options?.enabled ?? true) &&
       Boolean(params.knowledgeBaseId && params.documentId && params.search.trim()),
-    staleTime: 60 * 1000,
+    staleTime: KNOWLEDGE_CHUNK_SEARCH_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -782,7 +792,7 @@ export function useTagDefinitionsQuery(knowledgeBaseId?: string | null) {
     queryKey: knowledgeKeys.tagDefinitions(knowledgeBaseId ?? ''),
     queryFn: ({ signal }) => fetchTagDefinitions(knowledgeBaseId as string, signal),
     enabled: Boolean(knowledgeBaseId),
-    staleTime: 60 * 1000,
+    staleTime: KNOWLEDGE_TAG_DEFINITION_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -804,7 +814,7 @@ export function useTagUsageQuery(knowledgeBaseId?: string | null, options?: { en
     queryKey: knowledgeKeys.tagUsage(knowledgeBaseId ?? ''),
     queryFn: ({ signal }) => fetchTagUsage(knowledgeBaseId as string, signal),
     enabled: Boolean(knowledgeBaseId) && (options?.enabled ?? true),
-    staleTime: 60 * 1000,
+    staleTime: KNOWLEDGE_TAG_USAGE_STALE_TIME,
   })
 }
 
@@ -927,7 +937,7 @@ export function useDocumentTagDefinitionsQuery(
     queryFn: ({ signal }) =>
       fetchDocumentTagDefinitions(knowledgeBaseId as string, documentId as string, signal),
     enabled: Boolean(knowledgeBaseId && documentId),
-    staleTime: 60 * 1000,
+    staleTime: KNOWLEDGE_DOCUMENT_TAG_DEFINITION_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/logs.ts
+++ b/apps/sim/hooks/queries/logs.ts
@@ -31,6 +31,12 @@ export type { DashboardStatsResponse, WorkflowStats }
 export type LogSortBy = 'date' | 'duration' | 'cost' | 'status'
 export type LogSortOrder = 'asc' | 'desc'
 
+export const LOG_LIST_STALE_TIME = 30 * 1000
+export const LOG_DETAIL_STALE_TIME = 30 * 1000
+export const LOG_BY_EXECUTION_STALE_TIME = 30 * 1000
+export const LOG_DASHBOARD_STATS_STALE_TIME = 30 * 1000
+export const EXECUTION_SNAPSHOT_STALE_TIME = 5 * 60 * 1000
+
 export const logKeys = {
   all: ['logs'] as const,
   lists: () => [...logKeys.all, 'list'] as const,
@@ -169,7 +175,7 @@ export function useLogsList(
       fetchLogsPage(workspaceId as string, filters, pageParam, signal),
     enabled: Boolean(workspaceId) && (options?.enabled ?? true),
     refetchInterval: options?.refetchInterval ?? false,
-    staleTime: 30 * 1000,
+    staleTime: LOG_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -194,7 +200,7 @@ export function useLogDetail(
     queryFn: ({ signal }) => fetchLogDetail(logId as string, workspaceId as string, signal),
     enabled: Boolean(logId) && Boolean(workspaceId) && (options?.enabled ?? true),
     refetchInterval: options?.refetchInterval ?? false,
-    staleTime: 30 * 1000,
+    staleTime: LOG_DETAIL_STALE_TIME,
     retry: (failureCount, err) =>
       !(isApiClientError(err) && err.status === 404) && failureCount < 3,
   })
@@ -217,7 +223,7 @@ export function useLogByExecutionId(
       return data
     },
     enabled: Boolean(workspaceId) && Boolean(executionId),
-    staleTime: 30 * 1000,
+    staleTime: LOG_BY_EXECUTION_STALE_TIME,
   })
 }
 
@@ -225,7 +231,7 @@ export function prefetchLogDetail(queryClient: QueryClient, logId: string, works
   queryClient.prefetchQuery({
     queryKey: logKeys.detail(workspaceId, logId),
     queryFn: ({ signal }) => fetchLogDetail(logId, workspaceId, signal),
-    staleTime: 30 * 1000,
+    staleTime: LOG_DETAIL_STALE_TIME,
   })
 }
 
@@ -261,7 +267,7 @@ export function useDashboardStats(
     queryFn: ({ signal }) => fetchDashboardStats(workspaceId as string, filters, signal),
     enabled: Boolean(workspaceId) && (options?.enabled ?? true),
     refetchInterval: options?.refetchInterval ?? false,
-    staleTime: 30 * 1000,
+    staleTime: LOG_DASHBOARD_STATS_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -288,7 +294,7 @@ export function useExecutionSnapshot(executionId: string | undefined) {
     queryKey: logKeys.executionSnapshot(executionId),
     queryFn: ({ signal }) => fetchExecutionSnapshot(executionId as string, signal),
     enabled: Boolean(executionId),
-    staleTime: 5 * 60 * 1000,
+    staleTime: EXECUTION_SNAPSHOT_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -41,6 +41,11 @@ const logger = createLogger('McpQueries')
 
 export type { McpServerStatusConfig, McpTool, StoredMcpTool }
 
+export const MCP_SERVER_LIST_STALE_TIME = 60 * 1000
+export const MCP_SERVER_TOOLS_STALE_TIME = 30 * 1000
+export const MCP_STORED_TOOL_LIST_STALE_TIME = 60 * 1000
+export const MCP_ALLOWED_DOMAINS_STALE_TIME = 5 * 60 * 1000
+
 export const mcpKeys = {
   all: ['mcp'] as const,
   servers: () => [...mcpKeys.all, 'servers'] as const,
@@ -91,7 +96,7 @@ export function useMcpServers(workspaceId: string) {
     queryFn: ({ signal }) => fetchMcpServers(workspaceId, signal),
     enabled: !!workspaceId,
     retry: false,
-    staleTime: 60 * 1000,
+    staleTime: MCP_SERVER_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -147,7 +152,7 @@ export function useMcpToolsQuery(workspaceId: string) {
         fetchMcpTools(workspaceId, false, signal, serverId),
       enabled: !!workspaceId,
       retry: false,
-      staleTime: 30 * 1000,
+      staleTime: MCP_SERVER_TOOLS_STALE_TIME,
       refetchOnWindowFocus: false,
     })),
   })
@@ -441,7 +446,7 @@ export function useStoredMcpTools(workspaceId: string) {
     queryKey: mcpKeys.storedToolsList(workspaceId),
     queryFn: ({ signal }) => fetchStoredMcpTools(workspaceId, signal),
     enabled: !!workspaceId,
-    staleTime: 60 * 1000,
+    staleTime: MCP_STORED_TOOL_LIST_STALE_TIME,
   })
 }
 
@@ -595,6 +600,6 @@ export function useAllowedMcpDomains() {
   return useQuery<string[] | null>({
     queryKey: mcpKeys.allowedDomains(),
     queryFn: ({ signal }) => fetchAllowedMcpDomains(signal),
-    staleTime: 5 * 60 * 1000,
+    staleTime: MCP_ALLOWED_DOMAINS_STALE_TIME,
   })
 }

--- a/apps/sim/hooks/queries/mothership-admin.ts
+++ b/apps/sim/hooks/queries/mothership-admin.ts
@@ -70,6 +70,12 @@ async function byokFetch(url: string, init?: RequestInit) {
   return res.json()
 }
 
+export const MOTHERSHIP_BYOK_STALE_TIME = 30 * 1000
+export const MOTHERSHIP_REQUESTS_STALE_TIME = 60 * 1000
+export const MOTHERSHIP_USER_BREAKDOWN_STALE_TIME = 60 * 1000
+export const MOTHERSHIP_LICENSE_LIST_STALE_TIME = 60 * 1000
+export const MOTHERSHIP_LICENSE_DETAIL_STALE_TIME = 60 * 1000
+
 export const mothershipKeys = {
   all: ['mothership-admin'] as const,
   requests: (env: MothershipEnv, start: string, end: string, userId?: string) =>
@@ -97,7 +103,7 @@ export function useMothershipByokKeys(workspaceId: string) {
     queryFn: ({ signal }) =>
       byokFetch(`${BYOK_BASE}?workspaceId=${encodeURIComponent(workspaceId)}`, { signal }),
     enabled: !!workspaceId,
-    staleTime: 30 * 1000,
+    staleTime: MOTHERSHIP_BYOK_STALE_TIME,
   })
 }
 
@@ -153,7 +159,7 @@ export function useMothershipRequests(
         signal
       ),
     enabled: !!start && !!end,
-    staleTime: 60 * 1000,
+    staleTime: MOTHERSHIP_REQUESTS_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -163,7 +169,7 @@ export function useMothershipUserBreakdown(environment: MothershipEnv, start: st
     queryKey: mothershipKeys.userBreakdown(environment, start, end),
     queryFn: ({ signal }) => mothershipPost('user-breakdown', environment, { start, end }, signal),
     enabled: !!start && !!end,
-    staleTime: 60 * 1000,
+    staleTime: MOTHERSHIP_USER_BREAKDOWN_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -172,7 +178,7 @@ export function useMothershipLicenses(environment: MothershipEnv) {
   return useQuery({
     queryKey: mothershipKeys.licenses(environment),
     queryFn: ({ signal }) => mothershipGet('licenses', environment, undefined, signal),
-    staleTime: 60 * 1000,
+    staleTime: MOTHERSHIP_LICENSE_LIST_STALE_TIME,
   })
 }
 
@@ -194,7 +200,7 @@ export function useMothershipLicenseDetails(
         signal
       ),
     enabled: !!(id || name),
-    staleTime: 60 * 1000,
+    staleTime: MOTHERSHIP_LICENSE_DETAIL_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/mothership-chats.ts
+++ b/apps/sim/hooks/queries/mothership-chats.ts
@@ -63,6 +63,7 @@ export const mothershipChatKeys = {
 
 /** Shared by the `useMothershipChats` hook and the workspace sidebar prefetch. */
 export const MOTHERSHIP_CHAT_LIST_STALE_TIME = 60 * 1000
+export const MOTHERSHIP_CHAT_HISTORY_STALE_TIME = 30 * 1000
 
 function assertValid(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -262,7 +263,7 @@ export function useMothershipChatHistory(chatId: string | undefined) {
   return useQuery({
     queryKey: mothershipChatKeys.detail(chatId),
     queryFn: chatId ? ({ signal }) => fetchMothershipChatHistory(chatId, signal) : skipToken,
-    staleTime: 30 * 1000,
+    staleTime: MOTHERSHIP_CHAT_HISTORY_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/oauth/oauth-connections.ts
+++ b/apps/sim/hooks/queries/oauth/oauth-connections.ts
@@ -14,6 +14,9 @@ import { OAUTH_PROVIDERS, type OAuthServiceConfig } from '@/lib/oauth'
 
 const logger = createLogger('OAuthConnectionsQuery')
 
+export const OAUTH_CONNECTIONS_STALE_TIME = 30 * 1000
+export const OAUTH_CONNECTED_ACCOUNTS_STALE_TIME = 60 * 1000
+
 /**
  * Query key factory for OAuth connection queries.
  * Provides hierarchical cache keys for connections and provider-specific accounts.
@@ -116,7 +119,7 @@ export function useOAuthConnections() {
   return useQuery({
     queryKey: oauthConnectionsKeys.connections(),
     queryFn: ({ signal }) => fetchOAuthConnections(signal),
-    staleTime: 30 * 1000,
+    staleTime: OAUTH_CONNECTIONS_STALE_TIME,
     retry: false,
   })
 }
@@ -249,7 +252,7 @@ export function useConnectedAccounts(provider: string, options?: { enabled?: boo
     queryKey: oauthConnectionsKeys.account(provider),
     queryFn: ({ signal }) => fetchConnectedAccounts(provider, signal),
     enabled: options?.enabled ?? true,
-    staleTime: 60 * 1000,
+    staleTime: OAUTH_CONNECTED_ACCOUNTS_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/oauth/oauth-credentials.ts
+++ b/apps/sim/hooks/queries/oauth/oauth-credentials.ts
@@ -6,6 +6,9 @@ import { CREDENTIAL_SET } from '@/executor/constants'
 import { useCredentialSetDetail } from '@/hooks/queries/credential-sets'
 import { useWorkspaceCredential } from '@/hooks/queries/credentials'
 
+export const OAUTH_CREDENTIAL_LIST_STALE_TIME = 60 * 1000
+export const OAUTH_CREDENTIAL_DETAIL_STALE_TIME = 60 * 1000
+
 export const oauthCredentialKeys = {
   all: ['oauthCredentials'] as const,
   lists: () => [...oauthCredentialKeys.all, 'list'] as const,
@@ -102,7 +105,7 @@ export function useOAuthCredentials(
         signal
       ),
     enabled: Boolean(providerId) && enabled,
-    staleTime: 60 * 1000,
+    staleTime: OAUTH_CREDENTIAL_LIST_STALE_TIME,
   })
 }
 
@@ -115,7 +118,7 @@ export function useOAuthCredentialDetail(
     queryKey: oauthCredentialKeys.detail(credentialId, workflowId),
     queryFn: ({ signal }) => fetchOAuthCredentialDetail(credentialId ?? '', workflowId, signal),
     enabled: Boolean(credentialId) && enabled,
-    staleTime: 60 * 1000,
+    staleTime: OAUTH_CREDENTIAL_DETAIL_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/organization.ts
+++ b/apps/sim/hooks/queries/organization.ts
@@ -49,6 +49,15 @@ import { workspaceKeys } from '@/hooks/queries/workspace'
 const logger = createLogger('OrganizationQueries')
 const invitationListsKey = ['invitations', 'list'] as const
 
+export const ORGANIZATION_ROSTER_STALE_TIME = 30 * 1000
+export const ORGANIZATION_LIST_STALE_TIME = 30 * 1000
+export const ORGANIZATION_DETAIL_STALE_TIME = 30 * 1000
+export const ORGANIZATION_SUBSCRIPTION_STALE_TIME = 30 * 1000
+export const ORGANIZATION_BILLING_STALE_TIME = 30 * 1000
+export const ORGANIZATION_MEMBERS_STALE_TIME = 30 * 1000
+export const ORGANIZATION_MEMBER_USAGE_LIMIT_STALE_TIME = 30 * 1000
+export const ORGANIZATION_MY_MEMBER_CREDITS_STALE_TIME = 30 * 1000
+
 type OrganizationSubscriptionCandidate = {
   id: string
   referenceId: string
@@ -140,7 +149,7 @@ export function useOrganizationRoster(orgId: string | undefined | null) {
     queryKey: organizationKeys.roster(orgId ?? ''),
     queryFn: ({ signal }) => fetchOrganizationRoster(orgId as string, signal),
     enabled: !!orgId,
-    staleTime: 30 * 1000,
+    staleTime: ORGANIZATION_ROSTER_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -169,7 +178,7 @@ export function useOrganizations() {
   return useQuery({
     queryKey: organizationKeys.lists(),
     queryFn: ({ signal }) => fetchOrganizations(signal),
-    staleTime: 30 * 1000,
+    staleTime: ORGANIZATION_LIST_STALE_TIME,
   })
 }
 
@@ -197,7 +206,7 @@ export function useOrganization(orgId: string) {
     queryKey: organizationKeys.detail(orgId),
     queryFn: ({ signal }) => fetchOrganization(orgId, signal),
     enabled: !!orgId,
-    staleTime: 30 * 1000,
+    staleTime: ORGANIZATION_DETAIL_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -244,7 +253,7 @@ export function useOrganizationSubscription(orgId: string) {
     queryFn: ({ signal }) => fetchOrganizationSubscription(orgId, signal),
     enabled: !!orgId,
     retry: false,
-    staleTime: 30 * 1000,
+    staleTime: ORGANIZATION_SUBSCRIPTION_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -281,7 +290,7 @@ export function useOrganizationBilling(
     queryFn: ({ signal }) => fetchOrganizationBilling(orgId, signal),
     enabled: !!orgId && (options?.enabled ?? true),
     retry: false,
-    staleTime: 30 * 1000,
+    staleTime: ORGANIZATION_BILLING_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -321,7 +330,7 @@ export function useOrganizationMembers(orgId: string) {
     queryKey: organizationKeys.memberUsage(orgId),
     queryFn: ({ signal }) => fetchOrganizationMembers(orgId, signal),
     enabled: !!orgId,
-    staleTime: 30 * 1000,
+    staleTime: ORGANIZATION_MEMBERS_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -534,7 +543,7 @@ export function useOrganizationMemberUsageLimit(orgId?: string, userId?: string,
     queryFn: ({ signal }) =>
       fetchOrganizationMemberUsageLimit(orgId as string, userId as string, signal),
     enabled: Boolean(orgId) && Boolean(userId) && enabled,
-    staleTime: 30 * 1000,
+    staleTime: ORGANIZATION_MEMBER_USAGE_LIMIT_STALE_TIME,
   })
 }
 
@@ -583,7 +592,7 @@ export function useMyMemberCredits(workspaceId?: string) {
     queryKey: organizationKeys.myMemberCredits(workspaceId ?? ''),
     queryFn: ({ signal }) => fetchMyMemberCredits(workspaceId as string, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 30 * 1000,
+    staleTime: ORGANIZATION_MY_MEMBER_CREDITS_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/providers.ts
+++ b/apps/sim/hooks/queries/providers.ts
@@ -18,6 +18,8 @@ import type { ProviderName } from '@/stores/providers'
 
 const logger = createLogger('ProviderModelsQuery')
 
+export const PROVIDER_MODELS_STALE_TIME = 5 * 60 * 1000
+
 export const providerKeys = {
   all: ['provider-models'] as const,
   lists: () => [...providerKeys.all, 'list'] as const,
@@ -90,6 +92,6 @@ export function useProviderModels(provider: ProviderName, workspaceId?: string) 
   return useQuery({
     queryKey: providerKeys.list(provider, workspaceId),
     queryFn: ({ signal }) => fetchProviderModels(provider, signal, workspaceId),
-    staleTime: 5 * 60 * 1000,
+    staleTime: PROVIDER_MODELS_STALE_TIME,
   })
 }

--- a/apps/sim/hooks/queries/public-shares.ts
+++ b/apps/sim/hooks/queries/public-shares.ts
@@ -14,6 +14,8 @@ import {
 } from '@/lib/api/contracts/public-shares'
 import { workspaceFilesKeys } from '@/hooks/queries/workspace-files'
 
+export const FILE_SHARE_STALE_TIME = 30 * 1000
+
 /**
  * Query key factories for public shares
  */
@@ -41,7 +43,7 @@ export function useFileShare(workspaceId: string, fileId: string, options?: { en
     queryKey: shareKeys.detail(workspaceId, fileId),
     queryFn: ({ signal }) => fetchFileShare(workspaceId, fileId, signal),
     enabled: Boolean(workspaceId) && Boolean(fileId) && (options?.enabled ?? true),
-    staleTime: 30 * 1000,
+    staleTime: FILE_SHARE_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/resume-execution.ts
+++ b/apps/sim/hooks/queries/resume-execution.ts
@@ -7,6 +7,8 @@ import {
 } from '@/lib/api/contracts/workflows'
 import type { ResumeStatus } from '@/executor/types'
 
+export const RESUME_EXECUTION_DETAIL_STALE_TIME = 30 * 1000
+
 export const resumeKeys = {
   all: ['resume-execution'] as const,
   executions: () => [...resumeKeys.all, 'execution'] as const,
@@ -120,7 +122,7 @@ export function useResumeExecutionDetail(
       return raw as unknown as PausedExecutionDetail
     },
     enabled: Boolean(workflowId && executionId),
-    staleTime: 30 * 1000,
+    staleTime: RESUME_EXECUTION_DETAIL_STALE_TIME,
     initialData,
   })
 }

--- a/apps/sim/hooks/queries/schedules.ts
+++ b/apps/sim/hooks/queries/schedules.ts
@@ -25,6 +25,10 @@ import { deploymentKeys } from '@/hooks/queries/deployments'
 
 const logger = createLogger('ScheduleQueries')
 
+export const SCHEDULE_LIST_STALE_TIME = 30 * 1000
+export const SCHEDULE_DETAIL_STALE_TIME = 30 * 1000
+export const SCHEDULE_BLOCK_STALE_TIME = 30 * 1000
+
 export const scheduleKeys = {
   all: ['schedules'] as const,
   lists: () => [...scheduleKeys.all, 'list'] as const,
@@ -85,7 +89,7 @@ export function useWorkspaceSchedules(workspaceId?: string) {
       return data.schedules || []
     },
     enabled: Boolean(workspaceId),
-    staleTime: 30 * 1000,
+    staleTime: SCHEDULE_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -109,7 +113,7 @@ export function useScheduleById(scheduleId?: string) {
       return data.schedule
     },
     enabled: Boolean(scheduleId),
-    staleTime: 30 * 1000,
+    staleTime: SCHEDULE_DETAIL_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -126,7 +130,7 @@ export function useScheduleQuery(
     queryKey: scheduleKeys.schedule(workflowId ?? '', blockId ?? ''),
     queryFn: ({ signal }) => fetchSchedule(workflowId!, blockId!, signal),
     enabled: !!workflowId && !!blockId && (options?.enabled ?? true),
-    staleTime: 30 * 1000, // 30 seconds
+    staleTime: SCHEDULE_BLOCK_STALE_TIME,
     retry: false,
     placeholderData: keepPreviousData,
   })

--- a/apps/sim/hooks/queries/session.ts
+++ b/apps/sim/hooks/queries/session.ts
@@ -5,6 +5,8 @@ import {
   extractSessionDataFromAuthClientResult,
 } from '@/lib/auth/session-response'
 
+export const SESSION_STALE_TIME = 5 * 60 * 1000
+
 export const sessionKeys = {
   all: ['session'] as const,
   detail: () => [...sessionKeys.all, 'detail'] as const,
@@ -29,7 +31,7 @@ export function useSessionQuery() {
   return useQuery({
     queryKey: sessionKeys.detail(),
     queryFn: ({ signal }) => fetchSession(signal),
-    staleTime: 5 * 60 * 1000,
+    staleTime: SESSION_STALE_TIME,
     retry: false,
   })
 }

--- a/apps/sim/hooks/queries/skills.ts
+++ b/apps/sim/hooks/queries/skills.ts
@@ -10,6 +10,8 @@ import {
 
 const logger = createLogger('SkillsQueries')
 
+export const SKILL_LIST_STALE_TIME = 60 * 1000
+
 export type SkillDefinition = Skill
 
 /**
@@ -40,7 +42,7 @@ export function useSkills(workspaceId: string) {
     queryKey: skillsKeys.list(workspaceId),
     queryFn: ({ signal }) => fetchSkills(workspaceId, signal),
     enabled: !!workspaceId,
-    staleTime: 60 * 1000,
+    staleTime: SKILL_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/subscription.ts
+++ b/apps/sim/hooks/queries/subscription.ts
@@ -17,6 +17,10 @@ import { workspaceKeys } from '@/hooks/queries/workspace'
 
 export type { SubscriptionApiResponse }
 
+export const SUBSCRIPTION_DATA_STALE_TIME = 5 * 60 * 1000
+export const USAGE_LIMIT_STALE_TIME = 30 * 1000
+export const INVOICES_STALE_TIME = 5 * 60 * 1000
+
 /**
  * Query key factories for subscription-related queries
  */
@@ -58,7 +62,7 @@ interface UseSubscriptionDataOptions {
  * @param options - Optional configuration
  */
 export function useSubscriptionData(options: UseSubscriptionDataOptions = {}) {
-  const { includeOrg = false, enabled = true, staleTime = 5 * 60 * 1000 } = options
+  const { includeOrg = false, enabled = true, staleTime = SUBSCRIPTION_DATA_STALE_TIME } = options
 
   return useQuery({
     queryKey: subscriptionKeys.user(includeOrg),
@@ -77,7 +81,7 @@ export function prefetchSubscriptionData(queryClient: QueryClient) {
   queryClient.prefetchQuery({
     queryKey: subscriptionKeys.user(false),
     queryFn: ({ signal }) => fetchSubscriptionData(false, signal),
-    staleTime: 5 * 60 * 1000,
+    staleTime: SUBSCRIPTION_DATA_STALE_TIME,
   })
 }
 
@@ -96,12 +100,12 @@ export function prefetchUpgradeBillingData(queryClient: QueryClient) {
   queryClient.prefetchQuery({
     queryKey: subscriptionKeys.user(true),
     queryFn: ({ signal }) => fetchSubscriptionData(true, signal),
-    staleTime: 5 * 60 * 1000,
+    staleTime: SUBSCRIPTION_DATA_STALE_TIME,
   })
   queryClient.prefetchQuery({
     queryKey: subscriptionKeys.usage(),
     queryFn: ({ signal }) => fetchUsageLimitData(signal),
-    staleTime: 30 * 1000,
+    staleTime: USAGE_LIMIT_STALE_TIME,
   })
 }
 
@@ -133,7 +137,7 @@ export function useUsageLimitData(options: UseUsageLimitDataOptions = {}) {
   return useQuery({
     queryKey: subscriptionKeys.usage(),
     queryFn: ({ signal }) => fetchUsageLimitData(signal),
-    staleTime: 30 * 1000,
+    staleTime: USAGE_LIMIT_STALE_TIME,
     enabled,
   })
 }
@@ -172,7 +176,7 @@ export function useInvoices(options: UseInvoicesOptions = {}) {
   return useQuery({
     queryKey: subscriptionKeys.invoices(context, organizationId),
     queryFn: ({ signal }) => fetchInvoices(context, organizationId, signal),
-    staleTime: 5 * 60 * 1000,
+    staleTime: INVOICES_STALE_TIME,
     enabled: enabled && (context !== 'organization' || Boolean(organizationId)),
   })
 }

--- a/apps/sim/hooks/queries/tables.ts
+++ b/apps/sim/hooks/queries/tables.ts
@@ -95,13 +95,22 @@ import {
   optimisticallyScheduleNewlyEligibleGroups,
 } from '@/lib/table/deps'
 import { runUploadStrategy } from '@/lib/uploads/client/direct-upload'
-import { type TableQueryScope, tableKeys } from '@/hooks/queries/utils/table-keys'
+import {
+  TABLE_LIST_STALE_TIME,
+  type TableQueryScope,
+  tableKeys,
+} from '@/hooks/queries/utils/table-keys'
 import {
   getNextTableRowsPageParam,
   type TableRowsPageParam,
 } from '@/hooks/queries/utils/table-rows-pagination'
 
 const logger = createLogger('TableQueries')
+export const TABLE_DETAIL_STALE_TIME = 30 * 1000
+export const TABLE_RUN_STATE_STALE_TIME = 30 * 1000
+export const TABLE_FIND_STALE_TIME = 30 * 1000
+export const TABLE_ROWS_STALE_TIME = 30 * 1000
+export const TABLE_EXPORT_JOBS_STALE_TIME = 5 * 1000
 
 type TableRowsParams = Omit<TableRowsQueryInput, 'filter' | 'sort'> &
   TableIdParamsInput & {
@@ -226,7 +235,7 @@ export function useTablesList(
       return response.data.tables
     },
     enabled: Boolean(workspaceId),
-    staleTime: 30 * 1000,
+    staleTime: TABLE_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
     refetchInterval:
       typeof refetchInterval === 'function'
@@ -244,7 +253,7 @@ export function useTable(workspaceId: string | undefined, tableId: string | unde
     queryKey: tableKeys.detail(tableId ?? ''),
     queryFn: ({ signal }) => fetchTable(workspaceId as string, tableId as string, signal),
     enabled: Boolean(workspaceId && tableId),
-    staleTime: 30 * 1000,
+    staleTime: TABLE_DETAIL_STALE_TIME,
   })
 }
 
@@ -256,7 +265,7 @@ export function getTableDetailQueryOptions(workspaceId: string, tableId: string)
   return {
     queryKey: tableKeys.detail(tableId),
     queryFn: ({ signal }: { signal?: AbortSignal }) => fetchTable(workspaceId, tableId, signal),
-    staleTime: 30 * 1000,
+    staleTime: TABLE_DETAIL_STALE_TIME,
   }
 }
 
@@ -382,7 +391,7 @@ export function useTableRunState(tableId: string | undefined) {
     queryKey: tableKeys.activeDispatches(tableId ?? ''),
     queryFn: ({ signal }) => fetchTableRunState(tableId as string, signal),
     enabled: Boolean(tableId),
-    staleTime: 30 * 1000,
+    staleTime: TABLE_RUN_STATE_STALE_TIME,
   })
 }
 
@@ -444,7 +453,7 @@ export function useFindTableRows({ workspaceId, tableId, q, filter, sort }: Find
     queryFn: ({ signal }) =>
       fetchTableRowMatches({ workspaceId, tableId, q, filter, sort, signal }),
     enabled: Boolean(workspaceId && tableId) && q.trim().length > 0,
-    staleTime: 30 * 1000,
+    staleTime: TABLE_FIND_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -480,7 +489,7 @@ export function tableRowsInfiniteOptions({
     // Sorted views (and legacy rows without an order key) fall back to offset paging.
     getNextPageParam: (_lastPage, allPages): TableRowsPageParam | undefined =>
       getNextTableRowsPageParam(allPages, Boolean(sort)),
-    staleTime: 30 * 1000,
+    staleTime: TABLE_ROWS_STALE_TIME,
   })
 }
 
@@ -1675,7 +1684,7 @@ export function useWorkspaceExportJobs(workspaceId?: string) {
     queryKey: tableKeys.exportJobs(workspaceId),
     queryFn: ({ signal }) => fetchWorkspaceExportJobs(workspaceId as string, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 5 * 1000,
+    staleTime: TABLE_EXPORT_JOBS_STALE_TIME,
     refetchInterval: (query) =>
       query.state.data?.some((j) => j.status === 'running') ? 2000 : false,
   })

--- a/apps/sim/hooks/queries/unsubscribe.ts
+++ b/apps/sim/hooks/queries/unsubscribe.ts
@@ -8,6 +8,8 @@ import {
   unsubscribePostContract,
 } from '@/lib/api/contracts/user'
 
+export const UNSUBSCRIBE_DETAIL_STALE_TIME = 5 * 60 * 1000
+
 export const unsubscribeKeys = {
   all: ['unsubscribe'] as const,
   details: () => [...unsubscribeKeys.all, 'detail'] as const,
@@ -32,7 +34,7 @@ export function useUnsubscribe(email?: string, token?: string) {
     queryKey: unsubscribeKeys.detail(email, token),
     queryFn: ({ signal }) => fetchUnsubscribe(email as string, token as string, signal),
     enabled: Boolean(email) && Boolean(token),
-    staleTime: 5 * 60 * 1000,
+    staleTime: UNSUBSCRIBE_DETAIL_STALE_TIME,
     retry: false,
   })
 }

--- a/apps/sim/hooks/queries/usage-logs.ts
+++ b/apps/sim/hooks/queries/usage-logs.ts
@@ -11,6 +11,9 @@ import { usageLogKeys } from '@/hooks/queries/utils/usage-log-keys'
 
 const PAGE_SIZE = 25
 
+export const USAGE_LOGS_LIST_STALE_TIME = 30 * 1000
+export const USAGE_SUMMARY_STALE_TIME = 30 * 1000
+
 interface UsagePeriodFilter {
   period: UsageLogPeriod
   /** Required when `period` is `'custom'`. */
@@ -51,7 +54,7 @@ export function useUsageLogs({ period, startDate, endDate, enabled = true }: Use
     getNextPageParam: (lastPage) =>
       lastPage.pagination.hasMore ? lastPage.pagination.nextCursor : undefined,
     enabled,
-    staleTime: 30 * 1000,
+    staleTime: USAGE_LOGS_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -65,7 +68,7 @@ export function useUsageSummary(period: Exclude<UsageLogPeriod, 'custom'>) {
   return useQuery({
     queryKey: usageLogKeys.summary(period),
     queryFn: ({ signal }) => fetchUsageLogs({ period }, 1, undefined, signal, false),
-    staleTime: 30 * 1000,
+    staleTime: USAGE_SUMMARY_STALE_TIME,
     select: (data) => data.summary.totalCredits,
   })
 }

--- a/apps/sim/hooks/queries/user-profile.ts
+++ b/apps/sim/hooks/queries/user-profile.ts
@@ -15,6 +15,8 @@ const logger = createLogger('UserProfileQuery')
 /**
  * Query key factories for user profile
  */
+export const USER_PROFILE_STALE_TIME = 5 * 60 * 1000
+
 export const userProfileKeys = {
   all: ['userProfile'] as const,
   profile: () => [...userProfileKeys.all, 'profile'] as const,
@@ -54,7 +56,7 @@ export function useUserProfile() {
   return useQuery({
     queryKey: userProfileKeys.profile(),
     queryFn: ({ signal }) => fetchUserProfile(signal),
-    staleTime: 5 * 60 * 1000,
+    staleTime: USER_PROFILE_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/utils/table-keys.ts
+++ b/apps/sim/hooks/queries/utils/table-keys.ts
@@ -10,6 +10,8 @@
 
 export type TableQueryScope = 'active' | 'archived' | 'all'
 
+export const TABLE_LIST_STALE_TIME = 30 * 1000
+
 export const tableKeys = {
   all: ['tables'] as const,
   lists: () => [...tableKeys.all, 'list'] as const,

--- a/apps/sim/hooks/queries/voice-settings.ts
+++ b/apps/sim/hooks/queries/voice-settings.ts
@@ -6,6 +6,8 @@ import { getVoiceSettingsContract } from '@/lib/api/contracts'
 /**
  * Query key factory for voice settings queries
  */
+export const VOICE_SETTINGS_STALE_TIME = 5 * 60 * 1000
+
 export const voiceSettingsKeys = {
   all: ['voiceSettings'] as const,
   availability: () => [...voiceSettingsKeys.all, 'availability'] as const,
@@ -30,6 +32,6 @@ export function useVoiceSettings() {
   return useQuery({
     queryKey: voiceSettingsKeys.availability(),
     queryFn: ({ signal }) => fetchVoiceSettings(signal),
-    staleTime: 5 * 60 * 1000,
+    staleTime: VOICE_SETTINGS_STALE_TIME,
   })
 }

--- a/apps/sim/hooks/queries/webhooks.ts
+++ b/apps/sim/hooks/queries/webhooks.ts
@@ -8,6 +8,8 @@ import {
   type WebhookData,
 } from '@/lib/api/contracts/webhooks'
 
+export const WEBHOOK_DETAIL_STALE_TIME = 60 * 1000
+
 export const webhookKeys = {
   all: ['webhooks'] as const,
   details: () => [...webhookKeys.all, 'detail'] as const,
@@ -45,7 +47,7 @@ export function useWebhookQuery(workflowId: string, blockId: string, enabled = t
     queryKey: webhookKeys.byBlock(workflowId, blockId),
     queryFn: ({ signal }) => fetchWebhooks(workflowId, blockId, signal),
     enabled: enabled && Boolean(workflowId && blockId),
-    staleTime: 60 * 1000,
+    staleTime: WEBHOOK_DETAIL_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/workflow-mcp-servers.ts
+++ b/apps/sim/hooks/queries/workflow-mcp-servers.ts
@@ -38,6 +38,11 @@ export const workflowMcpServerKeys = {
 
 export type { WorkflowMcpServer, WorkflowMcpTool }
 
+export const WORKFLOW_MCP_SERVERS_LIST_STALE_TIME = 60 * 1000
+export const WORKFLOW_MCP_SERVER_DETAIL_STALE_TIME = 30 * 1000
+export const WORKFLOW_MCP_TOOLS_STALE_TIME = 30 * 1000
+export const WORKFLOW_MCP_DEPLOYED_WORKFLOWS_STALE_TIME = 30 * 1000
+
 /**
  * Fetch workflow MCP servers for a workspace
  */
@@ -68,7 +73,7 @@ export function useWorkflowMcpServers(workspaceId: string) {
     queryFn: ({ signal }) => fetchWorkflowMcpServers(workspaceId, signal),
     enabled: !!workspaceId,
     retry: false,
-    staleTime: 60 * 1000,
+    staleTime: WORKFLOW_MCP_SERVERS_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -102,7 +107,7 @@ export function useWorkflowMcpServer(workspaceId: string, serverId: string | nul
     queryFn: ({ signal }) => fetchWorkflowMcpServer(workspaceId, serverId!, signal),
     enabled: !!workspaceId && !!serverId,
     retry: false,
-    staleTime: 30 * 1000,
+    staleTime: WORKFLOW_MCP_SERVER_DETAIL_STALE_TIME,
   })
 }
 
@@ -138,7 +143,7 @@ export function useWorkflowMcpTools(workspaceId: string, serverId: string | null
     queryFn: ({ signal }) => fetchWorkflowMcpTools(workspaceId, serverId!, signal),
     enabled: !!workspaceId && !!serverId,
     retry: false,
-    staleTime: 30 * 1000,
+    staleTime: WORKFLOW_MCP_TOOLS_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -414,7 +419,7 @@ export function useDeployedWorkflows(workspaceId: string) {
     queryKey: workflowMcpServerKeys.deployedWorkflows(workspaceId),
     queryFn: ({ signal }) => fetchDeployedWorkflows(workspaceId, signal),
     enabled: !!workspaceId,
-    staleTime: 30 * 1000,
+    staleTime: WORKFLOW_MCP_DEPLOYED_WORKFLOWS_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/workflow-search-replace.ts
+++ b/apps/sim/hooks/queries/workflow-search-replace.ts
@@ -102,6 +102,21 @@ export const workflowSearchReplaceKeys = {
     ] as const,
 }
 
+export const WORKFLOW_SEARCH_OAUTH_DETAIL_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_KNOWLEDGE_DETAIL_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_TABLE_DETAIL_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_FILE_LIST_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_MCP_SERVER_LIST_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_MCP_TOOL_LIST_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_SELECTOR_DETAIL_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_OAUTH_REPLACEMENT_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_KNOWLEDGE_REPLACEMENT_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_TABLE_REPLACEMENT_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_FILE_REPLACEMENT_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_MCP_SERVER_REPLACEMENT_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_MCP_TOOL_REPLACEMENT_STALE_TIME = 60 * 1000
+export const WORKFLOW_SEARCH_SELECTOR_REPLACEMENT_STALE_TIME = 60 * 1000
+
 function uniqueMatches(
   matches: WorkflowSearchMatch[],
   kind: WorkflowSearchMatch['kind']
@@ -172,7 +187,7 @@ export function useWorkflowSearchOAuthCredentialDetails(
       queryFn: ({ signal }: { signal: AbortSignal }) =>
         fetchOAuthCredentialDetail(match.rawValue, workflowId, signal),
       enabled: Boolean(match.rawValue),
-      staleTime: 60 * 1000,
+      staleTime: WORKFLOW_SEARCH_OAUTH_DETAIL_STALE_TIME,
       select: (credentials: Credential[]): WorkflowSearchResolvedResource => {
         const credential = credentials[0]
         return {
@@ -195,7 +210,7 @@ export function useWorkflowSearchKnowledgeBaseDetails(matches: WorkflowSearchMat
       queryKey: workflowSearchReplaceKeys.knowledgeDetail(match.rawValue),
       queryFn: ({ signal }: { signal: AbortSignal }) => fetchKnowledgeBase(match.rawValue, signal),
       enabled: Boolean(match.rawValue),
-      staleTime: 60 * 1000,
+      staleTime: WORKFLOW_SEARCH_KNOWLEDGE_DETAIL_STALE_TIME,
       select: (knowledgeBase: KnowledgeBaseData): WorkflowSearchResolvedResource => ({
         matchRawValue: match.rawValue,
         resourceGroupKey: match.resource?.resourceGroupKey,
@@ -223,7 +238,7 @@ export function useWorkflowSearchTableDetails(
           signal,
         }),
       enabled: Boolean(workspaceId && match.rawValue),
-      staleTime: 60 * 1000,
+      staleTime: WORKFLOW_SEARCH_TABLE_DETAIL_STALE_TIME,
       select: (response: GetTableResponse): WorkflowSearchResolvedResource => ({
         matchRawValue: match.rawValue,
         resourceGroupKey: match.resource?.resourceGroupKey,
@@ -254,7 +269,7 @@ export function useWorkflowSearchFileDetails(matches: WorkflowSearchMatch[], wor
         signal,
       }),
     enabled: Boolean(workspaceId && fileMatches.length > 0),
-    staleTime: 60 * 1000,
+    staleTime: WORKFLOW_SEARCH_FILE_LIST_STALE_TIME,
   })
 
   return useMemo(
@@ -293,7 +308,7 @@ export function useWorkflowSearchMcpServerDetails(
         signal,
       }),
     enabled: Boolean(workspaceId && serverMatches.length > 0),
-    staleTime: 60 * 1000,
+    staleTime: WORKFLOW_SEARCH_MCP_SERVER_LIST_STALE_TIME,
   })
 
   return useMemo(
@@ -330,7 +345,7 @@ export function useWorkflowSearchMcpToolDetails(
         signal,
       }),
     enabled: Boolean(workspaceId && toolMatches.length > 0),
-    staleTime: 60 * 1000,
+    staleTime: WORKFLOW_SEARCH_MCP_TOOL_LIST_STALE_TIME,
   })
 
   return useMemo(
@@ -382,7 +397,7 @@ export function useWorkflowSearchSelectorDetails(matches: WorkflowSearchMatch[])
           return options.find((option) => option.id === match.rawValue) ?? null
         },
         enabled: Boolean(selectorKey && match.rawValue && baseEnabled),
-        staleTime: definition.staleTime ?? 60 * 1000,
+        staleTime: definition.staleTime ?? WORKFLOW_SEARCH_SELECTOR_DETAIL_STALE_TIME,
         select: (option: SelectorOption | null): WorkflowSearchResolvedResource => ({
           matchRawValue: match.rawValue,
           resourceGroupKey: match.resource?.resourceGroupKey,
@@ -420,7 +435,7 @@ export function useWorkflowSearchOAuthReplacementOptions(
       queryFn: ({ signal }: { signal: AbortSignal }) =>
         fetchOAuthCredentials({ providerId, workspaceId, workflowId }, signal),
       enabled: Boolean(providerId && workspaceId),
-      staleTime: 60 * 1000,
+      staleTime: WORKFLOW_SEARCH_OAUTH_REPLACEMENT_STALE_TIME,
       select: (credentials: Credential[]): WorkflowSearchReplacementOption[] =>
         credentials.map((credential) => ({
           kind: 'oauth-credential',
@@ -449,7 +464,7 @@ export function useWorkflowSearchKnowledgeReplacementOptions(
         queryFn: ({ signal }: { signal: AbortSignal }) =>
           fetchKnowledgeBases(workspaceId, 'active', signal),
         enabled: Boolean(workspaceId && knowledgeGroups.length > 0),
-        staleTime: 60 * 1000,
+        staleTime: WORKFLOW_SEARCH_KNOWLEDGE_REPLACEMENT_STALE_TIME,
         placeholderData: (previous: KnowledgeBaseData[] | undefined) => previous,
         select: (knowledgeBases: KnowledgeBaseData[]): WorkflowSearchReplacementOption[] =>
           knowledgeGroups.flatMap((match) =>
@@ -481,7 +496,7 @@ export function useWorkflowSearchTableReplacementOptions(
             signal,
           }),
         enabled: Boolean(workspaceId && tableGroups.length > 0),
-        staleTime: 60 * 1000,
+        staleTime: WORKFLOW_SEARCH_TABLE_REPLACEMENT_STALE_TIME,
         select: (response: ListTablesResponse): WorkflowSearchReplacementOption[] =>
           tableGroups.flatMap((match) =>
             response.data.tables.map((table) => ({
@@ -516,7 +531,7 @@ export function useWorkflowSearchFileReplacementOptions(
             signal,
           }),
         enabled: Boolean(workspaceId && fileGroups.length > 0),
-        staleTime: 60 * 1000,
+        staleTime: WORKFLOW_SEARCH_FILE_REPLACEMENT_STALE_TIME,
         select: (response: ListWorkspaceFilesResponse): WorkflowSearchReplacementOption[] =>
           fileGroups.flatMap((match) =>
             response.files.map((file) => ({
@@ -553,7 +568,7 @@ export function useWorkflowSearchMcpServerReplacementOptions(
             signal,
           }),
         enabled: Boolean(workspaceId && serverGroups.length > 0),
-        staleTime: 60 * 1000,
+        staleTime: WORKFLOW_SEARCH_MCP_SERVER_REPLACEMENT_STALE_TIME,
         select: (response: ListMcpServersResponse): WorkflowSearchReplacementOption[] =>
           serverGroups.flatMap((match) =>
             response.data.servers.map((server) => ({
@@ -601,7 +616,7 @@ export function useWorkflowSearchMcpToolReplacementOptions(
             signal,
           }),
         enabled: Boolean(workspaceId && toolGroups.length > 0),
-        staleTime: 60 * 1000,
+        staleTime: WORKFLOW_SEARCH_MCP_TOOL_REPLACEMENT_STALE_TIME,
         select: (response: DiscoverMcpToolsResponse): WorkflowSearchReplacementOption[] =>
           buildWorkflowSearchMcpToolReplacementOptions(toolGroups, response.data.tools),
       },
@@ -626,7 +641,7 @@ export function useWorkflowSearchSelectorReplacementOptions(matches: WorkflowSea
         queryFn: ({ signal }: { signal: AbortSignal }) =>
           loadAllSelectorOptions(definition, { ...queryArgs, signal }),
         enabled: Boolean(selectorKey && baseEnabled),
-        staleTime: definition.staleTime ?? 60 * 1000,
+        staleTime: definition.staleTime ?? WORKFLOW_SEARCH_SELECTOR_REPLACEMENT_STALE_TIME,
         select: (options: SelectorOption[]): WorkflowSearchReplacementOption[] =>
           options.map((option) => ({
             kind: match.kind,

--- a/apps/sim/hooks/queries/workflows.ts
+++ b/apps/sim/hooks/queries/workflows.ts
@@ -50,6 +50,9 @@ const logger = createLogger('WorkflowQueries')
 
 export { type WorkflowQueryScope, workflowKeys } from '@/hooks/queries/utils/workflow-keys'
 
+export const WORKFLOW_STATE_STALE_TIME = 30 * 1000
+export const WORKFLOW_DEPLOYMENT_VERSION_STATE_STALE_TIME = 5 * 60 * 1000
+
 /**
  * Projects the in-state slice of the workflow envelope into the canvas-facing
  * `WorkflowState` shape consumed by preview/editor surfaces.
@@ -78,7 +81,7 @@ export function useWorkflowState(workflowId: string | undefined) {
     queryKey: workflowKeys.state(workflowId),
     queryFn: workflowId ? ({ signal }) => fetchWorkflowEnvelope(workflowId, signal) : skipToken,
     select: mapWorkflowState,
-    staleTime: 30 * 1000,
+    staleTime: WORKFLOW_STATE_STALE_TIME,
   })
 }
 
@@ -98,7 +101,7 @@ export function useWorkflowStates(
       queryKey: workflowKeys.state(id),
       queryFn: ({ signal }: { signal?: AbortSignal }) => fetchWorkflowEnvelope(id, signal),
       select: mapWorkflowState,
-      staleTime: 30 * 1000,
+      staleTime: WORKFLOW_STATE_STALE_TIME,
     })),
   })
   const map = new Map<string, WorkflowState | null>()
@@ -563,7 +566,7 @@ export function useDeploymentVersionState(workflowId: string | null, version: nu
       workflowId && version !== null
         ? ({ signal }) => fetchDeploymentVersionState(workflowId, version, signal)
         : skipToken,
-    staleTime: 5 * 60 * 1000,
+    staleTime: WORKFLOW_DEPLOYMENT_VERSION_STATE_STALE_TIME,
   })
 }
 

--- a/apps/sim/hooks/queries/workspace-file-folders.ts
+++ b/apps/sim/hooks/queries/workspace-file-folders.ts
@@ -16,6 +16,8 @@ import { workspaceFilesKeys } from '@/hooks/queries/workspace-files'
 type WorkspaceFileFolderScope = 'active' | 'archived' | 'all'
 export type { WorkspaceFileFolderApi }
 
+export const WORKSPACE_FILE_FOLDERS_STALE_TIME = 30 * 1000
+
 export const workspaceFileFolderKeys = {
   all: ['workspaceFileFolders'] as const,
   lists: () => [...workspaceFileFolderKeys.all, 'list'] as const,
@@ -55,7 +57,7 @@ export function useWorkspaceFileFolders(
     queryKey: workspaceFileFolderKeys.list(workspaceId, scope),
     queryFn: ({ signal }) => fetchWorkspaceFileFolders(workspaceId, scope, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_FILE_FOLDERS_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/workspace-file-table.ts
+++ b/apps/sim/hooks/queries/workspace-file-table.ts
@@ -9,6 +9,8 @@ import {
  * Query keys for the streamed CSV file-viewer preview. `key` (storage object key) and
  * `version` (the record's `updatedAt`) are folded in so a re-upload or edit busts the cache.
  */
+export const WORKSPACE_CSV_PREVIEW_STALE_TIME = 30 * 1000
+
 export const workspaceFileTableKeys = {
   all: ['workspaceFileTable'] as const,
   previews: () => [...workspaceFileTableKeys.all, 'preview'] as const,
@@ -45,6 +47,6 @@ export function useWorkspaceCsvPreview(
     queryKey: workspaceFileTableKeys.preview(workspaceId, fileId, key, version),
     queryFn: ({ signal }) => fetchWorkspaceCsvPreview(workspaceId, fileId, key, version, signal),
     enabled: !!workspaceId && !!fileId && !!key && (options?.enabled ?? true),
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_CSV_PREVIEW_STALE_TIME,
   })
 }

--- a/apps/sim/hooks/queries/workspace-files.ts
+++ b/apps/sim/hooks/queries/workspace-files.ts
@@ -54,6 +54,11 @@ export const workspaceFilesKeys = {
   storageInfo: () => [...workspaceFilesKeys.all, 'storageInfo'] as const,
 }
 
+export const WORKSPACE_FILES_LIST_STALE_TIME = 30 * 1000
+export const WORKSPACE_FILE_CONTENT_STALE_TIME = 30 * 1000
+export const WORKSPACE_FILE_BINARY_STALE_TIME = 30 * 1000
+export const WORKSPACE_STORAGE_INFO_STALE_TIME = 60 * 1000
+
 /**
  * Storage info type
  */
@@ -76,7 +81,7 @@ export function useWorkspaceFileRecord(workspaceId: string, fileId: string) {
     queryKey: workspaceFilesKeys.list(workspaceId, 'active'),
     queryFn: ({ signal }) => fetchWorkspaceFiles(workspaceId, 'active', signal),
     enabled: !!workspaceId && !!fileId,
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_FILES_LIST_STALE_TIME,
     select: (files) => files.find((f) => f.id === fileId) ?? null,
   })
 }
@@ -109,7 +114,7 @@ export function useWorkspaceFiles(
     queryKey: workspaceFilesKeys.list(workspaceId, scope),
     queryFn: ({ signal }) => fetchWorkspaceFiles(workspaceId, scope, signal),
     enabled: !!workspaceId && (options?.enabled ?? true),
-    staleTime: 30 * 1000, // 30 seconds - files can change frequently
+    staleTime: WORKSPACE_FILES_LIST_STALE_TIME, // 30 seconds - files can change frequently
     placeholderData: keepPreviousData, // Show cached data immediately
   })
 }
@@ -145,7 +150,7 @@ export function useWorkspaceFileContent(
     queryFn: ({ signal }) =>
       fetchWorkspaceFileContent(source.buildUrl(key, { raw, bust: true }), signal),
     enabled: !!workspaceId && !!fileId && !!key,
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_FILE_CONTENT_STALE_TIME,
     refetchOnWindowFocus: 'always',
   })
 }
@@ -222,7 +227,7 @@ export function useWorkspaceFileBinary(
     // compiled artifact hasn't been written yet — the doc is fetched once, when
     // it's actually ready, instead of hammering the serve URL through generation.
     enabled: !!workspaceId && !!fileId && !!key && (options?.enabled ?? true),
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_FILE_BINARY_STALE_TIME,
     refetchOnWindowFocus: 'always',
     placeholderData: keepPreviousData,
     // While a generated doc is still compiling, serve returns 409. Poll (stay in
@@ -276,7 +281,7 @@ export function useStorageInfo(enabled = true) {
     queryFn: ({ signal }) => fetchStorageInfo(signal),
     enabled,
     retry: false, // Don't retry on 404
-    staleTime: 60 * 1000, // 1 minute - storage info doesn't change often
+    staleTime: WORKSPACE_STORAGE_INFO_STALE_TIME, // 1 minute - storage info doesn't change often
   })
 }
 

--- a/apps/sim/hooks/queries/workspace-fork.ts
+++ b/apps/sim/hooks/queries/workspace-fork.ts
@@ -35,13 +35,18 @@ export const forkKeys = {
   resources: (workspaceId?: string) => [...forkKeys.resourcesAll(), workspaceId ?? ''] as const,
 }
 
+export const WORKSPACE_FORK_RESOURCES_STALE_TIME = 30 * 1000
+export const WORKSPACE_FORK_LINEAGE_STALE_TIME = 30 * 1000
+export const WORKSPACE_FORK_MAPPING_STALE_TIME = 15 * 1000
+export const WORKSPACE_FORK_DIFF_STALE_TIME = 10 * 1000
+
 export function useForkResources(workspaceId?: string, enabled = true) {
   return useQuery({
     queryKey: forkKeys.resources(workspaceId),
     queryFn: ({ signal }) =>
       requestJson(getForkResourcesContract, { params: { id: workspaceId as string }, signal }),
     enabled: Boolean(workspaceId) && enabled,
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_FORK_RESOURCES_STALE_TIME,
   })
 }
 
@@ -51,7 +56,7 @@ export function useForkLineage(workspaceId?: string, enabled = true) {
     queryFn: ({ signal }) =>
       requestJson(getForkLineageContract, { params: { id: workspaceId as string }, signal }),
     enabled: Boolean(workspaceId) && enabled,
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_FORK_LINEAGE_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -100,7 +105,7 @@ export function useForkMapping(args: {
         signal,
       }),
     enabled: Boolean(args.workspaceId && args.otherWorkspaceId) && (args.enabled ?? true),
-    staleTime: 15 * 1000,
+    staleTime: WORKSPACE_FORK_MAPPING_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -132,7 +137,7 @@ export function useForkDiff(args: {
         signal,
       }),
     enabled: Boolean(args.workspaceId && args.otherWorkspaceId) && (args.enabled ?? true),
-    staleTime: 10 * 1000,
+    staleTime: WORKSPACE_FORK_DIFF_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/sim/hooks/queries/workspace.ts
+++ b/apps/sim/hooks/queries/workspace.ts
@@ -42,6 +42,12 @@ export const workspaceKeys = {
 
 export type { Workspace, WorkspaceCreationPolicy, WorkspaceMember, WorkspacePermissions }
 
+export const WORKSPACE_PERMISSIONS_STALE_TIME = 30 * 1000
+export const WORKSPACE_LIST_STALE_TIME = 30 * 1000
+export const WORKSPACE_SETTINGS_STALE_TIME = 30 * 1000
+export const WORKSPACE_MEMBERS_STALE_TIME = 5 * 60 * 1000
+export const WORKSPACE_ADMIN_LIST_STALE_TIME = 60 * 1000
+
 async function fetchWorkspaces(
   scope: WorkspaceQueryScope = 'active',
   signal?: AbortSignal
@@ -83,7 +89,7 @@ export function useWorkspacesQuery(enabled = true, scope: WorkspaceQueryScope = 
     queryFn: ({ signal }) => fetchWorkspaces(scope, signal),
     select: selectWorkspaces,
     enabled,
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -97,7 +103,7 @@ export function useWorkspacesWithMetadata(enabled = true) {
     queryKey: workspaceKeys.list('active'),
     queryFn: ({ signal }) => fetchWorkspaces('active', signal),
     enabled,
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_LIST_STALE_TIME,
   })
 }
 
@@ -107,7 +113,7 @@ export function useWorkspaceCreationPolicy(enabled = true) {
     queryFn: ({ signal }) => fetchWorkspaces('active', signal),
     select: (data) => data.creationPolicy,
     enabled,
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_LIST_STALE_TIME,
   })
 }
 
@@ -250,7 +256,7 @@ export function useWorkspacePermissionsQuery(workspaceId: string | null | undefi
     queryKey: workspaceKeys.permissions(workspaceId ?? ''),
     queryFn: ({ signal }) => fetchWorkspacePermissions(workspaceId as string, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_PERMISSIONS_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -275,7 +281,7 @@ export function useWorkspaceMembersQuery(workspaceId: string | null | undefined)
     queryKey: workspaceKeys.members(workspaceId ?? ''),
     queryFn: ({ signal }) => fetchWorkspaceMembers(workspaceId as string, signal),
     enabled: Boolean(workspaceId),
-    staleTime: 5 * 60 * 1000,
+    staleTime: WORKSPACE_MEMBERS_STALE_TIME,
   })
 }
 
@@ -302,7 +308,7 @@ export function prefetchWorkspaceSettings(queryClient: QueryClient, workspaceId:
   queryClient.prefetchQuery({
     queryKey: workspaceKeys.settings(workspaceId),
     queryFn: ({ signal }) => fetchWorkspaceSettings(workspaceId, signal),
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_SETTINGS_STALE_TIME,
   })
 }
 
@@ -315,7 +321,7 @@ export function useWorkspaceSettings(workspaceId: string) {
     queryKey: workspaceKeys.settings(workspaceId),
     queryFn: ({ signal }) => fetchWorkspaceSettings(workspaceId, signal),
     enabled: !!workspaceId,
-    staleTime: 30 * 1000,
+    staleTime: WORKSPACE_SETTINGS_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }
@@ -401,7 +407,7 @@ export function useAdminWorkspaces(userId: string | undefined, organizationId?: 
     queryKey: [...workspaceKeys.adminList(userId), organizationId ?? ''] as const,
     queryFn: ({ signal }) => fetchAdminWorkspaces(userId, organizationId, signal),
     enabled: Boolean(userId),
-    staleTime: 60 * 1000,
+    staleTime: WORKSPACE_ADMIN_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
   })
 }


### PR DESCRIPTION
## Summary
- New repo-wide convention: every `staleTime` in `hooks/queries/**` must come from a named exported constant, never an inline numeric literal
- Reason: PR #5426's review caught `useFolders` duplicating the same duration as a separate server-side prefetch as a raw literal — if one changes and the other doesn't, the prefetched cache entry silently drifts out of sync with the client hook reading it
- Documented the rule in `.claude/rules/sim-queries.md`, root `CLAUDE.md`, and the `react-query-best-practices` skill/command (`.agents/skills/`, `.claude/commands/`, `.cursor/commands/`)
- Applied it mechanically across all ~47 files in `hooks/queries/**` (~140 call sites) and their 6 `prefetch.ts` consumers under `app/workspace/[workspaceId]/**`
- Deliberately left `staleTime: 0`/`Infinity` alone — those are deliberate always-refetch/never-refetch idioms, not durations that can drift
- Moved `TABLE_LIST_STALE_TIME` into the non-`'use client'` `hooks/queries/utils/table-keys.ts` (not `hooks/queries/tables.ts`, which is `'use client'`) so the tables prefetch can import it without a client-boundary violation
- No numeric value was changed anywhere — this is a pure rename/hoist, zero behavior change

## Type of Change
- [x] Refactor / consistency

## Testing
- `bunx tsc --noEmit` clean
- `bun run check:client-boundary` and `bun run check:react-query` both pass
- `bunx biome check` clean on all touched files
- 582 existing tests across `hooks/queries/**` and the tables/settings/knowledge/files/home pages pass unmodified

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)