### PR TITLE
feat(workflow-editor): open block palette on edge drag-release with auto-connect

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -529,6 +529,18 @@ const WorkflowContent = React.memo(
     /** Tracks whether onConnect successfully handled the connection (ReactFlow pattern). */
     const connectionCompletedRef = useRef(false)
 
+    /**
+     * Holds the drag origin + drop point when a connection is released on empty
+     * canvas and the command palette is opened. The block chosen from the palette
+     * is placed at the drop point and wired from this source handle. Cleared when
+     * the palette closes without a selection.
+     */
+    const pendingConnectRef = useRef<{
+      source: { nodeId: string; handleId: string }
+      screenX: number
+      screenY: number
+    } | null>(null)
+
     /** Stores start positions for multi-node drag undo/redo recording. */
     const multiNodeDragStartRef = useRef<Map<string, { x: number; y: number; parentId?: string }>>(
       new Map()
@@ -1977,16 +1989,39 @@ const WorkflowContent = React.memo(
         if (typeof type !== 'string' || !type) return
         if (type === 'connectionBlock') return
 
-        const basePosition = getViewportCenter()
+        // Consume any pending drag-release: it dictates the drop position and a
+        // forced edge from the released source handle, overriding auto-connect.
+        const pending = pendingConnectRef.current
+        pendingConnectRef.current = null
+        const pendingSourceExists = pending ? Boolean(blocks[pending.source.nodeId]) : false
+
+        let basePosition = getViewportCenter()
+        if (pending) {
+          const canvasElement = document.querySelector('.workflow-container') as HTMLElement | null
+          if (canvasElement) {
+            const bounds = canvasElement.getBoundingClientRect()
+            basePosition = screenToFlowPosition({
+              x: pending.screenX - bounds.left,
+              y: pending.screenY - bounds.top,
+            })
+          }
+        }
+
+        /**
+         * Edge for the new block: forced from the drag source when the palette was
+         * opened by a connection release, otherwise the normal auto-connect edge.
+         */
+        const resolveAutoConnectEdge = (targetId: string): Edge | undefined =>
+          pending && pendingSourceExists
+            ? createEdgeObject(pending.source.nodeId, targetId, pending.source.handleId)
+            : tryCreateAutoConnectEdge(basePosition, targetId, { targetParentId: null })
 
         if (type === 'loop' || type === 'parallel') {
           const id = generateId()
           const baseName = type === 'loop' ? 'Loop' : 'Parallel'
           const name = getUniqueBlockName(baseName, blocks)
 
-          const autoConnectEdge = tryCreateAutoConnectEdge(basePosition, id, {
-            targetParentId: null,
-          })
+          const autoConnectEdge = resolveAutoConnectEdge(id)
 
           addBlock(
             id,
@@ -2019,9 +2054,7 @@ const WorkflowContent = React.memo(
         const baseName = defaultTriggerName || blockConfig.name
         const name = getUniqueBlockName(baseName, blocks)
 
-        const autoConnectEdge = tryCreateAutoConnectEdge(basePosition, id, {
-          targetParentId: null,
-        })
+        const autoConnectEdge = resolveAutoConnectEdge(id)
 
         addBlock(
           id,
@@ -2054,7 +2087,25 @@ const WorkflowContent = React.memo(
       effectivePermissions.canEdit,
       checkTriggerConstraints,
       tryCreateAutoConnectEdge,
+      screenToFlowPosition,
+      createEdgeObject,
     ])
+
+    /**
+     * Drops a pending drag-release connection if the command palette is dismissed
+     * without picking a block. A real selection consumes the ref synchronously (via
+     * the `add-block-from-toolbar` event) before the modal closes, so a ref still
+     * set on close means the user cancelled.
+     */
+    useEffect(
+      () =>
+        useSearchModalStore.subscribe((state, prev) => {
+          if (prev.isOpen && !state.isOpen) {
+            pendingConnectRef.current = null
+          }
+        }),
+      []
+    )
 
     /**
      * Listen for toolbar drops that occur on the empty-workflow overlay (command list).
@@ -3131,6 +3182,18 @@ const WorkflowContent = React.memo(
             sourceHandle: source.handleId,
             target: targetNode.id,
             targetHandle: 'target',
+          })
+        } else if (!targetNode) {
+          // Released on empty canvas: open the command palette and remember the
+          // drag origin + drop point so the chosen block lands here, wired from
+          // this source handle.
+          pendingConnectRef.current = {
+            source: { nodeId: source.nodeId, handleId: source.handleId },
+            screenX: clientPos.clientX,
+            screenY: clientPos.clientY,
+          }
+          useSearchModalStore.getState().open({
+            sections: ['blocks', 'tools', 'toolOperations'],
           })
         }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -95,6 +95,7 @@ import { useCanvasModeStore } from '@/stores/canvas-mode'
 import { useChatStore } from '@/stores/chat/store'
 import { defaultWorkflowExecutionState, useExecutionStore } from '@/stores/execution'
 import { useSearchModalStore } from '@/stores/modals/search/store'
+import type { PendingConnect } from '@/stores/modals/search/types'
 import { usePanelEditorStore } from '@/stores/panel'
 import { useUndoRedoStore } from '@/stores/undo-redo'
 import { useVariablesModalStore } from '@/stores/variables/modal'
@@ -209,7 +210,7 @@ interface AddBlockFromToolbarDetail {
   type?: unknown
   enableTriggerMode?: unknown
   presetOperation?: unknown
-  connectToken?: unknown
+  pendingConnect?: PendingConnect
 }
 
 /**
@@ -529,19 +530,6 @@ const WorkflowContent = React.memo(
 
     /** Tracks whether onConnect successfully handled the connection (ReactFlow pattern). */
     const connectionCompletedRef = useRef(false)
-
-    /**
-     * Holds the drag origin + drop point when a connection is released on empty
-     * canvas and the command palette is opened. The block chosen from the palette
-     * is placed at the drop point and wired from this source handle. Cleared when
-     * the palette closes without a selection.
-     */
-    const pendingConnectRef = useRef<{
-      source: { nodeId: string; handleId: string }
-      screenX: number
-      screenY: number
-      token: string
-    } | null>(null)
 
     /** Stores start positions for multi-node drag undo/redo recording. */
     const multiNodeDragStartRef = useRef<Map<string, { x: number; y: number; parentId?: string }>>(
@@ -2044,29 +2032,26 @@ const WorkflowContent = React.memo(
           return
         }
 
-        const { type, enableTriggerMode, presetOperation, connectToken } = event.detail
+        const { type, enableTriggerMode, presetOperation, pendingConnect } = event.detail
 
         if (typeof type !== 'string' || !type) return
         if (type === 'connectionBlock') return
 
-        // Complete a pending drag-release only when THIS event is the palette
-        // selection it opened (matched by correlation token). Any other add-block
-        // event (toolbar, sidebar, command list) carries no matching token and
-        // cannot inherit the pending position/source. Delegating to handleToolbarDrop
-        // with the drag source gives container-aware placement AND an edge from the
-        // released handle that respects container boundaries, exactly like onConnect.
-        const pendingRef = pendingConnectRef.current
-        if (pendingRef && typeof connectToken === 'string' && connectToken === pendingRef.token) {
-          pendingConnectRef.current = null
+        // Complete an edge drag-release: only a genuine palette selection carries
+        // `pendingConnect` (other add-block dispatchers — toolbar, sidebar, command
+        // list — don't), so its presence is the signal. Delegating to
+        // handleToolbarDrop with the drag source gives container-aware placement AND
+        // an edge from the released handle that respects container boundaries.
+        if (pendingConnect) {
           // screenToFlowPosition subtracts the pane rect internally — pass raw client coords.
           handleToolbarDrop(
             {
               type,
               enableTriggerMode: enableTriggerMode === true,
               presetOperation: typeof presetOperation === 'string' ? presetOperation : undefined,
-              forcedSource: pendingRef.source,
+              forcedSource: pendingConnect.source,
             },
-            screenToFlowPosition({ x: pendingRef.screenX, y: pendingRef.screenY })
+            screenToFlowPosition({ x: pendingConnect.screenX, y: pendingConnect.screenY })
           )
           return
         }
@@ -2151,22 +2136,6 @@ const WorkflowContent = React.memo(
       screenToFlowPosition,
       handleToolbarDrop,
     ])
-
-    /**
-     * Drops a pending drag-release connection if the command palette is dismissed
-     * without picking a block. A real selection consumes the ref synchronously (via
-     * the `add-block-from-toolbar` event) before the modal closes, so a ref still
-     * set on close means the user cancelled.
-     */
-    useEffect(
-      () =>
-        useSearchModalStore.subscribe((state, prev) => {
-          if (prev.isOpen && !state.isOpen) {
-            pendingConnectRef.current = null
-          }
-        }),
-      []
-    )
 
     /**
      * Listen for toolbar drops that occur on the empty-workflow overlay (command list).
@@ -3245,19 +3214,15 @@ const WorkflowContent = React.memo(
             targetHandle: 'target',
           })
         } else if (!targetNode) {
-          // Released on empty canvas: open the command palette and remember the
-          // drag origin + drop point so the chosen block lands here, wired from
-          // this source handle.
-          const connectToken = generateId()
-          pendingConnectRef.current = {
-            source: { nodeId: source.nodeId, handleId: source.handleId },
-            screenX: clientPos.clientX,
-            screenY: clientPos.clientY,
-            token: connectToken,
-          }
+          // Released on empty canvas: open the command palette with the drag origin
+          // + drop point, so the chosen block lands here wired from this handle.
           useSearchModalStore.getState().open({
             sections: ['blocks', 'tools', 'toolOperations'],
-            connectToken,
+            pendingConnect: {
+              source: { nodeId: source.nodeId, handleId: source.handleId },
+              screenX: clientPos.clientX,
+              screenY: clientPos.clientY,
+            },
           })
         }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -1794,7 +1794,12 @@ const WorkflowContent = React.memo(
      */
     const handleToolbarDrop = useCallback(
       (
-        data: { type: string; enableTriggerMode?: boolean; presetOperation?: string },
+        data: {
+          type: string
+          enableTriggerMode?: boolean
+          presetOperation?: string
+          forcedSource?: { nodeId: string; handleId: string }
+        },
         position: { x: number; y: number }
       ) => {
         if (!data.type || data.type === 'connectionBlock') return
@@ -1802,6 +1807,40 @@ const WorkflowContent = React.memo(
         const operationConfig = data.presetOperation
           ? { operation: data.presetOperation }
           : undefined
+
+        const { forcedSource } = data
+
+        /**
+         * Edge for the new block. With a `forcedSource` (a drag-release from a
+         * handle), wire from that exact handle — but only when it stays within the
+         * resolved container context, matching onConnect's boundary rules; a
+         * cross-boundary source yields no edge. Otherwise fall back to normal
+         * proximity auto-connect.
+         */
+        const resolveEdge = (
+          targetId: string,
+          targetParentId: string | null,
+          fallback: () => Edge | undefined
+        ): Edge | undefined => {
+          if (!forcedSource) return fallback()
+
+          const isContainerStartHandle =
+            forcedSource.handleId === 'loop-start-source' ||
+            forcedSource.handleId === 'parallel-start-source'
+          if (isContainerStartHandle) {
+            // A container-start handle may only wire to a child of that container.
+            return forcedSource.nodeId === targetParentId
+              ? createEdgeObject(forcedSource.nodeId, targetId, forcedSource.handleId)
+              : undefined
+          }
+
+          const sourceBlock = blocks[forcedSource.nodeId]
+          if (!sourceBlock) return undefined
+          const sourceParentId = sourceBlock.data?.parentId ?? null
+          return sourceParentId === targetParentId
+            ? createEdgeObject(forcedSource.nodeId, targetId, forcedSource.handleId)
+            : undefined
+        }
 
         try {
           const containerInfo = isPointInLoopNode(position)
@@ -1832,11 +1871,13 @@ const WorkflowContent = React.memo(
                 .filter((b) => b.data?.parentId === containerInfo.loopId)
                 .map((b) => ({ id: b.id, type: b.type, position: b.position }))
 
-              const autoConnectEdge = tryCreateAutoConnectEdge(relativePosition, id, {
-                targetParentId: containerInfo.loopId,
-                existingChildBlocks,
-                containerId: containerInfo.loopId,
-              })
+              const autoConnectEdge = resolveEdge(id, containerInfo.loopId, () =>
+                tryCreateAutoConnectEdge(relativePosition, id, {
+                  targetParentId: containerInfo.loopId,
+                  existingChildBlocks,
+                  containerId: containerInfo.loopId,
+                })
+              )
 
               addBlock(
                 id,
@@ -1857,9 +1898,11 @@ const WorkflowContent = React.memo(
 
               resizeLoopNodesWrapper()
             } else {
-              const autoConnectEdge = tryCreateAutoConnectEdge(position, id, {
-                targetParentId: null,
-              })
+              const autoConnectEdge = resolveEdge(id, null, () =>
+                tryCreateAutoConnectEdge(position, id, {
+                  targetParentId: null,
+                })
+              )
 
               addBlock(
                 id,
@@ -1924,11 +1967,13 @@ const WorkflowContent = React.memo(
               .filter((b) => b.data?.parentId === containerInfo.loopId)
               .map((b) => ({ id: b.id, type: b.type, position: b.position }))
 
-            const autoConnectEdge = tryCreateAutoConnectEdge(relativePosition, id, {
-              targetParentId: containerInfo.loopId,
-              existingChildBlocks,
-              containerId: containerInfo.loopId,
-            })
+            const autoConnectEdge = resolveEdge(id, containerInfo.loopId, () =>
+              tryCreateAutoConnectEdge(relativePosition, id, {
+                targetParentId: containerInfo.loopId,
+                existingChildBlocks,
+                containerId: containerInfo.loopId,
+              })
+            )
 
             // Add block with parent info AND autoConnectEdge (atomic operation)
             addBlock(
@@ -1954,9 +1999,11 @@ const WorkflowContent = React.memo(
             // Centralized trigger constraints
             if (checkTriggerConstraints(data.type)) return
 
-            const autoConnectEdge = tryCreateAutoConnectEdge(position, id, {
-              targetParentId: null,
-            })
+            const autoConnectEdge = resolveEdge(id, null, () =>
+              tryCreateAutoConnectEdge(position, id, {
+                targetParentId: null,
+              })
+            )
 
             // Regular canvas drop with auto-connect edge
             // Use enableTriggerMode from drag data if present (when dragging from Triggers tab)
@@ -1985,6 +2032,7 @@ const WorkflowContent = React.memo(
         addBlock,
         tryCreateAutoConnectEdge,
         checkTriggerConstraints,
+        createEdgeObject,
       ]
     )
 
@@ -2001,65 +2049,38 @@ const WorkflowContent = React.memo(
         if (typeof type !== 'string' || !type) return
         if (type === 'connectionBlock') return
 
-        // Consume a pending drag-release only when THIS event is the palette
-        // selection it opened, matched by correlation token. Any other
-        // add-block event (toolbar, sidebar, command list) carries no matching
-        // token and cannot inherit the pending position/source.
+        // Complete a pending drag-release only when THIS event is the palette
+        // selection it opened (matched by correlation token). Any other add-block
+        // event (toolbar, sidebar, command list) carries no matching token and
+        // cannot inherit the pending position/source. Delegating to handleToolbarDrop
+        // with the drag source gives container-aware placement AND an edge from the
+        // released handle that respects container boundaries, exactly like onConnect.
         const pendingRef = pendingConnectRef.current
-        const pending =
-          pendingRef && typeof connectToken === 'string' && connectToken === pendingRef.token
-            ? pendingRef
-            : null
-        if (pending) pendingConnectRef.current = null
-
-        let basePosition = getViewportCenter()
-        if (pending) {
-          // screenToFlowPosition already subtracts the pane rect internally — pass
-          // raw client coords, do NOT pre-subtract container bounds.
-          basePosition = screenToFlowPosition({ x: pending.screenX, y: pending.screenY })
-
-          // Released inside a loop/parallel container: delegate to the container-aware
-          // drop path for correct parenting, clamping, and in-container auto-connect.
-          // A forced source→target edge would cross the container boundary, so it is
-          // intentionally not applied here.
-          if (isPointInLoopNode(basePosition)) {
-            handleToolbarDrop(
-              {
-                type,
-                enableTriggerMode: enableTriggerMode === true,
-                presetOperation: typeof presetOperation === 'string' ? presetOperation : undefined,
-              },
-              basePosition
-            )
-            return
-          }
+        if (pendingRef && typeof connectToken === 'string' && connectToken === pendingRef.token) {
+          pendingConnectRef.current = null
+          // screenToFlowPosition subtracts the pane rect internally — pass raw client coords.
+          handleToolbarDrop(
+            {
+              type,
+              enableTriggerMode: enableTriggerMode === true,
+              presetOperation: typeof presetOperation === 'string' ? presetOperation : undefined,
+              forcedSource: pendingRef.source,
+            },
+            screenToFlowPosition({ x: pendingRef.screenX, y: pendingRef.screenY })
+          )
+          return
         }
 
-        // Force the source→new-block edge only when it stays root-to-root, matching
-        // the root-level placement — a source inside a container (or a container-start
-        // handle) would cross the boundary and is rejected, as in onConnect.
-        const sourceBlock = pending ? blocks[pending.source.nodeId] : undefined
-        const isContainerStartHandle =
-          pending?.source.handleId === 'loop-start-source' ||
-          pending?.source.handleId === 'parallel-start-source'
-        const canForceEdge =
-          Boolean(sourceBlock) && !sourceBlock?.data?.parentId && !isContainerStartHandle
-
-        /**
-         * Edge for the new block: forced from the drag source when the palette was
-         * opened by a connection release, otherwise the normal auto-connect edge.
-         */
-        const resolveAutoConnectEdge = (targetId: string): Edge | undefined =>
-          pending && canForceEdge
-            ? createEdgeObject(pending.source.nodeId, targetId, pending.source.handleId)
-            : tryCreateAutoConnectEdge(basePosition, targetId, { targetParentId: null })
+        const basePosition = getViewportCenter()
 
         if (type === 'loop' || type === 'parallel') {
           const id = generateId()
           const baseName = type === 'loop' ? 'Loop' : 'Parallel'
           const name = getUniqueBlockName(baseName, blocks)
 
-          const autoConnectEdge = resolveAutoConnectEdge(id)
+          const autoConnectEdge = tryCreateAutoConnectEdge(basePosition, id, {
+            targetParentId: null,
+          })
 
           addBlock(
             id,
@@ -2092,7 +2113,9 @@ const WorkflowContent = React.memo(
         const baseName = defaultTriggerName || blockConfig.name
         const name = getUniqueBlockName(baseName, blocks)
 
-        const autoConnectEdge = resolveAutoConnectEdge(id)
+        const autoConnectEdge = tryCreateAutoConnectEdge(basePosition, id, {
+          targetParentId: null,
+        })
 
         addBlock(
           id,
@@ -2126,9 +2149,7 @@ const WorkflowContent = React.memo(
       checkTriggerConstraints,
       tryCreateAutoConnectEdge,
       screenToFlowPosition,
-      createEdgeObject,
       handleToolbarDrop,
-      isPointInLoopNode,
     ])
 
     /**

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -1793,8 +1793,15 @@ const WorkflowContent = React.memo(
      * @param position - Drop position in ReactFlow coordinates.
      */
     const handleToolbarDrop = useCallback(
-      (data: { type: string; enableTriggerMode?: boolean }, position: { x: number; y: number }) => {
+      (
+        data: { type: string; enableTriggerMode?: boolean; presetOperation?: string },
+        position: { x: number; y: number }
+      ) => {
         if (!data.type || data.type === 'connectionBlock') return
+
+        const operationConfig = data.presetOperation
+          ? { operation: data.presetOperation }
+          : undefined
 
         try {
           const containerInfo = isPointInLoopNode(position)
@@ -1935,7 +1942,9 @@ const WorkflowContent = React.memo(
               },
               containerInfo.loopId,
               'parent',
-              autoConnectEdge
+              autoConnectEdge,
+              undefined,
+              operationConfig
             )
 
             // Resize the container node to fit the new block
@@ -1961,7 +1970,8 @@ const WorkflowContent = React.memo(
               undefined,
               undefined,
               autoConnectEdge,
-              enableTriggerMode
+              enableTriggerMode,
+              operationConfig
             )
           }
         } catch (err) {
@@ -2013,7 +2023,14 @@ const WorkflowContent = React.memo(
           // A forced source→target edge would cross the container boundary, so it is
           // intentionally not applied here.
           if (isPointInLoopNode(basePosition)) {
-            handleToolbarDrop({ type, enableTriggerMode: enableTriggerMode === true }, basePosition)
+            handleToolbarDrop(
+              {
+                type,
+                enableTriggerMode: enableTriggerMode === true,
+                presetOperation: typeof presetOperation === 'string' ? presetOperation : undefined,
+              },
+              basePosition
+            )
             return
           }
         }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -209,6 +209,7 @@ interface AddBlockFromToolbarDetail {
   type?: unknown
   enableTriggerMode?: unknown
   presetOperation?: unknown
+  connectToken?: unknown
 }
 
 /**
@@ -539,6 +540,7 @@ const WorkflowContent = React.memo(
       source: { nodeId: string; handleId: string }
       screenX: number
       screenY: number
+      token: string
     } | null>(null)
 
     /** Stores start positions for multi-node drag undo/redo recording. */
@@ -1984,18 +1986,21 @@ const WorkflowContent = React.memo(
           return
         }
 
-        const { type, enableTriggerMode, presetOperation } = event.detail
+        const { type, enableTriggerMode, presetOperation, connectToken } = event.detail
 
         if (typeof type !== 'string' || !type) return
         if (type === 'connectionBlock') return
 
-        // Consume a pending drag-release only while the restricted connect-palette
-        // it opened is still up — never let an unrelated add-block event (toolbar,
-        // sidebar, command list) inherit its position/source.
-        const searchModal = useSearchModalStore.getState()
+        // Consume a pending drag-release only when THIS event is the palette
+        // selection it opened, matched by correlation token. Any other
+        // add-block event (toolbar, sidebar, command list) carries no matching
+        // token and cannot inherit the pending position/source.
+        const pendingRef = pendingConnectRef.current
         const pending =
-          searchModal.isOpen && searchModal.sections ? pendingConnectRef.current : null
-        pendingConnectRef.current = null
+          pendingRef && typeof connectToken === 'string' && connectToken === pendingRef.token
+            ? pendingRef
+            : null
+        if (pending) pendingConnectRef.current = null
 
         let basePosition = getViewportCenter()
         if (pending) {
@@ -3205,13 +3210,16 @@ const WorkflowContent = React.memo(
           // Released on empty canvas: open the command palette and remember the
           // drag origin + drop point so the chosen block lands here, wired from
           // this source handle.
+          const connectToken = generateId()
           pendingConnectRef.current = {
             source: { nodeId: source.nodeId, handleId: source.handleId },
             screenX: clientPos.clientX,
             screenY: clientPos.clientY,
+            token: connectToken,
           }
           useSearchModalStore.getState().open({
             sections: ['blocks', 'tools', 'toolOperations'],
+            connectToken,
           })
         }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -1989,30 +1989,46 @@ const WorkflowContent = React.memo(
         if (typeof type !== 'string' || !type) return
         if (type === 'connectionBlock') return
 
-        // Consume any pending drag-release: it dictates the drop position and a
-        // forced edge from the released source handle, overriding auto-connect.
-        const pending = pendingConnectRef.current
+        // Consume a pending drag-release only while the restricted connect-palette
+        // it opened is still up — never let an unrelated add-block event (toolbar,
+        // sidebar, command list) inherit its position/source.
+        const searchModal = useSearchModalStore.getState()
+        const pending =
+          searchModal.isOpen && searchModal.sections ? pendingConnectRef.current : null
         pendingConnectRef.current = null
-        const pendingSourceExists = pending ? Boolean(blocks[pending.source.nodeId]) : false
 
         let basePosition = getViewportCenter()
         if (pending) {
-          const canvasElement = document.querySelector('.workflow-container') as HTMLElement | null
-          if (canvasElement) {
-            const bounds = canvasElement.getBoundingClientRect()
-            basePosition = screenToFlowPosition({
-              x: pending.screenX - bounds.left,
-              y: pending.screenY - bounds.top,
-            })
+          // screenToFlowPosition already subtracts the pane rect internally — pass
+          // raw client coords, do NOT pre-subtract container bounds.
+          basePosition = screenToFlowPosition({ x: pending.screenX, y: pending.screenY })
+
+          // Released inside a loop/parallel container: delegate to the container-aware
+          // drop path for correct parenting, clamping, and in-container auto-connect.
+          // A forced source→target edge would cross the container boundary, so it is
+          // intentionally not applied here.
+          if (isPointInLoopNode(basePosition)) {
+            handleToolbarDrop({ type, enableTriggerMode: enableTriggerMode === true }, basePosition)
+            return
           }
         }
+
+        // Force the source→new-block edge only when it stays root-to-root, matching
+        // the root-level placement — a source inside a container (or a container-start
+        // handle) would cross the boundary and is rejected, as in onConnect.
+        const sourceBlock = pending ? blocks[pending.source.nodeId] : undefined
+        const isContainerStartHandle =
+          pending?.source.handleId === 'loop-start-source' ||
+          pending?.source.handleId === 'parallel-start-source'
+        const canForceEdge =
+          Boolean(sourceBlock) && !sourceBlock?.data?.parentId && !isContainerStartHandle
 
         /**
          * Edge for the new block: forced from the drag source when the palette was
          * opened by a connection release, otherwise the normal auto-connect edge.
          */
         const resolveAutoConnectEdge = (targetId: string): Edge | undefined =>
-          pending && pendingSourceExists
+          pending && canForceEdge
             ? createEdgeObject(pending.source.nodeId, targetId, pending.source.handleId)
             : tryCreateAutoConnectEdge(basePosition, targetId, { targetParentId: null })
 
@@ -2089,6 +2105,8 @@ const WorkflowContent = React.memo(
       tryCreateAutoConnectEdge,
       screenToFlowPosition,
       createEdgeObject,
+      handleToolbarDrop,
+      isPointInLoopNode,
     ])
 
     /**

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
@@ -351,7 +351,7 @@ export function SearchModal({
           detail: {
             type: block.type,
             enableTriggerMode,
-            connectToken: useSearchModalStore.getState().connectToken,
+            pendingConnect: useSearchModalStore.getState().pendingConnect,
           },
         })
       )
@@ -372,7 +372,7 @@ export function SearchModal({
           detail: {
             type: op.blockType,
             presetOperation: op.operationId,
-            connectToken: useSearchModalStore.getState().connectToken,
+            pendingConnect: useSearchModalStore.getState().pendingConnect,
           },
         })
       )

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
@@ -40,6 +40,7 @@ import { useSearchModalStore } from '@/stores/modals/search/store'
 import type {
   SearchBlockItem,
   SearchDocItem,
+  SearchSection,
   SearchToolOperationItem,
 } from '@/stores/modals/search/types'
 import {
@@ -117,6 +118,9 @@ export function SearchModal({
   const { blocks, tools, triggers, toolOperations, docs } = useSearchModalStore(
     (state) => state.data
   )
+
+  const sections = useSearchModalStore((state) => state.sections)
+  const showSection = (key: SearchSection) => !sections || sections.includes(key)
 
   const openHelpModal = useCallback(() => {
     window.dispatchEvent(new CustomEvent('open-help-modal'))
@@ -690,77 +694,107 @@ export function SearchModal({
                 No results found.
               </Command.Empty>
 
-              <ActionsGroup
-                items={filteredActions}
-                onSelect={handleActionSelect}
-                query={deferredSearch}
-              />
-              <ConnectedAccountsGroup
-                items={filteredConnectedAccounts}
-                onSelect={handleConnectedAccountSelect}
-                query={deferredSearch}
-              />
-              <IntegrationsGroup
-                items={filteredIntegrations}
-                onSelect={handleIntegrationSelect}
-                query={deferredSearch}
-              />
-              <BlocksGroup
-                items={filteredBlocks}
-                onSelect={handleBlockSelectAsBlock}
-                query={deferredSearch}
-              />
-              <ToolsGroup
-                items={filteredTools}
-                onSelect={handleBlockSelectAsTool}
-                query={deferredSearch}
-              />
-              <TriggersGroup
-                items={filteredTriggers}
-                onSelect={handleBlockSelectAsTrigger}
-                query={deferredSearch}
-              />
-              <ChatsGroup
-                items={filteredChats}
-                onSelect={handleChatSelect}
-                query={deferredSearch}
-              />
-              <WorkflowsGroup
-                items={filteredWorkflows}
-                onSelect={handleWorkflowSelect}
-                query={deferredSearch}
-              />
-              <TablesGroup
-                items={filteredTables}
-                onSelect={handleTableSelect}
-                query={deferredSearch}
-              />
-              <FilesGroup
-                items={filteredFiles}
-                onSelect={handleFileSelect}
-                query={deferredSearch}
-              />
-              <KnowledgeBasesGroup
-                items={filteredKnowledgeBases}
-                onSelect={handleKbSelect}
-                query={deferredSearch}
-              />
-              <ToolOpsGroup
-                items={filteredToolOps}
-                onSelect={handleToolOperationSelect}
-                query={deferredSearch}
-              />
-              <WorkspacesGroup
-                items={filteredWorkspaces}
-                onSelect={handleWorkspaceSelect}
-                query={deferredSearch}
-              />
-              <DocsGroup items={filteredDocs} onSelect={handleDocSelect} query={deferredSearch} />
-              <PagesGroup
-                items={filteredPages}
-                onSelect={handlePageSelect}
-                query={deferredSearch}
-              />
+              {showSection('actions') && (
+                <ActionsGroup
+                  items={filteredActions}
+                  onSelect={handleActionSelect}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('connectedAccounts') && (
+                <ConnectedAccountsGroup
+                  items={filteredConnectedAccounts}
+                  onSelect={handleConnectedAccountSelect}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('integrations') && (
+                <IntegrationsGroup
+                  items={filteredIntegrations}
+                  onSelect={handleIntegrationSelect}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('blocks') && (
+                <BlocksGroup
+                  items={filteredBlocks}
+                  onSelect={handleBlockSelectAsBlock}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('tools') && (
+                <ToolsGroup
+                  items={filteredTools}
+                  onSelect={handleBlockSelectAsTool}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('triggers') && (
+                <TriggersGroup
+                  items={filteredTriggers}
+                  onSelect={handleBlockSelectAsTrigger}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('chats') && (
+                <ChatsGroup
+                  items={filteredChats}
+                  onSelect={handleChatSelect}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('workflows') && (
+                <WorkflowsGroup
+                  items={filteredWorkflows}
+                  onSelect={handleWorkflowSelect}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('tables') && (
+                <TablesGroup
+                  items={filteredTables}
+                  onSelect={handleTableSelect}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('files') && (
+                <FilesGroup
+                  items={filteredFiles}
+                  onSelect={handleFileSelect}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('knowledgeBases') && (
+                <KnowledgeBasesGroup
+                  items={filteredKnowledgeBases}
+                  onSelect={handleKbSelect}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('toolOperations') && (
+                <ToolOpsGroup
+                  items={filteredToolOps}
+                  onSelect={handleToolOperationSelect}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('workspaces') && (
+                <WorkspacesGroup
+                  items={filteredWorkspaces}
+                  onSelect={handleWorkspaceSelect}
+                  query={deferredSearch}
+                />
+              )}
+              {showSection('docs') && (
+                <DocsGroup items={filteredDocs} onSelect={handleDocSelect} query={deferredSearch} />
+              )}
+              {showSection('pages') && (
+                <PagesGroup
+                  items={filteredPages}
+                  onSelect={handlePageSelect}
+                  query={deferredSearch}
+                />
+              )}
             </Command.List>
           </Command>
         </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
@@ -351,6 +351,7 @@ export function SearchModal({
           detail: {
             type: block.type,
             enableTriggerMode,
+            connectToken: useSearchModalStore.getState().connectToken,
           },
         })
       )
@@ -368,7 +369,11 @@ export function SearchModal({
     (op: SearchToolOperationItem) => {
       window.dispatchEvent(
         new CustomEvent('add-block-from-toolbar', {
-          detail: { type: op.blockType, presetOperation: op.operationId },
+          detail: {
+            type: op.blockType,
+            presetOperation: op.operationId,
+            connectToken: useSearchModalStore.getState().connectToken,
+          },
         })
       )
       captureEvent(posthogRef.current, 'search_result_selected', {

--- a/apps/sim/stores/modals/search/store.ts
+++ b/apps/sim/stores/modals/search/store.ts
@@ -68,23 +68,23 @@ export const useSearchModalStore = create<SearchModalState>()(
     (set, _) => ({
       isOpen: false,
       sections: null,
-      connectToken: null,
+      pendingConnect: null,
       data: initialData,
 
       setOpen: (open: boolean) => {
-        set({ isOpen: open, sections: null, connectToken: null })
+        set({ isOpen: open, sections: null, pendingConnect: null })
       },
 
       open: (options) => {
         set({
           isOpen: true,
           sections: options?.sections ?? null,
-          connectToken: options?.connectToken ?? null,
+          pendingConnect: options?.pendingConnect ?? null,
         })
       },
 
       close: () => {
-        set({ isOpen: false, sections: null, connectToken: null })
+        set({ isOpen: false, sections: null, pendingConnect: null })
       },
 
       initializeData: (filterBlocks) => {

--- a/apps/sim/stores/modals/search/store.ts
+++ b/apps/sim/stores/modals/search/store.ts
@@ -67,18 +67,19 @@ export const useSearchModalStore = create<SearchModalState>()(
   devtools(
     (set, _) => ({
       isOpen: false,
+      sections: null,
       data: initialData,
 
       setOpen: (open: boolean) => {
-        set({ isOpen: open })
+        set({ isOpen: open, sections: null })
       },
 
-      open: () => {
-        set({ isOpen: true })
+      open: (options) => {
+        set({ isOpen: true, sections: options?.sections ?? null })
       },
 
       close: () => {
-        set({ isOpen: false })
+        set({ isOpen: false, sections: null })
       },
 
       initializeData: (filterBlocks) => {

--- a/apps/sim/stores/modals/search/store.ts
+++ b/apps/sim/stores/modals/search/store.ts
@@ -68,18 +68,23 @@ export const useSearchModalStore = create<SearchModalState>()(
     (set, _) => ({
       isOpen: false,
       sections: null,
+      connectToken: null,
       data: initialData,
 
       setOpen: (open: boolean) => {
-        set({ isOpen: open, sections: null })
+        set({ isOpen: open, sections: null, connectToken: null })
       },
 
       open: (options) => {
-        set({ isOpen: true, sections: options?.sections ?? null })
+        set({
+          isOpen: true,
+          sections: options?.sections ?? null,
+          connectToken: options?.connectToken ?? null,
+        })
       },
 
       close: () => {
-        set({ isOpen: false, sections: null })
+        set({ isOpen: false, sections: null, connectToken: null })
       },
 
       initializeData: (filterBlocks) => {

--- a/apps/sim/stores/modals/search/types.ts
+++ b/apps/sim/stores/modals/search/types.ts
@@ -91,20 +91,30 @@ export interface SearchModalState {
    */
   sections: SearchSection[] | null
 
+  /**
+   * Correlation token for the open session. When the palette is opened to
+   * complete a specific action (e.g. an edge drag-release), the opener passes a
+   * token that a selection stamps onto its event, so only that selection — not
+   * an unrelated concurrent add — can consume the pending action. `null` for
+   * ordinary opens.
+   */
+  connectToken: string | null
+
   /** Pre-computed search data. */
   data: SearchData
 
   /**
    * Explicitly set the open state of the modal. Always resets to the full
-   * palette (no section restriction).
+   * palette (no section restriction, no correlation token).
    */
   setOpen: (open: boolean) => void
 
   /**
    * Convenience method to open the modal. Pass `sections` to restrict the
-   * palette to a subset of result groups.
+   * palette to a subset of result groups, and `connectToken` to correlate a
+   * selection with a pending action.
    */
-  open: (options?: { sections?: SearchSection[] }) => void
+  open: (options?: { sections?: SearchSection[]; connectToken?: string }) => void
 
   /**
    * Convenience method to close the modal.

--- a/apps/sim/stores/modals/search/types.ts
+++ b/apps/sim/stores/modals/search/types.ts
@@ -76,6 +76,18 @@ export const SEARCH_SECTIONS = [
 export type SearchSection = (typeof SEARCH_SECTIONS)[number]
 
 /**
+ * Context handed to the palette when it is opened to complete an edge
+ * drag-release: the dragged source handle and the release point. A selection
+ * stamps it onto its event so the canvas places the block at the drop point and
+ * wires it from that handle.
+ */
+export interface PendingConnect {
+  source: { nodeId: string; handleId: string }
+  screenX: number
+  screenY: number
+}
+
+/**
  * Global state for the universal search modal.
  *
  * Centralizing this state in a store allows any component (e.g. sidebar,
@@ -92,29 +104,27 @@ export interface SearchModalState {
   sections: SearchSection[] | null
 
   /**
-   * Correlation token for the open session. When the palette is opened to
-   * complete a specific action (e.g. an edge drag-release), the opener passes a
-   * token that a selection stamps onto its event, so only that selection — not
-   * an unrelated concurrent add — can consume the pending action. `null` for
-   * ordinary opens.
+   * Pending edge drag-release the palette was opened to complete. A selection
+   * stamps it onto its event; other add-block dispatchers carry none, so only a
+   * genuine palette pick completes the connection. `null` for ordinary opens.
    */
-  connectToken: string | null
+  pendingConnect: PendingConnect | null
 
   /** Pre-computed search data. */
   data: SearchData
 
   /**
    * Explicitly set the open state of the modal. Always resets to the full
-   * palette (no section restriction, no correlation token).
+   * palette (no section restriction, no pending connect).
    */
   setOpen: (open: boolean) => void
 
   /**
    * Convenience method to open the modal. Pass `sections` to restrict the
-   * palette to a subset of result groups, and `connectToken` to correlate a
-   * selection with a pending action.
+   * palette to a subset of result groups, and `pendingConnect` to complete an
+   * edge drag-release with the selection.
    */
-  open: (options?: { sections?: SearchSection[]; connectToken?: string }) => void
+  open: (options?: { sections?: SearchSection[]; pendingConnect?: PendingConnect }) => void
 
   /**
    * Convenience method to close the modal.

--- a/apps/sim/stores/modals/search/types.ts
+++ b/apps/sim/stores/modals/search/types.ts
@@ -50,6 +50,32 @@ export interface SearchData {
 }
 
 /**
+ * Every result group the search modal can render, in render order. Used to
+ * restrict the palette to a subset of sections when opened for a specific
+ * intent (e.g. a drag-release that should only offer canvas-insertable items).
+ */
+export const SEARCH_SECTIONS = [
+  'actions',
+  'connectedAccounts',
+  'integrations',
+  'blocks',
+  'tools',
+  'triggers',
+  'chats',
+  'workflows',
+  'tables',
+  'files',
+  'knowledgeBases',
+  'toolOperations',
+  'workspaces',
+  'docs',
+  'pages',
+] as const
+
+/** A single search-modal result group. */
+export type SearchSection = (typeof SEARCH_SECTIONS)[number]
+
+/**
  * Global state for the universal search modal.
  *
  * Centralizing this state in a store allows any component (e.g. sidebar,
@@ -60,18 +86,25 @@ export interface SearchModalState {
   /** Whether the search modal is currently open. */
   isOpen: boolean
 
+  /**
+   * When set, the palette renders only these sections; `null` shows all of them.
+   */
+  sections: SearchSection[] | null
+
   /** Pre-computed search data. */
   data: SearchData
 
   /**
-   * Explicitly set the open state of the modal.
+   * Explicitly set the open state of the modal. Always resets to the full
+   * palette (no section restriction).
    */
   setOpen: (open: boolean) => void
 
   /**
-   * Convenience method to open the modal.
+   * Convenience method to open the modal. Pass `sections` to restrict the
+   * palette to a subset of result groups.
    */
-  open: () => void
+  open: (options?: { sections?: SearchSection[] }) => void
 
   /**
    * Convenience method to close the modal.


### PR DESCRIPTION
## Summary
- Releasing a connection drag on empty canvas now opens the command palette so you can pick a block to connect to
- The chosen block lands at the drop position and is auto-wired from the source handle
- The palette is restricted to connectable sections only (Blocks, Tools, Tool operations) via a new typed `sections` allowlist on the search-modal store — triggers/pages/workflows/etc. are hidden since you can't connect into them
- The restriction self-resets, so normal palette opens (toolbar, keyboard, context menu) are unaffected

## Type of Change
- [x] New feature

## Testing
Tested manually. Lint and `check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)