### PR TITLE
fix(settings): restore header shell on workspace credit-usage page

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/billing/credit-usage/layout.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/billing/credit-usage/layout.tsx
@@ -1,0 +1,19 @@
+import {
+  SettingsHeaderProvider,
+  SettingsHeaderShell,
+} from '@/app/workspace/[workspaceId]/settings/components/settings-header/settings-header'
+
+/**
+ * Credit usage is a static route outside `[section]`, so it does not inherit
+ * `SettingsSectionLayout`'s chrome. `CreditUsageView` and its loading fallback
+ * render through `SettingsPanel`, which only registers header config into the
+ * `SettingsHeaderProvider` context — without this shell the page has no header
+ * bar, title, or scroll region.
+ */
+export default function CreditUsageLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <SettingsHeaderProvider>
+      <SettingsHeaderShell>{children}</SettingsHeaderShell>
+    </SettingsHeaderProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- fixes the workspace `settings/billing/credit-usage` page rendering with no header, title, or scroll region (user-reported: page "won't scroll")
- regressed in #5545: `CreditUsageView` moved from the self-chromed `CredentialDetailLayout` to `SettingsPanel`, which only registers header config into `SettingsHeaderProvider` context — the chrome renders in `SettingsHeaderShell`
- the workspace plane mounts that shell in `settings/[section]/layout.tsx`, but `billing/credit-usage` is a static route outside `[section]`, so the panel registered into nothing and the page rendered bare children with no scroll container (the account/org planes mount the shell at their settings root, which is why the same view works there)
- fix: mount `SettingsHeaderProvider` + `SettingsHeaderShell` in a route-level `layout.tsx` for `billing/credit-usage`, mirroring `[section]/layout.tsx`; this also covers the route's `loading.tsx` fallback
- audited every other `SettingsPanel` consumer (workspace sections, account/org renderers, ee components) — all render under a shell; this route was the only orphan

## Type of Change
- [x] Bug fix

## Testing
Typecheck clean, credit-usage + billing tests pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)