### PR TITLE
fix(mcp): coerce corrupted consecutiveFailures instead of crashing the whole server list

### DIFF
--- a/apps/sim/lib/api/contracts/mcp.ts
+++ b/apps/sim/lib/api/contracts/mcp.ts
@@ -38,9 +38,14 @@ export const mcpTransportSchema = z.enum(['streamable-http'])
 
 export const mcpAuthTypeSchema = z.enum(['none', 'headers', 'oauth'])
 
+const consecutiveFailuresSchema = z.preprocess(
+  (value) => (typeof value === 'number' ? value : undefined),
+  z.number().default(0)
+)
+
 export const mcpServerStatusConfigSchema = z
   .object({
-    consecutiveFailures: z.number().default(0),
+    consecutiveFailures: consecutiveFailuresSchema,
     lastSuccessfulDiscovery: z.string().nullable().default(null),
   })
   .passthrough()

--- a/apps/sim/lib/mcp/service.ts
+++ b/apps/sim/lib/mcp/service.ts
@@ -328,11 +328,14 @@ class McpService {
         )
         .limit(1)
 
-      const currentConfig: McpServerStatusConfig =
-        (currentServer?.statusConfig as McpServerStatusConfig | null) ?? {
-          consecutiveFailures: 0,
-          lastSuccessfulDiscovery: null,
-        }
+      const storedConfig = currentServer?.statusConfig as Partial<McpServerStatusConfig> | null
+      const currentConfig: McpServerStatusConfig = {
+        consecutiveFailures:
+          typeof storedConfig?.consecutiveFailures === 'number'
+            ? storedConfig.consecutiveFailures
+            : 0,
+        lastSuccessfulDiscovery: storedConfig?.lastSuccessfulDiscovery ?? null,
+      }
 
       const now = new Date()
 


### PR DESCRIPTION
## Summary
- **Active production incident**: 81 MCP servers across 69 workspaces currently have their entire "MCP tools" settings page blanked with "Response failed contract validation" — confirmed via direct DB query against the production database
- Root cause: `updateServerStatus()` in `lib/mcp/service.ts` only fell back to a default status config when the whole `statusConfig` column was null, not when it was a real-but-incomplete object (e.g. the column's `'{}'` default on server creation). This made `consecutiveFailures` `undefined`, `undefined + 1` evaluate to `NaN`, and `JSON.stringify(NaN)` persist as a literal `null` the first time a freshly-created server hit a connection failure
- That corrupted `null` then failed the server-list contract's Zod parse client-side (`consecutiveFailures: z.number()` rejects `null`) — since the response is an array, one bad server blanks the entire list for the whole workspace
- Fixed in two places: `service.ts` now normalizes the read-back status config so `consecutiveFailures` is always a real number going forward; the contract schema also coerces any non-number `consecutiveFailures` (including already-corrupted `null` rows) to the default of `0`, so all 69 currently-broken workspaces self-heal immediately on next page load — no DB migration needed

## Type of Change
- [x] Bug fix (production incident)

## Testing
- Verified the fix against the exact corrupted production data shape with a standalone Zod parse script (`{consecutiveFailures: null}` → `{consecutiveFailures: 0, ...}`, no longer throws)
- Existing `lib/mcp/service.test.ts` suite passes (11/11)
- `bun run check:api-validation` passes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)