### PR TITLE
fix(knowledge): accept relative internal file URLs in document processor

### DIFF
--- a/apps/sim/lib/knowledge/documents/document-processor.ts
+++ b/apps/sim/lib/knowledge/documents/document-processor.ts
@@ -403,10 +403,12 @@ async function downloadFileForBase64(fileUrl: string, userId?: string): Promise<
     }
     return Buffer.from(base64Data, 'base64')
   }
-  if (/^https?:\/\//i.test(fileUrl)) {
+  if (/^https?:\/\//i.test(fileUrl) || isInternalFileUrl(fileUrl)) {
     return downloadFileWithTimeout(fileUrl, userId)
   }
-  throw new Error('Unsupported fileUrl scheme: only data: URIs and http(s):// URLs are allowed')
+  throw new Error(
+    'Unsupported fileUrl scheme: only data: URIs, http(s):// URLs, and internal /api/files/serve/ paths are allowed'
+  )
 }
 
 function processOCRContent(result: OCRResult, filename: string): string {
@@ -801,12 +803,17 @@ async function parseWithFileParser(
 
     if (/^data:/i.test(fileUrl)) {
       content = await parseDataURI(fileUrl, filename, mimeType)
-    } else if (/^https?:\/\//i.test(fileUrl)) {
+    } else if (/^https?:\/\//i.test(fileUrl) || isInternalFileUrl(fileUrl)) {
+      // Internal URLs may arrive as an app-relative `/api/files/serve/...` path
+      // (some ingestion callers store the relative path); downloadFileFromUrl
+      // resolves it directly against storage without an absolute origin.
       const result = await parseHttpFile(fileUrl, filename, mimeType, userId)
       content = result.content
       metadata = result.metadata || {}
     } else {
-      throw new Error('Unsupported fileUrl scheme: only data: URIs and http(s):// URLs are allowed')
+      throw new Error(
+        'Unsupported fileUrl scheme: only data: URIs, http(s):// URLs, and internal /api/files/serve/ paths are allowed'
+      )
     }
 
     if (!content.trim()) {


### PR DESCRIPTION
## Summary
- KB document processing sporadically failed with `Unsupported fileUrl scheme: only data: URIs and http(s):// URLs are allowed` on `knowledge-process-document` runs.
- Root cause: some ingestion paths store an app-relative internal URL (`/api/files/serve/...?context=workspace`). The download layer (`downloadFileFromUrl`) already resolves these directly against storage, but `parseWithFileParser` and `downloadFileForBase64` applied a stricter scheme guard that threw before the URL ever reached the downloader.
- Fix at the consumer: both guards now accept internal URLs via `isInternalFileUrl(...)` and route them through the existing downloader, matching how the OCR path already behaves. Still fails fast on genuinely unsupported schemes.
- Consumer-side fix covers every producer and lets already-failed documents recover on retry with no data migration. Security is unchanged — the downloader still authorizes the resolved storage key against the billed actor and derives context from the trusted key prefix.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Ran `bun run lint` (no changes) and `bun run check:api-validation:strict` (passed). Typecheck clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)