### PR TITLE
fix(emcn): stop wiping virtualized code viewer row measurements on content changes

### DIFF
--- a/packages/emcn/src/components/code/code.tsx
+++ b/packages/emcn/src/components/code/code.tsx
@@ -1015,12 +1015,21 @@ const VirtualizedViewerInner = memo(function VirtualizedViewerInner({
   })
 
   /**
-   * Re-measure rows when wrap mode or content changes so dynamic (wrapped) row
-   * heights stay accurate. Fixed-height (`nowrap`) rows do not need re-measuring.
+   * Drop cached row measurements when leaving wrap mode: the measureElement
+   * refs detach with their wrapped heights still cached, and falling back to
+   * the fixed estimate is exactly correct for nowrap rows. Entering wrap needs
+   * no reset — refs re-attach and re-measure as rows render.
+   *
+   * Deliberately NOT keyed on content (`visibleLines`): `measure()` wipes the
+   * cache without re-measuring mounted rows (ResizeObserver only fires on size
+   * changes; React never re-invokes an unchanged ref), so a content change that
+   * keeps row heights — Prism resolving its lazy load, search `<mark>`
+   * highlighting — would permanently collapse wrapped rows onto the rows below.
+   * Genuine height changes are caught by the per-row ResizeObserver.
    */
   useEffect(() => {
-    virtualizer.measure()
-  }, [wrapText, visibleLines, virtualizer])
+    if (!wrapText) virtualizer.measure()
+  }, [wrapText, virtualizer])
 
   useEffect(() => {
     if (!searchQuery?.trim() || matchCount === 0 || !scrollRef.current) return


### PR DESCRIPTION
## Summary
- Fixes wrapped lines overlapping in the virtualized `Code.Viewer` (workflow editor terminal Output/Input panel) — reported in Slack with a wrapped `conversationId` line drawing over the row below it
- Root cause: the re-measure effect called `virtualizer.measure()` on every `visibleLines` identity change. TanStack Virtual's `measure()` wipes the size cache without re-measuring mounted rows — ResizeObserver only fires on size changes and React never re-invokes an unchanged `measureElement` ref — so any content change that keeps row heights (Prism finishing its lazy load right after first open, search-highlight `<mark>` wrapping) permanently collapsed every wrapped row to the 21px estimate
- The wipe now runs only when leaving wrap mode, the one transition that needs it: refs detach with wrapped heights still cached, and falling back to the fixed estimate is exactly correct for nowrap. Entering wrap re-measures as refs attach, and genuine height changes are caught by the per-row ResizeObserver, so no other trigger is needed (this also removes a redundant mount-time wipe + re-measure pass)

## Type of Change
- [x] Bug fix

## Testing
Reproduced deterministically in an isolated Playwright harness rendering `Code.Viewer` with `virtualized` + `wrapText`: before the fix, a height-preserving content change left rows at `translateY(0/21/42…)` while wrapped rows measured taller (overlap); after, every row's offset equals the cumulative measured heights. Ran a 12-scenario matrix (prism lazy-load, search set/clear, JSON collapse toggle on/off, content change both directions, width narrow/restore, wrap off/on, search after wrap cycle): original code fails 8/12 with overlap, fixed code passes 12/12 including every scenario the original passed. Typecheck (emcn + sim) and biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)