### PR TITLE
fix(icons): fix Meta icon clipping in model dropdown

### DIFF
--- a/apps/sim/components/icons.tsx
+++ b/apps/sim/components/icons.tsx
@@ -3696,7 +3696,7 @@ export function MetaIcon(props: SVGProps<SVGSVGElement>) {
     <svg
       {...props}
       height='1em'
-      viewBox='0 0 265 165'
+      viewBox='0 -48.28 287.56 287.56'
       width='1em'
       xmlns='http://www.w3.org/2000/svg'
     >


### PR DESCRIPTION
## Summary
- The Meta provider icon's `viewBox` (`265 165`) was smaller than the true bounding box of its path geometry (`287.56 191`, computed directly from the path data), so part of the mark was silently clipped by the SVG viewport
- It was also non-square, so the model dropdown's forced 14x14px icon slot letterboxed it asymmetrically instead of filling it edge-to-edge like every other provider icon
- Fixed the `viewBox` to the exact computed bounding box, padded to a square and vertically centered — matches the `GeminiIcon` convention

## Type of Change
- [x] Bug fix

## Testing
Verified by rasterizing the old and new `viewBox` at the actual deployed 14px icon size (via `rsvg-convert`) and comparing — new version fills the square slot cleanly with no clipping. Lint clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)