### PR TITLE
feat(copilot): add share_file tool + surface file share state to the agent

### DIFF
--- a/apps/sim/app/api/workspaces/[id]/files/[fileId]/share/route.ts
+++ b/apps/sim/app/api/workspaces/[id]/files/[fileId]/share/route.ts
@@ -104,8 +104,14 @@ export const PUT = withRouteHandler(
       // master on/off and the per-auth-type allow-list); disabling is always
       // allowed so users can still un-share after the policy is turned on.
       if (isActive) {
+        // Validate the auth type that will ACTUALLY be persisted. upsertFileShare
+        // falls back to the existing share's authType when none is passed, so a bare
+        // re-enable must be checked against that stored mode — not 'public' — or a
+        // now-disallowed password/email/sso share could be silently reactivated.
+        const existingShare = await getShareForResource('file', fileId)
+        const effectiveAuthType = authType ?? existingShare?.authType ?? 'public'
         try {
-          await validatePublicFileSharing(session.user.id, workspaceId, authType ?? 'public')
+          await validatePublicFileSharing(session.user.id, workspaceId, effectiveAuthType)
         } catch (error) {
           if (error instanceof PublicFileSharingNotAllowedError) {
             logger.warn(`[${requestId}] Public file sharing disabled for workspace ${workspaceId}`)

--- a/apps/sim/lib/copilot/generated/tool-catalog-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-catalog-v1.ts
@@ -94,6 +94,7 @@ export interface ToolCatalogEntry {
     | 'set_block_enabled'
     | 'set_environment_variables'
     | 'set_global_workflow_variables'
+    | 'share_file'
     | 'table'
     | 'update_deployment_version'
     | 'update_scheduled_task_history'
@@ -191,6 +192,7 @@ export interface ToolCatalogEntry {
     | 'set_block_enabled'
     | 'set_environment_variables'
     | 'set_global_workflow_variables'
+    | 'share_file'
     | 'table'
     | 'update_deployment_version'
     | 'update_scheduled_task_history'
@@ -3925,6 +3927,60 @@ export const SetGlobalWorkflowVariables: ToolCatalogEntry = {
   requiredPermission: 'write',
 }
 
+export const ShareFile: ToolCatalogEntry = {
+  id: 'share_file',
+  name: 'share_file',
+  route: 'sim',
+  mode: 'async',
+  parameters: {
+    type: 'object',
+    properties: {
+      action: {
+        type: 'string',
+        description: 'Whether to create/update the share link or deactivate it.',
+        enum: ['share', 'unshare'],
+        default: 'share',
+      },
+      allowedEmails: {
+        type: 'array',
+        description:
+          'Allowed emails or "@domain" patterns for authType "email" or "sso". Ignored for other auth types.',
+        items: { type: 'string' },
+      },
+      authType: {
+        type: 'string',
+        description: 'How viewers authenticate to open the link. Ignored for unshare.',
+        enum: ['public', 'password', 'email', 'sso'],
+        default: 'public',
+      },
+      password: {
+        type: 'string',
+        description:
+          'Password for authType "password". Leave empty to keep the file\'s existing password when re-sharing an already password-protected file. Ignored for other auth types.',
+      },
+      path: {
+        type: 'string',
+        description: 'Canonical workspace file VFS path to share, e.g. "files/Reports/Q4.md".',
+      },
+    },
+    required: ['path'],
+  },
+  resultSchema: {
+    type: 'object',
+    properties: {
+      data: {
+        type: 'object',
+        description:
+          'Share state. Contains url (the {baseUrl}/f/{token} link), token, authType, hasPassword, and isActive.',
+      },
+      message: { type: 'string', description: 'Human-readable outcome.' },
+      success: { type: 'boolean', description: 'Whether the share action succeeded.' },
+    },
+    required: ['success', 'message'],
+  },
+  requiredPermission: 'write',
+}
+
 export const Table: ToolCatalogEntry = {
   id: 'table',
   name: 'table',
@@ -4879,6 +4935,7 @@ export const TOOL_CATALOG: Record<string, ToolCatalogEntry> = {
   [SetBlockEnabled.id]: SetBlockEnabled,
   [SetEnvironmentVariables.id]: SetEnvironmentVariables,
   [SetGlobalWorkflowVariables.id]: SetGlobalWorkflowVariables,
+  [ShareFile.id]: ShareFile,
   [Table.id]: Table,
   [UpdateDeploymentVersion.id]: UpdateDeploymentVersion,
   [UpdateScheduledTaskHistory.id]: UpdateScheduledTaskHistory,

--- a/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
@@ -3715,6 +3715,62 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
+  share_file: {
+    parameters: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          description: 'Whether to create/update the share link or deactivate it.',
+          enum: ['share', 'unshare'],
+          default: 'share',
+        },
+        allowedEmails: {
+          type: 'array',
+          description:
+            'Allowed emails or "@domain" patterns for authType "email" or "sso". Ignored for other auth types.',
+          items: {
+            type: 'string',
+          },
+        },
+        authType: {
+          type: 'string',
+          description: 'How viewers authenticate to open the link. Ignored for unshare.',
+          enum: ['public', 'password', 'email', 'sso'],
+          default: 'public',
+        },
+        password: {
+          type: 'string',
+          description:
+            'Password for authType "password". Leave empty to keep the file\'s existing password when re-sharing an already password-protected file. Ignored for other auth types.',
+        },
+        path: {
+          type: 'string',
+          description: 'Canonical workspace file VFS path to share, e.g. "files/Reports/Q4.md".',
+        },
+      },
+      required: ['path'],
+    },
+    resultSchema: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          description:
+            'Share state. Contains url (the {baseUrl}/f/{token} link), token, authType, hasPassword, and isActive.',
+        },
+        message: {
+          type: 'string',
+          description: 'Human-readable outcome.',
+        },
+        success: {
+          type: 'boolean',
+          description: 'Whether the share action succeeded.',
+        },
+      },
+      required: ['success', 'message'],
+    },
+  },
   table: {
     parameters: {
       properties: {

--- a/apps/sim/lib/copilot/tools/server/files/share-file.ts
+++ b/apps/sim/lib/copilot/tools/server/files/share-file.ts
@@ -1,0 +1,186 @@
+import { AuditAction, AuditResourceType, recordAudit } from '@sim/audit'
+import { createLogger } from '@sim/logger'
+import type { ShareAuthType } from '@/lib/api/contracts/public-shares'
+import { ShareFile } from '@/lib/copilot/generated/tool-catalog-v1'
+import { ensureWorkspaceAccess } from '@/lib/copilot/tools/handlers/access'
+import {
+  assertServerToolNotAborted,
+  type BaseServerTool,
+  type ServerToolContext,
+} from '@/lib/copilot/tools/server/base-tool'
+import {
+  getShareForResource,
+  ShareValidationError,
+  upsertFileShare,
+} from '@/lib/public-shares/share-manager'
+import {
+  getWorkspaceFile,
+  resolveWorkspaceFileReference,
+} from '@/lib/uploads/contexts/workspace/workspace-file-manager'
+import {
+  PublicFileSharingNotAllowedError,
+  validatePublicFileSharing,
+} from '@/ee/access-control/utils/permission-check'
+
+const logger = createLogger('ShareFileServerTool')
+
+interface ShareFileArgs {
+  path?: string
+  fileId?: string
+  action?: 'share' | 'unshare'
+  authType?: ShareAuthType
+  password?: string
+  allowedEmails?: string[]
+  args?: Record<string, unknown>
+}
+
+interface ShareFileResult {
+  success: boolean
+  message: string
+  data?: {
+    url: string
+    token: string
+    authType: ShareAuthType
+    hasPassword: boolean
+    isActive: boolean
+  }
+}
+
+export const shareFileServerTool: BaseServerTool<ShareFileArgs, ShareFileResult> = {
+  name: ShareFile.id,
+  async execute(params: ShareFileArgs, context?: ServerToolContext): Promise<ShareFileResult> {
+    if (!context?.userId) {
+      throw new Error('Authentication required')
+    }
+    const workspaceId = context.workspaceId
+    if (!workspaceId) {
+      return { success: false, message: 'Workspace ID is required' }
+    }
+    await ensureWorkspaceAccess(workspaceId, context.userId, 'write')
+
+    const nested = params.args
+    const path = params.path || (nested?.path as string) || ''
+    const legacyFileId = params.fileId || (nested?.fileId as string) || ''
+    const action = (params.action || (nested?.action as string) || 'share') as 'share' | 'unshare'
+    const authType = (params.authType || (nested?.authType as ShareAuthType | undefined)) as
+      | ShareAuthType
+      | undefined
+    const password = params.password || (nested?.password as string) || undefined
+    const allowedEmails =
+      params.allowedEmails || (nested?.allowedEmails as string[] | undefined) || undefined
+
+    const targetRef = path || legacyFileId
+    if (!targetRef) return { success: false, message: 'path is required' }
+
+    const existingFile = path
+      ? await resolveWorkspaceFileReference(workspaceId, path)
+      : await getWorkspaceFile(workspaceId, legacyFileId)
+    if (!existingFile) {
+      return { success: false, message: `File not found: ${targetRef}` }
+    }
+    const fileId = existingFile.id
+    const isActive = action !== 'unshare'
+    const existingShare = await getShareForResource('file', fileId)
+
+    // Unsharing a file that was never shared (or is already disabled) is a no-op:
+    // never insert an inactive row, emit a FILE_SHARE_DISABLED audit, or return a
+    // link claiming a share was revoked when none existed.
+    if (!isActive && !existingShare?.isActive) {
+      return {
+        success: true,
+        message: `"${existingFile.name}" isn't shared — nothing to unshare.`,
+      }
+    }
+
+    // Enabling a share is gated by the org's access-control policy (both the
+    // master on/off and the per-auth-type allow-list); disabling is always
+    // allowed so users can still un-share after the policy is turned on.
+    if (isActive) {
+      // Validate the auth type that will ACTUALLY be persisted. upsertFileShare
+      // falls back to the existing share's authType when none is passed, so a bare
+      // re-enable must be checked against that stored mode — not 'public' — or a
+      // now-disallowed password/email/sso share could be silently reactivated.
+      const effectiveAuthType = authType ?? existingShare?.authType ?? 'public'
+      try {
+        await validatePublicFileSharing(context.userId, workspaceId, effectiveAuthType)
+      } catch (error) {
+        if (error instanceof PublicFileSharingNotAllowedError) {
+          return { success: false, message: error.message }
+        }
+        throw error
+      }
+    }
+
+    assertServerToolNotAborted(context)
+
+    let share
+    try {
+      share = await upsertFileShare({
+        workspaceId,
+        fileId,
+        userId: context.userId,
+        isActive,
+        authType,
+        password,
+        allowedEmails,
+      })
+    } catch (error) {
+      if (error instanceof ShareValidationError) {
+        return { success: false, message: error.message }
+      }
+      throw error
+    }
+
+    logger.info(`${isActive ? 'Enabled' : 'Disabled'} share for file via share_file`, {
+      fileId,
+      workspaceId,
+      authType: share.authType,
+      userId: context.userId,
+    })
+
+    recordAudit({
+      workspaceId,
+      actorId: context.userId,
+      action: isActive ? AuditAction.FILE_SHARED : AuditAction.FILE_SHARE_DISABLED,
+      resourceType: AuditResourceType.FILE,
+      resourceId: fileId,
+      resourceName: existingFile.name,
+      description: `${isActive ? 'Enabled' : 'Disabled'} public share for "${existingFile.name}"`,
+    })
+
+    if (!isActive) {
+      return {
+        success: true,
+        message: `Stopped sharing "${existingFile.name}". The previous link no longer works.`,
+        data: {
+          url: share.url,
+          token: share.token,
+          authType: share.authType,
+          hasPassword: share.hasPassword,
+          isActive: share.isActive,
+        },
+      }
+    }
+
+    const authNote =
+      share.authType === 'password'
+        ? ' (password-protected — share the password separately)'
+        : share.authType === 'email'
+          ? ' (restricted to allowed emails via one-time code)'
+          : share.authType === 'sso'
+            ? ' (restricted to allowed emails via SSO)'
+            : ''
+
+    return {
+      success: true,
+      message: `Shared "${existingFile.name}"${authNote}: ${share.url}`,
+      data: {
+        url: share.url,
+        token: share.token,
+        authType: share.authType,
+        hasPassword: share.hasPassword,
+        isActive: share.isActive,
+      },
+    }
+  },
+}

--- a/apps/sim/lib/copilot/tools/server/router.ts
+++ b/apps/sim/lib/copilot/tools/server/router.ts
@@ -40,6 +40,7 @@ import {
   renameFileFolderServerTool,
 } from '@/lib/copilot/tools/server/files/file-folders'
 import { renameFileServerTool } from '@/lib/copilot/tools/server/files/rename-file'
+import { shareFileServerTool } from '@/lib/copilot/tools/server/files/share-file'
 import { workspaceFileServerTool } from '@/lib/copilot/tools/server/files/workspace-file'
 import { validateGeneratedToolPayload } from '@/lib/copilot/tools/server/generated-schema'
 import { generateImageServerTool } from '@/lib/copilot/tools/server/image/generate-image'
@@ -129,6 +130,7 @@ const WRITE_ACTIONS: Record<string, string[]> = {
   [CreateFile.id]: ['*'],
   rename_file: ['*'],
   [DeleteFile.id]: ['*'],
+  [shareFileServerTool.name]: ['*'],
   move_file: ['*'],
   create_file_folder: ['*'],
   rename_file_folder: ['*'],
@@ -176,6 +178,7 @@ const baseServerToolRegistry: Record<string, BaseServerTool> = {
   [createFileServerTool.name]: createFileServerTool,
   [renameFileServerTool.name]: renameFileServerTool,
   [deleteFileServerTool.name]: deleteFileServerTool,
+  [shareFileServerTool.name]: shareFileServerTool,
   [moveFileServerTool.name]: moveFileServerTool,
   [listFileFoldersServerTool.name]: listFileFoldersServerTool,
   [createFileFolderServerTool.name]: createFileFolderServerTool,

--- a/apps/sim/lib/copilot/tools/tool-display.ts
+++ b/apps/sim/lib/copilot/tools/tool-display.ts
@@ -615,6 +615,12 @@ export function getToolDisplayTitle(name: string, args?: Record<string, unknown>
       const targets = stringArrayArg(args, 'paths').map(pathLeaf)
       return `Deleting ${summarizeTargets(targets, 'folder')}`
     }
+    case 'share_file': {
+      const action = stringArg(args, 'action') || 'share'
+      const path = stringArg(args, 'path')
+      const target = firstStringArg(args, 'toolTitle', 'title') || (path ? pathLeaf(path) : 'file')
+      return action === 'unshare' ? `Unsharing ${target}` : `Sharing ${target}`
+    }
     case 'create_workflow': {
       const target = firstStringArg(args, 'name', 'workflowName', 'title')
       return `Creating ${target || 'workflow'}`
@@ -864,11 +870,13 @@ const COMPLETED_VERB_REWRITES: Record<string, string> = {
   Scraping: 'Scraped',
   Searching: 'Searched',
   Setting: 'Set',
+  Sharing: 'Shared',
   Summarizing: 'Summarized',
   Syncing: 'Synced',
   Toggling: 'Toggled',
   Trimming: 'Trimmed',
   Undeploying: 'Undeployed',
+  Unsharing: 'Unshared',
   Updating: 'Updated',
   Validating: 'Validated',
   Viewing: 'Viewed',

--- a/apps/sim/lib/copilot/vfs/serializers.ts
+++ b/apps/sim/lib/copilot/vfs/serializers.ts
@@ -1,3 +1,4 @@
+import type { ShareAuthType } from '@/lib/api/contracts/public-shares'
 import { getCopilotToolDescription } from '@/lib/copilot/tools/descriptions'
 import { isHosted } from '@/lib/core/config/env-flags'
 import { type FilterFieldType, getOperatorsForFieldType } from '@/lib/knowledge/filters/types'
@@ -366,6 +367,12 @@ export function serializeFileMeta(file: {
   size: number
   uploadedAt: Date
   updatedAt: Date
+  /** Whether the file has an active public share link. */
+  shared?: boolean
+  /** Auth mode of the active share; only meaningful when `shared` is true. */
+  shareAuthType?: ShareAuthType
+  /** Public share link (`{baseUrl}/f/{token}`); only meaningful when `shared` is true. */
+  shareUrl?: string
 }): string {
   return JSON.stringify(
     {
@@ -379,6 +386,9 @@ export function serializeFileMeta(file: {
       uploadedAt: file.uploadedAt.toISOString(),
       updatedAt: file.updatedAt.toISOString(),
       readContentWith: file.vfsPath ? `${file.vfsPath}/content` : undefined,
+      shared: Boolean(file.shared),
+      shareAuthType: file.shared ? file.shareAuthType : undefined,
+      shareUrl: file.shared ? file.shareUrl : undefined,
       note: 'This is file metadata only. To read the file text/bytes, read the readContentWith path (i.e. append /content).',
     },
     null,

--- a/apps/sim/lib/copilot/vfs/workspace-vfs.ts
+++ b/apps/sim/lib/copilot/vfs/workspace-vfs.ts
@@ -104,6 +104,7 @@ import { BINARY_DOC_TASKS, MAX_DOCUMENT_PREVIEW_CODE_BYTES } from '@/lib/executi
 import { runSandboxTask, SandboxUserCodeError } from '@/lib/execution/sandbox/run-task'
 import { getKnowledgeBases } from '@/lib/knowledge/service'
 import { validateMermaidSource } from '@/lib/mermaid/validate'
+import { getSharesForResources } from '@/lib/public-shares/share-manager'
 import { listTables } from '@/lib/table/service'
 import { listWorkspaceFileFolders } from '@/lib/uploads/contexts/workspace/workspace-file-folder-manager'
 import {
@@ -1738,6 +1739,23 @@ export class WorkspaceVFS {
         includeReservedSystemFiles: true,
         throwOnError: true,
       })
+      // Batch-load public share state so each file's metadata carries an ambient
+      // `shared` flag (mirrors how the files-list UI enriches rows) — no N+1.
+      // Fail soft: share state is only metadata enrichment, so a lookup failure
+      // must not drop the whole file tree (the outer catch returns []) — fall back
+      // to no shares, and files still materialize with `shared: false`.
+      let shareByFileId: Awaited<ReturnType<typeof getSharesForResources>> = new Map()
+      try {
+        shareByFileId = await getSharesForResources(
+          'file',
+          files.map((file) => file.id)
+        )
+      } catch (error) {
+        logger.warn('Failed to load file share state; file metadata will show shared: false', {
+          workspaceId,
+          error: toError(error).message,
+        })
+      }
       for (const folder of folders) {
         if (
           !workflowArtifactsEnabled &&
@@ -1756,6 +1774,8 @@ export class WorkspaceVFS {
         if (!workflowArtifactsEnabled && isWorkflowAliasBackingPath(filePath)) {
           continue
         }
+        const share = shareByFileId.get(file.id)
+        const shared = share?.isActive ?? false
         this.files.set(
           filePath,
           serializeFileMeta({
@@ -1768,6 +1788,9 @@ export class WorkspaceVFS {
             size: file.size,
             uploadedAt: file.uploadedAt,
             updatedAt: file.updatedAt,
+            shared,
+            shareAuthType: shared ? share?.authType : undefined,
+            shareUrl: shared ? share?.url : undefined,
           })
         )
       }


### PR DESCRIPTION
## Summary
- Add the sim-side `share_file` server tool handler: resolves a VFS `path` to the file, **keeps the existing checks** (org public-sharing policy, write/admin permission, `ShareValidationError`, and the `FILE_SHARED`/`FILE_SHARE_DISABLED` audit), then delegates to the shared `upsertFileShare` — same path the files UI uses
- Register it in the server tool router (+ generated catalog entries)
- Surface an ambient `shared`/`shareAuthType` flag on each file's metadata via one batched share lookup (no N+1), so the agent can see and `grep` what's shared — mirrors how workflows expose `isDeployed`

## Pairs with
- Copilot: **simstudioai/mothership#353** (tool definition + agent routing). **That must merge first** — `mship-tools:check` regenerates the catalog from the copilot repo's `tool-catalog-v1.json`, so this PR's check stays red until #353 lands.

## Type of Change
- [x] New feature

## Testing
- `tsc --noEmit` 0 errors; `bun run lint:check` and `check:api-validation:strict` pass; biome clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)


Companion: simstudioai/mothership#353
