### PR TITLE
fix(copilot): don't surface custom blocks whose definition was deleted

### DIFF
--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -123,7 +123,7 @@ import {
   hasWorkspaceAdminAccess,
 } from '@/lib/workspaces/permissions/utils'
 import { computeNeedsRedeployment } from '@/app/api/workflows/utils'
-import { buildCustomBlockConfig } from '@/blocks/custom/build-config'
+import { buildCustomBlockConfig, isCustomBlockType } from '@/blocks/custom/build-config'
 import { getAllBlocks } from '@/blocks/registry'
 import type { BlockIcon } from '@/blocks/types'
 import { CONNECTOR_REGISTRY } from '@/connectors/registry.server'
@@ -171,7 +171,12 @@ function getStaticComponentFiles(): Map<string, string> {
   const files = new Map<string, string>()
 
   const allBlocks = getAllBlocks()
-  const visibleBlocks = allBlocks.filter((b) => !b.hideFromToolbar)
+  // Never bake custom blocks into the per-process static cache: `getAllBlocks()` is
+  // overlay-aware, so if this memoized build first runs inside a custom-block
+  // overlay it would freeze that org's blocks here forever — and a later-deleted
+  // definition's `components/blocks/*.json` would linger (the copilot still "sees"
+  // it) even though `materializeCustomBlocks` rebuilds the live set every request.
+  const visibleBlocks = allBlocks.filter((b) => !b.hideFromToolbar && !isCustomBlockType(b.type))
 
   let blocksFiltered = 0
   for (const block of visibleBlocks) {

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -171,12 +171,7 @@ function getStaticComponentFiles(): Map<string, string> {
   const files = new Map<string, string>()
 
   const allBlocks = getAllBlocks()
-  // Never bake custom blocks into the per-process static cache: `getAllBlocks()` is
-  // overlay-aware, so if this memoized build first runs inside a custom-block
-  // overlay it would freeze that org's blocks here forever — and a later-deleted
-  // definition's `components/blocks/*.json` would linger (the copilot still "sees"
-  // it) even though `materializeCustomBlocks` rebuilds the live set every request.
-  const visibleBlocks = allBlocks.filter((b) => !b.hideFromToolbar && !isCustomBlockType(b.type))
+  const visibleBlocks = allBlocks.filter((b) => !b.hideFromToolbar)
 
   let blocksFiltered = 0
   for (const block of visibleBlocks) {

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -415,8 +415,13 @@ export class WorkspaceVFS {
    * still resolves/renders). Populated by {@link materializeCustomBlocks}; used to
    * drop a placed custom block from a workflow's state when its definition has been
    * deleted, so the copilot never sees a block it can't render.
+   *
+   * `null` means "not loaded" — either not materialized yet or the load FAILED. In
+   * that case {@link dropDeletedCustomBlocks} strips nothing, so a transient failure
+   * can't wrongly nuke every placed custom block. An empty `Set` is distinct: it
+   * means the org genuinely has no custom blocks, so any placed one IS deleted.
    */
-  private _customBlockTypes = new Set<string>()
+  private _customBlockTypes: Set<string> | null = null
 
   get workspaceId(): string {
     return this._workspaceId
@@ -455,12 +460,15 @@ export class WorkspaceVFS {
   private dropDeletedCustomBlocks(
     normalized: Awaited<ReturnType<typeof loadWorkflowFromNormalizedTables>>
   ): Awaited<ReturnType<typeof loadWorkflowFromNormalizedTables>> {
-    if (!normalized) return normalized
+    // `null` = definitions never loaded (or the load failed) — strip nothing rather
+    // than treat every placed custom block as deleted.
+    if (!normalized || this._customBlockTypes === null) return normalized
+    const validTypes = this._customBlockTypes
     const dropped = new Set<string>()
     const blocks: Record<string, unknown> = {}
     for (const [id, block] of Object.entries(normalized.blocks)) {
       const type = (block as { type?: string }).type
-      if (isCustomBlockType(type) && !this._customBlockTypes.has(type)) {
+      if (isCustomBlockType(type) && !validTypes.has(type)) {
         dropped.add(id)
         continue
       }
@@ -565,7 +573,7 @@ export class WorkspaceVFS {
     this.lazy = new Map()
     this.normalizedCache = new Map()
     this.deploymentCache = new Map()
-    this._customBlockTypes = new Set()
+    this._customBlockTypes = null
     this._workspaceId = workspaceId
     this._betaEnabled = await isFeatureEnabled('mothership-beta', { userId })
 

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -410,6 +410,13 @@ export class WorkspaceVFS {
   private deploymentCache = new Map<string, Promise<DeploymentData | null>>()
   private _workspaceId = ''
   private _betaEnabled = false
+  /**
+   * Types of the org's CURRENT custom blocks (enabled + disabled — a disabled block
+   * still resolves/renders). Populated by {@link materializeCustomBlocks}; used to
+   * drop a placed custom block from a workflow's state when its definition has been
+   * deleted, so the copilot never sees a block it can't render.
+   */
+  private _customBlockTypes = new Set<string>()
 
   get workspaceId(): string {
     return this._workspaceId
@@ -430,10 +437,40 @@ export class WorkspaceVFS {
   ): Promise<Awaited<ReturnType<typeof loadWorkflowFromNormalizedTables>>> {
     let cached = this.normalizedCache.get(workflowId)
     if (!cached) {
-      cached = loadWorkflowFromNormalizedTables(workflowId)
+      cached = loadWorkflowFromNormalizedTables(workflowId).then((n) =>
+        this.dropDeletedCustomBlocks(n)
+      )
       this.normalizedCache.set(workflowId, cached)
     }
     return cached
+  }
+
+  /**
+   * Strip placed custom blocks whose definition no longer exists from a loaded
+   * workflow (and any edges touching them), so the copilot never sees a block it
+   * can't render — mirroring how the serializer drops an unresolvable custom block.
+   * A live definition (enabled or disabled) is kept; only a DELETED one is removed.
+   * Runs lazily (after materialize), so `_customBlockTypes` is populated by then.
+   */
+  private dropDeletedCustomBlocks(
+    normalized: Awaited<ReturnType<typeof loadWorkflowFromNormalizedTables>>
+  ): Awaited<ReturnType<typeof loadWorkflowFromNormalizedTables>> {
+    if (!normalized) return normalized
+    const dropped = new Set<string>()
+    const blocks: Record<string, unknown> = {}
+    for (const [id, block] of Object.entries(normalized.blocks)) {
+      const type = (block as { type?: string }).type
+      if (isCustomBlockType(type) && !this._customBlockTypes.has(type)) {
+        dropped.add(id)
+        continue
+      }
+      blocks[id] = block
+    }
+    if (dropped.size === 0) return normalized
+    const edges = (normalized.edges ?? []).filter(
+      (e) => !dropped.has(e.source) && !dropped.has(e.target)
+    )
+    return { ...normalized, blocks: blocks as typeof normalized.blocks, edges }
   }
 
   /** Load a workflow's deployment data once per instance (deployment.json + versions.json share it). */
@@ -528,6 +565,7 @@ export class WorkspaceVFS {
     this.lazy = new Map()
     this.normalizedCache = new Map()
     this.deploymentCache = new Map()
+    this._customBlockTypes = new Set()
     this._workspaceId = workspaceId
     this._betaEnabled = await isFeatureEnabled('mothership-beta', { userId })
 
@@ -1829,6 +1867,9 @@ export class WorkspaceVFS {
   ): Promise<NonNullable<WorkspaceMdData['customBlocks']>> {
     try {
       const blocks = await listCustomBlocksWithInputsForWorkspace(workspaceId)
+      // Every current definition (incl. disabled) — the authoritative set used to
+      // drop deleted-definition instances from workflow state (see loadNormalized).
+      this._customBlockTypes = new Set(blocks.map((cb) => cb.type))
       const summary: NonNullable<WorkspaceMdData['customBlocks']> = []
 
       for (const cb of blocks) {


### PR DESCRIPTION
## Summary
- The copilot kept seeing a custom block after its definition was deleted. Two leaks, both fixed:
- **Placed instances (the reported bug):** a workflow's `state.json`/`lint.json` come from the raw normalized blocks, so a custom block placed in a workflow survived deletion of its definition and the copilot still read it. `loadNormalized` now drops any placed `custom_block_*` whose definition no longer exists (plus edges touching it), keyed off the workspace's current definitions. A live definition — enabled or disabled — is kept; only a deleted one is removed.
- **Static component cache:** `getStaticComponentFiles` is per-process and built from the overlay-aware `getAllBlocks()`, so a first build inside a custom-block overlay could freeze that org's blocks in and let a later-deleted definition linger. Custom blocks are now excluded from the static cache — they're per-org/dynamic and materialized fresh every request.

## Type of Change
- [x] Bug fix

## Testing
Deleted a published custom block still placed in a workflow → the copilot no longer resolves or reads it (state.json omits the block + its edges). `bun run lint` and `check:api-validation:strict` pass; existing VFS tests pass (41).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
