### PR TITLE
fix(mcp): route object params to JSON editor, keep invalid drafts out of tool args

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -42,6 +42,15 @@ function requiresJsonValue(paramSchema: any): boolean {
   )
 }
 
+/**
+ * Stable signature of a tool schema's properties, for detecting whether the
+ * effective param shape has changed (independent of object identity).
+ */
+function schemaSignature(schema: unknown): string {
+  const properties = (schema as { properties?: unknown } | undefined)?.properties
+  return properties ? JSON.stringify(properties) : ''
+}
+
 interface McpDynamicArgsProps {
   blockId: string
   subBlockId: string
@@ -101,12 +110,13 @@ export function McpDynamicArgs({
    * Draft text for JSON-value params (object/array/non-primitive-enum) whose current
    * edit isn't valid JSON yet. Keeping this out of toolArgs means the stored argument
    * is always either the last valid parsed value or untouched — never malformed text
-   * that could reach tool execution. Drafts reset whenever the selected tool or its
-   * effective schema changes, so a stale draft can't outlive the param shape it was
-   * typed against.
+   * that could reach tool execution. Drafts reset whenever the selected tool or either
+   * schema source changes — `toolSchema` prefers the cached `_toolSchema` snapshot over
+   * the live discovered schema, so the reset key tracks both independently rather than
+   * the resolved `toolSchema`, which wouldn't change on a live-only refresh.
    */
   const [invalidJsonDrafts, setInvalidJsonDrafts] = useState<Record<string, string>>({})
-  const draftResetKey = `${selectedTool ?? ''}|${toolSchema?.properties ? JSON.stringify(toolSchema.properties) : ''}`
+  const draftResetKey = `${selectedTool ?? ''}|${schemaSignature(cachedSchema)}|${schemaSignature(selectedToolConfig?.inputSchema)}`
   const [prevDraftResetKey, setPrevDraftResetKey] = useState(draftResetKey)
   if (prevDraftResetKey !== draftResetKey) {
     setPrevDraftResetKey(draftResetKey)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -43,12 +43,13 @@ function requiresJsonValue(paramSchema: any): boolean {
 }
 
 /**
- * Stable signature of a tool schema's properties, for detecting whether the
- * effective param shape has changed (independent of object identity).
+ * Stable signature of an entire tool schema, for detecting whether the effective
+ * param shape has changed (independent of object identity). Signs the whole schema
+ * rather than cherry-picking fields (e.g. just `properties`) so a refresh that only
+ * changes `required`, or any other schema-level field, isn't silently missed.
  */
 function schemaSignature(schema: unknown): string {
-  const properties = (schema as { properties?: unknown } | undefined)?.properties
-  return properties ? JSON.stringify(properties) : ''
+  return schema ? JSON.stringify(schema) : ''
 }
 
 interface McpDynamicArgsProps {
@@ -108,14 +109,20 @@ export function McpDynamicArgs({
 
   /**
    * Draft text for JSON-value params (object/array/non-primitive-enum) whose current
-   * edit isn't valid JSON yet. Keeping this out of toolArgs means the stored argument
-   * is always either the last valid parsed value or untouched — never malformed text
-   * that could reach tool execution. Drafts reset whenever the selected tool or either
-   * schema source changes — `toolSchema` prefers the cached `_toolSchema` snapshot over
-   * the live discovered schema, so the reset key tracks both independently rather than
-   * the resolved `toolSchema`, which wouldn't change on a live-only refresh.
+   * edit isn't valid JSON yet, paired with a signature of the persisted value it was
+   * typed against. Keeping this out of toolArgs means the stored argument is always
+   * either the last valid parsed value or untouched — never malformed text that could
+   * reach tool execution. A draft is only displayed while its baseline still matches
+   * the live persisted value, so an external change to that value (undo/redo, a diff
+   * baseline switch, a collaborator's edit) can't be shadowed by stale draft text.
+   * Drafts also reset wholesale whenever the selected tool or either schema source
+   * changes — `toolSchema` prefers the cached `_toolSchema` snapshot over the live
+   * discovered schema, so the reset key tracks both independently rather than the
+   * resolved `toolSchema`, which wouldn't change on a live-only refresh.
    */
-  const [invalidJsonDrafts, setInvalidJsonDrafts] = useState<Record<string, string>>({})
+  const [invalidJsonDrafts, setInvalidJsonDrafts] = useState<
+    Record<string, { text: string; baseline: string }>
+  >({})
   const draftResetKey = `${selectedTool ?? ''}|${schemaSignature(cachedSchema)}|${schemaSignature(selectedToolConfig?.inputSchema)}`
   const [prevDraftResetKey, setPrevDraftResetKey] = useState(draftResetKey)
   if (prevDraftResetKey !== draftResetKey) {
@@ -297,10 +304,13 @@ export function McpDynamicArgs({
       case 'long-input': {
         const config = createParamConfig(paramName, paramSchema, 'long-input')
         const needsJsonValue = requiresJsonValue(paramSchema)
+        const valueSignature = JSON.stringify(value ?? null)
         const draft = invalidJsonDrafts[paramName]
+        const activeDraft =
+          needsJsonValue && draft && draft.baseline === valueSignature ? draft.text : undefined
         const displayValue =
-          needsJsonValue && draft !== undefined
-            ? draft
+          activeDraft !== undefined
+            ? activeDraft
             : typeof value === 'string' || value == null
               ? value || ''
               : JSON.stringify(value)
@@ -333,7 +343,10 @@ export function McpDynamicArgs({
                 updateParameter(paramName, JSON.parse(newValue))
                 clearDraft()
               } catch {
-                setInvalidJsonDrafts((prev) => ({ ...prev, [paramName]: newValue }))
+                setInvalidJsonDrafts((prev) => ({
+                  ...prev,
+                  [paramName]: { text: newValue, baseline: valueSignature },
+                }))
               }
             }}
             isPreview={isPreview}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -94,21 +94,24 @@ export function McpDynamicArgs({
     : schemaFromStore
   const [toolArgs, setToolArgs] = useSubBlockValue(blockId, subBlockId)
 
+  const selectedToolConfig = mcpTools.find((tool) => tool.id === selectedTool)
+  const toolSchema = cachedSchema || selectedToolConfig?.inputSchema
+
   /**
    * Draft text for JSON-value params (object/array/non-primitive-enum) whose current
    * edit isn't valid JSON yet. Keeping this out of toolArgs means the stored argument
    * is always either the last valid parsed value or untouched — never malformed text
-   * that could reach tool execution.
+   * that could reach tool execution. Drafts reset whenever the selected tool or its
+   * effective schema changes, so a stale draft can't outlive the param shape it was
+   * typed against.
    */
   const [invalidJsonDrafts, setInvalidJsonDrafts] = useState<Record<string, string>>({})
-  const [prevSelectedTool, setPrevSelectedTool] = useState(selectedTool)
-  if (prevSelectedTool !== selectedTool) {
-    setPrevSelectedTool(selectedTool)
+  const draftResetKey = `${selectedTool ?? ''}|${toolSchema?.properties ? JSON.stringify(toolSchema.properties) : ''}`
+  const [prevDraftResetKey, setPrevDraftResetKey] = useState(draftResetKey)
+  if (prevDraftResetKey !== draftResetKey) {
+    setPrevDraftResetKey(draftResetKey)
     setInvalidJsonDrafts({})
   }
-
-  const selectedToolConfig = mcpTools.find((tool) => tool.id === selectedTool)
-  const toolSchema = cachedSchema || selectedToolConfig?.inputSchema
 
   const currentArgs = useCallback(() => {
     if (isPreview && previewValue) {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -129,12 +129,14 @@ export function McpDynamicArgs({
    * Drafts also reset wholesale on either of two independent triggers:
    *  - the selected tool or the cached `_toolSchema` snapshot changes (this pair
    *    always drives `toolSchema` whenever a cached snapshot exists), or
-   *  - the live discovered schema's signature changes from one non-empty value to
-   *    a *different* non-empty value — a genuine re-discovery/refresh. A bare empty
-   *    → non-empty transition is excluded because that's just `mcpTools` finishing
-   *    its initial async load, not a schema change, and would otherwise spuriously
-   *    wipe drafts even while a cached snapshot (unaffected by the load) still
-   *    governs what's actually rendered.
+   *  - the live discovered schema's signature changes to a *different* non-empty
+   *    value than the last non-empty value actually observed — a genuine
+   *    re-discovery/refresh. Comparing against the last known non-empty value
+   *    (rather than merely the previous render's value) means a schema that
+   *    transiently disappears and reappears — e.g. `mcpTools` refetching, or the
+   *    tool briefly missing from a fresh list — still resets drafts if it comes
+   *    back different, while a plain empty → non-empty transition (the initial
+   *    async load) does not, since there is no prior non-empty value to compare.
    */
   const [invalidJsonDrafts, setInvalidJsonDrafts] = useState<
     Record<string, { text: string; baseline: string }>
@@ -143,20 +145,24 @@ export function McpDynamicArgs({
   const liveSchemaSignature = schemaSignature(selectedToolConfig?.inputSchema)
   const [prevToolAndCachedSchemaKey, setPrevToolAndCachedSchemaKey] =
     useState(toolAndCachedSchemaKey)
-  const [prevLiveSchemaSignature, setPrevLiveSchemaSignature] = useState(liveSchemaSignature)
+  const [lastNonEmptyLiveSchemaSignature, setLastNonEmptyLiveSchemaSignature] =
+    useState(liveSchemaSignature)
+  const toolOrCachedSchemaChanged = prevToolAndCachedSchemaKey !== toolAndCachedSchemaKey
+  const nextLastNonEmptyLiveSchemaSignature =
+    liveSchemaSignature !== '' ? liveSchemaSignature : lastNonEmptyLiveSchemaSignature
   if (
-    prevToolAndCachedSchemaKey !== toolAndCachedSchemaKey ||
-    prevLiveSchemaSignature !== liveSchemaSignature
+    toolOrCachedSchemaChanged ||
+    nextLastNonEmptyLiveSchemaSignature !== lastNonEmptyLiveSchemaSignature
   ) {
     const isGenuineLiveRefresh =
-      prevLiveSchemaSignature !== '' &&
       liveSchemaSignature !== '' &&
-      prevLiveSchemaSignature !== liveSchemaSignature
-    if (prevToolAndCachedSchemaKey !== toolAndCachedSchemaKey || isGenuineLiveRefresh) {
+      lastNonEmptyLiveSchemaSignature !== '' &&
+      liveSchemaSignature !== lastNonEmptyLiveSchemaSignature
+    if (toolOrCachedSchemaChanged || isGenuineLiveRefresh) {
       setInvalidJsonDrafts({})
     }
     setPrevToolAndCachedSchemaKey(toolAndCachedSchemaKey)
-    setPrevLiveSchemaSignature(liveSchemaSignature)
+    setLastNonEmptyLiveSchemaSignature(nextLastNonEmptyLiveSchemaSignature)
   }
 
   const currentArgs = useCallback(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -126,20 +126,37 @@ export function McpDynamicArgs({
    * reach tool execution. A draft is only displayed while its baseline still matches
    * the live persisted value, so an external change to that value (undo/redo, a diff
    * baseline switch, a collaborator's edit) can't be shadowed by stale draft text.
-   * Drafts also reset wholesale whenever the selected tool or the schema actually
-   * backing `toolSchema` changes. The live discovered schema only factors in when
-   * there's no cached snapshot to prefer — otherwise it's not what's rendered, so
-   * live schema arriving/changing while a cached snapshot is already in effect
-   * (e.g. `mcpTools` finishing an async load) must not spuriously reset drafts.
+   * Drafts also reset wholesale on either of two independent triggers:
+   *  - the selected tool or the cached `_toolSchema` snapshot changes (this pair
+   *    always drives `toolSchema` whenever a cached snapshot exists), or
+   *  - the live discovered schema's signature changes from one non-empty value to
+   *    a *different* non-empty value — a genuine re-discovery/refresh. A bare empty
+   *    → non-empty transition is excluded because that's just `mcpTools` finishing
+   *    its initial async load, not a schema change, and would otherwise spuriously
+   *    wipe drafts even while a cached snapshot (unaffected by the load) still
+   *    governs what's actually rendered.
    */
   const [invalidJsonDrafts, setInvalidJsonDrafts] = useState<
     Record<string, { text: string; baseline: string }>
   >({})
-  const draftResetKey = `${selectedTool ?? ''}|${schemaSignature(cachedSchema)}|${cachedSchema ? '' : schemaSignature(selectedToolConfig?.inputSchema)}`
-  const [prevDraftResetKey, setPrevDraftResetKey] = useState(draftResetKey)
-  if (prevDraftResetKey !== draftResetKey) {
-    setPrevDraftResetKey(draftResetKey)
-    setInvalidJsonDrafts({})
+  const toolAndCachedSchemaKey = `${selectedTool ?? ''}|${schemaSignature(cachedSchema)}`
+  const liveSchemaSignature = schemaSignature(selectedToolConfig?.inputSchema)
+  const [prevToolAndCachedSchemaKey, setPrevToolAndCachedSchemaKey] =
+    useState(toolAndCachedSchemaKey)
+  const [prevLiveSchemaSignature, setPrevLiveSchemaSignature] = useState(liveSchemaSignature)
+  if (
+    prevToolAndCachedSchemaKey !== toolAndCachedSchemaKey ||
+    prevLiveSchemaSignature !== liveSchemaSignature
+  ) {
+    const isGenuineLiveRefresh =
+      prevLiveSchemaSignature !== '' &&
+      liveSchemaSignature !== '' &&
+      prevLiveSchemaSignature !== liveSchemaSignature
+    if (prevToolAndCachedSchemaKey !== toolAndCachedSchemaKey || isGenuineLiveRefresh) {
+      setInvalidJsonDrafts({})
+    }
+    setPrevToolAndCachedSchemaKey(toolAndCachedSchemaKey)
+    setPrevLiveSchemaSignature(liveSchemaSignature)
   }
 
   const currentArgs = useCallback(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { Combobox, FieldDivider, Label, Slider, Switch } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
 import { useParams } from 'next/navigation'
@@ -94,6 +94,19 @@ export function McpDynamicArgs({
     : schemaFromStore
   const [toolArgs, setToolArgs] = useSubBlockValue(blockId, subBlockId)
 
+  /**
+   * Draft text for JSON-value params (object/array/non-primitive-enum) whose current
+   * edit isn't valid JSON yet. Keeping this out of toolArgs means the stored argument
+   * is always either the last valid parsed value or untouched — never malformed text
+   * that could reach tool execution.
+   */
+  const [invalidJsonDrafts, setInvalidJsonDrafts] = useState<Record<string, string>>({})
+  const [prevSelectedTool, setPrevSelectedTool] = useState(selectedTool)
+  if (prevSelectedTool !== selectedTool) {
+    setPrevSelectedTool(selectedTool)
+    setInvalidJsonDrafts({})
+  }
+
   const selectedToolConfig = mcpTools.find((tool) => tool.id === selectedTool)
   const toolSchema = cachedSchema || selectedToolConfig?.inputSchema
 
@@ -158,7 +171,7 @@ export function McpDynamicArgs({
       if (paramSchema.maxLength && paramSchema.maxLength > 100) return 'long-input'
       return 'short-input'
     }
-    if (paramSchema.type === 'array') return 'long-input'
+    if (paramSchema.type === 'array' || paramSchema.type === 'object') return 'long-input'
     return 'short-input'
   }
 
@@ -270,8 +283,14 @@ export function McpDynamicArgs({
 
       case 'long-input': {
         const config = createParamConfig(paramName, paramSchema, 'long-input')
+        const needsJsonValue = requiresJsonValue(paramSchema)
+        const draft = invalidJsonDrafts[paramName]
         const displayValue =
-          typeof value === 'string' || value == null ? value || '' : JSON.stringify(value)
+          needsJsonValue && draft !== undefined
+            ? draft
+            : typeof value === 'string' || value == null
+              ? value || ''
+              : JSON.stringify(value)
         return (
           <LongInput
             key={`${paramName}-long`}
@@ -282,14 +301,26 @@ export function McpDynamicArgs({
             rows={4}
             value={displayValue}
             onChange={(newValue) => {
-              if (!requiresJsonValue(paramSchema)) {
+              if (!needsJsonValue) {
                 updateParameter(paramName, newValue)
+                return
+              }
+              const clearDraft = () =>
+                setInvalidJsonDrafts((prev) => {
+                  if (!(paramName in prev)) return prev
+                  const { [paramName]: _removed, ...rest } = prev
+                  return rest
+                })
+              if (newValue === '') {
+                updateParameter(paramName, '')
+                clearDraft()
                 return
               }
               try {
                 updateParameter(paramName, JSON.parse(newValue))
+                clearDraft()
               } catch {
-                updateParameter(paramName, newValue)
+                setInvalidJsonDrafts((prev) => ({ ...prev, [paramName]: newValue }))
               }
             }}
             isPreview={isPreview}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -52,6 +52,17 @@ function schemaSignature(schema: unknown): string {
   return schema ? JSON.stringify(schema) : ''
 }
 
+/**
+ * True when text looks like an attempted JSON array/object literal (starts with `[`
+ * or `{`), as opposed to plain freeform text. Used to tell an in-progress, incomplete
+ * JSON literal (which must not persist until valid — see `requiresJsonValue`) apart
+ * from the comma-separated/plain-text shorthand array params also accept.
+ */
+function looksLikeJsonLiteral(text: string): boolean {
+  const trimmed = text.trim()
+  return trimmed.startsWith('[') || trimmed.startsWith('{')
+}
+
 interface McpDynamicArgsProps {
   blockId: string
   subBlockId: string
@@ -115,15 +126,16 @@ export function McpDynamicArgs({
    * reach tool execution. A draft is only displayed while its baseline still matches
    * the live persisted value, so an external change to that value (undo/redo, a diff
    * baseline switch, a collaborator's edit) can't be shadowed by stale draft text.
-   * Drafts also reset wholesale whenever the selected tool or either schema source
-   * changes — `toolSchema` prefers the cached `_toolSchema` snapshot over the live
-   * discovered schema, so the reset key tracks both independently rather than the
-   * resolved `toolSchema`, which wouldn't change on a live-only refresh.
+   * Drafts also reset wholesale whenever the selected tool or the schema actually
+   * backing `toolSchema` changes. The live discovered schema only factors in when
+   * there's no cached snapshot to prefer — otherwise it's not what's rendered, so
+   * live schema arriving/changing while a cached snapshot is already in effect
+   * (e.g. `mcpTools` finishing an async load) must not spuriously reset drafts.
    */
   const [invalidJsonDrafts, setInvalidJsonDrafts] = useState<
     Record<string, { text: string; baseline: string }>
   >({})
-  const draftResetKey = `${selectedTool ?? ''}|${schemaSignature(cachedSchema)}|${schemaSignature(selectedToolConfig?.inputSchema)}`
+  const draftResetKey = `${selectedTool ?? ''}|${schemaSignature(cachedSchema)}|${cachedSchema ? '' : schemaSignature(selectedToolConfig?.inputSchema)}`
   const [prevDraftResetKey, setPrevDraftResetKey] = useState(draftResetKey)
   if (prevDraftResetKey !== draftResetKey) {
     setPrevDraftResetKey(draftResetKey)
@@ -343,6 +355,11 @@ export function McpDynamicArgs({
                 updateParameter(paramName, JSON.parse(newValue))
                 clearDraft()
               } catch {
+                if (paramSchema.type === 'array' && !looksLikeJsonLiteral(newValue)) {
+                  updateParameter(paramName, newValue)
+                  clearDraft()
+                  return
+                }
                 setInvalidJsonDrafts((prev) => ({
                   ...prev,
                   [paramName]: { text: newValue, baseline: valueSignature },

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/mcp-dynamic-args/mcp-dynamic-args.tsx
@@ -128,15 +128,19 @@ export function McpDynamicArgs({
    * baseline switch, a collaborator's edit) can't be shadowed by stale draft text.
    * Drafts also reset wholesale on either of two independent triggers:
    *  - the selected tool or the cached `_toolSchema` snapshot changes (this pair
-   *    always drives `toolSchema` whenever a cached snapshot exists), or
-   *  - the live discovered schema's signature changes to a *different* non-empty
-   *    value than the last non-empty value actually observed — a genuine
-   *    re-discovery/refresh. Comparing against the last known non-empty value
-   *    (rather than merely the previous render's value) means a schema that
-   *    transiently disappears and reappears — e.g. `mcpTools` refetching, or the
-   *    tool briefly missing from a fresh list — still resets drafts if it comes
-   *    back different, while a plain empty → non-empty transition (the initial
-   *    async load) does not, since there is no prior non-empty value to compare.
+   *    always drives `toolSchema` whenever a cached snapshot exists) — the live
+   *    schema tracker is also re-baselined to the new tool's current signature
+   *    here (even if still empty), so a tool switch never leaves the *previous*
+   *    tool's signature behind to be misread as a "refresh" once the new tool's
+   *    schema loads a moment later, or
+   *  - for the *same* tool, the live discovered schema's signature changes to a
+   *    different non-empty value than the last non-empty value actually observed
+   *    — a genuine re-discovery/refresh. Comparing against the last known
+   *    non-empty value (rather than merely the previous render's value) means a
+   *    schema that transiently disappears and reappears — e.g. `mcpTools`
+   *    refetching — still resets drafts if it comes back different, while a
+   *    plain empty → non-empty transition (the initial async load) does not,
+   *    since there is no prior non-empty value for this tool to compare against.
    */
   const [invalidJsonDrafts, setInvalidJsonDrafts] = useState<
     Record<string, { text: string; baseline: string }>
@@ -147,22 +151,23 @@ export function McpDynamicArgs({
     useState(toolAndCachedSchemaKey)
   const [lastNonEmptyLiveSchemaSignature, setLastNonEmptyLiveSchemaSignature] =
     useState(liveSchemaSignature)
-  const toolOrCachedSchemaChanged = prevToolAndCachedSchemaKey !== toolAndCachedSchemaKey
-  const nextLastNonEmptyLiveSchemaSignature =
-    liveSchemaSignature !== '' ? liveSchemaSignature : lastNonEmptyLiveSchemaSignature
-  if (
-    toolOrCachedSchemaChanged ||
-    nextLastNonEmptyLiveSchemaSignature !== lastNonEmptyLiveSchemaSignature
-  ) {
-    const isGenuineLiveRefresh =
-      liveSchemaSignature !== '' &&
-      lastNonEmptyLiveSchemaSignature !== '' &&
-      liveSchemaSignature !== lastNonEmptyLiveSchemaSignature
-    if (toolOrCachedSchemaChanged || isGenuineLiveRefresh) {
-      setInvalidJsonDrafts({})
-    }
+  if (prevToolAndCachedSchemaKey !== toolAndCachedSchemaKey) {
+    setInvalidJsonDrafts({})
     setPrevToolAndCachedSchemaKey(toolAndCachedSchemaKey)
-    setLastNonEmptyLiveSchemaSignature(nextLastNonEmptyLiveSchemaSignature)
+    setLastNonEmptyLiveSchemaSignature(liveSchemaSignature)
+  } else {
+    const nextLastNonEmptyLiveSchemaSignature =
+      liveSchemaSignature !== '' ? liveSchemaSignature : lastNonEmptyLiveSchemaSignature
+    if (nextLastNonEmptyLiveSchemaSignature !== lastNonEmptyLiveSchemaSignature) {
+      const isGenuineLiveRefresh =
+        liveSchemaSignature !== '' &&
+        lastNonEmptyLiveSchemaSignature !== '' &&
+        liveSchemaSignature !== lastNonEmptyLiveSchemaSignature
+      if (isGenuineLiveRefresh) {
+        setInvalidJsonDrafts({})
+      }
+      setLastNonEmptyLiveSchemaSignature(nextLastNonEmptyLiveSchemaSignature)
+    }
   }
 
   const currentArgs = useCallback(() => {


### PR DESCRIPTION
## Summary
- Route plain object-typed MCP tool params (no enum) to the long-input JSON editor — `getInputType` previously only handled array-typed and non-primitive-enum params, leaving object params on the short-input's raw `toString()` path
- Keep invalid/in-progress JSON edits out of the actual tool argument store — an incomplete edit (e.g. `{"a":1` before the closing brace) used to fall back to storing the raw text, which the MCP execute route's array-coercion step could then silently wrap into a corrupted array instead of failing validation. Invalid text now lives in local per-param draft state so the textarea stays responsive but the persisted argument is always either the last valid parsed value or untouched

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)