### PR TITLE
fix(canvas): raw tooltip shows up when hovering block params

### DIFF
--- a/packages/workflow-renderer/src/lib/overflow-span.tsx
+++ b/packages/workflow-renderer/src/lib/overflow-span.tsx
@@ -1,0 +1,29 @@
+import { FloatingTooltip, isTextClipped, useFloatingTooltip, useIsOverflowing } from '@sim/emcn'
+
+interface OverflowSpanProps {
+  value: string
+  className: string
+}
+
+/**
+ * Truncated span that reveals its full value in a floating tooltip when — and
+ * only when — the text is actually clipped. Never use a native `title`
+ * attribute here: on the canvas it pops the browser's raw, unstyled tooltip
+ * with the full untruncated value (including raw code/JSON) over the graph.
+ */
+export function OverflowSpan({ value, className }: OverflowSpanProps) {
+  const { ref, node } = useIsOverflowing<HTMLSpanElement>()
+  const { state, handlers } = useFloatingTooltip(() => {
+    const element = node.current
+    return element !== null && isTextClipped(element)
+  })
+
+  return (
+    <>
+      <span ref={ref} className={className} {...handlers}>
+        {value}
+      </span>
+      <FloatingTooltip label={value} state={state} />
+    </>
+  )
+}

--- a/packages/workflow-renderer/src/lib/overflow-span.tsx
+++ b/packages/workflow-renderer/src/lib/overflow-span.tsx
@@ -1,4 +1,4 @@
-import { FloatingTooltip, isTextClipped, useFloatingTooltip, useIsOverflowing } from '@sim/emcn'
+import { FloatingTooltip, isTextClipped, useFloatingTooltip } from '@sim/emcn'
 
 interface OverflowSpanProps {
   value: string
@@ -12,15 +12,11 @@ interface OverflowSpanProps {
  * with the full untruncated value (including raw code/JSON) over the graph.
  */
 export function OverflowSpan({ value, className }: OverflowSpanProps) {
-  const { ref, node } = useIsOverflowing<HTMLSpanElement>()
-  const { state, handlers } = useFloatingTooltip(() => {
-    const element = node.current
-    return element !== null && isTextClipped(element)
-  })
+  const { state, handlers } = useFloatingTooltip(isTextClipped)
 
   return (
     <>
-      <span ref={ref} className={className} {...handlers}>
+      <span className={className} {...handlers}>
         {value}
       </span>
       <FloatingTooltip label={value} state={state} />

--- a/packages/workflow-renderer/src/workflow-block/sub-block-row-view.tsx
+++ b/packages/workflow-renderer/src/workflow-block/sub-block-row-view.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@sim/emcn'
+import { OverflowSpan } from '../lib/overflow-span'
 
 /**
  * Props for the pure subblock summary row. The container resolves the value —
@@ -22,22 +23,18 @@ export interface SubBlockRowViewProps {
 export function SubBlockRowView({ title, displayValue, isMonospace }: SubBlockRowViewProps) {
   return (
     <div className='flex items-center gap-2'>
-      <span
+      <OverflowSpan
+        value={title}
         className='min-w-0 truncate text-[var(--text-tertiary)] text-sm capitalize'
-        title={title}
-      >
-        {title}
-      </span>
+      />
       {displayValue !== undefined && (
-        <span
+        <OverflowSpan
+          value={displayValue}
           className={cn(
             'flex-1 truncate text-right text-[var(--text-primary)] text-sm',
             isMonospace && 'font-mono'
           )}
-          title={displayValue}
-        >
-          {displayValue}
-        </span>
+        />
       )}
     </div>
   )

--- a/packages/workflow-renderer/src/workflow-block/workflow-block-view.tsx
+++ b/packages/workflow-renderer/src/workflow-block/workflow-block-view.tsx
@@ -2,6 +2,7 @@ import type { ComponentType, ReactNode, Ref } from 'react'
 import { Badge, cn, handleKeyboardActivation, Tooltip } from '@sim/emcn'
 import { Handle, Position } from 'reactflow'
 import { HANDLE_POSITIONS } from '../dimensions'
+import { OverflowSpan } from '../lib/overflow-span'
 import { tileIconColorClass } from '../lib/tile-icon-color'
 import type { BlockRunStatus } from '../types'
 import { SubBlockRowView } from './sub-block-row-view'
@@ -212,15 +213,13 @@ export function WorkflowBlockView({
                 )}
               />
             </div>
-            <span
+            <OverflowSpan
+              value={name}
               className={cn(
                 'truncate font-medium text-md',
                 !isEnabled && runPathStatus !== 'success' && 'text-[var(--text-muted)]'
               )}
-              title={name}
-            >
-              {name}
-            </span>
+            />
           </div>
           <div className='relative z-10 flex flex-shrink-0 items-center gap-1'>
             {isWorkflowSelector &&


### PR DESCRIPTION
## Summary
- Hovering a truncated block param value (or a long block name) on the canvas popped the browser's raw native tooltip, dumping the full untruncated content (including raw code) over the graph
- Root cause: `sub-block-row-view.tsx` and `workflow-block-view.tsx` used a native `title` attribute on truncated spans instead of the styled cursor-following Tooltip
- Added a small shared `OverflowSpan` component (built on the existing `@sim/emcn` floating-tooltip primitives) that shows the styled tooltip only when the text is actually clipped, and swapped both call sites to use it

## Type of Change
- [x] Bug fix

## Testing
- `bun run type-check` and `bun run lint:check` pass for the `workflow-renderer` package
- `bun run check:api-validation` and the monorepo boundary check pass
- Verified with a jsdom render test: no native `title` attribute is emitted, and the styled floating tooltip renders the full value only on hover when the text overflows

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)