### PR TITLE
refactor(permissions): make hasWorkspaceAdminAccess and getUserEntityPermissions thin wrappers of checkWorkspaceAccess

### DIFF
--- a/apps/sim/lib/workspaces/permissions/utils.test.ts
+++ b/apps/sim/lib/workspaces/permissions/utils.test.ts
@@ -772,6 +772,7 @@ describe('Permission Utils', () => {
         canWrite: false,
         canAdmin: false,
         workspace: null,
+        permission: null,
       })
     })
 
@@ -793,6 +794,7 @@ describe('Permission Utils', () => {
         canWrite: true,
         canAdmin: true,
         workspace: { id: 'workspace123', ownerId: 'user123' },
+        permission: 'admin',
       })
     })
 

--- a/apps/sim/lib/workspaces/permissions/utils.ts
+++ b/apps/sim/lib/workspaces/permissions/utils.ts
@@ -33,6 +33,8 @@ export interface WorkspaceAccess {
   canWrite: boolean
   canAdmin: boolean
   workspace: WorkspaceWithOwner | null
+  /** The viewer's raw effective permission, or `null` when the workspace doesn't exist or they have none. */
+  permission: PermissionType | null
 }
 
 /**
@@ -143,7 +145,14 @@ export async function checkWorkspaceAccess(
   const ws = await getWorkspaceWithOwner(workspaceId)
 
   if (!ws) {
-    return { exists: false, hasAccess: false, canWrite: false, canAdmin: false, workspace: null }
+    return {
+      exists: false,
+      hasAccess: false,
+      canWrite: false,
+      canAdmin: false,
+      workspace: null,
+      permission: null,
+    }
   }
 
   const permission = await getEffectiveWorkspacePermission(userId, ws)
@@ -151,7 +160,7 @@ export async function checkWorkspaceAccess(
   const canWrite = permissionSatisfies(permission, 'write')
   const canAdmin = permissionSatisfies(permission, 'admin')
 
-  return { exists: true, hasAccess, canWrite, canAdmin, workspace: ws }
+  return { exists: true, hasAccess, canWrite, canAdmin, workspace: ws, permission }
 }
 
 /**
@@ -200,11 +209,7 @@ export async function getUserEntityPermissions(
   entityId: string
 ): Promise<PermissionType | null> {
   if (entityType === 'workspace') {
-    const ws = await getWorkspaceWithOwner(entityId)
-    if (!ws) {
-      return null
-    }
-    return getEffectiveWorkspacePermission(userId, ws)
+    return (await checkWorkspaceAccess(entityId, userId)).permission
   }
 
   const result = await db
@@ -387,13 +392,7 @@ export async function hasWorkspaceAdminAccess(
   userId: string,
   workspaceId: string
 ): Promise<boolean> {
-  const ws = await getWorkspaceWithOwner(workspaceId)
-
-  if (!ws) {
-    return false
-  }
-
-  return (await getEffectiveWorkspacePermission(userId, ws)) === 'admin'
+  return (await checkWorkspaceAccess(workspaceId, userId)).canAdmin
 }
 
 /**


### PR DESCRIPTION
## Summary
- Follow-up to #5429 (custom-blocks dedup fix): the root cause of that bug was that `hasWorkspaceAdminAccess` and `getUserEntityPermissions('workspace', ...)` each independently re-implement the same `getWorkspaceWithOwner` + `getEffectiveWorkspacePermission` fetch that `checkWorkspaceAccess` already does. Any call site that uses two of these three functions for the same (userId, workspaceId) pair silently pays for redundant DB round-trips, and worse, the three implementations could drift apart over time
- Consolidated: `hasWorkspaceAdminAccess` and `getUserEntityPermissions`'s workspace branch are now thin wrappers around `checkWorkspaceAccess` — matching the pattern `assertActiveWorkspaceAccess` already used in this same file
- Added `permission: PermissionType | null` to the `WorkspaceAccess` return shape so `getUserEntityPermissions` doesn't need its own second `getEffectiveWorkspacePermission` call to get the raw value
- Zero behavior change: `canAdmin` is exactly `permission === 'admin'` (verified against `PERMISSION_RANK` — admin is the top rank, nothing else satisfies it)

## Type of Change
- [x] Refactor / code quality

## Testing
- `bunx tsc --noEmit` clean, `bunx biome check` clean
- 616 existing tests across `lib/workspaces`, `lib/credentials`, `lib/invitations`, `lib/copilot/vfs`, and the affected API routes pass unmodified
- 2 test assertions updated for the new additive `permission` field (exact-shape `.toEqual()` checks)
- Ran an independent security-focused review specifically checking argument-order correctness (`checkWorkspaceAccess(workspaceId, userId)` vs the wrapper functions' `(userId, workspaceId)` order) and privilege-escalation risk in the `canAdmin` delegation — no issues found

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)