### PR TITLE
add rest of academy use case videos

### DIFF
--- a/apps/docs/components/workflow-preview/academy-video-workflows.ts
+++ b/apps/docs/components/workflow-preview/academy-video-workflows.ts
@@ -391,3 +391,526 @@ export const AV_CONTENT_AGENT_WORKFLOW: PreviewWorkflow = {
     { id: 'evaluator-scores', source: 'evaluator', target: 'scores' },
   ],
 }
+
+/** use-cases/slack-it-triage — the IT triage machine from the video. */
+export const AV_IT_TRIAGE_WORKFLOW: PreviewWorkflow = {
+  id: 'av-it-triage',
+  name: 'it-triage',
+  blocks: [
+    {
+      id: 'ithelptrigger',
+      name: 'IT Help Trigger',
+      type: 'slack',
+      bgColor: '#611F69',
+      position: { x: 0, y: 100 },
+      hideTargetHandle: true,
+      rows: [{ title: 'Channel', value: '#it-help' }],
+    },
+    {
+      id: 'triage',
+      name: 'Triage',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 340, y: 100 },
+      rows: [
+        { title: 'Messages', value: 'Classify this request' },
+        { title: 'Model', value: 'gpt-5.6-luna' },
+        { title: 'Response Format', value: 'category · answerable | escalate' },
+      ],
+    },
+    {
+      id: 'condition',
+      name: 'Answerable?',
+      type: 'condition',
+      bgColor: '#FF752F',
+      position: { x: 680, y: 100 },
+      rows: [],
+      branches: [
+        { id: 'condition-if', label: 'If', value: '<triage.category> = answerable' },
+        { id: 'condition-else', label: 'else' },
+      ],
+    },
+    {
+      id: 'knowledge',
+      name: 'Knowledge',
+      type: 'knowledge',
+      bgColor: '#00B0B0',
+      position: { x: 1020, y: -10 },
+      rows: [
+        { title: 'Knowledge Base', value: 'IT Docs' },
+        { title: 'Top K', value: '3' },
+      ],
+    },
+    {
+      id: 'answer',
+      name: 'Answer',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 1360, y: -10 },
+      rows: [
+        { title: 'Messages', value: 'Answer from <knowledge.results>' },
+        { title: 'Model', value: 'claude-sonnet-5' },
+      ],
+    },
+    {
+      id: 'reply',
+      name: 'Reply',
+      type: 'slack',
+      bgColor: '#611F69',
+      position: { x: 1700, y: -10 },
+      rows: [
+        { title: 'Channel', value: '#it-help' },
+        { title: 'Thread TS', value: '<ithelptrigger.ts>' },
+      ],
+    },
+    {
+      id: 'escalate',
+      name: 'Escalate',
+      type: 'slack',
+      bgColor: '#611F69',
+      position: { x: 1020, y: 230 },
+      rows: [{ title: 'Channel', value: '#it-escalations' }],
+    },
+  ],
+  edges: [
+    { id: 'trigger-triage', source: 'ithelptrigger', target: 'triage' },
+    { id: 'triage-condition', source: 'triage', target: 'condition' },
+    {
+      id: 'condition-knowledge',
+      source: 'condition',
+      target: 'knowledge',
+      sourceHandle: 'condition-if',
+    },
+    { id: 'knowledge-answer', source: 'knowledge', target: 'answer' },
+    { id: 'answer-reply', source: 'answer', target: 'reply' },
+    {
+      id: 'condition-escalate',
+      source: 'condition',
+      target: 'escalate',
+      sourceHandle: 'condition-else',
+    },
+  ],
+}
+
+/** use-cases/monitoring-research — the morning-watch machine. */
+export const AV_MORNING_WATCH_WORKFLOW: PreviewWorkflow = {
+  id: 'av-morning-watch',
+  name: 'morning-watch',
+  blocks: [
+    {
+      id: 'schedule',
+      name: 'Schedule',
+      type: 'schedule',
+      bgColor: '#6366F1',
+      position: { x: 0, y: 0 },
+      hideTargetHandle: true,
+      rows: [{ title: 'Frequency', value: 'Daily · 7:00' }],
+    },
+    {
+      id: 'research',
+      name: 'Research',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 340, y: 0 },
+      rows: [
+        { title: 'Messages', value: 'What changed since yesterday?' },
+        { title: 'Model', value: 'claude-sonnet-5' },
+      ],
+      tools: [
+        { type: 'exa', name: 'Search', bgColor: '#1F40ED' },
+        { type: 'firecrawl', name: 'Read Pages', bgColor: '#181C1E' },
+      ],
+    },
+    {
+      id: 'digest',
+      name: 'Digest',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 680, y: 0 },
+      rows: [{ title: 'Messages', value: 'Summarize: <research.content>' }],
+    },
+    {
+      id: 'post',
+      name: 'Post',
+      type: 'slack',
+      bgColor: '#611F69',
+      position: { x: 1020, y: 0 },
+      rows: [{ title: 'Channel', value: '#market-watch' }],
+    },
+  ],
+  edges: [
+    { id: 'schedule-research', source: 'schedule', target: 'research' },
+    { id: 'research-digest', source: 'research', target: 'digest' },
+    { id: 'digest-post', source: 'digest', target: 'post' },
+  ],
+}
+
+/** use-cases/document-extraction — email attachment to table row. */
+export const AV_DOC_EXTRACTION_WORKFLOW: PreviewWorkflow = {
+  id: 'av-doc-extraction',
+  name: 'invoice-extraction',
+  blocks: [
+    {
+      id: 'gmailtrigger',
+      name: 'Gmail Email Trigger',
+      type: 'gmail',
+      bgColor: '#E0E0E0',
+      position: { x: 0, y: 0 },
+      hideTargetHandle: true,
+      rows: [{ title: 'Include Attachments', value: 'Enabled' }],
+    },
+    {
+      id: 'extract',
+      name: 'Extract',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 340, y: 0 },
+      rows: [
+        { title: 'Messages', value: 'Extract the invoice fields' },
+        { title: 'Model', value: 'claude-sonnet-5' },
+        { title: 'Response Format', value: 'vendor · amount · due_date' },
+      ],
+    },
+    {
+      id: 'saverow',
+      name: 'Save Row',
+      type: 'table',
+      bgColor: '#10B981',
+      position: { x: 680, y: 0 },
+      rows: [
+        { title: 'Operation', value: 'Insert Row' },
+        { title: 'Table', value: 'Invoices' },
+        { title: 'Data', value: '<extract.vendor> · <extract.amount>' },
+      ],
+    },
+  ],
+  edges: [
+    { id: 'trigger-extract', source: 'gmailtrigger', target: 'extract' },
+    { id: 'extract-saverow', source: 'extract', target: 'saverow' },
+  ],
+}
+
+/** use-cases/sales-data-enrichment — the per-row chain the table fans out. */
+export const AV_LEAD_ENRICHMENT_WORKFLOW: PreviewWorkflow = {
+  id: 'av-lead-enrichment',
+  name: 'enrich-lead',
+  blocks: [
+    {
+      id: 'start',
+      name: 'Start',
+      type: 'start_trigger',
+      bgColor: '#2FB3FF',
+      position: { x: 0, y: 0 },
+      hideTargetHandle: true,
+      rows: [{ title: 'Input', value: 'company · contact' }],
+    },
+    {
+      id: 'research',
+      name: 'Research',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 340, y: 0 },
+      rows: [
+        { title: 'Messages', value: 'Research <start.company>' },
+        { title: 'Model', value: 'claude-sonnet-5' },
+      ],
+      tools: [
+        { type: 'exa', name: 'Search', bgColor: '#1F40ED' },
+        { type: 'firecrawl', name: 'Read Pages', bgColor: '#181C1E' },
+      ],
+    },
+    {
+      id: 'score',
+      name: 'Score',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 680, y: 0 },
+      rows: [{ title: 'Messages', value: 'Score the fit: <research.content>' }],
+    },
+  ],
+  edges: [
+    { id: 'start-research', source: 'start', target: 'research' },
+    { id: 'research-score', source: 'research', target: 'score' },
+  ],
+}
+
+/** use-cases/telegram-personal-assistant — the three-lane assistant. */
+export const AV_TELEGRAM_ASSISTANT_WORKFLOW: PreviewWorkflow = {
+  id: 'av-telegram-assistant',
+  name: 'telegram-assistant',
+  blocks: [
+    {
+      id: 'telegramtrigger',
+      name: 'Telegram Trigger',
+      type: 'telegram',
+      bgColor: '#E0E0E0',
+      position: { x: 0, y: 200 },
+      hideTargetHandle: true,
+      rows: [{ title: 'Message', value: '<telegram.message>' }],
+    },
+    {
+      id: 'router',
+      name: 'Router',
+      type: 'router',
+      bgColor: '#28C43F',
+      position: { x: 340, y: 200 },
+      rows: [],
+      branches: [
+        { id: 'router-email', label: 'Email' },
+        { id: 'router-calendar', label: 'Calendar' },
+        { id: 'router-research', label: 'Research' },
+      ],
+    },
+    {
+      id: 'email',
+      name: 'Email',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 680, y: 0 },
+      rows: [{ title: 'Messages', value: 'Answer from my inbox' }],
+      tools: [{ type: 'gmail', name: 'Read Email', bgColor: '#E0E0E0' }],
+    },
+    {
+      id: 'calendar',
+      name: 'Calendar',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 680, y: 200 },
+      rows: [{ title: 'Messages', value: 'Answer from my calendar' }],
+      tools: [{ type: 'google_calendar', name: 'List Events', bgColor: '#E0E0E0' }],
+    },
+    {
+      id: 'research',
+      name: 'Research',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 680, y: 400 },
+      rows: [{ title: 'Messages', value: 'Research the question' }],
+      tools: [{ type: 'exa', name: 'Search', bgColor: '#1F40ED' }],
+    },
+    {
+      id: 'reply',
+      name: 'Reply',
+      type: 'telegram',
+      bgColor: '#E0E0E0',
+      position: { x: 1020, y: 200 },
+      rows: [{ title: 'Chat ID', value: '<telegramtrigger.chatId>' }],
+    },
+  ],
+  edges: [
+    { id: 'trigger-router', source: 'telegramtrigger', target: 'router' },
+    { id: 'router-email', source: 'router', target: 'email', sourceHandle: 'router-email' },
+    {
+      id: 'router-calendar',
+      source: 'router',
+      target: 'calendar',
+      sourceHandle: 'router-calendar',
+    },
+    {
+      id: 'router-research',
+      source: 'router',
+      target: 'research',
+      sourceHandle: 'router-research',
+    },
+    { id: 'email-reply', source: 'email', target: 'reply' },
+    { id: 'calendar-reply', source: 'calendar', target: 'reply' },
+    { id: 'research-reply', source: 'research', target: 'reply' },
+  ],
+}
+
+/** use-cases/telegram-personal-assistant — the second, scheduled brief. */
+export const AV_MORNING_BRIEF_WORKFLOW: PreviewWorkflow = {
+  id: 'av-morning-brief',
+  name: 'morning-brief',
+  blocks: [
+    {
+      id: 'schedule',
+      name: 'Schedule',
+      type: 'schedule',
+      bgColor: '#6366F1',
+      position: { x: 0, y: 0 },
+      hideTargetHandle: true,
+      rows: [{ title: 'Frequency', value: 'Daily · 7:00' }],
+    },
+    {
+      id: 'brief',
+      name: 'Brief',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 340, y: 0 },
+      rows: [{ title: 'Messages', value: 'Summarize my day' }],
+      tools: [
+        { type: 'gmail', name: 'Read Email', bgColor: '#E0E0E0' },
+        { type: 'google_calendar', name: 'List Events', bgColor: '#E0E0E0' },
+      ],
+    },
+    {
+      id: 'send',
+      name: 'Send',
+      type: 'telegram',
+      bgColor: '#E0E0E0',
+      position: { x: 680, y: 0 },
+      rows: [{ title: 'Message', value: '<brief.content>' }],
+    },
+  ],
+  edges: [
+    { id: 'schedule-brief', source: 'schedule', target: 'brief' },
+    { id: 'brief-send', source: 'brief', target: 'send' },
+  ],
+}
+
+/** use-cases/scheduled-report-rollup — two sources reconciled weekly. */
+export const AV_REPORT_ROLLUP_WORKFLOW: PreviewWorkflow = {
+  id: 'av-report-rollup',
+  name: 'weekly-rollup',
+  blocks: [
+    {
+      id: 'schedule',
+      name: 'Schedule',
+      type: 'schedule',
+      bgColor: '#6366F1',
+      position: { x: 0, y: 110 },
+      hideTargetHandle: true,
+      rows: [{ title: 'Frequency', value: 'Weekly · Mon 7:00' }],
+    },
+    {
+      id: 'stripe',
+      name: 'Stripe',
+      type: 'stripe',
+      bgColor: '#635BFF',
+      position: { x: 340, y: 0 },
+      rows: [{ title: 'Operation', value: 'List Charges' }],
+    },
+    {
+      id: 'sheets',
+      name: 'Sheets',
+      type: 'google_sheets',
+      bgColor: '#FFFFFF',
+      position: { x: 340, y: 220 },
+      rows: [
+        { title: 'Operation', value: 'Read Data' },
+        { title: 'Range', value: 'Tracking!A:D' },
+      ],
+    },
+    {
+      id: 'reconcile',
+      name: 'Reconcile',
+      type: 'function',
+      bgColor: '#FF402F',
+      position: { x: 680, y: 110 },
+      rows: [{ title: 'Code', value: 'reconcile(charges, rows)' }],
+    },
+    {
+      id: 'record',
+      name: 'Record',
+      type: 'table',
+      bgColor: '#10B981',
+      position: { x: 1020, y: 110 },
+      rows: [
+        { title: 'Operation', value: 'Insert Row' },
+        { title: 'Table', value: 'weekly_reports' },
+      ],
+    },
+    {
+      id: 'digest',
+      name: 'Digest',
+      type: 'slack',
+      bgColor: '#611F69',
+      position: { x: 1360, y: 110 },
+      rows: [{ title: 'Channel', value: '#finance' }],
+    },
+  ],
+  edges: [
+    { id: 'schedule-stripe', source: 'schedule', target: 'stripe' },
+    { id: 'schedule-sheets', source: 'schedule', target: 'sheets' },
+    { id: 'stripe-reconcile', source: 'stripe', target: 'reconcile' },
+    { id: 'sheets-reconcile', source: 'sheets', target: 'reconcile' },
+    { id: 'reconcile-record', source: 'reconcile', target: 'record' },
+    { id: 'record-digest', source: 'record', target: 'digest' },
+  ],
+}
+
+/** use-cases/whatsapp-storefront-bot — FAQ answers with an escalation gate. */
+export const AV_STOREFRONT_BOT_WORKFLOW: PreviewWorkflow = {
+  id: 'av-storefront-bot',
+  name: 'storefront-bot',
+  blocks: [
+    {
+      id: 'whatsapptrigger',
+      name: 'WhatsApp Trigger',
+      type: 'whatsapp',
+      bgColor: '#25D366',
+      position: { x: 0, y: 130 },
+      hideTargetHandle: true,
+      rows: [{ title: 'Message', value: '<whatsapp.message>' }],
+    },
+    {
+      id: 'condition',
+      name: 'Refund?',
+      type: 'condition',
+      bgColor: '#FF752F',
+      position: { x: 340, y: 130 },
+      rows: [],
+      branches: [
+        { id: 'condition-if', label: 'If', value: 'refund or complaint' },
+        { id: 'condition-else', label: 'else' },
+      ],
+    },
+    {
+      id: 'alertowner',
+      name: 'Alert Owner',
+      type: 'slack',
+      bgColor: '#611F69',
+      position: { x: 680, y: 0 },
+      rows: [{ title: 'Channel', value: '#storefront' }],
+    },
+    {
+      id: 'knowledge',
+      name: 'Knowledge',
+      type: 'knowledge',
+      bgColor: '#00B0B0',
+      position: { x: 680, y: 240 },
+      rows: [
+        { title: 'Knowledge Base', value: 'Shop FAQ' },
+        { title: 'Search Query', value: '<whatsapptrigger.message>' },
+      ],
+    },
+    {
+      id: 'answer',
+      name: 'Answer',
+      type: 'agent',
+      bgColor: '#33C482',
+      position: { x: 1020, y: 240 },
+      rows: [
+        { title: 'Messages', value: 'Answer from <knowledge.results>' },
+        { title: 'Model', value: 'claude-sonnet-5' },
+        { title: 'Memory', value: 'Conversation · <whatsapptrigger.from>' },
+      ],
+    },
+    {
+      id: 'reply',
+      name: 'Reply',
+      type: 'whatsapp',
+      bgColor: '#25D366',
+      position: { x: 1360, y: 240 },
+      rows: [{ title: 'To', value: '<whatsapptrigger.from>' }],
+    },
+  ],
+  edges: [
+    { id: 'trigger-condition', source: 'whatsapptrigger', target: 'condition' },
+    {
+      id: 'condition-alertowner',
+      source: 'condition',
+      target: 'alertowner',
+      sourceHandle: 'condition-if',
+    },
+    {
+      id: 'condition-knowledge',
+      source: 'condition',
+      target: 'knowledge',
+      sourceHandle: 'condition-else',
+    },
+    { id: 'knowledge-answer', source: 'knowledge', target: 'answer' },
+    { id: 'answer-reply', source: 'answer', target: 'reply' },
+  ],
+}

--- a/apps/docs/content/docs/en/academy/meta.json
+++ b/apps/docs/content/docs/en/academy/meta.json
@@ -34,6 +34,9 @@
     "use-cases/slack-it-triage",
     "use-cases/document-extraction",
     "use-cases/monitoring-research",
-    "use-cases/sales-data-enrichment"
+    "use-cases/sales-data-enrichment",
+    "use-cases/telegram-personal-assistant",
+    "use-cases/scheduled-report-rollup",
+    "use-cases/whatsapp-storefront-bot"
   ]
 }

--- a/apps/docs/content/docs/en/academy/use-cases/document-extraction.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/document-extraction.mdx
@@ -6,6 +6,8 @@ description: A pipeline that takes incoming documents, extracts the fields you c
 import { VideoPlaceholder } from '@/components/ui/video-placeholder'
 import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
 import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview } from '@/components/workflow-preview'
+import { AV_DOC_EXTRACTION_WORKFLOW } from '@/components/workflow-preview/academy-video-workflows'
 
 <VideoPlaceholder eyebrow="Use case" title="Document Intake & Extraction" className="mt-2" />
 
@@ -40,4 +42,16 @@ Turn a pile of unstructured documents, invoices, contracts, forms, into structur
 
 A **file** comes in, an **Agent** block extracts the fields into a [structured output](/academy/agents/intro) so the shape is predictable, and a **Table** block writes the row. Run it across a batch and a folder of documents becomes a queryable table.
 
+Here is the machine the video builds:
+
+<WorkflowPreview workflow={AV_DOC_EXTRACTION_WORKFLOW} />
+
 This composes [files](/academy/files/intro), [agents](/academy/agents/intro), and [tables](/academy/tables/intro).
+
+## How it works
+
+The **Gmail Email Trigger** polls the inbox and fires on each new email, with Include Attachments enabled so the invoice PDF arrives as part of the trigger's output. No one forwards anything; the inbox itself is the intake queue.
+
+The **Extract** agent reads the attachment and its Response Format is what makes the whole machine reliable: it must return `vendor`, `amount`, and `due_date` as named fields, not a paragraph that mentions them. Structured output turns each field into a root-level reference, so the next block can write `<extract.vendor>` and `<extract.amount>` directly instead of parsing prose. That is the difference between a demo and a pipeline.
+
+**Save Row** inserts those fields into the Invoices [table](/academy/tables/intro). Because the agent's output shape is fixed, the mapping from fields to columns never drifts, and every email that arrives becomes one more queryable row.

--- a/apps/docs/content/docs/en/academy/use-cases/monitoring-research.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/monitoring-research.mdx
@@ -6,6 +6,8 @@ description: A scheduled agent that watches sources you care about, researches w
 import { VideoPlaceholder } from '@/components/ui/video-placeholder'
 import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
 import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview } from '@/components/workflow-preview'
+import { AV_MORNING_WATCH_WORKFLOW } from '@/components/workflow-preview/academy-video-workflows'
 
 <VideoPlaceholder eyebrow="Use case" title="Monitoring & Automated Research" className="mt-2" />
 
@@ -40,4 +42,18 @@ Build a system that runs on a schedule, checks the sources you care about, resea
 
 A **Schedule trigger** kicks the workflow off. An **Agent** block with search tools gathers and reads sources, synthesizes what changed, and a final step delivers it: a Slack message, or a saved report [file](/academy/files/intro).
 
+Here is the machine the video builds:
+
+<WorkflowPreview workflow={AV_MORNING_WATCH_WORKFLOW} />
+
 This composes [workflows](/academy/workflows/intro), [agents](/academy/agents/intro), and [files](/academy/files/intro).
+
+## How it works
+
+The **Schedule** trigger fires every morning at 7:00, no message and no click. Scheduled workflows are the pattern for anything that should happen whether or not you remember it; the [triggers video](/academy/workflows/intro) covers how a trigger replaces the manual Start.
+
+The **Research** agent carries the tools: Exa for search and Firecrawl for reading pages. The agent decides what to search for and which results to open, calling the tools as many times as the question needs. That loop, model decides, tool runs, model reads the result, is [tool calling](/academy/agents/intro), and it is what makes this a researcher instead of a summarizer of whatever one query returned.
+
+The **Digest** agent is a separate block on purpose. Research and writing are different jobs: the first agent gathers with wide instructions, the second condenses with strict ones. Splitting them keeps each prompt short and each output predictable.
+
+**Post** delivers the digest to #market-watch. Swap this one block to change where the report lands: an email, a saved [file](/academy/files/intro), a [table](/academy/tables/intro) row per day.

--- a/apps/docs/content/docs/en/academy/use-cases/sales-data-enrichment.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/sales-data-enrichment.mdx
@@ -6,6 +6,8 @@ description: A table-backed system that takes thin lead records, enriches them i
 import { VideoPlaceholder } from '@/components/ui/video-placeholder'
 import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
 import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview } from '@/components/workflow-preview'
+import { AV_LEAD_ENRICHMENT_WORKFLOW } from '@/components/workflow-preview/academy-video-workflows'
 
 <VideoPlaceholder eyebrow="Use case" title="Sales Data Management & Enrichment" className="mt-2" />
 
@@ -40,4 +42,16 @@ Run your sales pipeline as data. Start with thin lead records in a table, enrich
 
 Leads live in a **table**. A **workflow column** runs per row: it enriches the record, an **Agent** block scores the fit, and the results are written straight back into the table. The table becomes both the queue and the record.
 
+Here is the workflow behind the column:
+
+<WorkflowPreview workflow={AV_LEAD_ENRICHMENT_WORKFLOW} />
+
 This is [tables](/academy/tables/intro) and [agents](/academy/agents/intro) composed into a pipeline that operates at scale.
+
+## How it works
+
+Notice what the workflow is not: there is no loop, no batch logic, no list handling. It is a plain chain built for exactly one lead, because the multiplicity lives in the [table](/academy/tables/intro), not the workflow. The table's workflow column runs this chain once per row, and fifty leads means fifty parallel runs of the same three blocks.
+
+The **Start** block declares the input: a company and a contact. When the table invokes the workflow, each row's cells fill these fields, so `<start.company>` inside the workflow always means this row's company.
+
+The **Research** agent carries Exa and Firecrawl as [tools](/academy/agents/intro) and gathers what is public about the company: what it does, how big it is, what it runs on. The **Score** agent then reads the research and grades the fit. Its output flows back into the row's result columns, which is what turns the table from a list of names into a ranked queue your team can sort.

--- a/apps/docs/content/docs/en/academy/use-cases/scheduled-report-rollup.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/scheduled-report-rollup.mdx
@@ -1,0 +1,43 @@
+---
+title: Scheduled Report Rollup
+description: A weekly workflow that pulls Stripe and Sheets data, reconciles the numbers, records the result, and posts the digest to Slack before the meeting.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+
+<VideoPlaceholder eyebrow="Use case" title="Scheduled Report Rollup" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Let the Monday number assemble itself. A schedule fires each week, pulls the charges from Stripe and the tracking tab from Sheets, reconciles the two, computes the delta against last week, and posts the digest to Slack before anyone sits down for the meeting.
+
+<WhatYouWillLearn
+  items={[
+    { title: 'Run on a schedule', body: 'Trigger the rollup every Monday morning so the report is never late.' },
+    { title: 'Reconcile two sources', body: 'Use a Function block to join Stripe and Sheets data and compute the delta.' },
+    { title: 'Record and deliver', body: 'Write the result as a table row and post the digest to Slack.' },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'The problem', time: '0:00' },
+    { title: 'Schedule trigger', time: '0:35' },
+    { title: 'Pull both sources', time: '1:10' },
+    { title: 'Reconcile and compute', time: '2:00' },
+    { title: 'Record and post', time: '2:50' },
+  ]}
+/>
+
+</div>
+
+## What you'll build
+
+A **Schedule trigger** fires every Monday at 7:00. The workflow pulls charges from the **Stripe API** and reads the tracking tab with **Google Sheets**. A **Function** block reconciles the two sources and computes this week's number and the delta. A **Table** block inserts the row, so every week's result is queryable later, and a **Slack message** posts the digest to the channel. Every run is recorded in the [logs](/logs-debugging).
+
+This composes [workflows](/academy/workflows/intro) and [tables](/academy/tables/intro): the foundations, composed.

--- a/apps/docs/content/docs/en/academy/use-cases/scheduled-report-rollup.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/scheduled-report-rollup.mdx
@@ -6,6 +6,8 @@ description: A weekly workflow that pulls Stripe and Sheets data, reconciles the
 import { VideoPlaceholder } from '@/components/ui/video-placeholder'
 import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
 import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview } from '@/components/workflow-preview'
+import { AV_REPORT_ROLLUP_WORKFLOW } from '@/components/workflow-preview/academy-video-workflows'
 
 <VideoPlaceholder eyebrow="Use case" title="Scheduled Report Rollup" className="mt-2" />
 
@@ -40,4 +42,16 @@ Let the Monday number assemble itself. A schedule fires each week, pulls the cha
 
 A **Schedule trigger** fires every Monday at 7:00. The workflow pulls charges from the **Stripe API** and reads the tracking tab with **Google Sheets**. A **Function** block reconciles the two sources and computes this week's number and the delta. A **Table** block inserts the row, so every week's result is queryable later, and a **Slack message** posts the digest to the channel. Every run is recorded in the [logs](/logs-debugging).
 
+Here is the machine the video builds:
+
+<WorkflowPreview workflow={AV_REPORT_ROLLUP_WORKFLOW} height={340} />
+
 This composes [workflows](/academy/workflows/intro) and [tables](/academy/tables/intro): the foundations, composed.
+
+## How it works
+
+The **Schedule** trigger fires weekly, Monday at 7:00, and fans out to both sources at once: two edges leave the trigger, so **Stripe** lists the week's charges while **Sheets** reads the tracking tab in parallel. Neither source waits on the other.
+
+The **Reconcile** function is where the two lanes meet. A [Function block](/academy/workflows/intro) runs plain code, which is the right tool here: matching charges to tracked rows and computing a delta is deterministic logic, not judgment, so no agent is involved and the result is the same every week.
+
+**Record** inserts the reconciled numbers into the weekly_reports [table](/academy/tables/intro) before anything is posted. That ordering is deliberate: the table is the durable record, so every past week stays queryable even if the Slack message scrolls away. **Digest** then posts the summary to #finance, and Monday's report is waiting before anyone asks for it.

--- a/apps/docs/content/docs/en/academy/use-cases/slack-it-triage.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/slack-it-triage.mdx
@@ -6,6 +6,8 @@ description: An agent that watches a Slack channel, classifies incoming IT reque
 import { VideoPlaceholder } from '@/components/ui/video-placeholder'
 import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
 import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview } from '@/components/workflow-preview'
+import { AV_IT_TRIAGE_WORKFLOW } from '@/components/workflow-preview/academy-video-workflows'
 
 <VideoPlaceholder eyebrow="Use case" title="Slack IT Triage Bot" className="mt-2" />
 
@@ -40,4 +42,18 @@ Build an agent that lives in a Slack channel: it reads each incoming IT request,
 
 A **Slack trigger** starts the workflow on each new message. An **Agent** block classifies the request and decides the path: a **knowledge-base search** drafts an answer for common questions, while anything it can't resolve is routed to a human or filed as a ticket. Every run is recorded in the [logs](/logs-debugging).
 
+Here is the machine the video builds:
+
+<WorkflowPreview workflow={AV_IT_TRIAGE_WORKFLOW} height={340} />
+
 This pulls together [workflows](/academy/workflows/intro), [agents](/academy/agents/intro), and [knowledge bases](/academy/knowledge-bases/intro) into one system: the foundations, composed.
+
+## How it works
+
+The **IT Help Trigger** fires on every message posted in the channel, and it hands the workflow more than the text: the sender, the channel, and the message timestamp all arrive as outputs the later blocks can reference. That timestamp matters at the end.
+
+The **Triage** agent classifies the request, and its Response Format is the lesson: instead of prose, it is forced to return a structured object with a `category` field that is either `answerable` or `escalate`. A structured decision is something the next block can branch on; free text is not. The [Agent block](/academy/agents/intro) page covers structured outputs in depth.
+
+The **Answerable?** condition reads `<triage.category>` and picks the path. On the answerable side, the **Knowledge** block searches the IT Docs [knowledge base](/academy/knowledge-bases/intro) and returns the top 3 chunks, the **Answer** agent writes a reply grounded in those chunks, and the **Reply** block posts it back to Slack with the trigger's Thread TS, so the answer lands in the same thread as the question instead of as a new channel message.
+
+Everything else takes the other branch: **Escalate** posts the request to #it-escalations, where a human picks it up. The bot never guesses on requests it was not built to answer.

--- a/apps/docs/content/docs/en/academy/use-cases/telegram-personal-assistant.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/telegram-personal-assistant.mdx
@@ -1,0 +1,43 @@
+---
+title: Telegram Personal Assistant
+description: An assistant you text like a friend, it reads your inbox, checks your calendar, researches on request, and sends a morning brief on its own.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+
+<VideoPlaceholder eyebrow="Use case" title="Telegram Personal Assistant" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Build an assistant you message like a friend. Each Telegram text, a question about your inbox, a calendar check, a quick research request, is routed to the right tools and answered in the same thread. A second trigger sends an unprompted brief every morning at 7:00.
+
+<WhatYouWillLearn
+  items={[
+    { title: 'Trigger from a message', body: 'Start a workflow from a Telegram text and reply in the same thread.' },
+    { title: 'Route to the right tools', body: 'Use a Router so inbox, calendar, and research requests each take their own path.' },
+    { title: 'Act without being asked', body: 'Add a schedule that assembles and sends a morning brief on its own.' },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'The problem', time: '0:00' },
+    { title: 'Telegram trigger', time: '0:35' },
+    { title: 'Route the request', time: '1:15' },
+    { title: 'Three agent lanes', time: '2:00' },
+    { title: 'The morning brief', time: '3:00' },
+  ]}
+/>
+
+</div>
+
+## What you'll build
+
+A **Telegram trigger** starts the workflow on each incoming message. A **Router** block reads the request and picks a lane: an **Agent** that reads Gmail, an **Agent** that checks Google Calendar, or an **Agent** that researches the web with Exa. Whichever lane runs, the answer goes back as a reply in the same Telegram thread. A second **Schedule trigger** fires daily at 7:00, a brief agent gathers the day's context, and a **Telegram send** delivers it before you ask. Every run is recorded in the [logs](/logs-debugging).
+
+This pulls together [workflows](/academy/workflows/intro) and [agents](/academy/agents/intro) into one system: the foundations, composed.

--- a/apps/docs/content/docs/en/academy/use-cases/telegram-personal-assistant.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/telegram-personal-assistant.mdx
@@ -6,6 +6,11 @@ description: An assistant you text like a friend, it reads your inbox, checks yo
 import { VideoPlaceholder } from '@/components/ui/video-placeholder'
 import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
 import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview } from '@/components/workflow-preview'
+import {
+  AV_MORNING_BRIEF_WORKFLOW,
+  AV_TELEGRAM_ASSISTANT_WORKFLOW,
+} from '@/components/workflow-preview/academy-video-workflows'
 
 <VideoPlaceholder eyebrow="Use case" title="Telegram Personal Assistant" className="mt-2" />
 
@@ -40,4 +45,20 @@ Build an assistant you message like a friend. Each Telegram text, a question abo
 
 A **Telegram trigger** starts the workflow on each incoming message. A **Router** block reads the request and picks a lane: an **Agent** that reads Gmail, an **Agent** that checks Google Calendar, or an **Agent** that researches the web with Exa. Whichever lane runs, the answer goes back as a reply in the same Telegram thread. A second **Schedule trigger** fires daily at 7:00, a brief agent gathers the day's context, and a **Telegram send** delivers it before you ask. Every run is recorded in the [logs](/logs-debugging).
 
+Here is the assistant the video builds:
+
+<WorkflowPreview workflow={AV_TELEGRAM_ASSISTANT_WORKFLOW} height={380} />
+
 This pulls together [workflows](/academy/workflows/intro) and [agents](/academy/agents/intro) into one system: the foundations, composed.
+
+## How it works
+
+The **Telegram Trigger** fires on each message you send the bot and carries the chat id, which is how the reply finds its way back to the same conversation.
+
+The **Router** is the block that makes this an assistant instead of a chain: it reads the request and picks exactly one lane. "Did anything come in from the landlord?" goes to **Email**, "what's on Thursday?" goes to **Calendar**, and "find me a standing desk under $400" goes to **Research**. Unlike a Condition, which tests a value you name, a [Router](/academy/workflows/intro) uses a model to read intent, which is the right tool when the input is free-form language.
+
+Each lane is a small [agent](/academy/agents/intro) with exactly the tools its job needs: Gmail for the email lane, Google Calendar for the calendar lane, Exa search for the research lane. Narrow agents with few tools are easier to steer than one agent with everything. Whichever lane runs, **Reply** sends the answer back to the trigger's chat id.
+
+The assistant also speaks first. A second workflow, on a **Schedule** trigger at 7:00, runs a **Brief** agent that reads the inbox and the calendar, and **Send** delivers the morning summary before you ask:
+
+<WorkflowPreview workflow={AV_MORNING_BRIEF_WORKFLOW} />

--- a/apps/docs/content/docs/en/academy/use-cases/whatsapp-storefront-bot.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/whatsapp-storefront-bot.mdx
@@ -1,0 +1,43 @@
+---
+title: WhatsApp Storefront Bot
+description: A shop that answers at any hour, a WhatsApp bot that replies from your FAQ with cited answers, remembers the conversation, and escalates refunds to you.
+---
+
+import { VideoPlaceholder } from '@/components/ui/video-placeholder'
+import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
+import { VideoChapters } from '@/components/ui/video-chapters'
+
+<VideoPlaceholder eyebrow="Use case" title="WhatsApp Storefront Bot" className="mt-2" />
+
+<div className="mt-8 grid grid-cols-1 items-start gap-10 lg:grid-cols-[1fr_300px]">
+<div>
+
+Build a shop that answers at any hour. Each customer message on WhatsApp is checked against the shop's FAQ, answered in-thread with citations, and remembered, so the next message from the same customer picks up where the last one left off. Refunds and complaints skip the bot and land in your Slack.
+
+<WhatYouWillLearn
+  items={[
+    { title: 'Trigger on a customer message', body: 'Start a workflow from a WhatsApp message and reply in the same thread.' },
+    { title: 'Ground the answer', body: 'Search a knowledge base of the shop FAQ so replies are accurate and cited.' },
+    { title: 'Remember the customer', body: 'Use conversation memory keyed to the sender so follow-ups stay in context.' },
+  ]}
+/>
+
+</div>
+
+<VideoChapters
+  chapters={[
+    { title: 'The problem', time: '0:00' },
+    { title: 'WhatsApp trigger', time: '0:30' },
+    { title: 'Escalate refunds', time: '1:10' },
+    { title: 'Answer from the FAQ', time: '1:50' },
+    { title: 'Remember the thread', time: '2:45' },
+  ]}
+/>
+
+</div>
+
+## What you'll build
+
+A **WhatsApp trigger** starts the workflow on each customer message. A **Condition** block checks it first: refunds and complaints route straight to the owner's **Slack**, everything else continues. A **knowledge-base search** pulls the relevant FAQ entries, and an **Agent** block with [conversation memory](/academy/agents/memory) keyed to the sender writes the reply, so each answer is cited and each thread remembers its history. The **WhatsApp reply** goes back in the same conversation.
+
+This pulls together [workflows](/academy/workflows/intro), [agents](/academy/agents/intro), and [knowledge bases](/academy/knowledge-bases/intro) into one system: the foundations, composed.

--- a/apps/docs/content/docs/en/academy/use-cases/whatsapp-storefront-bot.mdx
+++ b/apps/docs/content/docs/en/academy/use-cases/whatsapp-storefront-bot.mdx
@@ -6,6 +6,8 @@ description: A shop that answers at any hour, a WhatsApp bot that replies from y
 import { VideoPlaceholder } from '@/components/ui/video-placeholder'
 import { WhatYouWillLearn } from '@/components/ui/what-you-will-learn'
 import { VideoChapters } from '@/components/ui/video-chapters'
+import { WorkflowPreview } from '@/components/workflow-preview'
+import { AV_STOREFRONT_BOT_WORKFLOW } from '@/components/workflow-preview/academy-video-workflows'
 
 <VideoPlaceholder eyebrow="Use case" title="WhatsApp Storefront Bot" className="mt-2" />
 
@@ -40,4 +42,18 @@ Build a shop that answers at any hour. Each customer message on WhatsApp is chec
 
 A **WhatsApp trigger** starts the workflow on each customer message. A **Condition** block checks it first: refunds and complaints route straight to the owner's **Slack**, everything else continues. A **knowledge-base search** pulls the relevant FAQ entries, and an **Agent** block with [conversation memory](/academy/agents/memory) keyed to the sender writes the reply, so each answer is cited and each thread remembers its history. The **WhatsApp reply** goes back in the same conversation.
 
+Here is the machine the video builds:
+
+<WorkflowPreview workflow={AV_STOREFRONT_BOT_WORKFLOW} height={340} />
+
 This pulls together [workflows](/academy/workflows/intro), [agents](/academy/agents/intro), and [knowledge bases](/academy/knowledge-bases/intro) into one system: the foundations, composed.
+
+## How it works
+
+The **WhatsApp Trigger** fires on every customer message and carries the sender's number as an output, which the rest of the workflow uses twice: once to key the memory, once to address the reply.
+
+The **Refund?** condition runs before any AI does. Refunds and complaints are the messages a bot should not handle, so they route straight to **Alert Owner**, a Slack post in the owner's channel. Putting the guardrail first means the sensitive cases never even reach the agent; the [Condition block](/academy/workflows/intro) is the cheapest safety mechanism in the whole machine.
+
+Everything else flows to **Knowledge**, which searches the Shop FAQ [knowledge base](/academy/knowledge-bases/intro) with the customer's message as the query. The **Answer** agent writes a reply grounded in those FAQ chunks, and its Memory is set to Conversation keyed to the sender's number, so the third message in a thread is answered with the first two in context. Each customer gets their own thread of [memory](/academy/agents/memory); no two conversations mix.
+
+**Reply** sends the answer back over WhatsApp to the same number, and to the customer it is just the shop texting back.


### PR DESCRIPTION
Adds the three remaining academy use-case pages for the videos now in production:

- `use-cases/telegram-personal-assistant` — Telegram Personal Assistant (SIM-811)
- `use-cases/scheduled-report-rollup` — Scheduled Report Rollup (SIM-812)
- `use-cases/whatsapp-storefront-bot` — WhatsApp Storefront Bot (SIM-813)

Videos are in production; pages use the VideoPlaceholder like the existing four. Follows the existing use-case page conventions (frontmatter, WhatYouWillLearn, VideoChapters, "What you'll build" with foundation links) and registers the pages in the academy `meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)