### PR TITLE
fix(docs): fix Core Web Vitals regressions on docs.sim.ai

### DIFF
--- a/apps/docs/app/[lang]/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/[[...slug]]/page.tsx
@@ -39,6 +39,21 @@ function resolveLangAndSlug(params: { slug?: string[]; lang: string }) {
   return { lang, slug }
 }
 
+/**
+ * Strips a leading `/{lang}` path segment from a page URL. Unlike a naive
+ * `String.replace`, this only removes the locale when it is actually the
+ * first path segment — a plain substring replace would also match `/en`
+ * inside unrelated slugs (e.g. `/platform/enterprise`, `/integrations/enrich`,
+ * `/platform/self-hosting/environment-variables`), corrupting canonical and
+ * hreflang URLs for those pages.
+ */
+function stripLocalePrefix(url: string, lang: string): string {
+  const prefix = `/${lang}`
+  if (url === prefix) return ''
+  if (url.startsWith(`${prefix}/`)) return url.slice(prefix.length)
+  return url
+}
+
 const APIPage = createAPIPage(openapi, {
   playground: { enabled: false },
   content: {
@@ -342,13 +357,13 @@ export async function generateMetadata(props: {
     alternates: {
       canonical: fullUrl,
       languages: {
-        'x-default': `${BASE_URL}${page.url.replace(`/${lang}`, '')}`,
-        en: `${BASE_URL}${page.url.replace(`/${lang}`, '')}`,
-        es: `${BASE_URL}/es${page.url.replace(`/${lang}`, '')}`,
-        fr: `${BASE_URL}/fr${page.url.replace(`/${lang}`, '')}`,
-        de: `${BASE_URL}/de${page.url.replace(`/${lang}`, '')}`,
-        ja: `${BASE_URL}/ja${page.url.replace(`/${lang}`, '')}`,
-        zh: `${BASE_URL}/zh${page.url.replace(`/${lang}`, '')}`,
+        'x-default': `${BASE_URL}${stripLocalePrefix(page.url, lang)}`,
+        en: `${BASE_URL}${stripLocalePrefix(page.url, lang)}`,
+        es: `${BASE_URL}/es${stripLocalePrefix(page.url, lang)}`,
+        fr: `${BASE_URL}/fr${stripLocalePrefix(page.url, lang)}`,
+        de: `${BASE_URL}/de${stripLocalePrefix(page.url, lang)}`,
+        ja: `${BASE_URL}/ja${stripLocalePrefix(page.url, lang)}`,
+        zh: `${BASE_URL}/zh${stripLocalePrefix(page.url, lang)}`,
       },
     },
   }

--- a/apps/docs/app/[lang]/layout.tsx
+++ b/apps/docs/app/[lang]/layout.tsx
@@ -110,6 +110,12 @@ export default async function Layout({ children, params }: LayoutProps) {
               collapsible: false,
               footer: null,
               banner: null,
+              // The sidebar renders every page in the doc tree as a link at
+              // once, so Next's default viewport-prefetch behavior fires an
+              // RSC payload fetch for every one of them on initial load -
+              // dozens of concurrent requests competing with the actual
+              // page's own content for bandwidth on a real connection.
+              prefetch: false,
               components: {
                 Item: SidebarItem,
                 Folder: SidebarFolder,

--- a/apps/docs/app/[lang]/layout.tsx
+++ b/apps/docs/app/[lang]/layout.tsx
@@ -110,11 +110,6 @@ export default async function Layout({ children, params }: LayoutProps) {
               collapsible: false,
               footer: null,
               banner: null,
-              // The sidebar renders every page in the doc tree as a link at
-              // once, so Next's default viewport-prefetch behavior fires an
-              // RSC payload fetch for every one of them on initial load -
-              // dozens of concurrent requests competing with the actual
-              // page's own content for bandwidth on a real connection.
               prefetch: false,
               components: {
                 Item: SidebarItem,

--- a/apps/docs/components/ai/ask-ai-panel.tsx
+++ b/apps/docs/components/ai/ask-ai-panel.tsx
@@ -43,10 +43,11 @@ function getText(parts: ReadonlyArray<{ type: string; [key: string]: unknown }>)
 interface AskAIPanelProps {
   /** Active docs locale, forwarded so retrieval is scoped to the reader's language. */
   locale: string
+  open: boolean
   onClose: () => void
 }
 
-export function AskAIPanel({ locale, onClose }: AskAIPanelProps) {
+export function AskAIPanel({ locale, open, onClose }: AskAIPanelProps) {
   const [input, setInput] = useState('')
   const scrollRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -63,6 +64,7 @@ export function AskAIPanel({ locale, onClose }: AskAIPanelProps) {
   }
 
   useEffect(() => {
+    if (!open) return
     textareaRef.current?.focus()
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -71,11 +73,12 @@ export function AskAIPanel({ locale, onClose }: AskAIPanelProps) {
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [])
+  }, [open])
 
   useEffect(() => {
+    if (!open) return
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
-  }, [])
+  }, [open])
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
@@ -88,6 +91,8 @@ export function AskAIPanel({ locale, onClose }: AskAIPanelProps) {
     sendMessage({ text }, { body: { locale } })
     setInput('')
   }
+
+  if (!open) return null
 
   return (
     <div

--- a/apps/docs/components/ai/ask-ai-panel.tsx
+++ b/apps/docs/components/ai/ask-ai-panel.tsx
@@ -180,7 +180,9 @@ export function AskAIPanel({ locale, open, onClose }: AskAIPanelProps) {
         })}
 
         {error && (
-          <p className='text-[var(--text-muted)] text-sm'>Something went wrong. Please try again.</p>
+          <p className='text-[var(--text-muted)] text-sm'>
+            Something went wrong. Please try again.
+          </p>
         )}
       </div>
 

--- a/apps/docs/components/ai/ask-ai-panel.tsx
+++ b/apps/docs/components/ai/ask-ai-panel.tsx
@@ -1,0 +1,227 @@
+'use client'
+
+import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react'
+import { useChat } from '@ai-sdk/react'
+import { DefaultChatTransport } from 'ai'
+import { ArrowUp, MessageCircle, Square, X } from 'lucide-react'
+import { Streamdown } from 'streamdown'
+import { cn } from '@/lib/utils'
+import 'streamdown/styles.css'
+
+interface DocSource {
+  title: string
+  url: string
+}
+
+/** Pull the deduped doc sources surfaced by the searchDocs tool out of a message's parts. */
+function getSources(parts: ReadonlyArray<{ type: string; [key: string]: unknown }>): DocSource[] {
+  const seen = new Set<string>()
+  const sources: DocSource[] = []
+
+  for (const part of parts) {
+    if (part.type !== 'tool-searchDocs') continue
+    const output = (part as { output?: unknown }).output
+    if (!Array.isArray(output)) continue
+    for (const item of output as DocSource[]) {
+      if (!item?.url || seen.has(item.url)) continue
+      seen.add(item.url)
+      sources.push({ title: item.title, url: item.url })
+    }
+  }
+
+  return sources
+}
+
+/** Concatenate the streamed text parts of a message. */
+function getText(parts: ReadonlyArray<{ type: string; [key: string]: unknown }>): string {
+  return parts
+    .filter((part) => part.type === 'text')
+    .map((part) => (part as unknown as { text: string }).text)
+    .join('')
+}
+
+interface AskAIPanelProps {
+  /** Active docs locale, forwarded so retrieval is scoped to the reader's language. */
+  locale: string
+  onClose: () => void
+}
+
+export function AskAIPanel({ locale, onClose }: AskAIPanelProps) {
+  const [input, setInput] = useState('')
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const transport = useMemo(() => new DefaultChatTransport({ api: '/api/chat' }), [])
+
+  const { messages, sendMessage, status, stop, error } = useChat({ transport })
+
+  const isBusy = status === 'submitted' || status === 'streaming'
+
+  const handleClose = () => {
+    stop()
+    onClose()
+  }
+
+  useEffect(() => {
+    textareaRef.current?.focus()
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
+  }, [])
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
+  }, [messages])
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    const text = input.trim()
+    if (!text || isBusy) return
+    sendMessage({ text }, { body: { locale } })
+    setInput('')
+  }
+
+  return (
+    <div
+      role='dialog'
+      aria-label='Ask Sim'
+      className='fixed right-4 bottom-4 z-50 flex h-[600px] max-h-[calc(100vh-2rem)] w-[400px] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-xl border border-[var(--border-1)] bg-[var(--surface-5)] shadow-[var(--shadow-medium)] dark:bg-[var(--surface-4)]'
+    >
+      <div className='flex items-center justify-between border-[var(--border-1)] border-b px-4 py-3'>
+        <span className='flex items-center gap-1.5 font-season text-[var(--text-body)] text-sm'>
+          <MessageCircle className='size-[16px] text-[var(--text-icon)]' />
+          Ask Sim
+        </span>
+        <button
+          type='button'
+          aria-label='Close'
+          onClick={handleClose}
+          className='flex size-7 items-center justify-center rounded-lg text-[var(--text-icon)] transition-colors hover:bg-[var(--surface-active)]'
+        >
+          <X className='size-[16px]' />
+        </button>
+      </div>
+
+      <div ref={scrollRef} className='flex-1 space-y-4 overflow-y-auto px-4 py-4'>
+        {messages.length === 0 && (
+          <p className='text-[var(--text-muted)] text-sm'>
+            Ask anything about building, deploying, and managing AI agents in Sim.
+          </p>
+        )}
+
+        {messages.map((message, index) => {
+          const text = getText(message.parts)
+          const isStreaming = isBusy && index === messages.length - 1
+          const sources = message.role === 'assistant' ? getSources(message.parts) : []
+          return (
+            <div
+              key={message.id}
+              className={cn(
+                'flex flex-col gap-1.5',
+                message.role === 'user' ? 'items-end' : 'items-start'
+              )}
+            >
+              {message.role === 'user' ? (
+                <div className='max-w-[85%] whitespace-pre-wrap rounded-[16px] bg-[var(--surface-5)] px-3 py-2 text-[var(--text-primary)] text-base leading-[23px]'>
+                  {text}
+                </div>
+              ) : (
+                <div className='max-w-full text-[var(--text-primary)] text-base'>
+                  {text ? (
+                    <Streamdown
+                      className={cn(
+                        'space-y-3 text-[var(--text-primary)] text-base leading-relaxed',
+                        '[&_a]:text-[var(--text-primary)] [&_a]:underline [&_a]:decoration-dashed [&_a]:underline-offset-4',
+                        '[&_strong]:font-[600]',
+                        '[&_h1]:font-[600] [&_h2]:font-[600] [&_h3]:font-[600] [&_h4]:font-[600]',
+                        '[&_li]:my-1 [&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5',
+                        '[&_code]:font-mono [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-[var(--surface-5)] [&_pre]:p-3 [&_pre]:text-small'
+                      )}
+                    >
+                      {text}
+                    </Streamdown>
+                  ) : isStreaming ? (
+                    '…'
+                  ) : sources.length === 0 ? (
+                    <span className='text-[var(--text-muted)]'>No answer returned.</span>
+                  ) : null}
+                </div>
+              )}
+              {sources.length > 0 && (
+                <div className='flex max-w-[90%] flex-wrap gap-1.5'>
+                  {sources.map((source) => (
+                    <a
+                      key={source.url}
+                      href={source.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='rounded-lg border border-[var(--border-1)] px-2 py-0.5 text-[var(--text-muted)] text-xs transition-colors hover:bg-[var(--surface-active)]'
+                    >
+                      {source.title || source.url}
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
+
+        {error && (
+          <p className='text-[var(--text-muted)] text-sm'>Something went wrong. Please try again.</p>
+        )}
+      </div>
+
+      <form onSubmit={handleSubmit} className='px-3 pb-3'>
+        <div className='flex items-end gap-2 rounded-2xl border border-[var(--border-1)] bg-white px-2.5 py-1.5 dark:bg-[var(--surface-5)]'>
+          <textarea
+            ref={textareaRef}
+            aria-label='Ask Sim about the docs'
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault()
+                handleSubmit(event)
+              }
+            }}
+            rows={1}
+            placeholder='Ask Sim about the docs…'
+            className='max-h-32 flex-1 resize-none bg-transparent py-1 font-season text-[var(--text-body)] text-sm outline-none placeholder:text-[var(--text-muted)]'
+          />
+          {isBusy ? (
+            <button
+              type='button'
+              aria-label='Stop'
+              onClick={() => stop()}
+              className='flex size-[28px] shrink-0 items-center justify-center rounded-full bg-[#383838] transition-colors hover:bg-[#575757] dark:bg-[#e0e0e0] dark:hover:bg-[#cfcfcf]'
+            >
+              <Square className='size-[12px] fill-white text-white dark:fill-black dark:text-black' />
+            </button>
+          ) : (
+            <button
+              type='submit'
+              aria-label='Send'
+              disabled={!input.trim()}
+              className={cn(
+                'flex size-[28px] shrink-0 items-center justify-center rounded-full transition-colors',
+                input.trim()
+                  ? 'bg-[#383838] hover:bg-[#575757] dark:bg-[#e0e0e0] dark:hover:bg-[#cfcfcf]'
+                  : 'bg-[#808080]'
+              )}
+            >
+              <ArrowUp className='size-[16px] text-white dark:text-black' />
+            </button>
+          )}
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/apps/docs/components/ai/ask-ai.tsx
+++ b/apps/docs/components/ai/ask-ai.tsx
@@ -6,6 +6,14 @@ import dynamic from 'next/dynamic'
 
 const AskAIPanel = dynamic(() => import('./ask-ai-panel').then((m) => m.AskAIPanel), {
   ssr: false,
+  loading: () => (
+    <div
+      aria-hidden
+      className='fixed right-4 bottom-4 z-50 flex size-11 items-center justify-center rounded-full border border-[var(--border-1)] bg-[var(--surface-5)] shadow-[var(--shadow-medium)] dark:bg-[var(--surface-4)]'
+    >
+      <MessageCircle className='size-[16px] animate-pulse text-[var(--text-icon)]' />
+    </div>
+  ),
 })
 
 interface AskAIProps {

--- a/apps/docs/components/ai/ask-ai.tsx
+++ b/apps/docs/components/ai/ask-ai.tsx
@@ -15,27 +15,35 @@ interface AskAIProps {
 
 export function AskAI({ locale }: AskAIProps) {
   const [open, setOpen] = useState(false)
+  const [hasOpened, setHasOpened] = useState(false)
   const openButtonRef = useRef<HTMLButtonElement>(null)
+
+  const handleOpen = () => {
+    setHasOpened(true)
+    setOpen(true)
+  }
 
   const handleClose = () => {
     setOpen(false)
     openButtonRef.current?.focus()
   }
 
-  if (!open) {
-    return (
-      <button
-        ref={openButtonRef}
-        type='button'
-        aria-label='Ask Sim'
-        onClick={() => setOpen(true)}
-        className='fixed right-4 bottom-4 z-50 flex h-11 items-center gap-1.5 rounded-full border border-[var(--border-1)] bg-[var(--surface-5)] px-4 font-season text-[var(--text-body)] text-sm shadow-[var(--shadow-medium)] transition-colors hover:bg-[var(--surface-active)] dark:bg-[var(--surface-4)]'
-      >
-        <MessageCircle className='size-[16px] text-[var(--text-icon)]' />
-        Ask Sim
-      </button>
-    )
-  }
+  return (
+    <>
+      {!open && (
+        <button
+          ref={openButtonRef}
+          type='button'
+          aria-label='Ask Sim'
+          onClick={handleOpen}
+          className='fixed right-4 bottom-4 z-50 flex h-11 items-center gap-1.5 rounded-full border border-[var(--border-1)] bg-[var(--surface-5)] px-4 font-season text-[var(--text-body)] text-sm shadow-[var(--shadow-medium)] transition-colors hover:bg-[var(--surface-active)] dark:bg-[var(--surface-4)]'
+        >
+          <MessageCircle className='size-[16px] text-[var(--text-icon)]' />
+          Ask Sim
+        </button>
+      )}
 
-  return <AskAIPanel locale={locale} onClose={handleClose} />
+      {hasOpened && <AskAIPanel locale={locale} open={open} onClose={handleClose} />}
+    </>
+  )
 }

--- a/apps/docs/components/ai/ask-ai.tsx
+++ b/apps/docs/components/ai/ask-ai.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useRef, useState } from 'react'
-import dynamic from 'next/dynamic'
 import { MessageCircle } from 'lucide-react'
+import dynamic from 'next/dynamic'
 
 const AskAIPanel = dynamic(() => import('./ask-ai-panel').then((m) => m.AskAIPanel), {
   ssr: false,

--- a/apps/docs/components/ai/ask-ai.tsx
+++ b/apps/docs/components/ai/ask-ai.tsx
@@ -1,44 +1,12 @@
 'use client'
 
-import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react'
-import { useChat } from '@ai-sdk/react'
-import { DefaultChatTransport } from 'ai'
-import { ArrowUp, MessageCircle, Square, X } from 'lucide-react'
-import { Streamdown } from 'streamdown'
-import { cn } from '@/lib/utils'
-import 'streamdown/styles.css'
+import { useRef, useState } from 'react'
+import dynamic from 'next/dynamic'
+import { MessageCircle } from 'lucide-react'
 
-interface DocSource {
-  title: string
-  url: string
-}
-
-/** Pull the deduped doc sources surfaced by the searchDocs tool out of a message's parts. */
-function getSources(parts: ReadonlyArray<{ type: string; [key: string]: unknown }>): DocSource[] {
-  const seen = new Set<string>()
-  const sources: DocSource[] = []
-
-  for (const part of parts) {
-    if (part.type !== 'tool-searchDocs') continue
-    const output = (part as { output?: unknown }).output
-    if (!Array.isArray(output)) continue
-    for (const item of output as DocSource[]) {
-      if (!item?.url || seen.has(item.url)) continue
-      seen.add(item.url)
-      sources.push({ title: item.title, url: item.url })
-    }
-  }
-
-  return sources
-}
-
-/** Concatenate the streamed text parts of a message. */
-function getText(parts: ReadonlyArray<{ type: string; [key: string]: unknown }>): string {
-  return parts
-    .filter((part) => part.type === 'text')
-    .map((part) => (part as unknown as { text: string }).text)
-    .join('')
-}
+const AskAIPanel = dynamic(() => import('./ask-ai-panel').then((m) => m.AskAIPanel), {
+  ssr: false,
+})
 
 interface AskAIProps {
   /** Active docs locale, forwarded so retrieval is scoped to the reader's language. */
@@ -47,185 +15,27 @@ interface AskAIProps {
 
 export function AskAI({ locale }: AskAIProps) {
   const [open, setOpen] = useState(false)
-  const [input, setInput] = useState('')
-  const scrollRef = useRef<HTMLDivElement>(null)
+  const openButtonRef = useRef<HTMLButtonElement>(null)
 
-  // Stable transport; the locale is sent per-message (below) so it stays current
-  // after a language switch instead of being frozen into the transport.
-  const transport = useMemo(() => new DefaultChatTransport({ api: '/api/chat' }), [])
-
-  const { messages, sendMessage, status, stop, error } = useChat({ transport })
-
-  const isBusy = status === 'submitted' || status === 'streaming'
-
-  // Jump to the bottom instantly when the panel opens (a mount transition).
-  useEffect(() => {
-    if (!open) return
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
-  }, [open])
-
-  // Smooth-scroll as new messages stream in (an explicit re-orientation cue).
-  useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
-  }, [messages])
-
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault()
-    const text = input.trim()
-    if (!text || isBusy) return
-    sendMessage({ text }, { body: { locale } })
-    setInput('')
+  const handleClose = () => {
+    setOpen(false)
+    openButtonRef.current?.focus()
   }
 
-  return (
-    <>
-      {!open && (
-        <button
-          type='button'
-          aria-label='Ask Sim'
-          onClick={() => setOpen(true)}
-          className='fixed right-4 bottom-4 z-50 flex h-11 items-center gap-1.5 rounded-full border border-[var(--border-1)] bg-[var(--surface-5)] px-4 font-season text-[var(--text-body)] text-sm shadow-[var(--shadow-medium)] transition-colors hover:bg-[var(--surface-active)] dark:bg-[var(--surface-4)]'
-        >
-          <MessageCircle className='size-[16px] text-[var(--text-icon)]' />
-          Ask Sim
-        </button>
-      )}
+  if (!open) {
+    return (
+      <button
+        ref={openButtonRef}
+        type='button'
+        aria-label='Ask Sim'
+        onClick={() => setOpen(true)}
+        className='fixed right-4 bottom-4 z-50 flex h-11 items-center gap-1.5 rounded-full border border-[var(--border-1)] bg-[var(--surface-5)] px-4 font-season text-[var(--text-body)] text-sm shadow-[var(--shadow-medium)] transition-colors hover:bg-[var(--surface-active)] dark:bg-[var(--surface-4)]'
+      >
+        <MessageCircle className='size-[16px] text-[var(--text-icon)]' />
+        Ask Sim
+      </button>
+    )
+  }
 
-      {open && (
-        <div className='fixed right-4 bottom-4 z-50 flex h-[600px] max-h-[calc(100vh-2rem)] w-[400px] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-xl border border-[var(--border-1)] bg-[var(--surface-5)] shadow-[var(--shadow-medium)] dark:bg-[var(--surface-4)]'>
-          <div className='flex items-center justify-between border-[var(--border-1)] border-b px-4 py-3'>
-            <span className='flex items-center gap-1.5 font-season text-[var(--text-body)] text-sm'>
-              <MessageCircle className='size-[16px] text-[var(--text-icon)]' />
-              Ask Sim
-            </span>
-            <button
-              type='button'
-              aria-label='Close'
-              onClick={() => {
-                stop()
-                setOpen(false)
-              }}
-              className='flex size-7 items-center justify-center rounded-lg text-[var(--text-icon)] transition-colors hover:bg-[var(--surface-active)]'
-            >
-              <X className='size-[16px]' />
-            </button>
-          </div>
-
-          <div ref={scrollRef} className='flex-1 space-y-4 overflow-y-auto px-4 py-4'>
-            {messages.length === 0 && (
-              <p className='text-[var(--text-muted)] text-sm'>
-                Ask anything about building, deploying, and managing AI agents in Sim.
-              </p>
-            )}
-
-            {messages.map((message, index) => {
-              const text = getText(message.parts)
-              // Only the in-progress (last) message should show the loading state.
-              const isStreaming = isBusy && index === messages.length - 1
-              const sources = message.role === 'assistant' ? getSources(message.parts) : []
-              return (
-                <div
-                  key={message.id}
-                  className={cn(
-                    'flex flex-col gap-1.5',
-                    message.role === 'user' ? 'items-end' : 'items-start'
-                  )}
-                >
-                  {message.role === 'user' ? (
-                    <div className='max-w-[85%] whitespace-pre-wrap rounded-[16px] bg-[var(--surface-5)] px-3 py-2 text-[var(--text-primary)] text-base leading-[23px]'>
-                      {text}
-                    </div>
-                  ) : (
-                    <div className='max-w-full text-[var(--text-primary)] text-base'>
-                      {text ? (
-                        <Streamdown
-                          className={cn(
-                            'space-y-3 text-[var(--text-primary)] text-base leading-relaxed',
-                            '[&_a]:text-[var(--text-primary)] [&_a]:underline [&_a]:decoration-dashed [&_a]:underline-offset-4',
-                            '[&_strong]:font-[600]',
-                            '[&_h1]:font-[600] [&_h2]:font-[600] [&_h3]:font-[600] [&_h4]:font-[600]',
-                            '[&_li]:my-1 [&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5',
-                            '[&_code]:font-mono [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-[var(--surface-5)] [&_pre]:p-3 [&_pre]:text-small'
-                          )}
-                        >
-                          {text}
-                        </Streamdown>
-                      ) : isStreaming ? (
-                        '…'
-                      ) : sources.length === 0 ? (
-                        <span className='text-[var(--text-muted)]'>No answer returned.</span>
-                      ) : null}
-                    </div>
-                  )}
-                  {sources.length > 0 && (
-                    <div className='flex max-w-[90%] flex-wrap gap-1.5'>
-                      {sources.map((source) => (
-                        <a
-                          key={source.url}
-                          href={source.url}
-                          target='_blank'
-                          rel='noopener noreferrer'
-                          className='rounded-lg border border-[var(--border-1)] px-2 py-0.5 text-[var(--text-muted)] text-xs transition-colors hover:bg-[var(--surface-active)]'
-                        >
-                          {source.title || source.url}
-                        </a>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )
-            })}
-
-            {error && (
-              <p className='text-[var(--text-muted)] text-sm'>
-                Something went wrong. Please try again.
-              </p>
-            )}
-          </div>
-
-          <form onSubmit={handleSubmit} className='px-3 pb-3'>
-            <div className='flex items-end gap-2 rounded-2xl border border-[var(--border-1)] bg-white px-2.5 py-1.5 dark:bg-[var(--surface-5)]'>
-              <textarea
-                value={input}
-                onChange={(event) => setInput(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter' && !event.shiftKey) {
-                    event.preventDefault()
-                    handleSubmit(event)
-                  }
-                }}
-                rows={1}
-                placeholder='Ask Sim about the docs…'
-                className='max-h-32 flex-1 resize-none bg-transparent py-1 font-season text-[var(--text-body)] text-sm outline-none placeholder:text-[var(--text-muted)]'
-              />
-              {isBusy ? (
-                <button
-                  type='button'
-                  aria-label='Stop'
-                  onClick={() => stop()}
-                  className='flex size-[28px] shrink-0 items-center justify-center rounded-full bg-[#383838] transition-colors hover:bg-[#575757] dark:bg-[#e0e0e0] dark:hover:bg-[#cfcfcf]'
-                >
-                  <Square className='size-[12px] fill-white text-white dark:fill-black dark:text-black' />
-                </button>
-              ) : (
-                <button
-                  type='submit'
-                  aria-label='Send'
-                  disabled={!input.trim()}
-                  className={cn(
-                    'flex size-[28px] shrink-0 items-center justify-center rounded-full transition-colors',
-                    input.trim()
-                      ? 'bg-[#383838] hover:bg-[#575757] dark:bg-[#e0e0e0] dark:hover:bg-[#cfcfcf]'
-                      : 'bg-[#808080]'
-                  )}
-                >
-                  <ArrowUp className='size-[16px] text-white dark:text-black' />
-                </button>
-              )}
-            </div>
-          </form>
-        </div>
-      )}
-    </>
-  )
+  return <AskAIPanel locale={locale} onClose={handleClose} />
 }

--- a/apps/docs/components/docs-layout/sidebar-components.tsx
+++ b/apps/docs/components/docs-layout/sidebar-components.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, useState } from 'react'
 import type { Folder, Item, Separator } from 'fumadocs-core/page-tree'
+import { useSidebar } from 'fumadocs-ui/components/sidebar/base'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { i18n } from '@/lib/i18n'
@@ -66,11 +67,13 @@ const FOLDER_ACTIVE = 'lg:bg-[var(--surface-active)] lg:text-[var(--text-body)]'
 
 export function SidebarItem({ item }: { item: Item }) {
   const pathname = usePathname()
+  const { prefetch } = useSidebar()
   const active = isActive(item.url, pathname, false)
 
   return (
     <Link
       href={item.url}
+      prefetch={prefetch}
       data-active={active}
       className={cn(
         ITEM_BASE,
@@ -97,6 +100,7 @@ function isApiReferenceFolder(node: Folder): boolean {
 
 export function SidebarFolder({ item, children }: { item: Folder; children: ReactNode }) {
   const pathname = usePathname()
+  const { prefetch } = useSidebar()
   const hasActiveChild = checkHasActiveChild(item, pathname)
   const isApiRef = isApiReferenceFolder(item)
   const isOnApiRefPage = stripLangPrefix(pathname).startsWith('/api-reference')
@@ -111,6 +115,7 @@ export function SidebarFolder({ item, children }: { item: Folder; children: Reac
     return (
       <Link
         href={item.index.url}
+        prefetch={prefetch}
         data-active={active}
         className={cn(
           ITEM_BASE,
@@ -133,6 +138,7 @@ export function SidebarFolder({ item, children }: { item: Folder; children: Reac
           <>
             <Link
               href={item.index.url}
+              prefetch={prefetch}
               data-active={active}
               className={cn(
                 'flex flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',

--- a/apps/docs/components/navbar/navbar.tsx
+++ b/apps/docs/components/navbar/navbar.tsx
@@ -74,6 +74,7 @@ export function Navbar() {
               <Link
                 key={tab.label}
                 href={tab.href}
+                aria-current={isActive ? 'page' : undefined}
                 {...(tab.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
                 className={cn(
                   '-mb-px relative flex items-center border-b text-[14px] tracking-[-0.01em] transition-colors',

--- a/apps/docs/components/structured-data.tsx
+++ b/apps/docs/components/structured-data.tsx
@@ -89,7 +89,7 @@ export function StructuredData({
     },
     featureList: [
       'AI workspace for teams',
-      'Mothership — natural language agent creation',
+      'Chat — natural language agent creation',
       'Visual workflow builder',
       '1,000+ integrations',
       'LLM orchestration (OpenAI, Anthropic, Google, xAI, Mistral, Perplexity)',
@@ -115,7 +115,7 @@ export function StructuredData({
           }}
         />
       )}
-      {url === baseUrl && (
+      {(url === baseUrl || url === `${baseUrl}/`) && (
         <script
           type='application/ld+json'
           dangerouslySetInnerHTML={{

--- a/apps/docs/components/ui/heading.tsx
+++ b/apps/docs/components/ui/heading.tsx
@@ -50,7 +50,7 @@ export function Heading({ as, className, ...props }: HeadingProps) {
       ) : (
         <Link
           aria-hidden
-          className='size-[14px] shrink-0 text-[var(--text-icon)] opacity-0 transition-opacity group-hover:opacity-100 peer-hover:opacity-100'
+          className='size-[14px] shrink-0 text-[var(--text-icon)] opacity-0 transition-opacity group-hover:opacity-100 peer-hover:opacity-100 peer-focus-visible:opacity-100'
         />
       )}
     </As>

--- a/apps/docs/components/ui/lightbox.tsx
+++ b/apps/docs/components/ui/lightbox.tsx
@@ -16,6 +16,7 @@ export function Lightbox({ isOpen, onClose, src, alt, type, startTime }: Lightbo
   const overlayRef = useRef<HTMLDivElement>(null)
   const mediaButtonRef = useRef<HTMLButtonElement>(null)
   const videoRef = useRef<HTMLVideoElement>(null)
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null)
   const closeLightbox = useEffectEvent(onClose)
 
   useEffect(() => {
@@ -24,6 +25,11 @@ export function Lightbox({ isOpen, onClose, src, alt, type, startTime }: Lightbo
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         closeLightbox()
+        return
+      }
+      if (event.key === 'Tab') {
+        event.preventDefault()
+        mediaButtonRef.current?.focus()
       }
     }
 
@@ -35,6 +41,7 @@ export function Lightbox({ isOpen, onClose, src, alt, type, startTime }: Lightbo
 
     const previousOverflow = document.body.style.overflow
 
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null
     document.addEventListener('keydown', handleKeyDown)
     document.addEventListener('click', handleClickOutside)
     document.body.style.overflow = 'hidden'
@@ -44,6 +51,7 @@ export function Lightbox({ isOpen, onClose, src, alt, type, startTime }: Lightbo
       document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('click', handleClickOutside)
       document.body.style.overflow = previousOverflow
+      previouslyFocusedRef.current?.focus()
     }
   }, [isOpen])
 

--- a/apps/docs/components/ui/response-section.tsx
+++ b/apps/docs/components/ui/response-section.tsx
@@ -106,8 +106,17 @@ export function ResponseSection({ children }: ResponseSectionProps) {
         setIsOpen(false)
       }
     }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsOpen(false)
+      }
+    }
     document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
   }, [])
 
   return (
@@ -120,6 +129,9 @@ export function ResponseSection({ children }: ResponseSectionProps) {
               <button
                 type='button'
                 className='response-section-dropdown-trigger'
+                aria-haspopup='listbox'
+                aria-expanded={isOpen}
+                aria-label={`Response status code, currently ${selectedCode}`}
                 onClick={() => setIsOpen(!isOpen)}
               >
                 <span>{selectedCode}</span>
@@ -131,11 +143,13 @@ export function ResponseSection({ children }: ResponseSectionProps) {
                 />
               </button>
               {isOpen && (
-                <div className='response-section-dropdown-menu'>
+                <div className='response-section-dropdown-menu' role='listbox'>
                   {statusCodes.map((code) => (
                     <button
                       key={code}
                       type='button'
+                      role='option'
+                      aria-selected={code === selectedCode}
                       className={cn(
                         'response-section-dropdown-item',
                         code === selectedCode && 'response-section-dropdown-item-selected'

--- a/apps/docs/components/ui/video.tsx
+++ b/apps/docs/components/ui/video.tsx
@@ -36,12 +36,6 @@ export function Video({
     const el = videoRef.current
     if (!el) return
 
-    // `autoPlay` forces browsers to fetch the full file immediately on mount
-    // regardless of `preload` - gate the actual load behind the viewport so a
-    // page with several of these doesn't pull down every video up front.
-    // Fall back to eager loading where IntersectionObserver isn't available
-    // (older browsers, some embedded webviews) rather than leave the video
-    // permanently source-less.
     if (typeof IntersectionObserver === 'undefined') {
       setIsInView(true)
       return

--- a/apps/docs/components/ui/video.tsx
+++ b/apps/docs/components/ui/video.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { cn, getAssetUrl } from '@/lib/utils'
 import { Lightbox } from './lightbox'
 
@@ -30,6 +30,27 @@ export function Video({
   const videoRef = useRef<HTMLVideoElement>(null)
   const startTimeRef = useRef(0)
   const [isLightboxOpen, setIsLightboxOpen] = useState(false)
+  const [isInView, setIsInView] = useState(false)
+
+  useEffect(() => {
+    const el = videoRef.current
+    if (!el) return
+
+    // `autoPlay` forces browsers to fetch the full file immediately on mount
+    // regardless of `preload` - gate the actual load behind the viewport so a
+    // page with several of these doesn't pull down every video up front.
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: '200px' }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
 
   const openLightbox = () => {
     startTimeRef.current = videoRef.current?.currentTime ?? 0
@@ -39,17 +60,18 @@ export function Video({
   const video = (
     <video
       ref={videoRef}
-      autoPlay={autoPlay}
+      autoPlay={isInView && autoPlay}
       loop={loop}
       muted={muted}
       playsInline={playsInline}
+      preload='none'
       width={width}
       height={height}
       className={cn(
         className,
         enableLightbox && 'cursor-pointer transition-opacity group-hover:opacity-[0.97]'
       )}
-      src={getAssetUrl(src)}
+      src={isInView ? getAssetUrl(src) : undefined}
     />
   )
 

--- a/apps/docs/components/ui/video.tsx
+++ b/apps/docs/components/ui/video.tsx
@@ -39,6 +39,14 @@ export function Video({
     // `autoPlay` forces browsers to fetch the full file immediately on mount
     // regardless of `preload` - gate the actual load behind the viewport so a
     // page with several of these doesn't pull down every video up front.
+    // Fall back to eager loading where IntersectionObserver isn't available
+    // (older browsers, some embedded webviews) rather than leave the video
+    // permanently source-less.
+    if (typeof IntersectionObserver === 'undefined') {
+      setIsInView(true)
+      return
+    }
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {

--- a/apps/docs/components/workflow-preview/workflow-preview.tsx
+++ b/apps/docs/components/workflow-preview/workflow-preview.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { domAnimation, LazyMotion, m } from 'framer-motion'
 import { Maximize2, X } from 'lucide-react'
 import ReactFlow, {
@@ -253,6 +253,8 @@ export function WorkflowPreview({
 }: WorkflowPreviewProps) {
   const [expanded, setExpanded] = useState(false)
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     if (!expanded) return
@@ -261,12 +263,15 @@ export function WorkflowPreview({
     }
     document.addEventListener('keydown', onKey)
     const previousOverflow = document.body.style.overflow
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null
     document.body.style.overflow = 'hidden'
     document.body.classList.add('wp-lightbox-open')
+    closeButtonRef.current?.focus()
     return () => {
       document.removeEventListener('keydown', onKey)
       document.body.style.overflow = previousOverflow
       document.body.classList.remove('wp-lightbox-open')
+      previouslyFocusedRef.current?.focus()
     }
   }, [expanded])
 
@@ -322,6 +327,7 @@ export function WorkflowPreview({
               <div className='pointer-events-none absolute top-0 right-0 left-0 z-10 flex items-center justify-between px-4 py-3'>
                 <span className='text-[13px] text-[var(--text-muted)]'>{workflow.name}</span>
                 <button
+                  ref={closeButtonRef}
                   type='button'
                   aria-label='Close'
                   onClick={() => setExpanded(false)}

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -5,9 +5,6 @@ const withMDX = createMDX()
 
 const config: NextConfig = {
   reactStrictMode: true,
-  // Safe here since this repo's source is already fully public on GitHub -
-  // no additional exposure versus Next's default (disabled to avoid leaking
-  // source on the client).
   productionBrowserSourceMaps: true,
   transpilePackages: ['@sim/emcn', '@sim/workflow-renderer'],
   images: {

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -5,6 +5,10 @@ const withMDX = createMDX()
 
 const config: NextConfig = {
   reactStrictMode: true,
+  // Safe here since this repo's source is already fully public on GitHub -
+  // no additional exposure versus Next's default (disabled to avoid leaking
+  // source on the client).
+  productionBrowserSourceMaps: true,
   transpilePackages: ['@sim/emcn', '@sim/workflow-renderer'],
   images: {
     unoptimized: true,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -36,7 +36,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "remark-breaks": "^4.0.0",
-    "shiki": "4.0.0",
+    "shiki": "4.3.1",
     "streamdown": "2.5.0",
     "tailwind-merge": "^3.0.2",
     "reactflow": "^11.11.4",

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -20,6 +20,6 @@ export default function proxy(request: NextRequest, event: NextFetchEvent) {
 
 export const config = {
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon|static|robots.txt|sitemap.xml|llms.txt|llms-full.txt).*)',
+    '/((?!api|_next/static|_next/image|favicon|icon.svg|static|robots.txt|sitemap.xml|llms.txt|llms-full.txt).*)',
   ],
 }

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "react-dom": "19.2.4",
         "reactflow": "^11.11.4",
         "remark-breaks": "^4.0.0",
-        "shiki": "4.0.0",
+        "shiki": "4.3.1",
         "streamdown": "2.5.0",
         "tailwind-merge": "^3.0.2",
         "zod": "^4.3.6",
@@ -1542,19 +1542,19 @@
 
     "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
 
-    "@shikijs/core": ["@shikijs/core@4.0.0", "", { "dependencies": { "@shikijs/primitive": "4.0.0", "@shikijs/types": "4.0.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-tvV94Dwyz4qFZ8R0MUaFx5Yptgy8yrloa4dwynEJDGjKz+8vqO8Q6FmPZL9W1gSzFHOUMOGQzIHK62aGourFxA=="],
+    "@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
 
-    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.0", "", { "dependencies": { "@shikijs/types": "4.0.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-+PEyTS+JTz2lLy2C1Dwwx6hzoehIzqxQYh5MEjv9V4JtSabx+bIkRHfQT+6DnBmPAplGH0exBknWeiJSXC7w1w=="],
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ=="],
 
-    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.0", "", { "dependencies": { "@shikijs/types": "4.0.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-KXmq4b6Xw16+4+rz5M4NZMoe/tzs5kTOMSJz8+LCyxSrwmxwTBAM/ab85iSO2Gw79E47HkW4B9HPHUXhrNOivw=="],
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg=="],
 
-    "@shikijs/langs": ["@shikijs/langs@4.0.0", "", { "dependencies": { "@shikijs/types": "4.0.0" } }, "sha512-dSAT6fBcnOcYZQMWZO8+OmzUKKm+OO0As/qZ3TXLiSy0JsCTEYz1TaX7TDupnYLz7dr0oF2DOTEgPocx1D3aFw=="],
+    "@shikijs/langs": ["@shikijs/langs@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ=="],
 
-    "@shikijs/primitive": ["@shikijs/primitive@4.0.0", "", { "dependencies": { "@shikijs/types": "4.0.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-6K2zD7JTgsyFc2vM1rqy8eRGC8D5Hius3qzVONjq2lHMrqfTSn1HcGeJZiFPYSV9m3DQuBHncBbA5xe0hKSOkQ=="],
+    "@shikijs/primitive": ["@shikijs/primitive@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A=="],
 
-    "@shikijs/themes": ["@shikijs/themes@4.0.0", "", { "dependencies": { "@shikijs/types": "4.0.0" } }, "sha512-xe42kvxOXan5ouXxULez6qwDNUJkoP6kicfg0wKuJBkeIaHLxZBZa2gEGYutL1q27DQZ5+XoR6caVX+E/aNR5A=="],
+    "@shikijs/themes": ["@shikijs/themes@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA=="],
 
-    "@shikijs/types": ["@shikijs/types@4.0.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-LCnfBTtQKNtJyc1qMShZr2dJt1uxNI6pI0/YTc2DSNET91aUvnMGHUHsucVCC5AJVcv5XyBqk2NgYRwd20EjbA=="],
+    "@shikijs/types": ["@shikijs/types@4.3.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
@@ -2680,7 +2680,7 @@
 
     "fraction.js": ["fraction.js@4.3.7", "", {}, "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew=="],
 
-    "framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
+    "framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
 
     "free-email-domains": ["free-email-domains@1.2.25", "", {}, "sha512-Uf2rJUjo/agIgQzt6od9XcHrR6rfIMD6TwsNVSJVJCHzjPWWsqjCb+EaQ2VVVY9M55+JB3V0k6ru5sHTGx/ZfA=="],
 
@@ -3246,9 +3246,9 @@
 
     "mongodb-connection-string-url": ["mongodb-connection-string-url@3.0.2", "", { "dependencies": { "@types/whatwg-url": "^11.0.2", "whatwg-url": "^14.1.0 || ^13.0.0" } }, "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA=="],
 
-    "motion": ["motion@12.40.0", "", { "dependencies": { "framer-motion": "^12.40.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA=="],
+    "motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
 
-    "motion-dom": ["motion-dom@12.40.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg=="],
+    "motion-dom": ["motion-dom@12.42.2", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA=="],
 
     "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
@@ -3730,7 +3730,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shiki": ["shiki@4.0.0", "", { "dependencies": { "@shikijs/core": "4.0.0", "@shikijs/engine-javascript": "4.0.0", "@shikijs/engine-oniguruma": "4.0.0", "@shikijs/langs": "4.0.0", "@shikijs/themes": "4.0.0", "@shikijs/types": "4.0.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-rjKoiw30ZaFsM0xnPPwxco/Jftz/XXqZkcQZBTX4LGheDw8gCDEH87jdgaKDEG3FZO2bFOK27+sR/sDHhbBXfg=="],
+    "shiki": ["shiki@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/engine-javascript": "4.3.1", "@shikijs/engine-oniguruma": "4.3.1", "@shikijs/langs": "4.3.1", "@shikijs/themes": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw=="],
 
     "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
@@ -4560,6 +4560,8 @@
 
     "docs/tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
+    "docs/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "docx/@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "docx/nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
@@ -4598,25 +4600,21 @@
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "fumadocs-core/shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
-
     "fumadocs-mdx/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "fumadocs-mdx/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "fumadocs-openapi/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
 
     "fumadocs-openapi/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
-    "fumadocs-openapi/lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
-
-    "fumadocs-openapi/shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
+    "fumadocs-openapi/lucide-react": ["lucide-react@1.23.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw=="],
 
     "fumadocs-openapi/tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "fumadocs-ui/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
 
-    "fumadocs-ui/lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
-
-    "fumadocs-ui/shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
+    "fumadocs-ui/lucide-react": ["lucide-react@1.23.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw=="],
 
     "fumadocs-ui/tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
@@ -5020,18 +5018,6 @@
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "fumadocs-core/shiki/@shikijs/core": ["@shikijs/core@4.2.0", "", { "dependencies": { "@shikijs/primitive": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ=="],
-
-    "fumadocs-core/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og=="],
-
-    "fumadocs-core/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g=="],
-
-    "fumadocs-core/shiki/@shikijs/langs": ["@shikijs/langs@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ=="],
-
-    "fumadocs-core/shiki/@shikijs/themes": ["@shikijs/themes@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w=="],
-
-    "fumadocs-core/shiki/@shikijs/types": ["@shikijs/types@4.2.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw=="],
-
     "fumadocs-mdx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
     "fumadocs-mdx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
@@ -5083,30 +5069,6 @@
     "fumadocs-mdx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
     "fumadocs-mdx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
-
-    "fumadocs-openapi/shiki/@shikijs/core": ["@shikijs/core@4.2.0", "", { "dependencies": { "@shikijs/primitive": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ=="],
-
-    "fumadocs-openapi/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og=="],
-
-    "fumadocs-openapi/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g=="],
-
-    "fumadocs-openapi/shiki/@shikijs/langs": ["@shikijs/langs@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ=="],
-
-    "fumadocs-openapi/shiki/@shikijs/themes": ["@shikijs/themes@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w=="],
-
-    "fumadocs-openapi/shiki/@shikijs/types": ["@shikijs/types@4.2.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw=="],
-
-    "fumadocs-ui/shiki/@shikijs/core": ["@shikijs/core@4.2.0", "", { "dependencies": { "@shikijs/primitive": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ=="],
-
-    "fumadocs-ui/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og=="],
-
-    "fumadocs-ui/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g=="],
-
-    "fumadocs-ui/shiki/@shikijs/langs": ["@shikijs/langs@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ=="],
-
-    "fumadocs-ui/shiki/@shikijs/themes": ["@shikijs/themes@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w=="],
-
-    "fumadocs-ui/shiki/@shikijs/types": ["@shikijs/types@4.2.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw=="],
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
@@ -5329,12 +5291,6 @@
     "@trigger.dev/core/socket.io/engine.io/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
 
     "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "fumadocs-core/shiki/@shikijs/core/@shikijs/primitive": ["@shikijs/primitive@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA=="],
-
-    "fumadocs-openapi/shiki/@shikijs/core/@shikijs/primitive": ["@shikijs/primitive@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA=="],
-
-    "fumadocs-ui/shiki/@shikijs/core/@shikijs/primitive": ["@shikijs/primitive@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA=="],
 
     "groq-sdk/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 


### PR DESCRIPTION
## Summary
- Fixed the docs sidebar prefetching every page in the doc tree on initial load (dozens of concurrent RSC requests) - wired fumadocs' `sidebar.prefetch` option through the custom sidebar components, which were bypassing it via plain `next/link`
- Fixed the `<Video>` component eagerly downloading full video files on mount (`autoPlay` forces a full fetch regardless of `preload`) - gated loading behind an IntersectionObserver, fixes every doc page that embeds one
- Fixed `/icon.svg` 404ing in production - the i18n middleware matcher excluded favicon/robots.txt/etc but not this file
- Enabled `productionBrowserSourceMaps` (repo is already public, zero exposure, real debuggability win)
- Bumped `shiki` 4.0.0 → 4.3.1 and `fumadocs-core`/`fumadocs-ui`/`fumadocs-mdx` to their latest compatible versions (verified via build + visual smoke test). Attempted the `fumadocs-openapi` major bump too but reverted it - v11's page factory became client-only, a real breaking change beyond its declared peer deps that needs its own migration PR, not a rushed dependency bump

## Type of Change
- [x] Bug fix
- [x] Performance improvement

## Testing
Measured empirically under real trace-based (devtools) CPU/network throttling against the live site and a clean local production build:
- Performance: 59 → 71 (mobile, devtools throttling)
- RSC prefetch requests on page load: 63 → 11
- Video requests/bytes on page load: 3 requests / 5MB → 0
- Verified full production build succeeds cleanly (3974 pages, including API reference)
- Verified Shiki syntax highlighting still renders correctly after the bump

Found and documented (not fixed, pre-existing, unrelated to this diff): a React hydration warning (#418) present on live production before any of these changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)