### PR TITLE
fix(copilot): let edit_workflow set knowledge-base tag filters, and stop it clearing them

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/document-tag-entry/document-tag-entry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/document-tag-entry/document-tag-entry.tsx
@@ -100,13 +100,13 @@ export function DocumentTagEntry({
   const currentValue = isPreview ? previewValue : storeValue
 
   const parseTags = (tagValue: unknown): DocumentTag[] =>
-    (parseJsonArrayValue(tagValue) as DocumentTag[]).map((t) => ({
+    parseJsonArrayValue<DocumentTag>(tagValue).map((t) => ({
       ...t,
       fieldType: t.fieldType || 'text',
       collapsed: t.collapsed ?? false,
     }))
 
-  const parsedTags = parseTags(currentValue || null)
+  const parsedTags = parseTags(currentValue)
   const tags: DocumentTag[] = parsedTags.length > 0 ? parsedTags : [createDefaultTag()]
   const isReadOnly = isPreview || disabled
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/document-tag-entry/document-tag-entry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/document-tag-entry/document-tag-entry.tsx
@@ -98,19 +98,24 @@ export function DocumentTagEntry({
 
   const currentValue = isPreview ? previewValue : storeValue
 
-  const parseTags = (tagValue: string | null): DocumentTag[] => {
+  const parseTags = (tagValue: unknown): DocumentTag[] => {
     if (!tagValue) return []
-    try {
-      const parsed = JSON.parse(tagValue)
-      if (!Array.isArray(parsed)) return []
-      return parsed.map((t: DocumentTag) => ({
-        ...t,
-        fieldType: t.fieldType || 'text',
-        collapsed: t.collapsed ?? false,
-      }))
-    } catch {
-      return []
+    let parsed: unknown = tagValue
+    // Tolerate an already-parsed array: copilot edits persist documentTags as a raw
+    // array, whereas this component writes a JSON string. Accept both on read.
+    if (typeof tagValue === 'string') {
+      try {
+        parsed = JSON.parse(tagValue)
+      } catch {
+        return []
+      }
     }
+    if (!Array.isArray(parsed)) return []
+    return parsed.map((t: DocumentTag) => ({
+      ...t,
+      fieldType: t.fieldType || 'text',
+      collapsed: t.collapsed ?? false,
+    }))
   }
 
   const parsedTags = parseTags(currentValue || null)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/document-tag-entry/document-tag-entry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/document-tag-entry/document-tag-entry.tsx
@@ -21,6 +21,7 @@ import { getActiveWorkflowSearchHighlight } from '@/app/workspace/[workspaceId]/
 import { useDependsOnGate } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-depends-on-gate'
 import { useSubBlockInput } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-sub-block-input'
 import { useSubBlockValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-sub-block-value'
+import { parseJsonArrayValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/utils'
 import { useActiveSearchTarget } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/providers/active-search-target-provider'
 import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import type { SubBlockConfig } from '@/blocks/types'
@@ -98,25 +99,12 @@ export function DocumentTagEntry({
 
   const currentValue = isPreview ? previewValue : storeValue
 
-  const parseTags = (tagValue: unknown): DocumentTag[] => {
-    if (!tagValue) return []
-    let parsed: unknown = tagValue
-    // Tolerate an already-parsed array: copilot edits persist documentTags as a raw
-    // array, whereas this component writes a JSON string. Accept both on read.
-    if (typeof tagValue === 'string') {
-      try {
-        parsed = JSON.parse(tagValue)
-      } catch {
-        return []
-      }
-    }
-    if (!Array.isArray(parsed)) return []
-    return parsed.map((t: DocumentTag) => ({
+  const parseTags = (tagValue: unknown): DocumentTag[] =>
+    (parseJsonArrayValue(tagValue) as DocumentTag[]).map((t) => ({
       ...t,
       fieldType: t.fieldType || 'text',
       collapsed: t.collapsed ?? false,
     }))
-  }
 
   const parsedTags = parseTags(currentValue || null)
   const tags: DocumentTag[] = parsedTags.length > 0 ? parsedTags : [createDefaultTag()]

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/knowledge-tag-filters/knowledge-tag-filters.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/knowledge-tag-filters/knowledge-tag-filters.tsx
@@ -102,7 +102,7 @@ export function KnowledgeTagFilters({
   })
 
   const parseFilters = (filterValue: unknown): TagFilter[] =>
-    (parseJsonArrayValue(filterValue) as TagFilter[]).map((f) => ({
+    parseJsonArrayValue<TagFilter>(filterValue).map((f) => ({
       ...f,
       fieldType: f.fieldType || 'text',
       operator: f.operator || 'eq',
@@ -110,7 +110,7 @@ export function KnowledgeTagFilters({
     }))
 
   const currentValue = isPreview ? previewValue : storeValue
-  const parsedFilters = parseFilters(currentValue || null)
+  const parsedFilters = parseFilters(currentValue)
   const filters: TagFilter[] = parsedFilters.length > 0 ? parsedFilters : [createDefaultFilter()]
   const isReadOnly = isPreview || disabled
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/knowledge-tag-filters/knowledge-tag-filters.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/knowledge-tag-filters/knowledge-tag-filters.tsx
@@ -21,6 +21,7 @@ import { TagDropdown } from '@/app/workspace/[workspaceId]/w/[workflowId]/compon
 import { getActiveWorkflowSearchHighlight } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/workflow-search-highlight'
 import { useDependsOnGate } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-depends-on-gate'
 import { useSubBlockInput } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-sub-block-input'
+import { parseJsonArrayValue } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/utils'
 import { useActiveSearchTarget } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/providers/active-search-target-provider'
 import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-accessible-reference-prefixes'
 import type { SubBlockConfig } from '@/blocks/types'
@@ -100,26 +101,13 @@ export function KnowledgeTagFilters({
     disabled,
   })
 
-  const parseFilters = (filterValue: unknown): TagFilter[] => {
-    if (!filterValue) return []
-    let parsed: unknown = filterValue
-    // Tolerate an already-parsed array: copilot edits persist tagFilters as a raw
-    // array, whereas this component writes a JSON string. Accept both on read.
-    if (typeof filterValue === 'string') {
-      try {
-        parsed = JSON.parse(filterValue)
-      } catch {
-        return []
-      }
-    }
-    if (!Array.isArray(parsed)) return []
-    return parsed.map((f: TagFilter) => ({
+  const parseFilters = (filterValue: unknown): TagFilter[] =>
+    (parseJsonArrayValue(filterValue) as TagFilter[]).map((f) => ({
       ...f,
       fieldType: f.fieldType || 'text',
       operator: f.operator || 'eq',
       collapsed: f.collapsed ?? false,
     }))
-  }
 
   const currentValue = isPreview ? previewValue : storeValue
   const parsedFilters = parseFilters(currentValue || null)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/knowledge-tag-filters/knowledge-tag-filters.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/knowledge-tag-filters/knowledge-tag-filters.tsx
@@ -100,20 +100,25 @@ export function KnowledgeTagFilters({
     disabled,
   })
 
-  const parseFilters = (filterValue: string | null): TagFilter[] => {
+  const parseFilters = (filterValue: unknown): TagFilter[] => {
     if (!filterValue) return []
-    try {
-      const parsed = JSON.parse(filterValue)
-      if (!Array.isArray(parsed)) return []
-      return parsed.map((f: TagFilter) => ({
-        ...f,
-        fieldType: f.fieldType || 'text',
-        operator: f.operator || 'eq',
-        collapsed: f.collapsed ?? false,
-      }))
-    } catch {
-      return []
+    let parsed: unknown = filterValue
+    // Tolerate an already-parsed array: copilot edits persist tagFilters as a raw
+    // array, whereas this component writes a JSON string. Accept both on read.
+    if (typeof filterValue === 'string') {
+      try {
+        parsed = JSON.parse(filterValue)
+      } catch {
+        return []
+      }
     }
+    if (!Array.isArray(parsed)) return []
+    return parsed.map((f: TagFilter) => ({
+      ...f,
+      fieldType: f.fieldType || 'text',
+      operator: f.operator || 'eq',
+      collapsed: f.collapsed ?? false,
+    }))
   }
 
   const currentValue = isPreview ? previewValue : storeValue

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/utils.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/utils.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { parseJsonArrayValue } from './utils'
+
+interface TagFilter {
+  id: string
+  tagName: string
+}
+
+describe('parseJsonArrayValue', () => {
+  it('parses a JSON string array, the shape edit_workflow now persists', () => {
+    const filters: TagFilter[] = [{ id: 'f1', tagName: 'Department' }]
+
+    expect(parseJsonArrayValue<TagFilter>(JSON.stringify(filters))).toEqual(filters)
+  })
+
+  // Rows written by builds predating the edit_workflow stringify fix still hold raw arrays.
+  it('passes through an already-parsed array', () => {
+    const filters: TagFilter[] = [{ id: 'f1', tagName: 'Department' }]
+
+    expect(parseJsonArrayValue<TagFilter>(filters)).toEqual(filters)
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['an empty string', ''],
+  ])('returns an empty array for %s', (_label, value) => {
+    expect(parseJsonArrayValue(value)).toEqual([])
+  })
+
+  it.each([
+    ['a malformed JSON string', '{not json'],
+    ['a JSON string parsing to null', 'null'],
+    ['a JSON string parsing to an object', '{"a":1}'],
+    ['a JSON string parsing to a number', '5'],
+    ['a bare object', { a: 1 }],
+  ])('returns an empty array rather than throwing for %s', (_label, value) => {
+    expect(parseJsonArrayValue(value)).toEqual([])
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/utils.ts
@@ -16,3 +16,27 @@ export function resolvePreviewContextValue(raw: unknown): unknown {
   }
   return raw
 }
+
+/**
+ * Parses a sub-block value that may be stored as a JSON string or as an already-parsed array.
+ *
+ * @remarks
+ * These sub-blocks contract on a JSON string, which is what their components write. Copilot's
+ * `edit_workflow` persisted them as raw arrays until it was fixed to re-serialize, so rows
+ * written by older builds still hold an array. Both shapes are accepted on read.
+ *
+ * @param value - The stored sub-block value, of unknown shape
+ * @returns The parsed array, or `[]` when the value is absent, unparseable, or not an array
+ */
+export function parseJsonArrayValue(value: unknown): unknown[] {
+  if (!value) return []
+  let parsed: unknown = value
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value)
+    } catch {
+      return []
+    }
+  }
+  return Array.isArray(parsed) ? parsed : []
+}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/utils.ts
@@ -25,10 +25,13 @@ export function resolvePreviewContextValue(raw: unknown): unknown {
  * `edit_workflow` persisted them as raw arrays until it was fixed to re-serialize, so rows
  * written by older builds still hold an array. Both shapes are accepted on read.
  *
+ * The element type is asserted, not validated -- callers are responsible for defaulting any
+ * fields a malformed entry may be missing.
+ *
  * @param value - The stored sub-block value, of unknown shape
  * @returns The parsed array, or `[]` when the value is absent, unparseable, or not an array
  */
-export function parseJsonArrayValue(value: unknown): unknown[] {
+export function parseJsonArrayValue<T>(value: unknown): T[] {
   if (!value) return []
   let parsed: unknown = value
   if (typeof value === 'string') {
@@ -38,5 +41,5 @@ export function parseJsonArrayValue(value: unknown): unknown[] {
       return []
     }
   }
-  return Array.isArray(parsed) ? parsed : []
+  return Array.isArray(parsed) ? (parsed as T[]) : []
 }

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.test.ts
@@ -133,6 +133,21 @@ describe('normalizeSubblockValue', () => {
     expect(normalizeSubblockValue('systemPrompt', 'hello')).toBe('hello')
   })
 
+  // Validation treats null as an explicit clear. Coercing it to "[]" would persist a value
+  // where the caller asked for none, so the agent reads back an empty filter rather than an
+  // absent one -- the same absent-vs-empty ambiguity that caused the original data loss.
+  it.each(['tagFilters', 'documentTags', 'conditions', 'routes'])(
+    'passes a null %s through as a clear rather than serializing it to "[]"',
+    (key) => {
+      expect(normalizeSubblockValue(key, null)).toBeNull()
+      expect(normalizeSubblockValue(key, undefined)).toBeUndefined()
+    }
+  )
+
+  it('still serializes an explicitly empty array, which clears the field with a value', () => {
+    expect(normalizeSubblockValue('tagFilters', [])).toBe('[]')
+  })
+
   it('replaces non-uuid ids so copilot-authored rows match UI-created ones', () => {
     const result = normalizeSubblockValue('tagFilters', [{ id: 'filter-1', tagName: 'Department' }])
 

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import { describe, expect, it, vi } from 'vitest'
-import { createBlockFromParams } from './builders'
+import { createBlockFromParams, normalizeSubblockValue } from './builders'
 
 const agentBlockConfig = {
   type: 'agent',
@@ -20,10 +20,25 @@ const conditionBlockConfig = {
   subBlocks: [{ id: 'conditions', type: 'condition-input' }],
 }
 
+const knowledgeBlockConfig = {
+  type: 'knowledge',
+  name: 'Knowledge',
+  outputs: {},
+  subBlocks: [
+    { id: 'tagFilters', type: 'knowledge-tag-filters' },
+    { id: 'documentTags', type: 'document-tag-entry' },
+  ],
+}
+
+const blocksByType: Record<string, unknown> = {
+  agent: agentBlockConfig,
+  condition: conditionBlockConfig,
+  knowledge: knowledgeBlockConfig,
+}
+
 vi.mock('@/blocks/registry', () => ({
-  getAllBlocks: () => [agentBlockConfig, conditionBlockConfig],
-  getBlock: (type: string) =>
-    type === 'agent' ? agentBlockConfig : type === 'condition' ? conditionBlockConfig : undefined,
+  getAllBlocks: () => [agentBlockConfig, conditionBlockConfig, knowledgeBlockConfig],
+  getBlock: (type: string) => blocksByType[type],
 }))
 
 describe('createBlockFromParams', () => {
@@ -68,5 +83,59 @@ describe('createBlockFromParams', () => {
     const parsed = JSON.parse(block.subBlocks.conditions.value)
     expect(parsed[0].id).toBe('condition-1-if')
     expect(parsed[1].id).toBe('condition-1-else')
+  })
+
+  it('persists knowledge tag subblocks as JSON strings, not raw arrays', () => {
+    const block = createBlockFromParams('kb-1', {
+      type: 'knowledge',
+      name: 'Knowledge 1',
+      inputs: {
+        tagFilters: [{ tagName: 'Department', tagSlot: 'tag1', tagValue: 'it' }],
+        documentTags: [{ tagName: 'Team', tagSlot: 'tag2', value: 'infra' }],
+      },
+      triggerMode: false,
+    })
+
+    expect(typeof block.subBlocks.tagFilters.value).toBe('string')
+    expect(typeof block.subBlocks.documentTags.value).toBe('string')
+
+    const filters = JSON.parse(block.subBlocks.tagFilters.value)
+    expect(filters[0].tagName).toBe('Department')
+    expect(filters[0].id).toEqual(expect.any(String))
+  })
+})
+
+describe('normalizeSubblockValue', () => {
+  it.each(['tagFilters', 'documentTags', 'conditions', 'routes'])(
+    'serializes %s to a JSON string the subblock component can parse',
+    (key) => {
+      const result = normalizeSubblockValue(key, [{ id: 'not-a-uuid', title: 'a' }])
+
+      expect(typeof result).toBe('string')
+      expect(JSON.parse(result as string)[0].title).toBe('a')
+    }
+  )
+
+  it('accepts a JSON string as input and still returns a string', () => {
+    const result = normalizeSubblockValue('tagFilters', JSON.stringify([{ tagName: 'Department' }]))
+
+    expect(typeof result).toBe('string')
+    expect(JSON.parse(result as string)[0].tagName).toBe('Department')
+  })
+
+  it('leaves array-with-id subblocks that are not string-serialized as raw arrays', () => {
+    const result = normalizeSubblockValue('inputFormat', [{ id: 'x', name: 'field' }])
+
+    expect(Array.isArray(result)).toBe(true)
+  })
+
+  it('passes through subblock keys that need no normalization', () => {
+    expect(normalizeSubblockValue('systemPrompt', 'hello')).toBe('hello')
+  })
+
+  it('replaces non-uuid ids so copilot-authored rows match UI-created ones', () => {
+    const result = normalizeSubblockValue('tagFilters', [{ id: 'filter-1', tagName: 'Department' }])
+
+    expect(JSON.parse(result as string)[0].id).not.toBe('filter-1')
   })
 })

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.ts
@@ -266,19 +266,14 @@ const ARRAY_WITH_ID_SUBBLOCK_TYPES = new Set([
  * Subblock keys whose UI components expect a JSON string, not a raw array.
  * After normalizeArrayWithIds returns an array, these must be re-stringified.
  */
-export const JSON_STRING_SUBBLOCK_KEYS = new Set([
-  'conditions',
-  'routes',
-  'tagFilters',
-  'documentTags',
-])
+const JSON_STRING_SUBBLOCK_KEYS = new Set(['conditions', 'routes', 'tagFilters', 'documentTags'])
 
 /**
  * Normalizes array subblock values by ensuring each item has a valid UUID.
  * The LLM may generate arbitrary IDs like "input-desc-001" or "row-1" which need
  * to be converted to proper UUIDs for consistency with UI-created items.
  */
-export function normalizeArrayWithIds(value: unknown): any[] {
+function normalizeArrayWithIds(value: unknown): any[] {
   let arr: any[]
 
   if (Array.isArray(value)) {
@@ -312,7 +307,7 @@ export function normalizeArrayWithIds(value: unknown): any[] {
 /**
  * Checks if a subblock key should have its array items normalized with UUIDs.
  */
-export function shouldNormalizeArrayIds(key: string): boolean {
+function shouldNormalizeArrayIds(key: string): boolean {
   return ARRAY_WITH_ID_SUBBLOCK_TYPES.has(key)
 }
 

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.ts
@@ -93,15 +93,7 @@ export function createBlockFromParams(
         return
       }
 
-      let sanitizedValue = value
-
-      // Normalize array subblocks with id fields (inputFormat, table rows, etc.)
-      if (shouldNormalizeArrayIds(key)) {
-        sanitizedValue = normalizeArrayWithIds(value)
-        if (JSON_STRING_SUBBLOCK_KEYS.has(key)) {
-          sanitizedValue = JSON.stringify(sanitizedValue)
-        }
-      }
+      let sanitizedValue = normalizeSubblockValue(key, value)
 
       sanitizedValue = normalizeConditionRouterIds(blockId, key, sanitizedValue)
 
@@ -322,6 +314,19 @@ export function normalizeArrayWithIds(value: unknown): any[] {
  */
 export function shouldNormalizeArrayIds(key: string): boolean {
   return ARRAY_WITH_ID_SUBBLOCK_TYPES.has(key)
+}
+
+/**
+ * Normalizes an array-with-id subblock value, re-serializing it to a JSON string for the
+ * subblock keys whose UI components read a string rather than a raw array.
+ *
+ * Every write path that persists LLM-supplied subblock values must route through this so the
+ * two concerns cannot drift apart; returns non-array-with-id values untouched.
+ */
+export function normalizeSubblockValue(key: string, value: unknown): unknown {
+  if (!shouldNormalizeArrayIds(key)) return value
+  const normalized = normalizeArrayWithIds(value)
+  return JSON_STRING_SUBBLOCK_KEYS.has(key) ? JSON.stringify(normalized) : normalized
 }
 
 /**

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.ts
@@ -323,9 +323,16 @@ function shouldNormalizeArrayIds(key: string): boolean {
  *
  * Every write path that persists LLM-supplied subblock values must route through this so the
  * two concerns cannot drift apart; returns non-array-with-id values untouched.
+ *
+ * @remarks
+ * A nullish value passes through unchanged. `validateValueForSubBlockType` treats null as an
+ * explicit clear, and coercing it to `"[]"` here would persist a value where the caller asked
+ * for none -- leaving `sanitizeForCopilot` to show the agent an empty filter rather than an
+ * absent one, and callers that branch on the field's presence to see it as set.
  */
 export function normalizeSubblockValue(key: string, value: unknown): unknown {
   if (!shouldNormalizeArrayIds(key)) return value
+  if (value === null || value === undefined) return value
   const normalized = normalizeArrayWithIds(value)
   return JSON_STRING_SUBBLOCK_KEYS.has(key) ? JSON.stringify(normalized) : normalized
 }

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.ts
@@ -274,7 +274,12 @@ const ARRAY_WITH_ID_SUBBLOCK_TYPES = new Set([
  * Subblock keys whose UI components expect a JSON string, not a raw array.
  * After normalizeArrayWithIds returns an array, these must be re-stringified.
  */
-export const JSON_STRING_SUBBLOCK_KEYS = new Set(['conditions', 'routes'])
+export const JSON_STRING_SUBBLOCK_KEYS = new Set([
+  'conditions',
+  'routes',
+  'tagFilters',
+  'documentTags',
+])
 
 /**
  * Normalizes array subblock values by ensuring each item has a valid UUID.

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/builders.ts
@@ -269,26 +269,32 @@ const ARRAY_WITH_ID_SUBBLOCK_TYPES = new Set([
 const JSON_STRING_SUBBLOCK_KEYS = new Set(['conditions', 'routes', 'tagFilters', 'documentTags'])
 
 /**
+ * Coerces a subblock value to an array, accepting either a raw array or the JSON string
+ * the string-serialized subblocks persist.
+ *
+ * @returns The array, or `null` when the value is not an array and does not parse to one.
+ * Callers supply their own fallback, which differs by site.
+ */
+function parseJsonArray(value: unknown): any[] | null {
+  if (Array.isArray(value)) return value
+  if (typeof value !== 'string') return null
+
+  try {
+    const parsed = JSON.parse(value)
+    return Array.isArray(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/**
  * Normalizes array subblock values by ensuring each item has a valid UUID.
  * The LLM may generate arbitrary IDs like "input-desc-001" or "row-1" which need
  * to be converted to proper UUIDs for consistency with UI-created items.
  */
 function normalizeArrayWithIds(value: unknown): any[] {
-  let arr: any[]
-
-  if (Array.isArray(value)) {
-    arr = value
-  } else if (typeof value === 'string') {
-    try {
-      const parsed = JSON.parse(value)
-      if (!Array.isArray(parsed)) return []
-      arr = parsed
-    } catch {
-      return []
-    }
-  } else {
-    return []
-  }
+  const arr = parseJsonArray(value)
+  if (!arr) return []
 
   return arr.map((item: any) => {
     if (!item || typeof item !== 'object') {
@@ -332,19 +338,8 @@ export function normalizeSubblockValue(key: string, value: unknown): unknown {
 export function normalizeConditionRouterIds(blockId: string, key: string, value: unknown): unknown {
   if (key !== 'conditions' && key !== 'routes') return value
 
-  let parsed: any[]
-  if (typeof value === 'string') {
-    try {
-      parsed = JSON.parse(value)
-      if (!Array.isArray(parsed)) return value
-    } catch {
-      return value
-    }
-  } else if (Array.isArray(value)) {
-    parsed = value
-  } else {
-    return value
-  }
+  const parsed = parseJsonArray(value)
+  if (!parsed) return value
 
   let elseIfCounter = 0
   const normalized = parsed.map((item, index) => {

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/operations.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/operations.test.ts
@@ -221,6 +221,35 @@ describe('handleEditOperation nestedNodes merge', () => {
     expect(state.blocks['new-agent']).toBeUndefined()
   })
 
+  it('persists string-serialized subblocks as JSON strings on merged children', () => {
+    const workflow = makeLoopWorkflow()
+
+    const { state } = applyOperationsToWorkflowState(workflow, [
+      {
+        operation_type: 'edit',
+        block_id: 'loop-1',
+        params: {
+          nestedNodes: {
+            'new-condition': {
+              type: 'condition',
+              name: 'Condition 1',
+              inputs: {
+                conditions: [
+                  { id: 'x', title: 'if', value: 'x > 1' },
+                  { id: 'y', title: 'else', value: '' },
+                ],
+              },
+            },
+          },
+        },
+      },
+    ])
+
+    const value = state.blocks['condition-1'].subBlocks.conditions.value
+    expect(typeof value).toBe('string')
+    expect(JSON.parse(value as string)[0].title).toBe('if')
+  })
+
   it('preserves edges for matched children when connections are not provided', () => {
     const workflow = makeLoopWorkflow()
 

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/operations.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/operations.ts
@@ -8,12 +8,10 @@ import {
   applyTriggerConfigToBlockSubblocks,
   createBlockFromParams,
   filterDisallowedTools,
-  JSON_STRING_SUBBLOCK_KEYS,
-  normalizeArrayWithIds,
   normalizeConditionRouterIds,
   normalizeResponseFormat,
+  normalizeSubblockValue,
   normalizeTools,
-  shouldNormalizeArrayIds,
   updateCanonicalModesForInputs,
 } from './builders'
 import type { EditWorkflowOperation, OperationContext } from './types'
@@ -209,10 +207,7 @@ function mergeNestedNodesForParent(
 
         Object.entries(childValidation.validInputs).forEach(([key, value]) => {
           if (TRIGGER_RUNTIME_SUBBLOCK_IDS.includes(key)) return
-          let sanitizedValue = value
-          if (shouldNormalizeArrayIds(key)) {
-            sanitizedValue = normalizeArrayWithIds(value)
-          }
+          let sanitizedValue = normalizeSubblockValue(key, value)
           sanitizedValue = normalizeConditionRouterIds(existingId, key, sanitizedValue)
           if (key === 'tools' && Array.isArray(value)) {
             sanitizedValue = filterDisallowedTools(
@@ -444,15 +439,7 @@ export function handleEditOperation(op: EditWorkflowOperation, ctx: OperationCon
       if (TRIGGER_RUNTIME_SUBBLOCK_IDS.includes(key)) {
         return
       }
-      let sanitizedValue = value
-
-      // Normalize array subblocks with id fields (inputFormat, table rows, etc.)
-      if (shouldNormalizeArrayIds(key)) {
-        sanitizedValue = normalizeArrayWithIds(value)
-        if (JSON_STRING_SUBBLOCK_KEYS.has(key)) {
-          sanitizedValue = JSON.stringify(sanitizedValue)
-        }
-      }
+      let sanitizedValue = normalizeSubblockValue(key, value)
 
       sanitizedValue = normalizeConditionRouterIds(block_id, key, sanitizedValue)
 
@@ -920,15 +907,7 @@ export function handleInsertIntoSubflowOperation(
           return
         }
 
-        let sanitizedValue = value
-
-        // Normalize array subblocks with id fields (inputFormat, table rows, etc.)
-        if (shouldNormalizeArrayIds(key)) {
-          sanitizedValue = normalizeArrayWithIds(value)
-          if (JSON_STRING_SUBBLOCK_KEYS.has(key)) {
-            sanitizedValue = JSON.stringify(sanitizedValue)
-          }
-        }
+        let sanitizedValue = normalizeSubblockValue(key, value)
 
         sanitizedValue = normalizeConditionRouterIds(block_id, key, sanitizedValue)
 

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.test.ts
@@ -68,7 +68,11 @@ const knowledgeBlockConfig = {
   type: 'knowledge',
   name: 'Knowledge',
   outputs: {},
-  subBlocks: [{ id: 'knowledgeBaseId', type: 'knowledge-base-selector' }],
+  subBlocks: [
+    { id: 'knowledgeBaseId', type: 'knowledge-base-selector' },
+    { id: 'tagFilters', type: 'knowledge-tag-filters' },
+    { id: 'documentTags', type: 'document-tag-entry' },
+  ],
 }
 
 const canonicalCredBlockConfig = {
@@ -258,6 +262,47 @@ describe('validateInputsForBlock', () => {
     expect(result.validInputs.conditions).toBeUndefined()
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0]?.error).toContain('expected a JSON array')
+  })
+
+  // Without this guard, normalizeArrayWithIds coerces any unparseable value to [], which the
+  // write path then persists as "[]" -- silently destroying a tag filter the user configured.
+  it.each([
+    ['a double-encoded JSON string', JSON.stringify(JSON.stringify([{ tagName: 'Department' }]))],
+    ['an unparseable string', 'not-json'],
+    ['an object', { tagName: 'Department' }],
+    ['a number', 5],
+  ])('rejects knowledge-tag-filters values that are %s', (_label, value) => {
+    const result = validateInputsForBlock('knowledge', { tagFilters: value }, 'kb-1')
+
+    expect(result.validInputs.tagFilters).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]?.error).toContain('expected a JSON array')
+  })
+
+  it('rejects non-array document-tag-entry values', () => {
+    const result = validateInputsForBlock('knowledge', { documentTags: 'not-json' }, 'kb-1')
+
+    expect(result.validInputs.documentTags).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]?.error).toContain('expected a JSON array')
+  })
+
+  it.each([
+    ['a JSON string array', JSON.stringify([{ tagName: 'Department', tagValue: 'IT' }])],
+    ['a raw array', [{ tagName: 'Department', tagValue: 'IT' }]],
+    ['an empty array, clearing the filter', []],
+  ])('accepts knowledge-tag-filters values that are %s', (_label, value) => {
+    const result = validateInputsForBlock('knowledge', { tagFilters: value }, 'kb-1')
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.validInputs.tagFilters).toBeDefined()
+  })
+
+  it('accepts a null knowledge-tag-filters value so the field can still be cleared', () => {
+    const result = validateInputsForBlock('knowledge', { tagFilters: null }, 'kb-1')
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.validInputs.tagFilters).toBeNull()
   })
 
   it('accepts known agent model ids', () => {

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/validation.ts
@@ -367,7 +367,9 @@ export function validateValueForSubBlockType(
     }
 
     case 'condition-input':
-    case 'router-input': {
+    case 'router-input':
+    case 'knowledge-tag-filters':
+    case 'document-tag-entry': {
       const parsedValue =
         typeof value === 'string'
           ? (() => {

--- a/apps/sim/lib/copilot/vfs/serializers.test.ts
+++ b/apps/sim/lib/copilot/vfs/serializers.test.ts
@@ -68,16 +68,44 @@ describe('serializeKBMeta', () => {
       serializeKBMeta({
         ...baseKb,
         tagDefinitions: [
-          { displayName: 'Important', tagSlot: 'tag1', fieldType: 'text' },
-          { displayName: 'Department', tagSlot: 'tag2', fieldType: 'text' },
+          { tagName: 'Important', tagSlot: 'tag1', fieldType: 'text' },
+          { tagName: 'Department', tagSlot: 'tag2', fieldType: 'text' },
         ],
       })
     )
 
+    const textOperators = ['eq', 'neq', 'contains', 'not_contains', 'starts_with', 'ends_with']
     expect(json.tagDefinitions).toEqual([
-      { displayName: 'Important', tagSlot: 'tag1', fieldType: 'text' },
-      { displayName: 'Department', tagSlot: 'tag2', fieldType: 'text' },
+      { tagName: 'Important', tagSlot: 'tag1', fieldType: 'text', operators: textOperators },
+      { tagName: 'Department', tagSlot: 'tag2', fieldType: 'text', operators: textOperators },
     ])
+  })
+
+  // `between` is legal for number/date but not text/boolean -- the agent cannot infer this.
+  it.each([
+    ['number', ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'between']],
+    ['date', ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'between']],
+    ['boolean', ['eq', 'neq']],
+  ])('exposes the operators legal for a %s tag', (fieldType, expected) => {
+    const json = JSON.parse(
+      serializeKBMeta({
+        ...baseKb,
+        tagDefinitions: [{ tagName: 'Tag', tagSlot: 'tag1', fieldType }],
+      })
+    )
+
+    expect(json.tagDefinitions[0].operators).toEqual(expected)
+  })
+
+  it('emits an empty operator list for an unrecognized field type rather than throwing', () => {
+    const json = JSON.parse(
+      serializeKBMeta({
+        ...baseKb,
+        tagDefinitions: [{ tagName: 'Tag', tagSlot: 'tag1', fieldType: 'mystery' }],
+      })
+    )
+
+    expect(json.tagDefinitions[0].operators).toEqual([])
   })
 
   it('omits tag definitions when empty or undefined', () => {

--- a/apps/sim/lib/copilot/vfs/serializers.test.ts
+++ b/apps/sim/lib/copilot/vfs/serializers.test.ts
@@ -49,3 +49,42 @@ describe('VFS metadata serializers', () => {
     expect(knowledgeBase.documentCount).toBe(19)
   })
 })
+
+describe('serializeKBMeta', () => {
+  const baseKb = {
+    id: 'kb-1',
+    name: 'Support Docs',
+    description: null,
+    embeddingModel: 'text-embedding-3-small',
+    embeddingDimension: 1536,
+    tokenCount: 42,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    documentCount: 3,
+  }
+
+  it('includes tag definitions when present', () => {
+    const json = JSON.parse(
+      serializeKBMeta({
+        ...baseKb,
+        tagDefinitions: [
+          { displayName: 'Important', tagSlot: 'tag1', fieldType: 'text' },
+          { displayName: 'Department', tagSlot: 'tag2', fieldType: 'text' },
+        ],
+      })
+    )
+
+    expect(json.tagDefinitions).toEqual([
+      { displayName: 'Important', tagSlot: 'tag1', fieldType: 'text' },
+      { displayName: 'Department', tagSlot: 'tag2', fieldType: 'text' },
+    ])
+  })
+
+  it('omits tag definitions when empty or undefined', () => {
+    const empty = JSON.parse(serializeKBMeta({ ...baseKb, tagDefinitions: [] }))
+    const missing = JSON.parse(serializeKBMeta(baseKb))
+
+    expect(empty).not.toHaveProperty('tagDefinitions')
+    expect(missing).not.toHaveProperty('tagDefinitions')
+  })
+})

--- a/apps/sim/lib/copilot/vfs/serializers.ts
+++ b/apps/sim/lib/copilot/vfs/serializers.ts
@@ -1,5 +1,6 @@
 import { getCopilotToolDescription } from '@/lib/copilot/tools/descriptions'
 import { isHosted } from '@/lib/core/config/env-flags'
+import type { TagDefinition } from '@/lib/knowledge/types'
 import { isSubBlockHidden } from '@/lib/workflows/subblocks/visibility'
 import { isCustomBlockType } from '@/blocks/custom/build-config'
 import type { BlockConfig, SubBlockConfig } from '@/blocks/types'
@@ -84,11 +85,7 @@ export function serializeRecentExecutions(
 }
 
 /** A knowledge base tag definition, reduced to the fields the agent needs to bind a tag filter. */
-export interface KbTagDefinitionSummary {
-  displayName: string
-  tagSlot: string
-  fieldType: string
-}
+export type KbTagDefinitionSummary = Pick<TagDefinition, 'displayName' | 'tagSlot' | 'fieldType'>
 
 /**
  * Serialize knowledge base metadata for VFS meta.json.

--- a/apps/sim/lib/copilot/vfs/serializers.ts
+++ b/apps/sim/lib/copilot/vfs/serializers.ts
@@ -83,6 +83,13 @@ export function serializeRecentExecutions(
   )
 }
 
+/** A knowledge base tag definition, reduced to the fields the agent needs to bind a tag filter. */
+export interface KbTagDefinitionSummary {
+  displayName: string
+  tagSlot: string
+  fieldType: string
+}
+
 /**
  * Serialize knowledge base metadata for VFS meta.json.
  *
@@ -101,7 +108,7 @@ export function serializeKBMeta(kb: {
   updatedAt: Date
   documentCount: number
   connectorTypes?: string[]
-  tagDefinitions?: Array<{ displayName: string; tagSlot: string; fieldType: string }>
+  tagDefinitions?: KbTagDefinitionSummary[]
 }): string {
   return JSON.stringify(
     {

--- a/apps/sim/lib/copilot/vfs/serializers.ts
+++ b/apps/sim/lib/copilot/vfs/serializers.ts
@@ -1,6 +1,6 @@
 import { getCopilotToolDescription } from '@/lib/copilot/tools/descriptions'
 import { isHosted } from '@/lib/core/config/env-flags'
-import type { TagDefinition } from '@/lib/knowledge/types'
+import { type FilterFieldType, getOperatorsForFieldType } from '@/lib/knowledge/filters/types'
 import { isSubBlockHidden } from '@/lib/workflows/subblocks/visibility'
 import { isCustomBlockType } from '@/blocks/custom/build-config'
 import type { BlockConfig, SubBlockConfig } from '@/blocks/types'
@@ -84,15 +84,27 @@ export function serializeRecentExecutions(
   )
 }
 
-/** A knowledge base tag definition, reduced to the fields the agent needs to bind a tag filter. */
-export type KbTagDefinitionSummary = Pick<TagDefinition, 'displayName' | 'tagSlot' | 'fieldType'>
+/**
+ * A knowledge base tag definition, reduced to the fields the agent needs to bind a tag filter.
+ *
+ * @remarks
+ * `tagName` is the DB's `displayName`. It is renamed at this boundary because that is the key
+ * a `tagFilters` entry must carry -- an entry written with `displayName` validates and persists
+ * but never filters anything.
+ */
+export interface KbTagDefinitionSummary {
+  tagName: string
+  tagSlot: string
+  fieldType: string
+}
 
 /**
  * Serialize knowledge base metadata for VFS meta.json.
  *
- * `tagDefinitions` exposes the KB's defined tags (`displayName` → `tagSlot`) so the
- * agent can select and bind a knowledge-tag filter correctly instead of guessing a
- * tag name it cannot otherwise see.
+ * `tagDefinitions` exposes the KB's defined tags (`tagName` → `tagSlot`) plus the operators
+ * legal for each tag's `fieldType`, so the agent can bind a knowledge-tag filter without
+ * guessing a tag name it cannot otherwise see or an operator the field does not accept
+ * (`between` is valid for number/date but not text/boolean).
  */
 export function serializeKBMeta(kb: {
   id: string
@@ -119,7 +131,14 @@ export function serializeKBMeta(kb: {
       connectorTypes:
         kb.connectorTypes && kb.connectorTypes.length > 0 ? kb.connectorTypes : undefined,
       tagDefinitions:
-        kb.tagDefinitions && kb.tagDefinitions.length > 0 ? kb.tagDefinitions : undefined,
+        kb.tagDefinitions && kb.tagDefinitions.length > 0
+          ? kb.tagDefinitions.map((tag) => ({
+              ...tag,
+              operators: getOperatorsForFieldType(tag.fieldType as FilterFieldType).map(
+                (op) => op.value
+              ),
+            }))
+          : undefined,
       createdAt: kb.createdAt.toISOString(),
       updatedAt: kb.updatedAt.toISOString(),
     },

--- a/apps/sim/lib/copilot/vfs/serializers.ts
+++ b/apps/sim/lib/copilot/vfs/serializers.ts
@@ -84,7 +84,11 @@ export function serializeRecentExecutions(
 }
 
 /**
- * Serialize knowledge base metadata for VFS meta.json
+ * Serialize knowledge base metadata for VFS meta.json.
+ *
+ * `tagDefinitions` exposes the KB's defined tags (`displayName` → `tagSlot`) so the
+ * agent can select and bind a knowledge-tag filter correctly instead of guessing a
+ * tag name it cannot otherwise see.
  */
 export function serializeKBMeta(kb: {
   id: string
@@ -97,6 +101,7 @@ export function serializeKBMeta(kb: {
   updatedAt: Date
   documentCount: number
   connectorTypes?: string[]
+  tagDefinitions?: Array<{ displayName: string; tagSlot: string; fieldType: string }>
 }): string {
   return JSON.stringify(
     {
@@ -109,6 +114,8 @@ export function serializeKBMeta(kb: {
       documentCount: kb.documentCount,
       connectorTypes:
         kb.connectorTypes && kb.connectorTypes.length > 0 ? kb.connectorTypes : undefined,
+      tagDefinitions:
+        kb.tagDefinitions && kb.tagDefinitions.length > 0 ? kb.tagDefinitions : undefined,
       createdAt: kb.createdAt.toISOString(),
       updatedAt: kb.updatedAt.toISOString(),
     },

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -51,7 +51,7 @@ import {
   canonicalWorkspaceFilePath,
   encodeVfsPathSegments,
 } from '@/lib/copilot/vfs/path-utils'
-import type { DeploymentData } from '@/lib/copilot/vfs/serializers'
+import type { DeploymentData, KbTagDefinitionSummary } from '@/lib/copilot/vfs/serializers'
 import {
   serializeApiKeys,
   serializeBlockSchema,
@@ -1555,11 +1555,8 @@ export class WorkspaceVFS {
    */
   private async loadKbTagDefinitions(
     kbIds: string[]
-  ): Promise<Map<string, Array<{ displayName: string; tagSlot: string; fieldType: string }>>> {
-    const byKb = new Map<
-      string,
-      Array<{ displayName: string; tagSlot: string; fieldType: string }>
-    >()
+  ): Promise<Map<string, KbTagDefinitionSummary[]>> {
+    const byKb = new Map<string, KbTagDefinitionSummary[]>()
     if (kbIds.length === 0) return byKb
 
     const rows = await db

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -1552,6 +1552,12 @@ export class WorkspaceVFS {
    * Load tag definitions for the given knowledge bases in a single query, grouped by
    * KB id and ordered by tag slot. Surfaced inline in each KB's meta.json so the agent
    * knows which tags exist (and their slot binding) when editing a knowledge-tag filter.
+   *
+   * @remarks
+   * Tag definitions are an optional enrichment, so a query failure degrades to a meta.json
+   * without them rather than rejecting. This materializer runs inside the top-level
+   * `Promise.all`, whose rejection would fail the entire workspace VFS build and leave the
+   * agent unable to read any file.
    */
   private async loadKbTagDefinitions(
     kbIds: string[]
@@ -1559,16 +1565,29 @@ export class WorkspaceVFS {
     const byKb = new Map<string, KbTagDefinitionSummary[]>()
     if (kbIds.length === 0) return byKb
 
-    const rows = await db
-      .select({
-        knowledgeBaseId: knowledgeBaseTagDefinitions.knowledgeBaseId,
-        tagSlot: knowledgeBaseTagDefinitions.tagSlot,
-        displayName: knowledgeBaseTagDefinitions.displayName,
-        fieldType: knowledgeBaseTagDefinitions.fieldType,
+    let rows: Array<{
+      knowledgeBaseId: string
+      tagSlot: string
+      displayName: string
+      fieldType: string
+    }>
+    try {
+      rows = await db
+        .select({
+          knowledgeBaseId: knowledgeBaseTagDefinitions.knowledgeBaseId,
+          tagSlot: knowledgeBaseTagDefinitions.tagSlot,
+          displayName: knowledgeBaseTagDefinitions.displayName,
+          fieldType: knowledgeBaseTagDefinitions.fieldType,
+        })
+        .from(knowledgeBaseTagDefinitions)
+        .where(inArray(knowledgeBaseTagDefinitions.knowledgeBaseId, kbIds))
+        .orderBy(knowledgeBaseTagDefinitions.tagSlot)
+    } catch (err) {
+      logger.warn('Failed to load knowledge base tag definitions', {
+        error: toError(err).message,
       })
-      .from(knowledgeBaseTagDefinitions)
-      .where(inArray(knowledgeBaseTagDefinitions.knowledgeBaseId, kbIds))
-      .orderBy(knowledgeBaseTagDefinitions.tagSlot)
+      return byKb
+    }
 
     for (const row of rows) {
       const entry = {

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -1591,7 +1591,7 @@ export class WorkspaceVFS {
 
     for (const row of rows) {
       const entry = {
-        displayName: row.displayName,
+        tagName: row.displayName,
         tagSlot: row.tagSlot,
         fieldType: row.fieldType,
       }

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -6,6 +6,7 @@ import {
   customTools as customToolsTable,
   document,
   jobExecutionLogs,
+  knowledgeBaseTagDefinitions,
   knowledgeConnector,
   mcpServers as mcpServersTable,
   skill as skillTable,
@@ -18,7 +19,7 @@ import {
 } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
-import { and, desc, eq, isNotNull, isNull, ne, or, sql } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNotNull, isNull, ne, or, sql } from 'drizzle-orm'
 import { listApiKeys } from '@/lib/api-key/service'
 import {
   buildWorkspaceContextMd,
@@ -1455,6 +1456,8 @@ export class WorkspaceVFS {
   ): Promise<WorkspaceMdData['knowledgeBases']> {
     const kbs = await getKnowledgeBases(userId, workspaceId)
 
+    const tagDefinitionsByKb = await this.loadKbTagDefinitions(kbs.map((kb) => kb.id))
+
     await Promise.all(
       kbs.map(async (kb) => {
         const safeName = sanitizeName(kb.name)
@@ -1473,6 +1476,7 @@ export class WorkspaceVFS {
             updatedAt: kb.updatedAt,
             documentCount: kb.docCount,
             connectorTypes: kb.connectorTypes,
+            tagDefinitions: tagDefinitionsByKb.get(kb.id),
           })
         )
 
@@ -1542,6 +1546,45 @@ export class WorkspaceVFS {
       description: kb.description,
       connectorTypes: kb.connectorTypes.length > 0 ? kb.connectorTypes : undefined,
     }))
+  }
+
+  /**
+   * Load tag definitions for the given knowledge bases in a single query, grouped by
+   * KB id and ordered by tag slot. Surfaced inline in each KB's meta.json so the agent
+   * knows which tags exist (and their slot binding) when editing a knowledge-tag filter.
+   */
+  private async loadKbTagDefinitions(
+    kbIds: string[]
+  ): Promise<Map<string, Array<{ displayName: string; tagSlot: string; fieldType: string }>>> {
+    const byKb = new Map<
+      string,
+      Array<{ displayName: string; tagSlot: string; fieldType: string }>
+    >()
+    if (kbIds.length === 0) return byKb
+
+    const rows = await db
+      .select({
+        knowledgeBaseId: knowledgeBaseTagDefinitions.knowledgeBaseId,
+        tagSlot: knowledgeBaseTagDefinitions.tagSlot,
+        displayName: knowledgeBaseTagDefinitions.displayName,
+        fieldType: knowledgeBaseTagDefinitions.fieldType,
+      })
+      .from(knowledgeBaseTagDefinitions)
+      .where(inArray(knowledgeBaseTagDefinitions.knowledgeBaseId, kbIds))
+      .orderBy(knowledgeBaseTagDefinitions.tagSlot)
+
+    for (const row of rows) {
+      const entry = {
+        displayName: row.displayName,
+        tagSlot: row.tagSlot,
+        fieldType: row.fieldType,
+      }
+      const existing = byKb.get(row.knowledgeBaseId)
+      if (existing) existing.push(entry)
+      else byKb.set(row.knowledgeBaseId, [entry])
+    }
+
+    return byKb
   }
 
   /**

--- a/apps/sim/lib/workflows/sanitization/json-sanitizer.test.ts
+++ b/apps/sim/lib/workflows/sanitization/json-sanitizer.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { sanitizeForCopilot } from '@/lib/workflows/sanitization/json-sanitizer'
+import type { WorkflowState } from '@/stores/workflows/workflow/types'
+
+/**
+ * Builds a minimal one-block workflow whose knowledge block carries the two
+ * subblock keys `edit_workflow` is allowed to write.
+ */
+function makeKnowledgeWorkflow(tagFiltersValue: unknown) {
+  return {
+    blocks: {
+      'kb-1': {
+        id: 'kb-1',
+        type: 'knowledge',
+        name: 'Knowledge 1',
+        position: { x: 0, y: 0 },
+        enabled: true,
+        outputs: {},
+        subBlocks: {
+          operation: { id: 'operation', type: 'dropdown', value: 'search' },
+          tagFilters: { id: 'tagFilters', type: 'knowledge-tag-filters', value: tagFiltersValue },
+          documentTags: {
+            id: 'documentTags',
+            type: 'document-tag-entry',
+            value: JSON.stringify([{ id: 't1', tagName: 'Team' }]),
+          },
+        },
+      },
+    },
+    edges: [],
+    loops: {},
+    parallels: {},
+  } as unknown as WorkflowState
+}
+
+describe('sanitizeForCopilot knowledge tag subblocks', () => {
+  // Regression: these keys were stripped, which made them write-only for the agent --
+  // edit_workflow could set a tag filter but the agent read back an absent field and
+  // cleared the user's filter on the next edit.
+  it('retains tagFilters so the agent can read back what edit_workflow writes', () => {
+    const value = JSON.stringify([
+      { id: 'f1', tagName: 'Department', tagSlot: 'tag1', tagValue: 'it' },
+    ])
+
+    const result = sanitizeForCopilot(makeKnowledgeWorkflow(value))
+    const inputs = result.blocks['kb-1'].inputs
+
+    expect(inputs?.tagFilters).toBe(value)
+  })
+
+  it('retains documentTags alongside tagFilters', () => {
+    const result = sanitizeForCopilot(makeKnowledgeWorkflow(JSON.stringify([])))
+    const inputs = result.blocks['kb-1'].inputs
+
+    expect(inputs?.documentTags).toBeDefined()
+  })
+
+  it('still omits the key when no filter is set, so absent means unset', () => {
+    const result = sanitizeForCopilot(makeKnowledgeWorkflow(null))
+    const inputs = result.blocks['kb-1'].inputs
+
+    expect(inputs).not.toHaveProperty('tagFilters')
+  })
+})

--- a/apps/sim/lib/workflows/sanitization/json-sanitizer.ts
+++ b/apps/sim/lib/workflows/sanitization/json-sanitizer.ts
@@ -254,6 +254,13 @@ function isToolInput(value: unknown): value is ToolInput {
 /**
  * Sanitize subblocks by removing null values and simplifying structure
  * Maps each subblock key directly to its value instead of the full object
+ *
+ * @remarks
+ * `tagFilters` and `documentTags` are deliberately retained. This is the copilot's read
+ * view of workflow state, and `edit_workflow` can write both keys, so dropping them here
+ * makes the field write-only: the agent reads back an absent field and clears the user's
+ * filter on the next edit. Redaction for shared/exported workflows is a separate concern,
+ * already handled by `sanitizeWorkflowForSharing`.
  */
 function sanitizeSubBlocks(
   subBlocks: BlockState['subBlocks']
@@ -307,11 +314,6 @@ function sanitizeSubBlocks(
     if (key === 'tools' && Array.isArray(subBlock.value)) {
       const toolItems: unknown[] = subBlock.value
       sanitized[key] = sanitizeTools(toolItems.filter(isToolInput))
-      return
-    }
-
-    // Skip knowledge base tag filters and document tags (workspace-specific data)
-    if (key === 'tagFilters' || key === 'documentTags') {
       return
     }
 


### PR DESCRIPTION
## Summary

**The copilot could not edit a Knowledge block's tag filter at all.** Asking Sim to set or change a tag filter appeared to succeed, but the value never showed up in the block.

`edit_workflow` persisted `tagFilters` and `documentTags` as raw arrays, while their UI components store and read a JSON string. The write landed in the database in a shape nothing downstream could render, so the filter silently stayed empty. The same was true on the nested-node edit path.

Fixing that surfaced a second, worse bug underneath it. Once the agent could actually write a tag filter, it still could not *read one back*: `sanitizeForCopilot` stripped both keys out of the workflow state the agent sees. The field was **write-only**. So on a follow-up edit — "change it back" — the agent saw an absent field, concluded no filter was set, and **cleared the user's filter**. From the trace:

> The current state already shows no `tagFilters` field on the Knowledge block — but since the parent reported it was set, I'll explicitly clear it to be safe.

It was telling the truth. That redaction came from #1628, which added it in two places for workflow **export**. Export is now independently protected by `sanitizeWorkflowForSharing`, so the copy in the copilot read path had become redundant — and destructive.

This PR closes four gaps along the same read/write loop:

- **Serialization (the original defect)** — normalize `tagFilters`/`documentTags` to a JSON string on write via `normalizeSubblockValue`, on both the flat and nested-node edit paths, so an agent-authored filter actually renders and executes. `parseJsonArrayValue` keeps rows written by older builds readable, so no migration is needed.
- **Read view** — stop stripping the two keys from `sanitizeForCopilot`, so the agent can read back what it writes. Export/sharing redaction is untouched. `null` still omits the key, so *absent* now unambiguously means *unset*.
- **Write validation** — `knowledge-tag-filters` and `document-tag-entry` had no arm in the `edit_workflow` validator and fell through to a pass-through default. Any non-array value (a double-encoded string, an object, unparseable text) was coerced to `[]` by `normalizeArrayWithIds` and persisted as `"[]"` **over the user's filter**. `condition-input`/`router-input` already guarded against exactly this; the KB types now do too.
- **Discoverability** — `meta.json` exposed `displayName`, but a filter entry must carry `tagName`; an entry written with `displayName` validates, persists, and filters nothing. Renamed at the serializer boundary (DB column unchanged) and added the operators legal per `fieldType`, since `between` is valid for number/date but not text/boolean and the agent cannot infer that.

Together: the first bullet makes editing a tag filter work, the next three make it keep working across turns.

Reported by @justin. _No linked issue._

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: `tagFilters`/`documentTags` now persist as JSON strings (readers accept both shapes; no migration)

## Testing

**Unit tests — 176 passing across 15 files**, covering every touched path:
- `validation.test.ts` — 74/74, including 8 new cases pinning that a double-encoded string, an object, a number, and unparseable text are all *rejected* rather than coerced to `"[]"`, while `null` and `[]` still clear the field
- `json-sanitizer.test.ts` (new) — `tagFilters`/`documentTags` survive `sanitizeForCopilot`; a `null` value still omits the key
- `serializers.test.ts` — `tagName` rename, and the `between` asymmetry pinned per field type; an unrecognized `fieldType` yields `[]` rather than throwing
- `sub-block/utils.test.ts` (new) — `parseJsonArrayValue` across JSON string, raw array, `null`, malformed JSON, and JSON parsing to a non-array
- `builders.test.ts`, `operations.test.ts`, `mutations.test.ts` — round-trip through both edit paths

**Static checks:** `tsc --noEmit` exit 0; `biome check` clean on all changed files. Both re-run after rebasing onto current `dev`.

**Verified manually in the running app.** Both halves of the bug: asking Sim to change a Knowledge block's tag filter to a different tag definition and value now actually applies it to the block, and asking it to change back restores the original rather than clearing it. This is the check that matters most here — an earlier pass on this bug looked correct statically and still had a second data-loss path underneath it, which the unit tests alone did not surface.

**Reviewers should focus on:**
1. `json-sanitizer.ts` — confirm `sanitizeSubBlocks` really is copilot-only (one caller, `sanitizeForCopilot`) and that removing the strip cannot widen what workflow export, sharing, or templates expose. Export redaction lives in `credential-extractor.ts` and is untouched.
2. `validation.ts` — the new arm keys on subblock **type**, so the unrelated `tagFilters` `short-input` on the Algolia block is deliberately not affected. Worth confirming that intent.
3. `workspace-vfs.ts` — `loadKbTagDefinitions` is now wrapped in try/catch. It runs inside the top-level `Promise.all`, so an unguarded failure would have rejected the entire workspace VFS materialize over an optional `meta.json` enrichment, leaving the agent unable to read any file.
4. `serializers.test.ts` — resolved an add/add conflict during rebase; `dev` had independently added a file at this path. Both suites were kept.

**Known, pre-existing, and deliberately out of scope:** `ARRAY_WITH_ID_SUBBLOCK_TYPES` and `JSON_STRING_SUBBLOCK_KEYS` key on the subblock **id**, not its type, and ids collide across blocks. PostHog and RDS both expose a `conditions` subblock that is not a `condition-input`, so a copilot edit still flattens them to `"[]"`. That predates this branch (both keys were already in `ARRAY_WITH_ID_SUBBLOCK_TYPES` at the merge-base) and fixing it changes behavior for those blocks, so it belongs in its own PR. `validateValueForSubBlockType` already switches on type and is the working template.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

No UI changes. The failure is observable in mothership traces and in whether a Knowledge block's tag filter survives a round trip through the copilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
