### PR TITLE
fix(landing): complete Organization schema with legalName, foundingDate, and address

### DIFF
--- a/apps/sim/app/(landing)/components/site-structured-data/site-structured-data.tsx
+++ b/apps/sim/app/(landing)/components/site-structured-data/site-structured-data.tsx
@@ -9,9 +9,19 @@ const SITE_JSON_LD = {
       '@id': `${SITE_URL}#organization`,
       name: 'Sim',
       alternateName: 'Sim Studio',
+      legalName: 'Sim, Inc',
       description:
         'Sim is the open-source AI workspace where teams build, deploy, and manage AI agents. Connect 1,000+ integrations and every major LLM to create agents that automate real work.',
       url: SITE_URL,
+      foundingDate: '2025',
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: '80 Langton St',
+        addressLocality: 'San Francisco',
+        addressRegion: 'CA',
+        postalCode: '94103',
+        addressCountry: 'US',
+      },
       logo: {
         '@type': 'ImageObject',
         '@id': `${SITE_URL}#logo`,
@@ -61,7 +71,8 @@ const SITE_JSON_LD = {
  * fragment) - every per-page emitter (platform, solutions, pricing, home) points
  * `isPartOf`/`publisher`/`about` at these exact ids, so the graph resolves.
  *
- * Maintenance: `sameAs` must match the Footer social links.
+ * Maintenance: `sameAs` must match the Footer social links. `legalName`
+ * matches the entity named throughout `apps/sim/app/(landing)/terms`.
  */
 export function SiteStructuredData() {
   return <JsonLd data={SITE_JSON_LD} />


### PR DESCRIPTION
## Summary
- Follow-up to #5638, which intentionally omitted `legalName`, `foundingDate`, and `address` from the Organization JSON-LD pending real values
- Adds `legalName: "Sim, Inc"` — matches the entity named throughout the Terms of Service
- Adds `foundingDate: "2025"`
- Adds `address` (real registered office: 80 Langton St, San Francisco, CA 94103) as a `PostalAddress`

Researched schema.org Organization property value before adding: `address` and `legalName` are genuine trust/entity signals for Google's Knowledge Panel and AI answer engines (ChatGPT, Perplexity, Google AI Overviews) that parse schema for verified facts; `foundingDate` is lower-impact but standard practice and harmless to include. All three are purely additive JSON-LD fields — no risk of regression to existing rich results.

## Type of Change
- [x] Bug fix

## Testing
- `bunx tsc --noEmit` clean
- `bun run lint` clean
- Real production build + curled `/pricing` — confirmed `legalName`, `foundingDate`, `address` all render correctly in the Organization JSON-LD

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)