### PR TITLE
fix(pii): bump transformers to 5.5.0 for LightGlue RCE advisory

### DIFF
--- a/apps/pii/requirements-gliner.txt
+++ b/apps/pii/requirements-gliner.txt
@@ -6,5 +6,5 @@
 # torch is pinned in the Dockerfile instead: the CPU and CUDA targets install
 # the same version from different wheel indexes.
 gliner==0.2.27
-transformers==5.3.0
-huggingface_hub==1.3.0
+transformers==5.5.0
+huggingface_hub==1.23.0

--- a/docker/pii.Dockerfile
+++ b/docker/pii.Dockerfile
@@ -87,9 +87,16 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Bake the GLiNER weights at build time (cached layer) so startup never
 # touches the network. HF_HUB_OFFLINE makes a missing/overridden
 # PII_GLINER_MODEL fail fast at startup instead of silently downloading.
+# The predict_entities smoke assert (labels from engines.py's
+# GLINER_ENTITY_MAPPING) fails the build if a transformers/gliner bump loads
+# the model fine but silently stops returning detections.
 ENV HF_HOME=/opt/hf-cache
 ARG GLINER_MODEL=urchade/gliner_multi_pii-v1
-RUN python -c "from gliner import GLiNER; GLiNER.from_pretrained('${GLINER_MODEL}')" && \
+RUN python -c "from gliner import GLiNER; \
+model = GLiNER.from_pretrained('${GLINER_MODEL}'); \
+ents = model.predict_entities('John Smith flew to Paris on 4 May 2021.', ['person', 'location', 'date']); \
+labels = {e['label'] for e in ents}; \
+assert {'person', 'location'} <= labels, f'GLiNER smoke inference failed, got: {ents}'" && \
     chmod -R a+rX /opt/hf-cache
 ENV HF_HUB_OFFLINE=1
 

--- a/docker/pii.Dockerfile
+++ b/docker/pii.Dockerfile
@@ -96,7 +96,7 @@ RUN python -c "from gliner import GLiNER; \
 model = GLiNER.from_pretrained('${GLINER_MODEL}'); \
 ents = model.predict_entities('John Smith flew to Paris on 4 May 2021.', ['person', 'location', 'date']); \
 labels = {e['label'] for e in ents}; \
-assert {'person', 'location'} <= labels, f'GLiNER smoke inference failed, got: {ents}'" && \
+assert {'person', 'location', 'date'} <= labels, f'GLiNER smoke inference failed, got: {ents}'" && \
     chmod -R a+rX /opt/hf-cache
 ENV HF_HUB_OFFLINE=1
 


### PR DESCRIPTION
## Summary
- Bump `transformers` 5.3.0 → 5.5.0 in `apps/pii/requirements-gliner.txt` — first patched version for the LightGlue arbitrary-code-execution advisory (Dependabot alerts #174/#175, High)
- Bump `huggingface_hub` 1.3.0 → 1.23.0 — required: transformers 5.5.0 declares `huggingface-hub>=1.5.0,<2.0`, so bumping transformers alone (as Dependabot's #5645 does) fails pip resolution during the gliner image build
- Alert #175 against `requirements.txt` is a dependency-graph artifact (that file has never pinned transformers) and clears once the default branch re-scans
- Supersedes #5645 (targets main, misses the hub floor bump)

## Type of Change
- [x] Bug fix

## Testing
- Verified the full combined pin set (torch 2.11.0, gliner 0.2.27, transformers 5.5.0, huggingface_hub 1.23.0, presidio 2.2.362, spacy 3.8.14) resolves with `pip install --dry-run` in a clean venv — tokenizers resolves to 0.22.2 within transformers' `>=0.22.0,<=0.23.0` range
- gliner 0.2.27 allows `transformers>=4.51.3,<5.7.0` and `huggingface_hub>=0.21.4`; Dockerfile `torch==2.11.0` satisfies transformers' `torch>=2.4`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)