### PR TITLE
fix(chat-otp): re-check authType before minting deployment auth cookie

### DIFF
--- a/apps/sim/app/api/chat/[identifier]/otp/route.test.ts
+++ b/apps/sim/app/api/chat/[identifier]/otp/route.test.ts
@@ -529,6 +529,43 @@ describe('Chat OTP API Route', () => {
     })
   })
 
+  describe('PUT - Verify OTP (authType re-check)', () => {
+    beforeEach(() => {
+      mockGetStorageMethod.mockReturnValue('redis')
+      mockRedisGet.mockResolvedValue(`${mockOTP}:0`)
+    })
+
+    it('rejects verification when the chat has switched away from email auth', async () => {
+      mockDbSelect.mockImplementationOnce(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                id: mockChatId,
+                authType: 'password',
+                password: 'encrypted-password',
+              },
+            ]),
+          }),
+        }),
+      }))
+
+      const request = new NextRequest('http://localhost:3000/api/chat/test/otp', {
+        method: 'PUT',
+        body: JSON.stringify({ email: mockEmail, otp: mockOTP }),
+      })
+
+      await PUT(request, { params: Promise.resolve({ identifier: mockIdentifier }) })
+
+      expect(mockCreateErrorResponse).toHaveBeenCalledWith(
+        'This chat does not use email authentication',
+        400
+      )
+      expect(mockRedisGet).not.toHaveBeenCalled()
+      expect(mockSetChatAuthCookie).not.toHaveBeenCalled()
+    })
+  })
+
   describe('PUT - Verify OTP (Database path)', () => {
     beforeEach(() => {
       mockGetStorageMethod.mockReturnValue('database')

--- a/apps/sim/app/api/chat/[identifier]/otp/route.ts
+++ b/apps/sim/app/api/chat/[identifier]/otp/route.ts
@@ -174,6 +174,10 @@ export const PUT = withRouteHandler(
 
       const deployment = deploymentResult[0]
 
+      if (deployment.authType !== 'email') {
+        return createErrorResponse('This chat does not use email authentication', 400)
+      }
+
       const storedValue = await getOTP('chat', deployment.id, email)
       if (!storedValue) {
         return createErrorResponse('No verification code found, request a new one', 400)


### PR DESCRIPTION
## Summary
- The chat OTP verify endpoint (`PUT /api/chat/[identifier]/otp`) minted the deployment auth cookie using the chat's current `authType` without re-checking it was still `email`, unlike the sibling `POST` handler and the public-file OTP route
- Added the same `authType !== 'email'` guard used elsewhere, right before OTP verification/cookie minting

## Type of Change
- [x] Bug fix (security)

## Testing
- Added a regression test asserting the guard rejects verification when the chat is no longer email-auth, and confirmed it fails without the fix
- `bunx vitest run app/api/chat/[identifier]/otp/route.test.ts` — 17/17 passing
- `bun run check:api-validation` passes
- Typecheck and lint clean on changed files

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)