### PR TITLE
improvement(files): remove Save UI in favor of silent autosave with local-first draft recovery

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
@@ -101,6 +101,7 @@ interface FileViewerProps {
   onDirtyChange?: (isDirty: boolean) => void
   onSaveStatusChange?: (status: 'idle' | 'saving' | 'saved' | 'error') => void
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>
+  discardRef?: React.MutableRefObject<(() => void) | null>
   streamingContent?: string
   isAgentEditing?: boolean
   streamIsIncremental?: boolean
@@ -131,6 +132,7 @@ function FileViewerContent({
   onDirtyChange,
   onSaveStatusChange,
   saveRef,
+  discardRef,
   streamingContent,
   isAgentEditing,
   streamIsIncremental,
@@ -174,6 +176,7 @@ function FileViewerContent({
           onDirtyChange={onDirtyChange}
           onSaveStatusChange={onSaveStatusChange}
           saveRef={saveRef}
+          discardRef={discardRef}
           streamingContent={streamingContent}
           isAgentEditing={isAgentEditing}
           streamIsIncremental={streamIsIncremental}
@@ -193,6 +196,7 @@ function FileViewerContent({
         onDirtyChange={onDirtyChange}
         onSaveStatusChange={onSaveStatusChange}
         saveRef={saveRef}
+        discardRef={discardRef}
         streamingContent={streamingContent}
         isAgentEditing={isAgentEditing}
         disableStreamingAutoScroll={disableStreamingAutoScroll}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
@@ -99,7 +99,10 @@ interface FileViewerProps {
   previewMode?: PreviewMode
   autoFocus?: boolean
   onDirtyChange?: (isDirty: boolean) => void
-  onSaveStatusChange?: (status: 'idle' | 'saving' | 'saved' | 'error') => void
+  onSaveStatusChange?: (
+    status: 'idle' | 'saving' | 'saved' | 'error',
+    retry?: () => Promise<void>
+  ) => void
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>
   discardRef?: React.MutableRefObject<(() => void) | null>
   streamingContent?: string

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -357,6 +357,14 @@ export function LoadedRichMarkdownEditor({
   const lastStreamParseAtRef = useRef(0)
   useEffect(() => {
     if (!editor) return
+    const syncEditorBody = (body: string) => {
+      if (body === lastSyncedBodyRef.current) return
+      lastSyncedBodyRef.current = body
+      editor.commands.setContent(parseMarkdownToDoc(body), {
+        contentType: 'json',
+        emitUpdate: false,
+      })
+    }
     if (isStreaming) {
       wasStreamingRef.current = true
       if (editor.isEditable) editor.setEditable(false)
@@ -408,14 +416,7 @@ export function LoadedRichMarkdownEditor({
     if (isInitialSettle || wasStreamingRef.current) {
       wasStreamingRef.current = false
       settledRef.current = lockSettled(content)
-      const body = splitFrontmatter(content).body
-      if (body !== lastSyncedBodyRef.current) {
-        lastSyncedBodyRef.current = body
-        editor.commands.setContent(parseMarkdownToDoc(body), {
-          contentType: 'json',
-          emitUpdate: false,
-        })
-      }
+      syncEditorBody(splitFrontmatter(content).body)
       // `setContent` maps any pre-existing selection onto the new doc rather than clearing it — a
       // select-all survives as "select everything," permanently painting every divider/image with the
       // `rich-leaf-in-selection` decoration (keymap.ts) until the user clicks elsewhere. This must run
@@ -429,14 +430,7 @@ export function LoadedRichMarkdownEditor({
       if (isInitialSettle && autoFocus) editor.commands.focus('end')
       return
     }
-    const settledBody = splitFrontmatter(content).body
-    if (settledBody !== lastSyncedBodyRef.current) {
-      lastSyncedBodyRef.current = settledBody
-      editor.commands.setContent(parseMarkdownToDoc(settledBody), {
-        contentType: 'json',
-        emitUpdate: false,
-      })
-    }
+    syncEditorBody(splitFrontmatter(content).body)
     if (settledRef.current) editor.setEditable(canEdit && settledRef.current.verdict)
   }, [editor, content, isStreaming, canEdit, autoFocus, disableStreamingAutoScroll])
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -48,6 +48,7 @@ interface RichMarkdownEditorProps {
   onDirtyChange?: (isDirty: boolean) => void
   onSaveStatusChange?: (status: SaveStatus) => void
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>
+  discardRef?: React.MutableRefObject<(() => void) | null>
   streamingContent?: string
   isAgentEditing?: boolean
   /**
@@ -71,6 +72,7 @@ export const RichMarkdownEditor = memo(function RichMarkdownEditor({
   onDirtyChange,
   onSaveStatusChange,
   saveRef,
+  discardRef,
   streamingContent,
   isAgentEditing,
   streamIsIncremental,
@@ -94,6 +96,7 @@ export const RichMarkdownEditor = memo(function RichMarkdownEditor({
     onDirtyChange,
     onSaveStatusChange,
     saveRef,
+    discardRef,
     normalizeBaseline: normalizeMarkdownContent,
   })
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -429,6 +429,14 @@ export function LoadedRichMarkdownEditor({
       if (isInitialSettle && autoFocus) editor.commands.focus('end')
       return
     }
+    const settledBody = splitFrontmatter(content).body
+    if (settledBody !== lastSyncedBodyRef.current) {
+      lastSyncedBodyRef.current = settledBody
+      editor.commands.setContent(parseMarkdownToDoc(settledBody), {
+        contentType: 'json',
+        emitUpdate: false,
+      })
+    }
     if (settledRef.current) editor.setEditable(canEdit && settledRef.current.verdict)
   }, [editor, content, isStreaming, canEdit, autoFocus, disableStreamingAutoScroll])
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -46,7 +46,7 @@ interface RichMarkdownEditorProps {
   canEdit: boolean
   autoFocus?: boolean
   onDirtyChange?: (isDirty: boolean) => void
-  onSaveStatusChange?: (status: SaveStatus) => void
+  onSaveStatusChange?: (status: SaveStatus, retry?: () => Promise<void>) => void
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>
   discardRef?: React.MutableRefObject<(() => void) | null>
   streamingContent?: string

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -328,7 +328,10 @@ interface TextEditorProps {
   previewMode: PreviewMode
   autoFocus?: boolean
   onDirtyChange?: (isDirty: boolean) => void
-  onSaveStatusChange?: (status: 'idle' | 'saving' | 'saved' | 'error') => void
+  onSaveStatusChange?: (
+    status: 'idle' | 'saving' | 'saved' | 'error',
+    retry?: () => Promise<void>
+  ) => void
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>
   discardRef?: React.MutableRefObject<(() => void) | null>
   streamingContent?: string

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -330,6 +330,7 @@ interface TextEditorProps {
   onDirtyChange?: (isDirty: boolean) => void
   onSaveStatusChange?: (status: 'idle' | 'saving' | 'saved' | 'error') => void
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>
+  discardRef?: React.MutableRefObject<(() => void) | null>
   streamingContent?: string
   isAgentEditing?: boolean
   disableStreamingAutoScroll: boolean
@@ -345,6 +346,7 @@ export const TextEditor = memo(function TextEditor({
   onDirtyChange,
   onSaveStatusChange,
   saveRef,
+  discardRef,
   streamingContent,
   isAgentEditing,
   disableStreamingAutoScroll,
@@ -385,6 +387,7 @@ export const TextEditor = memo(function TextEditor({
     onDirtyChange,
     onSaveStatusChange,
     saveRef,
+    discardRef,
   })
   contentRef.current = content
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -34,7 +34,8 @@ interface UseEditableFileContentOptions {
   streamingContent?: string
   isAgentEditing?: boolean
   onDirtyChange?: (isDirty: boolean) => void
-  onSaveStatusChange?: (status: SaveStatus) => void
+  /** `retry` is this instance's own `saveImmediately`, passed alongside an `'error'` status so a caller-side retry never depends on a shared, remount-able ref. */
+  onSaveStatusChange?: (status: SaveStatus, retry?: () => Promise<void>) => void
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>
   /** Bridges an imperative "discard the current draft" command up to the caller, mirroring `saveRef`. */
   discardRef?: React.MutableRefObject<(() => void) | null>
@@ -210,8 +211,11 @@ export function useEditableFileContent({
   }, [isDirty])
 
   useEffect(() => {
-    onSaveStatusChangeRef.current?.(saveStatus)
-  }, [saveStatus])
+    onSaveStatusChangeRef.current?.(
+      saveStatus,
+      saveStatus === 'error' ? saveImmediately : undefined
+    )
+  }, [saveStatus, saveImmediately])
 
   useEffect(() => {
     if (!saveRef) return

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -185,11 +185,14 @@ export function useEditableFileContent({
   const contentRef = useRef(content)
   contentRef.current = content
 
-  const onSave = useCallback(async () => {
-    const next = contentRef.current
-    await updateContentRef.current.mutateAsync({ workspaceId, fileId: file.id, content: next })
-    markSavedContent(next)
-  }, [workspaceId, file.id, markSavedContent])
+  const onSave = useCallback(
+    async (overrideContent?: string) => {
+      const next = overrideContent ?? contentRef.current
+      await updateContentRef.current.mutateAsync({ workspaceId, fileId: file.id, content: next })
+      markSavedContent(next)
+    },
+    [workspaceId, file.id, markSavedContent]
+  )
 
   const autosaveEnabled = canEdit && isInitialized && !isStreamInteractionLocked
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -188,11 +188,6 @@ export function useEditableFileContent({
     markSavedContent(next)
   }, [workspaceId, file.id, markSavedContent])
 
-  const onRestoreDraft = useCallback(
-    (draftContent: string) => setDraftContent(draftContent),
-    [setDraftContent]
-  )
-
   const autosaveEnabled = canEdit && isInitialized && !isStreamInteractionLocked
 
   const { saveStatus, saveImmediately, isDirty } = useAutosave({
@@ -201,7 +196,7 @@ export function useEditableFileContent({
     onSave,
     enabled: autosaveEnabled,
     draftKey: autosaveEnabled ? `${workspaceId}:${file.id}` : undefined,
-    onRestoreDraft,
+    onRestoreDraft: setDraftContent,
   })
 
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
+import { toast } from '@sim/emcn'
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
 import {
   useUpdateWorkspaceFileContent,
@@ -197,6 +198,10 @@ export function useEditableFileContent({
 
   const autosaveEnabled = canEdit && isInitialized && !isStreamInteractionLocked
 
+  const onDiscardCorrectionFailed = useCallback(() => {
+    toast.error(`Failed to discard "${file.name}" — the server may still have the discarded edit`)
+  }, [file.name])
+
   const { saveStatus, saveImmediately, isDirty, discard } = useAutosave({
     content,
     savedContent,
@@ -204,6 +209,7 @@ export function useEditableFileContent({
     enabled: autosaveEnabled,
     draftKey: autosaveEnabled ? `${workspaceId}:${file.id}` : undefined,
     onRestoreDraft: setDraftContent,
+    onDiscardCorrectionFailed,
   })
 
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -36,6 +36,8 @@ interface UseEditableFileContentOptions {
   onDirtyChange?: (isDirty: boolean) => void
   onSaveStatusChange?: (status: SaveStatus) => void
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>
+  /** Bridges an imperative "discard the current draft" command up to the caller, mirroring `saveRef`. */
+  discardRef?: React.MutableRefObject<(() => void) | null>
   /**
    * Optional transform applied to the fetched content before it becomes the editor's baseline. A
    * surface whose editor re-serializes its content to a canonical form (the rich markdown editor)
@@ -115,6 +117,7 @@ export function useEditableFileContent({
   onDirtyChange,
   onSaveStatusChange,
   saveRef,
+  discardRef,
   normalizeBaseline,
 }: UseEditableFileContentOptions): EditableFileContent {
   const onDirtyChangeRef = useRef(onDirtyChange)
@@ -216,6 +219,21 @@ export function useEditableFileContent({
       }
     }
   }, [saveImmediately, saveRef])
+
+  const discardChanges = useCallback(
+    () => setDraftContent(savedContent),
+    [setDraftContent, savedContent]
+  )
+
+  useEffect(() => {
+    if (!discardRef) return
+    discardRef.current = discardChanges
+    return () => {
+      if (discardRef.current === discardChanges) {
+        discardRef.current = null
+      }
+    }
+  }, [discardChanges, discardRef])
 
   return {
     content: displayContent,

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -198,10 +198,6 @@ export function useEditableFileContent({
 
   const autosaveEnabled = canEdit && isInitialized && !isStreamInteractionLocked
 
-  const onDiscardCorrectionFailed = useCallback(() => {
-    toast.error(`Failed to discard "${file.name}" — the server may still have the discarded edit`)
-  }, [file.name])
-
   const { saveStatus, saveImmediately, isDirty, discard } = useAutosave({
     content,
     savedContent,
@@ -209,7 +205,10 @@ export function useEditableFileContent({
     enabled: autosaveEnabled,
     draftKey: autosaveEnabled ? `${workspaceId}:${file.id}` : undefined,
     onRestoreDraft: setDraftContent,
-    onDiscardCorrectionFailed,
+    onDiscardCorrectionFailed: () =>
+      toast.error(
+        `Failed to discard "${file.name}" — the server may still have the discarded edit`
+      ),
   })
 
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -193,7 +193,7 @@ export function useEditableFileContent({
 
   const autosaveEnabled = canEdit && isInitialized && !isStreamInteractionLocked
 
-  const { saveStatus, saveImmediately, isDirty } = useAutosave({
+  const { saveStatus, saveImmediately, isDirty, discard } = useAutosave({
     content,
     savedContent,
     onSave,
@@ -220,10 +220,10 @@ export function useEditableFileContent({
     }
   }, [saveImmediately, saveRef])
 
-  const discardChanges = useCallback(
-    () => setDraftContent(savedContent),
-    [setDraftContent, savedContent]
-  )
+  const discardChanges = useCallback(() => {
+    discard()
+    setDraftContent(savedContent)
+  }, [discard, setDraftContent, savedContent])
 
   useEffect(() => {
     if (!discardRef) return

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -188,11 +188,20 @@ export function useEditableFileContent({
     markSavedContent(next)
   }, [workspaceId, file.id, markSavedContent])
 
+  const onRestoreDraft = useCallback(
+    (draftContent: string) => setDraftContent(draftContent),
+    [setDraftContent]
+  )
+
+  const autosaveEnabled = canEdit && isInitialized && !isStreamInteractionLocked
+
   const { saveStatus, saveImmediately, isDirty } = useAutosave({
     content,
     savedContent,
     onSave,
-    enabled: canEdit && isInitialized && !isStreamInteractionLocked,
+    enabled: autosaveEnabled,
+    draftKey: autosaveEnabled ? `${workspaceId}:${file.id}` : undefined,
+    onRestoreDraft,
   })
 
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -171,6 +171,7 @@ function formatFileType(mimeType: string | null, filename: string): string {
 export function Files() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const saveRef = useRef<(() => Promise<void>) | null>(null)
+  const discardRef = useRef<(() => void) | null>(null)
 
   const params = useParams()
   const router = useRouter()
@@ -1117,6 +1118,7 @@ export function Files() {
   ])
 
   const handleDiscardChanges = () => {
+    discardRef.current?.()
     setShowUnsavedChangesAlert(false)
     setIsDirty(false)
     setSaveStatus('idle')
@@ -1877,6 +1879,7 @@ export function Files() {
             onDirtyChange={setIsDirty}
             onSaveStatusChange={setSaveStatus}
             saveRef={saveRef}
+            discardRef={discardRef}
           />
 
           <ChipConfirmModal

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -970,6 +970,16 @@ export function Files() {
     await saveRef.current()
   }, [])
 
+  const prevSaveStatusRef = useRef(saveStatus)
+  useEffect(() => {
+    if (saveStatus === 'error' && prevSaveStatusRef.current !== 'error') {
+      toast.error(`Failed to save "${selectedFileRef.current?.name ?? 'file'}"`, {
+        action: { label: 'Retry', onClick: handleSave },
+      })
+    }
+    prevSaveStatusRef.current = saveStatus
+  }, [saveStatus, handleSave])
+
   const handleNavigateFromFileDetail = useCallback(
     (url: string) => {
       if (isDirtyRef.current) {
@@ -1358,16 +1368,8 @@ export function Files() {
         handleSave()
       }
     }
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (!isDirtyRef.current) return
-      e.preventDefault()
-    }
     window.addEventListener('keydown', handleKeyDown)
-    window.addEventListener('beforeunload', handleBeforeUnload)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-      window.removeEventListener('beforeunload', handleBeforeUnload)
-    }
+    return () => window.removeEventListener('keydown', handleKeyDown)
   }, [handleSave])
 
   const selectedRowIdsRef = useRef(selectedRowIds)
@@ -1428,24 +1430,14 @@ export function Files() {
   const fileActions = useMemo<ResourceAction[]>(() => {
     if (!selectedFile) return []
     // A large CSV renders as a read-only streamed preview (no editor), so it gets neither the
-    // Save action nor the edit/split/preview toggle — just like a non-editable file.
+    // edit/split/preview toggle nor autosave — just like a non-editable file.
     const streamOnly = isCsvStreamOnly(selectedFile)
     const canEditText = isTextEditable(selectedFile) && !streamOnly
     const canPreview = isPreviewable(selectedFile) && !streamOnly
-    // Markdown renders in the single-surface inline editor, which has no raw/split/preview
-    // modes — so it keeps Save but drops the mode toggle.
+    // Markdown renders in the single-surface inline editor, which has no raw/split/preview modes.
     const isInlineMarkdown = isMarkdownFile(selectedFile)
     const hasSplitView = canEditText && canPreview && !isInlineMarkdown
     const showPreviewToggle = canPreview && !isInlineMarkdown
-
-    const saveLabel =
-      saveStatus === 'saving'
-        ? 'Saving...'
-        : saveStatus === 'saved'
-          ? 'Saved'
-          : saveStatus === 'error'
-            ? 'Save failed'
-            : 'Save'
 
     const nextModeLabel =
       previewMode === 'editor' ? 'Split' : previewMode === 'split' ? 'Preview' : 'Edit'
@@ -1453,18 +1445,6 @@ export function Files() {
       previewMode === 'editor' ? Columns2 : previewMode === 'split' ? Eye : Pencil
 
     return [
-      ...(canEditText
-        ? [
-            {
-              text: saveLabel,
-              onSelect: handleSave,
-              disabled:
-                (!isDirty && saveStatus === 'idle') ||
-                saveStatus === 'saving' ||
-                saveStatus === 'saved',
-            },
-          ]
-        : []),
       ...(hasSplitView
         ? [
             {
@@ -1505,12 +1485,9 @@ export function Files() {
   }, [
     selectedFile,
     canEdit,
-    saveStatus,
     previewMode,
-    isDirty,
     handleCyclePreviewMode,
     handleTogglePreview,
-    handleSave,
     handleDownloadSelected,
     handleShareSelected,
     handleDeleteSelected,

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -971,16 +971,14 @@ export function Files() {
     await saveRef.current()
   }, [])
 
-  const prevSaveStatusRef = useRef(saveStatus)
-  useEffect(() => {
-    if (saveStatus === 'error' && prevSaveStatusRef.current !== 'error') {
-      const retrySave = saveRef.current
+  const handleSaveStatusChange = useCallback((status: SaveStatus, retry?: () => Promise<void>) => {
+    setSaveStatus(status)
+    if (status === 'error') {
       toast.error(`Failed to save "${selectedFileRef.current?.name ?? 'file'}"`, {
-        action: { label: 'Retry', onClick: () => void retrySave?.() },
+        action: { label: 'Retry', onClick: () => void retry?.() },
       })
     }
-    prevSaveStatusRef.current = saveStatus
-  }, [saveStatus])
+  }, [])
 
   const handleNavigateFromFileDetail = useCallback(
     (url: string) => {
@@ -1877,7 +1875,7 @@ export function Files() {
             previewMode={previewMode}
             autoFocus={isNewFile || justCreatedFileIdRef.current === selectedFile.id}
             onDirtyChange={setIsDirty}
-            onSaveStatusChange={setSaveStatus}
+            onSaveStatusChange={handleSaveStatusChange}
             saveRef={saveRef}
             discardRef={discardRef}
           />

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -973,12 +973,13 @@ export function Files() {
   const prevSaveStatusRef = useRef(saveStatus)
   useEffect(() => {
     if (saveStatus === 'error' && prevSaveStatusRef.current !== 'error') {
+      const retrySave = saveRef.current
       toast.error(`Failed to save "${selectedFileRef.current?.name ?? 'file'}"`, {
-        action: { label: 'Retry', onClick: handleSave },
+        action: { label: 'Retry', onClick: () => void retrySave?.() },
       })
     }
     prevSaveStatusRef.current = saveStatus
-  }, [saveStatus, handleSave])
+  }, [saveStatus])
 
   const handleNavigateFromFileDetail = useCallback(
     (url: string) => {

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -719,5 +719,53 @@ describe('useAutosave', () => {
       await flush()
       expect(fakeDraftStore.has('autosave-draft:file-race')).toBe(false)
     })
+
+    it('serializes IndexedDB ops across an unmount and a fresh remount of the same draft key', async () => {
+      let resolveWrite: (() => void) | undefined
+      const idbKeyval = await import('idb-keyval')
+      vi.mocked(idbKeyval.set).mockImplementationOnce(
+        (key: string, value: unknown) =>
+          new Promise<void>((resolve) => {
+            resolveWrite = () => {
+              fakeDraftStore.set(key, value)
+              resolve()
+            }
+          })
+      )
+      const onSaveA = vi.fn(async () => {})
+      const { handle: handleA } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave: onSaveA,
+        draftKey: 'file-cross-mount',
+      })
+
+      handleA.rerender({ content: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(400)
+      })
+      await flush()
+      // The write is in flight when this instance unmounts — its own idbQueueRef dies with it,
+      // but the operation must still be ordered relative to whatever comes next for this key.
+      handleA.unmount()
+      await flush()
+
+      // A fresh instance mounts for the same file and immediately discards.
+      const onSaveB = vi.fn(async () => {})
+      const { handle: handleB } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave: onSaveB,
+        draftKey: 'file-cross-mount',
+      })
+      act(() => handleB.discard())
+      await flush()
+
+      // The old instance's slow write finally resolves — it must not resurrect the entry the
+      // new instance's delete already removed, even though they belong to different mounts.
+      resolveWrite?.()
+      await flush()
+      expect(fakeDraftStore.has('autosave-draft:file-cross-mount')).toBe(false)
+    })
   })
 })

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -594,6 +594,37 @@ describe('useAutosave', () => {
       expect(onSave).not.toHaveBeenCalled()
     })
 
+    it('does not treat a long-settled save as in flight when discard runs much later', async () => {
+      const onSave = vi.fn(async () => {})
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-discard-5',
+      })
+
+      // A save fully completes well before discard is ever called.
+      handle.rerender({ content: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+      await flush()
+      handle.rerender({ savedContent: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(600)
+      })
+      await flush()
+      expect(onSave).toHaveBeenCalledTimes(1)
+
+      // A later, unrelated edit is discarded. inFlightRef must have been cleared when the first
+      // save settled — otherwise this reads it as still "in flight" and fires a stale corrective
+      // save with whatever savedContent happened to be at that (now long-past) moment.
+      handle.rerender({ content: 'a12' })
+      act(() => handle.discard())
+      await flush()
+      expect(onSave).toHaveBeenCalledTimes(1)
+    })
+
     it('serializes IndexedDB writes and deletes so a slow write cannot resurrect a discarded draft', async () => {
       let resolveWrite: (() => void) | undefined
       const idbKeyval = await import('idb-keyval')

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -470,7 +470,7 @@ describe('useAutosave', () => {
       expect(onRestoreDraft).not.toHaveBeenCalled()
     })
 
-    it('discards a stale draft instead of restoring it when the server baseline has moved on', async () => {
+    it('discards and purges a stale draft when the server baseline has moved on', async () => {
       fakeDraftStore.set('autosave-draft:file-5', {
         content: 'stale-edit',
         savedContent: 'old-baseline',
@@ -487,6 +487,9 @@ describe('useAutosave', () => {
 
       await flush()
       expect(onRestoreDraft).not.toHaveBeenCalled()
+      // Purged, not merely skipped — otherwise a later open where the baseline coincidentally
+      // matches this stale snapshot again would silently resurrect the outdated edit.
+      expect(fakeDraftStore.has('autosave-draft:file-5')).toBe(false)
     })
 
     it('discard clears the local draft immediately and blocks any further write, even mid-race with unmount', async () => {

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -493,6 +493,36 @@ describe('useAutosave', () => {
       expect(fakeDraftStore.has('autosave-draft:file-5')).toBe(false)
     })
 
+    it('attempts recovery only once per mount, not every time draftKey toggles across a streaming lock', async () => {
+      fakeDraftStore.set('autosave-draft:file-once', { content: 'recovered', savedContent: 'a' })
+      const onSave = vi.fn(async () => {})
+      const onRestoreDraft = vi.fn()
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-once',
+        enabled: true,
+        onRestoreDraft,
+      })
+
+      await flush()
+      expect(onRestoreDraft).toHaveBeenCalledTimes(1)
+
+      // Mirrors autosave being disabled during agent streaming (effectiveDraftKey -> undefined)
+      // and re-enabled once the stream settles (effectiveDraftKey -> defined again). A stale
+      // pre-stream draft left behind in the meantime must not be re-offered on the second pass.
+      fakeDraftStore.set('autosave-draft:file-once', {
+        content: 'pre-agent-edit',
+        savedContent: 'a',
+      })
+      handle.rerender({ enabled: false })
+      await flush()
+      handle.rerender({ enabled: true })
+      await flush()
+      expect(onRestoreDraft).toHaveBeenCalledTimes(1)
+    })
+
     it('discard clears the local draft immediately and blocks any further write, even mid-race with unmount', async () => {
       const onSave = vi.fn(async () => {})
       const { handle } = renderAutosave({
@@ -682,6 +712,55 @@ describe('useAutosave', () => {
       act(() => handle.discard())
       await flush()
       expect(onSave).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not let a stale discard correction clobber a genuinely new edit made afterward', async () => {
+      const resolvers: Array<() => void> = []
+      const onSave = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolvers.push(resolve)
+          })
+      )
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-discard-8',
+      })
+
+      // A save is in flight when the user discards.
+      handle.rerender({ content: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+      await flush()
+      expect(onSave).toHaveBeenCalledTimes(1)
+      act(() => handle.discard())
+
+      // The caller resets content to the baseline, then the user types something genuinely new
+      // before the in-flight save (and its scheduled correction) has settled.
+      handle.rerender({ content: 'a' })
+      handle.rerender({ content: 'a2' })
+
+      // The in-flight save resolves; the correction runs but must defer, since content has
+      // moved on to something that's neither the discarded baseline nor what it was at discard.
+      await act(async () => {
+        resolvers[0]?.()
+      })
+      await flush()
+      await act(async () => {
+        vi.advanceTimersByTime(600)
+      })
+      await flush()
+
+      // A fresh save for the new edit fires instead of a correction pushing the stale baseline.
+      const targets = onSave.mock.calls.map((call) => call[0])
+      expect(targets).not.toContain('a')
+      expect(onSave.mock.calls.length).toBeGreaterThan(1)
+
+      resolvers[resolvers.length - 1]?.()
+      await flush()
     })
 
     it('serializes IndexedDB writes and deletes so a slow write cannot resurrect a discarded draft', async () => {

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -4,6 +4,22 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// jsdom has no real IndexedDB; fake idb-keyval with an in-memory map so draft persistence is
+// deterministic and inspectable without depending on a browser implementation.
+const { fakeDraftStore } = vi.hoisted(() => ({ fakeDraftStore: new Map<string, unknown>() }))
+vi.mock('idb-keyval', () => ({
+  get: vi.fn((key: string) => Promise.resolve(fakeDraftStore.get(key))),
+  set: vi.fn((key: string, value: unknown) => {
+    fakeDraftStore.set(key, value)
+    return Promise.resolve()
+  }),
+  del: vi.fn((key: string) => {
+    fakeDraftStore.delete(key)
+    return Promise.resolve()
+  }),
+}))
+
 import { type SaveStatus, useAutosave } from '@/hooks/use-autosave'
 
 interface ProbeProps {
@@ -12,6 +28,8 @@ interface ProbeProps {
   onSave: () => Promise<void>
   delay?: number
   enabled?: boolean
+  draftKey?: string
+  onRestoreDraft?: (content: string) => void
 }
 
 interface HookHandle {
@@ -69,6 +87,7 @@ async function flush() {
 describe('useAutosave', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    fakeDraftStore.clear()
   })
   afterEach(() => {
     vi.runOnlyPendingTimers()
@@ -263,5 +282,182 @@ describe('useAutosave', () => {
     handle.unmount()
     await flush()
     expect(onSave).not.toHaveBeenCalled()
+  })
+
+  describe('local draft persistence (draftKey)', () => {
+    it('mirrors dirty edits into IndexedDB on a short debounce, independent of the network save', async () => {
+      let resolveSave: (() => void) | undefined
+      const onSave = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve
+          })
+      )
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-1',
+      })
+
+      handle.rerender({ content: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(400)
+      })
+      await flush()
+      // The local draft lands well before the (longer) network debounce fires.
+      expect(fakeDraftStore.get('autosave-draft:file-1')).toEqual({
+        content: 'a1',
+        savedContent: 'a',
+      })
+      expect(onSave).not.toHaveBeenCalled()
+      resolveSave?.()
+    })
+
+    it('clears the local draft once the network save succeeds and the caller advances savedContent', async () => {
+      let resolveSave: (() => void) | undefined
+      const onSave = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve
+          })
+      )
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-2',
+      })
+
+      handle.rerender({ content: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+      await flush()
+      // The network save is in flight; the local draft is still the only record of the edit.
+      expect(fakeDraftStore.has('autosave-draft:file-2')).toBe(true)
+
+      handle.rerender({ savedContent: 'a1' })
+      await act(async () => {
+        resolveSave?.()
+      })
+      await flush()
+      expect(fakeDraftStore.has('autosave-draft:file-2')).toBe(false)
+    })
+
+    it('does not clear the local draft when a newer edit lands while the save is in flight', async () => {
+      let resolveSave: (() => void) | undefined
+      const onSave = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve
+          })
+      )
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-2b',
+      })
+
+      handle.rerender({ content: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+      await flush()
+      expect(fakeDraftStore.has('autosave-draft:file-2b')).toBe(true)
+
+      // A further edit lands while the first save is still in flight.
+      handle.rerender({ content: 'a12' })
+      await act(async () => {
+        vi.advanceTimersByTime(400)
+      })
+      await flush()
+
+      // The first save resolves; the caller advances savedContent only to the snapshot it saved.
+      handle.rerender({ savedContent: 'a1' })
+      await act(async () => {
+        resolveSave?.()
+      })
+      await flush()
+      // Still dirty ('a12' !== 'a1') — the local backup for the untransmitted edit must survive,
+      // even though `save()`'s success no longer explicitly clears it.
+      expect(fakeDraftStore.has('autosave-draft:file-2b')).toBe(true)
+      expect(fakeDraftStore.get('autosave-draft:file-2b')).toMatchObject({ content: 'a12' })
+    })
+
+    it('flushes the draft to IndexedDB when the page becomes hidden', async () => {
+      const onSave = vi.fn(async () => {})
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-3',
+      })
+
+      handle.rerender({ content: 'a1' })
+      // No timers advanced — simulates a tab close mid-keystroke, before either debounce fires.
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+      document.dispatchEvent(new Event('visibilitychange'))
+      await flush()
+      expect(fakeDraftStore.get('autosave-draft:file-3')).toEqual({
+        content: 'a1',
+        savedContent: 'a',
+      })
+    })
+
+    it('restores a draft left behind by a prior session, once, on mount', async () => {
+      fakeDraftStore.set('autosave-draft:file-4', { content: 'recovered', savedContent: 'a' })
+      const onSave = vi.fn(async () => {})
+      const onRestoreDraft = vi.fn()
+      renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-4',
+        onRestoreDraft,
+      })
+
+      await flush()
+      expect(onRestoreDraft).toHaveBeenCalledTimes(1)
+      expect(onRestoreDraft).toHaveBeenCalledWith('recovered')
+    })
+
+    it('does not clobber a fresh edit made while the recovery read was still in flight', async () => {
+      fakeDraftStore.set('autosave-draft:file-6', { content: 'recovered', savedContent: 'a' })
+      const onSave = vi.fn(async () => {})
+      const onRestoreDraft = vi.fn()
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-6',
+        onRestoreDraft,
+      })
+
+      // The user types before the async IndexedDB read resolves.
+      handle.rerender({ content: 'user-typed' })
+      await flush()
+      expect(onRestoreDraft).not.toHaveBeenCalled()
+    })
+
+    it('discards a stale draft instead of restoring it when the server baseline has moved on', async () => {
+      fakeDraftStore.set('autosave-draft:file-5', {
+        content: 'stale-edit',
+        savedContent: 'old-baseline',
+      })
+      const onSave = vi.fn(async () => {})
+      const onRestoreDraft = vi.fn()
+      renderAutosave({
+        content: 'new-baseline',
+        savedContent: 'new-baseline',
+        onSave,
+        draftKey: 'file-5',
+        onRestoreDraft,
+      })
+
+      await flush()
+      expect(onRestoreDraft).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -538,7 +538,7 @@ describe('useAutosave', () => {
       expect(onSave).not.toHaveBeenCalled()
     })
 
-    it('corrects the server once an already-in-flight save lands after discard', async () => {
+    it('corrects the server with the captured baseline, even if the caller never resets content in time', async () => {
       let resolveSave: (() => void) | undefined
       const onSave = vi.fn(
         () =>
@@ -561,17 +561,19 @@ describe('useAutosave', () => {
       await flush()
       expect(onSave).toHaveBeenCalledTimes(1)
 
-      // The user discards while that save is still pending, and the caller resets content back
-      // to the baseline (mirroring what discardChanges does synchronously right after discard()).
+      // The user discards while that save is still pending. Deliberately do NOT rerender content
+      // back to the baseline here — the correction must not depend on that caller-side reset
+      // landing before this continuation runs; it must push the baseline it captured at discard().
       act(() => handle.discard())
-      handle.rerender({ content: 'a' })
 
       await act(async () => {
         resolveSave?.()
       })
       await flush()
-      // The stale in-flight write landed; a second, corrective save pushes the reverted content.
+      // The stale in-flight write landed; a corrective save fires with the captured baseline ('a'),
+      // not whatever the still-dirty ambient content ('a1') happened to be.
       expect(onSave).toHaveBeenCalledTimes(2)
+      expect(onSave).toHaveBeenNthCalledWith(2, 'a')
     })
 
     it('does not issue a corrective save when discard finds nothing in flight', async () => {

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -276,6 +276,28 @@ describe('useAutosave', () => {
     expect(onSave).toHaveBeenCalledTimes(1)
   })
 
+  it('writes a local backup on unmount even if the network flush fails', async () => {
+    const onSave = vi.fn(async () => {
+      throw new Error('offline')
+    })
+    const { handle } = renderAutosave({
+      content: 'a',
+      savedContent: 'a',
+      onSave,
+      draftKey: 'file-unmount',
+    })
+
+    handle.rerender({ content: 'a1' })
+    // Unmount before the 400ms local-draft debounce fires — the pending timer is cancelled, so
+    // the cleanup itself must persist the draft, not just attempt (and here, fail) the network flush.
+    handle.unmount()
+    await flush()
+    expect(fakeDraftStore.get('autosave-draft:file-unmount')).toEqual({
+      content: 'a1',
+      savedContent: 'a',
+    })
+  })
+
   it('does not flush on unmount when the document is clean', async () => {
     const onSave = vi.fn(async () => {})
     const { handle } = renderAutosave({ content: 'a', savedContent: 'a', onSave })

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -25,11 +25,12 @@ import { type SaveStatus, useAutosave } from '@/hooks/use-autosave'
 interface ProbeProps {
   content: string
   savedContent: string
-  onSave: () => Promise<void>
+  onSave: (overrideContent?: string) => Promise<void>
   delay?: number
   enabled?: boolean
   draftKey?: string
   onRestoreDraft?: (content: string) => void
+  onDiscardCorrectionFailed?: () => void
 }
 
 interface HookHandle {
@@ -577,6 +578,64 @@ describe('useAutosave', () => {
       // not whatever the still-dirty ambient content ('a1') happened to be.
       expect(onSave).toHaveBeenCalledTimes(2)
       expect(onSave).toHaveBeenNthCalledWith(2, 'a')
+    })
+
+    it('surfaces a corrective save failure instead of only logging it', async () => {
+      let resolveSave: (() => void) | undefined
+      const onSave = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve
+          })
+      )
+      const onDiscardCorrectionFailed = vi.fn()
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-discard-6',
+        onDiscardCorrectionFailed,
+      })
+
+      handle.rerender({ content: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+      await flush()
+      act(() => handle.discard())
+
+      // The corrective save (the second call) fails.
+      onSave.mockImplementationOnce(() => Promise.reject(new Error('offline')))
+      await act(async () => {
+        resolveSave?.()
+      })
+      await flush()
+      expect(onDiscardCorrectionFailed).toHaveBeenCalledTimes(1)
+    })
+
+    it('resumes normal autosave for a genuinely new edit made after discard', async () => {
+      const onSave = vi.fn(async () => {})
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-discard-7',
+      })
+
+      handle.rerender({ content: 'a1' })
+      act(() => handle.discard())
+      // The caller resets content back to the baseline, mirroring discardChanges.
+      handle.rerender({ content: 'a' })
+
+      // The editor stays mounted a moment longer and the user starts a fresh edit.
+      handle.rerender({ content: 'b' })
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+      await flush()
+      // A brand-new edit made after discard must not be silently swallowed forever.
+      expect(onSave).toHaveBeenCalledTimes(1)
+      expect(onSave).toHaveBeenCalledWith()
     })
 
     it('does not issue a corrective save when discard finds nothing in flight', async () => {

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -508,6 +508,7 @@ describe('useAutosave', () => {
       // Discard fires before the caller's content===savedContent reset has landed — the hook's
       // own flag must block persistence regardless of that race, not just the IndexedDB delete.
       act(() => handle.discard())
+      await flush()
       expect(fakeDraftStore.has('autosave-draft:file-discard')).toBe(false)
 
       // Simulate the unmount flush racing in right after discard, while still (from the hook's
@@ -535,6 +536,93 @@ describe('useAutosave', () => {
       })
       await flush()
       expect(onSave).not.toHaveBeenCalled()
+    })
+
+    it('corrects the server once an already-in-flight save lands after discard', async () => {
+      let resolveSave: (() => void) | undefined
+      const onSave = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve
+          })
+      )
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-discard-3',
+      })
+
+      // A save is genuinely in flight (discardedRef can't stop it — it already started).
+      handle.rerender({ content: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+      await flush()
+      expect(onSave).toHaveBeenCalledTimes(1)
+
+      // The user discards while that save is still pending, and the caller resets content back
+      // to the baseline (mirroring what discardChanges does synchronously right after discard()).
+      act(() => handle.discard())
+      handle.rerender({ content: 'a' })
+
+      await act(async () => {
+        resolveSave?.()
+      })
+      await flush()
+      // The stale in-flight write landed; a second, corrective save pushes the reverted content.
+      expect(onSave).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not issue a corrective save when discard finds nothing in flight', async () => {
+      const onSave = vi.fn(async () => {})
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-discard-4',
+      })
+
+      handle.rerender({ content: 'a1' })
+      act(() => handle.discard())
+      await flush()
+      expect(onSave).not.toHaveBeenCalled()
+    })
+
+    it('serializes IndexedDB writes and deletes so a slow write cannot resurrect a discarded draft', async () => {
+      let resolveWrite: (() => void) | undefined
+      const idbKeyval = await import('idb-keyval')
+      vi.mocked(idbKeyval.set).mockImplementationOnce(
+        (key: string, value: unknown) =>
+          new Promise<void>((resolve) => {
+            resolveWrite = () => {
+              fakeDraftStore.set(key, value)
+              resolve()
+            }
+          })
+      )
+      const onSave = vi.fn(async () => {})
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-race',
+      })
+
+      handle.rerender({ content: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(400)
+      })
+      await flush()
+      // The write is now in flight (not yet resolved) when discard's delete is queued behind it.
+      act(() => handle.discard())
+      await flush()
+      expect(fakeDraftStore.has('autosave-draft:file-race')).toBe(false)
+
+      // The slow write finally resolves — it must not resurrect the entry the queued delete removed.
+      resolveWrite?.()
+      await flush()
+      expect(fakeDraftStore.has('autosave-draft:file-race')).toBe(false)
     })
   })
 })

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -36,6 +36,7 @@ interface HookHandle {
   status: () => SaveStatus
   isDirty: () => boolean
   saveImmediately: () => Promise<void>
+  discard: () => void
   rerender: (next: Partial<ProbeProps>) => void
   unmount: () => void
 }
@@ -49,7 +50,12 @@ function renderAutosave(initial: ProbeProps): { handle: HookHandle; props: Probe
   const container = document.createElement('div')
   const root: Root = createRoot(container)
   const props = { ...initial }
-  let latest = { saveStatus: 'idle' as SaveStatus, isDirty: false, saveImmediately: async () => {} }
+  let latest = {
+    saveStatus: 'idle' as SaveStatus,
+    isDirty: false,
+    saveImmediately: async () => {},
+    discard: () => {},
+  }
 
   function Probe(p: ProbeProps) {
     latest = useAutosave(p)
@@ -67,6 +73,7 @@ function renderAutosave(initial: ProbeProps): { handle: HookHandle; props: Probe
     status: () => latest.saveStatus,
     isDirty: () => latest.isDirty,
     saveImmediately: () => latest.saveImmediately(),
+    discard: () => latest.discard(),
     rerender: (next) => {
       Object.assign(props, next)
       render()
@@ -480,6 +487,54 @@ describe('useAutosave', () => {
 
       await flush()
       expect(onRestoreDraft).not.toHaveBeenCalled()
+    })
+
+    it('discard clears the local draft immediately and blocks any further write, even mid-race with unmount', async () => {
+      const onSave = vi.fn(async () => {})
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-discard',
+      })
+
+      handle.rerender({ content: 'a1' })
+      await act(async () => {
+        vi.advanceTimersByTime(400)
+      })
+      await flush()
+      expect(fakeDraftStore.has('autosave-draft:file-discard')).toBe(true)
+
+      // Discard fires before the caller's content===savedContent reset has landed — the hook's
+      // own flag must block persistence regardless of that race, not just the IndexedDB delete.
+      act(() => handle.discard())
+      expect(fakeDraftStore.has('autosave-draft:file-discard')).toBe(false)
+
+      // Simulate the unmount flush racing in right after discard, while still (from the hook's
+      // perspective) dirty: neither the local draft nor the network save must fire.
+      handle.unmount()
+      await flush()
+      expect(fakeDraftStore.has('autosave-draft:file-discard')).toBe(false)
+      expect(onSave).not.toHaveBeenCalled()
+    })
+
+    it('discard prevents a pending debounced network save from firing', async () => {
+      const onSave = vi.fn(async () => {})
+      const { handle } = renderAutosave({
+        content: 'a',
+        savedContent: 'a',
+        onSave,
+        draftKey: 'file-discard-2',
+      })
+
+      handle.rerender({ content: 'a1' })
+      act(() => handle.discard())
+
+      await act(async () => {
+        vi.advanceTimersByTime(1500)
+      })
+      await flush()
+      expect(onSave).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -245,8 +245,11 @@ export function useAutosave({
     }
   }, [effectiveDraftKey, persistLocalDraft])
 
+  const recoveryAttemptedRef = useRef(false)
+
   useEffect(() => {
-    if (!effectiveDraftKey) return
+    if (!effectiveDraftKey || recoveryAttemptedRef.current) return
+    recoveryAttemptedRef.current = true
     let cancelled = false
     void enqueueDraftOp(effectiveDraftKey, () =>
       get<LocalDraft>(localDraftDbKey(effectiveDraftKey))
@@ -282,12 +285,24 @@ export function useAutosave({
     const pendingSave = inFlightRef.current
     if (!pendingSave) return
     const target = savedContentRef.current
-    void pendingSave.then(() =>
-      onSaveRef.current(target).catch((error) => {
-        logger.warn('Corrective save after discard failed', { error })
-        onDiscardCorrectionFailedRef.current?.()
-      })
-    )
+    const contentAtDiscard = contentRef.current
+    void pendingSave.then(() => {
+      const current = contentRef.current
+      if (inFlightRef.current || (current !== target && current !== contentAtDiscard)) return
+      savingRef.current = true
+      const correctionRun = onSaveRef
+        .current(target)
+        .catch((error) => {
+          logger.warn('Corrective save after discard failed', { error })
+          onDiscardCorrectionFailedRef.current?.()
+        })
+        .finally(() => {
+          savingRef.current = false
+          inFlightRef.current = null
+        })
+      inFlightRef.current = correctionRun
+      return correctionRun
+    })
   }, [clearLocalDraft])
 
   return { saveStatus, saveImmediately, isDirty, discard }

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -33,6 +33,8 @@ interface UseAutosaveOptions {
    */
   draftKey?: string
   onRestoreDraft?: (content: string) => void
+  /** Called if `discard()`'s corrective save fails — the only way that failure can surface, since it happens after the component may already have unmounted. */
+  onDiscardCorrectionFailed?: () => void
 }
 
 interface UseAutosaveReturn {
@@ -56,6 +58,7 @@ export function useAutosave({
   enabled = true,
   draftKey,
   onRestoreDraft,
+  onDiscardCorrectionFailed,
 }: UseAutosaveOptions): UseAutosaveReturn {
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
@@ -75,6 +78,8 @@ export function useAutosave({
   draftKeyRef.current = effectiveDraftKey
   const onRestoreDraftRef = useRef(onRestoreDraft)
   onRestoreDraftRef.current = onRestoreDraft
+  const onDiscardCorrectionFailedRef = useRef(onDiscardCorrectionFailed)
+  onDiscardCorrectionFailedRef.current = onDiscardCorrectionFailed
 
   const isDirty = content !== savedContent
   const savingStartRef = useRef(0)
@@ -85,6 +90,8 @@ export function useAutosave({
   const discardedRef = useRef(false)
   const idbQueueRef = useRef<Promise<void>>(Promise.resolve())
   const MIN_SAVING_DISPLAY_MS = 600
+
+  if (discardedRef.current && isDirty) discardedRef.current = false
 
   const persistLocalDraft = useCallback(() => {
     const key = draftKeyRef.current
@@ -262,6 +269,7 @@ export function useAutosave({
     void pendingSave.then(() =>
       onSaveRef.current(target).catch((error) => {
         logger.warn('Corrective save after discard failed', { error })
+        onDiscardCorrectionFailedRef.current?.()
       })
     )
   }, [clearLocalDraft])

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -163,6 +163,7 @@ export function useAutosave({
       clearTimeout(idleTimerRef.current)
       clearTimeout(displayTimerRef.current)
       clearTimeout(localDraftTimerRef.current)
+      persistLocalDraft()
       if (!enabledRef.current || contentRef.current === savedContentRef.current) return
       // Flush the latest content on unmount, but chain it AFTER any in-flight save rather than
       // firing a concurrent PUT: the in-flight save captured an older snapshot, so writing the
@@ -174,7 +175,7 @@ export function useAutosave({
         }
       })()
     }
-  }, [clearLocalDraft])
+  }, [clearLocalDraft, persistLocalDraft])
 
   const wasDirtyRef = useRef(isDirty)
 

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -137,6 +137,7 @@ export function useAutosave({
       } catch {
         nextStatus = 'error'
       } finally {
+        inFlightRef.current = null
         if (unmountedRef.current) {
           savingRef.current = false
         } else {

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -38,6 +38,8 @@ interface UseAutosaveReturn {
   saveStatus: SaveStatus
   saveImmediately: () => Promise<void>
   isDirty: boolean
+  /** Abandons the current draft: cancels any pending save/local-draft write and clears the local draft immediately, so nothing written after this call can resurrect it. */
+  discard: () => void
 }
 
 /**
@@ -79,11 +81,12 @@ export function useAutosave({
   const unmountedRef = useRef(false)
   const localDraftTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const lastPersistedContentRef = useRef<string | null>(null)
+  const discardedRef = useRef(false)
   const MIN_SAVING_DISPLAY_MS = 600
 
   const persistLocalDraft = useCallback(() => {
     const key = draftKeyRef.current
-    if (!key || contentRef.current === savedContentRef.current) return
+    if (discardedRef.current || !key || contentRef.current === savedContentRef.current) return
     if (contentRef.current === lastPersistedContentRef.current) return
     void set(localDraftDbKey(key), {
       content: contentRef.current,
@@ -108,6 +111,7 @@ export function useAutosave({
 
   const save = useCallback(async () => {
     if (
+      discardedRef.current ||
       !enabledRef.current ||
       savingRef.current ||
       contentRef.current === savedContentRef.current
@@ -164,13 +168,19 @@ export function useAutosave({
       clearTimeout(displayTimerRef.current)
       clearTimeout(localDraftTimerRef.current)
       persistLocalDraft()
-      if (!enabledRef.current || contentRef.current === savedContentRef.current) return
+      if (
+        discardedRef.current ||
+        !enabledRef.current ||
+        contentRef.current === savedContentRef.current
+      ) {
+        return
+      }
       // Flush the latest content on unmount, but chain it AFTER any in-flight save rather than
       // firing a concurrent PUT: the in-flight save captured an older snapshot, so writing the
       // latest sequentially (last) prevents an out-of-order completion from clobbering it.
       void (async () => {
         await inFlightRef.current
-        if (contentRef.current !== savedContentRef.current) {
+        if (!discardedRef.current && contentRef.current !== savedContentRef.current) {
           await onSaveRef.current().then(clearLocalDraft, () => {})
         }
       })()
@@ -227,5 +237,12 @@ export function useAutosave({
     await save()
   }, [save])
 
-  return { saveStatus, saveImmediately, isDirty }
+  const discard = useCallback(() => {
+    discardedRef.current = true
+    clearTimeout(timerRef.current)
+    clearTimeout(localDraftTimerRef.current)
+    clearLocalDraft()
+  }, [clearLocalDraft])
+
+  return { saveStatus, saveImmediately, isDirty, discard }
 }

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -228,7 +228,11 @@ export function useAutosave({
     let cancelled = false
     void get<LocalDraft>(localDraftDbKey(effectiveDraftKey))
       .then((draft) => {
-        if (cancelled || !draft || draft.savedContent !== savedContentRef.current) return
+        if (cancelled || !draft) return
+        if (draft.savedContent !== savedContentRef.current) {
+          clearLocalDraft()
+          return
+        }
         if (draft.content === draft.savedContent) return
         if (contentRef.current !== savedContentRef.current) return
         onRestoreDraftRef.current?.(draft.content)
@@ -239,7 +243,7 @@ export function useAutosave({
     return () => {
       cancelled = true
     }
-  }, [effectiveDraftKey])
+  }, [effectiveDraftKey, clearLocalDraft])
 
   const saveImmediately = useCallback(async () => {
     clearTimeout(timerRef.current)

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -22,7 +22,8 @@ function localDraftDbKey(draftKey: string) {
 interface UseAutosaveOptions {
   content: string
   savedContent: string
-  onSave: () => Promise<void>
+  /** `overrideContent`, when passed, is what `discard()`'s corrective save pushes — the reverted baseline captured at discard time, not whatever the ambient content ref reads by the time the in-flight save it's correcting for has settled. */
+  onSave: (overrideContent?: string) => Promise<void>
   delay?: number
   enabled?: boolean
   /**
@@ -252,8 +253,9 @@ export function useAutosave({
     clearLocalDraft()
     const pendingSave = inFlightRef.current
     if (!pendingSave) return
+    const target = savedContentRef.current
     void pendingSave.then(() =>
-      onSaveRef.current().catch((error) => {
+      onSaveRef.current(target).catch((error) => {
         logger.warn('Corrective save after discard failed', { error })
       })
     )

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -67,8 +67,9 @@ export function useAutosave({
   savedContentRef.current = savedContent
   const contentRef = useRef(content)
   contentRef.current = content
-  const draftKeyRef = useRef(draftKey)
-  draftKeyRef.current = draftKey
+  const effectiveDraftKey = enabled ? draftKey : undefined
+  const draftKeyRef = useRef(effectiveDraftKey)
+  draftKeyRef.current = effectiveDraftKey
   const onRestoreDraftRef = useRef(onRestoreDraft)
   onRestoreDraftRef.current = onRestoreDraft
 
@@ -77,21 +78,28 @@ export function useAutosave({
   const inFlightRef = useRef<Promise<void> | null>(null)
   const unmountedRef = useRef(false)
   const localDraftTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const lastPersistedContentRef = useRef<string | null>(null)
   const MIN_SAVING_DISPLAY_MS = 600
 
   const persistLocalDraft = useCallback(() => {
     const key = draftKeyRef.current
     if (!key || contentRef.current === savedContentRef.current) return
+    if (contentRef.current === lastPersistedContentRef.current) return
     void set(localDraftDbKey(key), {
       content: contentRef.current,
       savedContent: savedContentRef.current,
-    } satisfies LocalDraft).catch((error) => {
-      logger.warn('IndexedDB draft write failed', { key, error })
-    })
+    } satisfies LocalDraft)
+      .then(() => {
+        lastPersistedContentRef.current = contentRef.current
+      })
+      .catch((error) => {
+        logger.warn('IndexedDB draft write failed', { key, error })
+      })
   }, [])
 
   const clearLocalDraft = useCallback(() => {
     const key = draftKeyRef.current
+    lastPersistedContentRef.current = null
     if (!key) return
     void del(localDraftDbKey(key)).catch((error) => {
       logger.warn('IndexedDB draft delete failed', { key, error })
@@ -171,16 +179,19 @@ export function useAutosave({
   const wasDirtyRef = useRef(isDirty)
 
   useEffect(() => {
-    if (draftKey && !isDirty && wasDirtyRef.current) clearLocalDraft()
+    if (effectiveDraftKey && !isDirty && wasDirtyRef.current) clearLocalDraft()
     wasDirtyRef.current = isDirty
-    if (!draftKey || !isDirty) return
+  }, [effectiveDraftKey, isDirty, clearLocalDraft])
+
+  useEffect(() => {
+    if (!effectiveDraftKey || !isDirty) return
     clearTimeout(localDraftTimerRef.current)
     localDraftTimerRef.current = setTimeout(persistLocalDraft, LOCAL_DRAFT_DELAY_MS)
     return () => clearTimeout(localDraftTimerRef.current)
-  }, [content, draftKey, isDirty, persistLocalDraft, clearLocalDraft])
+  }, [content, effectiveDraftKey, isDirty, persistLocalDraft])
 
   useEffect(() => {
-    if (!draftKey) return
+    if (!effectiveDraftKey) return
     const handleVisibility = () => {
       if (document.visibilityState === 'hidden') persistLocalDraft()
     }
@@ -190,12 +201,12 @@ export function useAutosave({
       window.removeEventListener('pagehide', persistLocalDraft)
       document.removeEventListener('visibilitychange', handleVisibility)
     }
-  }, [draftKey, persistLocalDraft])
+  }, [effectiveDraftKey, persistLocalDraft])
 
   useEffect(() => {
-    if (!draftKey) return
+    if (!effectiveDraftKey) return
     let cancelled = false
-    void get<LocalDraft>(localDraftDbKey(draftKey))
+    void get<LocalDraft>(localDraftDbKey(effectiveDraftKey))
       .then((draft) => {
         if (cancelled || !draft || draft.savedContent !== savedContentRef.current) return
         if (draft.content === draft.savedContent) return
@@ -203,12 +214,12 @@ export function useAutosave({
         onRestoreDraftRef.current?.(draft.content)
       })
       .catch((error) => {
-        logger.warn('IndexedDB draft read failed', { draftKey, error })
+        logger.warn('IndexedDB draft read failed', { draftKey: effectiveDraftKey, error })
       })
     return () => {
       cancelled = true
     }
-  }, [draftKey])
+  }, [effectiveDraftKey])
 
   const saveImmediately = useCallback(async () => {
     clearTimeout(timerRef.current)

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -14,6 +14,7 @@ interface LocalDraft {
 }
 
 const LOCAL_DRAFT_DELAY_MS = 400
+const MIN_SAVING_DISPLAY_MS = 600
 
 function localDraftDbKey(draftKey: string) {
   return `autosave-draft:${draftKey}`
@@ -75,18 +76,24 @@ export function useAutosave({
   onDiscardCorrectionFailed,
 }: UseAutosaveOptions): UseAutosaveReturn {
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
+
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const idleTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const displayTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const savingRef = useRef(false)
+  const savingStartRef = useRef(0)
+  const inFlightRef = useRef<Promise<void> | null>(null)
+  const unmountedRef = useRef(false)
   const onSaveRef = useRef(onSave)
   onSaveRef.current = onSave
   const enabledRef = useRef(enabled)
   enabledRef.current = enabled
+
   const savedContentRef = useRef(savedContent)
   savedContentRef.current = savedContent
   const contentRef = useRef(content)
   contentRef.current = content
+
   const effectiveDraftKey = enabled ? draftKey : undefined
   const draftKeyRef = useRef(effectiveDraftKey)
   draftKeyRef.current = effectiveDraftKey
@@ -95,15 +102,12 @@ export function useAutosave({
   const onDiscardCorrectionFailedRef = useRef(onDiscardCorrectionFailed)
   onDiscardCorrectionFailedRef.current = onDiscardCorrectionFailed
 
-  const isDirty = content !== savedContent
-  const savingStartRef = useRef(0)
-  const inFlightRef = useRef<Promise<void> | null>(null)
-  const unmountedRef = useRef(false)
   const localDraftTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const lastPersistedContentRef = useRef<string | null>(null)
-  const discardedRef = useRef(false)
-  const MIN_SAVING_DISPLAY_MS = 600
 
+  const discardedRef = useRef(false)
+
+  const isDirty = content !== savedContent
   if (discardedRef.current && isDirty) discardedRef.current = false
 
   const persistLocalDraft = useCallback(() => {
@@ -207,7 +211,7 @@ export function useAutosave({
       // latest sequentially (last) prevents an out-of-order completion from clobbering it.
       void (async () => {
         await inFlightRef.current
-        if (!discardedRef.current && contentRef.current !== savedContentRef.current) {
+        if (!discardedRef.current) {
           await onSaveRef.current().then(clearLocalDraft, () => {})
         }
       })()

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -38,7 +38,7 @@ interface UseAutosaveReturn {
   saveStatus: SaveStatus
   saveImmediately: () => Promise<void>
   isDirty: boolean
-  /** Abandons the current draft: cancels any pending save/local-draft write and clears the local draft immediately, so nothing written after this call can resurrect it. */
+  /** Abandons the current draft: blocks any save/local-draft write not yet started, clears the local draft immediately, and corrects the server if a save already in flight lands afterward. */
   discard: () => void
 }
 
@@ -82,18 +82,24 @@ export function useAutosave({
   const localDraftTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const lastPersistedContentRef = useRef<string | null>(null)
   const discardedRef = useRef(false)
+  const idbQueueRef = useRef<Promise<void>>(Promise.resolve())
   const MIN_SAVING_DISPLAY_MS = 600
 
   const persistLocalDraft = useCallback(() => {
     const key = draftKeyRef.current
     if (discardedRef.current || !key || contentRef.current === savedContentRef.current) return
     if (contentRef.current === lastPersistedContentRef.current) return
-    void set(localDraftDbKey(key), {
-      content: contentRef.current,
-      savedContent: savedContentRef.current,
-    } satisfies LocalDraft)
+    const content = contentRef.current
+    const savedContentSnapshot = savedContentRef.current
+    idbQueueRef.current = idbQueueRef.current
+      .then(() =>
+        set(localDraftDbKey(key), {
+          content,
+          savedContent: savedContentSnapshot,
+        } satisfies LocalDraft)
+      )
       .then(() => {
-        lastPersistedContentRef.current = contentRef.current
+        lastPersistedContentRef.current = content
       })
       .catch((error) => {
         logger.warn('IndexedDB draft write failed', { key, error })
@@ -104,9 +110,11 @@ export function useAutosave({
     const key = draftKeyRef.current
     lastPersistedContentRef.current = null
     if (!key) return
-    void del(localDraftDbKey(key)).catch((error) => {
-      logger.warn('IndexedDB draft delete failed', { key, error })
-    })
+    idbQueueRef.current = idbQueueRef.current
+      .then(() => del(localDraftDbKey(key)))
+      .catch((error) => {
+        logger.warn('IndexedDB draft delete failed', { key, error })
+      })
   }, [])
 
   const save = useCallback(async () => {
@@ -242,6 +250,13 @@ export function useAutosave({
     clearTimeout(timerRef.current)
     clearTimeout(localDraftTimerRef.current)
     clearLocalDraft()
+    const pendingSave = inFlightRef.current
+    if (!pendingSave) return
+    void pendingSave.then(() =>
+      onSaveRef.current().catch((error) => {
+        logger.warn('Corrective save after discard failed', { error })
+      })
+    )
   }, [clearLocalDraft])
 
   return { saveStatus, saveImmediately, isDirty, discard }

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -1,8 +1,23 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { createLogger } from '@sim/logger'
+import { del, get, set } from 'idb-keyval'
+
+const logger = createLogger('Autosave')
 
 export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+
+interface LocalDraft {
+  content: string
+  savedContent: string
+}
+
+const LOCAL_DRAFT_DELAY_MS = 400
+
+function localDraftDbKey(draftKey: string) {
+  return `autosave-draft:${draftKey}`
+}
 
 interface UseAutosaveOptions {
   content: string
@@ -10,6 +25,13 @@ interface UseAutosaveOptions {
   onSave: () => Promise<void>
   delay?: number
   enabled?: boolean
+  /**
+   * Uniquely identifies the document being edited (e.g. a file id). When set, the draft is
+   * mirrored into IndexedDB on a short debounce, independent of the network save, and recovered
+   * via `onRestoreDraft` on mount if newer than `savedContent`.
+   */
+  draftKey?: string
+  onRestoreDraft?: (content: string) => void
 }
 
 interface UseAutosaveReturn {
@@ -29,6 +51,8 @@ export function useAutosave({
   onSave,
   delay = 1500,
   enabled = true,
+  draftKey,
+  onRestoreDraft,
 }: UseAutosaveOptions): UseAutosaveReturn {
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
@@ -43,12 +67,36 @@ export function useAutosave({
   savedContentRef.current = savedContent
   const contentRef = useRef(content)
   contentRef.current = content
+  const draftKeyRef = useRef(draftKey)
+  draftKeyRef.current = draftKey
+  const onRestoreDraftRef = useRef(onRestoreDraft)
+  onRestoreDraftRef.current = onRestoreDraft
 
   const isDirty = content !== savedContent
   const savingStartRef = useRef(0)
   const inFlightRef = useRef<Promise<void> | null>(null)
   const unmountedRef = useRef(false)
+  const localDraftTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const MIN_SAVING_DISPLAY_MS = 600
+
+  const persistLocalDraft = useCallback(() => {
+    const key = draftKeyRef.current
+    if (!key || contentRef.current === savedContentRef.current) return
+    void set(localDraftDbKey(key), {
+      content: contentRef.current,
+      savedContent: savedContentRef.current,
+    } satisfies LocalDraft).catch((error) => {
+      logger.warn('IndexedDB draft write failed', { key, error })
+    })
+  }, [])
+
+  const clearLocalDraft = useCallback(() => {
+    const key = draftKeyRef.current
+    if (!key) return
+    void del(localDraftDbKey(key)).catch((error) => {
+      logger.warn('IndexedDB draft delete failed', { key, error })
+    })
+  }, [])
 
   const save = useCallback(async () => {
     if (
@@ -106,6 +154,7 @@ export function useAutosave({
       clearTimeout(timerRef.current)
       clearTimeout(idleTimerRef.current)
       clearTimeout(displayTimerRef.current)
+      clearTimeout(localDraftTimerRef.current)
       if (!enabledRef.current || contentRef.current === savedContentRef.current) return
       // Flush the latest content on unmount, but chain it AFTER any in-flight save rather than
       // firing a concurrent PUT: the in-flight save captured an older snapshot, so writing the
@@ -113,11 +162,53 @@ export function useAutosave({
       void (async () => {
         await inFlightRef.current
         if (contentRef.current !== savedContentRef.current) {
-          await onSaveRef.current().catch(() => {})
+          await onSaveRef.current().then(clearLocalDraft, () => {})
         }
       })()
     }
-  }, [])
+  }, [clearLocalDraft])
+
+  const wasDirtyRef = useRef(isDirty)
+
+  useEffect(() => {
+    if (draftKey && !isDirty && wasDirtyRef.current) clearLocalDraft()
+    wasDirtyRef.current = isDirty
+    if (!draftKey || !isDirty) return
+    clearTimeout(localDraftTimerRef.current)
+    localDraftTimerRef.current = setTimeout(persistLocalDraft, LOCAL_DRAFT_DELAY_MS)
+    return () => clearTimeout(localDraftTimerRef.current)
+  }, [content, draftKey, isDirty, persistLocalDraft, clearLocalDraft])
+
+  useEffect(() => {
+    if (!draftKey) return
+    const handleVisibility = () => {
+      if (document.visibilityState === 'hidden') persistLocalDraft()
+    }
+    window.addEventListener('pagehide', persistLocalDraft)
+    document.addEventListener('visibilitychange', handleVisibility)
+    return () => {
+      window.removeEventListener('pagehide', persistLocalDraft)
+      document.removeEventListener('visibilitychange', handleVisibility)
+    }
+  }, [draftKey, persistLocalDraft])
+
+  useEffect(() => {
+    if (!draftKey) return
+    let cancelled = false
+    void get<LocalDraft>(localDraftDbKey(draftKey))
+      .then((draft) => {
+        if (cancelled || !draft || draft.savedContent !== savedContentRef.current) return
+        if (draft.content === draft.savedContent) return
+        if (contentRef.current !== savedContentRef.current) return
+        onRestoreDraftRef.current?.(draft.content)
+      })
+      .catch((error) => {
+        logger.warn('IndexedDB draft read failed', { draftKey, error })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [draftKey])
 
   const saveImmediately = useCallback(async () => {
     clearTimeout(timerRef.current)

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -19,6 +19,20 @@ function localDraftDbKey(draftKey: string) {
   return `autosave-draft:${draftKey}`
 }
 
+const draftOpQueues = new Map<string, Promise<unknown>>()
+
+/** Serializes IndexedDB reads/writes for a given draft key across every `useAutosave` instance (including one that already unmounted), so a late write from a just-unmounted instance can't land after a newly-mounted instance's delete or recovery read. */
+function enqueueDraftOp<T>(key: string, op: () => Promise<T>): Promise<T> {
+  const prev = draftOpQueues.get(key) ?? Promise.resolve()
+  const result = prev.then(op, op)
+  const settled = result.catch(() => {})
+  draftOpQueues.set(key, settled)
+  void settled.then(() => {
+    if (draftOpQueues.get(key) === settled) draftOpQueues.delete(key)
+  })
+  return result
+}
+
 interface UseAutosaveOptions {
   content: string
   savedContent: string
@@ -88,7 +102,6 @@ export function useAutosave({
   const localDraftTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const lastPersistedContentRef = useRef<string | null>(null)
   const discardedRef = useRef(false)
-  const idbQueueRef = useRef<Promise<void>>(Promise.resolve())
   const MIN_SAVING_DISPLAY_MS = 600
 
   if (discardedRef.current && isDirty) discardedRef.current = false
@@ -99,13 +112,12 @@ export function useAutosave({
     if (contentRef.current === lastPersistedContentRef.current) return
     const content = contentRef.current
     const savedContentSnapshot = savedContentRef.current
-    idbQueueRef.current = idbQueueRef.current
-      .then(() =>
-        set(localDraftDbKey(key), {
-          content,
-          savedContent: savedContentSnapshot,
-        } satisfies LocalDraft)
-      )
+    void enqueueDraftOp(key, () =>
+      set(localDraftDbKey(key), {
+        content,
+        savedContent: savedContentSnapshot,
+      } satisfies LocalDraft)
+    )
       .then(() => {
         lastPersistedContentRef.current = content
       })
@@ -118,11 +130,9 @@ export function useAutosave({
     const key = draftKeyRef.current
     lastPersistedContentRef.current = null
     if (!key) return
-    idbQueueRef.current = idbQueueRef.current
-      .then(() => del(localDraftDbKey(key)))
-      .catch((error) => {
-        logger.warn('IndexedDB draft delete failed', { key, error })
-      })
+    void enqueueDraftOp(key, () => del(localDraftDbKey(key))).catch((error) => {
+      logger.warn('IndexedDB draft delete failed', { key, error })
+    })
   }, [])
 
   const save = useCallback(async () => {
@@ -234,7 +244,9 @@ export function useAutosave({
   useEffect(() => {
     if (!effectiveDraftKey) return
     let cancelled = false
-    void get<LocalDraft>(localDraftDbKey(effectiveDraftKey))
+    void enqueueDraftOp(effectiveDraftKey, () =>
+      get<LocalDraft>(localDraftDbKey(effectiveDraftKey))
+    )
       .then((draft) => {
         if (cancelled || !draft) return
         if (draft.savedContent !== savedContentRef.current) {


### PR DESCRIPTION
## Summary
- Removes the Save / Saving... / Save failed button from the Files editor - autosave already ran in the background, so the button was vestigial. Cmd+S still works as a manual trigger.
- Removes the `beforeunload` "leave site?" warning - it only blocked navigation, it never actually saved anything.
- Adds local-first draft persistence to the shared `useAutosave` hook (opt-in via `draftKey`): edits mirror into IndexedDB on a 400ms debounce, independent of the 1.5s network save, and flush best-effort on `visibilitychange`/`pagehide`. On reopen, a newer local draft is silently recovered and resynced.
- Adds a toast (with a Retry action) on save failure, since there's no more persistent status indicator to surface it.
- Fixes a gap where mid-stream agent-edited content could get written into the local draft store and later resurrected as if it were a user edit.
- Fixes a rich-markdown-editor gap where an externally-restored draft updated internal state but never resynced the visible ProseMirror doc.

## Type of Change
- [x] Improvement

## Testing
- Added/updated unit tests for `useAutosave`'s local-draft persistence, recovery, and race-condition guards (`apps/sim/hooks/use-autosave.test.tsx`)
- `bun run type-check` and `biome check` clean on all touched files
- Full existing test suite for the files module (485 tests) and knowledge chunk editor caller path pass unchanged

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)