### PR TITLE
improvement(flint): set json language on the pages code input

### DIFF
--- a/apps/sim/blocks/blocks/flint.ts
+++ b/apps/sim/blocks/blocks/flint.ts
@@ -80,6 +80,7 @@ export const FlintBlock: BlockConfig = {
       id: 'items',
       title: 'Pages (JSON)',
       type: 'code',
+      language: 'json',
       placeholder: `[
   {
     "targetPageSlug": "/case-studies/acme-corp",


### PR DESCRIPTION
## Summary
- Follow-up to #5641 (merged): set `language: 'json'` on the Flint block's Pages (JSON) code input so the editor applies JSON highlighting and inline validation, matching the pattern used by other JSON code inputs (apify, a2a)

## Type of Change
- [x] Improvement

## Testing
Typecheck, biome, and block registry tests (83) pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)