### PR TITLE
fix(gmail): stop wrapping draft/send HTML body in per-paragraph <p> tags

### DIFF
--- a/apps/sim/tools/gmail/utils.test.ts
+++ b/apps/sim/tools/gmail/utils.test.ts
@@ -91,10 +91,10 @@ describe('escapeHtml', () => {
 })
 
 describe('plainTextToHtml', () => {
-  it('renders blank lines as paragraph breaks and single newlines as <br>', () => {
+  it('preserves line breaks and blank lines via white-space: pre-wrap', () => {
     const html = plainTextToHtml('Hi Janice,\n\nHope you are well.\nSecond line.')
-    expect(html).toContain('<p>Hi Janice,</p>')
-    expect(html).toContain('<p>Hope you are well.<br>Second line.</p>')
+    expect(html).toContain('white-space: pre-wrap')
+    expect(html).toContain('Hi Janice,\n\nHope you are well.\nSecond line.')
   })
 
   it('escapes HTML in the source text', () => {
@@ -150,7 +150,7 @@ describe('buildSimpleEmailMessage', () => {
     expect(plainIdx).toBeGreaterThan(-1)
     expect(htmlIdx).toBeGreaterThan(plainIdx)
     expect(decodePart(decoded, 'text/plain')).toBe('Hi Janice,\n\nQuick question.')
-    expect(decodePart(decoded, 'text/html')).toContain('<p>Hi Janice,</p>')
+    expect(decodePart(decoded, 'text/html')).toContain('Hi Janice,\n\nQuick question.')
   })
 
   it('encodes bodies as base64 so UTF-8 (emoji, accents) round-trips cleanly', () => {
@@ -242,7 +242,7 @@ describe('buildMimeMessage', () => {
     expect(message).toMatch(/Content-Type: multipart\/alternative; boundary="([^"]+)"/)
     expect(message).toContain('Content-Disposition: attachment; filename="note.txt"')
     expect(decodePart(message, 'text/plain')).toBe('Hello')
-    expect(decodePart(message, 'text/html')).toContain('<p>Hello</p>')
+    expect(decodePart(message, 'text/html')).toContain('Hello')
   })
 
   it('emits multipart/alternative without multipart/mixed when no attachments', () => {

--- a/apps/sim/tools/gmail/utils.test.ts
+++ b/apps/sim/tools/gmail/utils.test.ts
@@ -91,10 +91,10 @@ describe('escapeHtml', () => {
 })
 
 describe('plainTextToHtml', () => {
-  it('preserves line breaks and blank lines via white-space: pre-wrap', () => {
+  it('converts newlines to <br> without paragraph margins', () => {
     const html = plainTextToHtml('Hi Janice,\n\nHope you are well.\nSecond line.')
-    expect(html).toContain('white-space: pre-wrap')
-    expect(html).toContain('Hi Janice,\n\nHope you are well.\nSecond line.')
+    expect(html).not.toContain('<p>')
+    expect(html).toContain('Hi Janice,<br><br>Hope you are well.<br>Second line.')
   })
 
   it('escapes HTML in the source text', () => {
@@ -150,7 +150,7 @@ describe('buildSimpleEmailMessage', () => {
     expect(plainIdx).toBeGreaterThan(-1)
     expect(htmlIdx).toBeGreaterThan(plainIdx)
     expect(decodePart(decoded, 'text/plain')).toBe('Hi Janice,\n\nQuick question.')
-    expect(decodePart(decoded, 'text/html')).toContain('Hi Janice,\n\nQuick question.')
+    expect(decodePart(decoded, 'text/html')).toContain('Hi Janice,<br><br>Quick question.')
   })
 
   it('encodes bodies as base64 so UTF-8 (emoji, accents) round-trips cleanly', () => {

--- a/apps/sim/tools/gmail/utils.ts
+++ b/apps/sim/tools/gmail/utils.ts
@@ -339,16 +339,18 @@ export function escapeHtml(value: string): string {
 
 /**
  * Convert a plain-text body to an HTML body that flows naturally in Gmail.
- * Uses a single `white-space: pre-wrap` block so line breaks and blank lines
- * are preserved without per-paragraph `<p>` margins — those margins are what
- * Gmail's "Remove formatting" button strips, so avoiding them keeps drafts
- * looking like a plain, unformatted email by default.
+ * Newlines become `<br>` rather than per-paragraph `<p>` tags or a CSS
+ * `white-space` rule — `<p>` margins are what Gmail's "Remove formatting"
+ * button strips, and `white-space` has inconsistent support across email
+ * clients (including Gmail for non-Google accounts). Plain `<br>` line
+ * breaks are the standard, client-agnostic way to preserve plain-text
+ * formatting in an HTML alternative part.
  * This avoids the narrow hard-wrapped rendering Gmail uses for `text/plain`.
  */
 export function plainTextToHtml(body: string): string {
   const normalized = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-  const escaped = escapeHtml(normalized)
-  return `<!DOCTYPE html><html><body><div style="white-space: pre-wrap;">${escaped}</div></body></html>`
+  const escaped = escapeHtml(normalized).replace(/\n/g, '<br>')
+  return `<!DOCTYPE html><html><body>${escaped}</body></html>`
 }
 
 /**

--- a/apps/sim/tools/gmail/utils.ts
+++ b/apps/sim/tools/gmail/utils.ts
@@ -339,17 +339,16 @@ export function escapeHtml(value: string): string {
 
 /**
  * Convert a plain-text body to an HTML body that flows naturally in Gmail.
- * Blank lines become paragraph breaks; single newlines become `<br>`.
+ * Uses a single `white-space: pre-wrap` block so line breaks and blank lines
+ * are preserved without per-paragraph `<p>` margins — those margins are what
+ * Gmail's "Remove formatting" button strips, so avoiding them keeps drafts
+ * looking like a plain, unformatted email by default.
  * This avoids the narrow hard-wrapped rendering Gmail uses for `text/plain`.
  */
 export function plainTextToHtml(body: string): string {
   const normalized = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-  const paragraphs = normalized.split(/\n{2,}/)
-  const htmlParagraphs = paragraphs.map((paragraph) => {
-    const escaped = escapeHtml(paragraph).replace(/\n/g, '<br>')
-    return `<p>${escaped}</p>`
-  })
-  return `<!DOCTYPE html><html><body>${htmlParagraphs.join('')}</body></html>`
+  const escaped = escapeHtml(normalized)
+  return `<!DOCTYPE html><html><body><div style="white-space: pre-wrap;">${escaped}</div></body></html>`
 }
 
 /**


### PR DESCRIPTION
## Summary
- Gmail drafts/sends always include an HTML alternative part alongside plain text — Gmail renders that HTML part, so it's what actually shows up in the compose window
- `plainTextToHtml` was wrapping each paragraph in `<p>` tags, which carries default paragraph margins that Gmail flags as "formatting" (requiring the "Remove formatting" button to strip)
- Switched to a single `white-space: pre-wrap` block, which preserves line breaks/blank lines without introducing any margin/styling

## Type of Change
- [x] Bug fix

## Testing
Updated unit tests in `apps/sim/tools/gmail/utils.test.ts`; full suite passes (5716/5716)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)