### PR TITLE
fix(landing): contain sr-only logos heading to stop phantom root scrollbar

### DIFF
--- a/apps/sim/app/(landing)/components/platform-page/components/platform-logos-row/platform-logos-row.tsx
+++ b/apps/sim/app/(landing)/components/platform-page/components/platform-logos-row/platform-logos-row.tsx
@@ -9,11 +9,16 @@ import { Logos } from '@/app/(landing)/components/logos'
  *
  * Wrapped as a labelled `<section>` so it is a discrete, crawlable landmark; the
  * heading is sr-only because the logos are a proof band rather than a content
- * section, but the H2 keeps the page's heading hierarchy intact.
+ * section, but the H2 keeps the page's heading hierarchy intact. The section is
+ * `relative` so the `sr-only` (`position: absolute`) heading is contained by it
+ * rather than falling back to the document root - matching {@link Features}'s
+ * `relative` wrapper for its own `sr-only` heading, and avoiding a phantom root
+ * scrollbar (the heading's un-offset static position would otherwise inflate
+ * `document.documentElement`'s scroll height by its own position in the page).
  */
 export function PlatformLogosRow() {
   return (
-    <section id='platform-logos' aria-labelledby='platform-logos-heading'>
+    <section id='platform-logos' aria-labelledby='platform-logos-heading' className='relative'>
       <h2 id='platform-logos-heading' className='sr-only'>
         Companies building AI agents with Sim
       </h2>

--- a/apps/sim/app/(landing)/components/solutions-page/components/solutions-logos-row/solutions-logos-row.tsx
+++ b/apps/sim/app/(landing)/components/solutions-page/components/solutions-logos-row/solutions-logos-row.tsx
@@ -9,11 +9,16 @@ import { Logos } from '@/app/(landing)/components/logos'
  *
  * Wrapped as a labelled `<section>` so it is a discrete, crawlable landmark; the
  * heading is sr-only because the logos are a proof band rather than a content
- * section, but the H2 keeps the page's heading hierarchy intact.
+ * section, but the H2 keeps the page's heading hierarchy intact. The section is
+ * `relative` so the `sr-only` (`position: absolute`) heading is contained by it
+ * rather than falling back to the document root - matching {@link Features}'s
+ * `relative` wrapper for its own `sr-only` heading, and avoiding a phantom root
+ * scrollbar (the heading's un-offset static position would otherwise inflate
+ * `document.documentElement`'s scroll height by its own position in the page).
  */
 export function SolutionsLogosRow() {
   return (
-    <section id='solutions-logos' aria-labelledby='solutions-logos-heading'>
+    <section id='solutions-logos' aria-labelledby='solutions-logos-heading' className='relative'>
       <h2 id='solutions-logos-heading' className='sr-only'>
         Companies building AI agents with Sim
       </h2>


### PR DESCRIPTION
## Summary
- The `/enterprise` page (and `/solutions/*`, `/workflows`) showed a second, real browser-level scrollbar that the home page didn't, causing a page-width shift when navigating between them
- Root cause: `SolutionsLogosRow` and `PlatformLogosRow` wrap a `sr-only` (`position: absolute`) `<h2>` in a `<section>` with no `position: relative`, so the heading's containing block falls back to the document root. Its un-offset "static position" (wherever the logos section lands in the page) inflated `document.documentElement`'s scroll height, producing a phantom root scrollbar in addition to the app's normal scroll container
- Fixed by adding `relative` to both sections' `<section>` wrapper — matching the existing convention already used by `Features`' own `sr-only` heading
- Verified against staging: `document.documentElement.scrollHeight` now equals `clientHeight` on `/enterprise`, `/solutions/it`, and `/workflows`, matching `/`; no visual change

## Type of Change
- [x] Bug fix

## Testing
Tested manually — ran the dev server, measured `document.documentElement.scrollHeight` vs `clientHeight` before/after on `/`, `/enterprise`, `/solutions/it`, `/workflows`, `/tables`, and screenshotted the enterprise page to confirm no visual regression.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)