### PR TITLE
fix(granola): align get_note with real API spec

### DIFF
--- a/apps/sim/blocks/blocks/granola.ts
+++ b/apps/sim/blocks/blocks/granola.ts
@@ -177,7 +177,8 @@ export const GranolaBlock: BlockConfig = {
     invitees: { type: 'json', description: 'Calendar event invitee emails' },
     transcript: {
       type: 'json',
-      description: 'Meeting transcript entries (speaker, speakerLabel, text, startTime, endTime)',
+      description:
+        'Meeting transcript entries (speaker, speakerLabel, speakerName, text, startTime, endTime)',
     },
   },
 }

--- a/apps/sim/tools/granola/get_note.ts
+++ b/apps/sim/tools/granola/get_note.ts
@@ -59,7 +59,7 @@ export const getNoteTool: ToolConfig<GranolaGetNoteParams, GranolaGetNoteRespons
         ownerEmail: data.owner?.email ?? '',
         createdAt: data.created_at ?? '',
         updatedAt: data.updated_at ?? '',
-        webUrl: data.web_url ?? null,
+        webUrl: data.web_url ?? '',
         summaryText: data.summary_text ?? '',
         summaryMarkdown: data.summary_markdown ?? null,
         attendees: (data.attendees ?? []).map((a: { name: string | null; email: string }) => ({
@@ -79,13 +79,14 @@ export const getNoteTool: ToolConfig<GranolaGetNoteParams, GranolaGetNoteRespons
         transcript: data.transcript
           ? data.transcript.map(
               (t: {
-                speaker: { source: string; diarization_label?: string }
+                speaker: { source: string; diarization_label?: string; name?: string }
                 text: string
                 start_time: string
                 end_time: string
               }) => ({
                 speaker: t.speaker?.source ?? 'unknown',
                 speakerLabel: t.speaker?.diarization_label ?? null,
+                speakerName: t.speaker?.name ?? null,
                 text: t.text ?? '',
                 startTime: t.start_time ?? '',
                 endTime: t.end_time ?? '',
@@ -103,7 +104,7 @@ export const getNoteTool: ToolConfig<GranolaGetNoteParams, GranolaGetNoteRespons
     ownerEmail: { type: 'string', description: 'Note owner email' },
     createdAt: { type: 'string', description: 'Creation timestamp' },
     updatedAt: { type: 'string', description: 'Last update timestamp' },
-    webUrl: { type: 'string', description: 'URL to view the note in Granola', optional: true },
+    webUrl: { type: 'string', description: 'URL to view the note in Granola' },
     summaryText: { type: 'string', description: 'Plain text summary of the meeting' },
     summaryMarkdown: {
       type: 'string',
@@ -153,6 +154,11 @@ export const getNoteTool: ToolConfig<GranolaGetNoteParams, GranolaGetNoteRespons
         speakerLabel: {
           type: 'string',
           description: 'Diarization label for the speaker (e.g., Speaker A)',
+          optional: true,
+        },
+        speakerName: {
+          type: 'string',
+          description: 'Resolved name of the identified speaker, when available',
           optional: true,
         },
         text: { type: 'string', description: 'Transcript text' },

--- a/apps/sim/tools/granola/types.ts
+++ b/apps/sim/tools/granola/types.ts
@@ -57,7 +57,7 @@ export interface GranolaGetNoteResponse extends ToolResponse {
     ownerEmail: string
     createdAt: string
     updatedAt: string
-    webUrl: string | null
+    webUrl: string
     summaryText: string
     summaryMarkdown: string | null
     attendees: { name: string | null; email: string }[]
@@ -72,6 +72,7 @@ export interface GranolaGetNoteResponse extends ToolResponse {
       | {
           speaker: string
           speakerLabel: string | null
+          speakerName: string | null
           text: string
           startTime: string
           endTime: string


### PR DESCRIPTION
## Summary
- Ran a full /validate-integration pass on Granola against the official OpenAPI spec (docs.granola.ai)
- Confirmed we cover all 3 public Granola API endpoints (list_notes, get_note, list_folders) — no gaps
- Fixed `webUrl` in `get_note` to be a required non-nullable string per spec (was modeled as optional/nullable)
- Added missing `speakerName` field to transcript entries (resolved speaker name, present in the API but previously dropped)

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)