### PR TITLE
fix(demo): preload the Cal.com booking embed while the visitor fills the form

### DIFF
--- a/apps/sim/app/(landing)/demo/components/demo-booking/demo-booking.tsx
+++ b/apps/sim/app/(landing)/demo/components/demo-booking/demo-booking.tsx
@@ -3,9 +3,18 @@
 import { type CSSProperties, useEffect, useRef, useState } from 'react'
 import { chipBorderShadowRing, cn } from '@sim/emcn'
 import dynamic from 'next/dynamic'
+import { preconnect } from 'react-dom'
 import { DemoForm, type DemoLead } from '@/app/(landing)/demo/components/demo-form'
 
 const importScheduler = () => import('@/app/(landing)/demo/components/demo-scheduler')
+
+/**
+ * Warm the entire booking path while the visitor fills the form: the scheduler
+ * chunk, Cal.com's embed.js, and the booker iframe assets (via the embed's
+ * `preload` instruction). Fired on first form focus so none of it competes
+ * with initial page load, and finished long before the visitor submits.
+ */
+const preloadScheduler = () => importScheduler().then((m) => m.preloadCalEmbed())
 
 /**
  * Lazy-loaded so the Cal.com embed never enters the initial landing bundle - it
@@ -42,6 +51,8 @@ interface DemoBookingProps {
  * hides/shows.
  */
 export function DemoBooking({ className }: DemoBookingProps) {
+  preconnect('https://app.cal.com')
+
   const [lead, setLead] = useState<DemoLead | null>(null)
   const [formHeight, setFormHeight] = useState<number>()
   const formRef = useRef<HTMLDivElement>(null)
@@ -75,7 +86,7 @@ export function DemoBooking({ className }: DemoBookingProps) {
         <div
           className='w-full min-w-0 shrink-0'
           inert={showScheduler}
-          onFocusCapture={() => void importScheduler()}
+          onFocusCapture={() => void preloadScheduler()}
         >
           <div ref={formRef} className='p-6 max-sm:p-5'>
             <DemoForm onComplete={setLead} />

--- a/apps/sim/app/(landing)/demo/components/demo-booking/demo-booking.tsx
+++ b/apps/sim/app/(landing)/demo/components/demo-booking/demo-booking.tsx
@@ -9,12 +9,17 @@ import { DemoForm, type DemoLead } from '@/app/(landing)/demo/components/demo-fo
 const importScheduler = () => import('@/app/(landing)/demo/components/demo-scheduler')
 
 /**
- * Warm the entire booking path while the visitor fills the form: the scheduler
- * chunk, Cal.com's embed.js, and the booker iframe assets (via the embed's
- * `preload` instruction). Fired on first form focus so none of it competes
- * with initial page load, and finished long before the visitor submits.
+ * Warm the entire booking path while the visitor fills the form: preconnect to
+ * app.cal.com, then load the scheduler chunk, Cal.com's embed.js, and the
+ * booker iframe assets (via the embed's `preload` instruction). Fired on first
+ * form focus so nothing Cal.com-related competes with initial page load — the
+ * connection handshake overlaps the chunk import, and it all finishes long
+ * before the visitor submits.
  */
-const preloadScheduler = () => importScheduler().then((m) => m.preloadCalEmbed())
+function preloadScheduler() {
+  preconnect('https://app.cal.com')
+  return importScheduler().then((m) => m.preloadCalEmbed())
+}
 
 /**
  * Lazy-loaded so the Cal.com embed never enters the initial landing bundle - it
@@ -51,8 +56,6 @@ interface DemoBookingProps {
  * hides/shows.
  */
 export function DemoBooking({ className }: DemoBookingProps) {
-  preconnect('https://app.cal.com')
-
   const [lead, setLead] = useState<DemoLead | null>(null)
   const [formHeight, setFormHeight] = useState<number>()
   const formRef = useRef<HTMLDivElement>(null)

--- a/apps/sim/app/(landing)/demo/components/demo-scheduler/demo-scheduler.tsx
+++ b/apps/sim/app/(landing)/demo/components/demo-scheduler/demo-scheduler.tsx
@@ -27,14 +27,20 @@ let calEmbedPreloaded = false
  * hidden `?preload=true` iframe so its assets are already cached when the real
  * embed renders on submit. Without this, nothing Cal.com-related starts
  * downloading until the visitor presses Continue, which is why the calendar
- * used to take several seconds to appear. Idempotent — repeat calls no-op.
+ * used to take several seconds to appear. Idempotent — repeat calls no-op
+ * while a warm-up is in flight or done, but a failed embed.js load resets the
+ * flag so a later focus can retry.
  */
 export function preloadCalEmbed(): void {
   if (calEmbedPreloaded) return
   calEmbedPreloaded = true
-  getCalApi({ namespace: CAL_NAMESPACE }).then((cal) => {
-    cal('preload', { calLink: CAL_LINK })
-  })
+  getCalApi({ namespace: CAL_NAMESPACE })
+    .then((cal) => {
+      cal('preload', { calLink: CAL_LINK })
+    })
+    .catch(() => {
+      calEmbedPreloaded = false
+    })
 }
 
 /**

--- a/apps/sim/app/(landing)/demo/components/demo-scheduler/demo-scheduler.tsx
+++ b/apps/sim/app/(landing)/demo/components/demo-scheduler/demo-scheduler.tsx
@@ -19,6 +19,24 @@ interface DemoSchedulerProps {
   lead: DemoLead
 }
 
+let calEmbedPreloaded = false
+
+/**
+ * Warm the Cal.com embed before the scheduler mounts. Loads `embed.js` and
+ * issues the embed's `preload` instruction, which fetches the booker in a
+ * hidden `?preload=true` iframe so its assets are already cached when the real
+ * embed renders on submit. Without this, nothing Cal.com-related starts
+ * downloading until the visitor presses Continue, which is why the calendar
+ * used to take several seconds to appear. Idempotent — repeat calls no-op.
+ */
+export function preloadCalEmbed(): void {
+  if (calEmbedPreloaded) return
+  calEmbedPreloaded = true
+  getCalApi({ namespace: CAL_NAMESPACE }).then((cal) => {
+    cal('preload', { calLink: CAL_LINK })
+  })
+}
+
 /**
  * Step 2 of the booking card - the Cal.com scheduler, prefilled from the form's
  * {@link DemoLead}. Rendered inside the card chrome owned by {@link DemoBooking}

--- a/apps/sim/app/(landing)/demo/components/demo-scheduler/index.ts
+++ b/apps/sim/app/(landing)/demo/components/demo-scheduler/index.ts
@@ -1,1 +1,1 @@
-export { DemoScheduler } from './demo-scheduler'
+export { DemoScheduler, preloadCalEmbed } from './demo-scheduler'


### PR DESCRIPTION
## Summary
- The demo page's Cal.com calendar took several seconds to appear after submitting the booking form: nothing embed-related (embed.js, the booker iframe, its assets) started downloading until the visitor pressed Continue
- Warm the entire path on first form focus using the embed's documented `preload` instruction — it caches the booker's assets in a hidden `?preload=true` iframe while the visitor fills the form
- Add a `preconnect` to app.cal.com (React 19 `react-dom` API) so the first embed request skips connection setup
- Zero Cal.com traffic at initial page load, so Lighthouse/LCP are untouched; verified with Playwright — the calendar now finishes loading ~815ms after submit instead of starting cold

## Type of Change
- [x] Bug fix

## Testing
Tested manually with Playwright against the running app: confirmed no cal.com requests on page load, preload iframe attaches ~200ms after first form focus, and the booker renders fully ~815ms after submit

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)