### PR TITLE
improvement(tables): show error message tooltip on errored workflow and enrichment cells

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
@@ -13,12 +13,12 @@ import { SimResourceCell, type SimResourceType } from './sim-resource-cell'
 export type CellRenderKind =
   // Workflow-output cells
   | { kind: 'value'; text: string }
-  | { kind: 'block-error' }
+  | { kind: 'block-error'; message: string }
   | { kind: 'running' }
   | { kind: 'pending-upstream' }
   | { kind: 'queued' }
   | { kind: 'cancelled' }
-  | { kind: 'error' }
+  | { kind: 'error'; message: string | null }
   | { kind: 'waiting'; labels: string[] }
   | { kind: 'not-found' }
   | { kind: 'no-output' }
@@ -68,7 +68,7 @@ export function resolveCellRender({
     const blockRunning = blockId ? (exec?.runningBlockIds?.includes(blockId) ?? false) : false
     const groupHasBlockErrors = !!(exec?.blockErrors && Object.keys(exec.blockErrors).length > 0)
 
-    if (blockError) return { kind: 'block-error' }
+    if (blockError) return { kind: 'block-error', message: blockError }
 
     const inFlight =
       exec?.status === 'running' || exec?.status === 'queued' || exec?.status === 'pending'
@@ -103,7 +103,7 @@ export function resolveCellRender({
       return { kind: 'waiting', labels: waitingOnLabels }
     }
     if (exec?.status === 'cancelled') return { kind: 'cancelled' }
-    if (exec?.status === 'error') return { kind: 'error' }
+    if (exec?.status === 'error') return { kind: 'error', message: exec.error }
     // Enrichment ran to completion but matched nothing → "Not found".
     if (isEnrichmentOutput && exec?.status === 'completed') return { kind: 'not-found' }
     // Workflow output: the group's run completed but this block produced no
@@ -249,12 +249,27 @@ export function CellRender({ kind, isEditing }: CellRenderProps): React.ReactEle
       )
 
     case 'block-error':
-    case 'error':
+    case 'error': {
+      if (!kind.message) {
+        return (
+          <Wrap isEditing={isEditing}>
+            <StatusBadge status='error' />
+          </Wrap>
+        )
+      }
       return (
         <Wrap isEditing={isEditing}>
-          <StatusBadge status='error' />
+          <Tooltip.Root>
+            <Tooltip.Trigger asChild>
+              <span>
+                <StatusBadge status='error' />
+              </span>
+            </Tooltip.Trigger>
+            <Tooltip.Content side='top'>{kind.message}</Tooltip.Content>
+          </Tooltip.Root>
         </Wrap>
       )
+    }
 
     case 'running':
       return (


### PR DESCRIPTION
## Summary
- Hovering the "Error" badge on a table cell now shows the underlying error message in a tooltip — for both workflow columns and enrichment columns
- Block-level errors surface the per-block message (`exec.blockErrors[blockId]`); run-level errors surface `exec.error` (workflow not found, rate limit, enrichment billing errors, etc.)
- UI-only change in `cell-render.tsx` — the messages were already persisted and hydrated on the grid read path, the renderer was just dropping them. Falls back to the plain badge when no message exists

## Type of Change
- [x] Improvement

## Testing
Tested manually; typecheck, lint, and check:api-validation:strict pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)