### PR TITLE
fix(ses): reject malformed startDate/endDate in list_suppressed_destinations

### DIFF
--- a/apps/sim/lib/api/contracts/tools/aws/ses-list-suppressed-destinations.ts
+++ b/apps/sim/lib/api/contracts/tools/aws/ses-list-suppressed-destinations.ts
@@ -17,8 +17,18 @@ const ListSuppressedDestinationsSchema = z.object({
   accessKeyId: z.string().min(1, 'AWS access key ID is required'),
   secretAccessKey: z.string().min(1, 'AWS secret access key is required'),
   reasons: z.string().nullish(),
-  startDate: z.string().nullish(),
-  endDate: z.string().nullish(),
+  startDate: z
+    .string()
+    .nullish()
+    .refine((v) => !v || !Number.isNaN(new Date(v).getTime()), {
+      message: 'startDate must be a valid date string',
+    }),
+  endDate: z
+    .string()
+    .nullish()
+    .refine((v) => !v || !Number.isNaN(new Date(v).getTime()), {
+      message: 'endDate must be a valid date string',
+    }),
   pageSize: z.number().int().min(1).max(1000).nullish(),
   nextToken: z.string().nullish(),
 })


### PR DESCRIPTION
## Summary
- Follow-up to #5450 — one review-round fix (Cursor round 6) got pushed to the source branch after that PR was already squash-merged, so it never landed on staging
- `ses_list_suppressed_destinations`'s `startDate`/`endDate` were passed through `new Date(...)` with no validity check; a malformed non-empty string became an `Invalid Date` and was still forwarded to AWS, surfacing as a generic 500 instead of a clear 400
- Fixed at the contract level with a Zod refine rejecting unparseable date strings

## Type of Change
- [x] Bug fix

## Testing
- `bunx tsc --noEmit`, `bun run lint`, `bun run check:api-validation` all pass
- Verified this is the only diff vs current staging (single-file, 12 insertions/2 deletions)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)