### PR TITLE
test(user-input): assert dismissed mention stays closed across repeated clicks

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.test.tsx
@@ -116,7 +116,7 @@ describe('usePromptEditor mention menu dismissal', () => {
     unmount()
   })
 
-  it('does not reopen after the user clicks away, even if the caret lands back inside the open mention', () => {
+  it('stays closed across repeated clicks at the same position after the user clicks away, even if the caret lands back inside the open mention', () => {
     const { result, textarea, unmount } = renderPromptEditor({ workspaceId: 'ws-1' })
     result().plusMenuRef.current = openMenu
 
@@ -134,10 +134,12 @@ describe('usePromptEditor mention menu dismissal', () => {
     })
     expect(result().mentionQuery).toBeNull()
 
-    act(() => {
-      textarea.setSelectionRange(2, 2)
-      result().handleSelectAdjust()
-    })
+    for (let i = 0; i < 3; i++) {
+      act(() => {
+        textarea.setSelectionRange(2, 2)
+        result().handleSelectAdjust()
+      })
+    }
 
     expect(result().mentionQuery).toBeNull()
     expect(openMenu.open).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary
- Follow-up to #5464 (already merged), which fixed the @mention/skill menu reopening after a click-away/Escape dismiss
- That PR's final commit (a test-only strengthening) landed after the squash-merge cut, so it never made it to staging — this re-adds it
- Strengthens the click-away regression test to click the same position three times after a dismiss, not just once, proving the suppression holds for the exact reported repro (repeatedly clicking the same trailing spot) rather than just a single follow-up click

## Type of Change
- [x] Chore (test-only, no production code change)

## Testing
Ran the full `use-prompt-editor.test.tsx` suite (5 tests, all passing) plus typecheck/lint.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)