### PR TITLE
fix(copilot): surface error cause chain in sim-to-go span status

### DIFF
--- a/apps/sim/lib/copilot/request/otel.ts
+++ b/apps/sim/lib/copilot/request/otel.ts
@@ -10,7 +10,7 @@ import {
   TraceFlags,
   trace,
 } from '@opentelemetry/api'
-import { toError } from '@sim/utils/errors'
+import { describeError, toError } from '@sim/utils/errors'
 import { RequestTraceV1Outcome } from '@/lib/copilot/generated/request-trace-v1'
 import {
   CopilotBranchKind,
@@ -95,10 +95,14 @@ export function isActionableErrorStatus(code: number): boolean {
 export function markSpanForError(span: Span, error: unknown): void {
   const asError = toError(error)
   span.recordException(asError)
+  const described = describeError(error)
+  if (described.code) {
+    span.setAttribute(TraceAttr.ErrorCode, described.code)
+  }
   if (!isExplicitUserStopError(error)) {
     span.setStatus({
       code: SpanStatusCode.ERROR,
-      message: asError.message,
+      message: described.causeChain ? described.causeChain.join(' <- ') : asError.message,
     })
   }
 }


### PR DESCRIPTION
## Summary
- `markSpanForError` only recorded the top-level exception message on the outbound Sim → Go span, so any `fetch()` failure showed up as the generic `TypeError: fetch failed` with no indication of the real cause
- This bit us diagnosing the Sim Mailer inbox processing failures — every failed task's OTel span and stored error message just said "fetch failed" with no way to tell it was `ENOTFOUND` on a stale `SIM_AGENT_API_URL` without manually cross-referencing dashboards
- Use `describeError` (already in `@sim/utils/errors`, previously unused here) to walk the `.cause` chain and surface it as the span status message plus a new `error.code` attribute

## Type of Change
- [x] Bug fix (observability gap)

## Testing
- `tsc --noEmit` and `biome check` clean
- Verified the exact failure mode this fixes against a real incident: reproduced a `TypeError: fetch failed` from a dead DNS target and confirmed `describeError` correctly extracts the underlying `ENOTFOUND` from `.cause`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)