### PR TITLE
fix(models): restore Anthropic models in landing page compare chart

### DIFF
--- a/apps/sim/app/(landing)/models/components/model-comparison-charts.tsx
+++ b/apps/sim/app/(landing)/models/components/model-comparison-charts.tsx
@@ -8,10 +8,11 @@ import {
   MODEL_CATALOG_PROVIDERS,
 } from '@/app/(landing)/models/utils'
 
-/** Providers that host other providers' models - deprioritized to avoid duplicates. */
-const RESELLER_PROVIDERS = new Set(
-  MODEL_CATALOG_PROVIDERS.flatMap((p) => (p.isReseller ? [p.id] : []))
-)
+/** Flagship providers featured in the landing-page comparison, in display order. */
+const FEATURED_COMPARISON_PROVIDER_IDS = ['anthropic', 'openai', 'google']
+
+/** Max latest models pulled from each featured provider. */
+const MAX_MODELS_PER_PROVIDER = 4
 
 const PROVIDER_ICON_MAP: Record<string, ComponentType<{ className?: string }>> = (() => {
   const map: Record<string, ComponentType<{ className?: string }>> = {}
@@ -27,22 +28,22 @@ function selectComparisonModels(models: CatalogModel[]): CatalogModel[] {
   const seen = new Set<string>()
   const result: CatalogModel[] = []
 
-  const sorted = [...models].sort((a, b) => {
-    const score = (m: CatalogModel) => {
-      const reseller = RESELLER_PROVIDERS.has(m.providerId) ? -50 : 0
-      const reasoning = m.capabilities.reasoningEffort || m.capabilities.thinking ? 10 : 0
-      const context = (m.contextWindow ?? 0) / 100000
-      return reseller + reasoning + context
-    }
-    return score(b) - score(a)
-  })
+  for (const providerId of FEATURED_COMPARISON_PROVIDER_IDS) {
+    const providerModels = models
+      .filter((model) => model.providerId === providerId && !model.deprecated)
+      .sort((a, b) => (b.releaseDate ?? '').localeCompare(a.releaseDate ?? ''))
 
-  for (const model of sorted) {
-    if (result.length >= 10) break
-    const nameKey = model.displayName.toLowerCase()
-    if (seen.has(nameKey)) continue
-    seen.add(nameKey)
-    result.push(model)
+    let takenForProvider = 0
+    for (const model of providerModels) {
+      if (takenForProvider >= MAX_MODELS_PER_PROVIDER) break
+
+      const nameKey = model.displayName.toLowerCase()
+      if (seen.has(nameKey)) continue
+
+      seen.add(nameKey)
+      result.push(model)
+      takenForProvider += 1
+    }
   }
 
   return result

--- a/apps/sim/app/(landing)/models/utils.ts
+++ b/apps/sim/app/(landing)/models/utils.ts
@@ -122,6 +122,7 @@ export interface CatalogModel {
   providerSlug: string
   contextWindow: number | null
   releaseDate: string | null
+  deprecated: boolean
   pricing: PricingInfo
   capabilities: ModelCapabilities
   capabilityTags: string[]
@@ -482,6 +483,7 @@ const rawProviders = Object.values(PROVIDER_DEFINITIONS).map((provider) => {
       providerSlug,
       contextWindow: model.contextWindow ?? null,
       releaseDate: model.releaseDate ?? null,
+      deprecated: model.deprecated ?? false,
       pricing: model.pricing,
       capabilities: mergedCapabilities,
       capabilityTags,


### PR DESCRIPTION
## Summary
- Fix compare-models chart on /models excluding Anthropic entirely — it scored models globally (context + reasoning bonus) and took a flat top-10, so OpenAI's larger GPT-5.x lineup crowded every Claude model out
- Now selects up to 4 latest non-deprecated models per flagship provider (Anthropic, OpenAI, Google) by release date instead
- Added `deprecated` to `CatalogModel` so retired models (e.g. gpt-4.1-nano, gemini-2.0-flash) are excluded from the comparison

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)