### PR TITLE
improvement(knowledge): open document tags from row context menu

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -344,7 +344,7 @@ export function KnowledgeBase({
   const [showRenameModal, setShowRenameModal] = useState(false)
   const [documentToRename, setDocumentToRename] = useState<DocumentData | null>(null)
   const [showDocumentTagsModal, setShowDocumentTagsModal] = useState(false)
-  const [documentForTags, setDocumentForTags] = useState<DocumentData | null>(null)
+  const [documentForTagsId, setDocumentForTagsId] = useState<string | null>(null)
   const showAddConnectorModal = addConnectorType != null
   const updateAddConnectorParam = useCallback(
     (value: string | null) => {
@@ -538,7 +538,7 @@ export function KnowledgeBase({
    * Opens the document tags modal
    */
   const handleViewDocumentTags = (doc: DocumentData) => {
-    setDocumentForTags(doc)
+    setDocumentForTagsId(doc.id)
     setShowDocumentTagsModal(true)
   }
 
@@ -1356,14 +1356,14 @@ export function KnowledgeBase({
         />
       )}
 
-      {documentForTags && (
+      {documentForTagsId && (
         <DocumentTagsModal
           open={showDocumentTagsModal}
           onOpenChange={setShowDocumentTagsModal}
           knowledgeBaseId={id}
-          documentId={documentForTags.id}
-          documentData={documentForTags}
-          onDocumentUpdate={(updates) => updateDocument(documentForTags.id, updates)}
+          documentId={documentForTagsId}
+          documentData={documents.find((doc) => doc.id === documentForTagsId) ?? null}
+          onDocumentUpdate={(updates) => updateDocument(documentForTagsId, updates)}
         />
       )}
 

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -49,6 +49,7 @@ import type {
   SortConfig,
 } from '@/app/workspace/[workspaceId]/components'
 import { FloatingOverflowText, Resource } from '@/app/workspace/[workspaceId]/components'
+import { DocumentTagsModal } from '@/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components'
 import {
   ActionBar,
   AddConnectorModal,
@@ -342,6 +343,8 @@ export function KnowledgeBase({
   const [contextMenuDocument, setContextMenuDocument] = useState<DocumentData | null>(null)
   const [showRenameModal, setShowRenameModal] = useState(false)
   const [documentToRename, setDocumentToRename] = useState<DocumentData | null>(null)
+  const [showDocumentTagsModal, setShowDocumentTagsModal] = useState(false)
+  const [documentForTags, setDocumentForTags] = useState<DocumentData | null>(null)
   const showAddConnectorModal = addConnectorType != null
   const updateAddConnectorParam = useCallback(
     (value: string | null) => {
@@ -529,6 +532,14 @@ export function KnowledgeBase({
   const handleRenameDocument = (doc: DocumentData) => {
     setDocumentToRename(doc)
     setShowRenameModal(true)
+  }
+
+  /**
+   * Opens the document tags modal
+   */
+  const handleViewDocumentTags = (doc: DocumentData) => {
+    setDocumentForTags(doc)
+    setShowDocumentTagsModal(true)
   }
 
   /**
@@ -1345,6 +1356,17 @@ export function KnowledgeBase({
         />
       )}
 
+      {documentForTags && (
+        <DocumentTagsModal
+          open={showDocumentTagsModal}
+          onOpenChange={setShowDocumentTagsModal}
+          knowledgeBaseId={id}
+          documentId={documentForTags.id}
+          documentData={documentForTags}
+          onDocumentUpdate={(updates) => updateDocument(documentForTags.id, updates)}
+        />
+      )}
+
       <ChipModal
         open={showConnectorsModal}
         onOpenChange={setShowConnectorsModal}
@@ -1371,11 +1393,6 @@ export function KnowledgeBase({
         onClose={handleContextMenuClose}
         hasDocument={contextMenuDocument !== null}
         isDocumentEnabled={contextMenuDocument?.enabled ?? true}
-        hasTags={
-          contextMenuDocument
-            ? getDocumentTags(contextMenuDocument, tagDefinitions).length > 0
-            : false
-        }
         selectedCount={selectedDocuments.size}
         enabledCount={enabledCount}
         disabledCount={disabledCount}
@@ -1414,15 +1431,7 @@ export function KnowledgeBase({
         }
         onViewTags={
           contextMenuDocument && selectedDocuments.size === 1
-            ? () => {
-                const urlParams = new URLSearchParams({
-                  kbName: knowledgeBaseName,
-                  docName: contextMenuDocument.filename || 'Document',
-                })
-                router.push(
-                  `/workspace/${workspaceId}/knowledge/${id}/${contextMenuDocument.id}?${urlParams.toString()}`
-                )
-              }
+            ? () => handleViewDocumentTags(contextMenuDocument)
             : undefined
         }
         onDelete={

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -1430,7 +1430,7 @@ export function KnowledgeBase({
             : undefined
         }
         onViewTags={
-          contextMenuDocument && selectedDocuments.size === 1
+          contextMenuDocument && selectedDocuments.size === 1 && userPermissions.canEdit
             ? () => handleViewDocumentTags(contextMenuDocument)
             : undefined
         }

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/document-context-menu/document-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/document-context-menu/document-context-menu.tsx
@@ -22,7 +22,6 @@ interface DocumentContextMenuProps {
   onAddDocument?: () => void
   isDocumentEnabled?: boolean
   hasDocument: boolean
-  hasTags?: boolean
   disableRename?: boolean
   disableToggleEnabled?: boolean
   disableDelete?: boolean
@@ -50,7 +49,6 @@ export function DocumentContextMenu({
   onAddDocument,
   isDocumentEnabled = true,
   hasDocument,
-  hasTags = false,
   disableRename = false,
   disableToggleEnabled = false,
   disableDelete = false,
@@ -70,7 +68,7 @@ export function DocumentContextMenu({
   }
 
   const hasNavigationSection = !isMultiSelect && (!!onOpenInNewTab || !!onOpenSource)
-  const hasEditSection = !isMultiSelect && (!!onRename || (hasTags && !!onViewTags))
+  const hasEditSection = !isMultiSelect && (!!onRename || !!onViewTags)
   const hasStateSection = !!onToggleEnabled
   const hasDestructiveSection = !!onDelete
 
@@ -121,10 +119,10 @@ export function DocumentContextMenu({
                 Rename
               </DropdownMenuItem>
             )}
-            {!isMultiSelect && hasTags && onViewTags && (
+            {!isMultiSelect && onViewTags && (
               <DropdownMenuItem onSelect={onViewTags}>
                 <TagIcon />
-                View tags
+                Tags
               </DropdownMenuItem>
             )}
             {hasEditSection && (hasStateSection || hasDestructiveSection) && (


### PR DESCRIPTION
## Summary
- Document row context menu had a "Tags" item that just navigated to the document detail page (per Justin's Slack feedback) — you'd then have to open the breadcrumb dropdown there to actually edit tags
- "Tags" now opens the existing `DocumentTagsModal` directly from the list, no navigation
- Item now shows even when the document has no tags yet, so a first tag can be added from the row (previously hidden until at least one tag existed)

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)