### PR TITLE
fix(analytics): GTM/GA4 missing on /demo and other landing pages

### DIFF
--- a/apps/sim/proxy.ts
+++ b/apps/sim/proxy.ts
@@ -283,11 +283,15 @@ export async function proxy(request: NextRequest) {
   const response = NextResponse.next()
   response.headers.set('Vary', 'User-Agent')
 
-  if (url.pathname === '/') {
-    response.headers.set('Content-Security-Policy', generateRuntimeCSP())
-    response.headers.set('X-Content-Type-Options', 'nosniff')
-    response.headers.set('X-Frame-Options', 'SAMEORIGIN')
-  }
+  // Every remaining matched route (landing/marketing pages, /demo, /pricing, etc.)
+  // needs the runtime CSP, not next.config.ts's build-time policy — the build-time
+  // policy bakes `isHosted` from whatever NEXT_PUBLIC_APP_URL was available at
+  // build/boot time, which silently drops the googletagmanager.com/google-analytics.com
+  // allowlist entries when that value wasn't resolved yet. Previously only '/' got this
+  // override, so GTM/GA loaded on the homepage but was CSP-blocked everywhere else.
+  response.headers.set('Content-Security-Policy', generateRuntimeCSP())
+  response.headers.set('X-Content-Type-Options', 'nosniff')
+  response.headers.set('X-Frame-Options', 'SAMEORIGIN')
 
   return track(request, response)
 }

--- a/apps/sim/proxy.ts
+++ b/apps/sim/proxy.ts
@@ -183,7 +183,11 @@ function handleInvitationRedirects(
       new URL(`/login?callbackUrl=${callbackParam}&invite_flow=true`, request.url)
     )
   }
-  return NextResponse.next()
+  const response = NextResponse.next()
+  response.headers.set('Content-Security-Policy', generateRuntimeCSP())
+  response.headers.set('X-Content-Type-Options', 'nosniff')
+  response.headers.set('X-Frame-Options', 'SAMEORIGIN')
+  return response
 }
 
 /**

--- a/apps/sim/proxy.ts
+++ b/apps/sim/proxy.ts
@@ -283,12 +283,6 @@ export async function proxy(request: NextRequest) {
   const response = NextResponse.next()
   response.headers.set('Vary', 'User-Agent')
 
-  // Every remaining matched route (landing/marketing pages, /demo, /pricing, etc.)
-  // needs the runtime CSP, not next.config.ts's build-time policy — the build-time
-  // policy bakes `isHosted` from whatever NEXT_PUBLIC_APP_URL was available at
-  // build/boot time, which silently drops the googletagmanager.com/google-analytics.com
-  // allowlist entries when that value wasn't resolved yet. Previously only '/' got this
-  // override, so GTM/GA loaded on the homepage but was CSP-blocked everywhere else.
   response.headers.set('Content-Security-Policy', generateRuntimeCSP())
   response.headers.set('X-Content-Type-Options', 'nosniff')
   response.headers.set('X-Frame-Options', 'SAMEORIGIN')


### PR DESCRIPTION
## Summary
- Andy (marketing) reported GTM/GA4 key-event tracking not firing on `/demo`. Confirmed live via `curl` against `sim.ai` that `script-src`/`connect-src` on `/demo` and `/pricing` are missing `googletagmanager.com`/`google-analytics.com`/`analytics.ahrefs.com`, while `/` has them.
- Root cause: those GTM/GA CSP entries are gated on `isHosted`, which `next.config.ts`'s build-time `getMainCSPPolicy()` bakes in once at build/boot. `apps/sim/proxy.ts` only overrides the response CSP with the request-time `generateRuntimeCSP()` for `/`, `/login`, `/signup`, and `/workspace/*` — every other route (all marketing/landing pages, including `/demo`) fell back to the stale build-time policy, which silently dropped the GTM allowlist.
- Fix: apply `generateRuntimeCSP()` to every remaining matched route in `proxy.ts` instead of gating it to `pathname === '/'`.

## Test plan
- [x] `bun run vitest run proxy.test.ts` — 11/11 pass
- [x] `tsc --noEmit` clean on `proxy.ts`
- [ ] Verify post-deploy: `curl -sL -D - -o /dev/null https://www.sim.ai/demo | grep -i content-security-policy` includes `googletagmanager.com`