### PR TITLE
improvement(chat): hide the agent-group viewport scrollbar

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/agent-group.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/agent-group.tsx
@@ -261,7 +261,10 @@ function BoundedViewport({ children, isStreaming }: BoundedViewportProps) {
 
   return (
     <div className='relative'>
-      <div ref={ref} className={cn('max-h-[110px] overflow-y-auto pr-2', hasOverflow && 'py-1')}>
+      <div
+        ref={ref}
+        className={cn('scrollbar-hide max-h-[110px] overflow-y-auto pr-2', hasOverflow && 'py-1')}
+      >
         {children}
       </div>
       {hasOverflow && (


### PR DESCRIPTION
## Summary
- Hide the scrollbar on the agent-group bounded viewport (the 110px narration window) using the existing `scrollbar-hide` utility
- The viewport is an ambient auto-following activity log — overflow is already signaled by the top/bottom fade edges, and wheel/trackpad scrolling (including detach/re-stick) still works

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)