### PR TITLE
fix(mcp): scope tools loading state to each server's own query

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
@@ -157,8 +157,7 @@ export function MCP() {
   const {
     data: mcpToolsData = [],
     error: toolsError,
-    isLoading: toolsLoading,
-    isFetching: toolsFetching,
+    toolsStateByServer,
   } = useMcpToolsQuery(workspaceId)
   const { data: storedTools = [], refetch: refetchStoredTools } = useStoredMcpTools(workspaceId)
   const forceRefreshToolsMutation = useForceRefreshMcpTools()
@@ -623,7 +622,10 @@ export function MCP() {
             {filteredServers.map((server) => {
               if (!server?.id) return null
               const tools = toolsByServer[server.id] || []
-              const isLoadingTools = toolsLoading || toolsFetching
+              const serverToolsState = toolsStateByServer.get(server.id)
+              const isLoadingTools = serverToolsState
+                ? serverToolsState.isLoading || serverToolsState.isFetching
+                : false
 
               return (
                 <ServerListItem

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -162,7 +162,12 @@ export function useMcpToolsQuery(workspaceId: string) {
     let hasData = false
     let anyServerLoading = false
     let firstError: Error | null = null
-    for (const result of results) {
+    const toolsStateByServer = new Map<
+      string,
+      { isLoading: boolean; isFetching: boolean; error: Error | null }
+    >()
+    for (let index = 0; index < results.length; index++) {
+      const result = results[index]
       // Drop stale data from servers whose latest refetch errored.
       if (result.data && !result.isError) {
         tools.push(...result.data)
@@ -170,16 +175,25 @@ export function useMcpToolsQuery(workspaceId: string) {
       }
       if (result.isLoading) anyServerLoading = true
       if (!firstError && result.error instanceof Error) firstError = result.error
+
+      const serverId = serverIds[index]
+      if (serverId) {
+        toolsStateByServer.set(serverId, {
+          isLoading: result.isLoading,
+          isFetching: result.isFetching,
+          error: result.error instanceof Error ? result.error : null,
+        })
+      }
     }
     return {
       data: tools,
       isLoading: (serversLoading || anyServerLoading) && !hasData,
       isFetching: serversLoading || results.some((r) => r.isFetching),
-      // Suppress when any healthy server rendered; per-server errors live in `perServer`.
+      // Suppress when any healthy server rendered; per-server errors live in `toolsStateByServer`.
       error: hasData ? null : firstError,
-      perServer: results,
+      toolsStateByServer,
     }
-  }, [results, serversLoading])
+  }, [results, serversLoading, serverIds])
 }
 
 export function useForceRefreshMcpTools() {


### PR DESCRIPTION
## Summary
- Settings > MCP tools rows derived their "Loading..." text from a workspace-wide `isLoading || isFetching` aggregate across every server's tool query, instead of that specific server's own query — so a row could stay stuck (or flicker back) showing "Loading..." while its tools had actually already resolved, whenever any other server's query was fetching. Only a full page refresh cleared it.
- `useMcpToolsQuery` now zips its per-server `useQueries` results with their `serverId`s into a `toolsStateByServer` map (replacing the previously unused `perServer` array), giving each row its own `isLoading`/`isFetching`/`error`.
- `mcp.tsx` reads each row's loading state from `toolsStateByServer.get(server.id)` instead of the global aggregate.

## Type of Change
- [x] Bug fix

## Testing
Tested manually; `bun run type-check`, `bunx biome check`, and `bun run check:react-query` pass on the changed files.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)