### PR TITLE
fix(providers): sync xai defaultModel with grok-4.5 recommended flag

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -1844,7 +1844,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     fileAttachment: { maxBytes: 20 * 1024 * 1024, strategy: 'remote-url' },
     name: 'xAI',
     description: "xAI's Grok models",
-    defaultModel: 'grok-4.3',
+    defaultModel: 'grok-4.5',
     modelPatterns: [/^grok/],
     icon: xAIIcon,
     color: '#555555',


### PR DESCRIPTION
## Summary
- Follow-up to #5511 (already merged) — that PR moved `recommended: true` to grok-4.5 but left `defaultModel: 'grok-4.3'` unsynced, flagged by Greptile as a valid P1 after merge
- Updates xai's `defaultModel` to `grok-4.5` to match the recommended flagship, consistent with how anthropic/google already keep `defaultModel` in sync with their recommended model

## Type of Change
- [x] Bug fix

## Testing
Tested manually (biome-clean, no test assertions reference the old default)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)