### PR TITLE
v0.7.31: sidebar shortcut, env var expansion in lifecycle triggers, ashby fixes

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.test.tsx
@@ -19,6 +19,11 @@ function RegisterModK({ handler }: { handler: () => void }) {
   return null
 }
 
+function RegisterModKOutsideEditable({ handler }: { handler: () => void }) {
+  useRegisterGlobalCommands([{ id: 'search', shortcut: 'Mod+K', handler, allowInEditable: false }])
+  return null
+}
+
 let container: HTMLDivElement
 let root: Root
 
@@ -83,6 +88,48 @@ describe('GlobalCommandsProvider owned-shortcut yielding', () => {
       </GlobalCommandsProvider>
     )
     ;(container.querySelector('[data-owned-shortcuts]') as HTMLElement).focus()
+    pressModK()
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('GlobalCommandsProvider editable guard', () => {
+  it('skips a non-editable command when focus is in an input', () => {
+    const handler = vi.fn()
+    mount(
+      <GlobalCommandsProvider>
+        <RegisterModKOutsideEditable handler={handler} />
+        <input type='text' />
+      </GlobalCommandsProvider>
+    )
+    ;(container.querySelector('input') as HTMLInputElement).focus()
+    pressModK()
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('skips a non-editable command when focus is in a contenteditable element', () => {
+    const handler = vi.fn()
+    mount(
+      <GlobalCommandsProvider>
+        <RegisterModKOutsideEditable handler={handler} />
+        <div contentEditable />
+      </GlobalCommandsProvider>
+    )
+    ;(container.querySelector('[contenteditable]') as HTMLElement).focus()
+    pressModK()
+    expect(handler).toHaveBeenCalledTimes(0)
+  })
+
+  it('fires a non-editable command when focus is in a contenteditable="false" element', () => {
+    const handler = vi.fn()
+    mount(
+      <GlobalCommandsProvider>
+        <RegisterModKOutsideEditable handler={handler} />
+        {/* biome-ignore lint/a11y/noNoninteractiveTabindex: focusable stand-in for a read-only editor */}
+        <div contentEditable={false} tabIndex={0} />
+      </GlobalCommandsProvider>
+    )
+    ;(container.querySelector('[contenteditable]') as HTMLElement).focus()
     pressModK()
     expect(handler).toHaveBeenCalledTimes(1)
   })

--- a/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.test.tsx
@@ -94,6 +94,15 @@ describe('GlobalCommandsProvider owned-shortcut yielding', () => {
 })
 
 describe('GlobalCommandsProvider editable guard', () => {
+  /**
+   * jsdom does not implement `isContentEditable`, so stub the browser's computed
+   * editability on the element the test focuses.
+   */
+  function focusWithEditability(element: HTMLElement, isContentEditable: boolean) {
+    Object.defineProperty(element, 'isContentEditable', { value: isContentEditable })
+    element.focus()
+  }
+
   it('skips a non-editable command when focus is in an input', () => {
     const handler = vi.fn()
     mount(
@@ -115,9 +124,25 @@ describe('GlobalCommandsProvider editable guard', () => {
         <div contentEditable />
       </GlobalCommandsProvider>
     )
-    ;(container.querySelector('[contenteditable]') as HTMLElement).focus()
+    focusWithEditability(container.querySelector('[contenteditable]') as HTMLElement, true)
     pressModK()
-    expect(handler).toHaveBeenCalledTimes(0)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('skips a non-editable command when focus is on a descendant of a contenteditable root', () => {
+    const handler = vi.fn()
+    mount(
+      <GlobalCommandsProvider>
+        <RegisterModKOutsideEditable handler={handler} />
+        <div contentEditable>
+          {/* biome-ignore lint/a11y/noNoninteractiveTabindex: focusable stand-in for a node view inside the editor */}
+          <span tabIndex={0} />
+        </div>
+      </GlobalCommandsProvider>
+    )
+    focusWithEditability(container.querySelector('span') as HTMLElement, true)
+    pressModK()
+    expect(handler).not.toHaveBeenCalled()
   })
 
   it('fires a non-editable command when focus is in a contenteditable="false" element', () => {
@@ -129,7 +154,7 @@ describe('GlobalCommandsProvider editable guard', () => {
         <div contentEditable={false} tabIndex={0} />
       </GlobalCommandsProvider>
     )
-    ;(container.querySelector('[contenteditable]') as HTMLElement).focus()
+    focusWithEditability(container.querySelector('[contenteditable]') as HTMLElement, false)
     pressModK()
     expect(handler).toHaveBeenCalledTimes(1)
   })

--- a/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.tsx
@@ -94,6 +94,18 @@ function shortcutSignature(parsed: ParsedShortcut, isMac: boolean): string {
 }
 
 /**
+ * Whether `element` is an editable region for the purposes of the editable guard.
+ * `contenteditable="false"` (e.g. a rich-text editor in read-only mode) is not editable,
+ * so commands with `allowInEditable: false` still fire while such an element has focus.
+ */
+function isEditableElement(element: Element | null): boolean {
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) return true
+  if (!(element instanceof HTMLElement)) return false
+  const contentEditable = element.getAttribute('contenteditable')
+  return contentEditable !== null && contentEditable.toLowerCase() !== 'false'
+}
+
+/**
  * Whether the focused element (or an ancestor) declares it owns `parsed` via a comma-separated
  * `data-owned-shortcuts` attribute (e.g. a rich-text editor that binds `Mod+K` to links). Such a
  * shortcut is left for that element to handle instead of firing the global command.
@@ -141,14 +153,7 @@ export function GlobalCommandsProvider({ children }: { children: ReactNode }) {
       if (e.isComposing) return
 
       for (const [, cmd] of registryRef.current) {
-        if (!cmd.allowInEditable) {
-          const ae = document.activeElement
-          const isEditable =
-            ae instanceof HTMLInputElement ||
-            ae instanceof HTMLTextAreaElement ||
-            ae?.hasAttribute('contenteditable')
-          if (isEditable) continue
-        }
+        if (!cmd.allowInEditable && isEditableElement(document.activeElement)) continue
 
         if (matchesShortcut(e, cmd.parsed)) {
           if (focusedElementOwnsShortcut(cmd.parsed, isMac)) continue

--- a/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.tsx
@@ -95,14 +95,13 @@ function shortcutSignature(parsed: ParsedShortcut, isMac: boolean): string {
 
 /**
  * Whether `element` is an editable region for the purposes of the editable guard.
- * `contenteditable="false"` (e.g. a rich-text editor in read-only mode) is not editable,
- * so commands with `allowInEditable: false` still fire while such an element has focus.
+ * `isContentEditable` is the browser's computed editability, so focusable descendants of a
+ * `contenteditable` root count as editable, while `contenteditable="false"` (e.g. a rich-text
+ * editor in read-only mode) does not — commands with `allowInEditable: false` still fire there.
  */
 function isEditableElement(element: Element | null): boolean {
   if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) return true
-  if (!(element instanceof HTMLElement)) return false
-  const contentEditable = element.getAttribute('contenteditable')
-  return contentEditable !== null && contentEditable.toLowerCase() !== 'false'
+  return element instanceof HTMLElement && element.isContentEditable
 }
 
 /**

--- a/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/utils/commands-utils.ts
@@ -17,6 +17,7 @@ export type CommandId =
   | 'clear-terminal-console'
   | 'focus-toolbar-search'
   | 'fit-to-view'
+  | 'toggle-sidebar'
 
 /**
  * Static metadata for a global command.
@@ -90,6 +91,11 @@ export const COMMAND_DEFINITIONS: Record<CommandId, CommandDefinition> = {
   'fit-to-view': {
     id: 'fit-to-view',
     shortcut: 'Mod+Shift+F',
+    allowInEditable: false,
+  },
+  'toggle-sidebar': {
+    id: 'toggle-sidebar',
+    shortcut: 'Mod+B',
     allowInEditable: false,
   },
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -120,18 +120,20 @@ export function SidebarTooltip({
   label,
   enabled,
   side = 'right',
+  shortcut,
 }: {
   children: React.ReactElement
   label: string
   enabled: boolean
   side?: 'right' | 'bottom'
+  shortcut?: string
 }) {
   if (!enabled) return children
   return (
     <Tooltip.Root>
       <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
       <Tooltip.Content side={side}>
-        <p>{label}</p>
+        {shortcut ? <Tooltip.Shortcut keys={shortcut}>{label}</Tooltip.Shortcut> : <p>{label}</p>}
       </Tooltip.Content>
     </Tooltip.Root>
   )
@@ -1234,6 +1236,12 @@ export const Sidebar = memo(function Sidebar({ isCollapsed }: SidebarProps) {
           handleCreateWorkflow()
         },
       },
+      {
+        id: 'toggle-sidebar',
+        handler: () => {
+          toggleCollapsed()
+        },
+      },
     ])
   )
 
@@ -1284,7 +1292,12 @@ export const Sidebar = memo(function Sidebar({ isCollapsed }: SidebarProps) {
                 isCollapsed={isCollapsed}
                 onExpandSidebar={toggleCollapsed}
               />
-              <SidebarTooltip label='Collapse sidebar' enabled={!isCollapsed} side='bottom'>
+              <SidebarTooltip
+                label='Collapse sidebar'
+                enabled={!isCollapsed}
+                side='bottom'
+                shortcut={isMac ? '⌘B' : 'Ctrl+B'}
+              >
                 <button
                   type='button'
                   onClick={toggleCollapsed}

--- a/apps/sim/blocks/blocks/ashby.test.ts
+++ b/apps/sim/blocks/blocks/ashby.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { AshbyBlock } from './ashby'
+
+describe('AshbyBlock', () => {
+  const buildParams = (operation: string, extra: Record<string, unknown>) => ({
+    operation,
+    ...extra,
+  })
+
+  describe('alternateEmailAddresses parsing (create_candidate)', () => {
+    it('parses a comma-separated string into an array', () => {
+      const result = AshbyBlock.tools.config.params!(
+        buildParams('create_candidate', {
+          alternateEmailAddresses: 'a@x.com, b@x.com',
+        })
+      )
+      expect(result.alternateEmailAddresses).toEqual(['a@x.com', 'b@x.com'])
+    })
+
+    it('parses a JSON array string into an array', () => {
+      const result = AshbyBlock.tools.config.params!(
+        buildParams('create_candidate', {
+          alternateEmailAddresses: '["a@x.com","b@x.com"]',
+        })
+      )
+      expect(result.alternateEmailAddresses).toEqual(['a@x.com', 'b@x.com'])
+    })
+
+    it('omits the field entirely when empty', () => {
+      const result = AshbyBlock.tools.config.params!(
+        buildParams('create_candidate', { alternateEmailAddresses: '' })
+      )
+      expect(result.alternateEmailAddresses).toBeUndefined()
+    })
+  })
+
+  describe('socialLinks parsing (update_candidate)', () => {
+    it('parses a JSON array of link objects', () => {
+      const result = AshbyBlock.tools.config.params!(
+        buildParams('update_candidate', {
+          socialLinks: '[{"type":"Twitter","url":"https://twitter.com/jane"}]',
+        })
+      )
+      expect(result.socialLinks).toEqual([{ type: 'Twitter', url: 'https://twitter.com/jane' }])
+    })
+
+    it('omits the field when the JSON is malformed', () => {
+      const result = AshbyBlock.tools.config.params!(
+        buildParams('update_candidate', { socialLinks: 'not json' })
+      )
+      expect(result.socialLinks).toBeUndefined()
+    })
+  })
+
+  describe('wandConfig on array-shaped fields', () => {
+    it('does not request object-wrapped output for alternateEmailAddresses or socialLinks', () => {
+      // generationType 'json-object' makes the wand API append "the response
+      // must start with { and end with }", which conflicts with these fields'
+      // array-or-comma-separated parsers (parseStringListInput/parseSocialLinksInput).
+      const alternateEmailAddresses = AshbyBlock.subBlocks.find(
+        (s) => s.id === 'alternateEmailAddresses'
+      )
+      const socialLinks = AshbyBlock.subBlocks.find((s) => s.id === 'socialLinks')
+      expect(alternateEmailAddresses?.wandConfig?.generationType).not.toBe('json-object')
+      expect(socialLinks?.wandConfig?.generationType).not.toBe('json-object')
+    })
+  })
+
+  describe('list_applications candidateId filter', () => {
+    it('has no filterCandidateId subBlock or wiring', () => {
+      // Ashby's application.list endpoint silently ignores a candidateId
+      // body field (confirmed live: passing a nonexistent candidate UUID
+      // still returns unfiltered results) — the correct path for a
+      // candidate's applications is ashby_get_candidate's applicationIds.
+      expect(AshbyBlock.subBlocks.find((s) => s.id === 'filterCandidateId')).toBeUndefined()
+      const result = AshbyBlock.tools.config.params!(
+        buildParams('list_applications', { filterCandidateId: 'some-id' })
+      )
+      expect(result.candidateId).toBeUndefined()
+    })
+  })
+})

--- a/apps/sim/blocks/blocks/ashby.test.ts
+++ b/apps/sim/blocks/blocks/ashby.test.ts
@@ -47,11 +47,22 @@ describe('AshbyBlock', () => {
       expect(result.socialLinks).toEqual([{ type: 'Twitter', url: 'https://twitter.com/jane' }])
     })
 
-    it('omits the field when the JSON is malformed', () => {
-      const result = AshbyBlock.tools.config.params!(
-        buildParams('update_candidate', { socialLinks: 'not json' })
-      )
-      expect(result.socialLinks).toBeUndefined()
+    it('throws instead of silently dropping the field when the JSON is malformed', () => {
+      // A silent [] here would let the Ashby update proceed without applying
+      // the requested links and with no error shown to the workflow author.
+      expect(() =>
+        AshbyBlock.tools.config.params!(
+          buildParams('update_candidate', { socialLinks: 'not json' })
+        )
+      ).toThrow(/Invalid JSON in Ashby social links/)
+    })
+
+    it('throws when the parsed JSON is not an array', () => {
+      expect(() =>
+        AshbyBlock.tools.config.params!(
+          buildParams('update_candidate', { socialLinks: '{"type":"Twitter"}' })
+        )
+      ).toThrow(/expected a JSON array/)
     })
   })
 

--- a/apps/sim/blocks/blocks/ashby.ts
+++ b/apps/sim/blocks/blocks/ashby.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@sim/utils/errors'
 import { AshbyIcon } from '@/components/icons'
 import { AuthMode, type BlockConfig, type BlockMeta, IntegrationType } from '@/blocks/types'
 import { getTrigger } from '@/triggers'
@@ -22,12 +23,20 @@ function parseStringListInput(value: unknown): string[] {
 function parseSocialLinksInput(value: unknown): Array<{ type: string; url: string }> {
   if (Array.isArray(value)) return value as Array<{ type: string; url: string }>
   if (typeof value !== 'string' || !value.trim()) return []
+  let parsed: unknown
   try {
-    const parsed = JSON.parse(value)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
+    parsed = JSON.parse(value)
+  } catch (error) {
+    throw new Error(
+      `Invalid JSON in Ashby social links: ${getErrorMessage(error)}. Expected a JSON array like [{"type":"Twitter","url":"https://twitter.com/x"}].`
+    )
   }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      'Invalid Ashby social links: expected a JSON array like [{"type":"Twitter","url":"https://twitter.com/x"}].'
+    )
+  }
+  return parsed
 }
 
 export const AshbyBlock: BlockConfig = {

--- a/apps/sim/blocks/blocks/ashby.ts
+++ b/apps/sim/blocks/blocks/ashby.ts
@@ -2,6 +2,34 @@ import { AshbyIcon } from '@/components/icons'
 import { AuthMode, type BlockConfig, type BlockMeta, IntegrationType } from '@/blocks/types'
 import { getTrigger } from '@/triggers'
 
+function parseStringListInput(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String)
+  if (typeof value !== 'string') return []
+  const trimmed = value.trim()
+  if (!trimmed) return []
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed)
+      if (Array.isArray(parsed)) return parsed.map(String)
+    } catch {}
+  }
+  return trimmed
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+function parseSocialLinksInput(value: unknown): Array<{ type: string; url: string }> {
+  if (Array.isArray(value)) return value as Array<{ type: string; url: string }>
+  if (typeof value !== 'string' || !value.trim()) return []
+  try {
+    const parsed = JSON.parse(value)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
 export const AshbyBlock: BlockConfig = {
   type: 'ashby',
   name: 'Ashby',
@@ -369,14 +397,6 @@ Output only the ISO 8601 timestamp string, nothing else.`,
       mode: 'advanced',
     },
     {
-      id: 'filterCandidateId',
-      title: 'Candidate ID Filter',
-      type: 'short-input',
-      placeholder: 'Filter by candidate UUID',
-      condition: { field: 'operation', value: 'list_applications' },
-      mode: 'advanced',
-    },
-    {
       id: 'createdAfter',
       title: 'Created After',
       type: 'short-input',
@@ -563,6 +583,13 @@ Output only the ISO 8601 timestamp string, nothing else.`,
       placeholder: 'Comma-separated or JSON array (e.g. ["a@x.com","b@x.com"])',
       condition: { field: 'operation', value: 'create_candidate' },
       mode: 'advanced',
+      wandConfig: {
+        enabled: true,
+        prompt: `Generate a comma-separated or JSON array of email addresses based on the user's description.
+Examples:
+- "her work and personal emails" -> ["work@company.com","personal@example.com"]
+Output only the list, nothing else.`,
+      },
     },
     {
       id: 'socialLinks',
@@ -571,6 +598,13 @@ Output only the ISO 8601 timestamp string, nothing else.`,
       placeholder: 'JSON array (e.g. [{"type":"Twitter","url":"https://twitter.com/x"}])',
       condition: { field: 'operation', value: 'update_candidate' },
       mode: 'advanced',
+      wandConfig: {
+        enabled: true,
+        prompt: `Generate a JSON array of social link objects ({"type","url"}) based on the user's description.
+Examples:
+- "his Twitter is @jane and portfolio is jane.dev" -> [{"type":"Twitter","url":"https://twitter.com/jane"},{"type":"Portfolio","url":"https://jane.dev"}]
+Output only the JSON array, nothing else.`,
+      },
     },
     {
       id: 'includeArchived',
@@ -720,9 +754,6 @@ Output only the ISO 8601 timestamp string, nothing else.`,
         if (params.searchEmail) result.email = params.searchEmail
         if (params.filterStatus) result.status = params.filterStatus
         if (params.filterJobId) result.jobId = params.filterJobId
-        if (params.operation === 'list_applications' && params.filterCandidateId) {
-          result.candidateId = params.filterCandidateId
-        }
         if (params.jobStatus) result.status = params.jobStatus
         if (params.sendNotifications === 'true' || params.sendNotifications === true) {
           result.sendNotifications = true
@@ -772,9 +803,14 @@ Output only the ISO 8601 timestamp string, nothing else.`,
           result.applicationId = params.offerApplicationId
         }
         if (params.alternateEmailAddresses) {
-          result.alternateEmailAddresses = params.alternateEmailAddresses
+          const alternateEmailAddresses = parseStringListInput(params.alternateEmailAddresses)
+          if (alternateEmailAddresses.length > 0)
+            result.alternateEmailAddresses = alternateEmailAddresses
         }
-        if (params.socialLinks) result.socialLinks = params.socialLinks
+        if (params.socialLinks) {
+          const socialLinks = parseSocialLinksInput(params.socialLinks)
+          if (socialLinks.length > 0) result.socialLinks = socialLinks
+        }
         return result
       },
     },
@@ -806,7 +842,6 @@ Output only the ISO 8601 timestamp string, nothing else.`,
     sendNotifications: { type: 'boolean', description: 'Send notifications' },
     filterStatus: { type: 'string', description: 'Application status filter' },
     filterJobId: { type: 'string', description: 'Job UUID filter' },
-    filterCandidateId: { type: 'string', description: 'Candidate UUID filter' },
     createdAfter: { type: 'string', description: 'Filter by creation date' },
     openedAfter: { type: 'string', description: 'Filter jobs opened after this timestamp' },
     openedBefore: { type: 'string', description: 'Filter jobs opened before this timestamp' },

--- a/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
@@ -10,7 +10,7 @@ export interface ToolRuntimeSchemaEntry {
 }
 
 export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
-  ['agent']: {
+  agent: {
     parameters: {
       properties: {
         request: {
@@ -23,7 +23,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['auth']: {
+  auth: {
     parameters: {
       properties: {
         request: {
@@ -36,7 +36,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['check_deployment_status']: {
+  check_deployment_status: {
     parameters: {
       type: 'object',
       properties: {
@@ -48,7 +48,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['complete_scheduled_task']: {
+  complete_scheduled_task: {
     parameters: {
       type: 'object',
       properties: {
@@ -61,7 +61,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['crawl_website']: {
+  crawl_website: {
     parameters: {
       type: 'object',
       properties: {
@@ -96,7 +96,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_file']: {
+  create_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -162,7 +162,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['create_file_folder']: {
+  create_file_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -180,7 +180,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_workflow']: {
+  create_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -205,7 +205,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['create_workspace_mcp_server']: {
+  create_workspace_mcp_server: {
     parameters: {
       type: 'object',
       properties: {
@@ -238,7 +238,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['delete_file']: {
+  delete_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -268,7 +268,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['delete_file_folder']: {
+  delete_file_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -284,7 +284,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['delete_workflow']: {
+  delete_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -300,7 +300,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['delete_workspace_mcp_server']: {
+  delete_workspace_mcp_server: {
     parameters: {
       type: 'object',
       properties: {
@@ -313,7 +313,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['deploy']: {
+  deploy: {
     parameters: {
       properties: {
         request: {
@@ -327,7 +327,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['deploy_api']: {
+  deploy_api: {
     parameters: {
       type: 'object',
       properties: {
@@ -411,7 +411,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       ],
     },
   },
-  ['deploy_chat']: {
+  deploy_chat: {
     parameters: {
       type: 'object',
       properties: {
@@ -570,7 +570,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       ],
     },
   },
-  ['deploy_custom_block']: {
+  deploy_custom_block: {
     parameters: {
       type: 'object',
       properties: {
@@ -698,7 +698,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['deploymentType', 'deploymentStatus'],
     },
   },
-  ['deploy_mcp']: {
+  deploy_mcp: {
     parameters: {
       type: 'object',
       properties: {
@@ -814,7 +814,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['deploymentType', 'deploymentStatus'],
     },
   },
-  ['diff_workflows']: {
+  diff_workflows: {
     parameters: {
       type: 'object',
       properties: {
@@ -838,7 +838,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['download_to_workspace_file']: {
+  download_to_workspace_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -887,7 +887,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['edit_content']: {
+  edit_content: {
     parameters: {
       type: 'object',
       properties: {
@@ -919,7 +919,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['edit_workflow']: {
+  edit_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -958,7 +958,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['enrichment_run']: {
+  enrichment_run: {
     parameters: {
       type: 'object',
       properties: {
@@ -1002,7 +1002,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['matched', 'result'],
     },
   },
-  ['ffmpeg']: {
+  ffmpeg: {
     parameters: {
       type: 'object',
       properties: {
@@ -1183,7 +1183,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['file']: {
+  file: {
     parameters: {
       properties: {
         prompt: {
@@ -1196,7 +1196,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['function_execute']: {
+  function_execute: {
     parameters: {
       type: 'object',
       properties: {
@@ -1334,7 +1334,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_api_key']: {
+  generate_api_key: {
     parameters: {
       type: 'object',
       properties: {
@@ -1352,7 +1352,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_audio']: {
+  generate_audio: {
     parameters: {
       type: 'object',
       properties: {
@@ -1504,7 +1504,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_image']: {
+  generate_image: {
     parameters: {
       type: 'object',
       properties: {
@@ -1632,7 +1632,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['generate_video']: {
+  generate_video: {
     parameters: {
       type: 'object',
       properties: {
@@ -1799,7 +1799,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_block_outputs']: {
+  get_block_outputs: {
     parameters: {
       type: 'object',
       properties: {
@@ -1820,7 +1820,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_block_upstream_references']: {
+  get_block_upstream_references: {
     parameters: {
       type: 'object',
       properties: {
@@ -1842,7 +1842,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_deployed_workflow_state']: {
+  get_deployed_workflow_state: {
     parameters: {
       type: 'object',
       properties: {
@@ -1855,7 +1855,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_deployment_log']: {
+  get_deployment_log: {
     parameters: {
       type: 'object',
       properties: {
@@ -1868,7 +1868,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_page_contents']: {
+  get_page_contents: {
     parameters: {
       type: 'object',
       properties: {
@@ -1896,14 +1896,14 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_platform_actions']: {
+  get_platform_actions: {
     parameters: {
       type: 'object',
       properties: {},
     },
     resultSchema: undefined,
   },
-  ['get_scheduled_task_logs']: {
+  get_scheduled_task_logs: {
     parameters: {
       type: 'object',
       properties: {
@@ -1928,7 +1928,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_workflow_data']: {
+  get_workflow_data: {
     parameters: {
       type: 'object',
       properties: {
@@ -1947,7 +1947,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['get_workflow_run_options']: {
+  get_workflow_run_options: {
     parameters: {
       type: 'object',
       properties: {
@@ -1960,7 +1960,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['glob']: {
+  glob: {
     parameters: {
       type: 'object',
       properties: {
@@ -1979,7 +1979,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['grep']: {
+  grep: {
     parameters: {
       type: 'object',
       properties: {
@@ -2027,7 +2027,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['knowledge']: {
+  knowledge: {
     parameters: {
       properties: {
         request: {
@@ -2040,7 +2040,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['knowledge_base']: {
+  knowledge_base: {
     parameters: {
       type: 'object',
       properties: {
@@ -2233,7 +2233,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['list_file_folders']: {
+  list_file_folders: {
     parameters: {
       type: 'object',
       properties: {
@@ -2245,7 +2245,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['list_integration_tools']: {
+  list_integration_tools: {
     parameters: {
       properties: {
         integration: {
@@ -2259,14 +2259,14 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['list_user_workspaces']: {
+  list_user_workspaces: {
     parameters: {
       type: 'object',
       properties: {},
     },
     resultSchema: undefined,
   },
-  ['list_workspace_mcp_servers']: {
+  list_workspace_mcp_servers: {
     parameters: {
       type: 'object',
       properties: {
@@ -2279,7 +2279,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['load_deployment']: {
+  load_deployment: {
     parameters: {
       type: 'object',
       properties: {
@@ -2298,7 +2298,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['load_integration_tool']: {
+  load_integration_tool: {
     parameters: {
       properties: {
         tool_ids: {
@@ -2315,7 +2315,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_credential']: {
+  manage_credential: {
     parameters: {
       type: 'object',
       properties: {
@@ -2344,7 +2344,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_custom_tool']: {
+  manage_custom_tool: {
     parameters: {
       type: 'object',
       properties: {
@@ -2424,7 +2424,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_folder']: {
+  manage_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -2463,7 +2463,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_mcp_tool']: {
+  manage_mcp_tool: {
     parameters: {
       type: 'object',
       properties: {
@@ -2515,7 +2515,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_scheduled_task']: {
+  manage_scheduled_task: {
     parameters: {
       type: 'object',
       properties: {
@@ -2590,7 +2590,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['manage_skill']: {
+  manage_skill: {
     parameters: {
       type: 'object',
       properties: {
@@ -2623,7 +2623,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['materialize_file']: {
+  materialize_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -2647,7 +2647,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['media']: {
+  media: {
     parameters: {
       properties: {
         prompt: {
@@ -2660,7 +2660,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['move_file']: {
+  move_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -2681,7 +2681,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['move_file_folder']: {
+  move_file_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -2699,7 +2699,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['move_workflow']: {
+  move_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -2719,7 +2719,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['oauth_get_auth_link']: {
+  oauth_get_auth_link: {
     parameters: {
       type: 'object',
       properties: {
@@ -2733,7 +2733,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['oauth_request_access']: {
+  oauth_request_access: {
     parameters: {
       type: 'object',
       properties: {
@@ -2747,7 +2747,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['open_resource']: {
+  open_resource: {
     parameters: {
       type: 'object',
       properties: {
@@ -2781,7 +2781,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['promote_to_live']: {
+  promote_to_live: {
     parameters: {
       type: 'object',
       properties: {
@@ -2800,7 +2800,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['query_logs']: {
+  query_logs: {
     parameters: {
       type: 'object',
       properties: {
@@ -2911,7 +2911,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['read']: {
+  read: {
     parameters: {
       type: 'object',
       properties: {
@@ -2938,7 +2938,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['redeploy']: {
+  redeploy: {
     parameters: {
       type: 'object',
       properties: {
@@ -3017,7 +3017,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       ],
     },
   },
-  ['rename_file']: {
+  rename_file: {
     parameters: {
       type: 'object',
       properties: {
@@ -3053,7 +3053,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['rename_file_folder']: {
+  rename_file_folder: {
     parameters: {
       type: 'object',
       properties: {
@@ -3070,7 +3070,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['rename_workflow']: {
+  rename_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -3087,7 +3087,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['research']: {
+  research: {
     parameters: {
       properties: {
         topic: {
@@ -3100,7 +3100,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['respond']: {
+  respond: {
     parameters: {
       additionalProperties: true,
       properties: {
@@ -3123,7 +3123,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['restore_resource']: {
+  restore_resource: {
     parameters: {
       type: 'object',
       properties: {
@@ -3141,7 +3141,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run']: {
+  run: {
     parameters: {
       properties: {
         context: {
@@ -3158,7 +3158,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_block']: {
+  run_block: {
     parameters: {
       type: 'object',
       properties: {
@@ -3190,7 +3190,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_from_block']: {
+  run_from_block: {
     parameters: {
       type: 'object',
       properties: {
@@ -3222,7 +3222,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_workflow']: {
+  run_workflow: {
     parameters: {
       type: 'object',
       properties: {
@@ -3260,7 +3260,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['run_workflow_until_block']: {
+  run_workflow_until_block: {
     parameters: {
       type: 'object',
       properties: {
@@ -3303,7 +3303,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['scheduled_task']: {
+  scheduled_task: {
     parameters: {
       properties: {
         request: {
@@ -3316,7 +3316,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['scrape_page']: {
+  scrape_page: {
     parameters: {
       type: 'object',
       properties: {
@@ -3337,7 +3337,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_documentation']: {
+  search_documentation: {
     parameters: {
       type: 'object',
       properties: {
@@ -3354,7 +3354,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_library_docs']: {
+  search_library_docs: {
     parameters: {
       type: 'object',
       properties: {
@@ -3375,7 +3375,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_online']: {
+  search_online: {
     parameters: {
       type: 'object',
       properties: {
@@ -3415,7 +3415,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['search_patterns']: {
+  search_patterns: {
     parameters: {
       type: 'object',
       properties: {
@@ -3437,7 +3437,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['set_block_enabled']: {
+  set_block_enabled: {
     parameters: {
       type: 'object',
       properties: {
@@ -3459,7 +3459,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['set_environment_variables']: {
+  set_environment_variables: {
     parameters: {
       type: 'object',
       properties: {
@@ -3493,7 +3493,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['set_global_workflow_variables']: {
+  set_global_workflow_variables: {
     parameters: {
       type: 'object',
       properties: {
@@ -3534,7 +3534,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['superagent']: {
+  superagent: {
     parameters: {
       properties: {
         task: {
@@ -3548,7 +3548,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['table']: {
+  table: {
     parameters: {
       properties: {
         request: {
@@ -3561,7 +3561,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['update_deployment_version']: {
+  update_deployment_version: {
     parameters: {
       type: 'object',
       properties: {
@@ -3590,7 +3590,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['update_scheduled_task_history']: {
+  update_scheduled_task_history: {
     parameters: {
       type: 'object',
       properties: {
@@ -3608,7 +3608,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['update_workspace_mcp_server']: {
+  update_workspace_mcp_server: {
     parameters: {
       type: 'object',
       properties: {
@@ -3633,7 +3633,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['user_memory']: {
+  user_memory: {
     parameters: {
       type: 'object',
       properties: {
@@ -3682,7 +3682,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['user_table']: {
+  user_table: {
     parameters: {
       type: 'object',
       properties: {
@@ -4045,7 +4045,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       required: ['success', 'message'],
     },
   },
-  ['workflow']: {
+  workflow: {
     parameters: {
       properties: {
         prompt: {
@@ -4058,7 +4058,7 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
-  ['workspace_file']: {
+  workspace_file: {
     parameters: {
       type: 'object',
       properties: {

--- a/apps/sim/lib/webhooks/provider-subscriptions.test.ts
+++ b/apps/sim/lib/webhooks/provider-subscriptions.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment node
+ */
+import type { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetEffectiveDecryptedEnv, mockGetProviderHandler } = vi.hoisted(() => ({
+  mockGetEffectiveDecryptedEnv: vi.fn(),
+  mockGetProviderHandler: vi.fn(),
+}))
+
+vi.mock('@/lib/environment/utils', () => ({
+  getEffectiveDecryptedEnv: mockGetEffectiveDecryptedEnv,
+}))
+
+vi.mock('@/lib/webhooks/providers', () => ({
+  getProviderHandler: mockGetProviderHandler,
+}))
+
+import { createExternalWebhookSubscription } from '@/lib/webhooks/provider-subscriptions'
+
+describe('createExternalWebhookSubscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetEffectiveDecryptedEnv.mockResolvedValue({ ASHBY_API_KEY: 'real-secret-key' })
+  })
+
+  it('resolves {{ENV_VAR}} references in providerConfig before calling the provider', async () => {
+    const createSubscription = vi.fn().mockResolvedValue({
+      providerConfigUpdates: { externalId: 'ext-1' },
+    })
+    mockGetProviderHandler.mockReturnValue({ createSubscription })
+
+    const webhookData = {
+      provider: 'ashby',
+      providerConfig: { apiKey: '{{ASHBY_API_KEY}}', triggerId: 'ashby_application_submit' },
+    }
+    const workflow = { id: 'wf-1', workspaceId: 'ws-1' }
+
+    await createExternalWebhookSubscription(
+      {} as NextRequest,
+      webhookData,
+      workflow,
+      'user-1',
+      'req-1'
+    )
+
+    expect(mockGetEffectiveDecryptedEnv).toHaveBeenCalledWith('user-1', 'ws-1')
+    const passedWebhook = createSubscription.mock.calls[0][0].webhook
+    expect(passedWebhook.providerConfig.apiKey).toBe('real-secret-key')
+  })
+
+  it('persists the unresolved providerConfig, not the resolved one, back to the caller', async () => {
+    const createSubscription = vi.fn().mockResolvedValue({
+      providerConfigUpdates: { externalId: 'ext-1' },
+    })
+    mockGetProviderHandler.mockReturnValue({ createSubscription })
+
+    const webhookData = {
+      provider: 'ashby',
+      providerConfig: { apiKey: '{{ASHBY_API_KEY}}', triggerId: 'ashby_application_submit' },
+    }
+    const workflow = { id: 'wf-1', workspaceId: 'ws-1' }
+
+    const result = await createExternalWebhookSubscription(
+      {} as NextRequest,
+      webhookData,
+      workflow,
+      'user-1',
+      'req-1'
+    )
+
+    expect(result.updatedProviderConfig.apiKey).toBe('{{ASHBY_API_KEY}}')
+    expect(result.updatedProviderConfig.externalId).toBe('ext-1')
+  })
+
+  it('falls back to personal-only env resolution when workspaceId is not a string', async () => {
+    const createSubscription = vi.fn().mockResolvedValue({
+      providerConfigUpdates: { externalId: 'ext-1' },
+    })
+    mockGetProviderHandler.mockReturnValue({ createSubscription })
+
+    const webhookData = {
+      provider: 'ashby',
+      providerConfig: { apiKey: '{{ASHBY_API_KEY}}', triggerId: 'ashby_application_submit' },
+    }
+    const workflow = { id: 'wf-1', workspaceId: null }
+
+    await createExternalWebhookSubscription(
+      {} as NextRequest,
+      webhookData,
+      workflow,
+      'user-1',
+      'req-1'
+    )
+
+    expect(mockGetEffectiveDecryptedEnv).toHaveBeenCalledWith('user-1', undefined)
+  })
+
+  it('skips resolution and provider call entirely when the provider has no createSubscription', async () => {
+    mockGetProviderHandler.mockReturnValue({})
+
+    const webhookData = {
+      provider: 'slack',
+      providerConfig: { token: '{{SLACK_TOKEN}}' },
+    }
+    const workflow = { id: 'wf-1', workspaceId: 'ws-1' }
+
+    const result = await createExternalWebhookSubscription(
+      {} as NextRequest,
+      webhookData,
+      workflow,
+      'user-1',
+      'req-1'
+    )
+
+    expect(mockGetEffectiveDecryptedEnv).not.toHaveBeenCalled()
+    expect(result.externalSubscriptionCreated).toBe(false)
+    expect(result.updatedProviderConfig.token).toBe('{{SLACK_TOKEN}}')
+  })
+})

--- a/apps/sim/lib/webhooks/provider-subscriptions.ts
+++ b/apps/sim/lib/webhooks/provider-subscriptions.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
 import type { NextRequest } from 'next/server'
+import { resolveWebhookProviderConfig } from '@/lib/webhooks/env-resolver'
 import { getProviderHandler } from '@/lib/webhooks/providers'
 
 const logger = createLogger('WebhookProviderSubscriptions')
@@ -88,6 +89,14 @@ export function shouldRecreateExternalWebhookSubscription({
  * Ask the provider handler to create an external webhook subscription, if that
  * provider supports automatic registration.
  *
+ * `providerConfig` may contain unresolved `{{ENV_VAR}}` references (e.g. an
+ * API key field backed by an environment variable) — these are resolved here
+ * before the provider call so deploy-triggered registration (this function is
+ * also called from the async deployment outbox, not just the interactive
+ * webhook-save route) behaves the same as a manual save. The persisted
+ * `providerConfig` returned to the caller stays unresolved; only the
+ * provider-managed fields from `result.providerConfigUpdates` get merged in.
+ *
  * The returned provider-managed fields are merged back into `providerConfig`
  * by the caller.
  */
@@ -106,8 +115,16 @@ export async function createExternalWebhookSubscription(
     return { updatedProviderConfig: providerConfig, externalSubscriptionCreated: false }
   }
 
+  const workspaceId = typeof workflow.workspaceId === 'string' ? workflow.workspaceId : undefined
+
+  const resolvedProviderConfig = await resolveWebhookProviderConfig(
+    providerConfig,
+    userId,
+    workspaceId
+  )
+
   const result = await handler.createSubscription({
-    webhook: webhookData,
+    webhook: { ...webhookData, providerConfig: resolvedProviderConfig },
     workflow,
     userId,
     requestId,

--- a/apps/sim/lib/workflows/migrations/subblock-migrations.ts
+++ b/apps/sim/lib/workflows/migrations/subblock-migrations.ts
@@ -46,6 +46,7 @@ export const SUBBLOCK_ID_MIGRATIONS: Record<string, Record<string, string>> = {
     phoneType: '_removed_phoneType',
     expandApplicationFormDefinition: '_removed_expandApplicationFormDefinition',
     expandSurveyFormDefinitions: '_removed_expandSurveyFormDefinitions',
+    filterCandidateId: '_removed_filterCandidateId',
   },
   apollo: {
     contact_ids_bulk: 'contacts',

--- a/apps/sim/tools/ashby/list_applications.ts
+++ b/apps/sim/tools/ashby/list_applications.ts
@@ -51,12 +51,6 @@ export const listApplicationsTool: ToolConfig<
       visibility: 'user-or-llm',
       description: 'Filter applications by a specific job UUID',
     },
-    candidateId: {
-      type: 'string',
-      required: false,
-      visibility: 'user-or-llm',
-      description: 'Filter applications by a specific candidate UUID',
-    },
     createdAfter: {
       type: 'string',
       required: false,
@@ -76,7 +70,6 @@ export const listApplicationsTool: ToolConfig<
       if (params.perPage) body.limit = params.perPage
       if (params.status) body.status = params.status
       if (params.jobId) body.jobId = params.jobId.trim()
-      if (params.candidateId) body.candidateId = params.candidateId.trim()
       if (params.createdAfter) {
         const ms = new Date(params.createdAfter).getTime()
         if (!Number.isNaN(ms)) body.createdAfter = ms

--- a/apps/sim/tools/ashby/types.ts
+++ b/apps/sim/tools/ashby/types.ts
@@ -148,7 +148,6 @@ export interface AshbyListApplicationsParams extends AshbyBaseParams {
   perPage?: number
   status?: string
   jobId?: string
-  candidateId?: string
   createdAfter?: string
 }
 


### PR DESCRIPTION
- **feat(sidebar): add Cmd+B shortcut to toggle sidebar collapse (#5618)**
- **fix(webhooks): resolve env var references before deploy-triggered subscription creation (#5619)**
- **fix(ashby): parse alternateEmailAddresses and socialLinks into arrays before dispatch (#5621)**
- **fix(global-commands): use isContentEditable for the editable guard (#5623)**
- **fix(ashby): fail loudly instead of silently dropping malformed socialLinks (#5624)**