### PR TITLE
fix(custom-blocks): dedupe redundant workspace lookup in POST admin check

### DIFF
--- a/apps/sim/app/api/custom-blocks/route.ts
+++ b/apps/sim/app/api/custom-blocks/route.ts
@@ -17,11 +17,7 @@ import {
   listCustomBlocksWithInputs,
   publishCustomBlock,
 } from '@/lib/workflows/custom-blocks/operations'
-import {
-  checkWorkspaceAccess,
-  getWorkspaceWithOwner,
-  hasWorkspaceAdminAccess,
-} from '@/lib/workspaces/permissions/utils'
+import { checkWorkspaceAccess } from '@/lib/workspaces/permissions/utils'
 
 const logger = createLogger('CustomBlocksAPI')
 
@@ -84,18 +80,18 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   const userId = session.user.id
   const { workspaceId, workflowId, name, description, iconUrl, exposedOutputs } = parsed.data.body
 
-  if (!(await hasWorkspaceAdminAccess(userId, workspaceId))) {
+  const access = await checkWorkspaceAccess(workspaceId, userId)
+  if (!access.canAdmin) {
     return NextResponse.json({ error: 'Admin permissions required' }, { status: 403 })
   }
 
-  const ws = await getWorkspaceWithOwner(workspaceId)
-  if (!ws?.organizationId) {
+  const organizationId = access.workspace?.organizationId
+  if (!organizationId) {
     return NextResponse.json(
       { error: 'Publishing a block requires the workspace to belong to an organization' },
       { status: 400 }
     )
   }
-  const organizationId = ws.organizationId
 
   if (!(await isFeatureEnabled('deploy-as-block', { userId, orgId: organizationId }))) {
     return NextResponse.json({ error: 'Deploy as block is not enabled' }, { status: 403 })


### PR DESCRIPTION
## Summary
- Found while auditing for the same pattern fixed in #5426: the `POST /api/custom-blocks` handler called `hasWorkspaceAdminAccess(userId, workspaceId)` then separately called `getWorkspaceWithOwner(workspaceId)` again just to read `organizationId` — two independent DB fetches of the same workspace row for the same request
- Consolidated into a single `checkWorkspaceAccess` call, matching the exact pattern the `GET` handler in this same file already uses a few lines above
- `access.canAdmin` is logically identical to `hasWorkspaceAdminAccess()`'s result — verified against `PERMISSION_RANK`/`permissionSatisfies` in `@sim/platform-authz/workspace`: `admin` is the top rank (3), so `permissionSatisfies(p, 'admin')` can only be true when `p === 'admin'`, same as the old check
- Same error responses, same status codes, same order of checks (admin check still runs before the organization-membership check) — zero behavior change, one fewer DB round-trip per publish request

## Type of Change
- [x] Refactor / minor perf

## Testing
- `bunx tsc --noEmit` clean
- `bunx biome check` clean
- `bun run check:react-query` passes
- No existing test file for this route (none broken); logic equivalence verified analytically against the permission-rank system

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)