### PR TITLE
fix(global-commands): use isContentEditable for the editable guard

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.test.tsx
@@ -135,6 +135,7 @@ describe('GlobalCommandsProvider editable guard', () => {
       <GlobalCommandsProvider>
         <RegisterModKOutsideEditable handler={handler} />
         <div contentEditable>
+          {/* biome-ignore lint/a11y/noNoninteractiveTabindex: focusable stand-in for a node view inside the editor */}
           <span tabIndex={0} />
         </div>
       </GlobalCommandsProvider>

--- a/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.test.tsx
@@ -94,6 +94,15 @@ describe('GlobalCommandsProvider owned-shortcut yielding', () => {
 })
 
 describe('GlobalCommandsProvider editable guard', () => {
+  /**
+   * jsdom does not implement `isContentEditable`, so stub the browser's computed
+   * editability on the element the test focuses.
+   */
+  function focusWithEditability(element: HTMLElement, isContentEditable: boolean) {
+    Object.defineProperty(element, 'isContentEditable', { value: isContentEditable })
+    element.focus()
+  }
+
   it('skips a non-editable command when focus is in an input', () => {
     const handler = vi.fn()
     mount(
@@ -115,9 +124,24 @@ describe('GlobalCommandsProvider editable guard', () => {
         <div contentEditable />
       </GlobalCommandsProvider>
     )
-    ;(container.querySelector('[contenteditable]') as HTMLElement).focus()
+    focusWithEditability(container.querySelector('[contenteditable]') as HTMLElement, true)
     pressModK()
-    expect(handler).toHaveBeenCalledTimes(0)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('skips a non-editable command when focus is on a descendant of a contenteditable root', () => {
+    const handler = vi.fn()
+    mount(
+      <GlobalCommandsProvider>
+        <RegisterModKOutsideEditable handler={handler} />
+        <div contentEditable>
+          <span tabIndex={0} />
+        </div>
+      </GlobalCommandsProvider>
+    )
+    focusWithEditability(container.querySelector('span') as HTMLElement, true)
+    pressModK()
+    expect(handler).not.toHaveBeenCalled()
   })
 
   it('fires a non-editable command when focus is in a contenteditable="false" element', () => {
@@ -129,7 +153,7 @@ describe('GlobalCommandsProvider editable guard', () => {
         <div contentEditable={false} tabIndex={0} />
       </GlobalCommandsProvider>
     )
-    ;(container.querySelector('[contenteditable]') as HTMLElement).focus()
+    focusWithEditability(container.querySelector('[contenteditable]') as HTMLElement, false)
     pressModK()
     expect(handler).toHaveBeenCalledTimes(1)
   })

--- a/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/global-commands-provider.tsx
@@ -95,14 +95,13 @@ function shortcutSignature(parsed: ParsedShortcut, isMac: boolean): string {
 
 /**
  * Whether `element` is an editable region for the purposes of the editable guard.
- * `contenteditable="false"` (e.g. a rich-text editor in read-only mode) is not editable,
- * so commands with `allowInEditable: false` still fire while such an element has focus.
+ * `isContentEditable` is the browser's computed editability, so focusable descendants of a
+ * `contenteditable` root count as editable, while `contenteditable="false"` (e.g. a rich-text
+ * editor in read-only mode) does not — commands with `allowInEditable: false` still fire there.
  */
 function isEditableElement(element: Element | null): boolean {
   if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) return true
-  if (!(element instanceof HTMLElement)) return false
-  const contentEditable = element.getAttribute('contenteditable')
-  return contentEditable !== null && contentEditable.toLowerCase() !== 'false'
+  return element instanceof HTMLElement && element.isContentEditable
 }
 
 /**


### PR DESCRIPTION
## Summary
- Follow-up to #5618, addressing [Greptile's ancestor-editability finding on the release PR](https://github.com/simstudioai/sim/pull/5622#discussion_r3565691501)
- Replace the attribute-string check in the global-command editable guard with `element.isContentEditable` — the browser's computed editability, which handles focusable descendants of a `contenteditable` root, `contenteditable="false"` islands, invalid attribute values, and `plaintext-only` natively (same approach as Mousetrap/hotkeys-js)
- Tests stub `isContentEditable` (jsdom doesn't implement it) and add a focused-descendant case

## Type of Change
- [x] Bug fix

## Testing
Provider tests pass (7/7)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)