### PR TITLE
fix(credentials): grant admin role to workspace admins on credential creation

### DIFF
--- a/apps/sim/app/api/credentials/route.ts
+++ b/apps/sim/app/api/credentials/route.ts
@@ -507,7 +507,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
     const now = new Date()
     const credentialId = generateId()
-    const { ownerId: workspaceOwnerId, memberUserIds: workspaceMemberUserIds } =
+    const { ownerId: workspaceOwnerId, memberUserIds: workspaceMemberUserIds, adminUserIds: workspaceAdminUserIds } =
       await getWorkspaceMembership(workspaceId)
 
     await db.transaction(async (tx) => {
@@ -543,12 +543,11 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       if ((type === 'env_workspace' || type === 'service_account') && workspaceOwnerId) {
         if (workspaceMemberUserIds.length > 0) {
           for (const memberUserId of workspaceMemberUserIds) {
-            const isAdmin = memberUserId === session.user.id
             await tx.insert(credentialMember).values({
               id: generateId(),
               credentialId,
               userId: memberUserId,
-              role: isAdmin ? 'admin' : 'member',
+              role: workspaceAdminUserIds.has(memberUserId) ? 'admin' : 'member',
               status: 'active',
               joinedAt: now,
               invitedBy: session.user.id,

--- a/apps/sim/lib/credentials/environment.ts
+++ b/apps/sim/lib/credentials/environment.ts
@@ -8,6 +8,8 @@ export interface WorkspaceMembership {
   ownerId: string | null
   /** All workspace members: the owner plus everyone with a workspace permission. */
   memberUserIds: string[]
+  /** Subset of memberUserIds with admin-level workspace permission (owner + explicit admins). */
+  adminUserIds: Set<string>
 }
 
 /**
@@ -23,18 +25,22 @@ export async function getWorkspaceMembership(workspaceId: string): Promise<Works
       .where(eq(workspace.id, workspaceId))
       .limit(1),
     db
-      .select({ userId: permissions.userId })
+      .select({ userId: permissions.userId, permissionType: permissions.permissionType })
       .from(permissions)
       .where(and(eq(permissions.entityType, 'workspace'), eq(permissions.entityId, workspaceId))),
   ])
 
   const ownerId = workspaceRows[0]?.ownerId ?? null
   const memberUserIds = new Set<string>(permissionRows.map((row) => row.userId))
+  const adminUserIds = new Set<string>(
+    permissionRows.filter((row) => row.permissionType === 'admin').map((row) => row.userId)
+  )
   if (ownerId) {
     memberUserIds.add(ownerId)
+    adminUserIds.add(ownerId)
   }
 
-  return { ownerId, memberUserIds: Array.from(memberUserIds) }
+  return { ownerId, memberUserIds: Array.from(memberUserIds), adminUserIds }
 }
 
 export interface WorkspaceEnvKeyAdminAccess {
@@ -122,7 +128,8 @@ export async function getUserWorkspaceIds(userId: string): Promise<string[]> {
 async function ensureWorkspaceCredentialMemberships(
   credentialId: string,
   memberUserIds: string[],
-  invitedBy: string
+  invitedBy: string,
+  adminUserIds: Set<string>
 ) {
   if (!memberUserIds.length) return
 
@@ -151,7 +158,7 @@ async function ensureWorkspaceCredentialMemberships(
     id: generateId(),
     credentialId,
     userId: memberUserId,
-    role: 'member' as const,
+    role: (adminUserIds.has(memberUserId) ? 'admin' : 'member') as 'admin' | 'member',
     status: 'active' as const,
     joinedAt: now,
     invitedBy,
@@ -180,7 +187,7 @@ export async function syncWorkspaceEnvCredentials(params: {
   actingUserId: string
 }) {
   const { workspaceId, envKeys, actingUserId } = params
-  const { ownerId, memberUserIds } = await getWorkspaceMembership(workspaceId)
+  const { ownerId, memberUserIds, adminUserIds } = await getWorkspaceMembership(workspaceId)
 
   if (!ownerId) return
 
@@ -231,7 +238,7 @@ export async function syncWorkspaceEnvCredentials(params: {
   }
 
   for (const credentialId of credentialIdsToEnsureMembership) {
-    await ensureWorkspaceCredentialMemberships(credentialId, memberUserIds, ownerId)
+    await ensureWorkspaceCredentialMemberships(credentialId, memberUserIds, ownerId, adminUserIds)
   }
 
   if (normalizedKeys.length > 0) {
@@ -265,7 +272,7 @@ export async function createWorkspaceEnvCredentials(params: {
   const keys = Array.from(new Set(newKeys.filter(Boolean)))
   if (keys.length === 0) return
 
-  const { ownerId, memberUserIds } = await getWorkspaceMembership(workspaceId)
+  const { ownerId, memberUserIds, adminUserIds } = await getWorkspaceMembership(workspaceId)
 
   if (!ownerId) return
 
@@ -297,7 +304,7 @@ export async function createWorkspaceEnvCredentials(params: {
       id: generateId(),
       credentialId,
       userId: memberUserId,
-      role: (memberUserId === actingUserId ? 'admin' : 'member') as 'admin' | 'member',
+      role: (adminUserIds.has(memberUserId) ? 'admin' : 'member') as 'admin' | 'member',
       status: 'active' as const,
       joinedAt: now,
       invitedBy: actingUserId,


### PR DESCRIPTION
Fixes #4698

## Problem

When seeding `credential_member` rows for workspace-scoped credentials (`env_workspace`, `service_account`), the role was determined by `userId === actingUserId` — only the person performing the action received `admin`. All other workspace members, including explicit workspace admins, got `member` and were therefore unable to edit or delete secrets they should control.

This affected three separate creation paths:
- `ensureWorkspaceCredentialMemberships` (called from `syncWorkspaceEnvCredentials`) — hardcoded `role: 'member'` for everyone
- `createWorkspaceEnvCredentials` — `actingUserId === memberUserId` check
- `POST /api/credentials` handler — `session.user.id === memberUserId` check

## Fix

`getWorkspaceMembership` now also selects `permissionType` from the `permissions` table and returns an `adminUserIds: Set<string>` containing the workspace owner plus all members with explicit `admin` permission. All three creation paths use `adminUserIds.has(userId)` to assign `'admin'` vs `'member'`.

No behavior change for personal (`env_personal`, `oauth`) credentials. Existing rows are unaffected — only new inserts receive the corrected role.