### PR TITLE
fix(uploads): fix Azure Blob connection-string-only auth and document self-host parity

### DIFF
--- a/apps/sim/.env.example
+++ b/apps/sim/.env.example
@@ -93,6 +93,19 @@ API_ENCRYPTION_KEY=your_api_encryption_key # Use `openssl rand -hex 32` to gener
 # S3_ENDPOINT=                                    # Custom endpoint for S3-compatible storage (Cloudflare R2, MinIO, Backblaze B2). Leave unset for AWS S3
 # S3_FORCE_PATH_STYLE=true                        # Required for MinIO/Ceph RGW. Leave unset for AWS S3 and R2
 
+# Azure Blob Storage takes precedence over S3 if both are configured
+# AZURE_ACCOUNT_NAME=                             # Azure storage account name
+# AZURE_ACCOUNT_KEY=                              # Azure storage account key
+# AZURE_CONNECTION_STRING=                        # Alternative to account name/key
+# AZURE_STORAGE_CONTAINER_NAME=                   # General workspace files container
+# AZURE_STORAGE_KB_CONTAINER_NAME=                # Knowledge base documents
+# AZURE_STORAGE_EXECUTION_FILES_CONTAINER_NAME=   # Workflow execution files
+# AZURE_STORAGE_CHAT_CONTAINER_NAME=              # Deployed chat assets
+# AZURE_STORAGE_COPILOT_CONTAINER_NAME=           # Copilot attachments
+# AZURE_STORAGE_PROFILE_PICTURES_CONTAINER_NAME=  # User profile pictures
+# AZURE_STORAGE_OG_IMAGES_CONTAINER_NAME=         # OpenGraph preview images (falls back to AZURE_STORAGE_CONTAINER_NAME)
+# AZURE_STORAGE_WORKSPACE_LOGOS_CONTAINER_NAME=   # Workspace logos (falls back to AZURE_STORAGE_CONTAINER_NAME)
+
 # Admin API (Optional - for self-hosted GitOps)
 # ADMIN_API_KEY=  # Use `openssl rand -hex 32` to generate. Enables admin API for workflow export/import.
                   # Usage: curl -H "x-admin-key: your_key" https://your-instance/api/v1/admin/workspaces

--- a/apps/sim/lib/uploads/core/storage-service.blob-connection-string.test.ts
+++ b/apps/sim/lib/uploads/core/storage-service.blob-connection-string.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests: Azure Blob storage must be fully usable with ONLY
+ * AZURE_CONNECTION_STRING set (no AZURE_ACCOUNT_NAME/AZURE_ACCOUNT_KEY) — this
+ * is the connection-string auth mode documented as a standalone alternative
+ * across .env.example, helm/sim/values.yaml, and env.ts.
+ *
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const CONNECTION_STRING =
+  'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
+
+const { mockHeadBlobObject, mockGetBlobServiceClient, mockGenerateBlobSASQueryParameters } =
+  vi.hoisted(() => ({
+    mockHeadBlobObject: vi.fn(),
+    mockGetBlobServiceClient: vi.fn(),
+    mockGenerateBlobSASQueryParameters: vi.fn(() => ({ toString: () => 'sig=fake' })),
+  }))
+
+vi.mock('@/lib/uploads/config', () => ({
+  USE_S3_STORAGE: false,
+  USE_BLOB_STORAGE: true,
+  // Connection-string-only: accountName/accountKey intentionally absent.
+  getStorageConfig: () => ({
+    containerName: 'workspace-files',
+    accountName: undefined,
+    accountKey: undefined,
+    connectionString: CONNECTION_STRING,
+  }),
+}))
+
+vi.mock('@/lib/uploads/providers/blob/client', () => ({
+  headBlobObject: mockHeadBlobObject,
+  getBlobServiceClient: mockGetBlobServiceClient,
+  parseConnectionString: (connectionString: string) => {
+    const accountName = connectionString.match(/AccountName=([^;]+)/)?.[1]
+    const accountKey = connectionString.match(/AccountKey=([^;]+)/)?.[1]
+    if (!accountName || !accountKey) throw new Error('cannot parse')
+    return { accountName, accountKey }
+  },
+}))
+
+vi.mock('@azure/storage-blob', () => ({
+  StorageSharedKeyCredential: vi.fn(),
+  BlobSASPermissions: { parse: vi.fn(() => 'w') },
+  generateBlobSASQueryParameters: mockGenerateBlobSASQueryParameters,
+}))
+
+import { generatePresignedUploadUrl, headObject } from '@/lib/uploads/core/storage-service'
+
+describe('Azure Blob storage — connection-string-only auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockHeadBlobObject.mockResolvedValue({ size: 42, contentType: 'text/plain' })
+    mockGetBlobServiceClient.mockResolvedValue({
+      getContainerClient: () => ({
+        getBlockBlobClient: () => ({ url: 'https://devstoreaccount1.blob.core.windows.net/c/k' }),
+      }),
+    })
+  })
+
+  it('headObject does not throw when only connectionString is configured', async () => {
+    await expect(headObject('some-key', 'workspace')).resolves.toEqual({
+      size: 42,
+      contentType: 'text/plain',
+    })
+    expect(mockHeadBlobObject).toHaveBeenCalled()
+  })
+
+  it('generatePresignedUploadUrl derives SAS credentials from connectionString when accountName/accountKey are absent', async () => {
+    const result = await generatePresignedUploadUrl({
+      fileName: 'report.csv',
+      contentType: 'text/csv',
+      context: 'workspace',
+      fileSize: 100,
+    })
+
+    expect(mockGenerateBlobSASQueryParameters).toHaveBeenCalled()
+    expect(result.url).toContain('sig=fake')
+  })
+})

--- a/apps/sim/lib/uploads/core/storage-service.ts
+++ b/apps/sim/lib/uploads/core/storage-service.ts
@@ -29,13 +29,13 @@ const logger = createLogger('StorageService')
  * @throws Error if required properties are missing
  */
 function createBlobConfig(config: StorageConfig): BlobConfig {
-  if (!config.containerName || !config.accountName) {
-    throw new Error('Blob configuration missing required properties: containerName and accountName')
+  if (!config.containerName) {
+    throw new Error('Blob configuration missing required property: containerName')
   }
 
-  if (!config.connectionString && !config.accountKey) {
+  if (!config.connectionString && !(config.accountName && config.accountKey)) {
     throw new Error(
-      'Blob configuration missing authentication: either connectionString or accountKey must be provided'
+      'Blob configuration missing authentication: either connectionString or both accountName and accountKey must be provided'
     )
   }
 
@@ -635,7 +635,9 @@ async function generateBlobPresignedUrl(
   },
   expirationSeconds: number
 ): Promise<PresignedUrlResponse> {
-  const { getBlobServiceClient } = await import('@/lib/uploads/providers/blob/client')
+  const { getBlobServiceClient, parseConnectionString } = await import(
+    '@/lib/uploads/providers/blob/client'
+  )
   const { BlobSASPermissions, generateBlobSASQueryParameters, StorageSharedKeyCredential } =
     await import('@azure/storage-blob')
 
@@ -650,26 +652,29 @@ async function generateBlobPresignedUrl(
   const startsOn = new Date()
   const expiresOn = new Date(startsOn.getTime() + expirationSeconds * 1000)
 
-  let sasToken: string
-
-  if (config.accountName && config.accountKey) {
-    const sharedKeyCredential = new StorageSharedKeyCredential(
-      config.accountName,
-      config.accountKey
-    )
-    sasToken = generateBlobSASQueryParameters(
-      {
-        containerName: config.containerName,
-        blobName: key,
-        permissions: BlobSASPermissions.parse('w'), // write permission for upload
-        startsOn,
-        expiresOn,
-      },
-      sharedKeyCredential
-    ).toString()
-  } else {
-    throw new Error('Azure Blob SAS generation requires accountName and accountKey')
+  let accountName = config.accountName
+  let accountKey = config.accountKey
+  if ((!accountName || !accountKey) && config.connectionString) {
+    ;({ accountName, accountKey } = parseConnectionString(config.connectionString))
   }
+
+  if (!accountName || !accountKey) {
+    throw new Error(
+      'Azure Blob SAS generation requires accountName/accountKey or a connectionString'
+    )
+  }
+
+  const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey)
+  const sasToken = generateBlobSASQueryParameters(
+    {
+      containerName: config.containerName,
+      blobName: key,
+      permissions: BlobSASPermissions.parse('w'), // write permission for upload
+      startsOn,
+      expiresOn,
+    },
+    sharedKeyCredential
+  ).toString()
 
   return {
     url: `${blobClient.url}?${sasToken}`,

--- a/apps/sim/lib/uploads/providers/blob/client.test.ts
+++ b/apps/sim/lib/uploads/providers/blob/client.test.ts
@@ -54,6 +54,7 @@ import {
   deleteFromBlob,
   downloadFromBlob,
   getPresignedUrl,
+  parseConnectionString,
   uploadToBlob,
 } from '@/lib/uploads/providers/blob/client'
 import { sanitizeFilenameForMetadata } from '@/lib/uploads/utils/file-utils'
@@ -204,6 +205,27 @@ describe('Azure Blob Storage Client', () => {
       expect(mockGenerateBlobSASQueryParameters).toHaveBeenCalled()
       expect(result).toContain('https://test.blob.core.windows.net/container/test-file')
       expect(result).toContain('sv=2021-06-08')
+    })
+  })
+
+  describe('parseConnectionString', () => {
+    it('extracts accountName and accountKey from a well-formed connection string', () => {
+      const result = parseConnectionString(
+        'DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey123;EndpointSuffix=core.windows.net'
+      )
+      expect(result).toEqual({ accountName: 'myaccount', accountKey: 'mykey123' })
+    })
+
+    it('throws when AccountName is missing', () => {
+      expect(() =>
+        parseConnectionString('DefaultEndpointsProtocol=https;AccountKey=mykey123')
+      ).toThrow('Cannot extract account name from connection string')
+    })
+
+    it('throws when AccountKey is missing', () => {
+      expect(() =>
+        parseConnectionString('DefaultEndpointsProtocol=https;AccountName=myaccount')
+      ).toThrow('Cannot extract account key from connection string')
     })
   })
 

--- a/apps/sim/lib/uploads/providers/blob/client.ts
+++ b/apps/sim/lib/uploads/providers/blob/client.ts
@@ -30,7 +30,7 @@ interface ParsedCredentials {
  * Extract account name and key from an Azure connection string.
  * Connection strings have the format: DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=...
  */
-function parseConnectionString(connectionString: string): ParsedCredentials {
+export function parseConnectionString(connectionString: string): ParsedCredentials {
   const accountNameMatch = connectionString.match(/AccountName=([^;]+)/)
   if (!accountNameMatch) {
     throw new Error('Cannot extract account name from connection string')

--- a/apps/sim/lib/uploads/providers/blob/types.ts
+++ b/apps/sim/lib/uploads/providers/blob/types.ts
@@ -1,6 +1,6 @@
 export interface BlobConfig {
   containerName: string
-  accountName: string
+  accountName?: string
   accountKey?: string
   connectionString?: string
 }

--- a/helm/sim/examples/values-azure.yaml
+++ b/helm/sim/examples/values-azure.yaml
@@ -320,5 +320,11 @@ ingressInternal:
 #       # AZURE_CONNECTION_STRING: "sim-azure-storage-connection-string"
 #       OCR_AZURE_API_KEY:       "sim-azure-ocr-api-key"
 #       AZURE_ACS_CONNECTION_STRING: "sim-azure-acs-connection-string"
+#       # Non-secret config (deployment names, endpoints) — still required here: ESO mode requires
+#       # every non-empty app.env key to be mapped, even ones that aren't sensitive.
+#       KB_OPENAI_MODEL_NAME:    "sim-kb-openai-model-name"
+#       WAND_OPENAI_MODEL_NAME:  "sim-wand-openai-model-name"
+#       OCR_AZURE_ENDPOINT:      "sim-azure-ocr-endpoint"
+#       OCR_AZURE_MODEL_NAME:    "sim-azure-ocr-model-name"
 #     postgresql:
 #       password: "sim-postgresql-password"

--- a/helm/sim/examples/values-azure.yaml
+++ b/helm/sim/examples/values-azure.yaml
@@ -98,6 +98,16 @@ app:
     AZURE_ANTHROPIC_API_KEY: ""                           # Azure Anthropic API key
     AZURE_ANTHROPIC_API_VERSION: ""                       # Azure Anthropic API version (e.g., 2023-06-01)
     NEXT_PUBLIC_AZURE_CONFIGURED: "true"                  # Set to "true" once credentials are configured above
+    KB_OPENAI_MODEL_NAME: ""                              # Azure deployment name serving the KB embedding model (used only when AZURE_OPENAI_* is set)
+    WAND_OPENAI_MODEL_NAME: ""                            # Wand generation model deployment name
+
+    # Azure Mistral OCR (optional — Azure-hosted document OCR for knowledge base processing)
+    OCR_AZURE_ENDPOINT: ""                                # Azure Mistral OCR service endpoint
+    OCR_AZURE_MODEL_NAME: ""                              # Azure Mistral OCR model name
+    OCR_AZURE_API_KEY: ""                                 # Azure Mistral OCR API key
+
+    # Email — Azure Communication Services (recommended on Azure; alternative to Resend/SES/SMTP)
+    AZURE_ACS_CONNECTION_STRING: ""                       # Azure Communication Services connection string
 
     # Azure Blob Storage Configuration (RECOMMENDED for production)
     # Create a storage account and containers in your Azure subscription
@@ -308,5 +318,7 @@ ingressInternal:
 #       AZURE_ACCOUNT_KEY:       "sim-azure-storage-account-key"
 #       # Use AZURE_CONNECTION_STRING instead if you prefer a single connection string:
 #       # AZURE_CONNECTION_STRING: "sim-azure-storage-connection-string"
+#       OCR_AZURE_API_KEY:       "sim-azure-ocr-api-key"
+#       AZURE_ACS_CONNECTION_STRING: "sim-azure-acs-connection-string"
 #     postgresql:
 #       password: "sim-postgresql-password"

--- a/helm/sim/values.schema.json
+++ b/helm/sim/values.schema.json
@@ -186,6 +186,10 @@
               "type": "string",
               "description": "AWS region for SES (e.g., 'us-east-1'). Credentials are resolved via the standard AWS provider chain (env vars, IRSA, EC2/ECS task role, SSO)."
             },
+            "AZURE_ACS_CONNECTION_STRING": {
+              "type": "string",
+              "description": "Azure Communication Services connection string (email provider — used when Resend/SES/SMTP are not configured)."
+            },
             "SMTP_HOST": {
               "type": "string",
               "description": "SMTP server hostname. When set together with SMTP_PORT, enables the SMTP mail provider."
@@ -269,6 +273,26 @@
             "ELEVENLABS_API_KEY": {
               "type": "string",
               "description": "ElevenLabs API key for text-to-speech in deployed chat"
+            },
+            "KB_OPENAI_MODEL_NAME": {
+              "type": "string",
+              "description": "Azure deployment name serving the configured KB embedding model (used only when AZURE_OPENAI_* credentials are set)."
+            },
+            "WAND_OPENAI_MODEL_NAME": {
+              "type": "string",
+              "description": "Wand generation model deployment name (works with both regular OpenAI and Azure OpenAI)."
+            },
+            "OCR_AZURE_ENDPOINT": {
+              "type": "string",
+              "description": "Azure Mistral OCR service endpoint."
+            },
+            "OCR_AZURE_MODEL_NAME": {
+              "type": "string",
+              "description": "Azure Mistral OCR model name."
+            },
+            "OCR_AZURE_API_KEY": {
+              "type": "string",
+              "description": "Azure Mistral OCR API key."
             },
             "RATE_LIMIT_WINDOW_MS": {
               "type": "string",

--- a/helm/sim/values.yaml
+++ b/helm/sim/values.yaml
@@ -117,6 +117,7 @@ app:
     FROM_EMAIL_ADDRESS: ""                                # Complete from address (e.g., "Sim <noreply@domain.com>" or "DoNotReply@domain.com")
     EMAIL_DOMAIN: ""                                      # Domain for sending emails (fallback when FROM_EMAIL_ADDRESS not set)
     AWS_SES_REGION: ""                                    # AWS region for SES (e.g., "us-east-1"); credentials resolved via the standard AWS provider chain (env, IRSA, instance profile)
+    AZURE_ACS_CONNECTION_STRING: ""                       # Azure Communication Services connection string (email provider — used when Resend/SES/SMTP are not configured)
     SMTP_HOST: ""                                         # SMTP server hostname (alternative to Resend/SES)
     SMTP_PORT: ""                                         # SMTP server port (465 for TLS, 587 for STARTTLS, 25 for plain)
     SMTP_USER: ""                                         # SMTP username (optional — omit for unauthenticated relays like MailHog)
@@ -145,6 +146,13 @@ app:
     AZURE_ANTHROPIC_ENDPOINT: ""                          # Azure AI Foundry endpoint for Anthropic models
     AZURE_ANTHROPIC_API_KEY: ""                           # Azure Anthropic API key
     AZURE_ANTHROPIC_API_VERSION: ""                       # Azure Anthropic API version (e.g., 2023-06-01)
+    KB_OPENAI_MODEL_NAME: ""                              # Azure deployment name serving the configured KB embedding model (used only when AZURE_OPENAI_* credentials are set)
+    WAND_OPENAI_MODEL_NAME: ""                            # Wand generation model deployment name (works with both regular OpenAI and Azure OpenAI)
+
+    # Azure Mistral OCR Configuration (leave empty if not using Azure-hosted OCR for document processing)
+    OCR_AZURE_ENDPOINT: ""                                # Azure Mistral OCR service endpoint
+    OCR_AZURE_MODEL_NAME: ""                              # Azure Mistral OCR model name
+    OCR_AZURE_API_KEY: ""                                 # Azure Mistral OCR API key
 
     # AI Provider API Keys (leave empty if not using)
     OPENAI_API_KEY: ""                                    # Primary OpenAI API key


### PR DESCRIPTION
## Summary
- Fixed a bug where every Azure Blob storage operation (upload, download, delete, head, presigned URLs) threw at runtime when only `AZURE_CONNECTION_STRING` was set — even though that's the documented alternative to `AZURE_ACCOUNT_NAME`/`AZURE_ACCOUNT_KEY` across `.env.example`, `env.ts`, and the Helm chart
- Fixed a second related bug: presigned upload (SAS) URL generation for Azure Blob had no fallback to derive credentials from the connection string, unlike the sibling download-URL path
- Verified the full Azure Blob code path end-to-end against a live Azurite emulator — upload, download, head, delete, multipart/block-blob upload, and real HTTP PUT/GET through generated SAS URLs — using the connection-string-only config
- Added regression tests for both bugs (confirmed they fail on the pre-fix code)
- Documented the remaining Azure self-host env vars that were missing from the Helm chart and `.env.example`: `AZURE_ACS_CONNECTION_STRING` (email), `OCR_AZURE_*` (OCR), `KB_OPENAI_MODEL_NAME`, `WAND_OPENAI_MODEL_NAME`

## Type of Change
- [x] Bug fix

## Testing
- Live verification against Azurite emulator (upload/download/head/delete/multipart/presigned SAS PUT+GET) using connection-string-only auth
- `bun run type-check`, `biome check`, `bun run vitest run lib/uploads/` (127/127 passing) all clean
- `helm lint` + `helm template` against base chart and Azure example profile
- `bun run check:api-validation` passes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)