### PR TITLE
fix(deps): install xlsx from @e965/xlsx npm mirror

### DIFF
--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -212,7 +212,7 @@
     "twilio": "5.9.0",
     "undici": "7.28.0",
     "unpdf": "1.4.0",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+    "xlsx": "npm:@e965/xlsx@0.20.3",
     "zod": "4.3.6",
     "zustand": "^5.0.13"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -280,7 +280,7 @@
         "twilio": "5.9.0",
         "undici": "7.28.0",
         "unpdf": "1.4.0",
-        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+        "xlsx": "npm:@e965/xlsx@0.20.3",
         "zod": "4.3.6",
         "zustand": "^5.0.13",
       },
@@ -4003,7 +4003,7 @@
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
-    "xlsx": ["xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz", { "bin": { "xlsx": "./bin/xlsx.njs" } }],
+    "xlsx": ["@e965/xlsx@0.20.3", "", { "bin": { "xlsx": "bin/xlsx.njs" } }, "sha512-703RN/3OdsRD5mtse2HBX7Um7xwaP9tlswEG6svOtjqokXoX7rJdQj7DyabD2I+xk22RgaIIU+R6BHgkpZGB/w=="],
 
     "xml": ["xml@1.0.1", "", {}, "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="],
 


### PR DESCRIPTION
## Summary
- `xlsx` was pinned to a direct tarball on `cdn.sheetjs.com`, which now returns **403** (Cloudflare bot-challenge) to automated clients — breaking `bun install --frozen-lockfile` in CI
- npm's own `xlsx` is deliberately frozen at 0.18.5, so switch to **`@e965/xlsx@0.20.3`**, a community npm republish of the identical SheetJS 0.20.3 CDN build
- No code changes — every import uses bare `'xlsx'`, so the npm alias is transparent

## Type of Change
- [x] Bug fix

## Testing
- `bun install` resolves cleanly; lockfile now points at `@e965/xlsx@0.20.3` (npm registry, integrity-hashed)
- Verified `node_modules/xlsx` is the real 0.20.3 build
- `bun run lint` passes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)