### PR TITLE
fix(ashby): fail loudly instead of silently dropping malformed socialLinks

### DIFF
--- a/apps/sim/blocks/blocks/ashby.test.ts
+++ b/apps/sim/blocks/blocks/ashby.test.ts
@@ -47,11 +47,22 @@ describe('AshbyBlock', () => {
       expect(result.socialLinks).toEqual([{ type: 'Twitter', url: 'https://twitter.com/jane' }])
     })
 
-    it('omits the field when the JSON is malformed', () => {
-      const result = AshbyBlock.tools.config.params!(
-        buildParams('update_candidate', { socialLinks: 'not json' })
-      )
-      expect(result.socialLinks).toBeUndefined()
+    it('throws instead of silently dropping the field when the JSON is malformed', () => {
+      // A silent [] here would let the Ashby update proceed without applying
+      // the requested links and with no error shown to the workflow author.
+      expect(() =>
+        AshbyBlock.tools.config.params!(
+          buildParams('update_candidate', { socialLinks: 'not json' })
+        )
+      ).toThrow(/Invalid JSON in Ashby social links/)
+    })
+
+    it('throws when the parsed JSON is not an array', () => {
+      expect(() =>
+        AshbyBlock.tools.config.params!(
+          buildParams('update_candidate', { socialLinks: '{"type":"Twitter"}' })
+        )
+      ).toThrow(/expected a JSON array/)
     })
   })
 

--- a/apps/sim/blocks/blocks/ashby.ts
+++ b/apps/sim/blocks/blocks/ashby.ts
@@ -22,12 +22,20 @@ function parseStringListInput(value: unknown): string[] {
 function parseSocialLinksInput(value: unknown): Array<{ type: string; url: string }> {
   if (Array.isArray(value)) return value as Array<{ type: string; url: string }>
   if (typeof value !== 'string' || !value.trim()) return []
+  let parsed: unknown
   try {
-    const parsed = JSON.parse(value)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
+    parsed = JSON.parse(value)
+  } catch (error) {
+    throw new Error(
+      `Invalid JSON in Ashby social links: ${error instanceof Error ? error.message : String(error)}. Expected a JSON array like [{"type":"Twitter","url":"https://twitter.com/x"}].`
+    )
   }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      'Invalid Ashby social links: expected a JSON array like [{"type":"Twitter","url":"https://twitter.com/x"}].'
+    )
+  }
+  return parsed
 }
 
 export const AshbyBlock: BlockConfig = {

--- a/apps/sim/blocks/blocks/ashby.ts
+++ b/apps/sim/blocks/blocks/ashby.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@sim/utils/errors'
 import { AshbyIcon } from '@/components/icons'
 import { AuthMode, type BlockConfig, type BlockMeta, IntegrationType } from '@/blocks/types'
 import { getTrigger } from '@/triggers'
@@ -27,7 +28,7 @@ function parseSocialLinksInput(value: unknown): Array<{ type: string; url: strin
     parsed = JSON.parse(value)
   } catch (error) {
     throw new Error(
-      `Invalid JSON in Ashby social links: ${error instanceof Error ? error.message : String(error)}. Expected a JSON array like [{"type":"Twitter","url":"https://twitter.com/x"}].`
+      `Invalid JSON in Ashby social links: ${getErrorMessage(error)}. Expected a JSON array like [{"type":"Twitter","url":"https://twitter.com/x"}].`
     )
   }
   if (!Array.isArray(parsed)) {


### PR DESCRIPTION
## Summary
- Greptile flagged a real bug on the release PR (staging→main), traced from the ashby.ts array-parsing fix merged in #5621: `parseSocialLinksInput` returns `[]` on any non-JSON-parseable input, and `tools.config.params` only sets `result.socialLinks` when the parsed array is non-empty. So malformed `socialLinks` input (a user typo, or a wand response that didn't follow the JSON-array prompt) silently omits the field entirely — the Ashby `candidate.update` call proceeds and "succeeds" without applying the requested links, with zero error surfaced to the workflow author.
- Fixed by throwing a clear error when the string is non-empty but fails to parse into a JSON array, matching the existing throw-on-invalid-JSON pattern already used elsewhere in the codebase (`blocks/airtable.ts`).
- Scope note: `alternateEmailAddresses` (parsed by `parseStringListInput`) doesn't have this problem the same way — it falls back to comma-splitting rather than failing outright, so it degrades gracefully for non-JSON input instead of silently vanishing. Left unchanged.

## Type of Change
- [x] Bug fix

## Testing
- Updated `apps/sim/blocks/blocks/ashby.test.ts`: malformed JSON now throws with a clear message; a valid-but-non-array JSON value (e.g. `{"type":"Twitter"}`) also throws (8 tests total, all passing).
- `bunx turbo run type-check --filter=sim --force` — clean (one pre-existing, unrelated `providers/meta/index.ts` error confirmed identical on unmodified staging).
- `bunx biome check` on touched files — clean.
- `bun run apps/sim/scripts/check-block-registry.ts origin/staging` — no subblock changes, all checks pass.
- `bun run check:api-validation` — passes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)