### PR TITLE
fix(webhooks): stop dropping pre-deployment verification response on shared paths

### DIFF
--- a/apps/sim/app/api/webhooks/trigger/[path]/route.test.ts
+++ b/apps/sim/app/api/webhooks/trigger/[path]/route.test.ts
@@ -666,6 +666,49 @@ describe('Webhook Trigger API Route', () => {
       expect(response.status).toBe(402)
     })
 
+    it('returns the pre-deployment verification 200 immediately even when the path is shared', async () => {
+      testData.webhooks.push(
+        {
+          id: 'not-yet-deployed-webhook',
+          provider: 'microsoft-teams',
+          path: 'test-path',
+          isActive: true,
+          providerConfig: {},
+          workflowId: 'test-workflow-id',
+        },
+        {
+          id: 'generic-webhook-b',
+          provider: 'generic',
+          path: 'test-path',
+          isActive: true,
+          providerConfig: { requireAuth: false },
+          workflowId: 'test-workflow-id',
+        }
+      )
+      testData.workflows.push({
+        id: 'test-workflow-id',
+        userId: 'test-user-id',
+        workspaceId: 'test-workspace-id',
+      })
+
+      const { NextResponse } = await import('next/server')
+      dispatchResolvedWebhookTargetMock.mockImplementationOnce(async () => ({
+        outcome: 'verified',
+        reason: 'block-missing',
+        response: NextResponse.json({ status: 'ok', message: 'Webhook endpoint verified' }),
+      }))
+
+      const req = createMockRequest('POST', { event: 'test', id: 'test-123' })
+      const params = Promise.resolve({ path: 'test-path' })
+
+      const response = await POST(req as any, { params })
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.message).toBe('Webhook endpoint verified')
+      expect(dispatchResolvedWebhookTargetMock).toHaveBeenCalledOnce()
+    })
+
     it('should authenticate with Bearer token when no custom header is configured', async () => {
       testData.webhooks.push({
         id: 'generic-webhook-id',

--- a/apps/sim/app/api/webhooks/trigger/[path]/route.ts
+++ b/apps/sim/app/api/webhooks/trigger/[path]/route.ts
@@ -186,6 +186,10 @@ async function handleWebhookPost(
       continue
     }
 
+    if (dispatchResult.outcome === 'verified') {
+      return dispatchResult.response
+    }
+
     if (dispatchResult.outcome === 'failed' || dispatchResult.reason === 'block-missing') {
       if (webhooksForPath.length > 1) {
         logger.warn(

--- a/apps/sim/lib/webhooks/processor.test.ts
+++ b/apps/sim/lib/webhooks/processor.test.ts
@@ -8,6 +8,8 @@ import {
   envFlagsMock,
   executionPreprocessingMock,
   executionPreprocessingMockFns,
+  workflowsPersistenceUtilsMock,
+  workflowsPersistenceUtilsMockFns,
 } from '@sim/testing'
 import type { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -19,6 +21,7 @@ const {
   mockProviderHandler,
   mockShouldExecuteInline,
   mockWebhookLookupResult,
+  mockRequiresPendingWebhookVerification,
 } = vi.hoisted(() => ({
   mockGenerateId: vi.fn(),
   mockEnqueue: vi.fn(),
@@ -26,6 +29,7 @@ const {
   mockProviderHandler: { current: {} as Record<string, unknown> },
   mockShouldExecuteInline: vi.fn(),
   mockWebhookLookupResult: { rows: [] as Array<{ webhook: any; workflow: any }> },
+  mockRequiresPendingWebhookVerification: vi.fn().mockReturnValue(false),
 }))
 
 const mockPreprocessExecution = executionPreprocessingMockFns.mockPreprocessExecution
@@ -86,8 +90,10 @@ vi.mock('@/lib/execution/preprocessing', () => executionPreprocessingMock)
 vi.mock('@/lib/webhooks/pending-verification', () => ({
   getPendingWebhookVerification: vi.fn(),
   matchesPendingWebhookVerificationProbe: vi.fn().mockReturnValue(false),
-  requiresPendingWebhookVerification: vi.fn().mockReturnValue(false),
+  requiresPendingWebhookVerification: mockRequiresPendingWebhookVerification,
 }))
+
+vi.mock('@/lib/workflows/persistence/utils', () => workflowsPersistenceUtilsMock)
 
 vi.mock('@/lib/webhooks/utils', () => ({
   convertSquareBracketsToTwiML: vi.fn((value: string) => value),
@@ -328,5 +334,44 @@ describe('webhook processor execution identity', () => {
       }),
       expect.any(Object)
     )
+  })
+})
+
+describe('webhook processor dispatch when the trigger block is missing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    workflowsPersistenceUtilsMockFns.mockBlockExistsInDeployment.mockResolvedValue(false)
+    mockRequiresPendingWebhookVerification.mockReturnValue(false)
+    mockProviderHandler.current = {}
+  })
+
+  it('reports outcome "verified" so callers never treat the URL-verification response as droppable', async () => {
+    mockRequiresPendingWebhookVerification.mockReturnValue(true)
+
+    const result = await dispatchResolvedWebhookTarget(
+      makeWebhookRecord({ blockId: 'block-not-yet-deployed', provider: 'generic' }),
+      makeWorkflowRecord({}),
+      {},
+      createMockRequest('POST', {}) as NextRequest,
+      { requestId: 'request-verify' }
+    )
+
+    expect(result.outcome).toBe('verified')
+    expect(result.reason).toBe('block-missing')
+    expect(result.response.status).toBe(200)
+  })
+
+  it('reports outcome "ignored" with a 404 when no verification is required', async () => {
+    const result = await dispatchResolvedWebhookTarget(
+      makeWebhookRecord({ blockId: 'block-not-yet-deployed', provider: 'generic' }),
+      makeWorkflowRecord({}),
+      {},
+      createMockRequest('POST', {}) as NextRequest,
+      { requestId: 'request-missing' }
+    )
+
+    expect(result.outcome).toBe('ignored')
+    expect(result.reason).toBe('block-missing')
+    expect(result.response.status).toBe(404)
   })
 })

--- a/apps/sim/lib/webhooks/processor.ts
+++ b/apps/sim/lib/webhooks/processor.ts
@@ -515,7 +515,7 @@ export async function checkWebhookPreprocessing(
   }
 }
 
-export type WebhookDispatchOutcome = 'queued' | 'ignored' | 'failed'
+export type WebhookDispatchOutcome = 'queued' | 'ignored' | 'failed' | 'verified'
 
 export interface WebhookDispatchResult {
   outcome: WebhookDispatchOutcome
@@ -739,7 +739,10 @@ async function queueWebhookExecutionWithResult(
 
 /**
  * Runs the common post-authentication lifecycle for a resolved webhook target and returns a typed
- * outcome so app-level fanout workers do not infer queue state from HTTP response bodies.
+ * outcome so app-level fanout workers do not infer queue state from HTTP response bodies. A
+ * `verified` outcome is the pre-deployment URL verification handshake some providers require
+ * before a workflow is even deployed; callers must return it as-is rather than treating it as a
+ * droppable per-webhook failure on a path shared by other webhooks.
  */
 export async function dispatchResolvedWebhookTarget(
   foundWebhook: typeof webhook.$inferSelect,
@@ -778,11 +781,12 @@ export async function dispatchResolvedWebhookTarget(
     const blockExists = await blockExistsInDeployment(foundWorkflow.id, webhookRecord.blockId)
     if (!blockExists) {
       const verificationResponse = handlePreDeploymentVerification(webhookRecord, options.requestId)
+      if (verificationResponse) {
+        return { outcome: 'verified', response: verificationResponse, reason: 'block-missing' }
+      }
       return {
         outcome: 'ignored',
-        response:
-          verificationResponse ??
-          new NextResponse('Trigger block not found in deployment', { status: 404 }),
+        response: new NextResponse('Trigger block not found in deployment', { status: 404 }),
         reason: 'block-missing',
       }
     }


### PR DESCRIPTION
## Summary
- `dispatchResolvedWebhookTarget`'s block-missing case now reports a distinct `verified` outcome for the pre-deployment URL-verification response, instead of the route inferring it from response internals
- the trigger route returns that `verified` response immediately, even when the path is shared by multiple webhooks - previously it was silently dropped via `continue`, which could surface a 500 instead of the 200 a provider needs to accept the trigger URL
- added a unit test for both `dispatchResolvedWebhookTarget` outcomes (verified vs. 404) and a route-level regression test for the shared-path case

## Type of Change
- [x] Bug fix

## Testing
- `bun vitest run lib/webhooks/processor.test.ts app/api/webhooks/trigger/[path]/route.test.ts` - 33 passed
- `bunx tsc --noEmit` - clean
- `bun run check:api-validation` - passed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)