### PR TITLE
feat(pii): env-driven uvicorn worker count (PII_WORKERS)

### DIFF
--- a/docker/pii.Dockerfile
+++ b/docker/pii.Dockerfile
@@ -42,13 +42,16 @@ USER pii
 # 5001 avoids colliding with the app's 3000 in local/compose runs on one host.
 EXPOSE 5001
 
-# start-period is generous: five large spaCy models load at import before
-# /health responds. Tune against measured cold-start once built.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
+# start-period covers the model cold start. With PII_WORKERS>1 each worker loads
+# the five spaCy models independently and in parallel, so allow generous headroom
+# (memory-bandwidth contention stretches the wall-time beyond the single-worker case).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=300s --retries=3 \
     CMD curl -fsS http://localhost:5001/health || exit 1
 
 # Worker count is env-driven so ONE image scales per task size: set PII_WORKERS to
 # the task's vCPU count (each worker loads the models independently, ~3 GB each, so
 # size task memory ≈ PII_WORKERS × 3 GB + overhead). Defaults to 1 for local/small.
 # `sh -c exec` expands the env var while keeping uvicorn as PID 1 for clean SIGTERM.
-CMD ["sh", "-c", "exec uvicorn server:app --host 0.0.0.0 --port 5001 --workers ${PII_WORKERS:-1}"]
+# Quote the expansion so a malformed PII_WORKERS fails uvicorn arg-parsing rather
+# than being interpreted by the shell.
+CMD ["sh", "-c", "exec uvicorn server:app --host 0.0.0.0 --port 5001 --workers \"${PII_WORKERS:-1}\""]

--- a/docker/pii.Dockerfile
+++ b/docker/pii.Dockerfile
@@ -47,4 +47,8 @@ EXPOSE 5001
 HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
     CMD curl -fsS http://localhost:5001/health || exit 1
 
-CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "5001"]
+# Worker count is env-driven so ONE image scales per task size: set PII_WORKERS to
+# the task's vCPU count (each worker loads the models independently, ~3 GB each, so
+# size task memory ≈ PII_WORKERS × 3 GB + overhead). Defaults to 1 for local/small.
+# `sh -c exec` expands the env var while keeping uvicorn as PID 1 for clean SIGTERM.
+CMD ["sh", "-c", "exec uvicorn server:app --host 0.0.0.0 --port 5001 --workers ${PII_WORKERS:-1}"]


### PR DESCRIPTION
## Summary
- Launch the Presidio service with `--workers` from a **`PII_WORKERS`** env var, so **one image scales per task size** (set `PII_WORKERS` = the task's vCPU count) with no rebuild.
- `sh -c exec` expands the var while keeping uvicorn as **PID 1** for clean SIGTERM. Defaults to `1`, so local/self-hosted behavior is unchanged.

## Why
Each Presidio task currently runs a single uvicorn worker → uses 1 of its 2 vCPUs, so the fleet processes very few NER requests in parallel while the app fans out many → queueing → ALB 504s under load. Making worker count env-driven lets us run one worker per vCPU without per-env images.

## Coupling (infra PR)
Each worker loads the spaCy models independently (**~3.3 GB measured**), so **task memory must be sized to `PII_WORKERS × ~3.3 GB + overhead`**. The infra PR sets `PII_WORKERS` (derived from vCPU) and bumps task cpu/memory accordingly, plus raises the ALB idle timeout and caps the app fan-out.

## Testing
- Rebuilt the image and ran locally: `PII_WORKERS=2` → uvicorn multi-worker mode (`Started parent process`); `PII_WORKERS=1` → single worker, `/health` + `/redact_batch` OK. Measured 3.28 GB RSS per worker.

## Type of Change
- [x] Performance improvement

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)