### PR TITLE
feat(providers): add xAI grok-4.5 model

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -1863,7 +1863,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
           temperature: { min: 0, max: 2 },
         },
         contextWindow: 500000,
-        releaseDate: '2026-07-09',
+        releaseDate: '2026-07-08',
         recommended: true,
       },
       {

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -1853,6 +1853,20 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     },
     models: [
       {
+        id: 'grok-4.5',
+        pricing: {
+          input: 2.0,
+          output: 6.0,
+          updatedAt: '2026-07-08',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 2 },
+        },
+        contextWindow: 500000,
+        releaseDate: '2026-07-09',
+        recommended: true,
+      },
+      {
         id: 'grok-4.3',
         pricing: {
           input: 1.25,
@@ -1865,7 +1879,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1000000,
         releaseDate: '2026-04-30',
-        recommended: true,
       },
       {
         id: 'grok-4-latest',


### PR DESCRIPTION
## Summary
- Add xAI's new grok-4.5 flagship model to the provider registry ($2/1M input, $6/1M output, 500K context, always-reasoning)
- Move `recommended: true` from grok-4.3 to grok-4.5

## Type of Change
- [x] New feature

## Testing
Tested manually (verified pricing/context/release date against docs.x.ai live docs + secondary sources, biome-clean on the changed file)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)