### PR TITLE
fix(slack): stop requesting unapproved OAuth scopes that break connect

### DIFF
--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -735,9 +735,12 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
           'groups:write',
           'chat:write',
           'chat:write.public',
-          'assistant:write',
-          'app_mentions:read',
-          'im:history',
+          // TODO: Re-add once Slack app review approves these. Requesting a scope
+          // the app is not yet approved for makes Slack reject the entire
+          // authorization with "unapproved permissions requested", breaking connect.
+          // 'assistant:write',
+          // 'app_mentions:read',
+          // 'im:history',
           'im:write',
           'im:read',
           'users:read',
@@ -748,7 +751,7 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
           'canvases:write',
           'reactions:write',
           'reactions:read',
-          'pins:read',
+          // TODO: Add 'pins:read' once Slack app review is approved
         ],
       },
     },


### PR DESCRIPTION
## Summary
- Connecting/reconnecting the **sim bot** (official Sim Slack app) fails with `Unapproved permissions requested: assistant:write, app_mentions:read, im:history, pins:read`. Slack rejects the **entire** authorization when it requests a scope the app isn't yet approved for.
- #5323 added those four scopes to the requested set, but the official Slack app hasn't been approved for them — so every native Slack connect regressed.
- Commented them out (same pattern as the existing `users:read.email` TODO). Core scopes — `chat:write`, `im:write`, channel/group ops, files, reactions, canvases — stay, so connect + send-message/DM work again. The four gated scopes get re-added once Slack app review approves them.

## Type of Change
- [x] Bug fix (regression)

## Testing
Tested manually; biome clean. Data-only change to the requested OAuth scope list.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)