### PR TITLE
fix(workflow): render agent tool chip names from static sources, not stored title

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -1713,9 +1713,6 @@ export const ToolInput = memo(function ToolInput({
             ? resolveCustomToolFromReference(tool, customTools)
             : null
 
-          const customToolTitle = isCustomTool
-            ? tool.title || resolvedCustomTool?.title || 'Unknown Tool'
-            : null
           const customToolSchema = isCustomTool ? tool.schema || resolvedCustomTool?.schema : null
           const customToolParams =
             isCustomTool && customToolSchema?.function?.parameters?.properties
@@ -1747,11 +1744,14 @@ export const ToolInput = memo(function ToolInput({
                 )
               : []
 
-          // Display name comes from static sources (registry / canonical records),
-          // never from the workflow JSON's mutable `title`, so edits to the stored
-          // state cannot change what the UI shows.
+          // Display name comes from static sources (registry / canonical records)
+          // where available; the stored `title` is only a last-resort fallback for
+          // MCP tools while server data is loading and for deleted custom-tool records.
           const toolDisplayName = isCustomTool
-            ? resolvedCustomTool?.title || customToolTitle
+            ? resolvedCustomTool?.title ||
+              resolvedCustomTool?.schema?.function?.name ||
+              tool.title ||
+              'Unknown Tool'
             : isMcpTool
               ? mcpTool?.name || tool.title
               : isWorkflowTool

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -1747,6 +1747,17 @@ export const ToolInput = memo(function ToolInput({
                 )
               : []
 
+          // Display name comes from static sources (registry / canonical records),
+          // never from the workflow JSON's mutable `title`, so edits to the stored
+          // state cannot change what the UI shows.
+          const toolDisplayName = isCustomTool
+            ? resolvedCustomTool?.title || customToolTitle
+            : isMcpTool
+              ? mcpTool?.name || tool.title
+              : isWorkflowTool
+                ? 'Workflow'
+                : toolBlock?.name || tool.type
+
           const useSubBlocks = !isCustomTool && !isMcpTool && subBlocksResult?.subBlocks?.length
           const displayParams: ToolParameterConfig[] = isCustomTool
             ? customToolParams
@@ -1854,7 +1865,7 @@ export const ToolInput = memo(function ToolInput({
                     )}
                   </div>
                   <span className='truncate font-medium text-[var(--text-primary)] text-small'>
-                    {formatDisplayText((isCustomTool ? customToolTitle : tool.title) ?? '', {
+                    {formatDisplayText(toolDisplayName ?? '', {
                       workflowSearchHighlight: getToolTitleSearchHighlight(toolIndex),
                     })}
                   </span>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -59,7 +59,7 @@ import {
   ActiveSearchTargetProvider,
   useActiveSearchTarget,
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/providers/active-search-target-provider'
-import { getAllBlocks } from '@/blocks'
+import { getAllBlocks, getBlock } from '@/blocks'
 import { getTileIconColorClass } from '@/blocks/icon-color'
 import type { SubBlockConfig as BlockSubBlockConfig } from '@/blocks/types'
 import { BUILT_IN_TOOL_TYPES } from '@/blocks/utils'
@@ -1756,7 +1756,7 @@ export const ToolInput = memo(function ToolInput({
               ? mcpTool?.name || tool.title
               : isWorkflowTool
                 ? 'Workflow'
-                : toolBlock?.name || tool.type
+                : getBlock(tool.type)?.name || tool.type
 
           const useSubBlocks = !isCustomTool && !isMcpTool && subBlocksResult?.subBlocks?.length
           const displayParams: ToolParameterConfig[] = isCustomTool

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -27,6 +27,7 @@ import {
 import type { McpToolSchema } from '@/lib/mcp/types'
 import { getProviderIdFromServiceId, type OAuthProvider, type OAuthService } from '@/lib/oauth'
 import { extractInputFieldsFromBlocks } from '@/lib/workflows/input-format'
+import { resolveStoredToolName } from '@/lib/workflows/subblocks/display'
 import { buildToolSubBlockId } from '@/lib/workflows/tool-input/synthetic-subblocks'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
 import { McpServerFormModal } from '@/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal'
@@ -60,6 +61,7 @@ import {
   useActiveSearchTarget,
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/providers/active-search-target-provider'
 import { getAllBlocks, getBlock } from '@/blocks'
+import { useCustomBlockOverlayVersion } from '@/blocks/custom/client-overlay'
 import { getTileIconColorClass } from '@/blocks/icon-color'
 import type { SubBlockConfig as BlockSubBlockConfig } from '@/blocks/types'
 import { BUILT_IN_TOOL_TYPES } from '@/blocks/utils'
@@ -543,6 +545,13 @@ export const ToolInput = memo(function ToolInput({
   const { data: customTools = [] } = useCustomTools(shouldFetchCustomTools ? workspaceId : '')
 
   const { mcpTools, isLoading: mcpLoading } = useMcpTools(workspaceId)
+  const mcpToolNamesById = useMemo(() => {
+    const names = new Map<string, string>()
+    for (const t of mcpTools) {
+      if (!names.has(t.id)) names.set(t.id, t.name)
+    }
+    return names
+  }, [mcpTools])
 
   const { data: mcpServers = [], isLoading: mcpServersLoading } = useMcpServers(workspaceId)
   const { data: storedMcpTools = [] } = useStoredMcpTools(workspaceId)
@@ -642,6 +651,7 @@ export const ToolInput = memo(function ToolInput({
 
   const { filterBlocks, config: permissionConfig } = usePermissionConfig()
 
+  const customBlockOverlayVersion = useCustomBlockOverlayVersion()
   const toolBlocks = useMemo(() => {
     const allToolBlocks = getAllBlocks().filter(
       (block) =>
@@ -659,7 +669,7 @@ export const ToolInput = memo(function ToolInput({
         block.type !== 'file'
     )
     return filterBlocks(allToolBlocks)
-  }, [filterBlocks])
+  }, [filterBlocks, customBlockOverlayVersion])
 
   const hasBackfilledRef = useRef(false)
   useEffect(() => {
@@ -1662,9 +1672,11 @@ export const ToolInput = memo(function ToolInput({
           const isCustomTool = tool.type === 'custom-tool'
           const isMcpTool = tool.type === 'mcp'
           const isWorkflowTool = tool.type === 'workflow'
+          // Fall back to the unfiltered registry so chips for types hidden
+          // from the picker (permissions, hideFromToolbar) keep their chrome.
           const toolBlock =
             !isCustomTool && !isMcpTool
-              ? toolBlocks.find((block) => block.type === tool.type)
+              ? (toolBlocks.find((block) => block.type === tool.type) ?? getBlock(tool.type))
               : null
 
           const currentToolId =
@@ -1744,19 +1756,10 @@ export const ToolInput = memo(function ToolInput({
                 )
               : []
 
-          // Display name comes from static sources (registry / canonical records)
-          // where available; the stored `title` is only a last-resort fallback for
-          // MCP tools while server data is loading and for deleted custom-tool records.
-          const toolDisplayName = isCustomTool
-            ? resolvedCustomTool?.title ||
-              resolvedCustomTool?.schema?.function?.name ||
-              tool.title ||
-              'Unknown Tool'
-            : isMcpTool
-              ? mcpTool?.name || tool.title
-              : isWorkflowTool
-                ? 'Workflow'
-                : getBlock(tool.type)?.name || tool.type
+          // Canonical name wins; stored title only when nothing resolves
+          // (same policy as the canvas summary — see resolveStoredToolName).
+          const toolDisplayName =
+            resolveStoredToolName(tool, { customTools, mcpToolNamesById }) ?? 'Unknown Tool'
 
           const useSubBlocks = !isCustomTool && !isMcpTool && subBlocksResult?.subBlocks?.length
           const displayParams: ToolParameterConfig[] = isCustomTool

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/search-replace/workflow-search-replace.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/search-replace/workflow-search-replace.tsx
@@ -35,7 +35,9 @@ import {
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/float'
 import { useCurrentWorkflow } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-current-workflow'
 import { getBlock } from '@/blocks'
+import { useMcpTools } from '@/hooks/mcp/use-mcp-tools'
 import { useWorkspaceCredentials } from '@/hooks/queries/credentials'
+import { useCustomTools } from '@/hooks/queries/custom-tools'
 import { useFolderMap } from '@/hooks/queries/folders'
 import { isWorkflowEffectivelyLocked } from '@/hooks/queries/utils/folder-tree'
 import { useWorkflowMap } from '@/hooks/queries/workflows'
@@ -170,6 +172,15 @@ export function WorkflowSearchReplace() {
   const prevIsOpenRef = useRef(false)
   const afterReplaceIndexRef = useRef<number | null>(null)
   const { data: workspaceCredentials } = useWorkspaceCredentials({ workspaceId, enabled: isOpen })
+  const { data: customTools = [] } = useCustomTools(isOpen && workspaceId ? workspaceId : '')
+  const { mcpTools } = useMcpTools(isOpen && workspaceId ? workspaceId : '')
+  const mcpToolNamesById = useMemo(() => {
+    const names = new Map<string, string>()
+    for (const t of mcpTools) {
+      if (!names.has(t.id)) names.set(t.id, t.name)
+    }
+    return names
+  }, [mcpTools])
 
   useRegisterGlobalCommands([
     createCommand({
@@ -215,10 +226,14 @@ export function WorkflowSearchReplace() {
         workspaceId,
         workflowId,
         credentialTypeById,
+        customTools,
+        mcpToolNamesById,
       }),
     [
       currentWorkflow.isSnapshotView,
       credentialTypeById,
+      customTools,
+      mcpToolNamesById,
       query,
       readonlyReason,
       searchBlocks,

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/search-replace/workflow-search-replace.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/search-replace/workflow-search-replace.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/float'
 import { useCurrentWorkflow } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-current-workflow'
 import { getBlock } from '@/blocks'
+import { useCustomBlockOverlayVersion } from '@/blocks/custom/client-overlay'
 import { useMcpTools } from '@/hooks/mcp/use-mcp-tools'
 import { useWorkspaceCredentials } from '@/hooks/queries/credentials'
 import { useCustomTools } from '@/hooks/queries/custom-tools'
@@ -213,6 +214,8 @@ export function WorkflowSearchReplace() {
     [workspaceCredentials]
   )
 
+  /** Overlay version invalidates getBlock-resolved tool names in the index. */
+  const customBlockOverlayVersion = useCustomBlockOverlayVersion()
   const matches = useMemo(
     () =>
       indexWorkflowSearchMatches({
@@ -232,6 +235,7 @@ export function WorkflowSearchReplace() {
     [
       currentWorkflow.isSnapshotView,
       credentialTypeById,
+      customBlockOverlayVersion,
       customTools,
       mcpToolNamesById,
       query,

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -331,9 +331,13 @@ const SubBlockRow = memo(function SubBlockRow({
 
   /** Hydrates tool references to display names. */
   const { data: customTools = [] } = useCustomTools(workspaceId || '')
+  const mcpToolSummaries = useMemo(
+    () => mcpToolsData.map((t) => ({ id: createMcpToolId(t.serverId, t.name), name: t.name })),
+    [mcpToolsData]
+  )
   const toolsDisplayValue = useMemo(
-    () => resolveToolsLabel(subBlock, rawValue, customTools),
-    [subBlock, rawValue, customTools]
+    () => resolveToolsLabel(subBlock, rawValue, customTools, mcpToolSummaries),
+    [subBlock, rawValue, customTools, mcpToolSummaries]
   )
 
   const filterDisplayValue = useMemo(

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/utils'
 import { useBlockVisual } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks'
 import { useBlockDimensions } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-block-dimensions'
+import { useCustomBlockOverlayVersion } from '@/blocks/custom/client-overlay'
 import { SELECTOR_TYPES_HYDRATION_REQUIRED, type SubBlockConfig } from '@/blocks/types'
 import { getDependsOnFields } from '@/blocks/utils'
 import { useKnowledgeBase } from '@/hooks/kb/use-knowledge'
@@ -67,6 +68,9 @@ const logger = createLogger('WorkflowBlock')
 
 /** Stable empty object to avoid creating new references */
 const EMPTY_SUBBLOCK_VALUES = {} as Record<string, any>
+
+/** Stable empty map for rows that never resolve MCP tool names */
+const EMPTY_MCP_TOOL_NAMES: ReadonlyMap<string, string> = new Map()
 
 interface SubBlockRowProps {
   title: string
@@ -274,17 +278,23 @@ const SubBlockRow = memo(function SubBlockRow({
   }, [subBlock?.type, rawValue, mcpServers])
 
   const { data: mcpToolsData = [] } = useMcpToolsQuery(workspaceId || '')
+  const mcpToolNamesById = useMemo(() => {
+    if (subBlock?.type !== 'mcp-tool-selector' && subBlock?.type !== 'tool-input') {
+      return EMPTY_MCP_TOOL_NAMES
+    }
+    const names = new Map<string, string>()
+    for (const t of mcpToolsData) {
+      const toolId = createMcpToolId(t.serverId, t.name)
+      if (!names.has(toolId)) names.set(toolId, t.name)
+    }
+    return names
+  }, [subBlock?.type, mcpToolsData])
   const mcpToolDisplayName = useMemo(() => {
     if (subBlock?.type !== 'mcp-tool-selector' || typeof rawValue !== 'string') {
       return null
     }
-
-    const tool = mcpToolsData.find((t) => {
-      const toolId = createMcpToolId(t.serverId, t.name)
-      return toolId === rawValue
-    })
-    return tool?.name ?? null
-  }, [subBlock?.type, rawValue, mcpToolsData])
+    return mcpToolNamesById.get(rawValue) ?? null
+  }, [subBlock?.type, rawValue, mcpToolNamesById])
 
   const { data: tables = [] } = useTablesList(workspaceId || '')
   const tableDisplayName = useMemo(() => {
@@ -329,15 +339,16 @@ const SubBlockRow = memo(function SubBlockRow({
     [subBlock, rawValue, workflowVariables]
   )
 
-  /** Hydrates tool references to display names. */
+  /**
+   * Hydrates tool references to display names. The overlay version is a dep
+   * because resolveToolsLabel reads getBlock, whose custom-block results
+   * change when the client overlay hydrates (see client-overlay.ts).
+   */
   const { data: customTools = [] } = useCustomTools(workspaceId || '')
-  const mcpToolSummaries = useMemo(
-    () => mcpToolsData.map((t) => ({ id: createMcpToolId(t.serverId, t.name), name: t.name })),
-    [mcpToolsData]
-  )
+  const customBlockOverlayVersion = useCustomBlockOverlayVersion()
   const toolsDisplayValue = useMemo(
-    () => resolveToolsLabel(subBlock, rawValue, customTools, mcpToolSummaries),
-    [subBlock, rawValue, customTools, mcpToolSummaries]
+    () => resolveToolsLabel(subBlock, rawValue, customTools, mcpToolNamesById),
+    [subBlock, rawValue, customTools, mcpToolNamesById, customBlockOverlayVersion]
   )
 
   const filterDisplayValue = useMemo(

--- a/apps/sim/lib/workflows/search-replace/indexer.test.ts
+++ b/apps/sim/lib/workflows/search-replace/indexer.test.ts
@@ -1387,6 +1387,10 @@ describe('indexWorkflowSearchMatches', () => {
         custom: {
           subBlocks: [{ id: 'tools', title: 'Tools', type: 'tool-input' }],
         },
+        native: {
+          name: 'Customer Mailer',
+          subBlocks: [],
+        },
       },
     }).filter((match) => match.blockId === 'tool-input-1')
 
@@ -1395,7 +1399,7 @@ describe('indexWorkflowSearchMatches', () => {
         expect.objectContaining({
           subBlockId: 'tools',
           valuePath: [0, 'title'],
-          searchText: 'Customer notifier',
+          searchText: 'Customer Mailer',
         }),
         expect.objectContaining({
           subBlockId: 'tools',
@@ -1404,6 +1408,7 @@ describe('indexWorkflowSearchMatches', () => {
         }),
       ])
     )
+    expect(matches.some((match) => match.searchText === 'Customer notifier')).toBe(false)
     expect(matches.some((match) => match.valuePath.includes('toolId'))).toBe(false)
     expect(matches.some((match) => match.valuePath.includes('operation'))).toBe(false)
     expect(matches.some((match) => match.valuePath.includes('credentialId'))).toBe(false)

--- a/apps/sim/lib/workflows/search-replace/indexer.test.ts
+++ b/apps/sim/lib/workflows/search-replace/indexer.test.ts
@@ -1423,6 +1423,50 @@ describe('indexWorkflowSearchMatches', () => {
     expect(matches.some((match) => match.valuePath.includes('schema'))).toBe(false)
   })
 
+  it('indexes canonical MCP and custom-tool names over mutated stored titles', () => {
+    const workflow = createSearchReplaceWorkflowFixture()
+    workflow.blocks['tool-input-1'] = {
+      id: 'tool-input-1',
+      type: 'custom',
+      name: 'Tool Input Block',
+      position: { x: 0, y: 0 },
+      enabled: true,
+      outputs: {},
+      subBlocks: {
+        tools: {
+          id: 'tools',
+          type: 'tool-input',
+          value: [
+            { type: 'mcp', toolId: 'mcp-tool-1', title: 'Mutated Title', params: {} },
+            { type: 'custom-tool', customToolId: 'ct-1', title: 'Mutated Title', params: {} },
+          ],
+        },
+      },
+    }
+
+    const matches = indexWorkflowSearchMatches({
+      workflow,
+      query: 'customer',
+      mode: 'text',
+      blockConfigs: {
+        ...SEARCH_REPLACE_BLOCK_CONFIGS,
+        custom: {
+          subBlocks: [{ id: 'tools', title: 'Tools', type: 'tool-input' }],
+        },
+      },
+      customTools: [{ id: 'ct-1', title: 'Customer Records' }],
+      mcpToolNamesById: new Map([['mcp-tool-1', 'customer_lookup']]),
+    }).filter((match) => match.blockId === 'tool-input-1')
+
+    expect(matches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ valuePath: [0, 'title'], searchText: 'customer_lookup' }),
+        expect.objectContaining({ valuePath: [1, 'title'], searchText: 'Customer Records' }),
+      ])
+    )
+    expect(matches.some((match) => match.searchText === 'Mutated Title')).toBe(false)
+  })
+
   it('indexes explicit secret tool params for intentional replacement', () => {
     const workflow = createSearchReplaceWorkflowFixture()
     workflow.blocks['tool-input-1'] = {

--- a/apps/sim/lib/workflows/search-replace/indexer.ts
+++ b/apps/sim/lib/workflows/search-replace/indexer.ts
@@ -932,6 +932,8 @@ function addToolInputMatches({
   workflowId,
   credentialTypeById,
   blockConfigs,
+  customTools,
+  mcpToolNamesById,
 }: {
   matches: WorkflowSearchMatch[]
   block: WorkflowSearchBlockState
@@ -951,6 +953,8 @@ function addToolInputMatches({
   workflowId?: string
   credentialTypeById?: Record<string, string | undefined>
   blockConfigs?: WorkflowSearchIndexerOptions['blockConfigs']
+  customTools?: WorkflowSearchIndexerOptions['customTools']
+  mcpToolNamesById?: WorkflowSearchIndexerOptions['mcpToolNamesById']
 }) {
   const parentCanonicalModes = getSearchCanonicalModes(block)
 
@@ -958,6 +962,8 @@ function addToolInputMatches({
     // Index the resolved display name (not the stored mutable title) so
     // search text and highlights match what the tool chip actually renders.
     const toolDisplayName = resolveStoredToolName(tool, {
+      customTools,
+      mcpToolNamesById,
       getBlockConfig: (type) => blockConfigs?.[type] ?? getBlock(type),
     })
     if (mode !== 'resource' && toolDisplayName) {
@@ -1234,6 +1240,8 @@ export function indexWorkflowSearchMatches(
     workflowId,
     blockConfigs = {},
     credentialTypeById,
+    customTools,
+    mcpToolNamesById,
   } = options
 
   const matches: WorkflowSearchMatch[] = []
@@ -1369,6 +1377,8 @@ export function indexWorkflowSearchMatches(
           workflowId,
           credentialTypeById,
           blockConfigs,
+          customTools,
+          mcpToolNamesById,
         })
         continue
       }

--- a/apps/sim/lib/workflows/search-replace/indexer.ts
+++ b/apps/sim/lib/workflows/search-replace/indexer.ts
@@ -23,6 +23,7 @@ import type {
 } from '@/lib/workflows/search-replace/types'
 import { pathToKey, walkStringValues } from '@/lib/workflows/search-replace/value-walker'
 import { SELECTOR_CONTEXT_FIELDS } from '@/lib/workflows/subblocks/context'
+import { resolveStoredToolName } from '@/lib/workflows/subblocks/display'
 import {
   buildCanonicalIndex,
   buildSubBlockValues,
@@ -954,7 +955,12 @@ function addToolInputMatches({
   const parentCanonicalModes = getSearchCanonicalModes(block)
 
   parseStoredToolInputValue(value).forEach((tool, toolIndex) => {
-    if (mode !== 'resource' && tool.title) {
+    // Index the resolved display name (not the stored mutable title) so
+    // search text and highlights match what the tool chip actually renders.
+    const toolDisplayName = resolveStoredToolName(tool, {
+      getBlockConfig: (type) => blockConfigs?.[type] ?? getBlock(type),
+    })
+    if (mode !== 'resource' && toolDisplayName) {
       addTextMatches({
         matches,
         idPrefix: 'tool-input-title',
@@ -963,7 +969,7 @@ function addToolInputMatches({
         canonicalSubBlockId,
         subBlockType: 'tool-input',
         fieldTitle: 'Tool',
-        value: tool.title,
+        value: toolDisplayName,
         valuePath: [toolIndex, 'title'],
         target: { kind: 'subblock' },
         query,

--- a/apps/sim/lib/workflows/search-replace/types.ts
+++ b/apps/sim/lib/workflows/search-replace/types.ts
@@ -3,6 +3,7 @@ import type {
   WorkflowSearchSubflowEditableValue,
   WorkflowSearchSubflowFieldId,
 } from '@/lib/workflows/search-replace/subflow-fields'
+import type { StoredCustomToolRecord } from '@/lib/workflows/subblocks/display'
 import type { SubBlockConfig } from '@/blocks/types'
 import type { SelectorContext } from '@/hooks/selectors/types'
 import type { BlockState, SubBlockState } from '@/stores/workflows/workflow/types'
@@ -96,10 +97,19 @@ export interface WorkflowSearchIndexerOptions {
   workflowId?: string
   blockConfigs?: Record<
     string,
-    | { subBlocks?: SubBlockConfig[]; triggers?: { enabled?: boolean }; category?: string }
+    | {
+        name?: string
+        subBlocks?: SubBlockConfig[]
+        triggers?: { enabled?: boolean }
+        category?: string
+      }
     | undefined
   >
   credentialTypeById?: Record<string, string | undefined>
+  /** Custom-tool records so indexed tool names match the rendered chips. */
+  customTools?: StoredCustomToolRecord[]
+  /** Live MCP tool names keyed by composite tool id, same as the chip renderers. */
+  mcpToolNamesById?: ReadonlyMap<string, string>
 }
 
 export interface WorkflowSearchReplacementOption {

--- a/apps/sim/lib/workflows/subblocks/display.test.ts
+++ b/apps/sim/lib/workflows/subblocks/display.test.ts
@@ -113,6 +113,30 @@ describe('resolveToolsLabel', () => {
       null
     )
   })
+
+  it('ignores the stored title on registry-backed tools so state edits cannot rename them', () => {
+    const slackName = resolveToolsLabel(toolInput, [{ type: 'slack' }], [])
+    expect(slackName).not.toBe(null)
+    expect(resolveToolsLabel(toolInput, [{ type: 'slack', title: 'Renamed By Copilot' }], [])).toBe(
+      slackName
+    )
+  })
+
+  it('falls back to the raw type id for unregistered block-backed tools', () => {
+    expect(
+      resolveToolsLabel(toolInput, [{ type: 'not_a_real_block', title: 'Sneaky Title' }], [])
+    ).toBe('not_a_real_block')
+  })
+
+  it('prefers the custom tool record over the stored title', () => {
+    expect(
+      resolveToolsLabel(
+        toolInput,
+        [{ type: 'custom-tool', customToolId: 'ct-1', title: 'Renamed By Copilot' }],
+        [{ id: 'ct-1', title: 'My Tool' }]
+      )
+    ).toBe('My Tool')
+  })
 })
 
 describe('resolveSkillsLabel', () => {

--- a/apps/sim/lib/workflows/subblocks/display.test.ts
+++ b/apps/sim/lib/workflows/subblocks/display.test.ts
@@ -135,6 +135,20 @@ describe('resolveToolsLabel', () => {
     expect(resolveToolsLabel(toolInput, [{ type: 'workflow_input' }], [])).toBe('Workflow')
   })
 
+  it('prefers the live MCP tool name over the stored title', () => {
+    expect(
+      resolveToolsLabel(
+        toolInput,
+        [{ type: 'mcp', toolId: 'mcp-1', title: 'Renamed By Copilot' }],
+        [],
+        [{ id: 'mcp-1', name: 'Live MCP Name' }]
+      )
+    ).toBe('Live MCP Name')
+    expect(
+      resolveToolsLabel(toolInput, [{ type: 'mcp', toolId: 'mcp-1', title: 'Snapshot' }], [], [])
+    ).toBe('Snapshot')
+  })
+
   it('prefers the custom tool record over the stored title', () => {
     expect(
       resolveToolsLabel(

--- a/apps/sim/lib/workflows/subblocks/display.test.ts
+++ b/apps/sim/lib/workflows/subblocks/display.test.ts
@@ -128,6 +128,13 @@ describe('resolveToolsLabel', () => {
     ).toBe('not_a_real_block')
   })
 
+  it('renders the static label for workflow-as-tool entries regardless of stored title', () => {
+    expect(
+      resolveToolsLabel(toolInput, [{ type: 'workflow', title: 'Renamed By Copilot' }], [])
+    ).toBe('Workflow')
+    expect(resolveToolsLabel(toolInput, [{ type: 'workflow_input' }], [])).toBe('Workflow')
+  })
+
   it('prefers the custom tool record over the stored title', () => {
     expect(
       resolveToolsLabel(

--- a/apps/sim/lib/workflows/subblocks/display.test.ts
+++ b/apps/sim/lib/workflows/subblocks/display.test.ts
@@ -4,7 +4,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/blocks', () => ({
-  getBlock: (type: string) => (type === 'slack' ? { name: 'Slack' } : undefined),
+  getBlock: (type: string) => {
+    if (type === 'slack') return { name: 'Slack' }
+    if (type === 'workflow' || type === 'workflow_input') return { name: 'Workflow' }
+    return undefined
+  },
 }))
 
 import {
@@ -122,10 +126,13 @@ describe('resolveToolsLabel', () => {
     )
   })
 
-  it('falls back to the raw type id for unregistered block-backed tools', () => {
+  it('falls back to the stored title, then the raw type id, for unresolvable block types', () => {
     expect(
-      resolveToolsLabel(toolInput, [{ type: 'not_a_real_block', title: 'Sneaky Title' }], [])
-    ).toBe('not_a_real_block')
+      resolveToolsLabel(toolInput, [{ type: 'custom_block_gone', title: 'Invoice Parser' }], [])
+    ).toBe('Invoice Parser')
+    expect(resolveToolsLabel(toolInput, [{ type: 'custom_block_gone' }], [])).toBe(
+      'custom_block_gone'
+    )
   })
 
   it('renders the static label for workflow-as-tool entries regardless of stored title', () => {
@@ -141,11 +148,11 @@ describe('resolveToolsLabel', () => {
         toolInput,
         [{ type: 'mcp', toolId: 'mcp-1', title: 'Renamed By Copilot' }],
         [],
-        [{ id: 'mcp-1', name: 'Live MCP Name' }]
+        new Map([['mcp-1', 'Live MCP Name']])
       )
     ).toBe('Live MCP Name')
     expect(
-      resolveToolsLabel(toolInput, [{ type: 'mcp', toolId: 'mcp-1', title: 'Snapshot' }], [], [])
+      resolveToolsLabel(toolInput, [{ type: 'mcp', toolId: 'mcp-1', title: 'Snapshot' }], [])
     ).toBe('Snapshot')
   })
 

--- a/apps/sim/lib/workflows/subblocks/display.ts
+++ b/apps/sim/lib/workflows/subblocks/display.ts
@@ -428,15 +428,17 @@ export function resolveVariablesLabel(
 
 /**
  * Resolves a tool-input value to a tool-name summary. Names come from static
- * sources first (block registry, custom-tool records) so that edits to the
- * stored entry's `title` cannot change what the UI shows; the stored title
- * and inline schema names are only fallbacks for shapes with no canonical
- * source (MCP snapshots, legacy entries).
+ * sources first (block registry, custom-tool records, live MCP tools) so that
+ * edits to the stored entry's `title` cannot change what the UI shows; the
+ * stored title and inline schema names are only fallbacks for shapes with no
+ * canonical source (MCP entries while server data is unavailable, legacy
+ * entries).
  */
 export function resolveToolsLabel(
   subBlock: SubBlockConfig | undefined,
   rawValue: unknown,
-  customTools: Array<{ id: string; title?: string; schema?: { function?: { name?: string } } }>
+  customTools: Array<{ id: string; title?: string; schema?: { function?: { name?: string } } }>,
+  mcpTools: Array<{ id: string; name: string }> = []
 ): string | null {
   if (subBlock?.type !== 'tool-input') return null
   if (!Array.isArray(rawValue) || rawValue.length === 0) return null
@@ -464,6 +466,11 @@ export function resolveToolsLabel(
         const customTool = customTools.find((candidate) => candidate.id === t.customToolId)
         if (customTool?.title) return customTool.title
         if (customTool?.schema?.function?.name) return customTool.schema.function.name
+      }
+
+      if (t.type === 'mcp' && typeof t.toolId === 'string') {
+        const mcpTool = mcpTools.find((candidate) => candidate.id === t.toolId)
+        if (mcpTool?.name) return mcpTool.name
       }
 
       if (typeof t.title === 'string' && t.title) return t.title

--- a/apps/sim/lib/workflows/subblocks/display.ts
+++ b/apps/sim/lib/workflows/subblocks/display.ts
@@ -458,6 +458,8 @@ export function resolveToolsLabel(
         return t.type
       }
 
+      if (t.type === 'workflow' || t.type === 'workflow_input') return 'Workflow'
+
       if (t.type === 'custom-tool' && typeof t.customToolId === 'string') {
         const customTool = customTools.find((candidate) => candidate.id === t.customToolId)
         if (customTool?.title) return customTool.title

--- a/apps/sim/lib/workflows/subblocks/display.ts
+++ b/apps/sim/lib/workflows/subblocks/display.ts
@@ -426,63 +426,89 @@ export function resolveVariablesLabel(
   return summarizeNames(names)
 }
 
+/** Custom-tool record shape needed to resolve a stored custom-tool reference. */
+export interface StoredCustomToolRecord {
+  id: string
+  title?: string
+  schema?: { function?: { name?: string } }
+}
+
+export interface ResolveStoredToolNameOptions {
+  customTools?: StoredCustomToolRecord[]
+  /** Live MCP tool names keyed by composite tool id (`createMcpToolId`). */
+  mcpToolNamesById?: ReadonlyMap<string, string>
+  /** Block-config lookup; overridable so snapshot views can scope configs. */
+  getBlockConfig?: (type: string) => { name?: string } | undefined
+}
+
 /**
- * Resolves a tool-input value to a tool-name summary. Names come from static
- * sources first (block registry, custom-tool records, live MCP tools) so that
- * edits to the stored entry's `title` cannot change what the UI shows; the
- * stored title and inline schema names are only fallbacks for shapes with no
- * canonical source (MCP entries while server data is unavailable, legacy
- * entries).
+ * Resolves one stored tool entry to its display name. Canonical sources win —
+ * the block registry (including the custom-block overlay), the custom-tool
+ * record, live MCP server data — so edits to the entry's mutable `title` in
+ * workflow state cannot relabel a tool that has a canonical name. The stored
+ * title is the fallback for entries with no resolvable source (deleted custom
+ * blocks, MCP entries while server data is unavailable, legacy inline custom
+ * tools where the title is the identity), ahead of the raw type id.
+ */
+export function resolveStoredToolName(
+  tool: unknown,
+  options: ResolveStoredToolNameOptions = {}
+): string | null {
+  if (!tool || typeof tool !== 'object') return null
+  const t = tool as Record<string, unknown>
+  const { customTools = [], mcpToolNamesById, getBlockConfig = getBlock } = options
+
+  const storedTitle = typeof t.title === 'string' && t.title ? t.title : null
+  const schema = t.schema as { function?: { name?: string } } | undefined
+  const schemaName = schema?.function?.name || null
+
+  if (t.type === 'custom-tool') {
+    if (typeof t.customToolId === 'string') {
+      const record = customTools.find((candidate) => candidate.id === t.customToolId)
+      if (record?.title) return record.title
+      if (record?.schema?.function?.name) return record.schema.function.name
+    }
+    return storedTitle || schemaName
+  }
+
+  if (t.type === 'mcp') {
+    if (typeof t.toolId === 'string') {
+      const liveName = mcpToolNamesById?.get(t.toolId)
+      if (liveName) return liveName
+    }
+    return storedTitle
+  }
+
+  if (typeof t.type === 'string' && t.type) {
+    const blockConfig = getBlockConfig(t.type)
+    if (blockConfig?.name) return blockConfig.name
+    return storedTitle || t.type
+  }
+
+  if (storedTitle) return storedTitle
+  if (schemaName) return schemaName
+
+  const fn = t.function as { name?: string } | undefined
+  if (fn?.name) return fn.name
+
+  return null
+}
+
+/**
+ * Resolves a tool-input value to a tool-name summary via
+ * {@link resolveStoredToolName}. Unresolvable entries are skipped.
  */
 export function resolveToolsLabel(
   subBlock: SubBlockConfig | undefined,
   rawValue: unknown,
-  customTools: Array<{ id: string; title?: string; schema?: { function?: { name?: string } } }>,
-  mcpTools: Array<{ id: string; name: string }> = []
+  customTools: StoredCustomToolRecord[],
+  mcpToolNamesById?: ReadonlyMap<string, string>
 ): string | null {
   if (subBlock?.type !== 'tool-input') return null
   if (!Array.isArray(rawValue) || rawValue.length === 0) return null
 
   const names = rawValue
-    .map((tool: unknown) => {
-      if (!tool || typeof tool !== 'object') return null
-      const t = tool as Record<string, unknown>
-
-      if (
-        typeof t.type === 'string' &&
-        t.type !== 'custom-tool' &&
-        t.type !== 'mcp' &&
-        t.type !== 'workflow' &&
-        t.type !== 'workflow_input'
-      ) {
-        const blockConfig = getBlock(t.type)
-        if (blockConfig?.name) return blockConfig.name
-        return t.type
-      }
-
-      if (t.type === 'workflow' || t.type === 'workflow_input') return 'Workflow'
-
-      if (t.type === 'custom-tool' && typeof t.customToolId === 'string') {
-        const customTool = customTools.find((candidate) => candidate.id === t.customToolId)
-        if (customTool?.title) return customTool.title
-        if (customTool?.schema?.function?.name) return customTool.schema.function.name
-      }
-
-      if (t.type === 'mcp' && typeof t.toolId === 'string') {
-        const mcpTool = mcpTools.find((candidate) => candidate.id === t.toolId)
-        if (mcpTool?.name) return mcpTool.name
-      }
-
-      if (typeof t.title === 'string' && t.title) return t.title
-
-      const schema = t.schema as { function?: { name?: string } } | undefined
-      if (schema?.function?.name) return schema.function.name
-
-      const fn = t.function as { name?: string } | undefined
-      if (fn?.name) return fn.name
-
-      return null
-    })
+    .map((tool: unknown) => resolveStoredToolName(tool, { customTools, mcpToolNamesById }))
     .filter((name): name is string => !!name)
 
   return summarizeNames(names)

--- a/apps/sim/lib/workflows/subblocks/display.ts
+++ b/apps/sim/lib/workflows/subblocks/display.ts
@@ -427,10 +427,11 @@ export function resolveVariablesLabel(
 }
 
 /**
- * Resolves a tool-input value to a tool-name summary. Stored tool entries
- * come in several historical shapes, checked in priority order: explicit
- * title, custom tool referenced by id, inline schema name, OpenAI function
- * name, then the block registry.
+ * Resolves a tool-input value to a tool-name summary. Names come from static
+ * sources first (block registry, custom-tool records) so that edits to the
+ * stored entry's `title` cannot change what the UI shows; the stored title
+ * and inline schema names are only fallbacks for shapes with no canonical
+ * source (MCP snapshots, legacy entries).
  */
 export function resolveToolsLabel(
   subBlock: SubBlockConfig | undefined,
@@ -445,20 +446,6 @@ export function resolveToolsLabel(
       if (!tool || typeof tool !== 'object') return null
       const t = tool as Record<string, unknown>
 
-      if (typeof t.title === 'string' && t.title) return t.title
-
-      if (t.type === 'custom-tool' && typeof t.customToolId === 'string') {
-        const customTool = customTools.find((candidate) => candidate.id === t.customToolId)
-        if (customTool?.title) return customTool.title
-        if (customTool?.schema?.function?.name) return customTool.schema.function.name
-      }
-
-      const schema = t.schema as { function?: { name?: string } } | undefined
-      if (schema?.function?.name) return schema.function.name
-
-      const fn = t.function as { name?: string } | undefined
-      if (fn?.name) return fn.name
-
       if (
         typeof t.type === 'string' &&
         t.type !== 'custom-tool' &&
@@ -468,7 +455,22 @@ export function resolveToolsLabel(
       ) {
         const blockConfig = getBlock(t.type)
         if (blockConfig?.name) return blockConfig.name
+        return t.type
       }
+
+      if (t.type === 'custom-tool' && typeof t.customToolId === 'string') {
+        const customTool = customTools.find((candidate) => candidate.id === t.customToolId)
+        if (customTool?.title) return customTool.title
+        if (customTool?.schema?.function?.name) return customTool.schema.function.name
+      }
+
+      if (typeof t.title === 'string' && t.title) return t.title
+
+      const schema = t.schema as { function?: { name?: string } } | undefined
+      if (schema?.function?.name) return schema.function.name
+
+      const fn = t.function as { name?: string } | undefined
+      if (fn?.name) return fn.name
 
       return null
     })


### PR DESCRIPTION
Renders agent tool chip names from canonical sources (block registry, custom-tool records, live MCP data) instead of the mutable `title` field in workflow JSON state, so copilot `edit_workflow` operations (or any direct state edit) can no longer change what the workflow UI displays for a tool. One shared resolver (`resolveStoredToolName`) drives the panel chips, the collapsed canvas summaries, and the workflow search index, so all surfaces agree. Resolution order: canonical name → stored title (only when nothing resolves: deleted custom blocks, MCP data not yet loaded, legacy inline custom tools) → raw type id.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
- Unit tests added/updated in `display.test.ts` (registry-backed entries ignore edited titles; workflow/workflow_input resolve statically; unresolvable types fall back to stored title then raw id; custom-tool record and live MCP name win over stored title) and `indexer.test.ts` (search indexes the resolved display name, not the mutated title; canonical MCP/custom-tool names indexed when live data is present) — 119 tests passing across the affected suites.
- `tsc --noEmit` clean, `biome check` clean, full CI (Test and Build) green.
- Reviewed through 4 bot review cycles (Greptile + Cursor Bugbot) plus a multi-agent internal review with adversarial verification; all findings fixed and threads resolved.

**Reviewer focus:**
- The resolution priority in `resolveStoredToolName` (`apps/sim/lib/workflows/subblocks/display.ts`) — this is now the single policy for all three surfaces.
- The custom-block overlay invalidation: memos deriving from `getBlock` carry the `useCustomBlockOverlayVersion` dep (canvas summary, panel picker, search index) per the contract in `client-overlay.ts`.
- Known accepted tradeoffs: MCP entries show the stored title only while server data is unavailable; legacy inline custom tools display their stored title because it is their identity (it also feeds the `custom_${title}` executor id); the read-only preview resolves without live MCP/custom data by design.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
No visual change for normal flows: chips already showed the canonical name (the stored title was snapshotted from it at add-time). The change only prevents state-edited titles from surfacing in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)