### PR TITLE
feat(providers): add OpenAI GPT-5.6 Sol, Terra, and Luna models

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -282,6 +282,69 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         releaseDate: '2025-04-14',
         deprecated: true,
       },
+      // GPT-5.6 family
+      {
+        id: 'gpt-5.6-sol',
+        pricing: {
+          input: 5.0,
+          cachedInput: 0.5,
+          output: 30.0,
+          updatedAt: '2026-07-09',
+        },
+        capabilities: {
+          reasoningEffort: {
+            values: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+          },
+          verbosity: {
+            values: ['low', 'medium', 'high'],
+          },
+          maxOutputTokens: 128000,
+        },
+        contextWindow: 1050000,
+        releaseDate: '2026-07-09',
+        recommended: true,
+      },
+      {
+        id: 'gpt-5.6-terra',
+        pricing: {
+          input: 2.5,
+          cachedInput: 0.25,
+          output: 15.0,
+          updatedAt: '2026-07-09',
+        },
+        capabilities: {
+          reasoningEffort: {
+            values: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+          },
+          verbosity: {
+            values: ['low', 'medium', 'high'],
+          },
+          maxOutputTokens: 128000,
+        },
+        contextWindow: 1050000,
+        releaseDate: '2026-07-09',
+      },
+      {
+        id: 'gpt-5.6-luna',
+        pricing: {
+          input: 1.0,
+          cachedInput: 0.1,
+          output: 6.0,
+          updatedAt: '2026-07-09',
+        },
+        capabilities: {
+          reasoningEffort: {
+            values: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+          },
+          verbosity: {
+            values: ['low', 'medium', 'high'],
+          },
+          maxOutputTokens: 128000,
+        },
+        contextWindow: 1050000,
+        releaseDate: '2026-07-09',
+        speedOptimized: true,
+      },
       // GPT-5.5 family
       {
         id: 'gpt-5.5-pro',
@@ -320,7 +383,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1050000,
         releaseDate: '2026-04-23',
-        recommended: true,
       },
       // GPT-5.4 family
       {


### PR DESCRIPTION
## Summary
- add GPT-5.6 Sol, Terra, and Luna to the openai provider in models.ts
- Sol is the new flagship (recommended: true, moved off gpt-5.5), Luna is speed-optimized
- pricing, context window (1.05M), max output (128K), and reasoning-effort levels (incl. new `max` tier) verified against OpenRouter's live model API and cross-checked against announced pricing

## Type of Change
- [x] New feature

## Testing
Tested manually — `bun run lint` passes, verified reasoningEffort/verbosity fields are consumed by openai/core.ts, confirmed no test suite hardcodes an exhaustive model list that would break.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)