### PR TITLE
chore(bunfig): restore minimumReleaseAge supply-chain gate with scoped excludes

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,6 +1,17 @@
 [install]
 exact = true
-minimumReleaseAge = 0
+# Supply-chain gate: only install package versions published at least 7 days ago
+# (blocks freshly published, potentially compromised releases).
+minimumReleaseAge = 604800
+# @typescript/native-preview stays excluded permanently: it only publishes nightly
+# dev builds, so every version is structurally younger than any age gate.
+# typescript@7.0.2 and @typescript/typescript6@6.0.2 were vetted in #5521; they age
+# out of the gate on 2026-07-15 and 2026-07-13 — drop those two entries after that.
+minimumReleaseAgeExcludes = [
+  "typescript",
+  "@typescript/typescript6",
+  "@typescript/native-preview",
+]
 
 [run]
 env = { NEXT_PUBLIC_APP_URL = "http://localhost:3000" }


### PR DESCRIPTION
## Summary
- restores the `minimumReleaseAge = 604800` (7-day) supply-chain gate in `bunfig.toml` that was temporarily set to `0` to unblock the TS7 upgrade (#5521)
- adds `minimumReleaseAgeExcludes` for the three packages currently inside the gate so `bun install --frozen-lockfile` passes today instead of staying red until 2026-07-15:
  - `@typescript/native-preview` — permanent: it only publishes nightly dev builds, so every version is structurally younger than any age gate
  - `typescript` + `@typescript/typescript6` — vetted in #5521; they age out on 2026-07-15 / 2026-07-13 and the entries can be dropped after that (noted in a comment in the file)

## Type of Change
- [x] Chore

## Testing
Verified locally in a clean worktree with the exact CI command:
- `bun install --frozen-lockfile` with the excludes → succeeds (1854 packages)
- same command with the excludes removed → fails with `blocked by minimum-release-age: 604800`, confirming the gate is actually enforcing

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)