### PR TITLE
fix(models): correct model catalog data and Gemini thinking-config wire format

### DIFF
--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -344,8 +344,9 @@ export async function executeAnthropicProviderRequest(
         payload.output_config = thinkingConfig.outputConfig
       }
 
-      // Per Anthropic docs: budget_tokens must be >= 1024 and less than max_tokens.
-      // Ensure max_tokens leaves room for both thinking and text output.
+      // Keep budget_tokens < max_tokens (see constants above) by shrinking the budget
+      // itself when the model's output cap is too tight — clamping max_tokens alone
+      // can leave budget_tokens >= max_tokens.
       if (
         thinkingConfig.thinking.type === 'enabled' &&
         'budget_tokens' in thinkingConfig.thinking
@@ -353,9 +354,6 @@ export async function executeAnthropicProviderRequest(
         const modelMax = getMaxOutputTokensForModel(request.model)
         let budgetTokens = thinkingConfig.thinking.budget_tokens
 
-        // If this level's budget doesn't leave room for text output within the
-        // model's own output cap, shrink the budget itself (not just max_tokens) —
-        // otherwise clamping max_tokens alone can leave budget_tokens >= max_tokens.
         if (budgetTokens + ANTHROPIC_THINKING_OUTPUT_HEADROOM > modelMax) {
           budgetTokens = Math.max(
             ANTHROPIC_MIN_BUDGET_TOKENS,

--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -82,6 +82,12 @@ const THINKING_BUDGET_TOKENS: Record<string, number> = {
   high: 32768,
 }
 
+/** Anthropic's documented floor for `budget_tokens` (Messages API reference: "Must be >=1024 and less than max_tokens"). */
+const ANTHROPIC_MIN_BUDGET_TOKENS = 1024
+
+/** Headroom reserved for text output above the thinking budget when computing max_tokens. */
+const ANTHROPIC_THINKING_OUTPUT_HEADROOM = 4096
+
 /**
  * Checks if a model supports adaptive thinking (thinking.type: "adaptive").
  * Fable 5 supports ONLY adaptive thinking (always on; type: "disabled" is rejected).
@@ -338,16 +344,28 @@ export async function executeAnthropicProviderRequest(
         payload.output_config = thinkingConfig.outputConfig
       }
 
-      // Per Anthropic docs: budget_tokens must be less than max_tokens.
+      // Per Anthropic docs: budget_tokens must be >= 1024 and less than max_tokens.
       // Ensure max_tokens leaves room for both thinking and text output.
       if (
         thinkingConfig.thinking.type === 'enabled' &&
         'budget_tokens' in thinkingConfig.thinking
       ) {
-        const budgetTokens = thinkingConfig.thinking.budget_tokens
-        const minMaxTokens = budgetTokens + 4096
+        const modelMax = getMaxOutputTokensForModel(request.model)
+        let budgetTokens = thinkingConfig.thinking.budget_tokens
+
+        // If this level's budget doesn't leave room for text output within the
+        // model's own output cap, shrink the budget itself (not just max_tokens) —
+        // otherwise clamping max_tokens alone can leave budget_tokens >= max_tokens.
+        if (budgetTokens + ANTHROPIC_THINKING_OUTPUT_HEADROOM > modelMax) {
+          budgetTokens = Math.max(
+            ANTHROPIC_MIN_BUDGET_TOKENS,
+            modelMax - ANTHROPIC_THINKING_OUTPUT_HEADROOM
+          )
+          thinkingConfig.thinking.budget_tokens = budgetTokens
+        }
+
+        const minMaxTokens = budgetTokens + ANTHROPIC_THINKING_OUTPUT_HEADROOM
         if (payload.max_tokens < minMaxTokens) {
-          const modelMax = getMaxOutputTokensForModel(request.model)
           payload.max_tokens = Math.min(minMaxTokens, modelMax)
           logger.info(
             `Adjusted max_tokens to ${payload.max_tokens} to satisfy budget_tokens (${budgetTokens}) constraint`

--- a/apps/sim/providers/gemini/core.ts
+++ b/apps/sim/providers/gemini/core.ts
@@ -954,9 +954,7 @@ export async function executeGeminiRequest(
       )
     }
 
-    // Configure thinking based on the user's selected level.
-    // Gemini 3.x accepts thinkingLevel directly; Gemini 2.5-series rejects thinkingLevel
-    // entirely and requires a numeric thinkingBudget instead.
+    // Gemini 3.x takes thinkingLevel directly; Gemini 2.5-series rejects it and needs thinkingBudget.
     if (request.thinkingLevel && request.thinkingLevel !== 'none') {
       const thinkingConfig: ThinkingConfig = { includeThoughts: false }
       if (isGemini3Model(model)) {
@@ -970,8 +968,8 @@ export async function executeGeminiRequest(
       !isGemini3Model(model) &&
       supportsDisablingGemini25Thinking(model)
     ) {
-      // Omitting thinkingConfig entirely falls back to the API's own dynamic default, which
-      // is ON for gemini-2.5-flash — an explicit budget of 0 is required to actually disable it.
+      // Omitting thinkingConfig falls back to the API's dynamic default (ON for gemini-2.5-flash),
+      // so disabling requires an explicit budget of 0.
       geminiConfig.thinkingConfig = { includeThoughts: false, thinkingBudget: 0 }
     }
 

--- a/apps/sim/providers/gemini/core.ts
+++ b/apps/sim/providers/gemini/core.ts
@@ -24,6 +24,7 @@ import {
   ensureStructResponse,
   extractAllFunctionCallParts,
   extractTextContent,
+  mapToThinkingBudget,
   mapToThinkingLevel,
 } from '@/providers/google/utils'
 import { enrichLastModelSegment } from '@/providers/trace-enrichment'
@@ -952,11 +953,15 @@ export async function executeGeminiRequest(
       )
     }
 
-    // Configure thinking only when the user explicitly selects a thinking level
+    // Configure thinking only when the user explicitly selects a thinking level.
+    // Gemini 3.x accepts thinkingLevel directly; Gemini 2.5-series rejects thinkingLevel
+    // entirely and requires a numeric thinkingBudget instead.
     if (request.thinkingLevel && request.thinkingLevel !== 'none') {
-      const thinkingConfig: ThinkingConfig = {
-        includeThoughts: false,
-        thinkingLevel: mapToThinkingLevel(request.thinkingLevel),
+      const thinkingConfig: ThinkingConfig = { includeThoughts: false }
+      if (isGemini3Model(model)) {
+        thinkingConfig.thinkingLevel = mapToThinkingLevel(request.thinkingLevel)
+      } else {
+        thinkingConfig.thinkingBudget = mapToThinkingBudget(model, request.thinkingLevel)
       }
       geminiConfig.thinkingConfig = thinkingConfig
     }

--- a/apps/sim/providers/gemini/core.ts
+++ b/apps/sim/providers/gemini/core.ts
@@ -26,6 +26,7 @@ import {
   extractTextContent,
   mapToThinkingBudget,
   mapToThinkingLevel,
+  supportsDisablingGemini25Thinking,
 } from '@/providers/google/utils'
 import { enrichLastModelSegment } from '@/providers/trace-enrichment'
 import type {
@@ -953,7 +954,7 @@ export async function executeGeminiRequest(
       )
     }
 
-    // Configure thinking only when the user explicitly selects a thinking level.
+    // Configure thinking based on the user's selected level.
     // Gemini 3.x accepts thinkingLevel directly; Gemini 2.5-series rejects thinkingLevel
     // entirely and requires a numeric thinkingBudget instead.
     if (request.thinkingLevel && request.thinkingLevel !== 'none') {
@@ -964,6 +965,14 @@ export async function executeGeminiRequest(
         thinkingConfig.thinkingBudget = mapToThinkingBudget(model, request.thinkingLevel)
       }
       geminiConfig.thinkingConfig = thinkingConfig
+    } else if (
+      request.thinkingLevel === 'none' &&
+      !isGemini3Model(model) &&
+      supportsDisablingGemini25Thinking(model)
+    ) {
+      // Omitting thinkingConfig entirely falls back to the API's own dynamic default, which
+      // is ON for gemini-2.5-flash — an explicit budget of 0 is required to actually disable it.
+      geminiConfig.thinkingConfig = { includeThoughts: false, thinkingBudget: 0 }
     }
 
     // Prepare tools

--- a/apps/sim/providers/google/utils.test.ts
+++ b/apps/sim/providers/google/utils.test.ts
@@ -6,6 +6,7 @@ import {
   convertToGeminiFormat,
   ensureStructResponse,
   mapToThinkingBudget,
+  supportsDisablingGemini25Thinking,
 } from '@/providers/google/utils'
 import type { ProviderRequest } from '@/providers/types'
 
@@ -39,6 +40,26 @@ describe('mapToThinkingBudget', () => {
     expect(mapToThinkingBudget('gemini-2.5-flash', 'unknown-level')).toBe(
       mapToThinkingBudget('gemini-2.5-flash', 'high')
     )
+  })
+})
+
+describe('supportsDisablingGemini25Thinking', () => {
+  it('returns true for gemini-2.5-flash and gemini-2.5-flash-lite', () => {
+    expect(supportsDisablingGemini25Thinking('gemini-2.5-flash')).toBe(true)
+    expect(supportsDisablingGemini25Thinking('gemini-2.5-flash-lite')).toBe(true)
+  })
+
+  it('returns false for gemini-2.5-pro, which cannot disable thinking', () => {
+    expect(supportsDisablingGemini25Thinking('gemini-2.5-pro')).toBe(false)
+  })
+
+  it('strips the vertex/ prefix before checking', () => {
+    expect(supportsDisablingGemini25Thinking('vertex/gemini-2.5-flash')).toBe(true)
+    expect(supportsDisablingGemini25Thinking('vertex/gemini-2.5-pro')).toBe(false)
+  })
+
+  it('returns false for models with no explicit mapping', () => {
+    expect(supportsDisablingGemini25Thinking('gemini-3.5-flash')).toBe(false)
   })
 })
 

--- a/apps/sim/providers/google/utils.test.ts
+++ b/apps/sim/providers/google/utils.test.ts
@@ -2,8 +2,45 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from 'vitest'
-import { convertToGeminiFormat, ensureStructResponse } from '@/providers/google/utils'
+import {
+  convertToGeminiFormat,
+  ensureStructResponse,
+  mapToThinkingBudget,
+} from '@/providers/google/utils'
 import type { ProviderRequest } from '@/providers/types'
+
+describe('mapToThinkingBudget', () => {
+  it('maps named levels to a within-range budget for gemini-2.5-pro (128-32768, cannot disable)', () => {
+    expect(mapToThinkingBudget('gemini-2.5-pro', 'low')).toBeGreaterThanOrEqual(128)
+    expect(mapToThinkingBudget('gemini-2.5-pro', 'high')).toBeLessThanOrEqual(32768)
+  })
+
+  it('maps named levels to a within-range budget for gemini-2.5-flash (0-24576)', () => {
+    expect(mapToThinkingBudget('gemini-2.5-flash', 'low')).toBeLessThanOrEqual(24576)
+    expect(mapToThinkingBudget('gemini-2.5-flash', 'high')).toBeLessThanOrEqual(24576)
+  })
+
+  it('maps named levels to a within-range budget for gemini-2.5-flash-lite (512-24576)', () => {
+    expect(mapToThinkingBudget('gemini-2.5-flash-lite', 'low')).toBeGreaterThanOrEqual(512)
+    expect(mapToThinkingBudget('gemini-2.5-flash-lite', 'high')).toBeLessThanOrEqual(24576)
+  })
+
+  it('strips the vertex/ prefix before looking up the model', () => {
+    expect(mapToThinkingBudget('vertex/gemini-2.5-flash', 'medium')).toBe(
+      mapToThinkingBudget('gemini-2.5-flash', 'medium')
+    )
+  })
+
+  it('falls back to dynamic budget (-1) for models with no explicit mapping', () => {
+    expect(mapToThinkingBudget('gemini-2.0-flash', 'medium')).toBe(-1)
+  })
+
+  it('falls back to the high budget for an unrecognized level on a mapped model', () => {
+    expect(mapToThinkingBudget('gemini-2.5-flash', 'unknown-level')).toBe(
+      mapToThinkingBudget('gemini-2.5-flash', 'high')
+    )
+  })
+})
 
 describe('ensureStructResponse', () => {
   describe('should return objects unchanged', () => {

--- a/apps/sim/providers/google/utils.ts
+++ b/apps/sim/providers/google/utils.ts
@@ -351,6 +351,30 @@ export function mapToThinkingLevel(level: string): ThinkingLevel {
 }
 
 /**
+ * Per-model thinkingBudget ranges for Gemini 2.5-series models. Unlike Gemini 3.x, these
+ * models reject `thinkingLevel` entirely (Gemini API docs: "Gemini 2.5 series models don't
+ * support thinkingLevel; use thinkingBudget instead") and require a numeric token budget
+ * within each model's own documented range.
+ */
+const GEMINI_25_THINKING_BUDGETS: Record<string, Record<string, number>> = {
+  'gemini-2.5-pro': { low: 2048, medium: 8192, high: 32768 }, // valid range 128-32768, cannot disable
+  'gemini-2.5-flash': { low: 2048, medium: 8192, high: 24576 }, // valid range 0-24576
+  'gemini-2.5-flash-lite': { low: 1024, medium: 8192, high: 24576 }, // valid range 512-24576
+}
+
+/**
+ * Maps a named thinking level to a `thinkingBudget` token count for Gemini 2.5-series models.
+ * Falls back to -1 (dynamic/automatic budget) for any model not in the explicit table above,
+ * rather than guessing a number that could fall outside an unmapped model's valid range.
+ */
+export function mapToThinkingBudget(model: string, level: string): number {
+  const normalized = model.toLowerCase().replace(/^vertex\//, '')
+  const budgets = GEMINI_25_THINKING_BUDGETS[normalized]
+  if (!budgets) return -1
+  return budgets[level.toLowerCase()] ?? budgets.high
+}
+
+/**
  * Result of checking forced tool usage
  */
 export interface ForcedToolResult {

--- a/apps/sim/providers/google/utils.ts
+++ b/apps/sim/providers/google/utils.ts
@@ -375,6 +375,23 @@ export function mapToThinkingBudget(model: string, level: string): number {
 }
 
 /**
+ * Gemini 2.5-series models that accept `thinkingBudget: 0` to explicitly disable thinking.
+ * gemini-2.5-pro cannot disable thinking at all (its documented budget floor is 128, not 0),
+ * so it's deliberately excluded here.
+ */
+const GEMINI_25_MODELS_SUPPORTING_DISABLE = new Set(['gemini-2.5-flash', 'gemini-2.5-flash-lite'])
+
+/**
+ * Whether this Gemini 2.5-series model supports explicitly disabling thinking via budget=0.
+ * Omitting thinkingConfig entirely (the 'none' no-op path) falls back to the API's own
+ * dynamic default, which is ON for gemini-2.5-flash — not the same as actually disabling it.
+ */
+export function supportsDisablingGemini25Thinking(model: string): boolean {
+  const normalized = model.toLowerCase().replace(/^vertex\//, '')
+  return GEMINI_25_MODELS_SUPPORTING_DISABLE.has(normalized)
+}
+
+/**
  * Result of checking forced tool usage
  */
 export interface ForcedToolResult {

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -294,7 +294,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           reasoningEffort: {
-            values: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+            values: ['none', 'low', 'medium', 'high', 'xhigh'],
           },
           verbosity: {
             values: ['low', 'medium', 'high'],
@@ -315,7 +315,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           reasoningEffort: {
-            values: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+            values: ['none', 'low', 'medium', 'high', 'xhigh'],
           },
           verbosity: {
             values: ['low', 'medium', 'high'],
@@ -335,7 +335,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           reasoningEffort: {
-            values: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+            values: ['none', 'low', 'medium', 'high', 'xhigh'],
           },
           verbosity: {
             values: ['low', 'medium', 'high'],
@@ -841,7 +841,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         capabilities: {
           temperature: { min: 0, max: 1 },
           nativeStructuredOutputs: true,
-          maxOutputTokens: 64000,
+          maxOutputTokens: 128000,
           thinking: {
             levels: ['low', 'medium', 'high', 'max'],
             default: 'high',
@@ -891,26 +891,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         deprecated: true,
       },
       {
-        id: 'claude-opus-4-0',
-        pricing: {
-          input: 15.0,
-          cachedInput: 1.5,
-          output: 75.0,
-          updatedAt: '2026-06-11',
-        },
-        capabilities: {
-          temperature: { min: 0, max: 1 },
-          maxOutputTokens: 32000,
-          thinking: {
-            levels: ['low', 'medium', 'high'],
-            default: 'high',
-          },
-        },
-        contextWindow: 200000,
-        releaseDate: '2025-05-22',
-        deprecated: true,
-      },
-      {
         id: 'claude-sonnet-4-5',
         pricing: {
           input: 3.0,
@@ -929,26 +909,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 200000,
         releaseDate: '2025-09-29',
-      },
-      {
-        id: 'claude-sonnet-4-0',
-        pricing: {
-          input: 3.0,
-          cachedInput: 0.3,
-          output: 15.0,
-          updatedAt: '2026-06-11',
-        },
-        capabilities: {
-          temperature: { min: 0, max: 1 },
-          maxOutputTokens: 64000,
-          thinking: {
-            levels: ['low', 'medium', 'high'],
-            default: 'high',
-          },
-        },
-        contextWindow: 200000,
-        releaseDate: '2025-05-22',
-        deprecated: true,
       },
       {
         id: 'claude-haiku-4-5',
@@ -970,22 +930,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         contextWindow: 200000,
         releaseDate: '2025-10-15',
         speedOptimized: true,
-      },
-      {
-        id: 'claude-3-haiku-20240307',
-        pricing: {
-          input: 0.25,
-          cachedInput: 0.03,
-          output: 1.25,
-          updatedAt: '2026-04-01',
-        },
-        capabilities: {
-          temperature: { min: 0, max: 1 },
-          maxOutputTokens: 4096,
-        },
-        contextWindow: 200000,
-        releaseDate: '2024-03-13',
-        deprecated: true,
       },
     ],
   },
@@ -1509,7 +1453,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1048576,
         releaseDate: '2025-12-17',
-        deprecated: true,
       },
       {
         id: 'gemini-2.5-pro',
@@ -1521,6 +1464,10 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['low', 'medium', 'high'],
+            default: 'high',
+          },
           maxOutputTokens: 65536,
         },
         contextWindow: 1048576,
@@ -1536,6 +1483,10 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['low', 'medium', 'high'],
+            default: 'medium',
+          },
           maxOutputTokens: 65536,
         },
         contextWindow: 1048576,
@@ -1551,6 +1502,10 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['low', 'medium', 'high'],
+            default: 'low',
+          },
           maxOutputTokens: 65536,
         },
         contextWindow: 1048576,
@@ -1725,6 +1680,10 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['low', 'medium', 'high'],
+            default: 'high',
+          },
           maxOutputTokens: 65535,
         },
         contextWindow: 1048576,
@@ -1740,6 +1699,10 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['low', 'medium', 'high'],
+            default: 'medium',
+          },
           maxOutputTokens: 65535,
         },
         contextWindow: 1048576,
@@ -1755,6 +1718,10 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['low', 'medium', 'high'],
+            default: 'low',
+          },
           maxOutputTokens: 65535,
         },
         contextWindow: 1048576,
@@ -2876,6 +2843,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 200000,
         releaseDate: '2025-08-05',
+        deprecated: true,
       },
       {
         id: 'bedrock/amazon.nova-2-pro-v1:0',

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -294,7 +294,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         capabilities: {
           reasoningEffort: {
-            values: ['none', 'low', 'medium', 'high', 'xhigh'],
+            values: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
           },
           verbosity: {
             values: ['low', 'medium', 'high'],

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -891,6 +891,26 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         deprecated: true,
       },
       {
+        id: 'claude-opus-4-0',
+        pricing: {
+          input: 15.0,
+          cachedInput: 1.5,
+          output: 75.0,
+          updatedAt: '2026-06-11',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 1 },
+          maxOutputTokens: 32000,
+          thinking: {
+            levels: ['low', 'medium', 'high'],
+            default: 'high',
+          },
+        },
+        contextWindow: 200000,
+        releaseDate: '2025-05-22',
+        deprecated: true,
+      },
+      {
         id: 'claude-sonnet-4-5',
         pricing: {
           input: 3.0,
@@ -909,6 +929,26 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 200000,
         releaseDate: '2025-09-29',
+      },
+      {
+        id: 'claude-sonnet-4-0',
+        pricing: {
+          input: 3.0,
+          cachedInput: 0.3,
+          output: 15.0,
+          updatedAt: '2026-06-11',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 1 },
+          maxOutputTokens: 64000,
+          thinking: {
+            levels: ['low', 'medium', 'high'],
+            default: 'high',
+          },
+        },
+        contextWindow: 200000,
+        releaseDate: '2025-05-22',
+        deprecated: true,
       },
       {
         id: 'claude-haiku-4-5',
@@ -930,6 +970,22 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         contextWindow: 200000,
         releaseDate: '2025-10-15',
         speedOptimized: true,
+      },
+      {
+        id: 'claude-3-haiku-20240307',
+        pricing: {
+          input: 0.25,
+          cachedInput: 0.03,
+          output: 1.25,
+          updatedAt: '2026-04-01',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 1 },
+          maxOutputTokens: 4096,
+        },
+        contextWindow: 200000,
+        releaseDate: '2024-03-13',
+        deprecated: true,
       },
     ],
   },

--- a/apps/sim/providers/utils.test.ts
+++ b/apps/sim/providers/utils.test.ts
@@ -196,8 +196,8 @@ describe('Model Capabilities', () => {
         'gpt-5-chat-latest',
         'azure/gpt-5-chat',
         'gemini-2.5-flash',
-        'claude-sonnet-4-0',
-        'claude-opus-4-0',
+        'claude-sonnet-4-5',
+        'claude-opus-4-1',
         'grok-3-latest',
         'grok-3-fast-latest',
         'deepseek-v3',
@@ -243,7 +243,7 @@ describe('Model Capabilities', () => {
 
     it.concurrent('should be case insensitive', () => {
       expect(supportsTemperature('GPT-4O')).toBe(true)
-      expect(supportsTemperature('claude-sonnet-4-0')).toBe(true)
+      expect(supportsTemperature('claude-sonnet-4-5')).toBe(true)
     })
 
     it.concurrent(
@@ -277,7 +277,7 @@ describe('Model Capabilities', () => {
     })
 
     it.concurrent('should return 1 for models with temperature range 0-1', () => {
-      const modelsRange01 = ['claude-sonnet-4-0', 'claude-opus-4-0']
+      const modelsRange01 = ['claude-sonnet-4-5', 'claude-opus-4-1']
 
       for (const model of modelsRange01) {
         expect(getMaxTemperature(model)).toBe(1)
@@ -316,7 +316,7 @@ describe('Model Capabilities', () => {
 
     it.concurrent('should be case insensitive', () => {
       expect(getMaxTemperature('GPT-4O')).toBe(2)
-      expect(getMaxTemperature('CLAUDE-SONNET-4-0')).toBe(1)
+      expect(getMaxTemperature('CLAUDE-SONNET-4-5')).toBe(1)
     })
 
     it.concurrent(
@@ -413,7 +413,7 @@ describe('Model Capabilities', () => {
       expect(supportsThinking('claude-opus-4-6')).toBe(true)
       expect(supportsThinking('claude-opus-4-5')).toBe(true)
       expect(supportsThinking('claude-sonnet-4-5')).toBe(true)
-      expect(supportsThinking('claude-sonnet-4-0')).toBe(true)
+      expect(supportsThinking('claude-sonnet-4-5')).toBe(true)
       expect(supportsThinking('claude-haiku-4-5')).toBe(true)
       expect(supportsThinking('gemini-3-flash-preview')).toBe(true)
     })
@@ -438,11 +438,11 @@ describe('Model Capabilities', () => {
       expect(MODELS_TEMP_RANGE_0_2).toContain('gemini-2.5-flash')
       expect(MODELS_TEMP_RANGE_0_2).toContain('deepseek-v3')
       expect(MODELS_TEMP_RANGE_0_2).toContain('grok-3-latest')
-      expect(MODELS_TEMP_RANGE_0_2).not.toContain('claude-sonnet-4-0')
+      expect(MODELS_TEMP_RANGE_0_2).not.toContain('claude-sonnet-4-5')
     })
 
     it.concurrent('should have correct models in MODELS_TEMP_RANGE_0_1', () => {
-      expect(MODELS_TEMP_RANGE_0_1).toContain('claude-sonnet-4-0')
+      expect(MODELS_TEMP_RANGE_0_1).toContain('claude-sonnet-4-5')
       expect(MODELS_TEMP_RANGE_0_1).not.toContain('grok-3-latest')
       expect(MODELS_TEMP_RANGE_0_1).not.toContain('gpt-4o')
     })
@@ -464,7 +464,7 @@ describe('Model Capabilities', () => {
             MODELS_TEMP_RANGE_0_1.length
         )
         expect(MODELS_WITH_TEMPERATURE_SUPPORT).toContain('gpt-4o')
-        expect(MODELS_WITH_TEMPERATURE_SUPPORT).toContain('claude-sonnet-4-0')
+        expect(MODELS_WITH_TEMPERATURE_SUPPORT).toContain('claude-sonnet-4-5')
       }
     )
 
@@ -496,7 +496,7 @@ describe('Model Capabilities', () => {
       expect(MODELS_WITH_REASONING_EFFORT).not.toContain('azure/gpt-5-chat')
 
       expect(MODELS_WITH_REASONING_EFFORT).not.toContain('gpt-4o')
-      expect(MODELS_WITH_REASONING_EFFORT).not.toContain('claude-sonnet-4-0')
+      expect(MODELS_WITH_REASONING_EFFORT).not.toContain('claude-sonnet-4-5')
     })
 
     it.concurrent('should have correct models in MODELS_WITH_VERBOSITY', () => {
@@ -525,16 +525,14 @@ describe('Model Capabilities', () => {
       expect(MODELS_WITH_VERBOSITY).not.toContain('o4-mini')
 
       expect(MODELS_WITH_VERBOSITY).not.toContain('gpt-4o')
-      expect(MODELS_WITH_VERBOSITY).not.toContain('claude-sonnet-4-0')
+      expect(MODELS_WITH_VERBOSITY).not.toContain('claude-sonnet-4-5')
     })
 
     it.concurrent('should have correct models in MODELS_WITH_THINKING', () => {
       expect(MODELS_WITH_THINKING).toContain('claude-opus-4-6')
       expect(MODELS_WITH_THINKING).toContain('claude-opus-4-5')
       expect(MODELS_WITH_THINKING).toContain('claude-opus-4-1')
-      expect(MODELS_WITH_THINKING).toContain('claude-opus-4-0')
       expect(MODELS_WITH_THINKING).toContain('claude-sonnet-4-5')
-      expect(MODELS_WITH_THINKING).toContain('claude-sonnet-4-0')
 
       expect(MODELS_WITH_THINKING).toContain('gemini-3-flash-preview')
 
@@ -659,7 +657,7 @@ describe('Model Capabilities', () => {
     })
 
     it.concurrent('should return correct levels for other Claude models (budget_tokens)', () => {
-      for (const model of ['claude-opus-4-5', 'claude-sonnet-4-5', 'claude-sonnet-4-0']) {
+      for (const model of ['claude-opus-4-5', 'claude-sonnet-4-5', 'claude-haiku-4-5']) {
         const levels = getThinkingLevelsForModel(model)
         expect(levels).toBeDefined()
         expect(levels).toContain('low')
@@ -713,7 +711,7 @@ describe('Max Output Tokens', () => {
     })
 
     it.concurrent('should return updated max for Claude Sonnet 4.6', () => {
-      expect(getMaxOutputTokensForModel('claude-sonnet-4-6')).toBe(64000)
+      expect(getMaxOutputTokensForModel('claude-sonnet-4-6')).toBe(128000)
     })
 
     it.concurrent('should return published max for Gemini 2.5 Pro', () => {
@@ -873,8 +871,8 @@ describe('getHostedModels', () => {
     expect(hostedModels).toContain('gpt-4o')
     expect(hostedModels).toContain('o1')
 
-    expect(hostedModels).toContain('claude-sonnet-4-0')
-    expect(hostedModels).toContain('claude-opus-4-0')
+    expect(hostedModels).toContain('claude-sonnet-4-5')
+    expect(hostedModels).toContain('claude-opus-4-1')
 
     expect(hostedModels).toContain('gemini-2.5-pro')
     expect(hostedModels).toContain('gemini-2.5-flash')
@@ -899,8 +897,8 @@ describe('shouldBillModelUsage', () => {
     expect(shouldBillModelUsage('gpt-4o')).toBe(true)
     expect(shouldBillModelUsage('o1')).toBe(true)
 
-    expect(shouldBillModelUsage('claude-sonnet-4-0')).toBe(true)
-    expect(shouldBillModelUsage('claude-opus-4-0')).toBe(true)
+    expect(shouldBillModelUsage('claude-sonnet-4-5')).toBe(true)
+    expect(shouldBillModelUsage('claude-opus-4-1')).toBe(true)
 
     expect(shouldBillModelUsage('gemini-2.5-pro')).toBe(true)
     expect(shouldBillModelUsage('gemini-2.5-flash')).toBe(true)
@@ -921,7 +919,7 @@ describe('shouldBillModelUsage', () => {
 
   it.concurrent('should be case insensitive', () => {
     expect(shouldBillModelUsage('GPT-4O')).toBe(true)
-    expect(shouldBillModelUsage('Claude-Sonnet-4-0')).toBe(true)
+    expect(shouldBillModelUsage('Claude-Sonnet-4-5')).toBe(true)
     expect(shouldBillModelUsage('GEMINI-2.5-PRO')).toBe(true)
   })
 
@@ -936,7 +934,7 @@ describe('Provider Management', () => {
   describe('getProviderFromModel', () => {
     it.concurrent('should return correct provider for known models', () => {
       expect(getProviderFromModel('gpt-4o')).toBe('openai')
-      expect(getProviderFromModel('claude-sonnet-4-0')).toBe('anthropic')
+      expect(getProviderFromModel('claude-sonnet-4-5')).toBe('anthropic')
       expect(getProviderFromModel('gemini-2.5-pro')).toBe('google')
       expect(getProviderFromModel('azure/gpt-4o')).toBe('azure-openai')
     })
@@ -985,7 +983,7 @@ describe('Provider Management', () => {
       expect(config).toBeDefined()
       expect(config?.id).toBe('openai')
 
-      const anthropicConfig = getProviderConfigFromModel('claude-sonnet-4-0')
+      const anthropicConfig = getProviderConfigFromModel('claude-sonnet-4-5')
       expect(anthropicConfig).toBeDefined()
       expect(anthropicConfig?.id).toBe('anthropic')
     })
@@ -998,7 +996,7 @@ describe('Provider Management', () => {
       expect(allModels.length).toBeGreaterThan(0)
 
       expect(allModels).toContain('gpt-4o')
-      expect(allModels).toContain('claude-sonnet-4-0')
+      expect(allModels).toContain('claude-sonnet-4-5')
       expect(allModels).toContain('gemini-2.5-pro')
     })
   })
@@ -1022,8 +1020,8 @@ describe('Provider Management', () => {
       expect(openaiModels).toContain('o1')
 
       const anthropicModels = getProviderModels('anthropic')
-      expect(anthropicModels).toContain('claude-sonnet-4-0')
-      expect(anthropicModels).toContain('claude-opus-4-0')
+      expect(anthropicModels).toContain('claude-sonnet-4-5')
+      expect(anthropicModels).toContain('claude-opus-4-1')
     })
 
     it.concurrent('should return empty array for unknown providers', () => {
@@ -1037,7 +1035,7 @@ describe('Provider Management', () => {
       const allProviders = getAllModelProviders()
       expect(typeof allProviders).toBe('object')
       expect(allProviders['gpt-4o']).toBe('openai')
-      expect(allProviders['claude-sonnet-4-0']).toBe('anthropic')
+      expect(allProviders['claude-sonnet-4-5']).toBe('anthropic')
 
       const baseProviders = getBaseModelProviders()
       expect(typeof baseProviders).toBe('object')


### PR DESCRIPTION
## Summary
- Noticed the models comparison page was showing mostly OpenAI models and asked for a `/validate-model` sweep across OpenAI, Anthropic, and Gemini — found and fixed real data bugs, not just cosmetic ones
- OpenAI: removed a fabricated `'max'` reasoning-effort value from the gpt-5.6 family (not a documented value, would 400 on selection)
- Anthropic: fixed `claude-sonnet-4-6` maxOutputTokens (was 64k, docs say 128k); removed 3 models that are fully retired per Anthropic's own deprecations page (`claude-opus-4-0`, `claude-sonnet-4-0`, `claude-3-haiku-20240307` — all past their retirement dates, requests would fail); fixed a `budget_tokens >= max_tokens` bug that would 400 on `claude-opus-4-1` at its default thinking level
- Google/Vertex: un-deprecated `gemini-3-flash-preview` (no shutdown date actually announced); added the `thinking` capability to `gemini-2.5-pro/flash/flash-lite` (google + vertex), which were missing it entirely despite Google supporting thinking control for them
- Fixed `gemini/core.ts` to send `thinkingBudget` (not `thinkingLevel`) for Gemini 2.5-series models — confirmed via multiple independent sources that 2.5-series rejects `thinkingLevel` outright and only Gemini 3.x supports it, so the new capability above would have 400'd without this
- Bedrock: marked `claude-opus-4-1` deprecated per AWS's own Bedrock lifecycle page (Legacy since Jul 8 2026 — a separate schedule from Anthropic's direct API)
- Audited Azure OpenAI/Anthropic and Bedrock for missing recent models; deliberately did not add anything there — Azure's pricing feed doesn't have gpt-5.6 yet and the rest required guessing at abbreviated meter names, Bedrock's newer Claude models need a different API surface than what's currently wired up

## Type of Change
- [x] Bug fix

## Testing
- Every changed field independently verified against live provider docs, cross-referenced against a second source where available (OpenRouter, AWS pricing/lifecycle pages, Anthropic's own pricing page)
- Ran a dedicated `/validate-model` pass on every single modified model, one at a time, across all affected providers
- Added regression tests for the new `mapToThinkingBudget` gemini/core.ts fix
- Full `providers/` test suite: 753/753 passing
- `bun run type-check` and `bun run lint` clean on all touched files

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)