### PR TITLE
fix(comparison): correct stale and unsourced claims on comparison pages

### DIFF
--- a/apps/docs/content/docs/en/platform/enterprise/access-control.mdx
+++ b/apps/docs/content/docs/en/platform/enterprise/access-control.mdx
@@ -77,7 +77,7 @@ Controls which workflow blocks members can place and execute.
 
 Controls visibility of platform features and modules.
 
-<Image src="/static/enterprise/access-control-platform.png" alt="Platform tab showing feature toggles grouped by category: Sidebar (Knowledge Base, Tables, Templates), Workflow Panel (Copilot), Settings Tabs, Tools, Deploy Tabs, Features, Logs, and Collaboration" width={900} height={500} /> Each checkbox maps to a specific feature; checking it hides or disables that feature for group members.
+<Image src="/static/enterprise/access-control-platform.png" alt="Platform tab showing feature toggles grouped by category: Sidebar (Knowledge Base, Tables), Workflow Panel (Copilot), Settings Tabs, Tools, Deploy Tabs, Features, Logs, and Collaboration" width={900} height={500} /> Each checkbox maps to a specific feature; checking it hides or disables that feature for group members.
 
 **Sidebar**
 
@@ -85,7 +85,6 @@ Controls visibility of platform features and modules.
 |---------|-------------------|
 | Knowledge Base | Hides the Knowledge Base section from the sidebar |
 | Tables | Hides the Tables section from the sidebar |
-| Templates | Hides the Templates section from the sidebar |
 
 **Workflow Panel**
 

--- a/apps/sim/content/blog/ai-agent-ideas/index.mdx
+++ b/apps/sim/content/blog/ai-agent-ideas/index.mdx
@@ -27,7 +27,7 @@ The selection filter is simple. Every idea on this list handles a high-frequency
 - **Good agent ideas share three traits:** They handle repetitive, high-frequency tasks, connect to your existing tools, and produce outputs you can measure and improve.
 - **Agents reason; automations follow rules:** Unlike a static Zapier zap, an AI agent can evaluate context, choose between paths, and act across multiple systems before returning a result.
 - **Start narrow, then expand:** One trigger, one action, one output. The biggest mistake teams make is trying to automate an entire department in their first agent.
-- **Most of these ideas can be live in under an hour:** Sim offers pre-built templates for seven of the 10 ideas, plus 1,000+ integrations you can connect on a drag-and-drop canvas.
+- **Most of these ideas can be live in under an hour:** Sim's Chat can scaffold a first draft of any of these workflows from a plain-language description, and there are 1,000+ integrations you can connect on a drag-and-drop canvas.
 - **You don't need a dedicated ML team:** Visual builders and multi-model support mean developers and operators can go from idea to deployed agent without writing infrastructure code.
 
 ## What Makes an AI Agent Idea Worth Building
@@ -56,7 +56,7 @@ The value here is pure time reclamation. On the support side, manual triage slow
 
 **Key integrations:** Gmail or Microsoft Outlook, a CRM like HubSpot or Salesforce for context lookup, Slack for escalation alerts.
 
-**Getting started with Sim:** Sim includes pre-built workflow templates covering email triage, connecting these integrations on a visual canvas. You can customize the classification logic and deploy it in under an hour.
+**Getting started with Sim:** Describe the workflow to Chat and it'll scaffold an Agent block wired to these integrations on a visual canvas. You can customize the classification logic and deploy it in under an hour.
 
 ### Competitor Monitoring Agent
 
@@ -66,7 +66,7 @@ Competitive intelligence typically falls into one of two categories: expensive (
 
 **Key integrations:** Web search tools (Tavily, Exa, or Google Search), Slack for delivery, Notion or a Google Sheet for tracking changes over time.
 
-**Getting started with Sim:** Sim has a pre-built competitor monitoring template that pairs search integrations with AI summarization. Set up your target competitors, define the schedule, and let it run.
+**Getting started with Sim:** Pair a scheduled trigger with search integrations and an Agent block for AI summarization. Set up your target competitors, define the schedule, and let it run.
 
 ### Lead Enrichment and Qualification Agent
 
@@ -76,7 +76,7 @@ Sales teams lose hours every week on manual research and misrouted leads. A rep 
 
 **Key integrations:** HubSpot or Salesforce, Apollo or Hunter.io for enrichment data, Slack for routing notifications, and Google Sheets or Airtable for logging.
 
-**Getting started with Sim:** The data enrichment template in Sim gives you a ready-made starting point. You can add conditional routing logic with Sim's router blocks to score leads and send them to different reps or channels based on criteria like company size, industry, or engagement signals.
+**Getting started with Sim:** Connect your CRM and enrichment tools to an Agent block, then add conditional routing logic with Sim's router blocks to score leads and send them to different reps or channels based on criteria like company size, industry, or engagement signals.
 
 ### Meeting Follow-Up Agent
 
@@ -86,7 +86,7 @@ Action items from meetings routinely evaporate. Someone said they'd "send that d
 
 **Key integrations:** Transcription tools or calendar triggers, Slack, Notion, Linear, or Jira for task creation, Gmail for follow-up emails.
 
-**Getting started with Sim:** Sim's meeting follow-up template connects to transcription sources via webhook. You configure the AI model to identify action items, assign them based on participant context, and route the output to your preferred task management and communication tools.
+**Getting started with Sim:** Wire a webhook trigger to your transcription source and an Agent block. You configure the AI model to identify action items, assign them based on participant context, and route the output to your preferred task management and communication tools.
 
 ### Customer Support Knowledge Agent
 
@@ -98,7 +98,7 @@ Modern support agents have also matured well past simple FAQ bots. They can chec
 
 **Key integrations:** A vector knowledge base (Sim's built-in Knowledge Base, or Pinecone/Qdrant), Slack or a chat interface for customer-facing interaction, and a ticketing system for escalation.
 
-**Getting started with Sim:** The knowledge base Q&A template in Sim lets you upload documents to a vector store and configure the agent to answer questions grounded in your specific content. Set a confidence threshold for escalation and connect the output to your support channel.
+**Getting started with Sim:** Sim's built-in Knowledge Base lets you upload documents to a vector store and configure the agent to answer questions grounded in your specific content. Set a confidence threshold for escalation and connect the output to your support channel.
 
 ### Content Research and Brief Generation Agent
 
@@ -118,7 +118,7 @@ Code review is a bottleneck in most engineering teams. Reviewers queue up PRs, c
 
 **Key integrations:** GitHub or GitLab (Sim has native integrations for both), Slack for reviewer notifications.
 
-**Getting started with Sim:** Sim's code review template connects directly to your repo. Configure the review rules (style guide, test coverage requirements, naming conventions), and the agent posts its analysis as a comment on every new PR.
+**Getting started with Sim:** Trigger a workflow directly off your repo's PR events. Configure the review rules (style guide, test coverage requirements, naming conventions), and the agent posts its analysis as a comment on every new PR.
 
 ### Resume Screening Agent
 
@@ -128,7 +128,7 @@ Early-stage screening consumes a significant portion of recruiter time. When you
 
 **Key integrations:** Gmail for application intake, Google Sheets or Airtable for candidate tracking, Slack for recruiter alerts.
 
-**Getting started with Sim:** The resume scanning template in Sim handles document parsing and criteria matching. Define your rubric (years of experience, required skills, education), and the agent scores and routes each application automatically.
+**Getting started with Sim:** An Agent block with document-parsing tools handles the parsing and criteria matching. Define your rubric (years of experience, required skills, education), and the agent scores and routes each application automatically.
 
 ### Data Pipeline and Report Generation Agent
 
@@ -148,7 +148,7 @@ Brand and marketing teams either miss important conversations entirely or spend 
 
 **Key integrations:** Social listening data sources, web search tools (Tavily, Exa), Slack for delivery, Notion or Airtable for trend logging.
 
-**Getting started with Sim:** Sim's social listening template handles the monitoring and classification pipeline. Configure your target keywords, brand names, and competitors, set up the sentiment analysis, and route the results to Slack or your preferred tracking tool.
+**Getting started with Sim:** A scheduled trigger feeding an Agent block handles the monitoring and classification pipeline. Configure your target keywords, brand names, and competitors, set up the sentiment analysis, and route the results to Slack or your preferred tracking tool.
 
 ## Choosing the Right Idea for Your Team
 
@@ -179,15 +179,14 @@ Sim is the open-source AI workspace where teams build, deploy, and manage AI age
 
 The path from idea to deployed agent looks like this:
 
-- **Open the Sim canvas:** Start from a pre-built template or a blank workflow.
-- **Connect your integrations:** Drag and drop the tools your agent needs (Gmail, Slack, GitHub, your CRM, databases). Each template connects real integrations and LLMs; pick one, customize it, and deploy in minutes.
+- **Open the Sim canvas:** Start from a blank workflow, or describe it to Chat and let Sim scaffold the first draft.
+- **Connect your integrations:** Drag and drop the tools your agent needs (Gmail, Slack, GitHub, your CRM, databases).
 - **Configure the AI model:** Choose from OpenAI, Claude, Gemini, Mistral, xAI, or local models via Ollama. Swap models anytime without rebuilding your workflow.
 - **Test with real data:** Run the workflow against actual inputs to validate the output before going live.
 - **Deploy:** Launch via chat interface, REST API, webhook, or scheduled cron job, depending on your use case.
 
 Several Sim features accelerate each step:
 
-- **Pre-built templates:** Sim includes 11 pre-built workflow templates covering OCR processing, release management, meeting follow-ups, resume scanning, email triage, competitor monitoring, social listening, data enrichment, feedback analysis, code review, and knowledge base Q&A. Seven of those map directly to the ideas in this article.
 - **1,000+ integrations:** Connect Slack, Gmail, GitHub, GitLab, Notion, HubSpot, Salesforce, Airtable, Linear, Jira, PostgreSQL, Supabase, and hundreds more via drag-and-drop.
 - **Multi-model support:** Run OpenAI, Claude, Gemini, Mistral, or xAI models in the same workflow. Bring your own API keys or use Sim's hosted keys.
 - **Chat:** Talk to Sim in Chat to generate nodes, fix errors, and iterate on flows directly from natural language. Describe what you want, and Sim proposes the workflow changes.
@@ -201,7 +200,7 @@ The gap between "AI agents sound useful" and "we have an agent running in produc
 
 The teams seeing the best results in 2026 aren't building grand autonomous systems. They're prioritizing task-specific, governed AI agents that integrate with real business systems rather than broad autonomous experimentation. They're starting narrow, proving value, and expanding.
 
-Pick the idea that matches your team's biggest pain point. Open Sim, grab the template, and deploy your first agent today. You'll learn more in that first hour of building than in another month of reading about what's possible.
+Pick the idea that matches your team's biggest pain point. Open Sim, build the workflow, and deploy your first agent today. You'll learn more in that first hour of building than in another month of reading about what's possible.
 
 ## FAQ
 
@@ -211,7 +210,7 @@ Start with email triage, meeting follow-ups, or report generation. These three i
 
 ### How long does it take to build an AI agent from scratch?
 
-With a visual builder like Sim and a pre-built template, a working prototype can be ready in under an hour. You pick a template, connect your integrations, configure the AI model, and test. Custom multi-step agents with conditional logic and multiple data sources take longer, but you're still measuring build time in days, not months.
+With a visual builder like Sim, a working prototype can be ready in under an hour. You describe the workflow to Chat or start from a blank canvas, connect your integrations, configure the AI model, and test. Custom multi-step agents with conditional logic and multiple data sources take longer, but you're still measuring build time in days, not months.
 
 ### Do I need coding skills to build AI agents?
 

--- a/apps/sim/content/blog/how-to-create-an-ai-agent/index.mdx
+++ b/apps/sim/content/blog/how-to-create-an-ai-agent/index.mdx
@@ -27,7 +27,7 @@ Here's what we'll cover: what AI agents actually are (and aren't), why most tuto
 
 - **Most tutorials push you toward two extremes:** Code-heavy frameworks (LangChain, CrewAI) that require weeks of setup, or generic automation tools (Zapier, Make) that can't handle agentic reasoning. Visual AI workspaces are the third path.
 
-- **You can build and deploy your first agent in one session:** Sim's free plan at sim.ai requires no credit card, no local setup, and includes 11 pre-built templates to get started fast.
+- **You can build and deploy your first agent in one session:** Sim's free plan at sim.ai requires no credit card and no local setup, so you can go from blank canvas to a deployed agent before your coffee gets cold.
 
 - **Start narrow, then expand:** The most common beginner mistake is giving an agent too many tools and an open-ended goal. Pick one specific task, nail it, then iterate.
 
@@ -100,9 +100,7 @@ Three beginner-friendly first use cases:
 
 ### Step 2: Create a new workflow in Sim
 
-Go to sim.ai, create an account on the free plan, and create a new task or workflow. You have the option to start from a pre-built template instead of a blank canvas.
-
-Sim includes pre-built workflow templates covering many different use-cases. Each template connects real integrations and LLMs; pick one, customize it, and deploy in minutes. Starting from a template cuts setup time significantly and can spark ideas for how to use agents in your business.
+Go to sim.ai, create an account on the free plan, and create a new task or workflow. You land on a blank canvas, or you can switch to Chat and describe the agent you want in plain language to have Sim scaffold the first draft of the workflow for you.
 
 ### Step 3: Add and configure an Agent block
 
@@ -190,7 +188,7 @@ Pick whichever one solves a real problem you have this week. An agent you'll act
 
 Learning how to build AI agents doesn't require a computer science degree, a complex local development environment, or weeks of framework study. AI agent adoption in 2026 marks a transition from experimentation to execution. The tools have caught up to the ambition, and visual AI workspaces like Sim mean you can go from idea to deployed agent in a single sitting.
 
-The pattern is straightforward: define a narrow task, open a workflow, add an Agent block with the right LLM and a tight system prompt, connect two or three tools, set a trigger, and iterate using execution logs. Start with one of the pre-built templates, get it working reliably, then expand from there.
+The pattern is straightforward: define a narrow task, open a workflow, add an Agent block with the right LLM and a tight system prompt, connect two or three tools, set a trigger, and iterate using execution logs. Start with the narrowest possible version of the idea, get it working reliably, then expand from there.
 
 Trusted by over 100,000 builders at startups and Fortune 500 companies, Sim offers a free plan with no credit card required. Open it, build something, and see what an agent can do for your workflow before the week is out.
 
@@ -202,7 +200,7 @@ An AI agent perceives input, reasons over it, uses tools to take real-world acti
 
 ### Can I build an AI agent for free?
 
-Yes. Sim's free plan requires no credit card and includes execution credits for testing and development, access to the full visual workflow builder, all 11 pre-built templates, and 1,000+ integrations. You can build, test, and deploy a working agent without spending anything.
+Yes. Sim's free plan requires no credit card and includes execution credits for testing and development, access to the full visual workflow builder, and 1,000+ integrations. You can build, test, and deploy a working agent without spending anything.
 
 ### How long does it take to build an AI agent with Sim?
 

--- a/apps/sim/content/blog/openai-vs-n8n-vs-sim/index.mdx
+++ b/apps/sim/content/blog/openai-vs-n8n-vs-sim/index.mdx
@@ -121,15 +121,9 @@ Sim provides an intuitive drag-and-drop canvas where developers can build comple
 
 #### AI Copilot for Workflow Building
 
-Sim includes an intelligent in-editor AI assistant that helps you build and edit workflows faster. Copilot can explain complex concepts, suggest best practices, and even make changes to your workflow when you approve them. Using the @ context menu, you can reference workflows, blocks, knowledge bases, documentation, templates, and execution logs—giving Copilot the full context it needs to provide accurate, relevant assistance. This dramatically accelerates workflow development compared to building from scratch.
+Sim includes an intelligent in-editor AI assistant that helps you build and edit workflows faster. Copilot can explain complex concepts, suggest best practices, and even make changes to your workflow when you approve them. Using the @ context menu, you can reference workflows, blocks, knowledge bases, documentation, and execution logs—giving Copilot the full context it needs to provide accurate, relevant assistance. This dramatically accelerates workflow development compared to building from scratch.
 
 ![Sim AI Copilot assisting with workflow development](/blog/openai-vs-n8n-vs-sim/copilot.png)
-
-#### Pre-Built Workflow Templates
-
-Get started quickly with Sim's extensive library of pre-built workflow templates. Browse templates across categories like Marketing, Sales, Finance, Support, and Artificial Intelligence. Each template is a production-ready workflow you can customize for your needs, saving hours of development time. Templates are created by the Sim team and community members, with popularity ratings and integration counts to help you find the right starting point.
-
-![Sim workflow templates gallery](/blog/openai-vs-n8n-vs-sim/templates.png)
 
 #### 80+ Built-in Integrations
 

--- a/apps/sim/lib/compare/data/competitors/claude-cowork.ts
+++ b/apps/sim/lib/compare/data/competitors/claude-cowork.ts
@@ -20,13 +20,13 @@ export const claudeCoworkProfile: CompetitorProfile = {
     {
       title: 'Dynamic, runtime tool selection (no pre-wiring)',
       description:
-        'Claude picks the fastest path itself at execution time: a connector for Slack, Chrome for web research, or direct screen/computer-use to open an app when no direct integration exists, rather than a builder pre-wiring which tool/connector an agent step uses.',
+        'Claude decides itself at execution time how to reach a given goal: "Tell Claude what you need, not how" — it opens a browser for web tasks and takes over the screen directly only when it has to, rather than a builder where a user pre-wires which tool a step uses.',
       shortDescription:
-        'Claude picks connectors, browser, or screen control at runtime instead of pre-wired steps.',
+        'Claude decides whether to use the browser or take over the screen at runtime, not pre-wired steps.',
       source: {
-        url: 'https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork',
-        label: 'Anthropic/Claude documentation',
-        asOf: '2026-07-02',
+        url: 'https://claude.com/product/cowork',
+        label: 'Claude Cowork product page (Claude)',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -79,38 +79,38 @@ export const claudeCoworkProfile: CompetitorProfile = {
   ],
   limitations: [
     {
-      title: 'No unattended/webhook-triggered automation. Desktop app must stay open',
+      title: 'No webhook/external-event-triggered automation',
       description:
-        'Task initiation is either manual (prompt via desktop or mobile) or on a user-defined schedule (hourly/daily/weekly/weekdays). Scheduled tasks only run while the computer is awake and the Claude Desktop app is open; if the device sleeps or the app is closed, the run is skipped and auto-executed on next wake, with a notification. There is no external event/webhook trigger capability.',
+        "Task initiation is manual (prompt via desktop or mobile) or on a user-defined schedule (hourly/daily/weekly/weekdays). Scheduled tasks now run remotely in the cloud on their set cadence, independent of whether the user's computer is awake or the Claude Desktop app is open. There is still no external event/webhook trigger capability — only time-based scheduling.",
       shortDescription:
-        'Tasks only run manually or on a schedule while the desktop app is open and awake.',
+        'Tasks run manually or on a schedule (now remote); no external event/webhook trigger.',
       source: {
         url: 'https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-claude-cowork',
         label: 'Anthropic/Claude documentation',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
       title: 'No API publishing / callable endpoint deployment',
       description:
-        'Cowork has no mechanism to publish or deploy a task as an API endpoint that external systems can call. Unlike a Sim workflow, it is strictly a session inside the Claude Desktop (and companion mobile) app, run manually or on a schedule.',
+        'Cowork has no mechanism to publish or deploy a task as an API endpoint that external systems can call. Unlike a Sim workflow, it is strictly a session inside the Claude apps (web, desktop, and mobile), run manually or on a schedule.',
       shortDescription: 'Tasks cannot be published as callable API endpoints for external systems.',
       source: {
         url: 'https://claude.com/product/cowork',
         label: 'Anthropic/Claude documentation',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
       title: 'Cowork activity is not captured in audit logs / Compliance API',
       description:
-        'Cowork activity does not appear in the Compliance API or standard data exports. OpenTelemetry (Team/Enterprise only) is the only visibility mechanism, and it can be cross-referenced with Compliance API records via a shared user identifier, but it is not a full audit trail on its own.',
+        'Cowork activity does not appear in the Compliance API or standard data exports. OpenTelemetry (Team/Enterprise only) is the only visibility mechanism documented for streaming Cowork events to SIEM/observability tools; Anthropic does not document a way to reconcile it with Compliance API records, so it is not a full audit trail on its own.',
       shortDescription:
         'Cowork actions are absent from the Compliance API and standard data exports.',
       source: {
         url: 'https://support.claude.com/en/articles/13364135-use-claude-cowork-safely',
         label: 'Anthropic/Claude documentation',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -159,14 +159,14 @@ export const claudeCoworkProfile: CompetitorProfile = {
       selfHostOption: {
         value: 'No',
         detail:
-          "Cowork is a proprietary desktop application (macOS/Windows, Linux in beta) that requires a paid Claude plan and connects to Anthropic's cloud. There is no self-hosted or on-prem deployment option.",
+          "Cowork is a proprietary application (web, macOS/Windows desktop, and mobile; Linux desktop in beta) that requires a paid Claude plan and connects to Anthropic's cloud. There is no self-hosted or on-prem deployment option.",
         shortValue: 'No self-hosting option',
         confidence: 'verified',
         sources: [
           {
             url: 'https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork',
             label: 'Get started with Claude Cowork',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -251,21 +251,21 @@ export const claudeCoworkProfile: CompetitorProfile = {
       },
       nativeFileStorage: {
         value:
-          "No: Claude Cowork works directly on the user's local files and folders inside an isolated sandboxed VM on their own machine. It is not a native cloud file-storage product with its own folder hierarchy, link-based sharing (password/SSO options), and deleted-item recovery. Recovering files after a destructive Cowork action relies on OS-level backup tools (Time Machine, File History, iCloud) or third-party recovery scripts, not a built-in trash or recovery feature.",
+          "No: Claude Cowork works on the user's connected local files/folders (via the Desktop app) and, as of the current beta, can also execute tasks remotely in an isolated environment on Anthropic's servers, saving sessions and files to the user's Claude account; it is not a native cloud file-storage product with its own folder hierarchy, link-based sharing, and deleted-item recovery.",
         detail:
-          'Cowork has deleted user files with no built-in recovery path, underscoring that this is local file access, not a managed storage product.',
-        shortValue: 'No: operates on local files, no native cloud storage/trash',
+          'Cowork has deleted user files with no built-in recovery path, underscoring that this is task/file access rather than a managed storage product.',
+        shortValue: 'No: local files + remote beta execution, no native storage/trash',
         confidence: 'verified',
         sources: [
           {
             url: 'https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork',
             label: 'Get started with Claude Cowork',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://github.com/anthropics/claude-code/issues/32637',
             label: '[BUG] Cowork destroys user files when reorganizing (GitHub issue)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -421,16 +421,17 @@ export const claudeCoworkProfile: CompetitorProfile = {
         ],
       },
       humanInTheLoop: {
-        value: 'Yes: plan review and per-action approval by default',
+        value:
+          'Partial: per-action approval for deletions/app access by default; full plan review is opt-in',
         detail:
-          "Claude shows a plan and waits for approval before acting. Explicit permission is required before permanently deleting files and before accessing each application. An opt-in 'Act Without Asking' mode removes step-by-step pauses but increases prompt-injection risk.",
-        shortValue: 'Plan review + per-action approval',
+          "Cowork's default mode is continuous execution without pausing. Explicit permission is still required before permanently deleting files and before accessing each application. Users can opt into 'Ask before acting' mode for a plan-review/step-by-step approval workflow on high-stakes tasks.",
+        shortValue: 'Partial: deletion/app approval by default, plan review opt-in',
         confidence: 'verified',
         sources: [
           {
             url: 'https://support.claude.com/en/articles/13364135-use-claude-cowork-safely',
             label: 'Use Claude Cowork safely',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -608,14 +609,19 @@ export const claudeCoworkProfile: CompetitorProfile = {
       customCodeSteps: {
         value: 'No user-authorable code-step primitive; agent can execute code internally',
         detail:
-          'Cowork tasks run in an isolated VM and can execute code as part of completing a task, but there is no workflow-builder-style code block a user writes or inserts into a task definition.',
+          'Custom logic is added via plugins that bundle skills (instructions in SKILL.md files), connectors, and sub-agents — not a user-written code block inserted into a task. Shell commands and any code Cowork writes execute inside an isolated Linux VM as part of the agent loop, not as a user-authored step.',
         shortValue: 'No user-authorable code step',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://www.anthropic.com/product/claude-cowork',
-            label: 'Claude Cowork product page (Anthropic)',
-            asOf: '2026-07-02',
+            url: 'https://support.claude.com/en/articles/13837440-use-plugins-in-claude',
+            label: 'Use plugins in Claude',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://support.claude.com/en/articles/14479288-claude-cowork-architecture-overview',
+            label: 'Claude Cowork architecture overview',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -721,9 +727,9 @@ export const claudeCoworkProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://support.claude.com/en/articles/10015870-what-certifications-has-anthropic-obtained',
-            label: 'What Certifications has Anthropic obtained?',
-            asOf: '2026-07-02',
+            url: 'https://platform.claude.com/docs/en/manage-claude/data-residency',
+            label: 'Data residency - Claude Platform Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -758,15 +764,15 @@ export const claudeCoworkProfile: CompetitorProfile = {
       },
       additionalCompliance: {
         value:
-          'ISO 27001:2022, ISO/IEC 42001:2023, HIPAA-ready (BAA via sales-assisted Enterprise), GDPR',
+          'ISO 27001:2022, ISO/IEC 42001:2023, HIPAA-ready (BAA via sales-assisted Enterprise)',
         detail: 'Company-wide Anthropic certifications, not Cowork-scoped.',
-        shortValue: 'ISO 27001, ISO 42001, HIPAA-ready, GDPR',
+        shortValue: 'ISO 27001, ISO 42001, HIPAA-ready',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://support.claude.com/en/articles/10015870-what-certifications-has-anthropic-obtained',
             label: 'What Certifications has Anthropic obtained?',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -824,21 +830,21 @@ export const claudeCoworkProfile: CompetitorProfile = {
       },
       dataRetention: {
         value:
-          'Yes: Enterprise plan Owners/Primary Owners can set a custom data retention period (minimum 30 days) for conversation data and audit logs in Organization settings > Data and Privacy. Without customization, data is kept indefinitely.',
+          "Yes for org-wide Claude data, but this does not cover Cowork: Enterprise plan Owners/Primary Owners can set a custom data retention period (minimum 30 days) for conversation and project data in Organization settings > Data and Privacy, and data is kept indefinitely without customization. Cowork conversation history is stored locally on users' computers, is not subject to this standard retention policy, and cannot be centrally managed or exported by admins; Cowork activity is also not currently captured in the Compliance API.",
         detail:
-          "This is an org-wide Claude Enterprise setting, not per-resource-type the way Sim's granular retention is. Cowork's local session history sits outside this policy entirely, stored only on-device. Anthropic's current documentation does not describe a Zero-Data-Retention addendum for conversation data.",
-        shortValue: 'Yes: org-configurable retention, min 30 days, indefinite by default',
+          "This is an org-wide Claude Enterprise setting, not per-resource-type the way Sim's granular retention is, and it explicitly excludes Cowork. Cowork's local session history sits outside this policy entirely, stored only on-device. No Zero-Data-Retention addendum is described for conversation data.",
+        shortValue: 'Org retention is min 30 days, but Cowork history stays local, unmanaged',
         confidence: 'verified',
         sources: [
           {
             url: 'https://privacy.claude.com/en/articles/10440198-configure-custom-data-retention-controls-for-enterprise-plans',
             label: 'Configure custom data retention controls for Enterprise plans',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://support.claude.com/en/articles/13455879-use-claude-cowork-on-team-and-enterprise-plans',
             label: 'Use Claude Cowork on Team and Enterprise plans',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -917,30 +923,30 @@ export const claudeCoworkProfile: CompetitorProfile = {
         ],
       },
       durabilityModel: {
-        value: 'Weak. Client-dependent, not durable server-side execution',
+        value: 'Durable server-side execution for scheduled tasks',
         detail:
-          "Scheduled tasks only run while the computer is awake and Claude Desktop is open. A missed run due to sleep or a closed app is skipped and auto-run on next wake (with a notification), rather than executed at the scheduled time on infrastructure independent of the user's machine.",
-        shortValue: 'Client-dependent, not server-durable',
+          "Scheduled tasks in Claude Cowork now run remotely on Anthropic's infrastructure, independent of whether the user's computer is awake or the Desktop app is open — this is durable server-side execution, not client-dependent.",
+        shortValue: 'Server-durable: runs remotely regardless of device state',
         confidence: 'verified',
         sources: [
           {
             url: 'https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-claude-cowork',
             label: 'Schedule recurring tasks in Claude Cowork',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       failureAlerting: {
-        value: 'Minimal. Notification only for skipped scheduled runs',
+        value: 'Not documented under the current remote-execution model',
         detail:
-          'Users receive a notification when a scheduled task run is skipped because the computer was asleep or the app was closed. There is no broader failure-alerting/retry policy for task errors.',
-        shortValue: 'Notifies only on skipped runs',
-        confidence: 'estimated',
+          'Earlier documentation described a notification only when a scheduled run was skipped due to sleep/closed app, but that premise no longer applies now that scheduled tasks run remotely regardless of device state. The current schedule-recurring-tasks article is silent on failure/retry alerting for task errors, so this behavior should be treated as unverified pending updated Anthropic documentation.',
+        shortValue: 'Not documented; prior skipped-run notification premise is outdated',
+        confidence: 'unknown',
         sources: [
           {
             url: 'https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-claude-cowork',
             label: 'Schedule recurring tasks in Claude Cowork',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -976,21 +982,22 @@ export const claudeCoworkProfile: CompetitorProfile = {
       },
       asyncExecution: {
         value:
-          'No: Claude Cowork does not offer true server-side background execution you can walk away from indefinitely. The Claude Desktop app must remain open while Claude works, and closing the app ends the session. Scheduled/recurring tasks (set up via the /schedule skill) run at a set cadence, but only while the computer is awake and the desktop app is open, and they are skipped, then caught up later, if the app is closed when the run was due.',
+          "Yes: Claude Cowork now supports true server-side background execution: remote sessions and scheduled tasks continue running on Anthropic's infrastructure even when the Desktop app is closed or the computer is asleep, except for tasks that require local file or browser access, which still need the app open.",
         detail:
-          "The phrase 'assign a task and step away' means you don't have to babysit each step in real time within an open session, and scheduled tasks let you check back later for results. But this is not equivalent to a cloud job you can trigger and poll while fully offline: the desktop app and an awake machine are hard prerequisites.",
-        shortValue: 'Requires app open, not fully async',
+          "The phrase 'assign a task and step away' now more closely matches a real cloud job: remote sessions and scheduled/recurring tasks (set up via the /schedule skill) run on their cadence independent of device state. Tasks that need local file system or browser access are the exception and still require the desktop app open on an awake machine.",
+        shortValue:
+          'Yes: remote sessions/tasks run without the app open, with local-access exceptions',
         confidence: 'verified',
         sources: [
           {
             url: 'https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork',
             label: 'Get started with Claude Cowork (Claude Help Center)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-claude-cowork',
             label: 'Schedule recurring tasks in Claude Cowork (Claude Help Center)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://www.anthropic.com/product/claude-cowork',
@@ -1048,16 +1055,16 @@ export const claudeCoworkProfile: CompetitorProfile = {
       },
       unattendedExecution: {
         value:
-          'No: scheduled tasks require the Claude Desktop app open and the computer awake on the client device',
+          "Yes: scheduled tasks execute server-side/remotely on Anthropic's infrastructure, independent of whether the Claude Desktop app is open or the device is awake, per Anthropic's current documentation",
         detail:
-          "There is no server-side execution path independent of the client. A scheduled/recurring task only fires while the desktop app is running and the machine is awake; if the device sleeps or the app is closed when a run is due, that run is skipped and auto-executed on next wake, with a notification, rather than firing on schedule from infrastructure independent of the user's machine.",
-        shortValue: 'No: requires desktop app open and computer awake',
+          "Scheduled/recurring tasks now run on their cadence on Anthropic's infrastructure regardless of client device state. Tasks that require local file or browser access remain the exception and still need the desktop app open and the machine awake.",
+        shortValue: 'Yes: runs remotely regardless of desktop app/device state',
         confidence: 'verified',
         sources: [
           {
             url: 'https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-claude-cowork',
             label: 'Schedule recurring tasks in Claude Cowork',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/crewai.ts
+++ b/apps/sim/lib/compare/data/competitors/crewai.ts
@@ -31,12 +31,12 @@ export const crewaiProfile: CompetitorProfile = {
     {
       title: 'Large, fast-growing open-source community',
       description:
-        'The crewAIInc/crewAI GitHub repository has surpassed 54,800 stars and is MIT licensed, one of the most-starred open-source multi-agent orchestration frameworks. CrewAI reports its open-source framework executes over 10 million agents per month and is used by roughly half of the Fortune 500.',
-      shortDescription: '54,800+ GitHub stars, MIT licensed, widely adopted.',
+        'The crewAIInc/crewAI GitHub repository has surpassed 55,000 stars and is MIT licensed, one of the most-starred open-source multi-agent orchestration frameworks. CrewAI reports over 100,000 developers certified through its community courses at learn.crewai.com.',
+      shortDescription: '55,000+ GitHub stars, MIT licensed, 100,000+ certified developers.',
       source: {
         url: 'https://github.com/crewAIInc/crewAI',
         label: 'crewAIInc/crewAI (GitHub)',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -91,12 +91,12 @@ export const crewaiProfile: CompetitorProfile = {
       title:
         'Human-in-the-loop input is a blocking, single-step primitive, not a rich approval workflow',
       description:
-        "The framework's built-in human_input=True flag on a Task pauses for a human response, but it is limited to synchronous stdin-style input in local runs. Production human-in-the-loop, via AMP webhooks and a pending-review state, requires the paid platform and custom webhook wiring rather than a built-in multi-channel approval UI.",
-      shortDescription: 'Basic human_input flag is stdin-style; rich approval needs AMP webhooks.',
+        "HITL in the open-source framework is now the @human_feedback decorator on Flows (v1.8.0+), which pauses for synchronous, console-based review in local runs, replacing the older Task human_input=True flag. Production HITL, via webhooks, an in-platform pending-review state, responder assignment, SLAs, and escalation policies (the 'Flow HITL Management Platform'), requires CrewAI AMP/Enterprise.",
+      shortDescription: 'OSS HITL is console-based via @human_feedback; rich approval needs AMP.',
       source: {
         url: 'https://docs.crewai.com/en/learn/human-in-the-loop',
         label: 'Human-in-the-Loop (HITL) Workflows - CrewAI Docs',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -415,9 +415,9 @@ export const crewaiProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://towardsdatascience.com/how-to-implement-guardrails-for-your-ai-agents-with-crewai-80b8cb55fa43/',
-            label: 'How to Implement Guardrails for Your AI Agents with CrewAI',
-            asOf: '2026-07-02',
+            url: 'https://docs.crewai.com/en/concepts/tasks',
+            label: 'Tasks (Guardrails) - CrewAI Docs',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.crewai.com/en/enterprise/features/hallucination-guardrail',
@@ -428,46 +428,51 @@ export const crewaiProfile: CompetitorProfile = {
       },
       humanInTheLoop: {
         value:
-          'Yes: a human_input flag pauses a Task for review; AMP adds a webhook-driven pending-review state',
+          'Yes: the @human_feedback decorator pauses a Flow for review, plus a Task-level human_input parameter; AMP adds a webhook-driven pending-review state',
         detail:
-          'Setting human_input=True on a Task pauses execution for human feedback before continuing, though the base mechanism is a synchronous, stdin-style prompt in local runs. CrewAI AMP extends this to a "Pending Human Input" state for deployed crews, where a reviewer\'s feedback and approval are submitted via task/webhook URLs to resume execution asynchronously.',
-        shortValue: 'Yes, human_input Task flag; async pending-review state on AMP',
+          'CrewAI supports human-in-the-loop via the @human_feedback decorator on Flows (v1.8.0+), which pauses for synchronous, console-based review in local runs, and a separate human_input Task parameter for agent-level review. CrewAI AMP/Enterprise extends this to a "Pending Human Input" state for deployed crews, resumed asynchronously via webhook URLs.',
+        shortValue: 'Yes, @human_feedback Flow decorator and Task human_input; async on AMP',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.crewai.com/en/learn/human-in-the-loop',
             label: 'Human-in-the-Loop (HITL) Workflows - CrewAI Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       generativeMedia: {
         value:
-          'Partial: image generation and vision tools exist via community/first-party tools, not a broad native suite',
+          'Partial: image generation and vision tools exist via first-party tools, not a broad native suite',
         detail:
-          'crewAI-tools includes a DallETool (image generation) and a VisionTool, giving CrewAI agents first-party access to image generation and image understanding. No native video-generation or text-to-speech/speech-to-text tool ships in the core crewAI-tools package; those require calling a provider directly through a custom or community tool.',
+          "crewAI's tools package (now maintained at github.com/crewAIInc/crewAI/tree/main/lib/crewai-tools, formerly the standalone crewAI-tools repo, archived November 2025) includes a DallETool (image generation) and a VisionTool, giving CrewAI agents first-party access to image generation and image understanding. No native video-generation or text-to-speech/speech-to-text tool ships in the core package; those require calling a provider directly through a custom or community tool.",
         shortValue: 'DallETool and VisionTool ship; no native video/TTS tool',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://github.com/crewAIInc/crewAI-tools',
-            label: 'crewAIInc/crewAI-tools (GitHub)',
-            asOf: '2026-07-02',
+            url: 'https://github.com/crewAIInc/crewAI/tree/main/lib/crewai-tools',
+            label: 'crewAIInc/crewAI - lib/crewai-tools (GitHub)',
+            asOf: '2026-07-08',
           },
         ],
       },
       dynamicToolUse: {
         value:
-          'Yes: an Agent selects among all tools assigned to it at reasoning time, rather than a fixed pre-wired call',
+          'Yes: agents call tools via LLM function-calling during execution, choosing among their assigned tools at each step',
         detail:
-          "An Agent's `tools` list is the pool it reasons over; the agent's LLM decides at runtime which tool, if any, to invoke for a given step, including tools loaded dynamically from an MCP server via MCPServerAdapter. This is a design property of the Agent/Task model itself, not a separately named feature.",
-        shortValue: 'Yes, agents reason over their assigned tool pool at runtime',
+          "An Agent's `tools` list (including tools loaded dynamically from an MCP server via MCPServerAdapter) is a set of callable functions passed to a function-calling LLM; the model decides which tool, if any, to call at each step of execution. CrewAI's own docs don't name this as a distinct feature: the Agents/Tools concept pages only show tools statically assigned at agent creation, and the underlying per-step tool-call behavior surfaces indirectly through CrewAI's Tool Call Hooks, which intercept tool calls the agent makes during execution.",
+        shortValue: 'Yes, via LLM function-calling per step; not documented as a named feature',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.crewai.com/en/concepts/agents',
             label: 'Agents - CrewAI Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.crewai.com/en/learn/tool-hooks',
+            label: 'Tool Call Hooks - CrewAI Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -576,21 +581,21 @@ export const crewaiProfile: CompetitorProfile = {
     integrations: {
       integrationCount: {
         value:
-          'crewAI-tools ships dozens of first-party tools; broader integration reach comes via Composio (1,000+ apps)',
+          'crewai-tools ships 70+ first-party tools; broader integration reach comes via Composio (250+ production-ready tools)',
         detail:
-          'The official crewAIInc/crewAI-tools repository provides dozens of built-in tools spanning file operations, web scraping, database search (Postgres, MySQL), search APIs, and AI tools (DALL-E, Vision); there is no single vendor-published total count. CrewAI docs separately show first-party ComposioTool integration, and Composio advertises 1,000+ pre-authenticated third-party apps pluggable into CrewAI agents.',
-        shortValue: 'Dozens of first-party tools; 1,000+ apps via Composio',
+          "crewAI's tools package (now maintained at github.com/crewAIInc/crewAI/tree/main/lib/crewai-tools, formerly the standalone crewAI-tools repo, archived November 2025) ships over 70 built-in tool modules spanning file operations, web scraping, database search (Postgres, MySQL, Snowflake, Databricks), search APIs, and AI tools (DALL-E, Vision, OCR); there is no single vendor-published total count. CrewAI docs separately show first-party ComposioTool integration, and Composio's own CrewAI docs advertise 250+ production-ready tools pluggable into CrewAI agents.",
+        shortValue: '70+ first-party tools; 250+ via Composio',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://github.com/crewAIInc/crewAI-tools',
-            label: 'crewAIInc/crewAI-tools (GitHub)',
-            asOf: '2026-07-02',
+            url: 'https://github.com/crewAIInc/crewAI/tree/main/lib/crewai-tools/src/crewai_tools/tools',
+            label: 'crewAIInc/crewAI - lib/crewai-tools/tools directory (GitHub)',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.crewai.com/en/tools/automation/composiotool',
             label: 'Composio Tool - CrewAI Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -665,31 +670,31 @@ export const crewaiProfile: CompetitorProfile = {
     pricing: {
       pricingModel: {
         value:
-          'Free open-source framework (self-hosted); CrewAI AMP tiers priced per monthly workflow execution plus seats',
+          'Free open-source framework (self-hosted); CrewAI AMP offers a free Basic tier plus custom Enterprise pricing',
         detail:
-          'The open-source Python framework has no license cost. CrewAI AMP is priced on a Free/Basic tier (50 executions/month), a Professional tier ($25/month, roughly double the execution cap plus an extra seat), and custom-quoted Enterprise pricing for compliance, dedicated support, and private-infrastructure deployment.',
-        shortValue: 'Free framework; AMP billed by monthly executions plus seats',
+          "The open-source Python framework has no license cost. CrewAI AMP currently lists a free Basic tier (50 executions/month) and custom-quoted Enterprise pricing for compliance, dedicated support, and private-infrastructure deployment; no separate mid-tier paid plan is currently shown on CrewAI's pricing page.",
+        shortValue: 'Free framework; AMP has a free Basic tier and custom Enterprise pricing',
         confidence: 'verified',
         sources: [
           {
             url: 'https://crewai.com/pricing',
             label: 'CrewAI Pricing',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       entryPaidPlan: {
         value:
-          'CrewAI AMP Professional: $25/month, roughly 100 workflow executions/month plus one added seat',
+          'No mid-tier paid plan currently listed; CrewAI AMP pricing goes from a free Basic tier straight to custom Enterprise pricing',
         detail:
-          "The Free/Basic AMP tier includes 50 executions/month; third-party pricing analyses put the $25/month Professional tier at roughly double that cap (about 100 executions/month) plus a team seat. CrewAI's own pricing page does not spell out the exact numeric caps per tier beyond the free tier's 50 executions/month.",
-        shortValue: '$25/month, ~100 executions/month, +1 seat',
+          "CrewAI AMP pricing currently lists only a free Basic tier (50 executions/month) and custom Enterprise pricing; the previously offered $25/month Professional tier is no longer shown on CrewAI's pricing page.",
+        shortValue: 'None currently listed: free Basic tier, then custom Enterprise',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://crewai.com/pricing',
             label: 'CrewAI Pricing',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -749,9 +754,9 @@ export const crewaiProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://sambanova.ai/blog/sambanova-and-crewai-partner-to-deliver-agentic-ai-at-scale-on-crewai-amp',
-            label: 'SambaNova and CrewAI Partner on CrewAI AMP',
-            asOf: '2026-07-02',
+            url: 'https://docs.crewai.com/en/enterprise/features/sso',
+            label: 'SSO - CrewAI Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -764,9 +769,9 @@ export const crewaiProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://sambanova.ai/blog/sambanova-and-crewai-partner-to-deliver-agentic-ai-at-scale-on-crewai-amp',
-            label: 'SambaNova and CrewAI Partner on CrewAI AMP',
-            asOf: '2026-07-02',
+            url: 'https://docs.crewai.com/en/enterprise/features/sso',
+            label: 'SSO - CrewAI Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -876,9 +881,9 @@ export const crewaiProfile: CompetitorProfile = {
       },
       thirdPartyVetting: {
         value:
-          'Partial: the core crewai-tools package is maintainer-reviewed, but the Enterprise Tool Repository lets any org publish public tools with only automated security checks, and CrewAI also supports the open, community-run MCP server ecosystem',
+          'Partial: the core crewai-tools code is maintainer-reviewed in the main crewAI repo, but the platform Tool Repository lets any org publish public tools with only automated security checks, and CrewAI also supports the open, community-run MCP server ecosystem',
         detail:
-          "CrewAI's official crewai-tools GitHub repository is a first-party, contribution-reviewed catalog: community pull requests are merged by CrewAI maintainers. Separately, CrewAI's Enterprise docs describe a Tool Repository where any user with org permissions can publish a tool with the --public flag, making it installable by other users; the docs state only that 'every published version undergoes automated security checks' before install, with no described human/editorial review process. CrewAI also supports the Model Context Protocol, giving agents access to 'thousands of tools from hundreds of MCP servers built by the community,' third-party code not authored or reviewed by CrewAI. No CrewAI-specific documented security incident (malicious tool, credential leak via a community tool or MCP server) was found in public sources.",
+          "crewAI's tools code now lives in the main crewAI monorepo (github.com/crewAIInc/crewAI/tree/main/lib/crewai-tools; the standalone crewAI-tools repo is archived as of November 2025) and is maintainer-reviewed via PRs there. Separately, CrewAI's platform docs describe a Tool Repository where any user with org permissions can publish a tool with the --public flag, making it installable by other users; the docs state only that 'every published version undergoes automated security checks' before install, with no described human/editorial review process, and it is not documented as an Enterprise-exclusive tier. CrewAI also supports the Model Context Protocol, giving agents access to 'thousands of tools from hundreds of MCP servers built by the community,' third-party code not authored or reviewed by CrewAI. No CrewAI-specific documented security incident (malicious tool, credential leak via a community tool or MCP server) was found in public sources.",
         shortValue: 'Partial, reviewed core repo + open public Tool Repository + community MCP',
         confidence: 'estimated',
         sources: [
@@ -888,9 +893,9 @@ export const crewaiProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://github.com/crewAIInc/crewAI-tools',
-            label: 'crewAI-tools GitHub repository',
-            asOf: '2026-07-02',
+            url: 'https://github.com/crewAIInc/crewAI/tree/main/lib/crewai-tools',
+            label: 'crewAIInc/crewAI - lib/crewai-tools (GitHub)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -936,16 +941,31 @@ export const crewaiProfile: CompetitorProfile = {
       },
       dataDrains: {
         value:
-          'Yes: third-party OpenTelemetry-based exports to Datadog, Dynatrace, SigNoz, and Instana are documented',
+          'Yes: OpenTelemetry-based exports to Datadog are documented by CrewAI; Dynatrace, SigNoz, and IBM Instana document their own CrewAI support',
         detail:
-          'CrewAI traces and execution data can be continuously exported to external observability platforms via OpenTelemetry-based integrations (documented by Datadog, Dynatrace, SigNoz, and IBM Instana), beyond viewing traces inside the native AMP dashboard.',
-        shortValue: 'Yes, via OpenTelemetry to Datadog/Dynatrace/SigNoz/Instana',
+          "CrewAI's own docs show traces exported straight to Datadog's OTLP intake, plus generic OTLP-compatible backend examples (Grafana, Honeycomb, New Relic). Separately, Dynatrace, SigNoz, and IBM Instana each document OpenTelemetry-based CrewAI support on their own sites (not in CrewAI's docs), so exporting continuously to any of those platforms, beyond viewing traces in the native AMP dashboard, is documented, just split across CrewAI's and each vendor's own pages.",
+        shortValue: 'Yes, via OpenTelemetry; Datadog documented by CrewAI, others by the vendor',
         confidence: 'verified',
         sources: [
           {
+            url: 'https://docs.crewai.com/en/enterprise/guides/capture_telemetry_logs',
+            label: 'Capture Telemetry Logs - CrewAI Docs',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://www.dynatrace.com/hub/detail/crewai-observability/',
+            label: 'CrewAI monitoring & observability - Dynatrace Hub',
+            asOf: '2026-07-08',
+          },
+          {
             url: 'https://signoz.io/docs/crewai-observability/',
             label: 'CrewAI Observability & Monitoring with OpenTelemetry - SigNoz Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://www.ibm.com/docs/en/instana-observability/1.0.304?topic=frameworks-crewai',
+            label: 'CrewAI - IBM Instana Observability Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -958,9 +978,9 @@ export const crewaiProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.crewai.com/how-to/kickoff-async',
+            url: 'https://docs.crewai.com/en/learn/kickoff-async',
             label: 'Kickoff Crew Asynchronously - CrewAI Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -988,9 +1008,9 @@ export const crewaiProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://towardsdatascience.com/how-to-implement-guardrails-for-your-ai-agents-with-crewai-80b8cb55fa43/',
-            label: 'How to Implement Guardrails for Your AI Agents with CrewAI',
-            asOf: '2026-07-02',
+            url: 'https://docs.crewai.com/en/concepts/tasks',
+            label: 'Tasks (Guardrails - guardrail_max_retries) - CrewAI Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1008,9 +1028,9 @@ export const crewaiProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://docs.crewai.com/enterprise/guides/use-crew-api',
-            label: 'Trigger Deployed Crew API - CrewAI Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.crewai.com/en/enterprise/guides/kickoff-crew',
+            label: 'Kickoff Crew - CrewAI Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1074,16 +1094,22 @@ export const crewaiProfile: CompetitorProfile = {
         ],
       },
       academy: {
-        value: 'Yes: CrewAI offers free, structured courses at learn.crewai.com',
+        value:
+          'Partial: CrewAI offers a free short course hosted on DeepLearning.AI, linked from learn.crewai.com',
         detail:
-          'CrewAI operates a learning platform with self-paced, structured courses covering the framework, Flows, and agent-building concepts, beyond ad hoc blog posts or docs pages.',
-        shortValue: "Yes, free structured courses at CrewAI's learning platform",
+          'CrewAI offers a short course, \'Multi AI Agent Systems with crewAI,\' hosted on DeepLearning.AI and linked from learn.crewai.com, covering the framework and agent-building concepts, beyond ad hoc blog posts or docs pages. The DeepLearning.AI course page states access is free ("free for a limited time during the DeepLearning.AI learning platform beta"). learn.crewai.com itself is a marketing landing page that points to this single third-party course rather than hosting a broader in-house curriculum.',
+        shortValue: 'Partial, one free DeepLearning.AI course linked from learn.crewai.com',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://learn.crewai.com',
             label: 'CrewAI Academy (learn.crewai.com)',
-            asOf: '2026-07-04',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://www.deeplearning.ai/short-courses/multi-ai-agent-systems-with-crewai/',
+            label: 'Multi AI Agent Systems with crewAI - DeepLearning.AI',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/dust.ts
+++ b/apps/sim/lib/compare/data/competitors/dust.ts
@@ -179,36 +179,31 @@ export const dustProfile: CompetitorProfile = {
       },
       deploymentOptions: {
         value:
-          'Multi-tenant hosted cloud with a choice of US or EU data-hosting region; Enterprise plan adds single-tenant deployment',
+          'Multi-tenant hosted cloud by default; an EU data-hosting option for databases, files, and vectors is available, documented as exclusive to Enterprise customers rather than a self-serve region choice on every tier',
         detail:
-          "Dust's Enterprise plan documentation lists 'US & EU data residency options' and 'single-tenant deployment' alongside SSO/SCIM; lower tiers are multi-tenant cloud only.",
-        shortValue: 'Hosted cloud, US/EU regions, single-tenant on Enterprise',
+          "Dust's changelog states the EU data hosting option is 'available exclusively for enterprise customers' and covers 'storage of databases, files, and vectors' (calls to third-party LLM provider APIs remain outside this hosting boundary). No Dust source documents a selectable US-region toggle or a named single-tenant deployment tier.",
+        shortValue: 'Multi-tenant cloud by default; EU data hosting is Enterprise-exclusive',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.dust.tt/changelog/eu-data-hosting-option-available',
             label: 'EU data hosting option available | Dust changelog',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://dust.tt/home/enterprise',
-            label: 'Dust for Enterprise',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       templates: {
         value:
-          'Yes: a Template Gallery of pre-built agents organized by department/use case (Sales, Support, Marketing, Engineering, HR, IT operations)',
+          'Yes: a Template Gallery of pre-built agents organized by department/use case (Sales, Customer Support, Marketing, Engineering, Data Analytics, Knowledge Management, Recruiting, Product Design, Collaboration)',
         detail:
-          "Selecting a template opens a Sidekick-guided creation flow pre-loaded with the template's instructions and suggested tools/data sources, which the builder then reviews, adjusts, and publishes.",
+          "Selecting a template opens a Sidekick-guided creation flow pre-loaded with the template's instructions and suggested tools/data sources; templates are organized by department/use case including Sales, Customer Support, Marketing, Engineering, Data Analytics, Knowledge Management, Recruiting, Product Design, and Collaboration. The builder reviews, adjusts, and publishes from there.",
         shortValue: 'Template gallery organized by department/use case',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.dust.tt/docs/templates',
             label: 'Templates | Dust Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -346,16 +341,16 @@ export const dustProfile: CompetitorProfile = {
     aiCapabilities: {
       multiLlmSupport: {
         value:
-          'Yes: agents can be configured with a choice of model (e.g. GPT-5, Claude, Gemini, Mistral) and a creativity/temperature setting, selectable per agent',
+          'Yes: agents can be configured with a choice of model (e.g. GPT-4 Turbo, Claude 3, Gemini Pro, Mistral Large) and a Reasoning Effort setting, selectable per agent',
         detail:
-          'Advanced agent settings let a builder pick the model and a temperature preset (Creative, Balanced, Factual, Deterministic); marketing materials name GPT-5, Claude, Gemini, and Mistral as selectable models.',
-        shortValue: 'GPT-5, Claude, Gemini, Mistral selectable per agent',
+          'Advanced agent settings let a builder pick the model and a reasoning-effort level (Light, Medium, High); Dust docs name GPT-4 Turbo, Claude 3, Gemini Pro, and Mistral Large as selectable models.',
+        shortValue: 'GPT-4 Turbo, Claude 3, Gemini Pro, Mistral Large selectable per agent',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.dust.tt/docs/what-settings-model-should-i-use',
             label: 'What settings / model should I use? | Dust Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -441,36 +436,37 @@ export const dustProfile: CompetitorProfile = {
       },
       humanInTheLoop: {
         value:
-          "Yes: MCP tool execution supports an approval step ('always ask' vs. auto-execute) before a tool call runs, and Dust's own guidance recommends human approval checkpoints before irreversible agent actions",
+          "Yes: MCP tool execution uses a stakes-tiered approval model (high/medium/low-stake tools, with argument-level approval required for certain medium-stake tool parameters), not a simple 'always ask' vs. auto-execute toggle, and Dust's own guidance recommends human approval before irreversible agent actions",
         detail:
-          "Dust's MCP tool architecture includes an approval-workflow layer for tool execution, and Dust recommends 'mandatory steps, and human approval points before any irreversible action' for consequential agent actions. This is tool-execution approval, not a single named workflow node like a dedicated approval action in a workflow tool.",
-        shortValue: 'MCP tool-execution approval step; documented best-practice guidance',
+          "Dust's MCP tool architecture tiers tools by stake level and requires argument-level approval for certain medium-stake tool parameters before execution, and Dust recommends 'mandatory steps, and human approval points before any irreversible action' for consequential agent actions. This is a graduated tool-execution approval model, not a single named workflow node like a dedicated approval action in a workflow tool.",
+        shortValue: 'Stakes-tiered MCP approval model; documented best-practice guidance',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://deepwiki.com/dust-tt/dust/4-agent-system',
             label: 'MCP Tool System | dust-tt/dust | DeepWiki',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://dust.tt/blog/ai-agent-workflows',
             label: 'AI agent workflows: How they work and how to build your own | Dust Blog',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       generativeMedia: {
         value:
-          'Partial: native image generation (via Gemini/Nano Banana) with reference-image consistency and parallel generation is built in; there is no dedicated native video-generation or text-to-speech/speech-to-text block',
+          "Partial: native image generation (via Google's gemini-3-pro-image model) with reference-image consistency (up to 14 reference images) and parallel generation is built in; there is no dedicated native video-generation block, though a separate 'Voice and sound generation' tool exists for audio",
         detail:
-          "Dust's Image Generation capability uses an underlying Gemini image model, supports up to 14 reference images for visual consistency across a series, and can run multiple generations in parallel; generated images are filtered for safety. Video and TTS/STT were not found as native Dust capabilities.",
-        shortValue: 'Native image generation with reference images; no native video/audio gen',
+          "Dust's Image Generation capability uses Google's gemini-3-pro-image model, supports up to 14 reference images for visual consistency across a series, and can run multiple generations in parallel; generated images are filtered for safety. A separate 'Voice and sound generation' tool provides native audio generation, but no dedicated native video-generation block was found.",
+        shortValue:
+          'Native image gen (gemini-3-pro-image) + reference images; separate audio tool; no native video',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.dust.tt/docs/image-generation',
             label: 'Image Generation | Dust Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -529,16 +525,17 @@ export const dustProfile: CompetitorProfile = {
       },
       kbChunkVisibility: {
         value:
-          "Partial: Dust surfaces footnote-style citations tied to a specific source document in agent answers, but there's no dedicated raw chunk-index/content debugging inspector distinct from citation footnotes",
+          "Partial: Dust's product UI surfaces citations tied to a specific source document in agent answers, but there's no dedicated raw chunk-index/content debugging inspector distinct from those citations",
         detail:
-          "Documentation confirms the Search/RAG method attributes answers to specific source documents via citations. Whether a raw chunk-content inspector view exists as a separate debugging surface isn't confirmed in available docs.",
-        shortValue: 'Citations point to source documents; raw chunk inspector not confirmed',
+          "Dust's general RAG/Search explainer describes semantic retrieval but doesn't itself document citation formatting; the citation behavior (source documents listed under an answer, or visible via 'tool inspection') is described in Dust's own community support threads rather than a product page, and appears to vary by model. Whether a raw chunk-content inspector exists as a separate debugging surface isn't confirmed in official docs.",
+        shortValue:
+          'Citations confirmed via product UI/community support, not a docs page; chunk inspector unconfirmed',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://docs.dust.tt/docs/understanding-retrieval-augmented-generation-rag-and-the-search-method-in-dust',
-            label: 'Understanding Retrieval Augmented Generation (RAG) | Dust Docs',
-            asOf: '2026-07-02',
+            url: 'https://community.dust.tt/x/03help/6ku3a37chfyo/how-to-access-documents-from-the-dust-agent-a-guid',
+            label: 'How to Access Documents from the Dust Agent | Dust Community',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -599,16 +596,17 @@ export const dustProfile: CompetitorProfile = {
       },
       triggerTypes: {
         value:
-          'Natural-language scheduled triggers and event-based triggers from connected systems (e.g. Slack messages), invoked in addition to manual chat invocation',
+          'Natural-language scheduled triggers and event-based triggers from connected systems (e.g. GitHub, Jira, Zendesk, Linear, Fathom, or custom webhooks), invoked in addition to manual chat invocation',
         detail:
-          "Scheduled triggers run an agent on a recurring, plain-language schedule ('Every weekday at 8:30am') without cron syntax; Dust's Triggers feature separately supports agents reacting to events from external systems rather than only manual chat.",
-        shortValue: 'Natural-language schedules plus event-based triggers',
+          "Scheduled triggers run an agent on a recurring, plain-language schedule ('Every weekday at 8:30am') without cron syntax; Dust's Webhook Triggers separately let agents react to events from built-in providers (GitHub, Jira, Zendesk, Linear, Fathom) or custom webhooks, rather than only manual chat.",
+        shortValue:
+          'Natural-language schedules plus webhook triggers (GitHub, Jira, Zendesk, Linear, Fathom)',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.dust.tt/docs/triggers',
             label: 'Triggers | Dust Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -885,21 +883,27 @@ export const dustProfile: CompetitorProfile = {
       },
       thirdPartyVetting: {
         value:
-          'Partial: native data connections (Slack, Notion, GitHub, Salesforce, and 50+ others) are first-party and built/maintained by the Dust team, but agent tools can also be extended with any external MCP server by pasting its public URL, with no Dust-led vetting or review of that server',
+          'Partial: native data connections (11 fully-managed sources including Google Drive, Notion, Confluence, GitHub, Salesforce, Microsoft, Snowflake, BigQuery, Zendesk, Gong, and Intercom) are first-party and built/maintained by the Dust team; Slack and dozens of other business tools (Airtable, Asana, HubSpot, Jira, Salesloft, and more) are documented as separate MCP-based Tools rather than native Connections, and agent tools can also be extended with any external MCP server by pasting its public URL, with no Dust-led vetting or review of that server',
         detail:
-          "Docs describe adding a remote MCP server as entering the server's public URL, with workspace admins responsible for choosing and authenticating it. No formal Dust review process is described, unlike the fully managed first-party connectors, and no publicly documented security incident involving a malicious or compromised third-party MCP server on Dust was found.",
-        shortValue: 'First-party connectors, open bring-your-own-URL MCP tools',
+          "Docs list 11 fully-managed native Connections under Connections Management, while Dust's own Slack integration docs describe it as 'Slack MCP tools' added by selecting Slack 'from the available MCP servers,' distinct from that native Connections list. Dust's Tools catalog documents dozens of further business-tool integrations (Airtable, Asana, HubSpot, Jira, Salesloft, and more) alongside the ability to add any external MCP server by pasting its public URL, with workspace admins responsible for choosing and authenticating it. No formal Dust review process is described for pasted third-party MCP server URLs, and no publicly documented security incident involving a malicious or compromised third-party MCP server on Dust was found.",
+        shortValue:
+          '11 first-party Connections; Slack + dozens more via MCP-based Tools; open bring-your-own-URL MCP',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.dust.tt/docs/remote-mcp-server',
-            label: 'Adding an MCP Server',
-            asOf: '2026-07-02',
+            url: 'https://docs.dust.tt/docs/connections',
+            label: 'Connections | Dust Docs',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://docs.dust.tt/docs/connections',
-            label: 'Connections',
-            asOf: '2026-07-02',
+            url: 'https://docs.dust.tt/docs/slack-mcp',
+            label: 'Slack tools | Dust Docs',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.dust.tt/docs/tools',
+            label: 'Tools | Dust Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -907,16 +911,17 @@ export const dustProfile: CompetitorProfile = {
     observability: {
       tracingDepth: {
         value:
-          'Yes: an Agent Builder dashboard shows real-time usage trends, tool execution patterns, feedback tracking, latency metrics, and RAG behavior tied to specific agent versions',
+          'Partial: an Admin > Analytics dashboard shows workspace-wide credit consumption, message/conversation volume, tool execution patterns, and feedback tracking (thumb reactions/comments), broken out by agent, user, or message source, but it does not track latency metrics or RAG-specific behavior, and is not broken out by individual agent version',
         detail:
-          "Described as built natively into the agent-builder workflow with 'zero setup', showing signals specific to how agents work on the Dust platform, rather than a general-purpose distributed-tracing/span export product.",
-        shortValue: 'Per-agent-version dashboard: usage, tools, feedback, latency, RAG',
-        confidence: 'estimated',
+          "Dust's Workspace Analytics docs describe an Admin > Analytics dashboard for adoption, credit consumption, and usage patterns, including tool-execution counts/unique users per tool and message feedback, explicitly stating analytics never include message content and are not differentiated by agent version. Latency metrics and RAG-specific behavior are not part of this dashboard.",
+        shortValue:
+          'Workspace-wide usage/feedback/tool dashboard; no latency or RAG metrics, not per-version',
+        confidence: 'verified',
         sources: [
           {
-            url: 'https://deepwiki.com/dust-tt/dust/3.1-agent-configuration-and-management',
-            label: 'Agent Configuration and Management | dust-tt/dust | DeepWiki',
-            asOf: '2026-07-02',
+            url: 'https://docs.dust.tt/docs/workspace-analytics',
+            label: 'Workspace Analytics | Dust Docs',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/flowise.ts
+++ b/apps/sim/lib/compare/data/competitors/flowise.ts
@@ -31,13 +31,13 @@ export const flowiseProfile: CompetitorProfile = {
     {
       title: 'Built-in dataset-based batch evaluation',
       description:
-        "Flowise ships a built-in Evaluations feature that runs chatflows/agentflows against a saved dataset in one batch, scoring outputs with string, numeric, or LLM-as-judge evaluators and reporting pass/fail rate, average tokens, and latency across the whole run. Sim's own Evaluator block scores individual calls against user-defined metrics, but has no equivalent golden-dataset batch runner. (Flowise's Agentflow V2 also has a Human Input node for pausing on approve/reject feedback, comparable to Sim's own human-in-the-loop approval block.)",
+        "Flowise ships an Evaluations feature, available on Flowise Cloud/Enterprise plans (not the open-source self-hosted product), that runs chatflows/agentflows against a saved dataset in one batch, scoring outputs with string, numeric, or LLM-as-judge evaluators and reporting pass/fail rate, average tokens, and latency across the whole run. Sim's own Evaluator block scores individual calls against user-defined metrics, but has no equivalent golden-dataset batch runner. (Flowise's Agentflow V2 also has a Human Input node for pausing on approve/reject feedback, comparable to Sim's own human-in-the-loop approval block.)",
       shortDescription:
-        'Built-in dataset-based batch evaluation with LLM-judge scoring and pass/fail reporting.',
+        'Built-in dataset-based batch evaluation (Cloud/Enterprise plans) with LLM-judge scoring and pass/fail reporting.',
       source: {
         url: 'https://docs.flowiseai.com/using-flowise/evaluations',
         label: 'Flowise Docs: Evaluations',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -69,12 +69,12 @@ export const flowiseProfile: CompetitorProfile = {
     {
       title: 'No native real-time multiplayer canvas editing',
       description:
-        "Flowise's core canvas supports only one user editing a flow at a time, with no built-in real-time co-editing (like Google Docs) of the same chatflow. Community members have requested true multi-user collaborative editing as a feature.",
+        "Flowise's core canvas supports only one user editing a flow at a time, with no built-in real-time co-editing of the same chatflow. A related multi-user/collaboration feature request (GitHub issue #2661) was closed as not planned.",
       shortDescription: 'No live multi-cursor concurrent editing of the same flow.',
       source: {
         url: 'https://github.com/FlowiseAI/Flowise/issues/2661',
-        label: 'GitHub Issue #2661: Multi User Support',
-        asOf: '2026-07-02',
+        label: 'GitHub Issue #2661: Multi User Support (closed, not planned)',
+        asOf: '2026-07-08',
       },
     },
   ],
@@ -163,9 +163,14 @@ export const flowiseProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://github.com/FlowiseAI/Flowise/issues/5164',
-            label: 'GitHub Issue #5164: Clarify Licensing Terms for Community vs Enterprise Code',
-            asOf: '2026-07-02',
+            url: 'https://docs.flowiseai.com/using-flowise/workspaces',
+            label: 'Flowise Docs: Workspaces',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.flowiseai.com/configuration/sso',
+            label: 'Flowise Docs: SSO',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -191,16 +196,16 @@ export const flowiseProfile: CompetitorProfile = {
       },
       realtimeCollaboration: {
         value:
-          "No: Flowise's canvas supports only one user per session, with no live, multi-cursor editing of the same flow. This has been an open community feature request.",
+          "No: Flowise's canvas supports only one user per session, with no live, multi-cursor editing of the same flow. Cloud/Enterprise multi-user features (workspaces, RBAC) govern access, not concurrent editing.",
         detail:
-          'Cloud/Enterprise multi-user features (workspaces, RBAC) govern access, not concurrent editing.',
+          'No public Flowise GitHub issue specifically tracks multi-cursor/real-time canvas collaboration as a feature request; GitHub issue #2661, sometimes cited for this, is actually a closed request about user authentication, RBAC, and audit trails, not concurrent editing.',
         shortValue: 'No live multi-user concurrent canvas editing',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://github.com/FlowiseAI/Flowise/issues/2661',
-            label: 'GitHub Issue #2661: Multi User Support',
-            asOf: '2026-07-02',
+            url: 'https://docs.flowiseai.com/using-flowise/workspaces',
+            label: 'Flowise Docs: Workspaces',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -242,7 +247,7 @@ export const flowiseProfile: CompetitorProfile = {
     aiCapabilities: {
       multiLlmSupport: {
         value:
-          'Yes: Flowise integrates a broad set of LLM providers including OpenAI, Azure OpenAI, AWS Bedrock, Google PaLM/Vertex AI, Cohere, HuggingFace Inference, Ollama, Replicate, and Anthropic models (Claude 3.5/4), covering both hosted and self-hosted open-source models.',
+          'Yes: Flowise integrates a broad set of LLM providers including OpenAI, Azure OpenAI, AWS Bedrock, Google Vertex AI, Cohere, HuggingFace Inference, Ollama, and Replicate, plus (via its separate Chat Models integrations, e.g. ChatAnthropic) Anthropic Claude models, covering both hosted and self-hosted open-source models.',
         shortValue: 'Broad support: OpenAI, Azure, Bedrock, Google, Anthropic, Ollama, more',
         confidence: 'verified',
         sources: [
@@ -250,6 +255,11 @@ export const flowiseProfile: CompetitorProfile = {
             url: 'https://docs.flowiseai.com/integrations/langchain/llms',
             label: 'Flowise Docs: LLMs',
             asOf: '2026-07-02',
+          },
+          {
+            url: 'https://docs.flowiseai.com/integrations/langchain/chat-models',
+            label: 'Flowise Docs: Chat Models (incl. ChatAnthropic)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -498,9 +508,9 @@ export const flowiseProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.flowiseai.com/integrations/utilities/custom-js-function',
-            label: 'Flowise Docs: Custom JS Function',
-            asOf: '2026-07-02',
+            url: 'https://docs.flowiseai.com/integrations/langchain/tools/custom-tool',
+            label: 'Flowise Docs: Custom Tool (JS function support, built-in/external modules)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -871,9 +881,9 @@ export const flowiseProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://www.aicuflow.com/blog/enterprise-ai-sso-rbac-audit',
-            label: 'Aicuflow: Enterprise AI Platform with SSO, Role-Based Access, and Audit Trails',
-            asOf: '2026-07-02',
+            url: 'https://www.lindy.ai/blog/flowise-pricing',
+            label: 'Lindy: Flowise Pricing, Features, and Alternatives for 2026',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/gumloop.ts
+++ b/apps/sim/lib/compare/data/competitors/gumloop.ts
@@ -25,26 +25,26 @@ export const gumloopProfile: CompetitorProfile = {
     'Gumloop is a hosted, no-code visual platform for building and deploying AI agents and automations: a drag-and-drop canvas, an AI copilot ("Gen") for natural-language flow creation, and native MCP (Model Context Protocol) integration support.',
   standoutFeatures: [
     {
-      title: '100+ fully hosted MCP servers',
+      title: '250+ fully hosted MCP servers',
       description:
-        'Gumloop offers 100+ pre-built, zero-setup hosted MCP servers, plus any custom MCP server over HTTPS, with both native-MCP and backend-connector execution modes.',
-      shortDescription:
-        '100+ zero-setup hosted MCP servers, plus any custom MCP server over HTTPS.',
+        'Gumloop offers 250+ pre-built, zero-setup hosted MCP servers spanning popular services, letting agents connect to external tools without manual configuration.',
+      shortDescription: '250+ zero-setup hosted MCP servers across popular services.',
       source: {
         url: 'https://www.gumloop.com/mcp',
         label: 'Gumloop: Fully Hosted MCP Servers',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
-      title: 'Gen copilot debugs existing flows node-by-node on canvas',
+      title: 'Gummie copilot builds, edits, and debugs flows from natural language',
       description:
-        'Beyond building new flows from a prompt, Gen can step into an already-built workflow and debug it node-by-node directly on the canvas, working from a plain-English description of what is going wrong.',
-      shortDescription: 'Gen debugs an existing workflow node-by-node directly on the canvas.',
+        "Beyond building new flows from a prompt, Gumloop's AI copilot, Gummie, can edit, debug, and run existing workflows: users describe what they want changed or fixed in plain English and Gummie figures out the implementation.",
+      shortDescription:
+        'Gummie copilot can build, edit, debug, and run workflows from natural-language prompts.',
       source: {
-        url: 'https://www.gumloop.com/blog/agentic-ai-tools',
-        label: 'Gumloop blog: agentic AI tools',
-        asOf: '2026-07-02',
+        url: 'https://www.gumloop.com/changelog',
+        label: 'Gumloop Changelog',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -97,24 +97,24 @@ export const gumloopProfile: CompetitorProfile = {
     {
       title: 'Proprietary license, closed source',
       description:
-        'The core Gumloop application has no open-source license; it is a closed commercial product, unlike some workflow-automation competitors that ship an open-source core.',
+        'The core Gumloop application has no open-source license; Gumloop\'s own Terms of Service state the Service, its features, and its functionality "are and will remain the exclusive property of AgentHub Inc. (doing business as Gumloop) and its licensors," unlike some workflow-automation competitors that ship an open-source core.',
       shortDescription: 'Closed commercial product with no open-source core.',
       source: {
-        url: 'https://www.gumloop.com/pricing',
-        label: 'Gumloop Pricing',
-        asOf: '2026-07-02',
+        url: 'https://www.gumloop.com/tos',
+        label: 'Gumloop Terms of Service',
+        asOf: '2026-07-08',
       },
     },
     {
       title: 'Inconsistent/unclear integration count across vendor pages',
       description:
-        "Gumloop's own pages give differing figures for integrations ('100+ nodes and integrations' vs '100+ MCP servers'), and the dedicated /integrations directory page returns a 404, making an exact, citable integration count hard to pin down from primary sources.",
+        "Gumloop's own pages give differing figures for integrations: its docs introduction cites '100+ pre-built nodes and integrations,' while its dedicated MCP page separately advertises '250+ MCP servers.' These may be different countable categories (native nodes vs MCP-protocol connectors), but neither page cross-references the other, and the dedicated /integrations directory page still returns a 404, making an exact, citable integration count hard to pin down from primary sources.",
       shortDescription:
         'Vendor pages cite different integration counts with no single authoritative figure.',
       source: {
-        url: 'https://www.gumloop.com/mcp',
-        label: 'Gumloop: Fully Hosted MCP Servers',
-        asOf: '2026-07-02',
+        url: 'https://docs.gumloop.com/getting-started/introduction',
+        label: 'Getting Started - Gumloop docs',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -134,17 +134,17 @@ export const gumloopProfile: CompetitorProfile = {
     platform: {
       builderType: {
         value:
-          "Visual, no-code canvas builder with an AI copilot ('Gen') that can generate/modify flows from natural-language prompts",
+          "Visual, no-code canvas builder with an AI copilot ('Gummie') that can generate/modify flows from natural-language prompts",
         detail:
-          "Gumloop is a visual/no-code drag-and-drop canvas for chaining nodes (AI, integration, logic) into agent 'flows'; a chat-based AI copilot named Gen can build and edit these flows from plain-English instructions.",
-        shortValue: 'Visual canvas plus Gen AI copilot for building flows',
+          "Gumloop is a visual/no-code drag-and-drop canvas for chaining nodes (AI, integration, logic) into agent 'flows'; a chat-based AI agent named Gummie can build and edit these flows from plain-English instructions.",
+        shortValue: 'Visual canvas plus Gummie AI copilot for building flows',
         confidence: 'estimated',
         sources: [
-          { url: 'https://www.gumloop.com', label: 'Gumloop homepage', asOf: '2026-07-02' },
+          { url: 'https://www.gumloop.com', label: 'Gumloop homepage', asOf: '2026-07-08' },
           {
             url: 'https://www.gumloop.com/blog/agentic-ai-tools',
             label: 'Gumloop blog: agentic AI tools',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -330,12 +330,7 @@ export const gumloopProfile: CompetitorProfile = {
           {
             url: 'https://docs.gumloop.com/core-concepts/subflows',
             label: 'Subflows - Gumloop docs',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://www.gumloop.com/university/lessons/subflows',
-            label: 'Gumloop University: Subflows',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -372,14 +367,14 @@ export const gumloopProfile: CompetitorProfile = {
       },
       naturalLanguageBuilding: {
         value:
-          "Yes: an AI copilot named 'Gen' builds/edits flows from natural-language descriptions",
-        shortValue: 'Gen copilot builds and edits flows from prompts',
+          "Yes: an AI copilot named 'Gummie' builds/edits flows from natural-language descriptions",
+        shortValue: 'Gummie copilot builds and edits flows from prompts',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://www.gumloop.com/blog/agentic-ai-tools',
             label: 'Gumloop blog: agentic AI tools',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -393,21 +388,21 @@ export const gumloopProfile: CompetitorProfile = {
       },
       mcpSupport: {
         value:
-          'Yes: native MCP client/server support with 100+ pre-built hosted MCP servers plus custom MCP server connections',
+          'Yes: native MCP client/server support with 250+ pre-built hosted MCP servers plus custom MCP server connections',
         detail:
-          "Gumloop can connect to any MCP server (custom URL over HTTPS), offers 100+ fully-hosted MCP servers with zero setup, and supports both 'native MCP' (model connects directly) and a 'backend connector' mode (Gumloop executes tool calls).",
-        shortValue: '100+ hosted MCP servers plus custom MCP',
+          "Gumloop can connect to any MCP server (custom URL over HTTPS), offers 250+ fully-hosted MCP servers with zero setup, and supports both 'native MCP' (model connects directly) and a 'backend connector' mode (Gumloop executes tool calls).",
+        shortValue: '250+ hosted MCP servers plus custom MCP',
         confidence: 'verified',
         sources: [
           {
             url: 'https://www.gumloop.com/mcp',
             label: 'Gumloop: Fully Hosted MCP Servers',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.gumloop.com/nodes/mcp/custom_mcp_servers',
             label: 'Gumloop docs: Custom MCP Servers',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -422,12 +417,7 @@ export const gumloopProfile: CompetitorProfile = {
           {
             url: 'https://www.gumloop.com/changelog',
             label: 'Gumloop Changelog',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://www.gumloop.com/solutions/security',
-            label: 'Gumloop Security & Trust (guardrails/RBAC)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -581,21 +571,16 @@ export const gumloopProfile: CompetitorProfile = {
       },
       loopIteration: {
         value:
-          "Partial: Gumloop's only documented iteration primitive is 'Loop Mode', the same mechanism covered under parallelExecution, which auto-triggers when a list is connected to a node or Subflow and runs that node once per list item. Per Gumloop's docs this is concurrent (2 items at once on Free, 15 on Pro), not a strictly one-at-a-time sequential container, and no separate while-loop or fixed-iteration-count node is documented, only iteration over an existing list.",
+          "Partial: Gumloop's only documented iteration primitive is 'Loop Mode', the same mechanism covered under parallelExecution, which a user manually enables on a node so it runs once per item in a connected list. Per Gumloop's docs this is concurrent (2 items at once on Free, 15 on Pro), not a strictly one-at-a-time sequential container, and no separate while-loop or fixed-iteration-count node is documented, only manually-enabled iteration over an existing list.",
         detail:
-          "Gumloop docs describe Loop Mode as processing 'multiple items simultaneously' with concurrency capped by plan tier, distinct from a classic for-each node that guarantees one iteration finishes before the next starts. No dedicated while-loop (condition-based) or fixed-count repeat node is documented; all iteration is driven by connecting a list as input.",
-        shortValue: 'Partial: list-driven Loop Mode is concurrent, not a sequential loop node',
+          "Gumloop docs describe Loop Mode as a mode a user enables on a node ('When you enable Loop Mode on a node...'), which then processes multiple list items simultaneously with concurrency capped by plan tier, distinct from a classic for-each node that guarantees one iteration finishes before the next starts. No dedicated while-loop (condition-based) or fixed-count repeat node is documented; all iteration requires manually enabling Loop Mode with a list as input.",
+        shortValue: 'Partial: manually-enabled Loop Mode is concurrent, not a sequential loop node',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.gumloop.com/core-concepts/loop_mode',
             label: 'Loop Mode - Gumloop docs',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://www.gumloop.com/university/lessons/lists-loop-mode',
-            label: 'Gumloop University: Lists & Loop mode',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -603,16 +588,21 @@ export const gumloopProfile: CompetitorProfile = {
     integrations: {
       integrationCount: {
         value:
-          "Vendor-claimed figures vary by page: 100+ nodes/integrations, 100+ hosted MCP servers; third-party reviews cite '130+ native integrations'",
+          'Vendor-claimed figures vary by page: 100+ pre-built nodes and integrations (per docs.gumloop.com), 250+ hosted MCP servers (per gumloop.com/mcp)',
         detail:
-          "No single authoritative exact count is published on a primary Gumloop page. gumloop.com/mcp cites '100+ MCP servers, fully hosted, zero setup' while other Gumloop copy references '100+ pre-built nodes and integrations,' and the dedicated /integrations directory page returns a 404.",
-        shortValue: '100+ integrations and MCP servers (vendor figures vary)',
+          "No single authoritative exact count is published on a primary Gumloop page. docs.gumloop.com's introduction cites '100+ pre-built nodes and integrations' while gumloop.com/mcp separately cites '250+ MCP servers, zero setup'; the two pages do not cross-reference each other, and the dedicated /integrations directory page returns a 404.",
+        shortValue: '100+ nodes/integrations, 250+ MCP servers (vendor figures vary)',
         confidence: 'estimated',
         sources: [
           {
+            url: 'https://docs.gumloop.com/getting-started/introduction',
+            label: 'Getting Started - Gumloop docs',
+            asOf: '2026-07-08',
+          },
+          {
             url: 'https://www.gumloop.com/mcp',
             label: 'Gumloop: Fully Hosted MCP Servers',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -683,7 +673,7 @@ export const gumloopProfile: CompetitorProfile = {
       },
       mcpPublishing: {
         value:
-          "No: Gumloop's MCP capability mainly runs in the consuming direction. It connects agents/workflows to 100+ fully hosted MCP servers (Slack, Notion, GitHub, etc.) and lets users add custom MCP servers as tool sources. No official Gumloop documentation describes publishing a user's deployed workflow itself as a callable MCP server for external AI tools to consume.",
+          "No: Gumloop's MCP capability mainly runs in the consuming direction. It connects agents/workflows to 250+ fully hosted MCP servers and lets users add custom MCP servers as tool sources. No official Gumloop documentation describes publishing a user's deployed workflow itself as a callable MCP server for external AI tools to consume.",
         detail:
           'A third-party, unofficial open-source project ("gumloop-mcp" on GitHub) wraps the Gumloop management API as an MCP server, but that is not the same as natively publishing a specific deployed workflow as an MCP tool, and it is not an official Gumloop product.',
         shortValue: "No: consumes MCP servers, doesn't publish flows as one",
@@ -692,7 +682,7 @@ export const gumloopProfile: CompetitorProfile = {
           {
             url: 'https://www.gumloop.com/mcp',
             label: 'Fully Hosted MCP Servers for Your AI Agents - Gumloop',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.gumloop.com/nodes/mcp/custom_mcp_servers',
@@ -1152,7 +1142,7 @@ export const gumloopProfile: CompetitorProfile = {
       },
       academy: {
         value:
-          'Yes: Gumloop runs "Gumloop University," a structured learning resource with self-paced courses (e.g. "Gumloop 101"), live webinars, and week-long "Learning Cohorts" that award a certificate of completion for finishing practical challenges.',
+          'Yes: Gumloop runs "Gumloop University," a structured learning resource with self-paced courses (e.g. "Getting Started with Gumloop"), live webinars, and week-long "Learning Cohorts" that award a certificate of completion for finishing practical challenges.',
         detail:
           'Certification is tied to completing cohort challenges rather than a formal exam-based program, but it is a structured curriculum beyond ad hoc docs/blog posts.',
         shortValue: 'Yes: Gumloop University with courses and certificates',
@@ -1161,17 +1151,12 @@ export const gumloopProfile: CompetitorProfile = {
           {
             url: 'https://university.gumloop.com/',
             label: 'Gumloop University',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://www.gumloop.com/cohorts',
             label: 'Gumloop Learning Cohorts',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://www.gumloop.com/university/courses/gumloop-101',
-            label: 'Gumloop 101 course',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/langchain.ts
+++ b/apps/sim/lib/compare/data/competitors/langchain.ts
@@ -24,9 +24,9 @@ export const langchainProfile: CompetitorProfile = {
       shortDescription:
         'Snapshots graph state after every node so runs resume, not restart, on failure.',
       source: {
-        url: 'https://www.langchain.com/blog/fault-tolerance-in-langgraph',
-        label: 'Fault Tolerance in LangGraph (LangChain Blog)',
-        asOf: '2026-07-02',
+        url: 'https://docs.langchain.com/oss/python/langgraph/use-time-travel',
+        label: 'Time travel - Docs by LangChain',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -66,14 +66,15 @@ export const langchainProfile: CompetitorProfile = {
       },
     },
     {
-      title: 'LangGraph Studio: a browser-based visual agent IDE with time-travel debugging',
+      title: 'LangGraph Studio: browser-based execution visualization with hot-reload',
       description:
-        "Studio renders a running agent's graph (nodes, edges, conditional branches) visually, lets a developer inspect state at every node, rewind to a previous checkpoint, edit the state, and fork a new execution path from there, and hot-reloads when a prompt or tool signature changes in code.",
-      shortDescription: 'Visual graph IDE with checkpoint rewind, state editing, and hot-reload.',
+        "Studio is a browser-based UI (hosted at smith.langchain.com/studio) that connects to a locally running agent and shows each execution step, prompt, and tool call, and hot-reloads when a prompt or tool signature changes in code. LangGraph's time-travel capability (inspecting, editing, and forking from a prior checkpoint) is a separate, SDK-level feature exposed via code (get_state_history / update_state), not a point-and-click Studio UI.",
+      shortDescription:
+        'Browser-based execution viewer with hot-reload; checkpoint rewind/fork is a separate SDK capability.',
       source: {
-        url: 'https://www.langchain.com/blog/langgraph-studio-the-first-agent-ide',
-        label: 'LangGraph Studio: The first agent IDE',
-        asOf: '2026-07-02',
+        url: 'https://docs.langchain.com/oss/python/langgraph/studio',
+        label: 'LangGraph Studio - Docs by LangChain',
+        asOf: '2026-07-08',
       },
     },
   ],
@@ -91,15 +92,15 @@ export const langchainProfile: CompetitorProfile = {
       },
     },
     {
-      title: 'No native, publicly deployable chat UI shipped with the open-source libraries',
+      title: 'No one-click chat deployment tied to a specific agent',
       description:
-        'Neither LangChain nor LangGraph ships a first-party, hosted chat widget or public chat surface a builder can toggle on for an end user. Teams that want a deployed conversational UI build their own frontend (or use a separate framework like Chainlit/Streamlit) and call the LangGraph Agent Server as a backend.',
+        'Neither LangChain, LangGraph, nor LangSmith Deployment lets a builder toggle a hosted chat surface on for one specific agent the way a platform-managed deployment target would. LangChain does host a shared, generic "Agent Chat UI" instance at agentchat.vercel.app that any team can point at their own LangGraph Agent Server URL and API key, or a team can deploy the open-source Next.js app themselves (or use a separate framework like Chainlit/Streamlit).',
       shortDescription:
-        'No first-party hosted chat UI; teams build their own frontend against the Agent Server.',
+        'No per-agent hosted chat toggle; a shared generic Agent Chat UI instance exists, or self-deploy.',
       source: {
-        url: 'https://docs.langchain.com/langsmith/assistants',
-        label: 'Assistants - Docs by LangChain',
-        asOf: '2026-07-02',
+        url: 'https://github.com/langchain-ai/agent-chat-ui',
+        label: 'langchain-ai/agent-chat-ui (GitHub)',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -133,15 +134,15 @@ export const langchainProfile: CompetitorProfile = {
         value:
           'Code-first Python/JavaScript framework (LangChain) plus a low-level graph-orchestration library (LangGraph) for building agents in code. LangGraph Studio adds a browser-based visual IDE to render, inspect, and debug an already-coded agent graph, and Deep Agents provides a batteries-included harness on top of both.',
         detail:
-          'There is no drag-and-drop agent authoring surface; developers write Python or TypeScript against LangChain/LangGraph APIs, and Studio visualizes the resulting graph for debugging and time-travel, rather than authoring it visually from scratch.',
+          'There is no drag-and-drop agent authoring surface; developers write Python or TypeScript against LangChain/LangGraph APIs, and Studio visualizes execution steps for debugging (time-travel checkpoint rewind/fork is a separate SDK-level feature) rather than authoring the graph visually from scratch.',
         shortValue:
           'Code framework plus a graph-visualization/debugging Studio, not a visual builder',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://www.langchain.com/blog/langgraph-studio-the-first-agent-ide',
-            label: 'LangGraph Studio: The first agent IDE',
-            asOf: '2026-07-02',
+            url: 'https://docs.langchain.com/oss/python/langgraph/studio',
+            label: 'LangGraph Studio - Docs by LangChain',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://github.com/langchain-ai/deepagents',
@@ -279,7 +280,7 @@ export const langchainProfile: CompetitorProfile = {
       },
       nativeFileStorage: {
         value:
-          'No: neither LangChain, LangGraph, nor LangSmith provides a Drive-like file storage system with folder hierarchy, link sharing, or a recycle bin. File handling is done in application code via document loaders and external storage integrations (S3, GCS, local filesystem) that a developer wires up themselves',
+          "No: neither LangChain, LangGraph, nor LangSmith provides a Drive-like file storage system with folder hierarchy, link sharing, or a recycle bin. Deep Agents offers a virtual filesystem abstraction (in-memory, local disk, LangGraph store, or custom backends) for an agent's own working context, but persistent storage still relies on external integrations (S3, GCS, local filesystem) a developer wires up themselves",
         detail:
           "Deep Agents provides a virtual/in-memory filesystem abstraction for an agent's own working context (planning, scratch files), which is a per-run working memory concept, not a persistent, user-facing file manager.",
         shortValue: 'No, file handling is via document-loader code, not a built-in file manager',
@@ -288,7 +289,7 @@ export const langchainProfile: CompetitorProfile = {
           {
             url: 'https://docs.langchain.com/oss/python/deepagents/overview',
             label: 'Deep Agents overview - Docs by LangChain',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -336,16 +337,16 @@ export const langchainProfile: CompetitorProfile = {
     aiCapabilities: {
       multiLlmSupport: {
         value:
-          'Yes: LangChain provides a standardized interface (ChatModel/Runnable) to over 100 LLM providers and hundreds of documented integrations across providers, embeddings, and vector stores, including OpenAI, Anthropic, Google, AWS Bedrock, Azure OpenAI, Mistral, Cohere, and local models via Ollama',
+          'Yes: LangChain provides a standardized model interface and advertises 1,000+ documented integrations across providers, embeddings, and vector stores, including OpenAI, Anthropic, Google, AWS, Groq, Hugging Face, Databricks, Mistral, and local models via Ollama',
         detail:
           "This is the framework's foundational design goal: swap providers by changing the model class instantiation, with the rest of a chain/graph remaining unchanged.",
-        shortValue: '100+ LLM providers via a standardized model interface',
+        shortValue: '1,000+ integrations via a standardized model interface',
         confidence: 'verified',
         sources: [
           {
             url: 'https://www.langchain.com/langchain',
             label: 'LangChain: Open Source AI Agent Framework',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -384,9 +385,14 @@ export const langchainProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://blog.langchain.com/launching-langgraph-templates/',
-            label: 'Launching LangGraph Templates (LangChain Blog)',
-            asOf: '2026-07-02',
+            url: 'https://docs.langchain.com/oss/python/langchain/retrieval',
+            label: 'Retrieval - Docs by LangChain',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.langchain.com/oss/python/integrations/vectorstores',
+            label: 'VectorStore Interface and Integrations - Docs by LangChain',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -455,9 +461,9 @@ export const langchainProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://blog.langchain.com/launching-langgraph-templates/',
-            label: 'Launching LangGraph Templates (LangChain Blog)',
-            asOf: '2026-07-02',
+            url: 'https://docs.langchain.com/oss/python/langchain/models',
+            label: 'Models - Docs by LangChain',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -470,9 +476,9 @@ export const langchainProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://python.langchain.com/v0.2/docs/how_to/fallbacks/',
-            label: 'How to add fallbacks to a runnable | LangChain',
-            asOf: '2026-07-02',
+            url: 'https://reference.langchain.com/python/langchain-core/runnables/fallbacks/RunnableWithFallbacks',
+            label: 'RunnableWithFallbacks - LangChain Reference',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -493,16 +499,16 @@ export const langchainProfile: CompetitorProfile = {
       },
       nativeChatDeployment: {
         value:
-          'No: neither the open-source libraries nor LangGraph Platform ship a first-party, publicly deployable chat widget or hosted chat page. A team deploying a conversational agent builds its own frontend (or uses a separate UI framework) calling the LangGraph Agent Server as a backend',
+          'Partial: neither the open-source libraries nor LangSmith Deployment let a builder toggle a hosted chat surface on for one specific agent. LangChain hosts a shared, generic "Agent Chat UI" instance at agentchat.vercel.app that any team can point at their own LangGraph Agent Server URL and API key, or a team can deploy the open-source Next.js app itself',
         detail:
           'LangGraph Studio itself provides a chat-style interaction panel for testing/debugging a graph during development, but this is a developer tool, not a shippable end-user chat deployment target.',
-        shortValue: 'No first-party public chat surface; teams build and host their own frontend',
+        shortValue: 'Partial: shared generic hosted chat client, no per-agent one-click toggle',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://docs.langchain.com/langsmith/assistants',
-            label: 'Assistants - Docs by LangChain',
-            asOf: '2026-07-02',
+            url: 'https://github.com/langchain-ai/agent-chat-ui',
+            label: 'langchain-ai/agent-chat-ui (GitHub)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -516,9 +522,9 @@ export const langchainProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://blog.langchain.com/launching-langgraph-templates/',
-            label: 'Launching LangGraph Templates (LangChain Blog)',
-            asOf: '2026-07-02',
+            url: 'https://reference.langchain.com/python/langchain-core/documents/base/Document',
+            label: 'Document - LangChain Reference',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -572,23 +578,22 @@ export const langchainProfile: CompetitorProfile = {
     },
     integrations: {
       integrationCount: {
-        value:
-          '1,000+ integrations across model providers, vector stores, document loaders, and tools, with a unified interface to 100+ LLM providers specifically',
+        value: '1,000+ integrations, spanning model providers, data sources, and tools',
         detail:
-          'The langchain-community package hosts many additional community-maintained integrations beyond what is centrally documented, so the true count is larger and harder to pin to one authoritative live number, unlike a connector-count page some workflow builders publish.',
-        shortValue: '1,000+ integrations; 100+ LLM providers via a unified interface',
+          'Community-maintained integrations beyond what LangChain centrally documents also exist across dedicated integration repos, so the true count is larger and harder to pin to one authoritative live number, unlike a connector-count page some workflow builders publish.',
+        shortValue: '1,000+ integrations',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://www.langchain.com/langchain',
             label: 'LangChain: Open Source AI Agent Framework',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       triggerTypes: {
         value:
-          "Not a workflow-builder concept: agents are invoked programmatically (function/API call) or served over the LangGraph Agent Server's REST/SDK interface. The Agent Server also exposes protocol-level entry points (A2A, MCP), but there is no equivalent to a connector-event/schedule/webhook trigger picker.",
+          "Not a workflow-builder concept: agents are invoked programmatically (function/API call) or served over the LangGraph Agent Server's REST interface. The Agent Server also exposes protocol-level entry points (A2A), but there is no equivalent to a connector-event/schedule/webhook trigger picker.",
         detail:
           'A developer wires up whatever trigger mechanism they need in their own application code (a cron job, a webhook handler, a queue consumer) that then calls the LangGraph SDK or REST API to start a run.',
         shortValue:
@@ -596,9 +601,9 @@ export const langchainProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://docs.langchain.com/langsmith/assistants',
-            label: 'Assistants - Docs by LangChain',
-            asOf: '2026-07-02',
+            url: 'https://docs.langchain.com/langsmith/server-api-ref',
+            label: 'Agent Server API reference - Docs by LangChain',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -613,52 +618,57 @@ export const langchainProfile: CompetitorProfile = {
       },
       apiPublishing: {
         value:
-          'Yes: the LangGraph Agent Server exposes deployed graphs over a REST API and SDKs (Python/JS), and additionally supports the Agent Protocol, MCP, and A2A as callable interfaces for the same deployed agent',
+          'Yes: the LangGraph Agent Server exposes deployed graphs over a REST API, and additionally supports A2A as a callable interface for the same deployed agent',
         detail:
-          'A single deployed graph can be called via plain REST, the LangGraph SDK, or one of the standardized agent-interop protocols, depending on the caller.',
-        shortValue: 'Yes, REST/SDK plus Agent Protocol, MCP, and A2A interfaces',
+          'A single deployed graph can be called via plain REST or the standardized A2A agent-interop protocol, depending on the caller.',
+        shortValue: 'Yes, REST API plus an A2A interface',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.langchain.com/langsmith/agent-server',
-            label: 'Agent Server - Docs by LangChain',
-            asOf: '2026-07-04',
+            url: 'https://docs.langchain.com/langsmith/server-api-ref',
+            label: 'Agent Server API reference - Docs by LangChain',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.langchain.com/langsmith/server-a2a',
             label: 'A2A endpoint in Agent Server - Docs by LangChain',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       extensibilitySdk: {
         value:
-          'Official Python and JavaScript/TypeScript SDKs for both LangChain and LangGraph, a public REST API for the Agent Server, and an open, MIT-licensed codebase that any developer can extend, fork, or contribute integrations back to via langchain-community',
+          'Official Python and JavaScript/TypeScript SDKs for both LangChain and LangGraph, a public REST API for the Agent Server, and an open, MIT-licensed codebase that any developer can extend or fork; community integrations now live in their own dedicated repositories rather than the sunset langchain-community package',
         detail:
           'Because the whole product is a set of open-source libraries, extensibility is inherent rather than a separately bolted-on SDK layer, distinct from a workflow builder that offers a custom-node development kit for an otherwise closed core product.',
         shortValue:
-          'Official Python/JS SDKs, open MIT-licensed codebase, community integration package',
+          'Official Python/JS SDKs, open MIT-licensed codebase, integrations in standalone repos',
         confidence: 'verified',
         sources: [
           {
             url: 'https://github.com/langchain-ai/langchain',
             label: 'langchain-ai/langchain (GitHub)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://pypi.org/project/langchain-community/',
+            label: 'langchain-community on PyPI (sunset notice)',
+            asOf: '2026-07-08',
           },
         ],
       },
       mcpPublishing: {
         value:
-          'Yes: an agent built with LangChain/LangGraph can be exposed as MCP tools/resources for external AI clients to call, via the same langchain-mcp-adapters ecosystem used to consume external MCP servers, in addition to native A2A server exposure',
+          "Yes: a LangGraph agent deployed on LangGraph Server is automatically exposed as an MCP-compatible tool via the server's built-in /mcp endpoint (Streamable HTTP), a separate mechanism from langchain-mcp-adapters, which is used only to consume external MCP servers as LangChain tools. LangGraph also supports native A2A server exposure",
         detail:
           "This is the reverse direction from consuming an external MCP server's tools, publishing a LangGraph agent's own capabilities for other MCP clients to invoke.",
-        shortValue: 'Yes, agents can be exposed as MCP tools via langchain-mcp-adapters',
+        shortValue: 'Yes, LangGraph Server exposes deployed agents via a built-in /mcp endpoint',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://github.com/langchain-ai/langchain-mcp-adapters',
-            label: 'langchain-ai/langchain-mcp-adapters (GitHub)',
-            asOf: '2026-07-02',
+            url: 'https://docs.langchain.com/langsmith/server-api-ref',
+            label: 'Agent Server API reference - Docs by LangChain',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -696,16 +706,16 @@ export const langchainProfile: CompetitorProfile = {
       },
       freeTier: {
         value:
-          "Yes: the LangChain/LangGraph open-source libraries are free with no usage limits of their own, and LangSmith's Developer plan is $0/seat/month with up to 5,000 base traces/month and a free, limited self-hosted LangGraph server tier (up to 100,000 nodes executed/month)",
+          "Yes: the LangChain/LangGraph open-source libraries are free with no usage limits of their own, and LangSmith's Developer plan is $0/seat/month with up to 5,000 base traces/month. Self-hosted LangGraph deployment is now an Enterprise (custom-priced) offering rather than a free tier",
         detail:
-          'The free LangSmith Developer tier is capped at a single seat and community-only support; higher usage or team seats require moving to the Plus or Enterprise tier.',
+          'The free LangSmith Developer tier is capped at a single seat and community-only support; higher usage, team seats, or self-hosted deployment require moving to a paid or Enterprise tier.',
         shortValue: 'Free OSS libraries, plus a free single-seat LangSmith Developer tier',
         confidence: 'verified',
         sources: [
           {
             url: 'https://www.langchain.com/pricing',
             label: 'LangSmith Pricing',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -722,27 +732,23 @@ export const langchainProfile: CompetitorProfile = {
     },
     security: {
       soc2: {
-        value: 'Yes: both LangSmith and LangGraph Platform are SOC 2 Type II compliant.',
+        value:
+          "Yes: LangSmith is SOC 2 Type II certified. LangGraph Platform (now branded LangSmith Deployment) is publicly announced as carrying the same attestation, sharing LangSmith's infrastructure and compliance posture.",
         detail:
-          'Both LangSmith and LangGraph Platform (now branded LangSmith Deployment) carry the same SOC 2 Type II attestation.',
-        shortValue: 'Yes, SOC 2 Type II for both LangSmith and LangGraph Platform',
+          "LangChain's Trust Center (trust.langchain.com) is the canonical source but renders via client-side JavaScript, so it could not be directly verified by an automated fetch; the LangSmith-side certification is independently confirmed on a static docs page.",
+        shortValue: 'Yes, SOC 2 Type II for LangSmith; LangGraph Platform shares it',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://changelog.langchain.com/announcements/langsmith-is-now-soc-2-type-ii-compliant',
-            label: 'LangSmith is now SOC 2 Type II compliant (LangChain Changelog)',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://trust.langchain.com/',
-            label: 'LangChain Trust Center',
-            asOf: '2026-07-02',
+            url: 'https://docs.langchain.com/langsmith/regions-faq',
+            label: 'Regions FAQ - Docs by LangChain (confirms SOC 2 Type 2)',
+            asOf: '2026-07-08',
           },
         ],
       },
       dataResidency: {
         value:
-          'Yes: LangSmith offers selectable regions at no extra cost, US (GCP US, default), EU (GCP EU), APAC (GCP APAC), and a separate AWS US region, plus multi-geo data residency options for self-hosted deployments',
+          'Yes: LangSmith offers selectable regions at no extra cost — US (GCP US), EU (GCP EU), APAC (GCP APAC), and a separate AWS US region',
         detail:
           'Migrating an existing organization between regions is not supported; the region must be chosen at signup. Full self-hosting (of the OSS libraries or LangGraph Platform) is a further, absolute form of data residency control.',
         shortValue: 'Yes, US/EU/APAC/AWS-US selectable regions, no migration between them',
@@ -751,7 +757,7 @@ export const langchainProfile: CompetitorProfile = {
           {
             url: 'https://docs.langchain.com/langsmith/regions-faq',
             label: 'Regions FAQ - Docs by LangChain',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -849,7 +855,7 @@ export const langchainProfile: CompetitorProfile = {
       },
       piiRedaction: {
         value:
-          'Yes: LangSmith supports masking sensitive data before it reaches the backend via environment-variable-level hiding of all inputs/outputs, custom masking functions for selective redaction, and regex-based anonymizers (with a reference implementation in langsmith-pii-removal) covering emails, IPs, phone numbers, credit cards, SSNs, and dates. It also integrates with third-party tools like Microsoft Presidio.',
+          'Yes: LangSmith supports masking sensitive data before it reaches the backend via environment-variable-level hiding of all inputs/outputs, custom masking functions for selective redaction, and a reference regex-based anonymizer example covering emails, phone numbers, full names, credit cards, and SSNs. It also integrates with third-party tools like Microsoft Presidio.',
         detail:
           "Redaction happens client-side, before the trace payload is serialized and sent, via a create_anonymizer hook, so sensitive data is stripped in the customer's own process rather than being redacted after ingestion.",
         shortValue: 'Yes, client-side masking/anonymizer hooks with regex PII detection',
@@ -858,7 +864,7 @@ export const langchainProfile: CompetitorProfile = {
           {
             url: 'https://docs.langchain.com/langsmith/mask-inputs-outputs',
             label: 'Prevent logging of sensitive data in traces - Docs by LangChain',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -871,9 +877,9 @@ export const langchainProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://changelog.langchain.com/announcements/saml-sso-for-unified-access-to-langsmith',
-            label: 'SAML SSO for unified access to LangSmith (LangChain Changelog)',
-            asOf: '2026-07-02',
+            url: 'https://docs.langchain.com/langsmith/user-management',
+            label: 'User management - Docs by LangChain',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -910,9 +916,14 @@ export const langchainProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://www.langchain.com/blog/langgraph-studio-the-first-agent-ide',
-            label: 'LangGraph Studio: The first agent IDE',
-            asOf: '2026-07-02',
+            url: 'https://docs.langchain.com/langsmith/observability-concepts',
+            label: 'Observability concepts - Docs by LangChain',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.langchain.com/oss/python/langgraph/use-time-travel',
+            label: 'Time travel - Docs by LangChain',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -958,16 +969,16 @@ export const langchainProfile: CompetitorProfile = {
       },
       asyncExecution: {
         value:
-          'Yes: the LangGraph Agent Server supports background/async execution. A run can be started and its result polled or streamed later via the SDK/REST API, and interrupt()-paused runs inherently execute asynchronously across a human-response gap by design.',
+          'Yes: the LangGraph Agent Server enqueues each run for a queue worker to pick up, and its result can be polled or streamed later via the REST API, independent of the client connection that started it.',
         detail:
           "This is a natural consequence of the Agent Server's run/thread model, where a run's state persists server-side independent of any single blocking client connection.",
-        shortValue: "Yes, via the Agent Server's run/thread API and checkpoint-backed pausing",
+        shortValue: "Yes, via the Agent Server's queued run/thread API",
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://docs.langchain.com/langsmith/assistants',
-            label: 'Assistants - Docs by LangChain',
-            asOf: '2026-07-02',
+            url: 'https://docs.langchain.com/langsmith/agent-server',
+            label: 'Agent Server - Docs by LangChain',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/langflow.ts
+++ b/apps/sim/lib/compare/data/competitors/langflow.ts
@@ -766,32 +766,42 @@ export const langflowProfile: CompetitorProfile = {
       },
       thirdPartyVetting: {
         value:
-          'Partial: Langflow disclosed CVE-2025-3248, an unauthenticated remote code execution flaw in the custom-component code-validation endpoint, actively exploited in the wild to deploy the Flodrix botnet on unpatched instances before it was fixed in version 1.3.0. That incident reflects the underlying trust model: most built-in integration bundles are contributed as pull requests to the official langflow-ai/langflow codebase and merged by core maintainers, but Langflow also ships a community Store where users can share and install flows and components with lighter, informal vetting, plus a custom-component system that lets any user author and run their own Python code with full server access, the same trust level as the core server itself.',
+          'Partial: Langflow disclosed CVE-2025-3248, an unauthenticated remote code execution flaw in the custom-component code-validation endpoint, fixed in version 1.3.0; security researchers confirmed it was actively exploited in the wild to deploy the Flodrix botnet on unpatched instances before the fix shipped. That incident reflects the underlying trust model: built-in integration bundles are contributed by third-party contributors as pull requests to the official langflow-ai/langflow codebase and reviewed and merged by core maintainers, but Langflow also ships a custom-component system that lets any user author and run their own Python code with full server access, the same trust level as the core server itself.',
         detail:
-          "Langflow documents that it does not enforce isolation between users or restrict local disk/network access, so both bundle and custom-component code run with the same trust level as the core server. By contrast, every one of Sim's blocks is first-party authored and code-reviewed through Sim's own pull-request process, and Sim has no public marketplace where a third party can publish installable executable tool code.",
+          "Langflow documents that it does not enforce isolation between users or restrict local disk/network access, so custom-component code runs with the same trust level as the core server. By contrast, every one of Sim's blocks is first-party authored and code-reviewed through Sim's own pull-request process, and Sim has no public marketplace where a third party can publish installable executable tool code.",
         shortValue:
-          'Partial: disclosed CVE-2025-3248 RCE; lighter-vetted community Store and custom code',
+          'Partial: disclosed CVE-2025-3248 RCE exploited via Flodrix botnet; custom code runs at full server trust',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.langflow.org/components-bundle-components',
             label: 'Langflow Docs - About bundles',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.langflow.org/contributing-components',
+            label: 'Langflow Docs - Contribute components',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.langflow.org/components-custom-components',
             label: 'Langflow Docs - Create custom Python components',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.langflow.org/security',
             label: 'Langflow Docs - Security',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://github.com/langflow-ai/langflow/security/advisories/GHSA-vwmf-pq79-vjvx',
-            label: 'GitHub Security Advisory GHSA-vwmf-pq79-vjvx (CVE-2025-3248)',
-            asOf: '2026-07-02',
+            url: 'https://github.com/langflow-ai/langflow/security/advisories/GHSA-rvqx-wpfh-mfx7',
+            label: 'GitHub Security Advisory GHSA-rvqx-wpfh-mfx7 (CVE-2025-3248)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://www.securityweek.com/recent-langflow-vulnerability-exploited-by-flodrix-botnet/',
+            label: 'SecurityWeek - Langflow Vulnerability Exploited by Flodrix Botnet',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/make.ts
+++ b/apps/sim/lib/compare/data/competitors/make.ts
@@ -79,34 +79,35 @@ export const makeProfile: CompetitorProfile = {
     {
       title: 'Proprietary, closed-source license',
       description:
-        "Unlike open-source workflow tools, Make's codebase is not published; there is no community fork/self-audit path and organizations depend entirely on Make's (Celonis-owned) roadmap and infrastructure.",
+        "Unlike open-source workflow tools, Make's codebase is not published; Celonis (Make's owner) retains exclusive ownership of the Services, and customers are contractually barred from copying, modifying, creating derivative works from, or reverse-engineering the platform, so there is no community fork/self-audit path and organizations depend entirely on Celonis's roadmap and infrastructure.",
       shortDescription: 'Closed-source codebase with no community fork or audit path.',
       source: {
-        url: 'https://www.make.com/en/pricing',
-        label: 'Make Pricing page',
-        asOf: '2026-07-02',
+        url: 'https://www.make.com/master-service-agreement.pdf',
+        label: 'Master Services Agreement for Make, Section 4.4 & 6.1 (Celonis)',
+        asOf: '2026-07-08',
       },
     },
     {
-      title: 'Code step is sandboxed with no network access or package installs',
+      title: 'Code step allows direct HTTP calls; custom package installs need Enterprise',
       description:
-        'The native Make Code (JS/Python) module cannot make HTTP requests, has no external network access, and cannot install npm or PyPI packages, limiting it to pure in-memory data transforms rather than general-purpose custom integration code.',
-      shortDescription: 'Code step blocks network calls and package installs.',
+        "The native Make Code (JS/Python) module can make direct HTTP requests, though Make recommends using the dedicated HTTP module instead to avoid exposing credentials. Enterprise-plan customers can import custom third-party npm/PyPI libraries as declared dependencies; lower tiers only get Make's pre-installed common libraries.",
+      shortDescription:
+        'Code step permits HTTP calls; custom package installs are Enterprise-only.',
       source: {
         url: 'https://apps.make.com/code',
         label: 'Make Code app docs',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
       title: 'Granular RBAC gated to the Teams plan and above',
       description:
-        "Full team/role-based permission management is only available starting on the Teams plan ($38/mo) and Enterprise; lower tiers (Free, Core, Pro) get unlimited users but no role-based access controls, unlike Sim, which ships admin/write/read roles on every tier. Audit logs are also gated to Teams/Enterprise, with default retention of just 30 days on paid plans, though this specific gating pattern isn't unique to Make: Sim's own dedicated audit-log API is likewise Enterprise-only.",
-      shortDescription: 'RBAC needs the Teams plan or above; audit logs are similarly gated.',
+        "Full team/role-based permission management ('Teams and team roles', letting admins manage unlimited team permissions for scenario apps, templates, and connections) is only listed as a feature starting on the Teams plan ($38/mo) and Enterprise; lower tiers (Free, Core, Pro) get unlimited users but no role-based access controls, unlike Sim, which ships admin/write/read roles on every tier.",
+      shortDescription: 'RBAC needs the Teams plan ($38/mo) or above.',
       source: {
         url: 'https://www.make.com/en/pricing',
         label: 'Make Pricing page',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
   ],
@@ -135,14 +136,19 @@ export const makeProfile: CompetitorProfile = {
         value:
           'Low for simple linear automations; moderate-to-steep for complex branching/error-handling logic',
         detail:
-          'Marketed as a no-code tool for non-developers building basic scenarios (drag modules, map fields). Complexity rises with routers, iterators/aggregators, error handlers, and AI Agent configuration/reasoning setup, which several reviews describe as requiring more automation experience than simpler tools like Zapier.',
+          'Third-party reviews consistently describe Make as having a steeper learning curve than simpler tools like Zapier: new users need time to understand field mapping and branching, while routers, filters, iterators/aggregators, and error handlers give more control for complex, multi-step workflows once learned.',
         shortValue: 'Easy for basics, steep for advanced logic',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://www.make.com/en/pricing',
-            label: 'Make Pricing page (Free tier description)',
-            asOf: '2026-07-02',
+            url: 'https://learn.g2.com/make-vs-zapier',
+            label: 'Make vs. Zapier - G2 Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://www.lindy.ai/blog/make-review',
+            label: 'Make Review 2026 - Lindy',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -203,14 +209,14 @@ export const makeProfile: CompetitorProfile = {
       license: {
         value: 'Proprietary',
         detail:
-          'Make (owned by Celonis) is closed-source commercial software; there is no open-source license or public source repository.',
+          'Make (owned by Celonis) is closed-source commercial software; the Master Services Agreement states Celonis remains the exclusive owner of all right, title, and interest in the Services, and bars customers from copying, modifying, or reverse-engineering the platform, so there is no open-source license or public source repository.',
         shortValue: 'Closed-source, owned by Celonis',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://www.make.com/en/pricing',
-            label: 'Make Pricing page',
-            asOf: '2026-07-02',
+            url: 'https://www.make.com/master-service-agreement.pdf',
+            label: 'Master Services Agreement for Make, Section 6.1 (Celonis)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -303,11 +309,6 @@ export const makeProfile: CompetitorProfile = {
             label: 'Working with files - Make Help Center',
             asOf: '2026-07-02',
           },
-          {
-            url: 'https://www.make.com/en/help/apps/file-and-document-management',
-            label: 'File and document management - Make Help Center',
-            asOf: '2026-07-02',
-          },
         ],
       },
       dataTables: {
@@ -339,9 +340,9 @@ export const makeProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://www.make.com/en/help/apps/file-and-document-management',
-            label: 'File and document management - Make Help Center',
-            asOf: '2026-07-02',
+            url: 'https://apps.make.com/google-docs',
+            label: 'Google Docs - Apps Documentation - Make',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://www.make.com/en/help/app/markdown',
@@ -654,10 +655,11 @@ export const makeProfile: CompetitorProfile = {
         ],
       },
       customCodeSteps: {
-        value: "Yes: native 'Make Code' module supporting JavaScript (Node.js) and Python",
+        value:
+          "Yes: native 'Make Code' module supporting JavaScript (Node.js) and Python, plus optional third-party packages on Enterprise",
         detail:
-          'The Make Code app lets users write and run arbitrary JS or Python inside a scenario execution with no external servers; standard-library modules are available in Python, but the sandbox has no external network access and cannot install npm/PyPI packages.',
-        shortValue: 'Native JS/Python step, sandboxed',
+          'The Make Code app lets users write and run JS or Python inside a scenario execution with no external servers; common libraries (moment/lodash for JS, pendulum/toolz/requests for Python) are pre-installed, and Enterprise plans can import additional third-party packages as declared dependencies. Direct outbound API calls are technically possible, but Make recommends using the HTTP module instead to avoid exposing credentials.',
+        shortValue: 'Native JS/Python step; HTTP calls possible, packages on Enterprise',
         confidence: 'verified',
         sources: [
           {
@@ -665,7 +667,7 @@ export const makeProfile: CompetitorProfile = {
             label: 'Make blog: Make Code App',
             asOf: '2026-07-02',
           },
-          { url: 'https://apps.make.com/code', label: 'Make Code app docs', asOf: '2026-07-02' },
+          { url: 'https://apps.make.com/code', label: 'Make Code app docs', asOf: '2026-07-08' },
         ],
       },
       apiPublishing: {
@@ -707,9 +709,10 @@ export const makeProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://developers.make.com/custom-apps-documentation/apps-marketplace/about',
-            label: 'About | Make Developer Hub (Apps Marketplace)',
-            asOf: '2026-07-02',
+            url: 'https://developers.make.com/custom-apps-documentation/app-components',
+            label:
+              'App components (base, connections, modules, RPCs, webhooks) | Make Developer Hub',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://developers.make.com/api-documentation',
@@ -1010,9 +1013,9 @@ export const makeProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://developers.make.com/custom-apps-documentation/apps-marketplace/terms-and-conditions',
-            label: 'Apps Marketplace terms and conditions - Make Developer Hub',
-            asOf: '2026-07-02',
+            url: 'https://developers.make.com/custom-apps-documentation/app-review/prerequisites',
+            label: 'App review prerequisites - Make Developer Hub',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1126,26 +1129,27 @@ export const makeProfile: CompetitorProfile = {
       },
       executionLimits: {
         value:
-          "Make publishes a hard 40-minute maximum run time per single scenario execution, confirmed in its own MCP Server documentation: a called scenario 'continues running in Make for up to 40 minutes.' Individual module/API calls within a run are also documented by users as timing out around 40 seconds. Make additionally lets admins cap how many instant-trigger scenario runs can start per minute, a configurable rate limit available on all plans. Concurrency across scenarios is plan-gated, though Make does not publish the exact concurrent-run numbers per plan tier in its public help docs.",
+          "Make's MCP Server enforces a per-call timeout of 25 seconds (OAuth authentication) or 40 seconds (MCP token authentication) before returning a timeout response, after which the called scenario continues running for up to 40 minutes in the background. Make does not publish a general per-module/API-call timeout figure or documented concurrent-execution caps per plan tier; the commonly cited ~40-second module timeout is user-reported, not officially documented. Make lets admins cap how many instant-trigger scenario runs can start per minute, a configurable rate limit available on all plans, though no specific default number is published.",
         detail:
-          "The 40-minute figure comes directly from Make's developer docs (MCP server page). The per-minute instant-trigger cap is configurable per the 'Scenario rate limits for instant triggers' help page, but that page does not state the exact default numeric ceiling per plan, and Make does not publicly document precise concurrent-execution-count limits per plan tier.",
-        shortValue: '40-min run cap; per-minute trigger rate limit',
+          "Per Make's MCP Server docs, the timeout before a timeout response is returned depends on the authentication method: 25 seconds for OAuth, 40 seconds for an MCP token; the called scenario itself keeps running in the background for up to 40 minutes. help.make.com/scenario-settings, sometimes cited for general module/API-call execution limits, does not document any timeout figure at all. Admins can cap instant-trigger scenario starts per minute via help.make.com/scenario-rate-limits-for-instant-triggers, but that page does not state a specific default numeric ceiling, and Make does not publicly document concurrent-execution-count limits per plan tier.",
+        shortValue:
+          '25s/40s MCP call timeout; 40-min background run; no published module-timeout figure',
         confidence: 'verified',
         sources: [
           {
             url: 'https://developers.make.com/mcp-server',
-            label: 'Make MCP Server docs: 40-minute execution limit',
-            asOf: '2026-07-02',
+            label: 'Make MCP Server docs: 25s/40s call timeout, 40-minute background run',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://help.make.com/scenario-rate-limits-for-instant-triggers',
             label: 'Make Help Center: Scenario rate limits for instant triggers',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://help.make.com/scenario-settings',
-            label: 'Make Help Center: Scenario settings (cycles per run, other execution controls)',
-            asOf: '2026-07-02',
+            label: 'Make Help Center: Scenario settings (no documented timeout figure)',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/microsoft-copilot.ts
+++ b/apps/sim/lib/compare/data/competitors/microsoft-copilot.ts
@@ -56,13 +56,13 @@ export const microsoftCopilotProfile: CompetitorProfile = {
     {
       title: 'Deep, per-session orchestration traces',
       description:
-        'Conversation transcripts capture which topic fired, which knowledge sources were consulted, which tools and child agents or MCP servers were invoked, the orchestration plan, and how long each step took. They are viewable per-session in the Analytics area for the last 28 days and extendable via export to Azure Data Lake Storage.',
+        "Session tracking in the Monitor tab (part of Copilot Studio's new agent experience, currently in preview) lists each conversation session's status, duration, message count, and which tools were used, and selecting a session opens its full transcript with tool-invocation and knowledge-source usage detail.",
       shortDescription:
-        'Per-session traces cover topics, tools, knowledge, sub-agents, and timing.',
+        'Per-session transcripts in the Monitor tab cover status, tools, and knowledge used.',
       source: {
         url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/agents-experience/analytics-overview',
         label: 'Monitor an agent overview (preview) - Microsoft Copilot Studio | Microsoft Learn',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
   ],
@@ -94,16 +94,16 @@ export const microsoftCopilotProfile: CompetitorProfile = {
       },
     },
     {
-      title: 'Session transcript detail defaults to a 28-day window',
+      title: 'Session transcript detail defaults to a 29-day window',
       description:
-        "An agent's per-session transcripts, showing which topic fired, tools called, and knowledge consulted, are available in the Analytics area for the last 28 days by default. Retaining that detail longer requires a separate export pipeline (Azure Synapse Link for Dataverse into Azure Data Lake Storage Gen2), not a built-in retention setting.",
+        "An agent's per-session transcripts, showing which topic fired, tools called, and knowledge consulted, are downloadable from the Analytics area for roughly the last 29 days by default. Retaining that detail longer requires a separate export pipeline, not a built-in retention setting.",
       shortDescription:
-        'Detailed session transcripts default to 28 days; longer retention needs a manual export.',
+        'Detailed session transcripts default to ~29 days; longer retention needs a manual export.',
       source: {
         url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/analytics-transcripts-studio',
         label:
           'Understand downloaded session data from Copilot Studio - Microsoft Copilot Studio | Microsoft Learn',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -220,7 +220,7 @@ export const microsoftCopilotProfile: CompetitorProfile = {
       },
       templates: {
         value:
-          'Yes: an Agent Library of ready-to-use, pre-built agent templates (e.g. Employee Self-Service, Prompt Coach, IT Helpdesk, Financial Insights) with preconfigured instructions, actions, topics, and starter knowledge, deployable into an environment and then customized',
+          'Yes: an Agent Library of ready-to-use, pre-built agent templates (e.g. My Company Policy, Request Tracker, Know Your Customer, Plan My Day, Executive Brief) with preconfigured instructions, actions, topics, and starter knowledge, deployable into an environment and then customized',
         detail:
           'Templates are distributed as a visual, guided-deployment catalog on Microsoft Marketplace and as raw solution files on GitHub.',
         shortValue: 'Yes, Agent Library of pre-built, customizable templates',
@@ -230,13 +230,13 @@ export const microsoftCopilotProfile: CompetitorProfile = {
             url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/guidance/agent-library-overview',
             label:
               'Configure and deploy agents from the Agent Library - Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/template-fundamentals',
             label:
               'Create a custom agent from a template - Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -324,16 +324,22 @@ export const microsoftCopilotProfile: CompetitorProfile = {
       },
       dataTables: {
         value:
-          'No: Copilot Studio does not offer a lightweight, spreadsheet-like data table with arrow-key navigation and copy-paste. Its native structured-data store is Microsoft Dataverse, a full relational database with tables, relationships, and business rules, used both as an agent knowledge source and for storing conversation transcripts and custom analytics.',
+          'No: Copilot Studio does not offer a lightweight, spreadsheet-like data table with arrow-key navigation and copy-paste. Its native structured-data store is Microsoft Dataverse, a full relational database with tables, relationships, and business rules, used both as an agent knowledge source and, via dedicated bot/botcomponent/conversationtranscript tables, for storing conversation transcripts and custom analytics.',
         detail:
-          'Dataverse is the same underlying data platform Power Automate uses. It serves as the agent data platform for grounding, but it is a relational database product, not a simple spreadsheet-grid UI.',
+          "Dataverse is the same underlying data platform Power Automate uses, offering rich metadata/relationships plus business rules and workflows for data validation, not a simple spreadsheet-grid UI. Copilot Studio's custom-analytics guidance documents the ConversationTranscript, Copilot (bot), and Copilot component (botcomponent) tables it writes usage data into.",
         shortValue: 'Dataverse tables are a full DB, not a spreadsheet grid',
-        confidence: 'estimated',
+        confidence: 'verified',
         sources: [
           {
-            url: 'https://www.microsoft.com/en-us/power-platform/blog/2026/05/05/dataverse-agent-data-platform/',
-            label: 'Dataverse Is Your Agent Data Platform - Microsoft Power Platform Blog',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/power-apps/maker/data-platform/data-platform-intro',
+            label: 'What is Microsoft Dataverse? - Power Apps | Microsoft Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/guidance/custom-analytics-strategy',
+            label:
+              'Develop a custom analytics strategy - Microsoft Copilot Studio | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -363,15 +369,9 @@ export const microsoftCopilotProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/flow-designer',
-            label:
-              'Edit and manage your agent flow in the designer - Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/advanced-use-flow',
-            label: 'Call an agent flow from an agent - Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-overview',
+            label: 'Agent flows overview - Microsoft Copilot Studio | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -400,7 +400,7 @@ export const microsoftCopilotProfile: CompetitorProfile = {
       },
       agentReasoningBlocks: {
         value:
-          "Yes: generative orchestration is an LLM-driven planning layer that selects among an agent's topics, tools, knowledge sources, and child agents at runtime, and an optional deep reasoning model (GPT-5.5 Reasoning) can be enabled for tasks requiring step-by-step logical analysis, distinct from a fixed decision-tree topic flow",
+          "Yes: generative orchestration is an LLM-driven planning layer that selects among an agent's topics, tools, knowledge sources, and child agents at runtime, and an optional deep reasoning model (the Azure OpenAI o3 model) can be enabled for tasks requiring step-by-step logical analysis, distinct from a fixed decision-tree topic flow",
         detail:
           'Deep reasoning is regionally limited to the United States and the EU (excluding the UK) and trades response speed for accuracy on complex tasks. The agent decides when to apply it, or a maker can force it via a "reason" keyword in instructions.',
         shortValue: 'Generative orchestration planning plus an optional deep reasoning model',
@@ -416,7 +416,7 @@ export const microsoftCopilotProfile: CompetitorProfile = {
             url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-reasoning-models',
             label:
               'Add a deep reasoning model for complex tasks (preview) - Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -606,18 +606,21 @@ export const microsoftCopilotProfile: CompetitorProfile = {
       },
       kbChunkVisibility: {
         value:
-          "Partial: Copilot Studio's test/preview panel shows a trace of which knowledge sources an agent consulted for an answer, with footnote-style citations tied to specific chunk metadata (e.g. document and page), and a maker can navigate from a citation to the source component to edit it, but there is no dedicated raw chunk-content inspector distinct from citation footnotes.",
+          "Partial: generative answers return citation links back to the knowledge source consulted for an answer, rendered automatically in the chat surface (Copilot Studio's own chat and Microsoft Teams, unless the response is customized), letting a user trace an answer to its source, but there is no documented chunk-level metadata (such as document/page numbers) or a dedicated raw chunk-content inspector distinct from the citation link itself.",
         detail:
-          'Some knowledge formats, such as local JSON, lack citation metadata entirely, so chunk-level detail is not uniformly available across every knowledge-source type.',
-        shortValue:
-          'Test panel shows citations/trace with chunk metadata, not a full chunk inspector',
+          "Citations returned from a knowledge source currently can't be used as inputs to other tools or actions, per Copilot Studio's own knowledge-sources documentation, and citation rendering must be explicitly re-added when a generative answer is customized before being sent to Teams.",
+        shortValue: 'Citation links trace an answer to its source; no chunk-inspector documented',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/knowledge-test',
-            label:
-              "Test your agent's knowledge sources - Microsoft Copilot Studio | Microsoft Learn",
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/knowledge-copilot-studio',
+            label: 'Knowledge sources summary - Microsoft Copilot Studio | Microsoft Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/nlu-boost-node',
+            label: 'Add a generative answers node - Microsoft Copilot Studio | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -688,32 +691,34 @@ export const microsoftCopilotProfile: CompetitorProfile = {
     },
     integrations: {
       integrationCount: {
-        value: '1,000+ pre-built connectors',
+        value: 'Many pre-built connectors from the shared Power Platform connector catalog',
         detail:
-          'Copilot Studio shares the same underlying Power Platform connector catalog that Power Automate and Power Apps use, split into standard connectors (included with all plans) and premium connectors (available on select plans), plus custom connectors for any other API.',
-        shortValue: '1,000+ connectors from the shared Power Platform catalog',
+          'Copilot Studio shares the same underlying Power Platform connector catalog that Power Automate and Power Apps use, split into standard connectors (included with all plans) and premium connectors (available on select plans), plus custom connectors for any other API. Microsoft does not publish a single current total connector count on this catalog documentation.',
+        shortValue:
+          'Many connectors from the shared Power Platform catalog, standard/premium/custom',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/advanced-connectors',
             label:
               'Use connectors in Copilot Studio agents - Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-04',
+            asOf: '2026-07-08',
           },
         ],
       },
       triggerTypes: {
         value:
-          'Conversational trigger phrases (topics), autonomous event-based triggers that wait for a specific event to fire the agent without a user prompting it, connector-event triggers, and schedule-based triggers for agent flows',
+          'Conversational trigger phrases (topics) that fire only when a user types a matching phrase, plus event triggers that let an agent act autonomously without user input in response to a connector-sourced event, such as a new SharePoint item, an added OneDrive file, a completed Planner task, or a changed Dataverse row, including a built-in, schedule-based Recurrence trigger',
         detail:
-          'Autonomous triggers let an agent proactively respond to events, such as a new record or an incoming email, rather than only reacting to a live conversation.',
-        shortValue: 'Trigger phrases, autonomous event triggers, connector events, schedules',
-        confidence: 'estimated',
+          "Event triggers require generative orchestration and deliver a JSON or plain-text payload describing the event to the agent, whose instructions then choose which action or topic to call in response. The Recurrence trigger is Copilot Studio's schedule-based event-trigger type, firing after a configured amount of time passes.",
+        shortValue:
+          'Topic trigger phrases, plus connector-sourced and schedule-based event triggers',
+        confidence: 'verified',
         sources: [
           {
-            url: 'https://adoption.microsoft.com/files/copilot-studio/Autonomous-agents-with-Microsoft-Copilot-Studio.pdf',
-            label: 'Autonomous Agents with Microsoft Copilot Studio',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-triggers-about',
+            label: 'Event triggers overview - Microsoft Copilot Studio | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -951,9 +956,10 @@ export const microsoftCopilotProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://learn.microsoft.com/en-us/power-platform/admin/wp-data-loss-prevention',
-            label: 'Data policies - Power Platform | Microsoft Learn',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/admin-data-loss-prevention',
+            label:
+              'Configure data policies for agents - Microsoft Copilot Studio | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -990,17 +996,24 @@ export const microsoftCopilotProfile: CompetitorProfile = {
       },
       dataRetention: {
         value:
-          'Partial: session/transcript detail in the Analytics area defaults to a 28-day window (conversation transcripts downloadable for 29 days), extendable only via a separate export pipeline (Azure Synapse Link for Dataverse into Azure Data Lake Storage Gen2) rather than a built-in, admin-configurable retention setting for that transcript detail',
+          'Partial: conversation transcripts downloaded directly from Copilot Studio only cover the past 29 days, while the underlying Dataverse conversation-transcript and custom-analytics tables default to a 30-day retention period; extending retention beyond that default requires either an admin changing the Dataverse retention setting or exporting the data via Azure Synapse Link for Dataverse into Azure Data Lake Storage Gen2',
         detail:
-          "This differs from Power Automate's flow-run-history retention, which is directly admin-configurable in the Power Platform admin center (28/14/7 days or a custom Dataverse field edit). Copilot Studio's session-transcript detail requires the export workaround instead.",
-        shortValue: '28-day default transcript window; longer retention needs a manual export',
-        confidence: 'estimated',
+          "Copilot Studio's own download experience is capped at the past 29 days regardless of the underlying Dataverse retention window. Microsoft's custom-analytics guidance documents the 30-day default retention on the Dataverse-side bot/botcomponent/conversationtranscript tables and recommends Synapse Link as the export path for longer-term or custom-reporting needs.",
+        shortValue:
+          '29-day direct download; 30-day default Dataverse retention, extendable via export',
+        confidence: 'verified',
         sources: [
           {
             url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/analytics-transcripts-studio',
             label:
               'Understand downloaded session data from Copilot Studio - Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/guidance/custom-analytics-strategy',
+            label:
+              'Develop a custom analytics strategy - Microsoft Copilot Studio | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1013,10 +1026,10 @@ export const microsoftCopilotProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://learn.microsoft.com/en-us/purview/ai-copilot-studio',
+            url: 'https://learn.microsoft.com/en-us/purview/dlp-microsoft365-copilot-location-learn-about',
             label:
-              'Use Microsoft Purview to manage data security & compliance for Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-02',
+              'Microsoft Purview DLP for Microsoft 365 Copilot and Copilot Chat | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1183,21 +1196,21 @@ export const microsoftCopilotProfile: CompetitorProfile = {
       },
       unattendedExecution: {
         value:
-          "Yes: autonomous event-triggered agent runs and agent flows execute on Microsoft-operated cloud infrastructure (the same Commercial/GCC/GCC High/DoD environments Copilot Studio's authoring and runtime services run in), not on a maker's own device or browser session",
+          "Yes in Commercial environments: autonomous event-triggered agent runs and agent flows execute on Microsoft-operated cloud infrastructure, not on a maker's own device or browser session. Per Microsoft's own GCC/GCC High licensing documentation, Triggers/Autonomous Agents are currently NOT available in GCC or GCC High government cloud environments.",
         detail:
-          "Autonomous triggers let an agent proactively respond to a connector event or schedule without a live conversation open, and agent flows run on the Power Automate flow engine's server-side runtime. Closing the authoring browser tab or shutting down a laptop has no effect on a published agent's ability to fire on a trigger or complete a run.",
-        shortValue: 'Yes, runs server-side on Microsoft-operated infrastructure',
+          "Autonomous triggers let an agent proactively respond to a connector event or schedule without a live conversation open, and agent flows run on the Power Automate flow engine's server-side runtime in Commercial environments. Closing the authoring browser tab or shutting down a laptop has no effect on a published agent's ability to fire on a trigger or complete a run, but Microsoft's GCC/GCC High feature-availability table lists Triggers/Autonomous Agents as unavailable in those government-cloud environments.",
+        shortValue: 'Yes in Commercial cloud; not available in GCC/GCC High per Microsoft docs',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-licensing-gcc',
             label: 'US Government customers - Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-04',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://adoption.microsoft.com/files/copilot-studio/Autonomous-agents-with-Microsoft-Copilot-Studio.pdf',
             label: 'Autonomous Agents with Microsoft Copilot Studio',
-            asOf: '2026-07-04',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/n8n.ts
+++ b/apps/sim/lib/compare/data/competitors/n8n.ts
@@ -402,7 +402,7 @@ export const n8nProfile: CompetitorProfile = {
             asOf: '2026-07-08',
           },
           {
-            url: 'https://docs.n8n.io/build/ways-of-building-workflows/ai-workflow-builder.md',
+            url: 'https://docs.n8n.io/build/ways-of-building-workflows/ai-workflow-builder',
             label: 'n8n AI Workflow Builder docs',
             asOf: '2026-07-08',
           },

--- a/apps/sim/lib/compare/data/competitors/n8n.ts
+++ b/apps/sim/lib/compare/data/competitors/n8n.ts
@@ -52,12 +52,12 @@ export const n8nProfile: CompetitorProfile = {
     {
       title: 'Built-in Evaluations for AI workflows',
       description:
-        "A dedicated Evaluations feature runs a workflow against a test dataset with expected outputs. 'Light evaluations' are for dev-time spot checks, while 'Metric-based evaluations' score at production scale using built-in metrics (AI-judged helpfulness, string similarity, categorization, tools used) plus custom metrics.",
+        "A dedicated Evaluations feature runs a workflow against a test dataset with expected outputs. 'Light evaluations' are for dev-time spot checks, while 'Metric-based evaluations' score at production scale using built-in metrics (AI-judged Correctness and Helpfulness, String Similarity, Categorization, and Tools Used) plus custom metrics.",
       shortDescription: 'Native test-dataset evaluations for dev checks and production monitoring.',
       source: {
-        url: 'https://docs.n8n.io/advanced-ai/evaluations/overview/',
-        label: 'n8n Evaluations docs',
-        asOf: '2026-07-02',
+        url: 'https://docs.n8n.io/build/integrate-ai/test-and-improve-ai-workflows/use-metrics-to-measure-quality.md',
+        label: 'n8n docs: Use metrics to measure quality',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -127,19 +127,19 @@ export const n8nProfile: CompetitorProfile = {
       builderType: {
         value: 'Hybrid visual/code node-based builder',
         detail:
-          "n8n's core interface is a visual, drag-and-drop node canvas where each node is a step. It supports a Custom Code node (JavaScript/Python) and an HTTP Request Tool for arbitrary API calls, plus a beta natural-language AI Workflow Builder that generates an editable draft workflow from a text prompt.",
+          "n8n's core interface is a visual, drag-and-drop node canvas where each node is a step. It supports a Custom Code node (JavaScript/Python) and an HTTP Request Tool for arbitrary API calls, plus a natural-language AI Workflow Builder, gated by pricing tier rather than a beta flag, that generates an editable draft workflow from a text prompt.",
         shortValue: 'Visual canvas plus code node and AI builder',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.n8n.io/advanced-ai/ai-workflow-builder/',
+            url: 'https://docs.n8n.io/build/ways-of-building-workflows/ai-workflow-builder',
             label: 'n8n AI Workflow Builder docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent',
-            label: 'n8n Tools Agent docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.code',
+            label: 'n8n Code node docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -222,19 +222,14 @@ export const n8nProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.n8n.io/source-control-environments/understand/environments/',
-            label: 'Environments in n8n | n8n Docs',
-            asOf: '2026-07-02',
-          },
-          {
             url: 'https://docs.n8n.io/administer/use-source-control-and-environments/push-and-pull-changes',
             label: 'Push and pull changes | Administer | n8n Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://docs.n8n.io/source-control-environments/using/push-pull/',
-            label: 'Push and pull | n8n Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/deploy/host-n8n/community-edition-features.md',
+            label: 'Community edition features | n8n Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -267,14 +262,14 @@ export const n8nProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.n8n.io/source-control-environments/',
-            label: 'Source control and environments | n8n Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/deploy/host-n8n/community-edition-features.md',
+            label: 'Community edition features | n8n Docs',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://docs.n8n.io/hosting/community-edition-features/',
-            label: 'Community edition features | n8n Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/administer/use-source-control-and-environments',
+            label: 'Use source control and environments | Administer | n8n Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -327,9 +322,9 @@ export const n8nProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.n8n.io/workflows/components/sticky-notes/',
+            url: 'https://docs.n8n.io/build/understand-workflows/workflow-components/add-notes-and-documentation.md',
             label: 'Sticky Notes | n8n Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://www.createwith.com/tool/n8n/updates/n8n-adds-markdown-support-to-workflow-sticky-notes-for-embedded-images-and-video',
@@ -391,24 +386,25 @@ export const n8nProfile: CompetitorProfile = {
             label: 'n8n Tools Agent docs',
             asOf: '2026-07-02',
           },
-          {
-            url: 'https://docs.n8n.io/advanced-ai/examples/understand-agents/',
-            label: "n8n docs: What's an agent in AI?",
-            asOf: '2026-07-02',
-          },
         ],
       },
       naturalLanguageBuilding: {
-        value: 'Yes: beta AI Workflow Builder, Cloud only currently',
+        value:
+          'Yes: AI Workflow Builder, generally available on Starter, Pro, and Enterprise Cloud',
         detail:
-          'Users describe a workflow in plain text and the beta AI Workflow Builder generates a draft, editable node-based workflow with iterative multi-turn refinement. Available in beta on Cloud (Trial, Starter, Pro plans), with Enterprise and self-hosted support planned for later.',
-        shortValue: 'Beta builder, Cloud plans only',
+          'Users describe a workflow in plain text and the AI Workflow Builder generates a draft, editable node-based workflow with iterative multi-turn refinement. Launched in beta in late 2025, it reached general availability for n8n Cloud customers on the Starter, Pro, and Enterprise plans; self-hosted availability is not documented.',
+        shortValue: 'GA on Starter/Pro/Enterprise Cloud plans',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.n8n.io/advanced-ai/ai-workflow-builder/',
+            url: 'https://blog.n8n.io/ai-workflow-builder-best-practices/',
+            label: 'n8n Blog: AI Workflow Builder Best Practices',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.n8n.io/build/ways-of-building-workflows/ai-workflow-builder.md',
             label: 'n8n AI Workflow Builder docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -555,9 +551,9 @@ export const n8nProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://docs.n8n.io/advanced-ai/chat-hub/',
+            url: 'https://docs.n8n.io/build/ways-of-building-workflows/chat-hub',
             label: 'Chat Hub | n8n Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -591,9 +587,9 @@ export const n8nProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://docs.n8n.io/flow-logic/execution-order/',
+            url: 'https://docs.n8n.io/build/flow-logic/understand-execution-order',
             label: 'Execution order in multi-branch workflows | n8n Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.n8n.io/build/flow-logic/merge-data',
@@ -640,16 +636,16 @@ export const n8nProfile: CompetitorProfile = {
     },
     integrations: {
       integrationCount: {
-        value: '1,921 integrations (per n8n.io/integrations)',
+        value: '1,936 integrations (per n8n.io/integrations)',
         detail:
-          "The n8n.io integrations directory page lists 1,921 integrations. n8n's GitHub repo description separately advertises a rounder '400+ integrations,' so the two vendor sources disagree slightly.",
-        shortValue: '1,921 listed integrations',
+          "The n8n.io integrations directory page lists 1,936 integrations. n8n's GitHub repo description separately advertises a rounder '400+ integrations,' so the two vendor sources disagree slightly.",
+        shortValue: '1,936 listed integrations',
         confidence: 'verified',
         sources: [
           {
             url: 'https://n8n.io/integrations/',
             label: 'n8n.io Integrations directory',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -667,9 +663,9 @@ export const n8nProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://docs.n8n.io/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp/',
-            label: 'MCP Client/Server Trigger docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger',
+            label: 'MCP Server Trigger docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -681,9 +677,14 @@ export const n8nProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent',
-            label: 'n8n Tools Agent docs (mentions Custom Code Tool)',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.code',
+            label: 'Code node docs',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.n8n.io/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode/',
+            label: 'Code Tool docs (AI agent custom code tool)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -696,9 +697,14 @@ export const n8nProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://docs.n8n.io/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp/',
-            label: 'MCP Server/Client Tool docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook/',
+            label: 'Webhook trigger docs',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger',
+            label: 'MCP Server Trigger docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -711,9 +717,9 @@ export const n8nProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.n8n.io/api/',
-            label: 'n8n public REST API Documentation | n8n Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/connect/n8n-api',
+            label: 'n8n API | Connect | n8n Docs',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://www.npmjs.com/package/@n8n/rest-api-client',
@@ -721,9 +727,9 @@ export const n8nProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://docs.n8n.io/integrations/creating-nodes/build/reference/code-standards/',
-            label: 'Code standards | n8n Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/connect/create-nodes/build-your-node/using-the-n8n-node-tool',
+            label: 'Using the n8n-node tool | Connect | n8n Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -741,9 +747,9 @@ export const n8nProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://docs.n8n.io/advanced-ai/mcp/accessing-n8n-mcp-server/',
-            label: 'Set up and use n8n MCP server | n8n Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/connect/connect-to-n8n-mcp-server',
+            label: 'Connect to n8n MCP server | n8n Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -760,10 +766,10 @@ export const n8nProfile: CompetitorProfile = {
       entryPaidPlan: {
         value: 'Starter plan: €20/month (billed annually), 2,500 executions/month, cloud-hosted',
         detail:
-          'Starter includes 2,500 workflow executions per month, 5 concurrent executions, 1 shared project, unlimited users, 50 AI credits, and forum support.',
+          'Starter includes 2,500 workflow executions per month, 5 concurrent executions, 1 shared project, unlimited users, 2,300 AI credits, and forum support.',
         shortValue: '€20/month, 2,500 executions',
         confidence: 'verified',
-        sources: [{ url: 'https://n8n.io/pricing/', label: 'n8n Pricing', asOf: '2026-07-02' }],
+        sources: [{ url: 'https://n8n.io/pricing/', label: 'n8n Pricing', asOf: '2026-07-08' }],
       },
       freeTier: {
         value: 'Yes: free self-hosted Community Edition, plus a free cloud trial (no credit card)',
@@ -782,12 +788,23 @@ export const n8nProfile: CompetitorProfile = {
       },
       byok: {
         value:
-          'De facto yes: all Chat Model nodes require users\' own provider API credentials, though n8n does not name this "BYOK"',
+          'De facto yes: Chat Model nodes require users\' own provider API credentials, though n8n does not name this "BYOK"',
         detail:
-          "n8n's pricing page describes plan-included 'AI credits' (50/150/1,000 depending on tier) for its own hosted AI features, but doesn't name a bring-your-own-API-key policy. Since all Chat Model nodes require users to supply their own provider API credentials to call OpenAI, Anthropic, and others directly, BYOK is the de facto default for workflow-level LLM calls.",
+          "n8n's OpenAI and Anthropic credential docs both walk users through generating an API key in the provider's own console and entering it as the node credential; no n8n-hosted key is supplied for these Chat Model nodes. Separately, n8n's pricing page describes plan-included 'AI credits' (2,300 on Starter, up to 13,700+ on higher tiers) for n8n's own in-app AI Assistant feature, which is distinct from the provider credentials Chat Model nodes require. n8n does not name a bring-your-own-API-key policy, but requiring each provider's own key for Chat Model nodes makes BYOK the de facto default for workflow-level LLM calls.",
         shortValue: 'De facto via provider API keys, not named',
         confidence: 'estimated',
-        sources: [{ url: 'https://n8n.io/pricing/', label: 'n8n Pricing', asOf: '2026-07-02' }],
+        sources: [
+          {
+            url: 'https://docs.n8n.io/integrations/builtin/credentials/openai',
+            label: 'n8n docs: OpenAI credentials',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.n8n.io/integrations/builtin/credentials/anthropic',
+            label: 'n8n docs: Anthropic credentials',
+            asOf: '2026-07-08',
+          },
+        ],
       },
     },
     security: {
@@ -858,22 +875,22 @@ export const n8nProfile: CompetitorProfile = {
       },
       additionalCompliance: {
         value:
-          'GDPR (as data processor) and a publicly downloadable SOC 3 report; SOC 2 report available on request, not a certified SOC 2 Type II; no HIPAA, ISO 27001, PCI, or FedRAMP certification found',
+          'GDPR (as data processor), SOC 2 Type II certification, and a publicly downloadable SOC 3 report; no HIPAA, ISO 27001, PCI, or FedRAMP certification found',
         detail:
-          "n8n's Trust Center (SafeBase-hosted) and legal/security page list GDPR compliance (as a data processor with a standard DPA), CAIQ self-assessment questionnaires for both cloud and self-hosted deployments, and a SOC 3 report that is publicly downloadable from the Security page. Its security program is aligned to the SOC 2 framework with annual independent audits, but n8n does not claim a certified SOC 2 Type II attestation, and the SOC 2 report itself is provided to enterprise customers on request rather than published. n8n holds no ISO 27001, HIPAA BAA, PCI-DSS, or FedRAMP certification. Third-party blog posts describe self-hosted n8n as helping organizations map to HIPAA/ISO 27001 requirements, but that is not the same as holding those certifications.",
-        shortValue: 'GDPR, public SOC 3, SOC 2 aligned (report on request)',
+          "n8n's Trust Center (SafeBase-hosted) and legal/security page list GDPR compliance (as a data processor with a standard DPA), CAIQ self-assessment questionnaires for both cloud and self-hosted deployments, and a SOC 3 report that is publicly downloadable from the Security page. n8n now holds SOC 2 Type II certification, viewable via the Trust Center, in addition to the public SOC 3 report. n8n holds no ISO 27001, HIPAA BAA, PCI-DSS, or FedRAMP certification. Third-party blog posts describe self-hosted n8n as helping organizations map to HIPAA/ISO 27001 requirements, but that is not the same as holding those certifications.",
+        shortValue: 'GDPR, SOC 2 Type II certified, public SOC 3 report',
         confidence: 'verified',
         sources: [
           {
             url: 'https://trust.n8n.io/',
             label: 'n8n Trust Center | Powered by SafeBase',
-            asOf: '2026-07-04',
+            asOf: '2026-07-08',
           },
-          { url: 'https://n8n.io/legal/security/', label: 'Security | n8n', asOf: '2026-07-04' },
+          { url: 'https://n8n.io/legal/security/', label: 'Security | n8n', asOf: '2026-07-08' },
           {
             url: 'https://support.n8n.io/article/request-for-soc-2-report',
             label: 'Request for SOC-2 report | n8n Help Center',
-            asOf: '2026-07-04',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -886,21 +903,21 @@ export const n8nProfile: CompetitorProfile = {
       },
       credentialGovernance: {
         value:
-          "Yes: n8n's RBAC model is scope-based, with custom project roles (Enterprise feature) letting admins grant or restrict access to specific credentials, workflows, and folders at a granular, per-resource level, beyond the built-in Admin/Editor/Viewer roles.",
+          "Yes: n8n's RBAC model is project-based, with built-in Admin/Editor/Viewer project roles, and custom project roles (Enterprise feature) let admins scope access across resource types, including credentials, workflows, folders, data tables, variables, and source control, beyond the default three roles.",
         detail:
-          'Custom Project Roles (Enterprise) let admins build least-privilege roles scoped to particular credentials/resources, not just feature-level RBAC.',
-        shortValue: 'Yes, custom roles gate specific credentials',
+          "n8n's docs describe access control as project-based rather than scope-based: users get one of three built-in project roles (Admin, Editor, Viewer). Custom Project Roles (Enterprise) let admins build least-privilege roles whose permission surface spans Projects, Folders, Workflows, Credentials, Data tables, Variables, and Source control, rather than being limited to the three default roles.",
+        shortValue: 'Yes, project-based RBAC with custom Enterprise roles',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.n8n.io/user-management/rbac/custom-roles/',
-            label: 'Custom project roles | n8n Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/administer/manage-users-and-access/set-permissions-and-roles-rbac/see-available-roles',
+            label: 'See available roles | Administer | n8n Docs',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://blog.n8n.io/introducing-custom-project-roles-and-user-provisioning-via-sso-built-for-enterprise-governance/',
             label: 'Introducing Custom Project Roles and User Provisioning via SSO',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -933,14 +950,14 @@ export const n8nProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.n8n.io/hosting/scaling/execution-data/',
-            label: 'Execution data | n8n Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/deploy/host-n8n/configure-n8n/scaling/manage-execution-data',
+            label: 'Manage execution data | Deploy | n8n Docs',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://docs.n8n.io/manage-cloud/cloud-data-management/',
-            label: 'Cloud data management | n8n Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.n8n.io/deploy/use-n8n-cloud/configure-cloud/manage-your-data',
+            label: 'Manage your data | Deploy | n8n Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1161,22 +1178,21 @@ export const n8nProfile: CompetitorProfile = {
       },
       unattendedExecution: {
         value:
-          "Yes: scheduled, webhook, and other trigger-based executions run on n8n's own servers (n8n Cloud) or on the self-hosted n8n server process, not on a user's local machine",
+          'Yes: active trigger-based executions (schedule, webhook, etc.) keep running on the n8n instance itself after a user closes their browser, whether that instance is n8n Cloud or a self-hosted server',
         detail:
-          "On n8n Cloud, n8n operates the infrastructure, so a trigger-based workflow fires and completes with no dependency on any user's browser tab or device staying open. Self-hosted n8n instead depends on the operator's own server/container (Docker, Kubernetes, or a host machine) staying up, since n8n is a server process rather than a desktop app; as long as that server process is running, individual client devices can disconnect freely.",
-        shortValue:
-          "Runs on n8n's server (Cloud) or the operator's own server (self-hosted); no client device dependency",
+          "n8n staff confirm in the community forum that once a workflow is activated with a trigger, execution continues on the n8n instance independent of the browser tab that was used to activate it; only workflows kicked off via a manual 'Execute Workflow' click stop when the browser closes mid-run. Since n8n itself is a server process (n8n Cloud or a self-hosted Docker/Kubernetes/host-machine instance) rather than a desktop app, unattended trigger-based runs depend on that server staying up, not on any individual client device.",
+        shortValue: 'Trigger-based runs continue on the server after the browser closes',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.n8n.io/choose-how-to-use-n8n.md',
-            label: 'n8n docs: Choose how to use n8n',
-            asOf: '2026-07-04',
+            url: 'https://community.n8n.io/t/does-the-process-continue-even-though-i-close-the-browser-window/15307',
+            label: 'n8n Community: Does the process continue if I close the browser window?',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://docs.n8n.io/hosting/',
-            label: 'n8n Docs: Hosting n8n',
-            asOf: '2026-07-04',
+            url: 'https://docs.n8n.io/choose-how-to-use-n8n.md',
+            label: 'n8n docs: Choose how to use n8n',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1206,18 +1222,22 @@ export const n8nProfile: CompetitorProfile = {
         sources: [{ url: 'https://n8n.io/pricing/', label: 'n8n Pricing', asOf: '2026-07-02' }],
       },
       community: {
-        value: 'Large community: ~195k GitHub stars, ~82k Discord members, 30k+ forum members',
+        value: 'Large community: ~195k GitHub stars, 200k+ community members across all channels',
         detail:
-          'The n8n-io/n8n GitHub repository shows about 194,939 stargazers (via GitHub API). The n8n Discord server is cited by third-party community trackers at roughly 82,422 members. The official n8n Community Forum is described as having 30k+ members.',
-        shortValue: '~195k GitHub stars, ~82k Discord members',
+          "The n8n-io/n8n GitHub repository shows 195,690 stargazers (via GitHub API). n8n's own homepage advertises 200k+ community members in aggregate across its Discord, forum, and other channels, but does not break that figure down by channel, and neither the n8n Discord server nor the official Community Forum (community.n8n.io) publishes an individual member-count total.",
+        shortValue: '~195k GitHub stars, 200k+ community members',
         confidence: 'verified',
         sources: [
           {
             url: 'https://api.github.com/repos/n8n-io/n8n',
             label: 'GitHub API: n8n-io/n8n repo',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
-          { url: 'https://community.n8n.io/', label: 'n8n Community Forum', asOf: '2026-07-02' },
+          {
+            url: 'https://n8n.io',
+            label: 'n8n.io homepage (200k+ community members)',
+            asOf: '2026-07-08',
+          },
         ],
       },
       companyMaturity: {

--- a/apps/sim/lib/compare/data/competitors/openai-agentkit.ts
+++ b/apps/sim/lib/compare/data/competitors/openai-agentkit.ts
@@ -827,16 +827,26 @@ export const openaiAgentkitProfile: CompetitorProfile = {
       },
       rbac: {
         value:
-          'Yes, at the organization level. The Global Admin Console gates access to the Connector Registry, and the Admin API lets Organization Owners assign custom roles and enable or disable specific apps and actions. Granular access scoped to individual Agent Builder workflows is not documented.',
+          'Yes, at the workspace level. Workspace Owners create custom roles and use per-role "Connected data" controls to allow or restrict which apps/connectors (and their actions) each role can use, with all apps disabled by default. A separate Global Admin Console (beta) adds a distinct Global admin role for centralizing access management across workspaces. Granular access scoped to individual Agent Builder workflows is not documented.',
         detail:
-          'The Global Admin Console manages access to the Connector Registry used by Agent Builder, and the Admin API lets Organization Owners centrally manage workspaces, assign custom roles to teams, and enable/disable specific apps and actions. This is org/admin-level RBAC, not workflow-scoped permissions within Agent Builder itself.',
-        shortValue: 'Org-level RBAC via Admin API and Console',
+          'ChatGPT Enterprise/Edu/Business workspaces let Workspace Owners create custom roles and, under each role\'s Connected data section, turn on "Allow members to use apps" and select which specific apps that role can access; when an admin enables an app, they can also set action controls (allow all actions, read-only, or a custom action set). All apps are disabled by default until an admin turns them on. The Global Admin Console is a newer, separate beta surface with its own Global admin role and an Access tab for centralizing SSO, domain, and external-application access across workspaces. This is workspace/role-level RBAC over apps and connectors, not permissions scoped to individual Agent Builder workflows.',
+        shortValue: 'Workspace-level RBAC via custom roles, per-app controls',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://developers.openai.com/api/docs/guides/admin-apis',
-            label: 'Admin APIs | OpenAI API',
-            asOf: '2026-07-02',
+            url: 'https://help.openai.com/en/articles/11750701-rbac',
+            label: 'RBAC | OpenAI Help Center',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://help.openai.com/en/articles/11509118-admin-controls-security-and-compliance-in-apps-enterprise-edu-and-business',
+            label: 'Admin Controls, Security, and Compliance in apps | OpenAI Help Center',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://help.openai.com/en/articles/12289294-global-admin-console',
+            label: 'Global Admin Console | OpenAI Help Center',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -857,22 +867,23 @@ export const openaiAgentkitProfile: CompetitorProfile = {
       },
       additionalCompliance: {
         value:
-          'SOC 2 Type 2, ISO/IEC 27001:2022, ISO/IEC 27701:2019; supports customer HIPAA/GDPR/CCPA/FERPA compliance via DPA + BAA',
+          'FedRAMP Moderate Authorization (ChatGPT Enterprise and API Platform), PCI DSS v4.0.1, SOC 2 Type 2, ISO/IEC 27001:2022, ISO/IEC 27701:2019; supports customer HIPAA compliance via BAA and GDPR/CCPA via DPA; FERPA covered via a separate Student Data Privacy Agreement for ChatGPT Edu',
         detail:
-          "OpenAI's SOC 2 Type 2 examination (Security, Availability, Confidentiality, Privacy criteria) covers the API Platform, ChatGPT Enterprise, ChatGPT Edu, and ChatGPT Team, alongside ISO/IEC 27001:2022 and ISO/IEC 27701:2019 certifications for the same services. OpenAI supports customers' compliance with GDPR, CCPA, HIPAA, and FERPA, and offers a Data Processing Addendum and a Business Associate Agreement for HIPAA-regulated customers. This is enablement rather than OpenAI itself being HIPAA-certified, since HIPAA has no formal certification body. No FedRAMP or PCI attestation was found for the AgentKit/API products.",
-        shortValue: 'SOC 2, ISO 27001/27701, HIPAA/GDPR support',
+          "OpenAI's ChatGPT Enterprise and API Platform hold FedRAMP Moderate (Class C) authorization per the FedRAMP Marketplace listing. OpenAI's trust portal lists PCI DSS v4.0.1 for payment-processing components, a SOC 2 Type 2 examination (Security, Availability, Confidentiality, Privacy criteria) covering the API Platform, ChatGPT Enterprise, ChatGPT Edu, and ChatGPT Team, plus ISO/IEC 27001:2022, 27017:2015, 27018:2019, and 27701:2019 certifications, and lists GDPR and CCPA. OpenAI offers a Data Processing Addendum for GDPR/CCPA and a Business Associate Agreement for HIPAA-regulated customers on ChatGPT Enterprise/Edu and the API (not standard ChatGPT Business); this is enablement rather than OpenAI itself being HIPAA-certified, since HIPAA has no formal certification body. FERPA compliance for ChatGPT Edu/for Teachers runs through a separate Student Data Privacy Agreement rather than the general DPA.",
+        shortValue: 'FedRAMP Moderate, PCI DSS, SOC 2, ISO 27001/27701, HIPAA BAA',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://openai.com/security-and-privacy/',
-            label: 'Security and privacy at OpenAI',
-            asOf: '2026-07-02',
+            url: 'https://www.fedramp.gov/marketplace/products/FR2533155773/',
+            label: 'ChatGPT Enterprise and API Platform | FedRAMP Marketplace',
+            asOf: '2026-07-08',
           },
-          { url: 'https://trust.openai.com/', label: 'OpenAI Trust Portal', asOf: '2026-07-02' },
+          { url: 'https://trust.openai.com/', label: 'OpenAI Trust Portal', asOf: '2026-07-08' },
           {
-            url: 'https://openai.com/business-data/',
-            label: 'Business data privacy, security, and compliance',
-            asOf: '2026-07-02',
+            url: 'https://help.openai.com/en/articles/8660679-how-can-i-get-a-business-associate-agreement-baa-with-openai',
+            label:
+              'How can I get a Business Associate Agreement (BAA) with OpenAI? | OpenAI Help Center',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1232,26 +1243,21 @@ export const openaiAgentkitProfile: CompetitorProfile = {
       },
       companyMaturity: {
         value:
-          'Founded 2015; ~9,000+ employees; $852B valuation after $122B round closed March 2026',
+          'Founded December 2015; ~4,500 employees (targeting ~8,000 by end of 2026); $852B valuation after $122B round closed April 2026',
         detail:
-          'OpenAI was founded in December 2015 (originally as a nonprofit) by Sam Altman, Greg Brockman, Elon Musk, Ilya Sutskever, and others. On March 31, 2026, OpenAI closed a $122B funding round at an $852B post-money valuation, with Amazon ($50B, partly contingent on an IPO or reaching AGI), Nvidia ($30B), and SoftBank ($30B) as the largest backers, alongside co-investors including Andreessen Horowitz, D.E. Shaw Ventures, MGX, TPG, and T. Rowe Price-advised accounts; cumulative funding raised is around $180B+ across 15 rounds. Employee headcount estimates vary by source, with one tracker citing roughly 9,268 employees as of May 31, 2026 (other estimates range 3,800-8,000 depending on scope/date). This is a mature, well-capitalized company, though AgentKit/Agent Builder is a relatively new (October 2025) product line now being wound down, with shutdown scheduled for November 30, 2026.',
-        shortValue: 'Founded 2015, $852B valuation, ~9,000 employees',
+          'OpenAI was founded in December 2015 (originally as a nonprofit) by Sam Altman, Greg Brockman, Elon Musk, Ilya Sutskever, and others. OpenAI closed a $122B funding round in April 2026 at an $852B post-money valuation, with Amazon ($50B), Nvidia ($30B), and SoftBank ($30B) as the largest backers. Employee headcount was roughly 4,500 as of 2026 per Wikipedia, with Financial Times reporting (via Engadget) that OpenAI aims to nearly double its headcount to about 8,000 employees by the end of 2026. This is a mature, well-capitalized company, though AgentKit/Agent Builder is a relatively new (October 2025) product line now being wound down, with shutdown scheduled for November 30, 2026.',
+        shortValue: 'Founded 2015, $852B valuation, ~4,500 employees',
         confidence: 'verified',
         sources: [
           {
             url: 'https://en.wikipedia.org/wiki/OpenAI',
             label: 'OpenAI: Wikipedia',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://sacra.com/c/openai/',
-            label: 'OpenAI revenue, valuation & funding: Sacra',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://tracxn.com/d/companies/openai/__kElhSG7uVGeFk1i71Co9-nwFtmtyMVT7f-YHMn4TFBg',
-            label: 'OpenAI: Tracxn company profile',
-            asOf: '2026-07-02',
+            url: 'https://www.engadget.com/ai/openai-reportedly-plans-to-double-its-workforce-to-8000-employees-161028377.html',
+            label: 'OpenAI reportedly plans to double its workforce to 8,000 employees: Engadget',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/openclaw.ts
+++ b/apps/sim/lib/compare/data/competitors/openclaw.ts
@@ -44,13 +44,13 @@ export const openClawProfile: CompetitorProfile = {
     {
       title: 'Sub-agent orchestration for parallel background work',
       description:
-        'A running agent can spawn sub-agents, background runs in their own isolated session and (by default) sandbox, that work in parallel on research, long-running tools, or verification tasks and report results back to the requesting chat when finished. Nesting depth is capped at 2 levels.',
+        'A running agent can spawn sub-agents, background runs in their own isolated session and (by default) sandbox, that work in parallel on research, long-running tools, or verification tasks and report results back to the requesting chat when finished. Nesting depth defaults to 1 level, with an orchestrator pattern recommended at depth 2, and a configurable maximum of 5 levels.',
       shortDescription:
         'Spawns isolated sub-agents that run tasks in parallel and report back to chat.',
       source: {
         url: 'https://docs.openclaw.ai/tools/subagents',
         label: 'OpenClaw Docs: Sub-agents',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -78,15 +78,15 @@ export const openClawProfile: CompetitorProfile = {
       },
     },
     {
-      title: 'Foundation-governed, MIT-licensed, with committed multi-year sponsorship',
+      title: 'MIT-licensed, moving to independent foundation governance',
       description:
-        'After creator Peter Steinberger joined OpenAI in February 2026, governance passed to the independent, non-profit OpenClaw Foundation (a board of community-elected maintainers). OpenAI sponsors the project with funding and inference/security support (Codex Security scanning) but does not own it.',
+        'After creator Peter Steinberger joined OpenAI in February 2026, he confirmed OpenClaw will become an open-source project run "under a foundation, supported by OpenAI but independent." Public reporting does not detail the foundation\'s formal name, board structure, or specific sponsorship terms.',
       shortDescription:
-        'MIT-licensed, run by a non-profit Foundation with OpenAI sponsorship, not one company.',
+        'MIT-licensed; governance is moving to an independent foundation supported, not owned, by OpenAI.',
       source: {
-        url: 'https://openclaw.ai/ecosystem/',
-        label: 'OpenClaw Ecosystem page',
-        asOf: '2026-07-02',
+        url: 'https://www.forbes.com/sites/ronschmelzer/2026/02/16/openai-hires-openclaw-creator-peter-steinberger-and-sets-up-foundation/',
+        label: 'Forbes: OpenAI Hires OpenClaw Creator Peter Steinberger And Sets Up Foundation',
+        asOf: '2026-07-08',
       },
     },
   ],
@@ -106,13 +106,13 @@ export const openClawProfile: CompetitorProfile = {
     {
       title: 'ClawHub marketplace has documented, ongoing supply-chain security incidents',
       description:
-        'Researchers found 283 ClawHub skills (roughly 7.1% of the registry at the time) leaking API keys and other credentials, and a separate scan identified 24 accounts distributing over 600 malicious skills before scanning was introduced. OpenClaw has since added VirusTotal and SkillSpector scanning, but its documentation still tells users to "treat third-party skills as untrusted code."',
+        'A Kaspersky/Securelist scan of the ClawHub skill hub in April 2026 identified 24 accounts distributing more than 600 malicious skills. In response, OpenClaw added preliminary VirusTotal and NVIDIA SkillSpector scanning to the skill-publishing pipeline, but its documentation still tells users to treat third-party skills as untrusted code.',
       shortDescription:
-        'Researchers found hundreds of ClawHub skills leaking credentials or containing malware.',
+        'A single scan found 24 accounts distributing over 600 malicious ClawHub skills.',
       source: {
-        url: 'https://snyk.io/blog/openclaw-skills-credential-leaks-research/',
-        label: 'Snyk: 280+ Leaky Skills: How OpenClaw & ClawHub Are Exposing API Keys and PII',
-        asOf: '2026-07-02',
+        url: 'https://securelist.com/openclaw-security/120484/',
+        label: 'Securelist: Security risks for OpenClaw users and how to mitigate these risks',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -130,24 +130,24 @@ export const openClawProfile: CompetitorProfile = {
     {
       title: 'No SOC 2 report or other compliance attestation',
       description:
-        'OpenClaw is a self-hosted open-source project run by a non-profit foundation, not a vendor selling a hosted service, so it publishes no SOC 2 report or other compliance attestation. Sim is SOC 2 compliant; like OpenClaw, Sim does not currently hold ISO 27001 or HIPAA certification. Security for data-at-rest and processing on OpenClaw falls entirely on the operator running their own instance.',
+        "OpenClaw has no OpenClaw-operated hosted service, only self-hosted software, and no SOC 2 report, trust center, or other compliance attestation is published anywhere on its official sites. Sim is SOC 2 compliant; like OpenClaw, Sim does not currently hold ISO 27001 or HIPAA certification. OpenClaw's own security documentation places responsibility for data-at-rest and processing security squarely on the operator running their own instance.",
       shortDescription: 'No SOC 2 report; the self-hosting operator owns all compliance risk.',
       source: {
         url: 'https://docs.openclaw.ai/gateway/security',
         label: 'OpenClaw Docs: Security',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
-      title: 'Rapid rebranding and name churn created real confusion and scam risk',
+      title: 'Rapid rebranding and name churn created real confusion',
       description:
-        'The project launched in November 2025 as "Warelay," was renamed to "Clawdbot," then to "Moltbot" on January 27, 2026 after an Anthropic trademark complaint over similarity to "Claude," then to "OpenClaw" three days later. Coverage from the period documents scam and impersonation activity, including a reported $16M crypto scam, riding the confusion.',
+        'The project launched on November 24, 2025 as "Warelay," then went through "CLAWDIS" and "Clawdbot" before being renamed to "Moltbot" on January 27, 2026 after an Anthropic trademark complaint over similarity to "Claude," then to "OpenClaw" three days later. Four name changes in about ten weeks made it hard for users to know which name, repo, or site was the legitimate project.',
       shortDescription:
-        'Three name changes in about ten weeks, including an Anthropic trademark dispute, fueled scam activity.',
+        'Four name changes in about ten weeks, including an Anthropic trademark dispute.',
       source: {
         url: 'https://en.wikipedia.org/wiki/OpenClaw',
         label: 'Wikipedia: OpenClaw',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
   ],
@@ -225,16 +225,16 @@ export const openClawProfile: CompetitorProfile = {
       },
       templates: {
         value:
-          'No workflow templates in the visual-builder sense; OpenClaw has no workflow canvas. ClawHub instead offers 60,000+ community-built Skills as installable starter packages for specific tasks.',
+          'No workflow templates in the visual-builder sense; OpenClaw has no workflow canvas. ClawHub instead offers a small, curated catalog of community-built Skills as installable starter packages for specific tasks: the live registry currently lists roughly 30 featured skills and 12 plugins.',
         detail:
-          "ClawHub's live registry lists over 60,000 community-built skills and 56,000+ certified skills, the closest analog to a template gallery, but each is a Markdown instruction package installed into the agent, not a prebuilt multi-step workflow.",
-        shortValue: '60,000+ ClawHub skills, not workflow templates',
+          'ClawHub is the closest analog to a template gallery, installable Markdown Skill packages for specific tasks, but its catalog is a curated set rather than a large template gallery, and catalog size has shifted significantly over time (including a security-driven cleanup, see integrations for detail). Each skill is a Markdown instruction package installed into the agent, not a prebuilt multi-step workflow.',
+        shortValue: '~30 ClawHub skills and 12 plugins currently listed, not workflow templates',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://clawhub.ai/',
             label: 'ClawHub registry',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -299,16 +299,16 @@ export const openClawProfile: CompetitorProfile = {
       },
       nativeFileStorage: {
         value:
-          "No: OpenClaw has no cloud file-storage product of its own (no folder hierarchy, link-based sharing with password/SSO, or deleted-item recovery). It reads/writes files directly on the operator's own local filesystem or connected apps (e.g. via MCP servers, channel attachments) inside a sandboxed workspace directory.",
+          "No: OpenClaw has no cloud file-storage product of its own. It reads and writes files directly on the operator's own local filesystem, inside a sandboxed workspace directory, rather than through a dedicated hosted file-storage/sharing surface.",
         detail:
-          'Tool access defaults to sandbox-isolated directories under the local workspace (~/.openclaw/workspace). There is no first-party hosted file-storage/sharing surface distinct from the local filesystem.',
+          'Tool access defaults to sandbox-isolated directories under ~/.openclaw/sandboxes (agents.defaults.sandbox.workspaceAccess). There is no first-party hosted file-storage/sharing surface distinct from the local filesystem.',
         shortValue: 'No: operates on the local filesystem, no hosted file store',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.openclaw.ai/gateway/security',
             label: 'OpenClaw Docs: Security',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -426,16 +426,16 @@ export const openClawProfile: CompetitorProfile = {
       },
       mcpSupport: {
         value:
-          'Yes: native MCP client support over both stdio and HTTP/SSE transports, connecting to any published MCP server by adding an mcpServers block to the OpenClaw config',
+          'Yes: native MCP client support over both stdio and HTTP/SSE transports, connecting to any published MCP server by adding an mcpServers block to the OpenClaw config. Compatible with the entire published ecosystem of MCP servers (e.g. GitHub, Notion, Postgres, Slack). OpenClaw can also itself be run as an MCP server via `openclaw mcp serve`, exposing its channel conversations to external MCP clients like Claude Code.',
         detail:
-          'Compatible with "the entire published ecosystem of MCP servers" (e.g. GitHub, Notion, Postgres, Slack). Whether OpenClaw itself can be published as an MCP server for external tools to call is undocumented (see mcpPublishing).',
-        shortValue: 'Yes, MCP client over stdio and HTTP/SSE',
+          'The docs.openclaw.ai/cli/mcp page documents both directions: consuming external MCP servers via an mcpServers config block, and running `openclaw mcp serve` to start OpenClaw as a stdio MCP server exposing its channel conversations to external MCP clients.',
+        shortValue: 'Yes, MCP client over stdio/HTTP+SSE, and can run as an MCP server too',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.openclaw.ai/cli/mcp',
             label: 'OpenClaw Docs: MCP',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -491,16 +491,16 @@ export const openClawProfile: CompetitorProfile = {
       },
       dynamicToolUse: {
         value:
-          'Yes: the agent dynamically selects among its configured tools, connectors, and installed Skills at runtime based on the request, rather than following a pre-wired sequence of steps chosen at build time',
+          'Partial: which Skills are even eligible for a session is snapshotted once when that session starts and reused for every subsequent turn, not re-selected per request; within that fixed snapshot, the agent still chooses which tool/skill to invoke on a given turn based on the request, rather than following a pre-wired sequence of steps chosen at build time.',
         detail:
-          'This is the core operating model described throughout the docs (tool/skill dispatch decided per-turn by the agent), a consequence of there being no visual builder with pre-wired steps.',
-        shortValue: 'Yes, picks tools/skills dynamically per request',
-        confidence: 'estimated',
+          'OpenClaw\'s own docs state it "snapshots eligible skills when a session starts and reuses that list for all subsequent turns in the session," with changes to skills or config taking effect only on the next new session (or when a skills-file watcher detects an edit).',
+        shortValue: 'Partial: skills are snapshotted per session, not re-selected per request',
+        confidence: 'verified',
         sources: [
           {
             url: 'https://docs.openclaw.ai/tools/skills',
             label: 'OpenClaw Docs: Skills',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -553,16 +553,16 @@ export const openClawProfile: CompetitorProfile = {
       },
       parallelExecution: {
         value:
-          'Yes: sub-agents can run in parallel, working simultaneously on separate tasks (e.g. research, content generation, verification) and report back to the requesting session, up to a documented 2-level nesting depth (main session can spawn depth-1 sub-agents, which can spawn depth-2 workers, where depth-2 spawning further sub-agents is denied)',
+          'Yes: sub-agents can run in parallel, working simultaneously on separate tasks (e.g. research, content generation, verification) and report back to the requesting session. Nesting defaults to depth 1, with a documented maxSpawnDepth configurable up to 5 levels via the maxSpawnDepth parameter (range 1-5).',
         detail:
           'Each sub-agent gets its own session identifier, context window, and execution environment (with optional sandboxing), isolated from the main session and from sibling sub-agents.',
-        shortValue: 'Yes, parallel sub-agents up to 2 levels of nesting',
+        shortValue: 'Yes, parallel sub-agents with configurable nesting depth (up to 5)',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.openclaw.ai/tools/subagents',
             label: 'OpenClaw Docs: Sub-agents',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -607,21 +607,21 @@ export const openClawProfile: CompetitorProfile = {
     integrations: {
       integrationCount: {
         value:
-          '22+ native messaging channels plus 60,000+ community-built Skills and MCP access to the broader MCP server ecosystem',
+          "29 native messaging channels plus ClawHub's live registry of roughly 30 featured skills and 12 plugins, and MCP access to the broader MCP server ecosystem",
         detail:
-          "Native channel integrations (WhatsApp, Telegram, Slack, Discord, Signal, iMessage, Microsoft Teams, and more) are documented directly. ClawHub's live registry separately lists over 60,000 community-built skills (56,000+ certified), and MCP support adds access to hundreds of third-party MCP servers on top of that.",
-        shortValue: '22+ channels, 60,000+ Skills, plus MCP servers',
+          "Native channel integrations (WhatsApp, Telegram, Slack, Discord, Signal, iMessage, Microsoft Teams, and more) are documented directly, and the openclaw.ai homepage advertises 29 channels. ClawHub's live registry currently lists roughly 30 featured skills and 12 plugins; MCP support adds access to hundreds of third-party MCP servers on top of that.",
+        shortValue: '29 channels, ~30 ClawHub skills/12 plugins, plus MCP servers',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://openclaw.ai/',
             label: 'OpenClaw homepage',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://clawhub.ai/',
             label: 'ClawHub registry',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -785,16 +785,21 @@ export const openClawProfile: CompetitorProfile = {
       },
       dataResidency: {
         value:
-          'Yes, by construction: because OpenClaw is self-hosted only, all agent data (sessions, memory files, credentials) resides wherever the operator chooses to run the Gateway (laptop, homelab, or their own VPS/cloud region), giving complete control over data location with no vendor-side residency question.',
+          "Yes, by construction: because OpenClaw runs only as a self-hosted Gateway process, with no OpenClaw-operated hosted/SaaS version, all agent data (sessions, memory files, credentials) resides wherever the operator chooses to run it, e.g. a personal laptop or a self-hosted VPS/homelab using the project's own Ansible/NixOS deployment tooling, giving the operator full control over data location with no vendor-side residency question.",
         detail:
-          'The OpenClaw Ecosystem page states data lives "where you choose, laptop, homelab, or VPS," a direct consequence of there being no vendor-operated cloud service.',
+          'The OpenClaw Ecosystem page lists self-host infrastructure tooling (an Ansible playbook, NixOS packaging) for operators running the Gateway on their own server. Combined with there being no OpenClaw-operated cloud service, data residency is entirely a function of where the operator deploys the Gateway.',
         shortValue: 'Yes, fully controlled by self-hosting location',
         confidence: 'verified',
         sources: [
           {
             url: 'https://openclaw.ai/ecosystem/',
             label: 'OpenClaw Ecosystem page',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.openclaw.ai/',
+            label: 'OpenClaw Docs home',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -845,16 +850,17 @@ export const openClawProfile: CompetitorProfile = {
       },
       modelAndToolGovernance: {
         value:
-          'Yes, at the single-operator level: OpenClaw supports per-agent tool allow/deny lists, sandbox-level tool filters, and per-model-provider configuration, so an operator can restrict which tools/models a given agent may use. This is configured by one trusted operator, not enforced org-wide across multiple admin-managed users.',
+          "Yes, at the single-operator level: OpenClaw supports per-agent tool allow/deny lists and sandbox-level workspace/tool restrictions (agents.defaults.sandbox, tools.allow/tools.deny), configured by one trusted operator, not enforced org-wide. The docs frame this as a layered 'identity → scope → model' design principle rather than a formally named three-gate system.",
         detail:
-          'Documented as a three-gate system (agent-level tools.allow/deny, sandbox-level tools.allow, and container network access), plus explicit provider/model selection per agent in configuration.',
-        shortValue: 'Yes, operator-configured per-agent tool/model restrictions',
+          "Documented via agent-level tools.allow/tools.deny lists and sandbox-level workspace/tool restrictions, plus explicit provider/model selection per agent in configuration, framed by the docs around an 'identity → scope → model' design principle.",
+        shortValue:
+          'Yes, operator-configured per-agent tool/model restrictions (identity → scope → model)',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.openclaw.ai/gateway/security',
             label: 'OpenClaw Docs: Security',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -941,10 +947,9 @@ export const openClawProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://openclaw.ai/blog/openclaw-nvidia-skill-security',
-            label:
-              'OpenClaw Blog: OpenClaw Collaborates with NVIDIA for Stronger Agent Skill Security',
-            asOf: '2026-07-02',
+            url: 'https://securelist.com/openclaw-security/120484/',
+            label: 'Securelist: Security risks for OpenClaw users and how to mitigate these risks',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -967,31 +972,32 @@ export const openClawProfile: CompetitorProfile = {
       },
       durabilityModel: {
         value:
-          'Partial: cron-scheduled jobs run as isolated sessions that start clean and get pruned after a retention window, giving each run a clean, repeatable environment, but there is no automatic retry-with-backoff or checkpoint/replay-of-a-past-run feature for either scheduled jobs or interactive chat sessions.',
+          'Partial: cron-scheduled jobs run as isolated sessions with retention/pruning, and OpenClaw now provides automatic retry-with-backoff for both one-shot jobs (up to retry.maxAttempts, default 3 attempts, at 30s/60s/5m) and recurring jobs (an extended 30s/60s/5m/15m/60m backoff on consecutive errors), though there is still no checkpoint/replay-of-a-past-run feature for either scheduled jobs or interactive chat sessions.',
         detail:
-          'The cron docs describe delivery diagnostics (intended target, resolved target, fallback delivery used, final delivered state) for message delivery specifically, not a general execution-retry/checkpoint mechanism.',
-        shortValue: 'Clean isolated cron runs; no documented retry/checkpoint system',
+          'The cron docs describe both delivery diagnostics (intended target, resolved target, fallback delivery used, final delivered state) for message delivery, and the retry/backoff schedule (cron.sessionRetention, runLog.keepLines, retry.maxAttempts) as configurable per job.',
+        shortValue: 'Clean isolated cron runs with retry-with-backoff; no checkpoint/replay',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.openclaw.ai/automation/cron-jobs',
             label: 'OpenClaw Docs: Scheduled tasks (cron jobs)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       failureAlerting: {
         value:
-          'Partial: cron job runs report delivery diagnostics (whether the agent sent directly, whether fallback delivery was used, the final delivered state) back through the chat channel, but there is no separate proactive alerting mechanism (email/webhook alert on failure or cost/latency threshold).',
+          'Partial: cron jobs support a dedicated failure-alerting path (a configurable cron.failureDestination global/per-job override, a webhook delivery mode, and --failure-alert-after/--failure-alert-cooldown tuning flags) in addition to normal chat delivery diagnostics, so failure alerting is a distinct feature rather than merely folded into chat delivery. There is still no email or cost/latency-threshold alerting.',
         detail:
-          'Failure visibility is folded into the normal chat-delivery flow (the operator sees the delivery outcome in the channel where the job reports), not a distinct alerting/notification product feature.',
-        shortValue: 'Delivery diagnostics via chat, no separate alerting feature',
+          'Failure alerting is a dedicated, tunable path (webhook delivery mode plus alert-frequency flags), separate from the normal chat-delivery flow where the operator otherwise sees delivery outcomes in the channel where the job reports.',
+        shortValue:
+          'Dedicated failure-alerting path (webhook + tuning flags); no email/threshold alerts',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.openclaw.ai/automation/cron-jobs',
             label: 'OpenClaw Docs: Scheduled tasks (cron jobs)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1026,17 +1032,17 @@ export const openClawProfile: CompetitorProfile = {
       },
       executionLimits: {
         value:
-          'No fixed platform-wide execution-time or concurrency ceiling is published by OpenClaw itself. Sub-agent nesting is capped at 2 levels deep (depth-2 sessions cannot spawn further sub-agents), and any other limits (request timeouts, rate limits) come from whichever LLM provider API the operator has configured, not from OpenClaw.',
+          'No fixed platform-wide execution-time ceiling is published by default (runTimeoutSeconds defaults to 0/unlimited). Sub-agents cannot spawn their own children by default (maxSpawnDepth defaults to 1); setting maxSpawnDepth to 2 opts into one level of nesting (the documented "orchestrator pattern"), up to a configurable maximum of 5. agents.defaults.subagents.maxConcurrent caps concurrent sub-agent runs at 8 by default, with maxChildrenPerAgent capping children per orchestrator at 5 by default.',
         detail:
-          "Because OpenClaw runs on infrastructure the operator controls, execution-time/concurrency limits are a function of that operator's own hardware and their model provider's API limits, not an OpenClaw-side ceiling.",
+          "Because OpenClaw runs on infrastructure the operator controls, execution-time/concurrency limits beyond these published defaults (runTimeoutSeconds, maxSpawnDepth, maxConcurrent, maxChildrenPerAgent) are a function of that operator's own hardware and their model provider's API limits, not an OpenClaw-side ceiling.",
         shortValue:
-          'No OpenClaw-side limit; only sub-agent depth cap (2 levels) and provider limits',
-        confidence: 'estimated',
+          'No nesting by default (maxSpawnDepth 1, opt-in to 2+); maxConcurrent 8; no fixed time limit',
+        confidence: 'verified',
         sources: [
           {
             url: 'https://docs.openclaw.ai/tools/subagents',
             label: 'OpenClaw Docs: Sub-agents',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/pipedream.ts
+++ b/apps/sim/lib/compare/data/competitors/pipedream.ts
@@ -185,26 +185,21 @@ export const pipedreamProfile: CompetitorProfile = {
       },
       environmentPromotion: {
         value:
-          'Partial: GitHub Sync gives file-level promotion; no native fork/clone-project push between dev and prod',
+          'Partial: GitHub Sync promotes an entire project (all its workflows) via a development-to-production branch merge; no per-file promotion and no native clone/fork of an existing project into a new one',
         detail:
-          "Pipedream projects have only two built-in environments (Development and Production) per project, used mainly for scoping env vars and Connect API tokens, not a promote/push pipeline. The closest equivalent is GitHub Sync (Advanced/Business plans): each project links to one GitHub repo, workflows are serialized to YAML and edited/committed via GitHub or a local clone, and pushing to the production branch triggers a deploy. This gives git-based promotion of an entire project's workflows, but it's opt-in, one repo per project, and not a dedicated staging-to-prod UI flow.",
-        shortValue: 'GitHub Sync gives file-level promotion',
+          "Pipedream Connect projects have Development and Production environments, but these scope connected end-user accounts and Connect API tokens — not general per-project workflow promotion. The closest equivalent for promoting workflows is GitHub Sync (Advanced/Business plans): each project links to one GitHub repo, all of a project's workflows and resources are serialized to YAML, changes are made in a development branch, and merging that branch into `production` deploys everything that changed to production workflows. This is project-level (whole-project, branch-merge) promotion, not file-level. Pipedream's own docs also state that syncing an existing GitHub repo of workflows into a new Pipedream project ('cloning' a project via GitHub Sync) is not currently possible.",
+        shortValue: 'GitHub Sync promotes whole projects via branch merge',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://pipedream.com/docs/workflows/projects/',
-            label: 'Pipedream Docs – Projects',
-            asOf: '2026-07-02',
+            url: 'https://pipedream.com/docs/connect/managed-auth/environments/',
+            label: 'Pipedream Docs – Connect Environments',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://pipedream.com/docs/workflows/git',
             label: 'Pipedream Docs – GitHub Sync',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://pipedream.com/blog/github-sync/',
-            label: 'Pipedream Blog – GitHub Sync',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -371,19 +366,19 @@ export const pipedreamProfile: CompetitorProfile = {
       mcpSupport: {
         value: 'Yes: first-class, hosted MCP server',
         detail:
-          'Pipedream runs a hosted MCP server (mcp.pipedream.com) exposing 3,000+ apps / 10,000+ tools to any MCP client, with managed OAuth and credential isolation; also ships an official MCP server package in its GitHub repo.',
+          'Pipedream runs a hosted MCP server (mcp.pipedream.com) exposing 3,000+ apps / 10,000+ tools to any MCP client, with managed OAuth and credential isolation. Its GitHub repo also includes a reference/self-hosted MCP server implementation, though Pipedream notes it is no longer actively maintained and recommends the hosted remote MCP server for production use.',
         shortValue: 'Hosted MCP server, 3,000+ apps as tools',
         confidence: 'verified',
         sources: [
           {
             url: 'https://pipedream.com/docs/connect/mcp',
             label: 'Pipedream Docs: MCP Servers',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://github.com/PipedreamHQ/pipedream/blob/master/modelcontextprotocol/README.md',
-            label: 'GitHub: Modelcontextprotocol README',
-            asOf: '2026-07-02',
+            label: 'GitHub: Modelcontextprotocol README (reference implementation, unmaintained)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -581,34 +576,34 @@ export const pipedreamProfile: CompetitorProfile = {
         value:
           'Yes: official TypeScript SDK (@pipedream/sdk) and Python SDK (pipedream on PyPI), plus @pipedream/connect-react for embeddable connect UI',
         detail:
-          "Pipedream ships an official TypeScript SDK, @pipedream/sdk (v3.1.1), and an official Python SDK, published as `pipedream` on PyPI (v2.1.8), both for programmatic access to the Pipedream/Connect APIs, alongside a companion @pipedream/connect-react package for embeddable React auth/connect UI. Beyond the SDKs, Pipedream provides a full component development kit: triggers and actions ('components') are plain Node.js modules that run on Pipedream's serverless infrastructure and can use most npm packages with no install step. Components are open-sourced in the public PipedreamHQ/pipedream GitHub monorepo, and community members can build and publish their own actions/sources that appear in Pipedream's UI/marketplace alongside first-party ones, functioning as a de facto community integration marketplace.",
+          "Pipedream ships an official TypeScript SDK, @pipedream/sdk (v3.1.1 on npm), and an official Python SDK, published as `pipedream` on PyPI (v2.1.14), both for programmatic access to the Pipedream/Connect APIs, alongside a companion @pipedream/connect-react package (v3.0.1 on npm) for embeddable React auth/connect UI. Beyond the SDKs, Pipedream provides a full component development kit: triggers and actions ('components') are plain Node.js modules that run on Pipedream's serverless infrastructure and can use most npm packages with no install step. Components are open-sourced in the public PipedreamHQ/pipedream GitHub monorepo, and community members can build and publish their own actions/sources that appear in Pipedream's UI/marketplace alongside first-party ones, functioning as a de facto community integration marketplace.",
         shortValue: 'TypeScript + Python SDKs, plus components SDK',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://www.npmjs.com/package/@pipedream/sdk',
-            label: 'npm – @pipedream/sdk',
-            asOf: '2026-07-02',
+            url: 'https://registry.npmjs.org/@pipedream/sdk/latest',
+            label: 'npm registry – @pipedream/sdk (latest)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://registry.npmjs.org/@pipedream/connect-react/latest',
+            label: 'npm registry – @pipedream/connect-react (latest)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://pypi.org/project/pipedream/',
+            label: 'PyPI – pipedream package',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://pipedream.com/docs/components/guidelines',
             label: 'Pipedream Docs – Components Guidelines & Patterns',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://pipedream.com/docs/workflows/contributing/components/',
-            label: 'Pipedream Docs – Contributing Components',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://github.com/PipedreamHQ/pipedream',
             label: 'GitHub – PipedreamHQ/pipedream monorepo',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://pypi.org/project/pipedream/',
-            label: 'PyPI package page',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1088,26 +1083,31 @@ export const pipedreamProfile: CompetitorProfile = {
       },
       companyMaturity: {
         value:
-          'Founded 2019, San Francisco; ~11-50 employees pre-acquisition; raised ~$22M across 2 rounds; agreed to be acquired by Workday (signed Nov 19, 2025), with no public confirmation the deal has closed as of mid-2026',
+          "Founded 2019 (some sources say 2018), San Francisco; ~21-50 employees; raised at least $20M in Series A financing; Workday signed a definitive agreement to acquire Pipedream (Nov 19, 2025), with the deal expected to close by the end of Workday's fiscal Q4 2026 (Jan 31, 2026) — no independently reachable source confirms the acquisition has actually closed",
         detail:
-          "Per Crunchbase, Pipedream was founded in 2019 and headquartered in San Francisco, CA, with founders including Tod Sacerdoti (CEO), Dylan Sather, TJ Koblentz, and Pravin Savkar; it raised a total of ~$22M across 2 funding rounds (investors include Felicis and CRV) and had a headcount signal of 11-50 employees. Workday signed a definitive agreement to acquire Pipedream on November 19, 2025, with the transaction originally expected to close in Workday's Q4 FY2026 (by end of January 2026), subject to closing conditions. That expected close date has since passed, and as of this writing neither Workday nor Pipedream has publicly announced that the deal has closed.",
-        shortValue: 'Founded 2019; agreed to be acquired by Workday, close unconfirmed',
+          "Pipedream was founded in 2019 and is headquartered in San Francisco, CA (company-data aggregators put the founding team at 8 people, including Tod Sacerdoti, Dylan Sather, and TJ Koblentz), with a current headcount signal of roughly 21-50 employees. Pipedream's own blog confirms it closed a $20M Series A round led by True Ventures, with CRV, Felicis Ventures, and World Innovation Lab participating. Workday signed a definitive agreement to acquire Pipedream on November 19, 2025; per Workday's own newsroom release, the transaction is expected to close in Workday's fiscal Q4 2026 (ending January 31, 2026), subject to closing conditions. Crunchbase (previously cited for a 'deal closed' date) returned 403 and could not be independently verified, so this claim no longer asserts the acquisition has closed.",
+        shortValue: 'Founded 2019; Workday acquisition pending, expected to close by Jan 2026',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://newsroom.workday.com/2025-11-19-Workday-Signs-Definitive-Agreement-to-Acquire-Pipedream',
             label: 'Workday Newsroom – Workday Signs Definitive Agreement to Acquire Pipedream',
-            asOf: '2026-07-06',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://pipedream.com/blog/pipedream-to-be-acquired-by-workday/',
             label: 'Pipedream Blog – Pipedream to be acquired by Workday',
-            asOf: '2026-07-06',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://www.crunchbase.com/organization/pipedream',
-            label: 'Crunchbase – Pipedream company profile',
-            asOf: '2026-07-02',
+            url: 'https://pipedream.com/blog/series-a-financing/',
+            label: 'Pipedream Blog – Pipedream Closes $20M Series A Financing',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://prospeo.io/c/pipedream',
+            label: 'Prospeo – Pipedream company profile',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/power-automate.ts
+++ b/apps/sim/lib/compare/data/competitors/power-automate.ts
@@ -33,9 +33,9 @@ export const powerAutomateProfile: CompetitorProfile = {
       shortDescription:
         'Flows promote dev to test to production via Dataverse Solutions and Pipelines.',
       source: {
-        url: 'https://learn.microsoft.com/en-us/power-automate/export-flow-solution',
-        label: 'Export a solution - Power Automate | Microsoft Learn',
-        asOf: '2026-07-02',
+        url: 'https://learn.microsoft.com/en-us/power-platform/alm/pipelines',
+        label: 'Overview of pipelines in Power Platform - Microsoft Learn',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -62,15 +62,14 @@ export const powerAutomateProfile: CompetitorProfile = {
       },
     },
     {
-      title: 'Built-in per-run analytics dashboard and proactive failure alerting',
+      title: 'Built-in per-run analytics dashboard for cloud flows',
       description:
-        'Each flow has an Analytics dashboard (run counts, success/failure rate, average execution time, 30-day rolling history) plus automatic per-run failure alert emails and a weekly failure digest, without needing a third-party observability tool.',
-      shortDescription:
-        'Native run analytics and automatic failure alert emails, no third-party tool needed.',
+        'The Power Platform admin center ships a native Power Automate Analytics dashboard with Runs, Usage, Created, Errors, Shared, and Connectors reports for cloud flows, without needing a third-party observability tool.',
+      shortDescription: 'Native run analytics dashboard, no third-party tool needed.',
       source: {
-        url: 'https://learn.microsoft.com/en-us/power-automate/understand-flow-failure-notifications',
-        label: 'Understand flow failure notifications - Power Automate | Microsoft Learn',
-        asOf: '2026-07-02',
+        url: 'https://learn.microsoft.com/en-us/power-platform/admin/analytics-flow',
+        label: 'View analytics for Power Automate cloud flows - Power Platform | Microsoft Learn',
+        asOf: '2026-07-08',
       },
     },
   ],
@@ -182,31 +181,41 @@ export const powerAutomateProfile: CompetitorProfile = {
       },
       deploymentOptions: {
         value:
-          'Commercial multi-tenant cloud; Office 365 GCC, GCC High, and DoD sovereign/government cloud environments; on-prem gateway and desktop-flow runtime for local systems',
+          'Commercial multi-tenant cloud; Office 365 GCC, GCC High, and DoD sovereign/government cloud environments; an on-premises data gateway for connecting cloud flows to on-prem systems (e.g., on-prem SQL Server, file shares); and a local desktop-flow runtime (Power Automate for desktop) for automating tasks on individual Windows workstations',
         detail:
-          "Microsoft's SOC 2 compliance documentation lists Commercial/GCC/GCC High/DoD as in-scope environments for Power Apps/Power Automate.",
-        shortValue: 'Commercial cloud plus GCC/GCC High/DoD government clouds',
+          "Microsoft's Power Automate US Government service description confirms separate Commercial, GCC, GCC High, and DoD deployment environments; the on-premises data gateway is a locally installed Windows service that relays cloud flow connections to on-prem resources without opening inbound ports; desktop flows run via a locally installed Power Automate for desktop application on the user's machine.",
+        shortValue: 'Commercial cloud, GCC/GCC High/DoD, on-prem gateway, desktop-flow runtime',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://learn.microsoft.com/en-us/compliance/regulatory/offering-soc-2',
-            label: 'SOC 2 Type 2 - Microsoft Compliance | Microsoft Learn',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/power-automate/us-govt',
+            label: 'Power Automate US Government - Power Automate | Microsoft Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/power-platform/admin/wp-onpremises-gateway',
+            label: 'About on-premises gateways - Power Platform | Microsoft Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/power-automate/desktop-flows/introduction',
+            label: 'Introduction to desktop flows - Power Automate | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
       templates: {
         value:
-          'Large built-in template gallery for common connector-to-connector automations (approvals, notifications, file sync) accessible from the flow creation screen',
+          'Built-in template gallery for common connector-to-connector automations, searchable or browsable by category from the Templates navigation pane when creating a flow',
         detail:
-          'Templates surface directly on the flow creation screen for common automation patterns.',
-        shortValue: 'Large built-in template gallery',
-        confidence: 'estimated',
+          "Users can search all templates or browse by category to find a matching scenario, then create a cloud flow directly from the template's predefined triggers and actions.",
+        shortValue: 'Built-in template gallery, searchable or browsable by category',
+        confidence: 'verified',
         sources: [
           {
-            url: 'https://www.microsoft.com/en-us/power-platform/products/power-automate',
-            label: 'Power Automate product page',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/power-automate/get-started-logic-template',
+            label: 'Get started from a template - Power Automate | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -385,10 +394,16 @@ export const powerAutomateProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp',
+            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/guidance/generative-orchestration',
             label:
-              'Extend your agent with Model Context Protocol - Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-02',
+              'Apply generative orchestration capabilities - Microsoft Copilot Studio | Microsoft Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/guidance/multi-agent-patterns',
+            label:
+              'Multi-agent orchestration patterns and best practices - Microsoft Copilot Studio | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -408,21 +423,21 @@ export const powerAutomateProfile: CompetitorProfile = {
       },
       knowledgeBaseRag: {
         value:
-          'Yes: agents can be grounded via Retrieval-Augmented Generation over Dataverse tables, SharePoint/Office files, and connectors to systems like Salesforce/ServiceNow, using a semantic index with vector embeddings',
+          'Yes: agents can be grounded via Retrieval-Augmented Generation over Dataverse tables and connectors to systems like Salesforce, Oracle, SAP, and Zendesk (Power Automate prompts only), using a semantic search index',
         detail:
           'Dataverse is positioned as the agent data platform: the same semantic search index powering Power Apps global search provides retrieval/grounding for Copilot, agents, and MCP tools.',
-        shortValue: 'RAG grounding over Dataverse, SharePoint, connectors',
+        shortValue: 'RAG grounding over Dataverse and select connector tables',
         confidence: 'verified',
         sources: [
           {
             url: 'https://www.microsoft.com/en-us/power-platform/blog/2026/05/05/dataverse-agent-data-platform/',
             label: 'Dataverse Is Your Agent Data Platform - Microsoft Power Platform Blog',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://learn.microsoft.com/en-us/ai-builder/use-your-own-prompt-data',
             label: 'Add knowledge to your prompt - Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -478,7 +493,7 @@ export const powerAutomateProfile: CompetitorProfile = {
       },
       generativeMedia: {
         value:
-          'Partial: AI Builder ships an image-description (captioning) model and GPT-based text generation/summarization prompts, but no dedicated native image-generation, video-generation, or text-to-speech/speech-to-text block exists in its catalog',
+          "Partial: AI Builder ships an image-description (captioning) model and GPT-based text generation/summarization via the current prompt builder ('Create text using a prompt'/'Run a prompt'), but no dedicated native image-generation, video-generation, or text-to-speech/speech-to-text block exists in its catalog",
         detail:
           'Generating images or audio requires calling an external connector, such as Azure OpenAI DALL-E or Azure AI Speech, rather than a first-party AI Builder generative-media model.',
         shortValue: 'Captioning and text gen only, no native image/audio generation',
@@ -490,9 +505,9 @@ export const powerAutomateProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://learn.microsoft.com/en-us/ai-builder/azure-openai-model-pauto',
-            label: 'Use the text generation model in Power Automate - Microsoft Learn',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/ai-builder/use-a-custom-prompt-in-flow',
+            label: 'Use your prompt in Power Automate - Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -579,10 +594,10 @@ export const powerAutomateProfile: CompetitorProfile = {
       },
       parallelExecution: {
         value:
-          "Yes: a flow can add a dedicated 'Parallel branch' from any step, so multiple branches of actions execute concurrently rather than sequentially, and the flow only continues once all parallel branches complete. Power Automate supports up to 50 total branches (main path plus up to 49 parallel branches) in a single flow.",
+          "Yes: a flow can add a dedicated 'Parallel branch' from any step, so multiple branches of actions execute concurrently rather than sequentially, and the flow only continues once all parallel branches complete.",
         detail:
-          "Added via the '+' icon between steps, then 'Add a parallel branch'; this is a native canvas feature, not a workaround using separate flows or a sequential loop.",
-        shortValue: 'Yes, native parallel branch (up to 50 concurrent branches)',
+          "Added via the '+' icon between steps, then 'Add a parallel branch'; this is a native canvas feature, not a workaround using separate flows or a sequential loop. Microsoft's guidance doesn't publish a specific numeric limit on the number of parallel branches in a flow (a separate, unrelated setting lets a maker set 'Apply to each' loop concurrency from 1 to 50).",
+        shortValue: 'Yes, native parallel branch functionality',
         confidence: 'verified',
         sources: [
           {
@@ -600,23 +615,17 @@ export const powerAutomateProfile: CompetitorProfile = {
       },
       a2aProtocol: {
         value:
-          "No native support: Power Automate/Copilot Studio do not ship a first-party Agent2Agent (A2A) implementation. A third-party custom connector (built on the standard Custom Connector framework) can wrap an external A2A v1.0 agent's JSON-RPC or HTTP+JSON endpoints, and Microsoft has stated A2A is 'coming soon' to Azure AI Foundry and Copilot Studio as of mid-2026, but no built-in Agent Card discovery or native A2A peer-to-peer calling feature ships today.",
+          'Yes, native support: Copilot Studio agents can connect to an external agent that implements the open Agent2Agent (A2A) protocol, letting the Copilot Studio agent delegate a task to the remote A2A agent and receive back a structured response (including full chat-history metadata for context continuity), rather than only calling it as a plain HTTP API.',
         detail:
-          'The available A2A connectors, such as the community-built Agent2Agent/Power A2A Template connectors for Work IQ, are custom connectors that translate Power Platform requests into A2A protocol calls; they are not a native, first-party A2A feature in the Power Automate or Copilot Studio product surface.',
-        shortValue:
-          'No native A2A; only third-party custom connectors, native support "coming soon"',
-        confidence: 'estimated',
+          "Configured from the agent's Agents page via 'Add an agent' > 'Connect to an external agent' > 'Agent2Agent', pointing at the remote agent's endpoint URL (with None, API key, or OAuth 2.0 authentication); Copilot Studio auto-populates the agent's name/description from its `.well-known` agent card when available.",
+        shortValue: 'Yes, native A2A protocol support for task delegation',
+        confidence: 'verified',
         sources: [
           {
-            url: 'https://troystaylor.com/power%20platform/custom%20connectors/2026-05-05-agent-to-agent-a2a-connector-work-iq.html',
-            label: 'Agent-to-Agent (A2A) connector for Copilot Studio and Power Automate',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://www.powercommunity.com/empowering-multi-agent-apps-with-the-open-agent2agent-a2a-protocol/',
+            url: 'https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-agent-agent-to-agent',
             label:
-              'Empowering multi-agent apps with the open Agent2Agent (A2A) protocol - Power Community',
-            asOf: '2026-07-02',
+              'Connect to an agent over the Agent2Agent (A2A) protocol - Microsoft Copilot Studio | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -669,16 +678,33 @@ export const powerAutomateProfile: CompetitorProfile = {
       },
       triggerTypes: {
         value:
-          'Connector-event triggers (e.g., new email, new SharePoint item), scheduled/recurrence triggers, manual/button triggers (incl. Mobile), HTTP request/webhook triggers, Dataverse record-change triggers, and desktop-flow/UI-automation triggers',
+          "Connector-event triggers (e.g., new email, new SharePoint item), scheduled/recurrence triggers, manual/instant triggers (incl. mobile), the 'When an HTTP request is received' webhook trigger, and Dataverse 'row added, modified, or deleted' triggers. Desktop flows (RPA) are launched from a cloud flow via the 'Run a flow built with Power Automate for desktop' action, in attended or unattended mode, rather than having their own independent trigger type.",
         detail:
-          'Trigger types span connector events, schedules, manual buttons, HTTP webhooks, Dataverse record changes, and desktop UI-automation events.',
-        shortValue: 'Connector, schedule, manual, webhook, Dataverse, desktop triggers',
-        confidence: 'estimated',
+          'Trigger types span connector events, schedules, manual buttons, HTTP request/webhook endpoints, and Dataverse record changes; desktop-flow automation is invoked as a cloud-flow action, not a standalone trigger category.',
+        shortValue: 'Connector, schedule, manual, HTTP/webhook, and Dataverse triggers',
+        confidence: 'verified',
         sources: [
           {
-            url: 'https://www.microsoft.com/en-us/power-platform/products/power-automate',
-            label: 'Power Automate product page',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/power-automate/triggers-introduction',
+            label: 'Triggers - Power Automate | Microsoft Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/power-automate/oauth-authentication',
+            label:
+              'Add OAuth authentication for HTTP request triggers - Power Automate | Microsoft Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/power-automate/dataverse/create-update-delete-trigger',
+            label:
+              'Trigger flows when a row is added, modified, or deleted - Power Automate | Microsoft Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/power-automate/desktop-flows/trigger-desktop-flows',
+            label: 'Trigger desktop flows from cloud flows - Power Automate | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -711,9 +737,15 @@ export const powerAutomateProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://www.microsoft.com/en-us/power-platform/products/power-automate',
-            label: 'Power Automate product page',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/power-automate/oauth-authentication',
+            label:
+              'Add OAuth authentication for HTTP request triggers - Power Automate | Microsoft Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/overview',
+            label: 'Use the Microsoft Dataverse Web API (Dataverse) - Power Apps | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -937,10 +969,10 @@ export const powerAutomateProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://powerusers.microsoft.com/t5/Building-Power-Apps/Can-we-Rebrand-Power-APP-mobile-app-for-our-own-company-or/td-p/690023',
+            url: 'https://community.powerplatform.com/forums/thread/details/?threadid=76b575a4-f741-46fc-84e0-8de11a6f7b78',
             label:
               'Can we Rebrand Power APP mobile app for our own company - Power Platform Community',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -966,23 +998,24 @@ export const powerAutomateProfile: CompetitorProfile = {
       },
       piiRedaction: {
         value:
-          "Yes, but as a block rather than a redaction: Microsoft Purview Data Loss Prevention (DLP) for Microsoft 365 Copilot (GA per Ignite 2025) scans Copilot prompts for sensitive content like SSNs and credit card numbers and blocks processing when it finds them. This protection extends to agents built in Copilot Studio, the Power Platform's agent surface. It stops sensitive content from being processed rather than redacting it in-line, and is not a feature built into Power Automate flows themselves.",
+          'Yes, but as a block rather than a redaction: Microsoft Purview DLP for Microsoft 365 Copilot can block files/emails with sensitivity labels from being processed (generally available) and, in preview, can block prompts containing sensitive information types like SSNs and credit card numbers. It stops sensitive content from being processed rather than redacting it in-line, and is not a feature built into Power Automate flows themselves.',
         detail:
-          'This is Microsoft Purview functionality (a separate, integrated compliance product) covering Microsoft 365 Copilot and Copilot Studio agents; it blocks processing rather than performing in-line redaction, and is not a native Power Automate flow-content feature.',
-        shortValue: 'Purview DLP blocks/detects PII in Copilot prompts (incl. Studio agents)',
+          'This is Microsoft Purview functionality (a separate, integrated compliance product). Blocking prompts with sensitive information types is still a preview capability, not GA; DLP protection for agents built in Copilot Studio is currently limited to sensitivity-label-based restriction when the knowledge source is SharePoint, not general SIT-based prompt blocking, and none of this is a native Power Automate flow-content feature.',
+        shortValue:
+          'Purview DLP blocks sensitivity-labeled content (GA); SIT prompt block (preview)',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://learn.microsoft.com/en-us/purview/dlp-microsoft365-copilot-location-learn-about',
             label:
               'Microsoft Purview DLP for Microsoft 365 Copilot and Copilot Chat | Microsoft Learn',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://learn.microsoft.com/en-us/purview/ai-copilot-studio',
             label:
               'Use Microsoft Purview to manage data security & compliance for Microsoft Copilot Studio | Microsoft Learn',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1053,21 +1086,22 @@ export const powerAutomateProfile: CompetitorProfile = {
       },
       durabilityModel: {
         value:
-          "Yes: configurable retry policies with exponential backoff on individual actions, and flow run history (including a Dataverse-backed FlowRun table option) that lets a user review a past run's inputs/outputs; resubmission/resubmit-from-history is a documented pattern for reprocessing a failed run",
+          "Yes: configurable retry policies with exponential backoff on individual actions, flow run history that lets a user review a past run's inputs/outputs, and a documented Resubmit action from the Run history page that reprocesses a past run with its original inputs after an issue (e.g., a connection or parameter) has been fixed",
         detail:
-          "Retry policies are set per-action with configurable interval/count and exponential backoff; run history in Dataverse's FlowRun table records start/end time, duration, status, and error detail for large-scale tracking.",
-        shortValue: 'Per-action retries with backoff plus resubmit-from-history',
+          "Retry policies are set per-action with configurable interval/count and exponential backoff. Resubmit is available from the flow's Run history page (individually or in bulk, up to 20 runs at a time); flows initiated by instant/manual triggers can always be resubmitted by their owner, and admins can extend resubmission to other users via a tenant setting.",
+        shortValue: 'Per-action retries with backoff, plus resubmit from run history',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://www.citrincooperman.com/In-Focus-Resource-Center/How-to-Automatically-Retry-a-Flow-in-Power-Automate',
-            label: 'Power Automate Flow: How to Automatically Retry When Flows Fail',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/error-handling',
+            label: 'Employ robust error handling - Power Automate | Microsoft Learn',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/monitoring-and-alerting',
-            label: 'Monitor your flows - Power Automate | Microsoft Learn',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/power-automate/how-tos-bulk-resubmit',
+            label:
+              'Cancel or resubmit flow runs in bulk in Power Automate - Power Automate | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1187,16 +1221,23 @@ export const powerAutomateProfile: CompetitorProfile = {
     support: {
       supportChannels: {
         value:
-          'Documentation via Microsoft Learn, the large Power Users community forum, and paid Microsoft support plans. Enterprise customers typically get support through their Microsoft account or Unified Support contract.',
+          'Documentation via Microsoft Learn, the Power Platform Community forums, and paid Microsoft support plans (Professional Direct and Microsoft Unified Support) with severity-based initial response times, available on top of self-help resources in the Power Platform admin center.',
         detail:
-          "Drawn from Microsoft's broader support ecosystem and the active Power Platform community forum, rather than a single Power Automate-specific support-tier page.",
-        shortValue: 'Docs, community forum, and paid Microsoft support plans',
-        confidence: 'estimated',
+          'Technical break-fix support and billing/subscription support are available at all support levels; advisory, escalation, and account-management services require a Professional Direct or Unified Support plan. Initial response times range from under 1 hour (Severity A, critical business impact) to under 8 hours (Severity C, minimum impact) depending on plan tier.',
+        shortValue: 'Docs, community forums, and paid Professional Direct/Unified Support plans',
+        confidence: 'verified',
         sources: [
           {
-            url: 'https://powerusers.microsoft.com/t5/Building-Flows/How-to-restore-a-previous-version-of-a-flow/td-p/288145',
-            label: 'Power Platform Community forum example thread',
-            asOf: '2026-07-02',
+            url: 'https://learn.microsoft.com/en-us/power-platform/admin/support-overview',
+            label:
+              'Support for Microsoft Power Platform and Dynamics 365 apps - Power Platform | Microsoft Learn',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://learn.microsoft.com/en-us/power-platform/admin/get-help-support',
+            label:
+              'Get support in the Power Platform admin center - Power Platform | Microsoft Learn',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1211,16 +1252,16 @@ export const powerAutomateProfile: CompetitorProfile = {
       },
       community: {
         value:
-          'Large. Active official Power Platform/Power Users community forums with structured Q&A on building, approvals, and troubleshooting flows',
+          'Active, Microsoft-hosted Power Platform Community forums for Power Automate, organized into structured category boards (Building flows, Using flows, Using connectors, Power Automate Desktop, AI Builder, Power Automate Mobile App, General topics) with ongoing Q&A threads',
         detail:
-          'Multiple community threads on powerusers.microsoft.com cover real production troubleshooting scenarios, such as restoring flow versions, showing an active, Microsoft-hosted community forum.',
-        shortValue: 'Large, active Power Platform community forum',
+          'The Power Automate forum area on community.powerplatform.com is split into dedicated boards for building flows, using connectors, using flows, desktop automation, and AI Builder, with active threads receiving dozens of replies.',
+        shortValue: 'Active Power Platform community forum with structured category boards',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://powerusers.microsoft.com/t5/Building-Flows/How-to-restore-a-previous-version-of-a-flow/td-p/288145',
-            label: 'Power Platform Community - How to restore a previous version of a flow',
-            asOf: '2026-07-02',
+            url: 'https://community.powerplatform.com/forums/thread/?groupid=46ce02a3-e1a7-4176-81fc-d93a4001d287',
+            label: 'Power Automate forums - Microsoft Power Platform Community',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/retool.ts
+++ b/apps/sim/lib/compare/data/competitors/retool.ts
@@ -27,13 +27,13 @@ export const retoolProfile: CompetitorProfile = {
     {
       title: 'Full internal business applications, not just agent workflows',
       description:
-        "Retool builds custom internal UI screens, forms, admin panels, and dashboards backed by Retool Database, a genuine Postgres database with real SQL joins and foreign keys, not a spreadsheet-like grid, plus a mature React app runtime. AppGen lets users describe an app in plain English and Retool generates pages, queries, components, data bindings, and event handlers already wired to production data and inheriting the org's existing SSO/RBAC/audit policies.",
+        "Retool builds full internal business applications, not just agent workflows: apps are now written in React on the frontend and TypeScript on the backend, giving teams a real app runtime instead of a proprietary component tree. AppGen lets users describe an app in plain English; Retool's agent generates the UI, data queries, and bindings from that prompt, wired to production data, with every generated app automatically inheriting the org's existing centralized authentication, role-based access controls, and data-access policies rather than having auth logic baked into the app code.",
       shortDescription:
-        'Builds full internal apps on a real relational database, not just agent workflows.',
+        'Builds full internal apps on a real React/TypeScript runtime, not just agent workflows.',
       source: {
-        url: 'https://retool.com/ai-app-generation',
-        label: 'Retool AI App Generation',
-        asOf: '2026-07-02',
+        url: 'https://retool.com/blog/retool-launches-react-ai-app-builder',
+        label: 'Retool launches a full-stack React AI app builder',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -79,9 +79,9 @@ export const retoolProfile: CompetitorProfile = {
         'Retool is proprietary and closed-source. The self-hosted deployment can be forked and customized and bundles open-source dependencies, but still requires a Retool-issued license key to run. No OSS license covers the product itself.',
       shortDescription: 'Closed-source product; self-hosted still requires a Retool license key.',
       source: {
-        url: 'https://docs.retool.com/legal/open-source-license-disclosure',
-        label: 'Open Source License Disclosure | Retool Docs',
-        asOf: '2026-07-02',
+        url: 'https://docs.retool.com/self-hosted/tutorials/docker',
+        label: 'Deploy Self-hosted Retool with Docker | Retool Docs',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -277,13 +277,28 @@ export const retoolProfile: CompetitorProfile = {
       },
       dataTables: {
         value:
-          "Yes: Retool Database is a real, built-in Postgres-backed database (not a spreadsheet-like store), so tables can be queried with actual SQL and joined against other Resources, in addition to a spreadsheet-style Edit Table view for inline editing. Retool's Table UI component separately renders and scrolls through 100,000+ rows and hundreds of columns without slowing down.",
+          "Yes: Retool Database is a real, built-in Postgres-backed database (not a spreadsheet-like store). Tables support foreign-key fields that link rows between tables, and any query can be written in raw SQL (Retool's SQL mode supports arbitrary SELECT/UPDATE/DELETE and other statements, including joins), in addition to a spreadsheet-style Edit Table view for inline editing. Retool's Table UI component separately renders and scrolls through 100,000+ rows and hundreds of columns without slowing down.",
         detail:
-          "Because it's genuine Postgres under the hood, Retool Database supports relational features (foreign keys, SQL joins/queries) that a typed-column grid like Sim's Tables does not expose; Retool does not publish hard row/column caps for Retool Database itself (forum threads mention plan-dependent limits like 50,000 records, unconfirmed as current). The Table UI component is documented to handle 100K+ rows.",
+          "Because it's genuine Postgres under the hood, Retool Database supports foreign-key relationships (with configurable on-delete/on-update behavior) and hand-written SQL queries that a typed-column grid like Sim's Tables does not expose; Retool does not publish hard row/column caps for Retool Database itself (forum threads mention plan-dependent limits like 50,000 records, unconfirmed as current). The Table UI component is documented to handle 100K+ rows.",
         shortValue:
-          'Yes, real Postgres database (SQL-queryable), plus a large-dataset Table component',
+          'Yes, real Postgres database (foreign keys, SQL-queryable), plus a large-dataset Table component',
         confidence: 'verified',
         sources: [
+          {
+            url: 'https://retool.com/products/database',
+            label: 'Retool Database | Power apps with a built-in Postgres database',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.retool.com/data-sources/guides/retool-database/link-tables',
+            label: 'Link Retool Database tables (foreign keys) | Retool Docs',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.retool.com/queries/guides/sql/writes',
+            label: 'Write data to SQL databases | Retool Docs',
+            asOf: '2026-07-08',
+          },
           {
             url: 'https://retool.com/blog/supercharging-the-retool-table',
             label: 'Supercharging the Retool table',
@@ -379,14 +394,14 @@ export const retoolProfile: CompetitorProfile = {
       },
       knowledgeBaseRag: {
         value:
-          "Yes: Retool Vectors is a Retool-managed vector database that stores and indexes text, PDF, or web-page content, so AI apps and agents can retrieve relevant context in one click. Embedding calls always go through OpenAI's API (default model text-embedding-ada-002), regardless of which chat model is used.",
+          "Yes: Retool Vectors is a Retool-managed vector database that stores and indexes text, PDF, or web-page content, so AI apps and agents can retrieve relevant context in one click. Embedding calls go through OpenAI's API (default model text-embedding-ada-002).",
         shortValue: 'Managed vector store with built-in embeddings',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://retool.com/integrations/retool-vector',
-            label: 'Retool Vectors integration page',
-            asOf: '2026-07-02',
+            url: 'https://docs.retool.com/data-sources/tutorials/retool-vectors',
+            label: 'Retool-managed Vectors tutorial | Retool Docs',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.retool.com/data-sources/guides/vectors/embeddings',
@@ -445,14 +460,14 @@ export const retoolProfile: CompetitorProfile = {
         value:
           'Native image generation only. No native video generation, text-to-speech, or speech-to-text block.',
         detail:
-          'Retool\'s AI query block includes a native "Generate image" action (model options such as dall-e-2/gpt-image-1 via OpenAI) that returns a base64-encoded PNG. There is no native video-generation, text-to-speech, or speech-to-text block; users build these via third-party APIs.',
+          'Retool\'s AI query block includes a native "Generate image" action (model options: GPT Image 1, GPT Image 1 Mini, and GPT Image 1.5, all via OpenAI) that returns a base64-encoded image. There is no native video-generation, text-to-speech, or speech-to-text block; users build these via third-party APIs.',
         shortValue: 'Image generation only, no video/TTS/STT',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.retool.com/queries/guides/ai/image',
             label: 'Retool AI image actions (docs)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://community.retool.com/t/speech-to-text-anybody/26774',
@@ -882,10 +897,10 @@ export const retoolProfile: CompetitorProfile = {
       },
       sso: {
         value:
-          'Yes: Retool supports SAML 2.0 SSO (Business plan and above) compatible with Okta, Azure AD, Google Workspace, OneLogin and other SAML/OIDC providers, plus SCIM-based auto-provisioning (create/update/deactivate users automatically) available on Cloud or self-hosted 2.32.1+.',
+          'Yes: Retool supports SAML 2.0 SSO and Custom SSO (Okta, Azure AD/Entra ID, Google Workspace, OneLogin, and other SAML/OIDC providers) — but only on the Enterprise plan, not Business. SCIM-based auto-provisioning is available on Cloud or self-hosted 2.32.1+.',
         detail:
-          "The Enterprise plan separately lists 'Custom SSO' as a feature, suggesting tiered SSO capability between Business and Enterprise.",
-        shortValue: 'Yes, SAML/OIDC SSO plus SCIM auto-provisioning',
+          "Retool's current pricing page places SAML/Custom SSO exclusively on the Enterprise tier; the Business plan's feature list does not include SSO/SAML.",
+        shortValue: 'Yes, Enterprise-only SSO plus SCIM auto-provisioning',
         confidence: 'verified',
         sources: [
           {
@@ -896,13 +911,13 @@ export const retoolProfile: CompetitorProfile = {
           {
             url: 'https://retool.com/pricing',
             label: 'Retool Pricing',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       thirdPartyVetting: {
         value:
-          "Yes: Retool's built-in integrations (Resources) are a first-party catalog of roughly 50 databases, APIs, and cloud services built and maintained by Retool, not an open marketplace of third-party-submitted connectors. Retool separately offers Custom Component Libraries, which let a customer's own developers pull in npm packages to build custom UI components, but these are private to the authoring organization by default (or explicitly made public by that org), not a shared registry where other Retool customers install code published by unrelated third parties.",
+          "Yes: Retool's built-in integrations (Resources) are a first-party catalog of roughly 90+ databases, APIs, AI services, and cloud tools built and maintained by Retool, not an open marketplace of third-party-submitted connectors. Custom Component Libraries let a customer's own developers pull in npm packages to build custom UI components, but these are private to the authoring organization by default, not a shared registry of code from unrelated third parties.",
         detail:
           "A custom component loads into a sandboxed iframe, and Retool's custom-component-guide plus a community forum thread ('Custom Component Vulnerabilities') flag that developers should run npm audit on dependencies pulled into their own component libraries. This is a supply-chain caution for self-authored code, not an incident involving a shared marketplace, since no public component marketplace exists.",
         shortValue: 'Yes, first-party integration catalog, no public component marketplace',
@@ -911,7 +926,7 @@ export const retoolProfile: CompetitorProfile = {
           {
             url: 'https://retool.com/integrations',
             label: 'Retool Integrations',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.retool.com/apps/guides/custom/custom-component-libraries/',
@@ -999,26 +1014,27 @@ export const retoolProfile: CompetitorProfile = {
       },
       asyncExecution: {
         value:
-          "Yes: Retool Workflows can run asynchronously in the background. Triggering a workflow (via the API startTrigger endpoint or a webhook) kicks off a run that continues executing after the initial request returns, and you can check back on it later using the Retool API's Get Workflow Run Details endpoint, which returns the run's status and result.",
+          "Yes: Retool workflows triggered via their webhook URL (the same api.retool.com/v1/workflows/{id}/startTrigger endpoint used for classic-app and API triggers) can run asynchronously. If the workflow has no Response block, it is enqueued for asynchronous execution and responds immediately; if it has a Response block, it responds synchronously up to that block and the rest of the run continues asynchronously afterward. Retool's own docs define a 30-hour timeout for 'asynchronous workflow runs' versus 15 minutes for 'synchronous workflow runs' (bound to the first Response block). Run status can optionally be checked via the Get Workflow Run Details endpoint, currently in private beta (Retool 3.122+, requires a 'Workflows > Read' API token scope, access by request).",
         detail:
-          "Retool explicitly distinguishes 'synchronous workflow runs' (blocks until a Response block executes, 15-minute timeout) from 'asynchronous workflow runs' (up to 30 hours) in its own docs, and provides a Get Workflow Run Details API to fetch a run's status/result after triggering.",
-        shortValue: 'Yes, async trigger + poll for run status',
+          'The enqueue-and-respond-immediately behavior for Response-block-less runs is documented specifically for classic-app-triggered workflows, which fire through the same webhook/startTrigger mechanism as API-triggered ones. The Get Workflow Run Details API to fetch a run status/result after triggering is gated behind a private-beta signup, not generally available.',
+        shortValue:
+          'Yes, async execution with Response-block gating; run-status API is private beta',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.retool.com/workflows/concepts/limits',
             label: 'Retool Docs: Workflow limits (sync vs async execution modes)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.retool.com/api/get-workflow-run-details',
-            label: 'Retool API Docs: Get Workflow Run Details',
-            asOf: '2026-07-02',
+            label: 'Retool API Docs: Get Workflow Run Details (private beta)',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.retool.com/workflows/guides/webhooks',
             label: 'Retool Docs: Trigger workflows with webhooks',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1076,39 +1092,48 @@ export const retoolProfile: CompetitorProfile = {
     support: {
       supportChannels: {
         value:
-          'Community Discourse forum (free tier), email + chat (Team plan), dedicated/priority support (Business and Enterprise plans); a Slack group is available to invited "Power Users."',
+          "A 'Report a Breakage' form and billing/account email support (all customers, 2-business-day response), a Developer Forum and weekly office-hours Zoom calls with Community Engineers, and a Reddit community; a dedicated Enterprise Support Portal with response times per the Enterprise Support Policy is available for Enterprise customers.",
         detail:
-          'Support channels scale with plan tier, from community forum access on the free tier up to dedicated support on Business and Enterprise.',
-        shortValue: 'Forum on free tier up to dedicated Enterprise support',
+          "No Team-tier email+chat or Business-tier dedicated support, and no Slack group for 'Power Users', is currently documented.",
+        shortValue: 'Breakage form/forum/office hours for all; dedicated portal on Enterprise',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.retool.com/support/',
             label: 'Contact Retool support | Retool Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       sla: {
         value:
-          'Yes: custom SLA available on the Enterprise plan, alongside dedicated support engineers/account management.',
+          "Enterprise plan includes Retool's Support Engineering team for technical support and access to a dedicated technical advisor for onboarding, training, and guidance.",
         detail:
-          'Enterprise plans include dedicated support engineers, account management, and a custom SLA.',
-        shortValue: 'Custom SLA on Enterprise plan',
+          "The pricing page does not explicitly reference a named 'custom SLA' or 'account management' service.",
+        shortValue: 'Support Engineering + technical advisor on Enterprise',
         confidence: 'estimated',
         sources: [
-          { url: 'https://retool.com/pricing', label: 'Retool Pricing', asOf: '2026-07-02' },
+          { url: 'https://retool.com/pricing', label: 'Retool Pricing', asOf: '2026-07-08' },
         ],
       },
       community: {
         value:
-          'Community Discourse forum with 1,000+ posts. No GitHub star count or Slack member count is publicly disclosed.',
+          'Community Discourse forum with 190,000+ posts across 22,900+ topics and 17,000+ registered users. No GitHub star count or Slack member count is publicly disclosed.',
         detail:
-          'Forum activity figures come from third-party reporting rather than a published Retool metrics page.',
-        shortValue: 'Active Discourse forum, no public star/member count',
-        confidence: 'estimated',
+          "Aggregate forum stats come from Retool's public Discourse instance stats endpoint rather than a published Retool metrics page.",
+        shortValue: 'Active Discourse forum (190K+ posts), no public star/member count',
+        confidence: 'verified',
         sources: [
-          { url: 'https://retool.com/community', label: 'Retool Community', asOf: '2026-07-02' },
+          {
+            url: 'https://community.retool.com/about.json',
+            label: 'Retool Forum stats (community.retool.com/about.json)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://community.retool.com/',
+            label: 'Retool Forum (community.retool.com)',
+            asOf: '2026-07-08',
+          },
         ],
       },
       companyMaturity: {
@@ -1133,26 +1158,26 @@ export const retoolProfile: CompetitorProfile = {
       },
       academy: {
         value:
-          'Yes: Retool University (university.retool.com) is a structured education platform with course paths for developers, admins, and architects, including a Retool Platform Developer certification path with earnable digital badges, plus Labs walkthroughs and recorded Developer Day sessions.',
+          'Yes: Retool University (university.retool.com) launched with five course paths (Fundamentals, Platform Developer, Platform Admin, Platform Architect, Platform Advanced Developer), with most courses awarding a digital badge on completion, and a live Retool Platform Developer badge is issued via Credly.',
         detail:
-          'Launched with five course paths; Retool Platform Developer and Platform Admin courses award Credly digital badges. A third-party Coursera course also exists but the primary academy is Retool University.',
+          "Retool's education docs (docs.retool.com/education) have since been reframed around AI Apps, Workflows, and Agents rather than these named course paths, though the original five-path structure and Credly badges remain live via university.retool.com and the announcement blog post.",
         shortValue: 'Yes, Retool University with certification badges',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.retool.com/education/',
             label: 'Retool University docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://retool.com/blog/introducing-retool-university',
             label: 'Introducing Retool University',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://www.credly.com/org/retool-inc/badge/retool-platform-developer',
             label: 'Retool Platform Developer badge on Credly',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/stackai.ts
+++ b/apps/sim/lib/compare/data/competitors/stackai.ts
@@ -65,12 +65,12 @@ export const stackaiProfile: CompetitorProfile = {
     {
       title: 'Not open source',
       description:
-        'StackAI is a proprietary, closed-source commercial SaaS platform. Its GitHub organization contains only auxiliary tools and integrations, not the core platform, so there is no self-hostable OSS codebase to audit or fork.',
+        'StackAI is a proprietary, closed-source commercial SaaS platform. Its GitHub organization (github.com/stackai) currently has no public repositories at all, so there is no self-hostable OSS codebase to audit or fork.',
       shortDescription: 'Closed-source SaaS with no auditable or forkable codebase.',
       source: {
         url: 'https://github.com/stackai',
         label: 'StackAI GitHub organization',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -113,15 +113,24 @@ export const stackaiProfile: CompetitorProfile = {
       builderType: {
         value: 'Visual/low-code node-based workflow builder',
         detail:
-          'Drag-and-drop canvas of nodes (LLM, tools, logic, multimodal) for building agents; also supports Python code nodes for custom logic.',
-        shortValue: 'Drag-and-drop nodes plus Python code nodes',
+          'A 2D canvas where builders drag and drop nodes and connect them to build a workflow, drawing from Input, Output, Core (e.g. AI Agent, Knowledge Bases), Apps/integration, and Utils/Logic node categories; supports a Code Node for custom logic (the older Python Code node is now deprecated in favor of it).',
+        shortValue: 'Drag-and-drop node canvas plus Code Node',
         confidence: 'verified',
         sources: [
-          { url: 'https://docs.stackai.com/', label: 'StackAI Docs Overview', asOf: '2026-07-02' },
           {
-            url: 'https://docs.stackai.com/logic/python-code',
-            label: 'Python Code node - StackAI Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.stackai.com/welcome-to-stackai/overview/platform-overview',
+            label: 'Platform Overview - StackAI Docs',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.stackai.com/workflow-builder',
+            label: 'Workflow Builder node index - StackAI Docs',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.stackai.com/workflow-builder/utils-logic-and-others/logic/python-code',
+            label: 'Python Code node (deprecated) - StackAI Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -178,14 +187,14 @@ export const stackaiProfile: CompetitorProfile = {
       license: {
         value: 'Proprietary / closed source',
         detail:
-          'Commercial SaaS platform; the GitHub org (github.com/stackai) contains only auxiliary repos, not the core platform.',
+          'Commercial SaaS platform; the GitHub org (github.com/stackai) currently has no public repositories at all — the core platform is not open source.',
         shortValue: 'Closed-source commercial SaaS',
         confidence: 'verified',
         sources: [
           {
             url: 'https://github.com/stackai',
             label: 'StackAI GitHub organization',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -241,9 +250,9 @@ export const stackaiProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://docs.stackai.com/governance-and-security/workspace-and-folder-access',
+            url: 'https://docs.stackai.com/welcome-to-stackai/security-and-governance/security-in-stackai/workspace-and-folder-access',
             label: 'Workspace and Folder Access docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -365,26 +374,26 @@ export const stackaiProfile: CompetitorProfile = {
           {
             url: 'https://www.stackai.com/blog/introducing-stackai-human-in-the-loop-agentic-workflows-you-can-trust',
             label: 'Introducing StackAI Human-in-the-Loop - StackAI blog',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       generativeMedia: {
         value: 'Yes: image and audio generation nodes; no dedicated video generation node',
         detail:
-          'A Text-to-Audio node uses ElevenLabs for TTS and voice cloning; an Image node generates images from text prompts using models such as OpenAI DALL·E 3 or Stable Diffusion.',
+          'A Text-to-Audio node uses ElevenLabs voice-synthesis models (e.g. eleven_multilingual_v2) for TTS; an Image node generates images from text prompts using models such as OpenAI DALL·E 3 or Stable Diffusion.',
         shortValue: 'Image and audio nodes, no video',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.stackai.com/workflow-builder/outputs/image-node',
             label: 'Image Node - StackAI Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.stackai.com/workflow-builder/outputs/audio-node',
             label: 'Audio Node - StackAI Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -409,9 +418,9 @@ export const stackaiProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://docs.stackai.com/other-views/prompt-library',
+            url: 'https://docs.stackai.com/agentic-adoption-and-security/scalability/prompt-library',
             label: 'Prompt Library docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -435,21 +444,21 @@ export const stackaiProfile: CompetitorProfile = {
       },
       kbChunkVisibility: {
         value:
-          "Yes: StackAI's Knowledge Base nodes return retrieved chunks and let builders configure the chunking algorithm, chunk length, and chunk overlap. An output-format toggle switches between chunks, pages, and full documents, and a document preview view lets builders inspect indexed content.",
+          "Yes: StackAI's Knowledge Base node returns results as an array of document snippets/content chunks plus metadata (source, date, tags). Chunk-level indexing is configurable — chunking algorithm, chunk length, and chunk overlap — via the separate Files and Documents nodes used to index content.",
         detail:
-          'Confirms chunk-level granularity is exposed (algorithm, length, overlap, chunk vs page vs doc output). A dedicated chunk-index debugging pane beyond the document preview is unconfirmed.',
-        shortValue: 'Yes, chunk-level config and output',
+          'Knowledge Base node output is chunk-level (results array + metadata), but chunk-size controls live on the Files/Documents nodes used for indexing, not on the Knowledge Base node itself. No output-format toggle between chunks/pages/full documents and no dedicated document preview view is documented.',
+        shortValue: 'Yes, chunk-level results with metadata',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.stackai.com/best-practices/chunking',
+            url: 'https://docs.stackai.com/getting-started/core-ai-concepts/chunking',
             label: 'Chunking docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.stackai.com/workflow-builder/apps/knowledge-base',
             label: 'Knowledge Base docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -528,46 +537,52 @@ export const stackaiProfile: CompetitorProfile = {
         value:
           'Scheduled/time-based triggers and outbound webhook calls (e.g., to Make); no native inbound webhook trigger node',
         detail:
-          'Supports scheduled workflows (daily/weekly/monthly automation) and a Make node that can POST to trigger a Make.com scenario. Deployment surfaces include chat, forms, API, Slack, Teams, and batch run.',
+          'Supports scheduled workflows (daily/weekly/monthly automation) and a Make node that can POST to trigger a Make.com scenario. Deployment surfaces (how a finished workflow is exposed, distinct from triggers) include Form, Chat Assistant, API, Website Chatbot, Batch Run, Slack App, and Microsoft Teams.',
         shortValue: 'Scheduled triggers, outbound webhooks only',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://www.stackai.com/insights/how-to-set-up-scheduled-ai-workflows-and-automated-reports-on-stackai',
             label: 'Scheduled AI Workflows - StackAI insights',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.stackai.com/workflow-builder/apps/make',
             label: 'Make node - StackAI Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.stackai.com/interface-and-deployment/end-user-interfaces',
+            label: 'End-User Interfaces - StackAI Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
       customCodeSteps: {
-        value: 'Yes: Python code node',
-        detail: 'A dedicated Python Code node allows custom logic within workflows.',
+        value: 'Yes: Python code node (being migrated to a newer Code Node)',
+        detail:
+          "A Python Code node allows custom logic within workflows; StackAI's docs now note this node is deprecated in favor of a newer Code Node.",
         shortValue: 'Python code node',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.stackai.com/logic/python-code',
+            url: 'https://docs.stackai.com/workflow-builder/utils-logic-and-others/logic/python-code',
             label: 'Python Code - StackAI Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       apiPublishing: {
         value: 'Yes: workflows publishable as a REST API with generated client snippets',
         detail:
-          'Any flow can be exported and published as an API. Docs provide request snippets in Python, JavaScript, and cURL, with OAuth2-token authentication and a separate API reference.',
+          'Any flow can be exported and published as an API. Docs provide request snippets in Python, JavaScript, and cURL, authenticated via a Bearer token using a public API key generated in Settings → API Keys.',
         shortValue: 'Publish workflows as REST APIs',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.stackai.com/export-options/api',
+            url: 'https://docs.stackai.com/interface-and-deployment/end-user-interfaces/api',
             label: 'API - StackAI Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -580,27 +595,22 @@ export const stackaiProfile: CompetitorProfile = {
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://docs.stackai.com/export-options/api',
+            url: 'https://docs.stackai.com/interface-and-deployment/end-user-interfaces/api',
             label: 'API - StackAI Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       mcpPublishing: {
         value:
-          'Yes: StackAI provides a hosted MCP server (mcp.stack.ai/mcp) and an open-source stack-ai-mcp server. Either lets external MCP-compatible clients, such as Claude Desktop, run a published StackAI workflow as a callable MCP tool, passing inputs in and getting structured results back.',
-        shortValue: 'Yes, publishes workflows as MCP servers',
+          'Yes: StackAI provides a hosted MCP server (mcp.stack.ai/mcp) that lets external MCP-compatible clients, such as Claude Desktop, Claude Code, or Cursor, run a published StackAI workflow as a callable MCP tool, passing inputs in and getting structured results back.',
+        shortValue: 'Yes, publishes workflows as an MCP server',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.stackai.com/workflow-builder/apps/mcp',
-            label: 'MCP node docs',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://www.stackai.com/blog/how-to-use-the-stack-ai-mcp-server',
-            label: 'How to Use the Stack AI MCP Server',
-            asOf: '2026-07-02',
+            url: 'https://docs.stackai.com/interface-and-deployment/mcp-reference/stackai-mcp-server',
+            label: 'StackAI MCP Server docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -673,21 +683,21 @@ export const stackaiProfile: CompetitorProfile = {
       },
       auditLogging: {
         value:
-          'Yes: automatic logs of every run, capturing input/output, token usage, and runtime, queryable through a pull-based Analytics API (filterable by run ID, status, user, and date range)',
+          'Yes: automatic logs of every run, capturing input/output, token usage, and runtime, queryable through a pull-based Analytics API (filterable by status, user, and date range — no run ID filter parameter is documented)',
         detail:
-          'The Analytics API is request/response only: a builder calls it to list flow runs or an org-level run summary. There is no documented continuous push/export of these logs to an external destination such as S3, BigQuery, Datadog, or a generic webhook sink, and no separate public audit-log API distinct from execution logs.',
+          'The Analytics API is request/response only: a builder calls it to list flow runs or an org-level run summary, filtered by user_id, state (status), and date range. There is no documented continuous push/export of these logs to an external destination such as S3, BigQuery, Datadog, or a generic webhook sink, and no separate public audit-log API distinct from execution logs.',
         shortValue: 'Automatic per-run logs via a pull-based API, no export destination',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.stackai.com/welcome-to-stackai/overview/platform-overview',
             label: 'StackAI Platform Overview docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.stackai.com/interface-and-deployment/api-reference/analytics.md',
             label: 'StackAI API Reference: Analytics',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -721,9 +731,14 @@ export const stackaiProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.stackai.com/governance-and-security/workspace-and-folder-access',
+            url: 'https://docs.stackai.com/welcome-to-stackai/security-and-governance/security-in-stackai/workspace-and-folder-access',
             label: 'Workspace and Folder Access docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.stackai.com/welcome-to-stackai/security-and-governance/security-in-stackai/connection-and-knowledge-base-permissions',
+            label: 'Connection and Knowledge Base Permissions docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -750,47 +765,37 @@ export const stackaiProfile: CompetitorProfile = {
             asOf: '2026-07-02',
           },
           {
-            url: 'https://docs.stackai.com/security-and-privacy',
+            url: 'https://docs.stackai.com/welcome-to-stackai/security-and-governance/security-and-privacy',
             label: 'Security & Privacy docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       piiRedaction: {
         value:
-          "Yes: StackAI's security page states that built-in mechanisms detect and mask personally identifiable information (PII) during processing. Its guardrails guidance also covers redacting PII in inputs, retrieval, and logs as part of enterprise agent design.",
-        shortValue: 'Yes, built-in PII detection/masking',
-        confidence: 'verified',
+          "Partial: StackAI's guardrails guidance recommends redacting personally identifiable information (PII) in inputs, retrieval, and logs as part of enterprise agent design, but StackAI's own security page does not itself assert a built-in PII detection/masking mechanism.",
+        shortValue: 'Guardrail guidance only, not a confirmed built-in feature',
+        confidence: 'estimated',
         sources: [
-          {
-            url: 'https://www.stackai.com/security',
-            label: 'StackAI Security page',
-            asOf: '2026-07-02',
-          },
           {
             url: 'https://www.stackai.com/insights/how-to-design-ai-agent-guardrails-best-practices-for-input-validation-output-filtering-and-safety-controls',
             label: 'AI Agent Guardrails guide',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       sso: {
         value:
-          'Yes: StackAI supports Single Sign-On through a dedicated SSO settings page, integrating with identity providers like Okta and Entra ID to inherit groups and permissions. Newly provisioned SSO users get a default role, and admins can require SSO for all interfaces org-wide.',
+          'Yes: StackAI supports Single Sign-On, integrating with identity providers like Okta and Entra ID to inherit groups and permissions. Newly provisioned SSO users get a default role, and admins can require SSO for all interfaces org-wide.',
         detail:
-          'Docs confirm SSO login and default-role auto-provisioning behavior. SAML vs OIDC protocol details are not specified beyond the Okta/Entra ID integration.',
+          'Docs confirm SSO login and default-role auto-provisioning behavior, enabled per interface or enforced org-wide via admin policy. SSO configuration is distributed across these governance controls rather than a single dedicated SSO settings page, and SAML vs OIDC protocol details are not specified beyond the Okta/Entra ID integration.',
         shortValue: 'Yes, SSO with Okta/Entra ID',
-        confidence: 'estimated',
+        confidence: 'verified',
         sources: [
           {
-            url: 'https://www.stackai.com/sso',
-            label: 'StackAI SSO login page',
-            asOf: '2026-07-02',
-          },
-          {
-            url: 'https://www.stackai.com/insights/sso-and-rbac-for-ai-agents-how-to-secure-enterprise-ai-deployments',
-            label: 'SSO and RBAC for AI Agents',
-            asOf: '2026-07-02',
+            url: 'https://docs.stackai.com/welcome-to-stackai/security-and-governance/ai-governance',
+            label: 'AI Governance - StackAI Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -934,12 +939,11 @@ export const stackaiProfile: CompetitorProfile = {
     },
     support: {
       supportChannels: {
-        value:
-          'Community Discord (free tier); dedicated solution engineers / forward-deployed engineers (Enterprise)',
+        value: 'Community Discord (free tier); dedicated solution engineers (Enterprise)',
         shortValue: 'Discord free, dedicated engineers on Enterprise',
         confidence: 'verified',
         sources: [
-          { url: 'https://www.stackai.com/pricing', label: 'StackAI Pricing', asOf: '2026-07-02' },
+          { url: 'https://www.stackai.com/pricing', label: 'StackAI Pricing', asOf: '2026-07-08' },
         ],
       },
       sla: {
@@ -950,11 +954,11 @@ export const stackaiProfile: CompetitorProfile = {
       },
       community: {
         value:
-          'Discord community, comprehensive docs, and a StackAI Academy with tutorials and courses',
+          'StackAI community support (Discord, at discord.gg/sSbwawtNsV, not linked from stackai.com/academy), comprehensive docs at docs.stackai.com, and a StackAI Academy with tutorials and courses',
         shortValue: 'Discord, docs, and StackAI Academy',
         confidence: 'verified',
         sources: [
-          { url: 'https://www.stackai.com/academy', label: 'StackAI Academy', asOf: '2026-07-02' },
+          { url: 'https://www.stackai.com/academy', label: 'StackAI Academy', asOf: '2026-07-08' },
         ],
       },
       companyMaturity: {

--- a/apps/sim/lib/compare/data/competitors/tines.ts
+++ b/apps/sim/lib/compare/data/competitors/tines.ts
@@ -915,24 +915,24 @@ export const tinesProfile: CompetitorProfile = {
     observability: {
       tracingDepth: {
         value:
-          'Each workflow run ("Story run") gets a unique ID and a full, action-by-action event chain viewable in the UI or API. A Tenant Health dashboard (self-hosted) and Story/Action status views surface errors, run volume, and worker capacity, but this isn\'t OpenTelemetry-style distributed tracing by default; a separate community guide shows customers wiring up their own OpenTelemetry dashboard',
+          'Each workflow run ("Story run") gets a unique ID and a full, action-by-action event chain viewable in the UI or API. A Tenant Health dashboard (self-hosted) and Story/Action status views surface errors, run volume, and worker capacity, but this isn\'t OpenTelemetry-style distributed tracing by default; Tines\' own documentation includes an official guide showing customers how to wire up their own OpenTelemetry dashboard',
         shortValue: 'Per-run GUID trace; no built-in OpenTelemetry dashboards',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://www.tines.com/docs/stories/story-runs/',
             label: 'Story runs docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://www.tines.com/docs/self-hosted/monitoring-tines/tenant-health-dashboard/',
             label: 'Tenant health dashboard docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://explained.tines.com/en/articles/14120923-opentelemetry-designing-a-dashboard',
-            label: 'OpenTelemetry: Designing a Dashboard',
-            asOf: '2026-07-02',
+            label: 'OpenTelemetry: Designing a Dashboard (official Tines guide)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1086,14 +1086,16 @@ export const tinesProfile: CompetitorProfile = {
     support: {
       supportChannels: {
         value:
-          'Dedicated support and training for Business/Enterprise plans; community Slack and documentation for lower tiers',
-        shortValue: 'Dedicated support for Business/Enterprise, Slack for others',
+          '"Dedicated support and training" for Business/Enterprise plans, per the pricing page; specific mechanisms (named CSM/CSE role, SLA terms) are not publicly itemized',
+        detail:
+          'The pricing page lists "Dedicated support and training" as a Business/Enterprise inclusion but does not name a specific role (e.g. Customer Success Manager/Engineer) or publish SLA terms.',
+        shortValue: 'Dedicated support and training for Business/Enterprise',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://explained.tines.com/en/articles/9620399-understanding-tines-pricing-and-packaging',
-            label: 'Understanding Tines pricing and packaging',
-            asOf: '2026-07-02',
+            url: 'https://www.tines.com/pricing/',
+            label: 'Pricing | Tines',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/vellum.ts
+++ b/apps/sim/lib/compare/data/competitors/vellum.ts
@@ -34,9 +34,9 @@ export const vellumProfile: CompetitorProfile = {
         'Enterprise customers can get a Vellum-managed dedicated deployment inside a single-tenant AWS, Azure, or GCP VPC via a Replicated-based install. Sim offers self-hosting (Docker Compose or Kubernetes/Helm) but has no documented managed single-tenant/VPC hosting tier.',
       shortDescription: 'Vendor-managed single-tenant VPC tier that Sim does not offer.',
       source: {
-        url: 'https://docs.vellum.ai/self-hosting/getting-started/introduction',
-        label: 'Self-Hosted Vellum: Vellum Docs',
-        asOf: '2026-07-02',
+        url: 'https://www.vellum.ai/blog/announcing-vellum-vpc',
+        label: 'Announcing Vellum VPC',
+        asOf: '2026-07-08',
       },
     },
   ],
@@ -54,21 +54,27 @@ export const vellumProfile: CompetitorProfile = {
       },
     },
     {
-      title: 'BYOK not documented on pricing',
+      title: 'Enterprise BYOK policy no longer verifiable',
       description:
-        "Vellum's pricing pages describe a prepaid-credit model that passes through LLM costs at cost, with no bring-your-own-API-key option mentioned as an alternative.",
-      shortDescription: 'No bring-your-own-key option mentioned on pricing pages.',
-      source: { url: 'https://www.vellum.ai/pricing', label: 'Vellum Pricing', asOf: '2026-07-02' },
+        "Vellum's pricing page has been replaced by a consumer 'Personal Intelligence' pricing model (subscription plus pay-as-you-go credits); the original enterprise LLM-cost-pass-through pricing this claim describes, including any bring-your-own-API-key policy, is no longer published at this URL.",
+      shortDescription:
+        'Pricing page now shows a different consumer product; enterprise BYOK policy unconfirmed.',
+      source: {
+        url: 'https://www.vellum.ai/pricing',
+        label: 'Vellum Pricing (now shows the consumer product)',
+        asOf: '2026-07-08',
+      },
     },
     {
-      title: 'No enterprise SLA published',
+      title: 'Enterprise SLA no longer verifiable',
       description:
-        'No uptime or response-time SLA commitments are published on the enterprise or pricing pages.',
-      shortDescription: 'No public SLA commitments found.',
+        "The /enterprise page has been repurposed for Vellum's consumer product and no longer represents its (formerly documented) enterprise LLMOps offering, so SLA absence can no longer be verified against genuine enterprise-tier content at this URL.",
+      shortDescription:
+        'SLA status unverifiable after the /enterprise page pivoted to the consumer product.',
       source: {
         url: 'https://www.vellum.ai/enterprise',
-        label: 'Vellum Enterprise',
-        asOf: '2026-07-02',
+        label: 'Vellum Enterprise (now shows the consumer product)',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -133,14 +139,20 @@ export const vellumProfile: CompetitorProfile = {
         ],
       },
       deploymentOptions: {
-        value: 'Vellum Cloud (SaaS), self-hosted, and VPC install on AWS/Azure/GCP or on-prem',
-        shortValue: 'Cloud, self-hosted, or VPC install',
+        value:
+          'Vellum Managed (fully managed hosted service), self-hosted, and Vellum VPC install on AWS, Azure, or GCP',
+        shortValue: 'Managed, self-hosted, or VPC install',
         confidence: 'estimated',
         sources: [
           {
             url: 'https://docs.vellum.ai/self-hosting/getting-started/introduction',
             label: 'Self-Hosted Vellum: Vellum Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://www.vellum.ai/blog/announcing-vellum-vpc',
+            label: 'Announcing Vellum VPC',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -294,14 +306,14 @@ export const vellumProfile: CompetitorProfile = {
       },
       agentReasoningBlocks: {
         value:
-          "Vellum's 'Agent Node' (formerly 'Tool Calling Node') is its dedicated agent/reasoning-and-tool-execution block within Workflows, supporting raw code, subworkflows, MCP tools, and Composio SaaS actions side by side in one node.",
-        shortValue: 'Agent Node handles reasoning + tool execution',
+          "Vellum's 'Agent Node' (formerly 'Tool Calling Node') is its dedicated agent/reasoning-and-tool-execution block within Workflows, currently documenting raw code, subworkflows, and Composio SaaS actions as tool types in one node; MCP tool support is not documented on the current Agent Node page.",
+        shortValue: 'Agent Node handles reasoning + tool execution; MCP not currently documented',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.vellum.ai/product/workflows/nodes/agent-node',
             label: 'Vellum Docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -674,13 +686,18 @@ export const vellumProfile: CompetitorProfile = {
         ],
       },
       byok: {
-        value: 'Not mentioned on current pricing pages',
+        value:
+          "Unconfirmed for the enterprise platform: Vellum's pricing page has been replaced by an unrelated consumer 'Personal Intelligence' product page, so BYOK availability can no longer be verified from vellum.ai/pricing.",
         detail:
-          'Pricing is structured around Vellum-provided credits passed through at cost, with no bring-your-own-API-key option described.',
-        shortValue: 'No BYOK option documented',
+          "The current pricing page describes Vellum-provided credits for the consumer product, not the enterprise platform's LLM-cost pass-through model; no bring-your-own-API-key policy is described for either product on this page.",
+        shortValue: 'Unverifiable after the pricing page pivoted to the consumer product',
         confidence: 'unknown',
         sources: [
-          { url: 'https://www.vellum.ai/pricing', label: 'Vellum Pricing', asOf: '2026-07-02' },
+          {
+            url: 'https://www.vellum.ai/pricing',
+            label: 'Vellum Pricing (now shows the consumer product)',
+            asOf: '2026-07-08',
+          },
         ],
       },
     },
@@ -872,14 +889,19 @@ export const vellumProfile: CompetitorProfile = {
       },
       durabilityModel: {
         value:
-          "Vellum supports 'Retry Node Adornments' (organized under an 'Error Handling' section of node Settings) that automatically re-invoke a failed node up to a configured max-attempts count.",
+          "Vellum supports a 'Retry Node Adornment' — a standalone adornment applied to a node (separate from that node's Settings) that automatically re-invokes the node until it succeeds or reaches a configured max-attempts count.",
         shortValue: 'Automatic node-level retries',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.vellum.ai/product/workflows/node-types',
-            label: 'Vellum Docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.vellum.ai/product/workflows/nodes/overview',
+            label: 'Vellum Docs: Nodes Overview (adornments, error handling)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.vellum.ai/changelog/2025/2025-03',
+            label: 'Vellum Changelog, March 2025 (Try/Retry node adornments)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -916,17 +938,17 @@ export const vellumProfile: CompetitorProfile = {
           {
             url: 'https://docs.vellum.ai/changelog/2025/2025-11',
             label: 'Vellum Changelog, November 2025 (async workflow execution)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://docs.vellum.ai/developers/client-sdk/workflows/execute-workflow',
-            label: 'Vellum Docs: Execute Workflow (synchronous SDK call)',
-            asOf: '2026-07-02',
+            url: 'https://docs.vellum.ai/developers/client-sdk/workflows/execute-workflow-async',
+            label: 'Vellum Docs: Execute Workflow Async',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://docs.vellum.ai/api-reference/workflows/execute-workflow-stream',
-            label: 'Vellum API Reference: Execute Workflow as Stream',
-            asOf: '2026-07-02',
+            url: 'https://docs.vellum.ai/developers/client-sdk/workflows/execute-workflow-stream',
+            label: 'Vellum Docs: Execute Workflow as Stream',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -970,30 +992,30 @@ export const vellumProfile: CompetitorProfile = {
           {
             url: 'https://docs.vellum.ai/changelog/2025/2025-11',
             label: 'Vellum Changelog, November 2025 (Scheduled and Integration Triggers)',
-            asOf: '2026-07-04',
-          },
-          {
-            url: 'https://docs.vellum.ai/product/workflows/api-integration',
-            label: 'Vellum Docs: Easy Integration with Vellum API for Workflows',
-            asOf: '2026-07-04',
+            asOf: '2026-07-08',
           },
         ],
       },
     },
     support: {
       supportChannels: {
-        value: 'Discord community; priority support included on paid plans',
+        value:
+          'Email, an in-app chat, a shared Slack channel for active customers, and a Discord community',
         detail:
-          'The pricing and enterprise pages reference a Discord community channel and note that the Pro plan includes priority support.',
-        shortValue: 'Discord community + priority support',
+          "Vellum's help center lists email (support@vellum.ai), in-app chat via the dashboard's 'Get Help' button, and a shared Slack channel for active customers; the enterprise page separately links a public Discord community. vellum.ai/pricing has since been repurposed for a different 'personal AI assistant' product, so its 'priority support' mention describes that product's paid add-on, not the workflow platform's support tiers — no priority-support or SLA claim is made here.",
+        shortValue: 'Email, in-app chat, Slack (customers), Discord community',
         confidence: 'estimated',
         sources: [
           {
+            url: 'https://docs.vellum.ai/home/getting-started/support',
+            label: "Vellum's Help Center",
+            asOf: '2026-07-08',
+          },
+          {
             url: 'https://www.vellum.ai/enterprise',
             label: 'Vellum Enterprise',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
-          { url: 'https://www.vellum.ai/pricing', label: 'Vellum Pricing', asOf: '2026-07-02' },
         ],
       },
       sla: {
@@ -1018,24 +1040,24 @@ export const vellumProfile: CompetitorProfile = {
       },
       companyMaturity: {
         value:
-          'Founded 2023 (Y Combinator W23) by Noa Flaherty, Sidd Seethepalli, and Akash Sharma. Raised a $5M seed (2023) and a $20M Series A (July 2025, led by Leaders Fund). Crunchbase reports $25.5M raised in total across three funding rounds, implying additional undisclosed funding beyond these two rounds. Based in New York City, with 150+ reported customers as of the Series A announcement.',
-        shortValue: 'YC W23, ~$25.5M raised across 3 rounds, NYC-based',
+          'Founded 2023 (Y Combinator W23) by Noa Flaherty, Sidd Seethepalli, and Akash Sharma. Raised a $5M seed (July 2023) and a $20M Series A (July 2025, led by Leaders Fund). Based in New York City, with 150+ reported customers as of the Series A announcement.',
+        shortValue: 'YC W23, $25M raised across 2 rounds, NYC-based',
         confidence: 'estimated',
         sources: [
           {
-            url: 'https://www.vellum.ai/blog/announcing-our-20m-series-a',
-            label: 'Announcing our $20m Series A: Vellum',
-            asOf: '2026-07-02',
+            url: 'https://www.ycombinator.com/companies/vellum',
+            label: 'Vellum: Y Combinator',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://www.crunchbase.com/organization/vellum-74f3',
-            label: 'Vellum: Crunchbase Company Profile & Funding',
-            asOf: '2026-07-02',
+            url: 'https://www.vellum.ai/blog/announcing-our-20m-series-a',
+            label: 'Announcing our $20m Series A: Vellum',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://voicebot.ai/2023/07/13/generative-ai-prompt-engineering-startup-vellum-ai-raises-5m/',
             label: 'Generative AI Prompt Engineering Startup Vellum.ai Raises $5M: Voicebot.ai',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/workato.ts
+++ b/apps/sim/lib/compare/data/competitors/workato.ts
@@ -103,25 +103,26 @@ export const workatoProfile: CompetitorProfile = {
       },
     },
     {
-      title: 'Native LLM choice limited to two providers',
+      title: 'Built-in AI actions limited to a fixed model set',
       description:
-        "AI Hub's native model picker for Genies covers Anthropic Claude and OpenAI GPT (plus BYOLLM for those same two providers); reaching other providers like Google Gemini or Amazon Bedrock requires going through separate integration connectors rather than a first-class in-agent model switch.",
-      shortDescription: 'Native model picker covers only Claude and GPT; others need connectors.',
+        "Workato's own 'AI by Workato' actions run on a fixed set of models under the hood — Anthropic's Claude Sonnet 4 in most regions, and OpenAI's GPT-4o mini in the Israel data center — rather than offering a first-class choice among the full range of LLM providers.",
+      shortDescription: 'Built-in AI actions run on a fixed Claude Sonnet 4 / GPT-4o mini set.',
       source: {
         url: 'https://docs.workato.com/connectors/ai-by-workato.html',
         label: 'AI by Workato | Workato docs',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
-      title: 'Knowledge base ingestion limited to text/PDF out of the box',
+      title: 'Knowledge base ingestion limited to four document formats',
       description:
-        "Workato's documented Knowledge Base Accelerator pattern natively supports only text and PDF document formats for RAG ingestion; support for other formats requires extending the accelerator yourself.",
-      shortDescription: 'RAG ingestion natively supports only text and PDF documents.',
+        "Workato's documented knowledge base data ingestion natively supports only PDF, PPTX, XLSX, and DOCX file types; other formats, including images, videos, and audio files, are not supported for RAG ingestion.",
+      shortDescription:
+        'RAG ingestion supports only PDF, PPTX, XLSX, DOCX — no images, video, or audio.',
       source: {
-        url: 'https://docs.workato.com/en/agentic/agent-studio/knowledge-bases/knowledge-bases.html',
-        label: 'Knowledge bases | Workato Docs',
-        asOf: '2026-07-02',
+        url: 'https://docs.workato.com/en/agentic/agent-studio/knowledge-bases/data-ingestion.html',
+        label: 'Workato Docs: Knowledge base data ingestion',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -187,14 +188,19 @@ export const workatoProfile: CompetitorProfile = {
       },
       deploymentOptions: {
         value:
-          'Cloud-hosted SaaS platform (multi-region data centers) with an optional on-prem agent for hybrid/on-prem app and database connectivity; the on-prem agent itself can run on AWS/Azure/GCP VMs or a private physical/virtual machine',
+          'Cloud-hosted SaaS platform (multi-region data centers) with an optional on-prem agent for hybrid/on-prem app and database connectivity; the on-prem agent itself installs on a Windows, Linux (DEB/RPM), Docker, or macOS host, whether that host is a cloud VM (AWS/Azure/GCP) or private physical/virtual machine',
         shortValue: 'Cloud SaaS with optional on-prem connectivity agent',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.workato.com/on-prem/agents.html',
-            label: 'On-prem agent | Workato docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.workato.com/on-prem.html',
+            label: 'On-prem connectivity | Workato Docs',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.workato.com/on-prem/groups/add-agent.html',
+            label: 'On-prem agent - Add an agent | Workato Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -846,19 +852,14 @@ export const workatoProfile: CompetitorProfile = {
       },
       dataResidency: {
         value:
-          "Yes, at signup: customers choose one data residency region per account from Workato's regional data centers (US, EU/Frankfurt, UK, Japan, Singapore, Australia, Israel, China, South Korea). That choice is fixed once the account is created; data cannot later be migrated to another region, and there is no ongoing per-workspace or per-project residency toggle. Using more than one region requires signing up for and maintaining a separate Workato account in each desired region. The on-prem agent additionally lets customers keep on-prem application data behind their own firewall, tunneling only authorized traffic to the Workato cloud.",
-        shortValue: 'Region chosen once at signup, fixed per account, not ongoing/toggleable',
+          "Yes, for enterprise customers: Workato enterprise customers can choose the region where their organization's automation data is stored and processed, from regional data centers (US, EU/Frankfurt, Japan, Singapore, Australia, Israel, China, South Korea). Once stored, data remains isolated in that region and is not shared or transferred across regions; there is no ongoing per-workspace or per-project residency toggle. Self-service (non-enterprise) users can't choose a region and are hosted in one of Workato's US data centers. Using more than one region requires signing up for and maintaining a separate Workato account in each desired region.",
+        shortValue: 'Enterprise customers pick a region; self-service defaults to US',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.workato.com/datacenter/datacenter-overview.html',
             label: 'Data center overview | Workato Docs',
-            asOf: '2026-07-04',
-          },
-          {
-            url: 'https://docs.workato.com/connectors/ai-by-workato.html',
-            label: 'AI by Workato | Workato docs',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -882,14 +883,14 @@ export const workatoProfile: CompetitorProfile = {
       },
       auditLogging: {
         value:
-          "Yes: an Activity audit log records users' significant actions across the workspace and can be streamed to an external destination for retention and analysis",
+          "Yes: an Activity audit log records users' significant actions across the workspace and can be streamed to an external destination (e.g. Amazon S3, Azure, Google Cloud Storage, Datadog, Splunk) for retention and analysis",
         shortValue: 'Activity audit log, streamable externally',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.workato.com/user-accounts-and-teams/role-based-access/access-control-v2.html',
-            label: 'Manage workspace collaborators with role-based access control | Workato docs',
-            asOf: '2026-07-02',
+            url: 'https://docs.workato.com/features/activity-audit-log-streaming.html',
+            label: 'Audit log streaming | Workato Docs',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -941,40 +942,40 @@ export const workatoProfile: CompetitorProfile = {
       },
       whiteLabeling: {
         value:
-          'Yes: Workato Embedded offers a Theme editor (Admin Console > Settings > Branding) for customizing colors, fonts, spacing, and adding a custom company logo/name, plus the ability to white-label error messages, notifications, and logs, for partners embedding Workato in their own product.',
+          'Yes, partially self-service: Workato Embedded offers a Theme editor (Admin Console/Manage Customers > Settings > Branding) for customizing colors, fonts, and spacing, for partners embedding Workato in their own product. Adding a custom company logo is not part of the self-service Theme editor and instead requires contacting a Workato Success Representative.',
         detail:
-          'This capability is scoped to the Workato Embedded/OEM offering, not the standard workspace UI.',
-        shortValue: 'Yes: Embedded theme editor with logo/branding',
+          'Scoped to the Embedded/OEM offering, not the standard workspace UI. No current documentation supports white-labeling of error messages, notifications, or logs.',
+        shortValue: 'Yes: Embedded theme editor (colors/fonts/spacing); logo needs Support',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.workato.com/oem/branding.html',
             label: 'Workato Docs: Branding - Theme editor',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://www.workato.com/product-hub/customization-possibilities-with-the-embedded-theme-editor/',
             label:
               'Workato Product Hub: Customization possibilities with the Embedded Theme editor',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       dataRetention: {
         value:
-          'Yes: Workato supports org-configurable data retention for recipe job logs, with a default of 30 to 90 days depending on the workspace plan. Enterprise Workspaces, or workspaces with the Data Monitoring/Advanced Security & Compliance capability, can customize retention per recipe down to 1 hour, up to 90 days, or to zero retention.',
-        shortValue: 'Yes: configurable retention (1hr-90 days, or zero)',
+          'Yes: Workato supports org-configurable data retention for recipe job logs, with a default of 30 to 90 days depending on the workspace plan. Enterprise Workspaces, or workspaces with the Data Monitoring/Advanced Security & Compliance capability, can set a workspace-wide custom retention period between 1 hour and 90 days; individual recipes can then be set to follow that workspace policy or to store no data at all.',
+        shortValue: 'Yes: org-configurable retention, 1hr-90 days (Enterprise/Data Monitoring)',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.workato.com/security/data-protection/data-retention/',
             label: 'Workato Docs: Data retention policies',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.workato.com/security/data-protection/data-retention/configure-retention-for-recipes.html',
             label: 'Workato Docs: Recipe-level data retention',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/competitors/zapier.ts
+++ b/apps/sim/lib/compare/data/competitors/zapier.ts
@@ -50,12 +50,12 @@ export const zapierProfile: CompetitorProfile = {
     {
       title: 'Zapier Copilot (natural-language build assistant)',
       description:
-        'Copilot (open beta) lets users describe an automation or agent in plain language and generates a draft Zap or agent, including custom code steps to fill integration gaps. Sim offers the same natural-language building capability via Chat and in-editor Copilot.',
+        'Copilot lets users describe an automation or agent in plain language and generates a draft Zap or agent, including custom code steps to fill integration gaps. Sim offers the same natural-language building capability via Chat and in-editor Copilot.',
       shortDescription: 'Describe an automation and Copilot builds the Zap or agent for you.',
       source: {
         url: 'https://zapier.com/blog/zapier-copilot-guide/',
         label: 'Zapier Copilot: Build systems even faster with AI',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
   ],
@@ -163,7 +163,11 @@ export const zapierProfile: CompetitorProfile = {
         shortValue: 'Large library of prebuilt templates',
         confidence: 'estimated',
         sources: [
-          { url: 'https://zapier.com/apps', label: 'Zapier App Directory', asOf: '2026-07-02' },
+          {
+            url: 'https://zapier.com/templates',
+            label: 'Zapier Workflow Automation Templates',
+            asOf: '2026-07-08',
+          },
         ],
       },
       license: {
@@ -172,9 +176,10 @@ export const zapierProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://zapier.com/pricing',
-            label: 'Zapier Plans & Pricing',
-            asOf: '2026-07-02',
+            url: 'https://zapier.com/legal/terms-of-service',
+            label:
+              'Zapier Terms of Service (Zapier and its licensors retain all right, title, and interest in the Service; no open-source license is offered)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -275,21 +280,21 @@ export const zapierProfile: CompetitorProfile = {
       },
       dataTables: {
         value:
-          'Yes: Zapier Tables is a native, spreadsheet-like data table feature (distinct from external DB connectors), with a spreadsheet-style grid interface and plan-based record limits (Free plan up to 2,500 records). Deleted records and fields go to a Trash with a 30-day recovery window.',
+          'Yes: Zapier Tables is a native, spreadsheet-like data table feature (distinct from external DB connectors), with a spreadsheet-style grid interface and plan-based record limits (see zapier.com/pricing for current tier limits, as the usage-limits help page no longer states the Free plan figure directly). Deleted records and fields go to a Trash with a 30-day recovery window.',
         detail:
           'Table components embedded in Interfaces/Forms display 20 rows by default (switchable to 10/20/50); keyboard-navigation parity with classic spreadsheets is not separately documented.',
-        shortValue: 'Yes: native Zapier Tables with record limits',
+        shortValue: 'Yes: native Zapier Tables with plan-based record limits',
         confidence: 'verified',
         sources: [
           {
             url: 'https://help.zapier.com/hc/en-us/articles/15721386410765-Zapier-Tables-usage-limits',
             label: 'Zapier Tables usage limits',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://help.zapier.com/hc/en-us/articles/45396606105741-Restore-deleted-records-and-fields-from-Trash-in-Zapier-Tables',
             label: 'Restore deleted records and fields from Trash in Zapier Tables',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -337,19 +342,19 @@ export const zapierProfile: CompetitorProfile = {
     aiCapabilities: {
       multiLlmSupport: {
         value:
-          'OpenAI (GPT family), Anthropic (Claude family), and Google (Gemini family), with BYOK for OpenAI, Anthropic, Gemini, and Azure OpenAI in Chatbots',
-        shortValue: 'OpenAI, Anthropic, and Google models, with BYOK',
+          'OpenAI (GPT family), Anthropic (Claude family), and Google (Gemini family), with BYOK for OpenAI and Anthropic only in Chatbots',
+        shortValue: 'OpenAI, Anthropic, and Google models; BYOK for OpenAI/Anthropic only',
         confidence: 'verified',
         sources: [
           {
             url: 'https://zapier.com/blog/ai-models-on-zapier/',
             label: 'Which AI models can you automate on Zapier?',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://help.zapier.com/hc/en-us/articles/21959873616013-Use-your-own-API-key-with-a-Zapier-Chatbot',
             label: 'Use your own API key with a Zapier Chatbot',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -390,16 +395,25 @@ export const zapierProfile: CompetitorProfile = {
       mcpSupport: {
         value: 'Yes',
         detail:
-          'Zapier operates a hosted MCP server (Streamable HTTP) exposing 9,000+ app connections and 30,000+ actions to any MCP client, and also offers an "MCP Client by Zapier" integration for calling external MCP servers from within Zaps. Costs 2 tasks per tool call on all plans.',
+          'Zapier operates a hosted MCP server (Streamable HTTP) exposing 9,000+ app connections and 40,000+ actions to any MCP client, and also offers an "MCP Client by Zapier" integration for calling external MCP servers from within Zaps. Costs 2 tasks per tool call on all plans.',
         shortValue: 'Hosted MCP server plus an MCP client to call others',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://zapier.com/blog/zapier-mcp-guide/',
-            label: 'Zapier MCP: Perform 30,000+ actions in your AI tool',
-            asOf: '2026-07-02',
+            url: 'https://docs.zapier.com/mcp/home',
+            label: 'Zapier MCP docs (9,000+ apps and 40,000+ actions)',
+            asOf: '2026-07-08',
           },
-          { url: 'https://docs.zapier.com/mcp/home', label: 'Zapier MCP docs', asOf: '2026-07-02' },
+          {
+            url: 'https://docs.zapier.com/mcp/clients',
+            label: 'Zapier MCP docs — Clients (requires Streamable HTTP; SSE not supported)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.zapier.com/mcp/usage/overview',
+            label: 'Zapier MCP docs — Usage overview (2 tasks per tool call)',
+            asOf: '2026-07-08',
+          },
         ],
       },
       evaluationGuardrails: {
@@ -501,21 +515,27 @@ export const zapierProfile: CompetitorProfile = {
       },
       nativeChatDeployment: {
         value:
-          'Yes: Zapier Chatbots let a builder create a conversational AI agent connected to knowledge sources and 9,000+ apps, then deploy it via a public shareable URL or embed it on a website, Slack, or Teams.',
+          'Yes: Zapier Chatbots let a builder create a conversational AI agent connected to knowledge sources, deployed via a public shareable URL or embedded on a website (pop-up, inline, or via Zapier Forms); Slack can also be connected via a separate Zap that triggers the chatbot\'s Generate Reply action and posts the reply back, rather than a direct "embed" option.',
         detail:
           "Chatbots and Interfaces are public by default unless restricted on a paid plan; the 'Built on Zapier' footer label can be removed on paid plans as well.",
-        shortValue: 'Yes: public chatbot URL or embed',
+        shortValue: 'Yes: public chatbot URL or website embed; Slack via a separate Zap',
         confidence: 'verified',
         sources: [
           {
             url: 'https://help.zapier.com/hc/en-us/articles/21958023866381-Share-and-embed-a-chatbot',
             label: 'Share and embed a chatbot',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://help.zapier.com/hc/en-us/articles/21960697323533-Set-up-a-chatbot',
             label: 'Set up a chatbot',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://community.zapier.com/featured-articles-65/how-to-connect-your-zapier-chatbot-to-slack-for-smart-replies-46213',
+            label:
+              'How to Connect Your Zapier Chatbot to Slack for Smart Replies (Zapier Community)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -685,17 +705,23 @@ export const zapierProfile: CompetitorProfile = {
         detail:
           'A task is one completed action step in a Zap; trigger steps are free. MCP tool calls cost 2 tasks each. Plans are sold as monthly task blocks (e.g., 750, 2,000) with per-user limits on Team/Enterprise.',
         shortValue: 'Metered per-task pricing, tiered by monthly allotment',
-        confidence: 'estimated',
+        confidence: 'verified',
         sources: [
           {
-            url: 'https://www.activepieces.com/blog/zapier-pricing',
-            label: 'Zapier Pricing Breakdown (third-party)',
-            asOf: '2026-07-02',
+            url: 'https://zapier.com/pricing',
+            label:
+              'Zapier Pricing (task tiers from 100 to 2M/month; seat limits on Team/Enterprise)',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://zapier.com/blog/zapier-mcp-guide/',
-            label: 'Zapier MCP guide (task cost per tool call)',
-            asOf: '2026-07-02',
+            url: 'https://help.zapier.com/hc/en-us/articles/8496196837261-How-is-task-usage-measured-in-Zapier',
+            label: 'How is task usage measured in Zapier? (Zap triggers never use tasks)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://docs.zapier.com/mcp/usage/overview',
+            label: 'Zapier MCP usage overview (task cost per tool call)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -729,14 +755,14 @@ export const zapierProfile: CompetitorProfile = {
       byok: {
         value: 'Yes, for Chatbots/AI steps',
         detail:
-          "Zapier Chatbots default to GPT-4.1 mini but let users add their own API key for OpenAI, Anthropic Claude, Google Gemini, or Azure OpenAI, with usage billed directly to the user's provider account.",
-        shortValue: 'Bring your own key for Chatbots/AI steps',
+          "Zapier Chatbots default to GPT-4.1 mini but let users add their own API key for OpenAI or Anthropic Claude, with usage billed directly to the user's provider account. (Gemini/Azure OpenAI BYOK is not documented.)",
+        shortValue: 'Bring your own key for OpenAI/Anthropic in Chatbots',
         confidence: 'verified',
         sources: [
           {
             url: 'https://help.zapier.com/hc/en-us/articles/21959873616013-Use-your-own-API-key-with-a-Zapier-Chatbot',
             label: 'Use your own API key with a Zapier Chatbot',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -838,41 +864,41 @@ export const zapierProfile: CompetitorProfile = {
       },
       credentialGovernance: {
         value:
-          "Yes, but coarser than per-role credential controls: Zapier lets an owner share a specific app connection with chosen users or teams (Enterprise), and Enterprise 'managed apps' let admins mark specific apps as admin-only, so only admins can create or share connections for that app while members still use admin-shared ones. This governs connections at the app/sharing level, not a fine-grained per-role permission matrix over individual stored credentials.",
+          "Yes, but coarser than per-role credential controls: Zapier lets an owner share a specific app connection with chosen individual users (Team plan) or with teams as a unit (Enterprise), and Enterprise 'managed apps' let admins mark specific apps as admin-only, so only admins can create or share connections for that app while members still use admin-shared ones. This governs connections at the app/sharing level, not a fine-grained per-role permission matrix over individual stored credentials.",
         detail:
           'Admins can also globally restrict connection sharing account-wide via a toggle in the Admin Center.',
-        shortValue: 'Coarse: connection sharing plus admin-managed apps',
+        shortValue: 'Coarse: connection sharing (Team) plus admin-managed apps (Enterprise)',
         confidence: 'verified',
         sources: [
           {
             url: 'https://help.zapier.com/hc/en-us/articles/8496326497037-Share-app-connections-with-members-of-your-Team-or-Enterprise-account',
             label: 'Share app connections with members of your Team or Enterprise account',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://help.zapier.com/hc/en-us/articles/44795921426317-Manage-app-connections-with-managed-apps',
             label: 'Manage app connections with managed apps',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
       whiteLabeling: {
         value:
-          "Yes, but partial and tiered: Zapier offers a White Label product for embedding automation UI into a customer's own product (Company/Enterprise pricing). Separately, paid-plan customers can remove the 'Built on Zapier' label from Chatbots and Forms and apply custom brand colors and a logo to Forms. There is no platform-wide white-labeling of the core Zap editor or workspace itself.",
+          "Yes, but partial and tiered: Zapier offers a White Label product for embedding automation UI into a customer's own product (currently limited access, contact sales). Separately, Team/Enterprise Forms customers can remove the 'Built on Zapier' label, while Professional/Team/Enterprise customers can apply custom brand colors and a logo to Forms (Free cannot). There is no platform-wide white-labeling of the core Zap editor or workspace itself.",
         detail:
-          'White Label is a distinct embedded product for SaaS builders; branding removal on Chatbots/Forms is a separate, narrower feature gated behind paid plans.',
+          'White Label is a distinct embedded product for SaaS builders; branding removal on Forms is a separate, narrower feature gated behind paid plans, with label removal itself requiring Team/Enterprise.',
         shortValue: 'Partial: White Label embed product, tiered branding removal',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.zapier.com/white-label/getting-started',
             label: 'White Label getting started',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://help.zapier.com/hc/en-us/articles/15932034572685-Customize-branding-and-colors-in-Zapier-Forms',
             label: 'Customize branding and colors in Zapier Forms',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1055,21 +1081,21 @@ export const zapierProfile: CompetitorProfile = {
       },
       dataDrains: {
         value:
-          "Yes: Zapier offers 'Log streams' (Enterprise) that continuously stream Zap configuration-change and run-outcome events to an external SIEM/monitoring destination such as Datadog or Splunk, in addition to an in-product account-wide audit log with a Zap Runs API for pulling history.",
+          "Yes: Zapier offers 'Log streams' (Enterprise) that continuously stream Zap configuration-change and run-outcome events to an external SIEM/monitoring destination such as Datadog or Splunk, in addition to an in-product account-wide audit log (Teams/Enterprise) for change and run-outcome history. (Note: a Zap Runs/Workflow API for programmatically pulling history exists only as an experimental, non-public feature, not generally available.)",
         detail:
           "Log streams capture events only from when they're configured, not historical backfill.",
-        shortValue: 'Yes: log streams to Datadog, Splunk, SIEM',
+        shortValue: 'Yes: log streams to Datadog, Splunk, SIEM, plus in-product audit log',
         confidence: 'verified',
         sources: [
           {
             url: 'https://help.zapier.com/hc/en-us/articles/43732241361421-Set-up-log-streams-to-monitor-Zap-activity',
             label: 'Set up log streams to monitor Zap activity',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://zapier.com/blog/mpe-admin-center-audit-logs/',
             label: 'Complete Control: Multi-Product Experience & Admin Center',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1158,15 +1184,15 @@ export const zapierProfile: CompetitorProfile = {
     support: {
       supportChannels: {
         value:
-          'Email/ticket support for all paid plans, Zapier Community forum (public, no account required), plus premium support (chat/priority) on Team and above',
-        shortValue: 'Email support, community forum, premium chat on Team+',
+          'Email/ticket support for all paid plans (Professional and above, with faster SLAs on Team/Enterprise), Zapier Community forum (public, no account required to browse), plus live chat support starting on higher-tier Professional plans and 24/7 priority chat plus a dedicated Technical Account Manager on Enterprise',
+        shortValue: 'Email support from Professional+, community forum, chat on higher tiers',
         confidence: 'estimated',
         sources: [
-          { url: 'https://community.zapier.com/', label: 'Zapier Community', asOf: '2026-07-02' },
+          { url: 'https://community.zapier.com/', label: 'Zapier Community', asOf: '2026-07-08' },
           {
             url: 'https://help.zapier.com/hc/en-us/articles/8496213764877-Get-help-and-support-with-Zapier',
             label: 'Get help and support with Zapier',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1225,21 +1251,32 @@ export const zapierProfile: CompetitorProfile = {
       },
       academy: {
         value:
-          'Yes: Zapier operates Zapier Academy (learn.zapier.com), a structured hub of self-paced courses, tutorials, and learning paths, plus a Certified Zapier Expert program with an application, an exam, and an expert directory listing.',
+          'Yes: Zapier operates Zapier Academy (learn.zapier.com), a hub of courses and tutorials, plus a Solution Partner Program (the rebranded successor to the former Zapier Experts/Certified Zapier Expert program) that requires an application and, per third-party accounts of the process, an invitation-only certification exam, leading to a partner directory listing at zapier.com/experts.',
         detail:
-          'Zapier Academy covers beginner to advanced automation topics. Certification is a separate application-based exam program leading to a badge and directory listing.',
-        shortValue: 'Yes: Academy plus expert certification program',
-        confidence: 'verified',
+          'Zapier Academy covers beginner to advanced automation topics. The former "Certified Zapier Expert" branding has been folded into the Solution Partner Program: applicants submit an application form, and if approved are invited to complete certification before earning a directory listing.',
+        shortValue: 'Yes: Academy plus Solution Partner Program (application-based)',
+        confidence: 'estimated',
         sources: [
           {
             url: 'https://learn.zapier.com/',
             label: 'Zapier Academy',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://community.zapier.com/show-tell-5/zapier-certification-42220',
-            label: 'Zapier Certification community thread',
-            asOf: '2026-07-02',
+            url: 'https://community.zapier.com/how-do-i-3/how-do-you-become-zapier-certified-3817',
+            label: 'How do you become Zapier Certified? (application process, Zapier Community)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://easyaiz.com/becoming-a-zapier-expert/',
+            label:
+              'Becoming a Zapier Solution Partner: Step-by-Step Guide (third-party account of the certification exam)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://zapier.com/experts',
+            label: 'Zapier Solution Partner Directory',
+            asOf: '2026-07-08',
           },
         ],
       },

--- a/apps/sim/lib/compare/data/sim.ts
+++ b/apps/sim/lib/compare/data/sim.ts
@@ -18,12 +18,13 @@ export const simProfile: CompetitorProfile = {
     {
       title: 'AI Copilot / Chat agent-building surface',
       description:
-        'A natural-language surface (Chat) and in-editor Copilot that can explain, suggest, and build workflow changes directly, backed by a dedicated copilot module with its own tool registry.',
-      shortDescription: 'Chat and in-editor Copilot suggest and build workflow changes directly.',
+        'A workspace-wide natural-language surface (Chat) that can build workflows, manage data, and take actions across integrations, plus an in-editor Copilot scoped to building and editing a single workflow directly.',
+      shortDescription:
+        'Chat builds and manages work across the workspace; in-editor Copilot edits a single workflow.',
       source: {
         url: 'https://docs.sim.ai/copilot',
         label: 'Sim Docs: Copilot',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -100,13 +101,13 @@ export const simProfile: CompetitorProfile = {
     {
       title: 'Smaller integration catalog than the largest generalist automation platforms',
       description:
-        "Sim ships 302 first-party blocks and roughly 3,900 underlying tool actions. Platforms like Zapier (9,000+ apps) or Pipedream (3,000+ apps) list larger raw app counts. Sim's MCP support lets teams add custom integrations beyond the built-in catalog.",
+        "Sim ships 266 first-party blocks and roughly 3,900 underlying tool actions. Platforms like Zapier (9,000+ apps) or Pipedream (3,000+ apps) list larger raw app counts. Sim's MCP support lets teams add custom integrations beyond the built-in catalog.",
       shortDescription:
-        "302 blocks and ~3,900 tool actions, versus Zapier and Pipedream's larger raw app counts.",
+        "266 blocks and ~3,900 tool actions, versus Zapier and Pipedream's larger raw app counts.",
       source: {
         url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/blocks/registry-maps.ts',
         label: 'Sim codebase: BLOCK_REGISTRY count',
-        asOf: '2026-07-02',
+        asOf: '2026-07-08',
       },
     },
     {
@@ -129,22 +130,24 @@ export const simProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/blocks/registry-maps.ts',
-            label: 'Sim codebase: block registry',
-            asOf: '2026-07-02',
+            url: 'https://docs.sim.ai/introduction',
+            label: 'Sim Docs: Introduction (visual, natural-language, and API/SDK building)',
+            asOf: '2026-07-08',
           },
         ],
       },
       learningCurve: {
-        value: 'Low for visual building; natural-language Chat surface for non-technical builders',
-        detail: 'Chat lets users describe a workflow in plain language and have Sim build it.',
+        value:
+          'Low for visual building; natural-language Chat surface (with a workflow-scoped Copilot) for non-technical builders',
+        detail:
+          'Chat lets users describe a workflow in plain language and have Sim scaffold or edit it; the visual canvas requires no code to connect blocks.',
         shortValue: 'Low, plus natural-language Chat for non-technical users',
-        confidence: 'verified',
+        confidence: 'estimated',
         sources: [
           {
-            url: 'https://docs.sim.ai/copilot',
-            label: 'Sim Docs: Copilot',
-            asOf: '2026-07-02',
+            url: 'https://docs.sim.ai/introduction',
+            label: 'Sim Docs: Introduction (visual, natural-language, and API/SDK building)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -174,9 +177,9 @@ export const simProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.sim.ai/platform/costs',
-            label: 'Sim Docs: Cost calculation & billing',
-            asOf: '2026-07-02',
+            url: 'https://docs.sim.ai/platform/self-hosting',
+            label: 'Sim Docs: Self-Hosting',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://www.sim.ai/pricing',
@@ -187,14 +190,14 @@ export const simProfile: CompetitorProfile = {
       },
       templates: {
         value:
-          'Yes: pre-built workflow template library across categories (Marketing, Sales, Finance, Support, AI)',
-        shortValue: 'Templates across Marketing, Sales, Finance, Support, AI',
+          'No: the pre-built workflow template gallery (landing and in-workspace) was removed platform-wide. Sim now surfaces per-integration starter prompts instead of a template library.',
+        shortValue: 'No template gallery; per-integration starter prompts only',
         confidence: 'verified',
         sources: [
           {
-            url: 'https://www.sim.ai/blog/openai-vs-n8n-vs-sim',
-            label: 'Sim blog: OpenAI AgentKit vs n8n vs Sim',
-            asOf: '2026-07-02',
+            url: 'https://github.com/simstudioai/sim/commit/df5ad7d45f4fd38ab724e7726b083c2b928a1542',
+            label: 'Sim codebase: templates gallery and APIs removed',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -277,9 +280,14 @@ export const simProfile: CompetitorProfile = {
         confidence: 'verified',
         sources: [
           {
-            url: 'https://docs.sim.ai/files',
-            label: 'Sim Docs: Files',
-            asOf: '2026-07-02',
+            url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/app/workspace/%5BworkspaceId%5D/files/components/share-modal/share-modal.tsx',
+            label: 'Sim codebase: file share modal (password/email/SSO modes)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/app/workspace/%5BworkspaceId%5D/settings/components/recently-deleted/recently-deleted.tsx',
+            label: 'Sim codebase: Recently Deleted (files, folders, and other resources)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -369,25 +377,24 @@ export const simProfile: CompetitorProfile = {
       },
       knowledgeBaseRag: {
         value:
-          'Yes: native hybrid vector (pgvector) + keyword search knowledge base, 11 supported file formats, configurable chunking, plus 51 connectors that continuously sync external sources (Google Drive, Confluence, Slack, Gmail, GitHub, HubSpot, Linear, Jira, and more) into the knowledge base rather than a one-shot upload',
-        shortValue:
-          'Hybrid vector + keyword search, 11 file formats, 51 continuously-synced connectors',
+          'Yes: hybrid vector (pgvector) plus full-text (tsvector) search knowledge base, 11 supported file formats (csv, doc, docx, html, json, md, pdf, pptx, txt, xlsx, yaml), configurable chunking, plus 51 connectors that continuously sync external sources (Google Drive, Confluence, Slack, Gmail, GitHub, HubSpot, Linear, Jira, and more) into the knowledge base rather than a one-shot upload',
+        shortValue: 'Hybrid vector + full-text search, 11 file formats, 51 connectors',
         confidence: 'verified',
         sources: [
           {
             url: 'https://github.com/simstudioai/sim/blob/main/packages/db/schema.ts',
             label: 'Sim codebase: KB schema (pgvector + tsvector)',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
-            url: 'https://docs.sim.ai/knowledgebase',
-            label: 'Sim Docs: Knowledge Base document types',
-            asOf: '2026-07-02',
+            url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/lib/file-parsers/index.ts',
+            label: 'Sim codebase: file-parser registry (11 format families)',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/connectors/registry.ts',
             label: 'Sim codebase: connector registry (51 connectors)',
-            asOf: '2026-07-04',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -449,19 +456,29 @@ export const simProfile: CompetitorProfile = {
       },
       generativeMedia: {
         value:
-          'Yes: dedicated image (4 provider families incl. OpenAI, Gemini, Fal.ai proxy), video (5+ provider families incl. Runway, Veo, Luma, Hailuo, Fal.ai proxy), text-to-speech (7 providers), and speech-to-text (5 providers) blocks',
+          'Yes: dedicated image (3 provider families incl. OpenAI, Gemini, Fal.ai proxy), video (5 provider families incl. Runway, Veo, Luma, Hailuo, Fal.ai proxy), text-to-speech (7 providers), and speech-to-text (5 providers) blocks',
         shortValue: 'Image, video, text-to-speech, and speech-to-text blocks',
         confidence: 'verified',
         sources: [
           {
             url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/blocks/blocks/image_generator.ts',
             label: 'Sim codebase: Image Generator V2',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/blocks/blocks/video_generator.ts',
             label: 'Sim codebase: Video Generator V3',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/blocks/blocks/tts.ts',
+            label: 'Sim codebase: TTS block (7 providers)',
+            asOf: '2026-07-08',
+          },
+          {
+            url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/blocks/blocks/stt.ts',
+            label: 'Sim codebase: STT block (5 providers)',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -586,16 +603,16 @@ export const simProfile: CompetitorProfile = {
     integrations: {
       integrationCount: {
         value:
-          '1,000+ integrations counting individual API actions, built from 302 first-party blocks and roughly 3,900 underlying tool actions',
+          '1,000+ integrations counting individual API actions, built from 266 first-party blocks and roughly 3,900 underlying tool actions',
         detail:
           'Sim\'s landing page cites the "1,000+ integrations" figure; the block/tool-action counts are the same integration surface measured at a different level of granularity.',
-        shortValue: '1,000+ integrations (302 blocks, ~3,900 tool actions)',
+        shortValue: '1,000+ integrations (266 blocks, ~3,900 tool actions)',
         confidence: 'verified',
         sources: [
           {
             url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/blocks/registry-maps.ts',
             label: 'Sim codebase: BLOCK_REGISTRY',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.sim.ai/tools',
@@ -647,19 +664,21 @@ export const simProfile: CompetitorProfile = {
       },
       apiPublishing: {
         value:
-          'Yes: versioned public REST API (/api/v1) with rollback, streaming (SSE) execution responses with a resumable event buffer, an API-trigger block, and a chat-deployment surface',
-        shortValue: 'Versioned REST API with rollback and streaming execution',
+          'Yes: a public REST API (mostly under /api/, with /api/v1 reserved for logs and audit-log endpoints) supporting API-triggered workflow execution and deployment rollback',
+        detail:
+          'The API reference does not document SSE streaming, a resumable event buffer, a dedicated API-trigger block, or a chat-deployment surface as part of the REST API itself.',
+        shortValue: 'REST API (partially versioned) with rollback support',
         confidence: 'verified',
         sources: [
           {
             url: 'https://docs.sim.ai/api-reference/getting-started',
             label: 'Sim Docs: API Reference - Getting Started',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://docs.sim.ai/execution/api',
             label: 'Sim Docs: External API',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -733,19 +752,19 @@ export const simProfile: CompetitorProfile = {
       },
       freeTier: {
         value:
-          'Yes: Free plan with 1,000 monthly credits (worth $5, env-configurable) refreshed daily, no credit card required',
-        shortValue: 'Free plan, 1,000 credits/month, no card required',
+          'Yes: Free plan with 1,000 monthly credits (worth $5, env-configurable), granted monthly with no daily refresh (daily refresh is a paid-plan feature)',
+        shortValue: 'Free plan, 1,000 credits/month',
         confidence: 'verified',
         sources: [
           {
             url: 'https://www.sim.ai/pricing',
             label: 'Sim Pricing',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
           {
             url: 'https://github.com/simstudioai/sim/blob/main/apps/sim/lib/billing/constants.ts',
             label: 'Sim codebase: DEFAULT_FREE_CREDITS',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -962,16 +981,16 @@ export const simProfile: CompetitorProfile = {
       },
       thirdPartyVetting: {
         value:
-          "Yes: every one of Sim's 302 blocks is first-party authored and code-reviewed through the standard pull-request process in the main Sim repository; there is no public marketplace where an arbitrary third party can publish and have other users install executable tool code without going through Sim's own review",
+          "Yes: every one of Sim's 266 blocks is first-party authored and code-reviewed through the standard pull-request process in the main Sim repository; there is no public marketplace where an arbitrary third party can publish and have other users install executable tool code without going through Sim's own review",
         detail:
           "Custom code steps run inside Sim's own isolated-vm sandbox rather than as an installable third-party skill package, so the supply-chain trust boundary is Sim's codebase review, not an open registry.",
-        shortValue: 'All 302 blocks are first-party authored and code-reviewed',
+        shortValue: 'All 266 blocks are first-party authored and code-reviewed',
         confidence: 'verified',
         sources: [
           {
             url: 'https://github.com/simstudioai/sim/tree/main/apps/sim/blocks/blocks',
             label: 'Sim codebase: first-party block directory',
-            asOf: '2026-07-02',
+            asOf: '2026-07-08',
           },
         ],
       },
@@ -1137,14 +1156,14 @@ export const simProfile: CompetitorProfile = {
       },
       sla: {
         value:
-          'Yes: the Enterprise plan includes a dedicated support SLA, negotiated per contract; specific response-time and uptime figures are not published on the self-serve pricing page',
-        shortValue: 'Enterprise SLA included (contract-based)',
+          'Yes: the Enterprise plan includes a "Dedicated Support" feature per the pricing plan-comparison table; no SLA terminology, response-time, or uptime figures are published on the enterprise or pricing pages',
+        shortValue: "Enterprise 'Dedicated Support' flag; no published SLA terms",
         confidence: 'verified',
         sources: [
           {
-            url: 'https://sim.ai/enterprise',
-            label: 'Sim Enterprise Page',
-            asOf: '2026-07-02',
+            url: 'https://www.sim.ai/pricing',
+            label: 'Sim Pricing Page',
+            asOf: '2026-07-08',
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Removed stale "Templates" references on the LangChain comparison page and a few blog posts — that feature was removed platform-wide and the copy hadn't caught up
- Reviewed every sourced claim across all comparison-page profiles (Sim's own facts and all 20 competitor profiles) and corrected ones that were outdated, unsupported, or pointing at dead links
- Fixed a stale sidebar permissions reference in the enterprise access-control docs

## Type of Change
- [x] Bug fix

## Testing
Tested manually — `tsc` and `biome check` pass clean on all touched files, spot-checked citations against live sources.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)