### PR TITLE
feat(context-dev): add Context.dev to hosted key rotation pool

### DIFF
--- a/apps/sim/.env.example
+++ b/apps/sim/.env.example
@@ -77,6 +77,9 @@ API_ENCRYPTION_KEY=your_api_encryption_key # Use `openssl rand -hex 32` to gener
 # PEOPLEDATALABS_API_KEY_COUNT=2                 # Number of People Data Labs keys for hosted PDL blocks
 # PEOPLEDATALABS_API_KEY_1=                      # People Data Labs API key #1
 # PEOPLEDATALABS_API_KEY_2=                      # People Data Labs API key #2
+# CONTEXT_DEV_API_KEY_COUNT=2                    # Number of Context.dev keys for hosted Context.dev blocks
+# CONTEXT_DEV_API_KEY_1=                         # Context.dev API key #1
+# CONTEXT_DEV_API_KEY_2=                         # Context.dev API key #2
 
 # File Storage (Optional - defaults to local disk; use S3 or Azure Blob for production)
 # AWS_REGION=us-east-1                            # Required with S3_BUCKET_NAME to enable S3. Use "auto" for Cloudflare R2

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/byok/byok.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/byok/byok.tsx
@@ -6,6 +6,7 @@ import {
   AnthropicIcon,
   BasetenIcon,
   BrandfetchIcon,
+  ContextDevIcon,
   DatagmaIcon,
   DropcontactIcon,
   EnrowIcon,
@@ -123,6 +124,13 @@ const PROVIDERS: (BYOKManagerProvider & { id: BYOKProviderId })[] = [
     icon: ExaAIIcon,
     description: 'AI-powered search and research',
     placeholder: 'Enter your Exa API key',
+  },
+  {
+    id: 'context_dev',
+    name: 'Context.dev',
+    icon: ContextDevIcon,
+    description: 'Web scraping, crawling, search, and brand intelligence',
+    placeholder: 'Enter your Context.dev API key',
   },
   {
     id: 'serper',
@@ -291,6 +299,7 @@ const PROVIDER_SECTIONS: BYOKProviderSection[] = [
     ids: [
       'firecrawl',
       'exa',
+      'context_dev',
       'serper',
       'linkup',
       'parallel_ai',

--- a/apps/sim/blocks/blocks/context_dev.ts
+++ b/apps/sim/blocks/blocks/context_dev.ts
@@ -540,6 +540,7 @@ Do not include any explanations, markdown formatting, or other text outside the 
       placeholder: 'Enter your Context.dev API key',
       password: true,
       required: true,
+      hideWhenHosted: true,
     },
   ],
   tools: {

--- a/apps/sim/lib/api/contracts/byok-keys.ts
+++ b/apps/sim/lib/api/contracts/byok-keys.ts
@@ -14,6 +14,7 @@ export const byokProviderIdSchema = z.enum([
   'falai',
   'firecrawl',
   'exa',
+  'context_dev',
   'serper',
   'linkup',
   'perplexity',

--- a/apps/sim/tools/context_dev/classify_naics.ts
+++ b/apps/sim/tools/context_dev/classify_naics.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevClassifyNaicsParams,
   ContextDevClassifyNaicsResponse,
@@ -21,6 +22,8 @@ export const contextDevClassifyNaicsTool: ToolConfig<
   name: 'Context.dev Classify NAICS',
   description: 'Classify a brand into NAICS industry codes from its domain or company name.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevClassifyNaicsParams>(),
 
   params: {
     input: {

--- a/apps/sim/tools/context_dev/classify_sic.ts
+++ b/apps/sim/tools/context_dev/classify_sic.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevClassifySicParams,
   ContextDevClassifySicResponse,
@@ -21,6 +22,8 @@ export const contextDevClassifySicTool: ToolConfig<
   name: 'Context.dev Classify SIC',
   description: 'Classify a brand into SIC industry codes from its domain or company name.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevClassifySicParams>(),
 
   params: {
     input: {

--- a/apps/sim/tools/context_dev/crawl.ts
+++ b/apps/sim/tools/context_dev/crawl.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type { ContextDevCrawlParams, ContextDevCrawlResponse } from '@/tools/context_dev/types'
 import { CRAWL_RESULT_OUTPUT_PROPERTIES } from '@/tools/context_dev/types'
 import {
@@ -14,6 +15,8 @@ export const contextDevCrawlTool: ToolConfig<ContextDevCrawlParams, ContextDevCr
   name: 'Context.dev Crawl',
   description: 'Crawl an entire website and return each discovered page as clean markdown.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevCrawlParams>(),
 
   params: {
     url: {

--- a/apps/sim/tools/context_dev/extract.ts
+++ b/apps/sim/tools/context_dev/extract.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type { ContextDevExtractParams, ContextDevExtractResponse } from '@/tools/context_dev/types'
 import {
   CONTEXT_DEV_BASE_URL,
@@ -14,6 +15,8 @@ export const contextDevExtractTool: ToolConfig<ContextDevExtractParams, ContextD
     name: 'Context.dev Extract',
     description: 'Crawl a website and extract structured data matching a provided JSON schema.',
     version: '1.0.0',
+
+    hosting: contextDevHosting<ContextDevExtractParams>(),
 
     params: {
       url: {

--- a/apps/sim/tools/context_dev/extract_product.ts
+++ b/apps/sim/tools/context_dev/extract_product.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevExtractProductParams,
   ContextDevExtractProductResponse,
@@ -20,6 +21,8 @@ export const contextDevExtractProductTool: ToolConfig<
   name: 'Context.dev Extract Product',
   description: 'Detect and extract structured product details from a single product page URL.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevExtractProductParams>(),
 
   params: {
     url: {

--- a/apps/sim/tools/context_dev/extract_products.ts
+++ b/apps/sim/tools/context_dev/extract_products.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevExtractProductsParams,
   ContextDevExtractProductsResponse,
@@ -20,6 +21,8 @@ export const contextDevExtractProductsTool: ToolConfig<
   name: 'Context.dev Extract Products',
   description: "Extract the product catalog from a brand's website by domain (beta).",
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevExtractProductsParams>(),
 
   params: {
     domain: {

--- a/apps/sim/tools/context_dev/get_brand.ts
+++ b/apps/sim/tools/context_dev/get_brand.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type { ContextDevBrandResponse, ContextDevGetBrandParams } from '@/tools/context_dev/types'
 import { BRAND_OUTPUT_PROPERTIES } from '@/tools/context_dev/types'
 import {
@@ -17,6 +18,8 @@ export const contextDevGetBrandTool: ToolConfig<ContextDevGetBrandParams, Contex
     description:
       'Retrieve brand data for a domain: logos, colors, backdrops, socials, address, and industry.',
     version: '1.0.0',
+
+    hosting: contextDevHosting<ContextDevGetBrandParams>(),
 
     params: {
       domain: {

--- a/apps/sim/tools/context_dev/get_brand_by_email.ts
+++ b/apps/sim/tools/context_dev/get_brand_by_email.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevBrandResponse,
   ContextDevGetBrandByEmailParams,
@@ -22,6 +23,8 @@ export const contextDevGetBrandByEmailTool: ToolConfig<
   description:
     'Retrieve brand data from a work email address. Free/disposable emails are rejected (422).',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevGetBrandByEmailParams>(),
 
   params: {
     email: {

--- a/apps/sim/tools/context_dev/get_brand_by_name.ts
+++ b/apps/sim/tools/context_dev/get_brand_by_name.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevBrandResponse,
   ContextDevGetBrandByNameParams,
@@ -22,6 +23,8 @@ export const contextDevGetBrandByNameTool: ToolConfig<
   description:
     'Retrieve brand data by company name: logos, colors, socials, address, and industry.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevGetBrandByNameParams>(),
 
   params: {
     name: {

--- a/apps/sim/tools/context_dev/get_brand_by_ticker.ts
+++ b/apps/sim/tools/context_dev/get_brand_by_ticker.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevBrandResponse,
   ContextDevGetBrandByTickerParams,
@@ -21,6 +22,8 @@ export const contextDevGetBrandByTickerTool: ToolConfig<
   name: 'Context.dev Get Brand by Ticker',
   description: 'Retrieve brand data for a public company by its stock ticker symbol.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevGetBrandByTickerParams>(),
 
   params: {
     ticker: {

--- a/apps/sim/tools/context_dev/get_brand_simplified.ts
+++ b/apps/sim/tools/context_dev/get_brand_simplified.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevGetBrandSimplifiedParams,
   ContextDevGetBrandSimplifiedResponse,
@@ -21,6 +22,8 @@ export const contextDevGetBrandSimplifiedTool: ToolConfig<
   name: 'Context.dev Get Brand (Simplified)',
   description: 'Retrieve essential brand data for a domain: title, colors, logos, and backdrops.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevGetBrandSimplifiedParams>(),
 
   params: {
     domain: {

--- a/apps/sim/tools/context_dev/hosting.test.ts
+++ b/apps/sim/tools/context_dev/hosting.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { contextDevClassifyNaicsTool } from '@/tools/context_dev/classify_naics'
+import { contextDevGetBrandTool } from '@/tools/context_dev/get_brand'
+import { CONTEXT_DEV_CREDIT_USD } from '@/tools/context_dev/hosting'
+import { contextDevScrapeMarkdownTool } from '@/tools/context_dev/scrape_markdown'
+import { contextDevScreenshotTool } from '@/tools/context_dev/screenshot'
+import type { ToolConfig } from '@/tools/types'
+
+function cost(tool: ToolConfig<any, any>, params: any, output: Record<string, unknown>) {
+  const pricing = tool.hosting?.pricing
+  if (!pricing || pricing.type !== 'custom') throw new Error('Expected custom pricing')
+  const result = pricing.getCost(params, output)
+  return typeof result === 'number' ? { cost: result } : result
+}
+
+describe('Context.dev hosted key pricing', () => {
+  it('declares hosting with the shared env prefix and BYOK provider on every tool', () => {
+    for (const tool of [
+      contextDevScrapeMarkdownTool,
+      contextDevScreenshotTool,
+      contextDevGetBrandTool,
+      contextDevClassifyNaicsTool,
+    ]) {
+      expect(tool.hosting?.envKeyPrefix).toBe('CONTEXT_DEV_API_KEY')
+      expect(tool.hosting?.byokProviderId).toBe('context_dev')
+    }
+  })
+
+  it('charges the reported credits at the per-credit rate for a 1-credit scrape', () => {
+    expect(cost(contextDevScrapeMarkdownTool, {}, { creditsConsumed: 1 }).cost).toBeCloseTo(
+      CONTEXT_DEV_CREDIT_USD
+    )
+  })
+
+  it('charges the reported credits at the per-credit rate for a 5-credit screenshot', () => {
+    expect(cost(contextDevScreenshotTool, {}, { creditsConsumed: 5 }).cost).toBeCloseTo(
+      5 * CONTEXT_DEV_CREDIT_USD
+    )
+  })
+
+  it('charges the reported credits at the per-credit rate for a 10-credit brand lookup', () => {
+    expect(cost(contextDevGetBrandTool, {}, { creditsConsumed: 10 }).cost).toBeCloseTo(
+      10 * CONTEXT_DEV_CREDIT_USD
+    )
+  })
+
+  it('charges zero when the response has no credit accounting', () => {
+    expect(cost(contextDevClassifyNaicsTool, {}, { creditsConsumed: null }).cost).toBe(0)
+    expect(cost(contextDevClassifyNaicsTool, {}, {}).cost).toBe(0)
+  })
+})

--- a/apps/sim/tools/context_dev/hosting.ts
+++ b/apps/sim/tools/context_dev/hosting.ts
@@ -1,0 +1,42 @@
+import type { ToolHostingConfig } from '@/tools/types'
+
+/**
+ * Env var prefix for Context.dev hosted keys. Provide keys as
+ * `CONTEXT_DEV_API_KEY_COUNT` plus `CONTEXT_DEV_API_KEY_1..N`.
+ */
+export const CONTEXT_DEV_API_KEY_PREFIX = 'CONTEXT_DEV_API_KEY'
+
+/**
+ * Dollar cost of a single Context.dev credit.
+ *
+ * Estimated from the $25/month Developer plan (10,000 credits = $0.0025/credit)
+ * — https://www.context.dev/pricing. Endpoints cost 1, 5, or 10 credits
+ * depending on operation; actual usage is read from each response's
+ * `key_metadata.credits_consumed` rather than hardcoded per endpoint.
+ */
+export const CONTEXT_DEV_CREDIT_USD = 0.0025
+
+/**
+ * Build a Context.dev `hosting` config. Every Context.dev response reports the
+ * exact credits consumed via `key_metadata.credits_consumed`, already surfaced
+ * on tool output as `creditsConsumed` by `extractCreditMetadata` — so cost is
+ * read directly from the response rather than estimated per endpoint.
+ */
+export function contextDevHosting<P>(): ToolHostingConfig<P> {
+  return {
+    envKeyPrefix: CONTEXT_DEV_API_KEY_PREFIX,
+    apiKeyParam: 'apiKey',
+    byokProviderId: 'context_dev',
+    pricing: {
+      type: 'custom',
+      getCost: (_params, output) => {
+        const credits = (output.creditsConsumed as number | null) ?? 0
+        return { cost: credits * CONTEXT_DEV_CREDIT_USD, metadata: { credits } }
+      },
+    },
+    rateLimit: {
+      mode: 'per_request',
+      requestsPerMinute: 60,
+    },
+  }
+}

--- a/apps/sim/tools/context_dev/identify_transaction.ts
+++ b/apps/sim/tools/context_dev/identify_transaction.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevBrandResponse,
   ContextDevIdentifyTransactionParams,
@@ -22,6 +23,8 @@ export const contextDevIdentifyTransactionTool: ToolConfig<
   description:
     'Identify the brand behind a raw bank/card transaction descriptor and return its brand data.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevIdentifyTransactionParams>(),
 
   params: {
     transactionInfo: {

--- a/apps/sim/tools/context_dev/map.ts
+++ b/apps/sim/tools/context_dev/map.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type { ContextDevMapParams, ContextDevMapResponse } from '@/tools/context_dev/types'
 import {
   appendParam,
@@ -14,6 +15,8 @@ export const contextDevMapTool: ToolConfig<ContextDevMapParams, ContextDevMapRes
   name: 'Context.dev Map',
   description: 'Build a sitemap of a domain and return every discovered page URL.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevMapParams>(),
 
   params: {
     domain: {

--- a/apps/sim/tools/context_dev/prefetch_by_email.ts
+++ b/apps/sim/tools/context_dev/prefetch_by_email.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevPrefetchByEmailParams,
   ContextDevPrefetchResponse,
@@ -20,6 +21,8 @@ export const contextDevPrefetchByEmailTool: ToolConfig<
   description:
     "Queue an email's domain for brand-data prefetching to reduce later latency (subscribers; 0 credits). Free/disposable emails are rejected.",
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevPrefetchByEmailParams>(),
 
   params: {
     email: {

--- a/apps/sim/tools/context_dev/prefetch_domain.ts
+++ b/apps/sim/tools/context_dev/prefetch_domain.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevPrefetchDomainParams,
   ContextDevPrefetchResponse,
@@ -20,6 +21,8 @@ export const contextDevPrefetchDomainTool: ToolConfig<
   description:
     'Queue a domain for brand-data prefetching to reduce latency on later requests (subscribers; 0 credits).',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevPrefetchDomainParams>(),
 
   params: {
     domain: {

--- a/apps/sim/tools/context_dev/scrape_fonts.ts
+++ b/apps/sim/tools/context_dev/scrape_fonts.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevScrapeFontsParams,
   ContextDevScrapeFontsResponse,
@@ -21,6 +22,8 @@ export const contextDevScrapeFontsTool: ToolConfig<
   name: 'Context.dev Scrape Fonts',
   description: 'Extract the font families, usage stats, and font files used by a domain.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevScrapeFontsParams>(),
 
   params: {
     domain: {

--- a/apps/sim/tools/context_dev/scrape_html.ts
+++ b/apps/sim/tools/context_dev/scrape_html.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevScrapeHtmlParams,
   ContextDevScrapeHtmlResponse,
@@ -20,6 +21,8 @@ export const contextDevScrapeHtmlTool: ToolConfig<
   name: 'Context.dev Scrape HTML',
   description: 'Scrape any URL and return the raw HTML content of the page.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevScrapeHtmlParams>(),
 
   params: {
     url: {

--- a/apps/sim/tools/context_dev/scrape_images.ts
+++ b/apps/sim/tools/context_dev/scrape_images.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevScrapeImagesParams,
   ContextDevScrapeImagesResponse,
@@ -21,6 +22,8 @@ export const contextDevScrapeImagesTool: ToolConfig<
   name: 'Context.dev Scrape Images',
   description: 'Discover every image asset on a page, with optional dimension and type enrichment.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevScrapeImagesParams>(),
 
   params: {
     url: {

--- a/apps/sim/tools/context_dev/scrape_markdown.ts
+++ b/apps/sim/tools/context_dev/scrape_markdown.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevScrapeMarkdownParams,
   ContextDevScrapeMarkdownResponse,
@@ -20,6 +21,8 @@ export const contextDevScrapeMarkdownTool: ToolConfig<
   name: 'Context.dev Scrape Markdown',
   description: 'Scrape any URL and return clean, LLM-ready markdown content.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevScrapeMarkdownParams>(),
 
   params: {
     url: {

--- a/apps/sim/tools/context_dev/scrape_styleguide.ts
+++ b/apps/sim/tools/context_dev/scrape_styleguide.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevScrapeStyleguideParams,
   ContextDevScrapeStyleguideResponse,
@@ -21,6 +22,8 @@ export const contextDevScrapeStyleguideTool: ToolConfig<
   description:
     "Extract a domain's design system: colors, typography, spacing, shadows, and UI components.",
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevScrapeStyleguideParams>(),
 
   params: {
     domain: {

--- a/apps/sim/tools/context_dev/screenshot.ts
+++ b/apps/sim/tools/context_dev/screenshot.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type {
   ContextDevScreenshotParams,
   ContextDevScreenshotResponse,
@@ -46,6 +47,8 @@ export const contextDevScreenshotTool: ToolConfig<
   name: 'Context.dev Screenshot',
   description: 'Capture a screenshot of any web page and store it as a downloadable image file.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevScreenshotParams>(),
 
   params: {
     url: {

--- a/apps/sim/tools/context_dev/search.ts
+++ b/apps/sim/tools/context_dev/search.ts
@@ -1,3 +1,4 @@
+import { contextDevHosting } from '@/tools/context_dev/hosting'
 import type { ContextDevSearchParams, ContextDevSearchResponse } from '@/tools/context_dev/types'
 import { SEARCH_RESULT_OUTPUT_PROPERTIES } from '@/tools/context_dev/types'
 import {
@@ -14,6 +15,8 @@ export const contextDevSearchTool: ToolConfig<ContextDevSearchParams, ContextDev
   name: 'Context.dev Search',
   description: 'Search the web with natural language and optionally scrape results to markdown.',
   version: '1.0.0',
+
+  hosting: contextDevHosting<ContextDevSearchParams>(),
 
   params: {
     query: {

--- a/apps/sim/tools/types.ts
+++ b/apps/sim/tools/types.ts
@@ -15,6 +15,7 @@ export type BYOKProviderId =
   | 'falai'
   | 'firecrawl'
   | 'exa'
+  | 'context_dev'
   | 'serper'
   | 'jina'
   | 'perplexity'


### PR DESCRIPTION
## Summary
- Add Context.dev to the hosted-key mechanism, mirroring Exa's pattern exactly
- New `apps/sim/tools/context_dev/hosting.ts` shared helper: `CONTEXT_DEV_API_KEY` env prefix (`_COUNT` + `_1..N` rotation), `byokProviderId: 'context_dev'`, `per_request` rate limit (60/min)
- All 22 `context_dev_*` tools wired with `hosting: contextDevHosting<...>()`
- Cost is computed from each response's actual `credits_consumed` (already surfaced as `output.creditsConsumed`) rather than a hardcoded per-endpoint guess — more accurate than static estimates since Context.dev reports real usage per call
- `context_dev` added to `BYOKProviderId`, `byokProviderIdSchema`, and the Settings → BYOK UI (`Search & web` section, next to Exa/Firecrawl)
- Block's API Key field gets `hideWhenHosted: true` — no operation split needed since all 22 ops support hosted keys (unlike Exa, which excludes `research`)
- `.env.example` documents `CONTEXT_DEV_API_KEY_COUNT/1/2`

## Type of Change
- [x] New feature

## Testing
- `bun run check:api-validation` passes
- `bunx tsc --noEmit` clean on touched files (1 pre-existing unrelated error elsewhere on staging)
- `bunx vitest run tools/context_dev/ tools/index.test.ts blocks/blocks.test.ts` — 168/168 passing
- `bun run lint` clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)