### PR TITLE
Add Unstructured Transform MCP starter template

### DIFF
--- a/apps/docs/content/docs/en/agents/mcp.mdx
+++ b/apps/docs/content/docs/en/agents/mcp.mdx
@@ -76,7 +76,7 @@ When you type `{{` in the URL or header fields, a dropdown appears showing avail
 
 The add modal includes starter templates for common MCP servers.
 
-For [Unstructured Transform](https://docs.unstructured.io/transform/quickstart), first add a workspace environment variable named `UNSTRUCTURED_API_KEY`, then choose the Unstructured Transform template. It pre-fills:
+For [Unstructured Transform](https://docs.unstructured.io/transform/quickstart), first add a workspace environment variable named `UNSTRUCTURED_API_KEY`, then choose the Unstructured Transform template. Unstructured Transform converts documents (PDF, DOCX, PPTX, HTML, and images, including scanned or image-only pages via OCR) into clean markdown, JSON, HTML, or text. It also supports RAG preprocessing with chunking, enrichment, and embedding. The template pre-fills:
 
 ```
 URL: https://mcp.transform.unstructured.io

--- a/apps/docs/content/docs/en/agents/mcp.mdx
+++ b/apps/docs/content/docs/en/agents/mcp.mdx
@@ -72,6 +72,19 @@ Authorization: Bearer {{MCP_API_TOKEN}}
 
 When you type `{{` in the URL or header fields, a dropdown appears showing available workspace environment variables.
 
+### Starter Configurations
+
+The add modal includes starter templates for common MCP servers.
+
+For [Unstructured Transform](https://docs.unstructured.io/transform/quickstart), first add a workspace environment variable named `UNSTRUCTURED_API_KEY`, then choose the Unstructured Transform template. It pre-fills:
+
+```
+URL: https://mcp.transform.unstructured.io
+Authorization: Bearer {{UNSTRUCTURED_API_KEY}}
+```
+
+If your self-hosted deployment sets `ALLOWED_MCP_DOMAINS`, include `mcp.transform.unstructured.io` before saving the server.
+
 ### Testing and Validation
 
 Click **Test Connection** before saving to verify the server is reachable and discover available tools. The test response shows the number of tools found and the protocol version.

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
@@ -16,7 +16,7 @@ import {
 } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { ChevronDown, ChevronRight, Plus } from 'lucide-react'
 import type { McpAuthType, McpTransport } from '@/lib/mcp/types'
 import {
   checkEnvVarTrigger,
@@ -24,6 +24,11 @@ import {
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/env-var-dropdown'
 import { formatDisplayText } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/formatted-text'
 import { useMcpServerTest } from '@/hooks/queries/mcp'
+import {
+  buildHeadersFromTemplate,
+  MCP_SERVER_TEMPLATES,
+  type McpServerTemplate,
+} from './mcp-server-templates'
 
 const logger = createLogger('McpServerFormModal')
 
@@ -300,6 +305,41 @@ function updateHeadersArray(
   return updated.filter((h, i) => i === lastIndex || h.key !== '' || h.value !== '')
 }
 
+interface TemplatePickerProps {
+  onSelect: (template: McpServerTemplate) => void
+}
+
+function TemplatePicker({ onSelect }: TemplatePickerProps) {
+  if (MCP_SERVER_TEMPLATES.length === 0) return null
+
+  return (
+    <ChipModalField type='custom' title='Starter templates'>
+      <div className='flex flex-col gap-2'>
+        {MCP_SERVER_TEMPLATES.map((template) => (
+          <button
+            key={template.id}
+            type='button'
+            onClick={() => onSelect(template)}
+            className='group flex w-full items-center justify-between gap-3 rounded-md border border-[var(--border-1)] bg-[var(--surface-3)] px-2.5 py-2 text-left transition-colors hover-hover:bg-[var(--surface-4)]'
+          >
+            <span className='flex min-w-0 flex-col gap-0.5'>
+              <span className='truncate font-medium text-[var(--text-primary)] text-sm'>
+                {template.name}
+              </span>
+              <span className='line-clamp-2 text-[var(--text-muted)] text-xs leading-relaxed'>
+                {template.description}
+              </span>
+            </span>
+            <span className='flex size-6 flex-shrink-0 items-center justify-center rounded-md border border-[var(--border-1)] text-[var(--text-muted)] transition-colors group-hover:text-[var(--text-primary)]'>
+              <Plus className='size-[14px]' />
+            </span>
+          </button>
+        ))}
+      </div>
+    </ChipModalField>
+  )
+}
+
 export function McpServerFormModal({
   open,
   onOpenChange,
@@ -413,6 +453,23 @@ export function McpServerFormModal({
       }))
     }
     resetEnvVarState()
+  }
+
+  const handleTemplateSelect = (template: McpServerTemplate) => {
+    if (testResult) clearTestResult()
+    if (submitError) setSubmitError(null)
+    resetEnvVarState()
+    setFormMode('form')
+    setFormData((prev) => ({
+      ...prev,
+      name: template.name,
+      transport: template.transport,
+      url: template.url,
+      timeout: template.timeout,
+      headers: buildHeadersFromTemplate(template),
+    }))
+    setUrlScrollLeft(0)
+    setHeaderScrollLeft({})
   }
 
   const handleHeaderScroll = (key: string, sl: number) => {
@@ -668,6 +725,7 @@ export function McpServerFormModal({
           />
         ) : (
           <>
+            {mode === 'add' && <TemplatePicker onSelect={handleTemplateSelect} />}
             <input
               type='text'
               name='fakeusernameremembered'

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-templates.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-templates.ts
@@ -1,0 +1,30 @@
+import type { McpTransport } from '@/lib/mcp/types'
+
+export interface McpServerTemplate {
+  id: string
+  name: string
+  description: string
+  transport: McpTransport
+  url: string
+  headers: readonly {
+    key: string
+    value: string
+  }[]
+  timeout: number
+}
+
+export const MCP_SERVER_TEMPLATES = [
+  {
+    id: 'unstructured-transform',
+    name: 'Unstructured Transform',
+    description: 'Process PDFs, images, Office files, and other documents through Transform.',
+    transport: 'streamable-http',
+    url: 'https://mcp.transform.unstructured.io',
+    headers: [{ key: 'Authorization', value: 'Bearer {{UNSTRUCTURED_API_KEY}}' }],
+    timeout: 30000,
+  },
+] as const satisfies readonly McpServerTemplate[]
+
+export function buildHeadersFromTemplate(template: McpServerTemplate) {
+  return [...template.headers.map((header) => ({ ...header })), { key: '', value: '' }]
+}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-templates.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-templates.ts
@@ -17,7 +17,8 @@ export const MCP_SERVER_TEMPLATES = [
   {
     id: 'unstructured-transform',
     name: 'Unstructured Transform',
-    description: 'Process PDFs, images, Office files, and other documents through Transform.',
+    description:
+      'Convert PDFs, DOCX, PPTX, HTML, and images into clean markdown, JSON, HTML, or text with OCR and RAG preprocessing.',
     transport: 'streamable-http',
     url: 'https://mcp.transform.unstructured.io',
     headers: [{ key: 'Authorization', value: 'Bearer {{UNSTRUCTURED_API_KEY}}' }],


### PR DESCRIPTION
## What changed

- Added a reusable MCP server template list to the Add MCP Server modal.
- Added Unstructured Transform as a starter template with the streamable HTTP endpoint and Authorization header placeholder.
- Clarified what Unstructured Transform does: converts PDFs, DOCX, PPTX, HTML, and images, including scanned/image-only pages via OCR, into clean markdown, JSON, HTML, or text, with RAG preprocessing for chunking, enrichment, and embedding.
- Documented the Unstructured setup flow in the MCP tools docs, including the required `UNSTRUCTURED_API_KEY` environment variable and allowlist domain.

## Why

Unstructured Transform is exposed as an MCP server, so discoverability fits best as a first-class MCP starter configuration instead of a guessed native REST connector. Selecting the template fills the server name, URL, transport, timeout, and header values while still using Sim's existing connection test and MCP execution flow.

## Validation

- `pnpm dlx @biomejs/biome@2.0.0-beta.5 check --no-errors-on-unmatched --files-ignore-unknown=true ...`
- `git diff --check`

Full workspace checks were not run in this fresh clone because Bun is not installed in the local shell and dependencies are not installed.