### PR TITLE
fix(mcp): fix caret misalignment and tool schema contract validation

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
@@ -157,7 +157,7 @@ function FormattedInput({
         onChange={onChange}
         onScroll={handleScroll}
         onInput={handleScroll}
-        inputClassName='text-transparent caret-[var(--text-primary)]'
+        inputClassName='font-medium font-sans text-transparent caret-[var(--text-primary)]'
       />
       <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden px-2 py-1.5 font-medium font-sans text-sm'>
         <div className='whitespace-nowrap' style={{ transform: `translateX(-${scrollLeft}px)` }}>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -258,6 +258,8 @@ export function McpDynamicArgs({
 
       case 'long-input': {
         const config = createParamConfig(paramName, paramSchema, 'long-input')
+        const displayValue =
+          typeof value === 'string' || value == null ? value || '' : JSON.stringify(value)
         return (
           <LongInput
             key={`${paramName}-long`}
@@ -266,7 +268,7 @@ export function McpDynamicArgs({
             config={config}
             placeholder={config.placeholder}
             rows={4}
-            value={value || ''}
+            value={displayValue}
             onChange={(newValue) => updateParameter(paramName, newValue)}
             isPreview={isPreview}
             disabled={disabled}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -18,7 +18,8 @@ const logger = createLogger('McpDynamicArgs')
 /**
  * The dropdown UI renders each enum member as a string label/value, so it can only
  * represent JSON Schema enums whose members are primitives — a non-primitive member
- * (object/array) would collapse to "[object Object]" and lose its identity.
+ * (object/array) would collapse to "[object Object]" and lose its identity. Callers
+ * route a non-primitive enum to the JSON editor (`long-input`) instead.
  */
 function isPrimitiveEnum(
   enumValues: unknown
@@ -131,9 +132,6 @@ export function McpDynamicArgs({
 
   const getInputType = (paramSchema: any) => {
     if (Array.isArray(paramSchema.enum)) {
-      // A non-primitive enum member (object/array) can't be represented by the
-      // dropdown's string label/value model — fall back to the JSON editor so the
-      // user can enter (and round-trip) one of the allowed JSON values verbatim.
       return isPrimitiveEnum(paramSchema.enum) ? 'dropdown' : 'long-input'
     }
     if (paramSchema.type === 'boolean') return 'switch'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -30,6 +30,18 @@ function isPrimitiveEnum(
   )
 }
 
+/**
+ * True when the schema's actual value must be a JSON object/array (a plain
+ * object/array type, or a non-primitive enum member) rather than a string.
+ */
+function requiresJsonValue(paramSchema: any): boolean {
+  return (
+    paramSchema.type === 'object' ||
+    paramSchema.type === 'array' ||
+    (Array.isArray(paramSchema.enum) && !isPrimitiveEnum(paramSchema.enum))
+  )
+}
+
 interface McpDynamicArgsProps {
   blockId: string
   subBlockId: string
@@ -269,7 +281,17 @@ export function McpDynamicArgs({
             placeholder={config.placeholder}
             rows={4}
             value={displayValue}
-            onChange={(newValue) => updateParameter(paramName, newValue)}
+            onChange={(newValue) => {
+              if (!requiresJsonValue(paramSchema)) {
+                updateParameter(paramName, newValue)
+                return
+              }
+              try {
+                updateParameter(paramName, JSON.parse(newValue))
+              } catch {
+                updateParameter(paramName, newValue)
+              }
+            }}
             isPreview={isPreview}
             disabled={disabled}
             workflowSearchValuePath={[paramName]}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -15,6 +15,20 @@ import { formatParameterLabel } from '@/tools/params'
 
 const logger = createLogger('McpDynamicArgs')
 
+/**
+ * The dropdown UI renders each enum member as a string label/value, so it can only
+ * represent JSON Schema enums whose members are primitives — a non-primitive member
+ * (object/array) would collapse to "[object Object]" and lose its identity.
+ */
+function isPrimitiveEnum(
+  enumValues: unknown
+): enumValues is Array<string | number | boolean | null> {
+  return (
+    Array.isArray(enumValues) &&
+    enumValues.every((value) => value === null || typeof value !== 'object')
+  )
+}
+
 interface McpDynamicArgsProps {
   blockId: string
   subBlockId: string
@@ -116,7 +130,7 @@ export function McpDynamicArgs({
   )
 
   const getInputType = (paramSchema: any) => {
-    if (paramSchema.enum) return 'dropdown'
+    if (isPrimitiveEnum(paramSchema.enum)) return 'dropdown'
     if (paramSchema.type === 'boolean') return 'switch'
     if (paramSchema.type === 'number' || paramSchema.type === 'integer') {
       if (paramSchema.minimum !== undefined && paramSchema.maximum !== undefined) {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -130,7 +130,12 @@ export function McpDynamicArgs({
   )
 
   const getInputType = (paramSchema: any) => {
-    if (isPrimitiveEnum(paramSchema.enum)) return 'dropdown'
+    if (Array.isArray(paramSchema.enum)) {
+      // A non-primitive enum member (object/array) can't be represented by the
+      // dropdown's string label/value model — fall back to the JSON editor so the
+      // user can enter (and round-trip) one of the allowed JSON values verbatim.
+      return isPrimitiveEnum(paramSchema.enum) ? 'dropdown' : 'long-input'
+    }
     if (paramSchema.type === 'boolean') return 'switch'
     if (paramSchema.type === 'number' || paramSchema.type === 'integer') {
       if (paramSchema.minimum !== undefined && paramSchema.maximum !== undefined) {

--- a/apps/sim/lib/api/contracts/mcp.ts
+++ b/apps/sim/lib/api/contracts/mcp.ts
@@ -50,10 +50,12 @@ export const mcpToolSchemaPropertySchema: z.ZodType<McpToolSchemaProperty> = z.l
     .object({
       type: z.union([z.string(), z.array(z.string())]).optional(),
       description: z.string().optional(),
-      items: mcpToolSchemaPropertySchema.optional(),
+      items: z
+        .union([mcpToolSchemaPropertySchema, z.array(mcpToolSchemaPropertySchema)])
+        .optional(),
       properties: z.record(z.string(), mcpToolSchemaPropertySchema).optional(),
       required: z.array(z.string()).optional(),
-      enum: z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
+      enum: z.array(z.unknown()).optional(),
       default: z.unknown().optional(),
     })
     .passthrough()

--- a/apps/sim/lib/mcp/types.ts
+++ b/apps/sim/lib/mcp/types.ts
@@ -68,10 +68,10 @@ export interface McpSecurityPolicy {
 export interface McpToolSchemaProperty {
   type?: string | string[]
   description?: string
-  items?: McpToolSchemaProperty
+  items?: McpToolSchemaProperty | McpToolSchemaProperty[]
   properties?: Record<string, McpToolSchemaProperty>
   required?: string[]
-  enum?: Array<string | number | boolean | null>
+  enum?: unknown[]
   default?: unknown
   [key: string]: unknown
 }


### PR DESCRIPTION
## Summary
- Fix MCP server form modal caret drifting from typed text in the Server URL and Header fields (font-weight mismatch between the ghost input and its formatted overlay)
- Fix "Response failed contract validation" crash on the MCP tools page when a real MCP server returns a tool schema with array-form `items` (tuple validation) or non-primitive `enum` values — the contract's property schema was stricter than valid JSON Schema

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)