### PR TITLE
improvement(new-relic): validate integration against NerdGraph docs, surface more entity fields

### DIFF
--- a/apps/sim/blocks/blocks/new_relic.ts
+++ b/apps/sim/blocks/blocks/new_relic.ts
@@ -345,9 +345,17 @@ Return ONLY the numeric timestamp - no explanations, no extra text.`,
     resultCount: { type: 'number', description: 'Number of NRQL result rows' },
     count: { type: 'number', description: 'Number of matching entities' },
     query: { type: 'string', description: 'Entity search query New Relic executed' },
-    entities: { type: 'json', description: 'Matching New Relic entities (guid, name, entityType)' },
+    entities: {
+      type: 'json',
+      description:
+        'Matching New Relic entities (guid, name, entityType, domain, reporting, alertSeverity, tags)',
+    },
     nextCursor: { type: 'string', description: 'Cursor for the next entity search page' },
-    entity: { type: 'json', description: 'New Relic entity details (guid, name, entityType)' },
+    entity: {
+      type: 'json',
+      description:
+        'New Relic entity details (guid, name, entityType, domain, reporting, alertSeverity, tags)',
+    },
     event: { type: 'json', description: 'Created change tracking event metadata' },
     messages: { type: 'json', description: 'New Relic change tracking messages' },
   },

--- a/apps/sim/tools/new_relic/get_entity.ts
+++ b/apps/sim/tools/new_relic/get_entity.ts
@@ -12,6 +12,10 @@ interface GetEntityData {
     entity?: {
       name?: string | null
       entityType?: string | null
+      domain?: string | null
+      reporting?: boolean | null
+      alertSeverity?: string | null
+      tags?: { key?: string | null; values?: string[] | null }[] | null
     } | null
   } | null
 }
@@ -54,6 +58,13 @@ export const newRelicGetEntityTool: ToolConfig<NewRelicGetEntityParams, NewRelic
     entity(guid: ${gqlString(params.guid.trim())}) {
       name
       entityType
+      domain
+      reporting
+      alertSeverity
+      tags {
+        key
+        values
+      }
     }
   }
 }`,
@@ -72,6 +83,14 @@ export const newRelicGetEntityTool: ToolConfig<NewRelicGetEntityParams, NewRelic
                 guid: params?.guid ?? null,
                 name: entity.name ?? null,
                 entityType: entity.entityType ?? null,
+                domain: entity.domain ?? null,
+                reporting: entity.reporting ?? null,
+                alertSeverity: entity.alertSeverity ?? null,
+                tags:
+                  entity.tags?.map((tag) => ({
+                    key: tag.key ?? null,
+                    values: tag.values ?? [],
+                  })) ?? [],
               }
             : null,
         },
@@ -87,6 +106,28 @@ export const newRelicGetEntityTool: ToolConfig<NewRelicGetEntityParams, NewRelic
           guid: { type: 'string', description: 'Entity GUID', nullable: true },
           name: { type: 'string', description: 'Entity name', nullable: true },
           entityType: { type: 'string', description: 'Entity type', nullable: true },
+          domain: { type: 'string', description: 'Entity domain, e.g. APM, INFRA', nullable: true },
+          reporting: {
+            type: 'boolean',
+            description: 'Whether the entity is currently reporting data',
+            nullable: true,
+          },
+          alertSeverity: {
+            type: 'string',
+            description: 'Current alert severity for the entity',
+            nullable: true,
+          },
+          tags: {
+            type: 'array',
+            description: 'Entity tags',
+            items: {
+              type: 'object',
+              properties: {
+                key: { type: 'string', description: 'Tag key', nullable: true },
+                values: { type: 'array', description: 'Tag values', items: { type: 'string' } },
+              },
+            },
+          },
         },
       },
     },

--- a/apps/sim/tools/new_relic/get_entity.ts
+++ b/apps/sim/tools/new_relic/get_entity.ts
@@ -55,7 +55,9 @@ export const newRelicGetEntityTool: ToolConfig<NewRelicGetEntityParams, NewRelic
       entityType
       domain
       reporting
-      alertSeverity
+      ... on AlertableEntity {
+        alertSeverity
+      }
       tags {
         key
         values

--- a/apps/sim/tools/new_relic/get_entity.ts
+++ b/apps/sim/tools/new_relic/get_entity.ts
@@ -2,21 +2,16 @@ import type { NewRelicGetEntityParams, NewRelicGetEntityResponse } from '@/tools
 import {
   getNerdGraphEndpoint,
   gqlString,
+  type NewRelicRawEntity,
   newRelicHeaders,
+  normalizeNewRelicEntity,
   parseNerdGraphResponse,
 } from '@/tools/new_relic/utils'
 import type { ToolConfig } from '@/tools/types'
 
 interface GetEntityData {
   actor?: {
-    entity?: {
-      name?: string | null
-      entityType?: string | null
-      domain?: string | null
-      reporting?: boolean | null
-      alertSeverity?: string | null
-      tags?: { key?: string | null; values?: string[] | null }[] | null
-    } | null
+    entity?: NewRelicRawEntity | null
   } | null
 }
 
@@ -79,19 +74,7 @@ export const newRelicGetEntityTool: ToolConfig<NewRelicGetEntityParams, NewRelic
         success: true,
         output: {
           entity: entity
-            ? {
-                guid: params?.guid ?? null,
-                name: entity.name ?? null,
-                entityType: entity.entityType ?? null,
-                domain: entity.domain ?? null,
-                reporting: entity.reporting ?? null,
-                alertSeverity: entity.alertSeverity ?? null,
-                tags:
-                  entity.tags?.map((tag) => ({
-                    key: tag.key ?? null,
-                    values: tag.values ?? [],
-                  })) ?? [],
-              }
+            ? { ...normalizeNewRelicEntity(entity), guid: params?.guid ?? null }
             : null,
         },
       }

--- a/apps/sim/tools/new_relic/search_entities.ts
+++ b/apps/sim/tools/new_relic/search_entities.ts
@@ -79,7 +79,9 @@ export const newRelicSearchEntitiesTool: ToolConfig<
           entityType
           domain
           reporting
-          alertSeverity
+          ... on AlertableEntityOutline {
+            alertSeverity
+          }
           tags {
             key
             values

--- a/apps/sim/tools/new_relic/search_entities.ts
+++ b/apps/sim/tools/new_relic/search_entities.ts
@@ -76,6 +76,13 @@ export const newRelicSearchEntitiesTool: ToolConfig<
           guid
           name
           entityType
+          domain
+          reporting
+          alertSeverity
+          tags {
+            key
+            values
+          }
         }
       }
     }
@@ -119,6 +126,28 @@ export const newRelicSearchEntitiesTool: ToolConfig<
           guid: { type: 'string', description: 'Entity GUID', nullable: true },
           name: { type: 'string', description: 'Entity name', nullable: true },
           entityType: { type: 'string', description: 'Entity type', nullable: true },
+          domain: { type: 'string', description: 'Entity domain, e.g. APM, INFRA', nullable: true },
+          reporting: {
+            type: 'boolean',
+            description: 'Whether the entity is currently reporting data',
+            nullable: true,
+          },
+          alertSeverity: {
+            type: 'string',
+            description: 'Current alert severity for the entity',
+            nullable: true,
+          },
+          tags: {
+            type: 'array',
+            description: 'Entity tags',
+            items: {
+              type: 'object',
+              properties: {
+                key: { type: 'string', description: 'Tag key', nullable: true },
+                values: { type: 'array', description: 'Tag values', items: { type: 'string' } },
+              },
+            },
+          },
         },
       },
     },

--- a/apps/sim/tools/new_relic/search_entities.ts
+++ b/apps/sim/tools/new_relic/search_entities.ts
@@ -1,11 +1,12 @@
 import type {
-  NewRelicEntity,
   NewRelicSearchEntitiesParams,
   NewRelicSearchEntitiesResponse,
 } from '@/tools/new_relic/types'
 import {
   getNerdGraphEndpoint,
+  type NewRelicRawEntity,
   newRelicHeaders,
+  normalizeNewRelicEntity,
   parseNerdGraphResponse,
 } from '@/tools/new_relic/utils'
 import type { ToolConfig } from '@/tools/types'
@@ -17,7 +18,7 @@ interface SearchEntitiesData {
       query?: string
       results?: {
         nextCursor?: string | null
-        entities?: NewRelicEntity[]
+        entities?: NewRelicRawEntity[]
       } | null
     } | null
   } | null
@@ -101,7 +102,7 @@ export const newRelicSearchEntitiesTool: ToolConfig<
     if (!entitySearch) {
       throw new Error('New Relic did not return entity search data')
     }
-    const entities = entitySearch?.results?.entities ?? []
+    const entities = (entitySearch?.results?.entities ?? []).map(normalizeNewRelicEntity)
 
     return {
       success: true,

--- a/apps/sim/tools/new_relic/types.ts
+++ b/apps/sim/tools/new_relic/types.ts
@@ -25,10 +25,19 @@ export interface NewRelicSearchEntitiesParams extends NewRelicBaseParams {
   cursor?: string
 }
 
+export interface NewRelicEntityTag {
+  key: string | null
+  values: string[]
+}
+
 export interface NewRelicEntity {
   guid: string | null
   name: string | null
   entityType: string | null
+  domain: string | null
+  reporting: boolean | null
+  alertSeverity: string | null
+  tags: NewRelicEntityTag[]
 }
 
 export interface NewRelicSearchEntitiesResponse extends ToolResponse {

--- a/apps/sim/tools/new_relic/utils.ts
+++ b/apps/sim/tools/new_relic/utils.ts
@@ -1,7 +1,17 @@
-import type { NewRelicRegion } from '@/tools/new_relic/types'
+import type { NewRelicEntity, NewRelicRegion } from '@/tools/new_relic/types'
 
 interface GraphQLError {
   message?: string
+}
+
+export interface NewRelicRawEntity {
+  guid?: string | null
+  name?: string | null
+  entityType?: string | null
+  domain?: string | null
+  reporting?: boolean | null
+  alertSeverity?: string | null
+  tags?: ({ key?: string | null; values?: string[] | null } | null)[] | null
 }
 
 interface GraphQLResponse<TData> {
@@ -40,3 +50,17 @@ export const cleanOptionalString = (value?: string): string | undefined => {
   const trimmed = value?.trim()
   return trimmed ? trimmed : undefined
 }
+
+export const normalizeNewRelicEntity = (entity: NewRelicRawEntity): NewRelicEntity => ({
+  guid: entity.guid ?? null,
+  name: entity.name ?? null,
+  entityType: entity.entityType ?? null,
+  domain: entity.domain ?? null,
+  reporting: entity.reporting ?? null,
+  alertSeverity: entity.alertSeverity ?? null,
+  tags:
+    entity.tags?.map((tag) => ({
+      key: tag?.key ?? null,
+      values: tag?.values ?? [],
+    })) ?? [],
+})


### PR DESCRIPTION
## Summary
- Validated all 4 New Relic tools (nrql_query, search_entities, get_entity, create_deployment_event) and the block against live NerdGraph API docs — auth, region endpoints, request/response shapes, and GraphQL injection handling all confirmed correct
- Added `domain`, `reporting`, `alertSeverity`, and `tags` to `get_entity`/`search_entities` outputs — stable New Relic Entity schema fields we weren't surfacing. Purely additive, no existing fields changed or renamed
- Considered NerdGraph's `aiIssues`/incidents API but skipped it — New Relic marks it "unsafe experimental," requires an opt-in header, and can break without notice

## Type of Change
- [x] Enhancement / validation pass

## Testing
Tested manually: typecheck (`bun run type-check`) and lint (`bun run lint`) both pass clean. Ran 5 independent audits (one per tool + one for block/registry wiring) against live New Relic docs to confirm alignment and backwards compatibility.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)