### PR TITLE
fix(pii): install CUDA torch on amd64 so GLiNER can run on GPU

### DIFF
--- a/docker/pii.Dockerfile
+++ b/docker/pii.Dockerfile
@@ -6,10 +6,10 @@
 # gliner package, and the baked GLiNER weights all ship in it, so flipping
 # engines never requires an image swap.
 #
-# GPU variant (EC2-GPU fleet follow-up): same Dockerfile, CUDA torch wheels —
-#   docker build --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128 ...
-# (torch CUDA wheels bundle their own CUDA libs; the host only needs the
-# nvidia container runtime.)
+# ONE image also serves both fleets: the amd64 build ships CUDA torch, which
+# falls back to CPU when no GPU is present, so the Fargate CPU tasks and the
+# EC2-GPU tasks pull the same tag. (torch CUDA wheels bundle their own CUDA
+# libs; the host only needs the nvidia driver + container runtime.)
 #
 # Source files are COPY'd last so code edits never re-download deps or models.
 # ========================================
@@ -47,10 +47,32 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # torch is pinned here (not requirements-gliner.txt) because the CPU and CUDA
 # builds install the same version from different wheel indexes. 2.11.0 is the
 # newest release published on both the cpu and cu128 indexes for py312.
+#
+# cu128's arch list keeps sm_75, the compute capability of the GPU fleet's T4s.
+# cu121 could not serve this pin anyway — that index stops at torch 2.5.1.
+# CUDA 12.8 needs an NVIDIA driver >=525 via minor-version compatibility, which
+# the ECS GPU AMI's nvidia-driver-latest-dkms satisfies.
+#
+# arm64 takes the cpu index: cu128 publishes no aarch64 wheel at 2.11.0, and no
+# arm64 target has a GPU.
 ARG TORCH_VERSION=2.11.0
-ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
+ARG TORCH_CUDA_INDEX_URL=https://download.pytorch.org/whl/cu128
+ARG TORCH_CPU_INDEX_URL=https://download.pytorch.org/whl/cpu
+ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install torch==${TORCH_VERSION} --index-url ${TORCH_INDEX_URL}
+    case "${TARGETARCH}" in \
+      amd64) torch_index="${TORCH_CUDA_INDEX_URL}" ;; \
+      arm64) torch_index="${TORCH_CPU_INDEX_URL}" ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    pip install torch==${TORCH_VERSION} --index-url "${torch_index}"
+
+# A CPU-only wheel on amd64 silently degrades to the "torch.cuda.is_available()
+# is False" crash only once GLiNER loads on a GPU host, so assert at build time.
+RUN python -c "import torch; \
+have = torch.version.cuda is not None; \
+want = '${TARGETARCH}' == 'amd64'; \
+assert have == want, f'{torch.__version__}: cuda build={have}, expected={want}'"
 
 COPY apps/pii/requirements-gliner.txt ./requirements-gliner.txt
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/docker/pii.Dockerfile
+++ b/docker/pii.Dockerfile
@@ -67,13 +67,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     esac && \
     pip install torch==${TORCH_VERSION} --index-url "${torch_index}"
 
-# A CPU-only wheel on amd64 silently degrades to the "torch.cuda.is_available()
-# is False" crash only once GLiNER loads on a GPU host, so assert at build time.
-RUN python -c "import torch; \
-have = torch.version.cuda is not None; \
-want = '${TARGETARCH}' == 'amd64'; \
-assert have == want, f'{torch.__version__}: cuda build={have}, expected={want}'"
-
 COPY apps/pii/requirements-gliner.txt ./requirements-gliner.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements-gliner.txt
@@ -105,6 +98,15 @@ ENV HF_HUB_OFFLINE=1
 COPY apps/pii/requirements-dev.txt ./requirements-dev.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements-dev.txt
+
+# Runs after every pip install, because the requirements above resolve against
+# PyPI and could swap the wheel torch_index chose. A cpu-only torch on amd64
+# otherwise surfaces only as "torch.cuda.is_available() is False" once GLiNER
+# loads on a GPU host.
+RUN python -c "import torch; \
+have = torch.version.cuda is not None; \
+want = '${TARGETARCH}' == 'amd64'; \
+assert have == want, f'{torch.__version__}: cuda build={have}, expected={want}'"
 
 RUN groupadd -g 1001 pii && \
     useradd -u 1001 -g pii pii && \


### PR DESCRIPTION
## Problem

The published `sim/pii` image installs a **CPU-only** torch build. On the ECS GPU fleet (g4dn.xlarge / NVIDIA T4), running with `PII_ENGINE=gliner` + `PII_DEVICE=cuda` crashes at model load:

```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False.
```

The GPU is genuinely attached — the nvidia container runtime injects it. The image's torch simply has no CUDA compiled in.

`docker/pii.Dockerfile` already had an `ARG TORCH_INDEX_URL` defaulting to `.../whl/cpu`, with a comment saying the GPU variant just needs `--build-arg`. But **no CI job ever passes a build arg**, so every published image silently took the CPU default.

## Fix

Select the wheel index from Docker's built-in `TARGETARCH`:

- **amd64 → `cu128`** (GPU-capable; also runs on CPU)
- **arm64 → `cpu`**

A CUDA torch falls back to CPU when no GPU is present, so **one image keeps serving both** the Fargate CPU tasks and the EC2 GPU tasks from the same `sim/pii:staging` tag. **No `ci.yml` change, no CDK change** — rebuild and push, then re-enable the infra flag.

Also adds a build-time assert so an amd64 image can never silently regress to a `+cpu` wheel again — that failure currently only surfaces at GLiNER load time on a GPU host.

## Why cu128, and why arm64 is different

- **`cu121` was never viable.** That index stops at **torch 2.5.1**; using it would downgrade the 2.11.0 pin by six minor versions.
- **cu128 keeps Turing.** Per pytorch `v2.11.0` `.ci/manywheel/build_cuda.sh`, the `12.8)` case yields `7.5;8.0;8.6;9.0;10.0;12.0` — `7.5` is the T4.
- **Driver floor is met.** CUDA 12.x minor-version compatibility needs driver `>=525`. `amzn2-ami-ecs-gpu-hvm-2.0.20260707-x86_64-ebs` installs `nvidia-driver-latest-dkms` (>=535).
- **arm64 must stay CPU.** cu128 publishes **no aarch64 wheel at 2.11.0** (it stops at 2.9.1), and the `build-ghcr-arm64` job builds this same Dockerfile for `linux/arm64`. A blanket CUDA default would break that job.
- **No CUDA base image needed.** The pip CUDA wheels bundle their own runtime (`cudnn`, `cublas`, `cuda_runtime`, …); the host AMI supplies the driver. Base stays `python:3.12-slim-bookworm`.

## Verification

Built the changed block for `linux/amd64` and ran it:

```
VER   2.11.0+cu128
CUDA  12.8
AVAIL False          <- expected: no GPU on the build box
ARCH  sm_75 sm_80 sm_86 sm_90 sm_100 sm_120
```

`torch.version.cuda` is set (a CUDA build, not `+cpu`) and `sm_75` is present, which is the root cause addressed. CUDA runtime libs ship in the image (`nvidia/{cublas,cudnn,cuda_runtime,nccl,...}`, `libtorch_cuda.so` ~912 MB).

`linux/arm64` build resolves to `2.11.0+cpu` / `cuda=None`, and the assert passes on both arches.

> Note: `torch.cuda.get_arch_list()` early-returns `[]` with no GPU present — `torch._C._cuda_getArchFlags()` is the correct accessor on a CPU box.

## Cost

torch wheel **181 MB → 782 MB**, plus the `nvidia-*` runtime packages: roughly **+3-4 GB** installed. The Fargate CPU tasks pull that too. Accepted in exchange for one image, one tag, and zero infra changes.

## Not verified here

The gated CPU-path suite (`RUN_PII_INTEGRATION=1 PII_DEVICE=cpu python -m pytest tests`) needs a full ~13 GB image build, which is emulated on an arm64 dev box. Device plumbing is untouched (`server.py:34` maps unset `PII_DEVICE` to `None` → auto-detect → cpu), and `torch.cuda.is_available()` is `False` without a GPU, so the CPU path behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHNEWVrh7k89m8Wtqzhs18