### PR TITLE
fix(sidebar): fix rename input losing its selection on open

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRef } from 'react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -40,7 +41,10 @@ interface ContextMenuProps {
    * can run after the rename input's own mount-time `focus()`/`select()` and
    * clobber the selection (the "rename deselects the text" bug). Focusing from
    * `onCloseAutoFocus` runs synchronously inside that same deferred teardown, so
-   * it always wins the race regardless of scheduler timing.
+   * it always wins the race regardless of scheduler timing. Only applied when
+   * this specific close was caused by selecting "Rename" (see
+   * `justSelectedRenameRef`) — an unrelated action closing the menu while an
+   * earlier rename is still live must not steal focus back into it.
    */
   renameInputRef?: React.RefObject<HTMLInputElement | null>
   onCreate?: () => void
@@ -142,6 +146,13 @@ export function ContextMenu({
     (showUploadLogo && onUploadLogo)
   const hasCopySection = (showDuplicate && onDuplicate) || (showExport && onExport)
 
+  /**
+   * Only the "Rename" item should trigger the `onCloseAutoFocus` refocus below —
+   * an unrelated action (Delete, Duplicate, ...) closing this menu while a rename
+   * from an earlier interaction is still live must not steal focus back into it.
+   */
+  const justSelectedRenameRef = useRef(false)
+
   return (
     <DropdownMenu open={isOpen} onOpenChange={(open) => !open && onClose()} modal={false}>
       <DropdownMenuTrigger asChild>
@@ -164,7 +175,9 @@ export function ContextMenu({
         className='max-h-[var(--radix-dropdown-menu-content-available-height,400px)]'
         onCloseAutoFocus={(e) => {
           e.preventDefault()
-          const input = renameInputRef?.current
+          const shouldFocusRenameInput = justSelectedRenameRef.current
+          justSelectedRenameRef.current = false
+          const input = shouldFocusRenameInput ? renameInputRef?.current : null
           if (input) {
             input.focus()
             input.select()
@@ -227,6 +240,7 @@ export function ContextMenu({
           <DropdownMenuItem
             disabled={disableRename}
             onSelect={() => {
+              justSelectedRenameRef.current = true
               onRename()
               onClose()
             }}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
@@ -34,6 +34,15 @@ interface ContextMenuProps {
   onMarkAsUnread?: () => void
   onTogglePin?: () => void
   onRename?: () => void
+  /**
+   * Ref to the rename input rendered by the "Rename" action, if any. Radix's
+   * FocusScope defers its close-time focus teardown to a `setTimeout(0)`, which
+   * can run after the rename input's own mount-time `focus()`/`select()` and
+   * clobber the selection (the "rename deselects the text" bug). Focusing from
+   * `onCloseAutoFocus` runs synchronously inside that same deferred teardown, so
+   * it always wins the race regardless of scheduler timing.
+   */
+  renameInputRef?: React.RefObject<HTMLInputElement | null>
   onCreate?: () => void
   onCreateFolder?: () => void
   onDuplicate?: () => void
@@ -84,6 +93,7 @@ export function ContextMenu({
   onMarkAsUnread,
   onTogglePin,
   onRename,
+  renameInputRef,
   onCreate,
   onCreateFolder,
   onDuplicate,
@@ -152,7 +162,14 @@ export function ContextMenu({
         side='bottom'
         sideOffset={4}
         className='max-h-[var(--radix-dropdown-menu-content-available-height,400px)]'
-        onCloseAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => {
+          e.preventDefault()
+          const input = renameInputRef?.current
+          if (input) {
+            input.focus()
+            input.select()
+          }
+        }}
       >
         {showOpenInNewTab && onOpenInNewTab && (
           <DropdownMenuItem

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -575,6 +575,7 @@ export const FolderItem = memo(function FolderItem({ workspaceId, folder }: Fold
         menuRef={menuRef}
         onClose={closeMenu}
         onRename={handleStartEdit}
+        renameInputRef={inputRef}
         onCreate={handleCreateWorkflowInFolder}
         onCreateFolder={handleCreateFolderInFolder}
         onDuplicate={handleDuplicate}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -487,6 +487,7 @@ export const WorkflowItem = memo(function WorkflowItem({
         onClose={closeMenu}
         onOpenInNewTab={handleOpenInNewTab}
         onRename={handleStartEdit}
+        renameInputRef={inputRef}
         onDuplicate={handleDuplicate}
         onExport={handleExport}
         onDelete={handleOpenDeleteModal}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
@@ -113,6 +113,7 @@ function WorkspaceHeaderImpl({
   const isContextMenuOpeningRef = useRef(false)
   const contextMenuClosedRef = useRef(true)
   const hasInputFocusedRef = useRef(false)
+  const renameInputRef = useRef<HTMLInputElement | null>(null)
 
   const [isMounted, setIsMounted] = useState(false)
   useEffect(() => {
@@ -408,6 +409,7 @@ function WorkspaceHeaderImpl({
                             )}
                             <input
                               ref={(el) => {
+                                renameInputRef.current = el
                                 if (el && !hasInputFocusedRef.current) {
                                   hasInputFocusedRef.current = true
                                   el.focus()
@@ -643,6 +645,7 @@ function WorkspaceHeaderImpl({
             menuRef={contextMenuRef}
             onClose={closeContextMenu}
             onRename={handleRenameAction}
+            renameInputRef={renameInputRef}
             onDelete={handleDeleteAction}
             onLeave={handleLeaveAction}
             onUploadLogo={handleUploadLogoAction}


### PR DESCRIPTION
## Summary
- Fixes rename occasionally deselecting the pre-highlighted text when opening the rename input for workflows, folders, and workspaces from the context/dropdown menu
- Root cause: Radix's `FocusScope` defers its close-time focus teardown to a `setTimeout(0)`, which can run after the rename input's own mount-time `focus()`/`select()` and clobber the selection — explains why it was intermittent rather than every time
- Fix: focus + select the rename input from the shared `ContextMenu`'s `onCloseAutoFocus` handler instead of a plain effect, since that callback runs synchronously inside Radix's own deferred teardown and always wins the race regardless of scheduler timing
- Additive-only change (new optional `renameInputRef` prop on `ContextMenu`, wired from the three rename call sites) — every other `ContextMenu` consumer is unaffected

## Type of Change
- [x] Bug fix

## Testing
Verified via typecheck (clean, no new errors) and lint (clean), and traced the fix against Radix's actual FocusScope source to confirm the timing race it closes. Could not click through the live repro in this environment (no DB/auth available locally) — worth a manual pass before merge.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)