### PR TITLE
fix(editor): allow references in boolean variable values and sync tag selections to canvas preview

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/variables-input/variables-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/variables-input/variables-input.tsx
@@ -9,10 +9,11 @@ import {
   Input,
   Label,
   Textarea,
+  Tooltip,
 } from '@sim/emcn'
 import { Trash } from '@sim/emcn/icons'
 import { generateId } from '@sim/utils/id'
-import { Plus } from 'lucide-react'
+import { ArrowLeftRight, Plus } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { formatDisplayText } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/formatted-text'
 import {
@@ -61,6 +62,12 @@ const BOOLEAN_OPTIONS: ComboboxOption[] = [
   { label: 'true', value: 'true' },
   { label: 'false', value: 'false' },
 ]
+
+/**
+ * Values representable by the boolean selector; anything else (e.g. a block
+ * reference) requires the manual input.
+ */
+const BOOLEAN_LITERALS = new Set(['', 'true', 'false'])
 
 /**
  * Parses a value that might be a JSON string or already an array of VariableAssignment.
@@ -116,6 +123,7 @@ export function VariablesInput({
   const overlayRefs = useRef<Record<string, HTMLDivElement>>({})
   const [dragHighlight, setDragHighlight] = useState<Record<string, boolean>>({})
   const [collapsedAssignments, setCollapsedAssignments] = useState<Record<string, boolean>>({})
+  const [manualBooleanModes, setManualBooleanModes] = useState<Record<string, boolean>>({})
 
   const currentWorkflowVariables = Object.values(workflowVariables).filter(
     (v: Variable) => v.workflowId === workflowId
@@ -375,6 +383,9 @@ export function VariablesInput({
               valuePath: [index, 'variableName'],
               label: variableLabel,
             })
+            const isManualBoolean =
+              assignment.type === 'boolean' &&
+              (manualBooleanModes[assignment.id] ?? !BOOLEAN_LITERALS.has(assignment.value ?? ''))
             const booleanLabelHighlight = getWorkflowSearchLabelHighlight({
               activeSearchTarget,
               blockId,
@@ -467,8 +478,44 @@ export function VariablesInput({
                     </div>
 
                     <div className='flex flex-col gap-1.5'>
-                      <Label className='text-small'>Value</Label>
-                      {assignment.type === 'boolean' ? (
+                      <div className='flex items-center justify-between'>
+                        <Label className='text-small'>Value</Label>
+                        {assignment.type === 'boolean' && (
+                          <Tooltip.Root>
+                            <Tooltip.Trigger asChild>
+                              <button
+                                type='button'
+                                className='flex size-[12px] flex-shrink-0 items-center justify-center bg-transparent p-0 disabled:cursor-not-allowed disabled:opacity-50'
+                                onClick={() =>
+                                  setManualBooleanModes((prev) => ({
+                                    ...prev,
+                                    [assignment.id]: !isManualBoolean,
+                                  }))
+                                }
+                                disabled={isReadOnly}
+                                aria-label={
+                                  isManualBoolean ? 'Switch to selector' : 'Switch to manual value'
+                                }
+                              >
+                                <ArrowLeftRight
+                                  className={cn(
+                                    '!h-[12px] !w-[12px]',
+                                    isManualBoolean
+                                      ? 'text-[var(--text-primary)]'
+                                      : 'text-[var(--text-secondary)]'
+                                  )}
+                                />
+                              </button>
+                            </Tooltip.Trigger>
+                            <Tooltip.Content side='top'>
+                              <p>
+                                {isManualBoolean ? 'Switch to selector' : 'Switch to manual value'}
+                              </p>
+                            </Tooltip.Content>
+                          </Tooltip.Root>
+                        )}
+                      </div>
+                      {assignment.type === 'boolean' && !isManualBoolean ? (
                         <Combobox
                           options={BOOLEAN_OPTIONS}
                           value={assignment.value ?? ''}

--- a/apps/sim/hooks/use-collaborative-workflow.ts
+++ b/apps/sim/hooks/use-collaborative-workflow.ts
@@ -1696,6 +1696,7 @@ export function useCollaborativeWorkflow() {
 
       // Apply locally first (immediate UI feedback)
       useSubBlockStore.getState().setValue(blockId, subblockId, value)
+      useWorkflowStore.getState().syncDynamicHandleSubblockValue(blockId, subblockId, value)
 
       if (isSyntheticToolSubBlockId(subblockId)) return
 


### PR DESCRIPTION
## Summary
- Variables block: boolean values can now hold block references — added the canonical left/right arrow mode toggle on the boolean Value field to switch between the true/false selector and the reference-capable manual input (same input all other types use, with tag dropdown + drag-drop). Rows whose value is already a reference default to manual mode
- Fixed canvas block preview not updating when a tag is selected from the tag dropdown in condition/router blocks: `collaborativeSetTagSelection` now calls `syncDynamicHandleSubblockValue` like the typing path does, so the workflow-store copy the canvas preview reads stays in sync

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)