### PR TITLE
fix(custom-blocks): stop draft-load sanitization deleting consumer-typed input values

### DIFF
--- a/apps/sim/lib/workflows/sanitization/subblocks.test.ts
+++ b/apps/sim/lib/workflows/sanitization/subblocks.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+vi.unmock('@/blocks/registry')
+
+import { migrateSubblockIds } from '@/lib/workflows/migrations/subblock-migrations'
+import { sanitizeMalformedSubBlocks } from '@/lib/workflows/sanitization/subblocks'
+import type { BlockState } from '@/stores/workflows/workflow/types'
+
+const FIELD_ID = 'cd7e4a16-c608-4087-8f2d-61f9672baeda'
+
+/**
+ * A placed custom block whose stored structure only has the wiring sub-blocks.
+ * `getBlock` cannot resolve `custom_block_*` types outside the org overlay —
+ * exactly the draft-load context where sanitization runs.
+ */
+function makeCustomBlock(subBlocks: Record<string, unknown>) {
+  return { id: 'block-1', type: 'custom_block_abc123', subBlocks }
+}
+
+describe('sanitizeMalformedSubBlocks', () => {
+  describe('custom blocks (schema-agnostic)', () => {
+    it('keeps and repairs a consumer-typed field value stored with the realtime "unknown" fallback', () => {
+      const { subBlocks, changed } = sanitizeMalformedSubBlocks(
+        makeCustomBlock({
+          workflowId: { id: 'workflowId', type: 'short-input', value: 'wf-1' },
+          inputMapping: { id: 'inputMapping', type: 'code', value: '{}' },
+          [FIELD_ID]: { id: FIELD_ID, type: 'unknown', value: 'theo' },
+        })
+      )
+
+      expect(changed).toBe(true)
+      expect(subBlocks[FIELD_ID]).toEqual({ id: FIELD_ID, type: 'short-input', value: 'theo' })
+      expect(subBlocks.workflowId.value).toBe('wf-1')
+      expect(subBlocks.inputMapping.value).toBe('{}')
+    })
+
+    it('keeps a raw non-record field value by wrapping it in a repaired entry', () => {
+      const { subBlocks, changed } = sanitizeMalformedSubBlocks(
+        makeCustomBlock({ [FIELD_ID]: 'theo' })
+      )
+
+      expect(changed).toBe(true)
+      expect(subBlocks[FIELD_ID]).toEqual({ id: FIELD_ID, type: 'short-input', value: 'theo' })
+    })
+
+    it('keeps an entry with missing metadata, keying it by the map key', () => {
+      const { subBlocks, changed } = sanitizeMalformedSubBlocks(
+        makeCustomBlock({ [FIELD_ID]: { value: 'theo' } })
+      )
+
+      expect(changed).toBe(true)
+      expect(subBlocks[FIELD_ID]).toEqual({ id: FIELD_ID, type: 'short-input', value: 'theo' })
+    })
+
+    it('leaves well-formed sub-blocks untouched and reports no change', () => {
+      const input = {
+        workflowId: { id: 'workflowId', type: 'short-input', value: 'wf-1' },
+        [FIELD_ID]: { id: FIELD_ID, type: 'short-input', value: 'theo' },
+      }
+      const { subBlocks, changed } = sanitizeMalformedSubBlocks(makeCustomBlock(input))
+
+      expect(changed).toBe(false)
+      expect(subBlocks).toBe(input)
+    })
+
+    it('still drops the literal "undefined" key', () => {
+      const { subBlocks, changed } = sanitizeMalformedSubBlocks(
+        makeCustomBlock({ undefined: { id: 'undefined', type: 'unknown', value: 'x' } })
+      )
+
+      expect(changed).toBe(true)
+      expect(subBlocks).toEqual({})
+    })
+  })
+
+  describe('through migrateSubblockIds (the draft-load migration pipeline)', () => {
+    it('a typed custom-block field value survives the load-time migration pass', () => {
+      const blocks: Record<string, BlockState> = {
+        b1: {
+          id: 'b1',
+          name: 'Update Internal Allowlist 1',
+          position: { x: 0, y: 0 },
+          type: 'custom_block_abc123',
+          subBlocks: {
+            workflowId: { id: 'workflowId', type: 'short-input', value: 'wf-child' },
+            inputMapping: { id: 'inputMapping', type: 'code', value: '{}' },
+            [FIELD_ID]: { id: FIELD_ID, type: 'unknown', value: 'test' },
+          },
+          outputs: {},
+          enabled: true,
+        } as BlockState,
+      }
+
+      const { blocks: migrated, migrated: changed } = migrateSubblockIds(blocks)
+
+      expect(changed).toBe(true)
+      expect(migrated.b1.subBlocks[FIELD_ID]).toEqual({
+        id: FIELD_ID,
+        type: 'short-input',
+        value: 'test',
+      })
+    })
+  })
+
+  describe('regular blocks (config is the schema)', () => {
+    it('still drops an "unknown"-typed entry that matches no configured sub-block', () => {
+      const { subBlocks, changed } = sanitizeMalformedSubBlocks({
+        id: 'block-1',
+        type: 'function',
+        subBlocks: {
+          code: { id: 'code', type: 'code', value: 'return 1' },
+          stale: { id: 'stale', type: 'unknown', value: 'x' },
+        },
+      })
+
+      expect(changed).toBe(true)
+      expect(subBlocks.stale).toBeUndefined()
+      expect(subBlocks.code.value).toBe('return 1')
+    })
+
+    it('repairs an "unknown"-typed entry that matches a configured sub-block', () => {
+      const { subBlocks, changed } = sanitizeMalformedSubBlocks({
+        id: 'block-1',
+        type: 'function',
+        subBlocks: {
+          code: { id: 'code', type: 'unknown', value: 'return 1' },
+        },
+      })
+
+      expect(changed).toBe(true)
+      expect(subBlocks.code).toEqual({ id: 'code', type: 'code', value: 'return 1' })
+    })
+  })
+})

--- a/apps/sim/lib/workflows/sanitization/subblocks.ts
+++ b/apps/sim/lib/workflows/sanitization/subblocks.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import { isPlainRecord } from '@sim/utils/object'
 import { DEFAULT_SUBBLOCK_TYPE } from '@sim/workflow-persistence/subblocks'
 import { getBlock } from '@/blocks'
+import { isCustomBlockType } from '@/blocks/custom/build-config'
 import type { BlockState } from '@/stores/workflows/workflow/types'
 
 const logger = createLogger('WorkflowSubblockSanitization')
@@ -19,6 +20,15 @@ interface SanitizableBlock {
 /**
  * Repairs legacy subBlock metadata when the map key identifies a real field,
  * and drops entries that cannot be associated with a stable subBlock.
+ *
+ * Custom blocks are schema-agnostic here: their server-side config never
+ * declares the per-field input sub-blocks (the execution overlay passes bare
+ * wiring rows, and this may run with no overlay at all), so "not in config"
+ * carries no signal for them. A consumer-typed field value stored via the
+ * realtime `type: 'unknown'` fallback must be repaired to a concrete type and
+ * kept — dropping it would delete user input from the draft. Values for fields
+ * the source workflow no longer has are filtered at serialization/execution
+ * (`customBlockHasDeclaredInputs`, `remapCustomBlockInputKeys`), never at rest.
  */
 export function sanitizeMalformedSubBlocks(
   block: SanitizableBlock,
@@ -26,6 +36,7 @@ export function sanitizeMalformedSubBlocks(
 ): { subBlocks: Record<string, BlockState['subBlocks'][string]>; changed: boolean } {
   let changed = false
   const blockConfig = getBlock(block.type)
+  const schemaAgnostic = isCustomBlockType(block.type)
   const result: Record<string, BlockState['subBlocks'][string]> = {}
 
   for (const [subBlockId, subBlock] of Object.entries(block.subBlocks || {})) {
@@ -38,7 +49,7 @@ export function sanitizeMalformedSubBlocks(
     const configuredType = blockConfig?.subBlocks?.find((config) => config.id === subBlockId)?.type
 
     if (!isPlainRecord(subBlock)) {
-      if (!configuredType) {
+      if (!configuredType && !schemaAgnostic) {
         logger.warn('Skipping malformed subBlock: unrecognized value entry', {
           blockId: block.id,
           subBlockId,
@@ -57,7 +68,7 @@ export function sanitizeMalformedSubBlocks(
       continue
     }
 
-    if (subBlock.type === 'unknown' && !configuredType) {
+    if (subBlock.type === 'unknown' && !configuredType && !schemaAgnostic) {
       logger.warn('Skipping malformed subBlock: type is "unknown"', {
         blockId: block.id,
         subBlockId,
@@ -75,7 +86,7 @@ export function sanitizeMalformedSubBlocks(
       typeof subBlock.type !== 'string' ||
       subBlock.type.length === 0
 
-    if (missingMetadata && !typeFromConfig) {
+    if (missingMetadata && !typeFromConfig && !schemaAgnostic) {
       logger.warn('Skipping malformed subBlock: unrecognized metadata entry', {
         blockId: block.id,
         subBlockId,


### PR DESCRIPTION
## Summary
- `sanitizeMalformedSubBlocks` treated any `type: 'unknown'` sub-block entry with no matching config as malformed and dropped it — then `persistMigratedBlocks` wrote the deletion back to `workflow_blocks`
- for custom blocks the server-side config never declares field sub-blocks (bare overlay wiring only), so every consumer-typed input value stored via the realtime `unknown` fallback was silently deleted on the next draft load (run, deploy, open) — deployments captured `{}` and API runs sent nothing to the child
- exempt `custom_block_*` types from the three not-in-config drops; the existing repair path heals `unknown` → `short-input` and keeps the value. Stale values for deleted fields stay inert: client serialization drops them from params and `remapCustomBlockInputKeys` drops keys matching no current child field
- regular blocks keep the old drop behavior (their config is the schema)

## Type of Change
- [x] Bug fix

## Testing
Unit tests for the sanitizer plus a pipeline test through `migrateSubblockIds` with the registry unmocked (custom block types unresolvable, same as production draft loads); repro'd against the staging incident state. `lint:check` and `check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)