### PR TITLE
fix(landing): fix 404ing OG images for every model and integration page

### DIFF
--- a/apps/sim/app/(landing)/integrations/(shell)/[slug]/opengraph-image.tsx
+++ b/apps/sim/app/(landing)/integrations/(shell)/[slug]/opengraph-image.tsx
@@ -19,6 +19,17 @@ const AUTH_LABEL: Record<AuthType, string> = {
   none: 'No auth required',
 }
 
+/**
+ * The sibling page.tsx sets `dynamicParams = false`, a segment-level
+ * restriction that also blocks this metadata route from rendering any
+ * param combination it wasn't statically generated for - but Next does not
+ * share generateStaticParams between a page and its sibling metadata
+ * routes, so without this export every integration's OG image 404s.
+ */
+export async function generateStaticParams() {
+  return integrations.map((integration) => ({ slug: integration.slug }))
+}
+
 export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
   const integration = bySlug.get(slug)

--- a/apps/sim/app/(landing)/models/(shell)/[provider]/[model]/opengraph-image.tsx
+++ b/apps/sim/app/(landing)/models/(shell)/[provider]/[model]/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 import {
+  ALL_CATALOG_MODELS,
   formatPrice,
   formatTokenCount,
   getModelBySlug,
@@ -11,6 +12,20 @@ export const contentType = 'image/png'
 export const size = {
   width: 1200,
   height: 630,
+}
+
+/**
+ * The sibling page.tsx sets `dynamicParams = false`, a segment-level
+ * restriction that also blocks this metadata route from rendering any
+ * param combination it wasn't statically generated for - but Next does not
+ * share generateStaticParams between a page and its sibling metadata
+ * routes, so without this export every model's OG image 404s.
+ */
+export async function generateStaticParams() {
+  return ALL_CATALOG_MODELS.map((model) => ({
+    provider: model.providerSlug,
+    model: model.slug,
+  }))
 }
 
 export default async function Image({

--- a/apps/sim/app/(landing)/models/(shell)/[provider]/opengraph-image.tsx
+++ b/apps/sim/app/(landing)/models/(shell)/[provider]/opengraph-image.tsx
@@ -5,6 +5,7 @@ import {
   getCheapestProviderModel,
   getLargestContextProviderModel,
   getProviderBySlug,
+  MODEL_PROVIDERS_WITH_CATALOGS,
 } from '@/app/(landing)/models/utils'
 import { createLandingOgImage } from '@/app/(landing)/og-utils'
 
@@ -12,6 +13,19 @@ export const contentType = 'image/png'
 export const size = {
   width: 1200,
   height: 630,
+}
+
+/**
+ * The sibling page.tsx sets `dynamicParams = false`, a segment-level
+ * restriction that also blocks this metadata route from rendering any
+ * param combination it wasn't statically generated for - but Next does not
+ * share generateStaticParams between a page and its sibling metadata
+ * routes, so without this export every provider's OG image 404s.
+ */
+export async function generateStaticParams() {
+  return MODEL_PROVIDERS_WITH_CATALOGS.map((provider) => ({
+    provider: provider.slug,
+  }))
 }
 
 export default async function Image({ params }: { params: Promise<{ provider: string }> }) {


### PR DESCRIPTION
## Summary
- Fixed every `/models/{provider}/{model}/opengraph-image` and `/integrations/{slug}/opengraph-image` route 404ing (~230 pages total, flagged by an SEO crawl of ~110 model pages plus every integration)
- Root cause: `page.tsx` sets `dynamicParams = false` for these routes, but Next doesn't share `generateStaticParams` between a page and its sibling metadata routes (`opengraph-image.tsx`) - since none of the three OG image files had their own `generateStaticParams`, every param was "unknown" and 404d
- Added a matching `generateStaticParams` to all three affected `opengraph-image.tsx` files

## Type of Change
- [x] Bug fix

## Testing
Verified on a real production build - the exact URLs in the SEO report (bare `/opengraph-image`, no suffix) aren't actually how Next serves these; the real URL has a build-generated hash suffix embedded in each page's `<meta property="og:image">` tag. Confirmed via curl that the actual embedded URL for both a model page and an integration page went from 404 to 200 after the fix.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)