### PR TITLE
fix(enrichments): remove Icypeas providers and show Running on in-flight cells

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
@@ -73,10 +73,6 @@ export function resolveCellRender({
     const inFlight =
       exec?.status === 'running' || exec?.status === 'queued' || exec?.status === 'pending'
     if (inFlight && blockRunning) return { kind: 'running' }
-    // Enrichment outputs share an empty blockId, so `runningBlockIds` can never
-    // match them — the group-level `running` status is the only "worker picked
-    // this up" signal an enrichment cell has.
-    if (isEnrichmentOutput && exec?.status === 'running') return { kind: 'running' }
 
     // Value wins over pending-upstream: a finished column stays finished even
     // while other blocks in the group are still running. An empty string is not
@@ -88,6 +84,12 @@ export function resolveCellRender({
       const text = stringifyValue(value)
       return resolveLinkKind(text, currentWorkspaceId) ?? { kind: 'value', text }
     }
+
+    // Enrichment outputs share an empty blockId, so `runningBlockIds` can never
+    // match them — the group-level `running` status is the only "worker picked
+    // this up" signal an enrichment cell has. Checked after the value so a
+    // rerun keeps showing the previous output until the new result lands.
+    if (isEnrichmentOutput && exec?.status === 'running') return { kind: 'running' }
 
     if (inFlight && !(groupHasBlockErrors && !blockRunning)) {
       // A `pending` cell whose jobId starts with `paused-` is mid-pause

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
@@ -73,6 +73,10 @@ export function resolveCellRender({
     const inFlight =
       exec?.status === 'running' || exec?.status === 'queued' || exec?.status === 'pending'
     if (inFlight && blockRunning) return { kind: 'running' }
+    // Enrichment outputs share an empty blockId, so `runningBlockIds` can never
+    // match them — the group-level `running` status is the only "worker picked
+    // this up" signal an enrichment cell has.
+    if (isEnrichmentOutput && exec?.status === 'running') return { kind: 'running' }
 
     // Value wins over pending-upstream: a finished column stays finished even
     // while other blocks in the group are still running. An empty string is not

--- a/apps/sim/enrichments/email-verification/email-verification.test.ts
+++ b/apps/sim/enrichments/email-verification/email-verification.test.ts
@@ -19,7 +19,6 @@ describe('email-verification enrichment cascade', () => {
       'zerobounce',
       'neverbounce',
       'millionverifier',
-      'icypeas',
       'enrow',
     ])
   })
@@ -35,31 +34,6 @@ describe('email-verification enrichment cascade', () => {
         deliverable: true,
       })
       expect(p.mapOutput({ status: 'unknown', deliverable: false })).toBeNull()
-      expect(p.mapOutput({})).toBeNull()
-    })
-  })
-
-  describe('icypeas', () => {
-    const p = provider('icypeas')
-    it('maps FOUND/DEBITED to deliverable and NOT_FOUND to undeliverable', () => {
-      expect(p.toolId).toBe('icypeas_verify_email')
-      expect(p.buildParams(emailInput)).toEqual({ email: 'john@acme.com' })
-      expect(p.buildParams({ email: '' })).toBeNull()
-      expect(p.mapOutput({ status: 'FOUND' })).toEqual({ status: 'valid', deliverable: true })
-      expect(p.mapOutput({ status: 'DEBITED' })).toEqual({ status: 'valid', deliverable: true })
-      expect(p.mapOutput({ status: 'NOT_FOUND' })).toEqual({
-        status: 'invalid',
-        deliverable: false,
-      })
-      expect(p.mapOutput({ status: 'DEBITED_NOT_FOUND' })).toEqual({
-        status: 'invalid',
-        deliverable: false,
-      })
-    })
-    it('falls through on inconclusive statuses', () => {
-      expect(p.mapOutput({ status: 'BAD_INPUT' })).toBeNull()
-      expect(p.mapOutput({ status: 'INSUFFICIENT_FUNDS' })).toBeNull()
-      expect(p.mapOutput({ status: 'ABORTED' })).toBeNull()
       expect(p.mapOutput({})).toBeNull()
     })
   })

--- a/apps/sim/enrichments/email-verification/email-verification.ts
+++ b/apps/sim/enrichments/email-verification/email-verification.ts
@@ -5,7 +5,7 @@ import type { EnrichmentConfig } from '@/enrichments/types'
 /**
  * Email Verification enrichment. Checks an email address's deliverability via a
  * verifier waterfall — ZeroBounce first (highest coverage), then NeverBounce,
- * then MillionVerifier, then Icypeas, then Enrow. A provider that returns a
+ * then MillionVerifier, then Enrow. A provider that returns a
  * definitive verdict (valid / invalid / catch_all / disposable / etc.) fills the
  * cell; a provider that can only return `unknown` falls through to the next so
  * the row gets the most confident answer available. All providers support hosted
@@ -66,26 +66,6 @@ export const emailVerificationEnrichment: EnrichmentConfig = {
         const status = str(output.status)
         if (!status || status === 'unknown') return null
         return { status, deliverable: output.deliverable === true }
-      },
-    }),
-    toolProvider({
-      id: 'icypeas',
-      label: 'Icypeas',
-      toolId: 'icypeas_verify_email',
-      buildParams: (inputs) => {
-        const email = str(inputs.email)
-        if (!email) return null
-        return { email }
-      },
-      mapOutput: (output) => {
-        // FOUND/DEBITED → deliverable, NOT_FOUND/DEBITED_NOT_FOUND → undeliverable.
-        // Bad input / insufficient funds / aborted are inconclusive → fall through.
-        const status = str(output.status)
-        if (status === 'FOUND' || status === 'DEBITED')
-          return { status: 'valid', deliverable: true }
-        if (status === 'NOT_FOUND' || status === 'DEBITED_NOT_FOUND')
-          return { status: 'invalid', deliverable: false }
-        return null
       },
     }),
     toolProvider({

--- a/apps/sim/enrichments/work-email/work-email.test.ts
+++ b/apps/sim/enrichments/work-email/work-email.test.ts
@@ -26,7 +26,6 @@ describe('work-email enrichment cascade', () => {
       'datagma',
       'leadmagic',
       'dropcontact',
-      'icypeas',
       'enrow',
     ])
   })
@@ -127,25 +126,6 @@ describe('work-email enrichment cascade', () => {
       expect(p.buildParams({ companyDomain: 'acme.com' })).toBeNull()
       expect(p.mapOutput({ email: 'j@acme.com' })).toEqual({ email: 'j@acme.com' })
       expect(p.mapOutput({})).toBeNull()
-    })
-  })
-
-  describe('icypeas', () => {
-    const p = provider('icypeas')
-    it('splits the name when possible and keeps mononym rows', () => {
-      expect(p.toolId).toBe('icypeas_find_email')
-      expect(p.buildParams(nameDomain)).toEqual({
-        firstname: 'John',
-        lastname: 'Doe',
-        domainOrCompany: 'acme.com',
-      })
-      // single-token name runs with firstname alone (lastname is optional)
-      expect(p.buildParams({ fullName: 'Cher', companyDomain: 'acme.com' })).toEqual({
-        firstname: 'Cher',
-        domainOrCompany: 'acme.com',
-      })
-      expect(p.buildParams({ fullName: 'John Doe' })).toBeNull()
-      expect(p.mapOutput({ email: 'j@acme.com' })).toEqual({ email: 'j@acme.com' })
     })
   })
 

--- a/apps/sim/enrichments/work-email/work-email.ts
+++ b/apps/sim/enrichments/work-email/work-email.ts
@@ -8,7 +8,7 @@ import type { EnrichmentConfig } from '@/enrichments/types'
  * available identifiers (company domain, LinkedIn URL) via a provider waterfall:
  * deterministic finders first (Hunter, Findymail by name then by LinkedIn), then
  * enrichment/reveal providers (Prospeo, Wiza), then People Data Labs as a broad
- * record-match fallback, then Datagma, LeadMagic, Dropcontact, Icypeas, and Enrow
+ * record-match fallback, then Datagma, LeadMagic, Dropcontact, and Enrow
  * as additional finders. Each provider opportunistically uses whatever
  * identifiers the row provides and self-skips when it has none usable, so adding
  * more inputs widens coverage. First email wins; all providers support hosted keys.
@@ -183,26 +183,6 @@ export const workEmailEnrichment: EnrichmentConfig = {
           website: website || undefined,
           linkedin: linkedin || undefined,
         })
-      },
-      mapOutput: (output) => {
-        const email = str(output.email)
-        return email ? { email } : null
-      },
-    }),
-    toolProvider({
-      id: 'icypeas',
-      label: 'Icypeas',
-      toolId: 'icypeas_find_email',
-      buildParams: (inputs) => {
-        // Icypeas only requires domainOrCompany; firstname/lastname are optional,
-        // so a mononym still runs with firstname alone rather than self-skipping.
-        const fullName = str(inputs.fullName)
-        const domainOrCompany = normalizeDomain(inputs.companyDomain)
-        if (!fullName || !domainOrCompany) return null
-        const name = splitName(inputs.fullName)
-        return name
-          ? { firstname: name.firstName, lastname: name.lastName, domainOrCompany }
-          : { firstname: fullName, domainOrCompany }
       },
       mapOutput: (output) => {
         const email = str(output.email)


### PR DESCRIPTION
## Summary
- Remove the Icypeas provider from the work-email and email-verification enrichment cascades — it's too slow and drags down cascade latency
- Fix enrichment cells showing Pending while actually running: enrichment outputs share an empty blockId so `runningBlockIds` never matches them; the cell renderer now treats the group-level `running` status as the running signal for enrichment cells

## Type of Change
- [x] Bug fix

## Testing
Enrichment cascade unit tests updated and passing; lint, lint:check, and check:api-validation:strict pass. tsc clean (two pre-existing errors on staging unrelated to this change).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjVoXKFCHaD6BpPGZrEKQE