### PR TITLE
fix(chat): reverse shimmer sweep to left-to-right

### DIFF
--- a/apps/sim/components/ui/shimmer-text.module.css
+++ b/apps/sim/components/ui/shimmer-text.module.css
@@ -13,7 +13,7 @@
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
-  animation: shimmer-sweep 2.2s linear infinite;
+  animation: shimmer-sweep 2.2s linear infinite reverse;
 }
 
 :global(.dark) .shimmer {


### PR DESCRIPTION
## Summary
- Flipped the active-label shimmer (subagent/tool rows) to sweep left-to-right instead of right-to-left by adding `reverse` to the animation shorthand
- Reduced-motion pulse fallback unaffected — it overrides the `animation` shorthand entirely with the symmetric `shimmer-pulse`

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run lint` and `bun run check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)