### PR TITLE
feat(community): add /linkedin redirect and route email footer LinkedIn through it

### DIFF
--- a/apps/sim/components/emails/components/email-footer.tsx
+++ b/apps/sim/components/emails/components/email-footer.tsx
@@ -81,10 +81,7 @@ export function EmailFooter({
                             </Link>
                           </td>
                           <td align='left' style={{ padding: '0 8px' }}>
-                            <Link
-                              href='https://www.linkedin.com/company/simdotai'
-                              rel='noopener noreferrer'
-                            >
+                            <Link href={`${baseUrl}/linkedin`} rel='noopener noreferrer'>
                               <Img
                                 src={`${baseUrl}/static/linkedin-icon.png`}
                                 width='20'

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -340,6 +340,11 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
       {
+        source: '/linkedin',
+        destination: 'https://www.linkedin.com/company/simstudioai/',
+        permanent: false,
+      },
+      {
         source: '/github',
         destination: 'https://github.com/simstudioai/sim',
         permanent: false,


### PR DESCRIPTION
## Summary
- Add `/linkedin` redirect (`sim.ai/linkedin` → `linkedin.com/company/simstudioai/`) alongside the existing `/discord`, `/slack`, `/x`, `/github` social redirects
- Route the transactional email footer's LinkedIn icon through `{baseUrl}/linkedin` like the X/GitHub/Slack icons, instead of a hardcoded URL
- Fixes a slug inconsistency: the email footer pointed at `linkedin.com/company/simdotai` while the landing footer and Organization JSON-LD use `linkedin.com/company/simstudioai/` — everything now resolves to the latter

## Type of Change
- [x] Improvement

## Testing
Verified on a dev server that all five social redirects 307 to the correct destinations. Lint passes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)