### PR TITLE
improvement(landing): SEO copy and metadata rewrite across marketing pages

### DIFF
--- a/apps/sim/app/(landing)/careers/components/job-board/job-groups.tsx
+++ b/apps/sim/app/(landing)/careers/components/job-board/job-groups.tsx
@@ -4,7 +4,7 @@ import type { CareerPosting } from '@/lib/ashby/jobs'
 import type { DepartmentGroup } from '@/app/(landing)/careers/components/job-board/utils'
 
 /** Empty-state copy: distinguishes a truly empty board from a filtered-to-zero view. */
-const NO_OPEN_ROLES_MESSAGE = 'No open roles right now — check back soon.'
+const NO_OPEN_ROLES_MESSAGE = 'No open roles right now. Check back soon.'
 const NO_MATCHING_ROLES_MESSAGE =
   'No roles match these filters right now. Try clearing them, or check back soon.'
 

--- a/apps/sim/app/(landing)/components/features/components/build-callout/components/build-chat-animation/build-chat-animation.tsx
+++ b/apps/sim/app/(landing)/components/features/components/build-callout/components/build-chat-animation/build-chat-animation.tsx
@@ -8,7 +8,7 @@ import { ThinkingLoader } from '@/components/ui'
 
 const PROMPT = 'Build a workflow to schedule and publish posts to my X account.'
 const REPLY =
-  'On it — building a workflow with a schedule trigger, a drafting agent, and an X publish step.'
+  'On it. Building a workflow with a schedule trigger, a drafting agent, and an X publish step.'
 const REPLY_WORDS = REPLY.split(' ')
 
 const TYPE_START_MS = 900

--- a/apps/sim/app/(landing)/components/features/features.tsx
+++ b/apps/sim/app/(landing)/components/features/features.tsx
@@ -54,7 +54,7 @@ export function Features() {
         <FeatureCard
           eyebrow='Context'
           title='Give Sim data it can reason over.'
-          description='Sim stores your data semantically in tables, files, and knowledge bases your agents read from to ground every answer in your own data.'
+          description='Sim stores your data in tables, files, and knowledge bases — semantic memory agents read to ground every answer.'
           backdropSrc='/landing/feature-context-backdrop.jpg'
           mediaSide='right'
         >
@@ -65,7 +65,7 @@ export function Features() {
         <FeatureCard
           eyebrow='Build'
           title='Build agents that solve real problems.'
-          description='Wire blocks, models, and integrations into agent logic on a visual builder, from one agent to many working in parallel.'
+          description="Wire blocks, models, and integrations into agent logic on Sim's visual builder, from one agent to many working in parallel."
           href='/workflows'
           linkLabel='Explore the workflow builder'
         >
@@ -76,7 +76,7 @@ export function Features() {
         <FeatureCard
           eyebrow='Monitor'
           title='Watch every run, end to end.'
-          description='Trace each run block by block, with full logs and the real cost, so you always know what ran and why.'
+          description='Sim traces each run block by block, with full logs and the real cost.'
           backdropSrc='/landing/feature-monitor-backdrop.jpg'
           mediaSide='right'
           flushBottom

--- a/apps/sim/app/(landing)/components/features/features.tsx
+++ b/apps/sim/app/(landing)/components/features/features.tsx
@@ -54,7 +54,7 @@ export function Features() {
         <FeatureCard
           eyebrow='Context'
           title='Give Sim data it can reason over.'
-          description='Sim stores your data in tables, files, and knowledge bases — semantic memory agents read to ground every answer.'
+          description='Sim stores your data in tables, files, and knowledge bases, the semantic memory agents read to ground every answer.'
           backdropSrc='/landing/feature-context-backdrop.jpg'
           mediaSide='right'
         >

--- a/apps/sim/app/(landing)/components/footer/footer.tsx
+++ b/apps/sim/app/(landing)/components/footer/footer.tsx
@@ -27,12 +27,20 @@ interface FooterItem {
   external?: boolean
 }
 
+/**
+ * Platform modules link to their local landing pages (internal link equity
+ * stays on the ranking pages); docs-only surfaces (MCP, API, Self Hosting)
+ * and Status remain external.
+ */
 const PRODUCT_LINKS: FooterItem[] = [
   { label: 'Enterprise', href: '/enterprise' },
-  { label: 'Mothership', href: 'https://docs.sim.ai/mothership', external: true },
-  { label: 'Workflows', href: 'https://docs.sim.ai', external: true },
-  { label: 'Knowledge Base', href: 'https://docs.sim.ai/knowledgebase', external: true },
-  { label: 'Tables', href: 'https://docs.sim.ai/tables', external: true },
+  { label: 'Chat', href: 'https://docs.sim.ai/mothership', external: true },
+  { label: 'Workflows', href: '/workflows' },
+  { label: 'Knowledge Base', href: '/knowledge' },
+  { label: 'Tables', href: '/tables' },
+  { label: 'Files', href: '/files' },
+  { label: 'Logs', href: '/logs' },
+  { label: 'Scheduled Tasks', href: '/scheduled-tasks' },
   { label: 'MCP', href: 'https://docs.sim.ai/agents/mcp', external: true },
   { label: 'API', href: 'https://docs.sim.ai/api-reference/getting-started', external: true },
   { label: 'Self Hosting', href: 'https://docs.sim.ai/platform/self-hosting', external: true },

--- a/apps/sim/app/(landing)/components/hero/hero.tsx
+++ b/apps/sim/app/(landing)/components/hero/hero.tsx
@@ -86,11 +86,11 @@ export function Hero() {
         headingId='hero-heading'
         heading={
           <>
-            Sim is your AI workspace <br />
-            for building agentic workflows.
+            Sim is the AI workspace <br />
+            for building AI agents.
           </>
         }
-        description='The open-source workspace where teams build, deploy, and manage AI agents.'
+        description='Open source, with 1,000+ integrations and every major LLM. Build, deploy, and manage agents visually, conversationally, or with code.'
       />
 
       <div

--- a/apps/sim/app/(landing)/components/home-structured-data/home-structured-data.tsx
+++ b/apps/sim/app/(landing)/components/home-structured-data/home-structured-data.tsx
@@ -16,6 +16,14 @@ import { JsonLd } from '@/app/(landing)/components/json-ld'
  * - All claims must also appear as visible text on the page.
  * - Do not add `aggregateRating` without real, verifiable review data.
  */
+/**
+ * The home page's canonical description - the single string shared by the
+ * `<meta name="description">`, OG/Twitter cards (`page.tsx`), and the JSON-LD
+ * `WebPage.description` below, so the three surfaces never drift.
+ */
+export const HOME_PAGE_DESCRIPTION =
+  'Sim is the open-source AI workspace where teams build, deploy, and manage AI agents across 1,000+ integrations and every major LLM — visually or with code.'
+
 const HOME_JSON_LD = {
   '@context': 'https://schema.org',
   '@graph': [
@@ -27,8 +35,7 @@ const HOME_JSON_LD = {
       isPartOf: { '@id': `${SITE_URL}#website` },
       about: { '@id': `${SITE_URL}#software` },
       datePublished: '2024-01-01T00:00:00+00:00',
-      description:
-        'Sim is the open-source AI workspace where teams build, deploy, and manage AI agents. Connect 1,000+ integrations and every major LLM to create agents that automate real work.',
+      description: HOME_PAGE_DESCRIPTION,
       breadcrumb: { '@id': `${SITE_URL}#breadcrumb` },
       inLanguage: 'en-US',
       speakable: {
@@ -93,7 +100,7 @@ const HOME_JSON_LD = {
       ],
       featureList: [
         'AI workspace for teams',
-        'Mothership: natural language agent creation',
+        'Chat: build and manage agents in natural language',
         'Visual workflow builder',
         '1,000+ integrations',
         'LLM orchestration (OpenAI, Anthropic, Google, xAI, Mistral, Perplexity)',

--- a/apps/sim/app/(landing)/components/home-structured-data/home-structured-data.tsx
+++ b/apps/sim/app/(landing)/components/home-structured-data/home-structured-data.tsx
@@ -22,7 +22,7 @@ import { JsonLd } from '@/app/(landing)/components/json-ld'
  * `WebPage.description` below, so the three surfaces never drift.
  */
 export const HOME_PAGE_DESCRIPTION =
-  'Sim is the open-source AI workspace where teams build, deploy, and manage AI agents across 1,000+ integrations and every major LLM — visually or with code.'
+  'Sim is the open-source AI workspace where teams build, deploy, and manage AI agents across 1,000+ integrations and every major LLM, visually or with code.'
 
 const HOME_JSON_LD = {
   '@context': 'https://schema.org',

--- a/apps/sim/app/(landing)/components/home-structured-data/index.ts
+++ b/apps/sim/app/(landing)/components/home-structured-data/index.ts
@@ -1,1 +1,1 @@
-export { HomeStructuredData } from './home-structured-data'
+export { HOME_PAGE_DESCRIPTION, HomeStructuredData } from './home-structured-data'

--- a/apps/sim/app/(landing)/components/mothership/mothership.tsx
+++ b/apps/sim/app/(landing)/components/mothership/mothership.tsx
@@ -45,7 +45,7 @@ const AREAS: Area[] = [
     size: 180,
     definition: (
       <>
-        One catalog of 1,000+ integrations
+        Sim&apos;s catalog of 1,000+ integrations
         <br />
         your agents act through.
       </>
@@ -55,7 +55,7 @@ const AREAS: Area[] = [
     word: 'Context',
     Mark: IsoIngestIllustration,
     size: 170,
-    definition: 'Your data, stored semantically as the memory your agents reason over.',
+    definition: 'Your data, stored semantically in Sim as the memory your agents reason over.',
   },
   {
     word: 'Build',
@@ -67,7 +67,7 @@ const AREAS: Area[] = [
     word: 'Monitor',
     Mark: IsoMonitorIllustration,
     size: 174,
-    definition: 'See inside every run with live traces, logs, and real cost.',
+    definition: 'See inside every run in Sim: live traces, logs, and real cost.',
   },
 ]
 

--- a/apps/sim/app/(landing)/components/product-demo/product-demo.tsx
+++ b/apps/sim/app/(landing)/components/product-demo/product-demo.tsx
@@ -46,7 +46,7 @@ export function ProductDemo() {
           </h2>
           <p className='mt-3 text-pretty text-[15px] text-[var(--text-muted)] leading-[1.6]'>
             Tell Sim what you need in plain English and it wires blocks, models, and integrations
-            into a working agent, ready to run.
+            into a working agent.
           </p>
         </div>
       </div>

--- a/apps/sim/app/(landing)/components/solutions-page/components/solutions-structured-data/solutions-structured-data.tsx
+++ b/apps/sim/app/(landing)/components/solutions-page/components/solutions-structured-data/solutions-structured-data.tsx
@@ -22,7 +22,7 @@ interface SolutionsStructuredDataProps {
 }
 
 export function SolutionsStructuredData({ config }: SolutionsStructuredDataProps) {
-  const { module, path, hero, rows } = config
+  const { module, path, seoDescription, offersFreeTier = true, hero, rows } = config
   const url = `${SITE_URL}${path}`
   const featureList = Array.from(
     new Set(rows.flatMap((row) => row.cards.map((card) => card.title)))
@@ -36,7 +36,7 @@ export function SolutionsStructuredData({ config }: SolutionsStructuredDataProps
         '@id': `${url}#webpage`,
         url,
         name: hero.heading,
-        description: hero.summary,
+        description: seoDescription ?? hero.summary,
         isPartOf: { '@id': `${SITE_URL}#website` },
         about: { '@id': `${url}#application` },
         breadcrumb: { '@id': `${url}#breadcrumb` },
@@ -59,7 +59,9 @@ export function SolutionsStructuredData({ config }: SolutionsStructuredDataProps
         operatingSystem: 'Web',
         url,
         featureList,
-        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        ...(offersFreeTier && {
+          offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        }),
       },
     ],
   }

--- a/apps/sim/app/(landing)/components/solutions-page/types.ts
+++ b/apps/sim/app/(landing)/components/solutions-page/types.ts
@@ -112,6 +112,18 @@ export interface SolutionsPageConfig {
   module: string
   /** Canonical path, e.g. "/workflows" - used to build the JSON-LD `url`/breadcrumb. */
   path: string
+  /**
+   * The page's meta description, shared with `page.tsx` so the JSON-LD
+   * `WebPage.description` and the `<meta name="description">` never drift.
+   * Falls back to `hero.summary` when absent.
+   */
+  seoDescription?: string
+  /**
+   * Whether the JSON-LD `WebApplication` advertises the free tier as an
+   * `Offer`. Defaults to true; sales-led pages (Enterprise) set false so a
+   * rich result never claims a $0 price for a quoted product.
+   */
+  offersFreeTier?: boolean
   /** The hero (the page's only `<h1>`). */
   hero: SolutionsHeroConfig
   /** Card rows rendered in order beneath the logos row. */

--- a/apps/sim/app/(landing)/enterprise/components/feature-graphics/build-methods-graphic.tsx
+++ b/apps/sim/app/(landing)/enterprise/components/feature-graphics/build-methods-graphic.tsx
@@ -62,7 +62,7 @@ const CODE_TOTAL_CHARS = CODE_LINE_LENGTHS.reduce((total, length) => total + len
 
 const PROMPT = 'Create a support agent that answers customer questions'
 const REPLY =
-  'On it — scaffolding a support agent with Zendesk and Slack that answers customer questions.'
+  'On it. Scaffolding a support agent with Zendesk and Slack that answers customer questions.'
 const REPLY_WORDS = REPLY.split(' ')
 
 const CODE_START_MS = 500

--- a/apps/sim/app/(landing)/enterprise/enterprise.tsx
+++ b/apps/sim/app/(landing)/enterprise/enterprise.tsx
@@ -44,14 +44,25 @@ import {
  * (each card), never skipped. Server Component; the interactive leaves live in
  * the shared landing components.
  */
+/**
+ * The enterprise page's canonical description - shared by `page.tsx` (the
+ * `<meta name="description">` and OG/Twitter cards) and the JSON-LD
+ * `WebPage.description` via {@link SolutionsPageConfig.seoDescription}.
+ */
+export const ENTERPRISE_SEO_DESCRIPTION =
+  'Sim is the AI workspace where teams build, deploy, and govern enterprise AI agents — SOC2, role-based access, audit trails, and 1,000+ integrations.'
+
 const ENTERPRISE_CONFIG: SolutionsPageConfig = {
   module: 'Enterprise',
   path: '/enterprise',
+  seoDescription: ENTERPRISE_SEO_DESCRIPTION,
+  offersFreeTier: false,
   hero: {
-    heading: 'The AI Agent Platform for Enterprise Teams',
-    description: 'Build, deploy, and govern enterprise AI agents in one workspace.',
+    heading: 'Sim is the AI workspace for enterprise AI agents.',
+    description:
+      'IT, operations, and technical teams build, deploy, and govern agents in Sim — with SOC2, role-based access, approvals, and full audit trails.',
     summary:
-      'Sim is the open-source enterprise AI agent platform where IT, operations, and technical teams build, deploy, and govern enterprise AI agents in one AI workspace. Connect 1,000+ integrations and every major LLM, with security, role-based access, approvals, observability, versioning, and audit trails for reliable deployment across teams.',
+      'Sim is the open-source AI workspace where IT, operations, and technical teams build, deploy, and govern enterprise AI agents. Connect 1,000+ integrations and every major LLM, with role-based access, approvals, versioning, and full audit trails.',
     /**
      * The shared {@link PlatformHeroVisual} backdrop-plus-demo-window
      * composition, filled by the {@link EnterprisePlatformLoop} - a sibling of
@@ -69,14 +80,14 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
   rows: [
     {
       id: 'build',
-      title: 'Build, Deploy, and Manage Enterprise AI Agents in One Workspace',
+      title: 'Build, Deploy, and Manage AI Agents in One Workspace',
       subtitle:
-        'Build enterprise AI agents, ship to production, and manage every version from one workspace.',
+        'Sim carries agents from first draft to production, with versioning and monitoring built in.',
       cta: { label: 'Start building', href: SIGNUP_HREF },
       cards: [
         {
           title: 'Build visually or with code',
-          description: 'Create agents in the visual builder, through chat, or directly in code.',
+          description: "Create agents in Sim's visual builder, through chat, or directly in code.",
           visual: <BuildMethodsGraphic />,
         },
         {
@@ -89,7 +100,7 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
         },
         {
           title: 'Manage the full lifecycle',
-          description: 'Version, monitor, and edit every agent as your workflows evolve.',
+          description: 'Version, monitor, and edit every agent in Sim as your workflows evolve.',
           visual: <LifecycleGraphic />,
         },
       ],
@@ -98,7 +109,7 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
       id: 'governance',
       title: 'Governance and Security for Enterprise AI Agents',
       subtitle:
-        'Security, approvals, and controls keep enterprise AI agents trusted in production.',
+        'Sim gives security teams role-based access, approval paths, and a complete audit trail for every deployment.',
       cta: { label: 'See security', href: DEMO_HREF },
       cards: [
         {
@@ -109,13 +120,13 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
         },
         {
           title: 'Prove every action',
-          description: 'Trace every run block by block with a complete audit trail.',
+          description: 'Sim traces every run block by block with a complete audit trail.',
           visual: <AuditTrailGraphic />,
         },
         {
           title: 'Meet enterprise standards',
           description:
-            'SOC2 compliance and open source give security teams a clear path to review.',
+            'Sim is SOC2 compliant and open source, giving security teams a clear path to review.',
           visual: <StandardsGraphic />,
           featureTileTone: 'dark',
           featureTileDescriptionTone: 'soft',
@@ -125,7 +136,8 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
     {
       id: 'deploy',
       title: 'Deploy Enterprise Workflow Agents with Confidence',
-      subtitle: 'Stage, observe, and version workflow agents before they reach production.',
+      subtitle:
+        'Test in staging, watch live runs, and roll back in seconds — Sim versions every deployment.',
       cta: { label: 'Explore deployment', href: SIGNUP_HREF },
       cards: [
         {
@@ -135,12 +147,12 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
         },
         {
           title: 'Watch every run',
-          description: 'See live logs, run history, and monitoring in one place.',
+          description: 'Sim shows live logs, run history, and monitoring in one place.',
           visual: <RunMonitoringGraphic />,
         },
         {
           title: 'Roll back safely',
-          description: 'Version workflows and roll back production agents in seconds.',
+          description: 'Sim versions workflows so you can roll back production agents in seconds.',
           visual: <RollbackGraphic />,
         },
       ],
@@ -149,7 +161,7 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
       id: 'teams',
       title: 'Built for Enterprise Teams',
       subtitle:
-        'Built for the teams that own enterprise AI agents across IT, operations, and engineering.',
+        'IT, operations, and engineering teams share one Sim workspace, each with the controls their role needs.',
       cta: { label: 'Talk to sales', href: DEMO_HREF },
       cards: [
         {
@@ -166,7 +178,7 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
         },
         {
           title: 'Technical teams',
-          description: 'Let technical teams ship, review, and maintain agents together.',
+          description: 'Technical teams ship, review, and maintain agents together in Sim.',
           visual: <TechnicalTeamsGraphic />,
         },
       ],

--- a/apps/sim/app/(landing)/enterprise/enterprise.tsx
+++ b/apps/sim/app/(landing)/enterprise/enterprise.tsx
@@ -50,7 +50,7 @@ import {
  * `WebPage.description` via {@link SolutionsPageConfig.seoDescription}.
  */
 export const ENTERPRISE_SEO_DESCRIPTION =
-  'Sim is the AI workspace where teams build, deploy, and govern enterprise AI agents — SOC2, role-based access, audit trails, and 1,000+ integrations.'
+  'Sim is the AI workspace where teams build, deploy, and govern enterprise AI agents with SOC2, role-based access, audit trails, and 1,000+ integrations.'
 
 const ENTERPRISE_CONFIG: SolutionsPageConfig = {
   module: 'Enterprise',
@@ -60,7 +60,7 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
   hero: {
     heading: 'Sim is the AI workspace for enterprise AI agents.',
     description:
-      'IT, operations, and technical teams build, deploy, and govern agents in Sim — with SOC2, role-based access, approvals, and full audit trails.',
+      'IT, operations, and technical teams build, deploy, and govern agents in Sim, with SOC2, role-based access, approvals, and full audit trails.',
     summary:
       'Sim is the open-source AI workspace where IT, operations, and technical teams build, deploy, and govern enterprise AI agents. Connect 1,000+ integrations and every major LLM, with role-based access, approvals, versioning, and full audit trails.',
     /**
@@ -137,7 +137,7 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
       id: 'deploy',
       title: 'Deploy Enterprise Workflow Agents with Confidence',
       subtitle:
-        'Test in staging, watch live runs, and roll back in seconds — Sim versions every deployment.',
+        'Test in staging, watch live runs, and roll back in seconds. Sim versions every deployment.',
       cta: { label: 'Explore deployment', href: SIGNUP_HREF },
       cards: [
         {

--- a/apps/sim/app/(landing)/enterprise/page.tsx
+++ b/apps/sim/app/(landing)/enterprise/page.tsx
@@ -1,15 +1,13 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import EnterprisePage from '@/app/(landing)/enterprise/enterprise'
+import EnterprisePage, { ENTERPRISE_SEO_DESCRIPTION } from '@/app/(landing)/enterprise/enterprise'
 
 export const revalidate = 3600
 
-const TITLE = 'Enterprise AI Agent Platform | Sim AI'
-const DESCRIPTION =
-  'Build, deploy, and govern enterprise AI agents in one workspace with security, approvals, observability, and collaboration.'
+const TITLE = 'Enterprise AI Agent Platform | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: ENTERPRISE_SEO_DESCRIPTION,
   path: '/enterprise',
   keywords:
     'enterprise ai agents, enterprise ai agent, enterprise ai agent platform, enterprise workflow agents',

--- a/apps/sim/app/(landing)/files/files.tsx
+++ b/apps/sim/app/(landing)/files/files.tsx
@@ -28,16 +28,21 @@ import { DocumentDraftGraphic } from '@/app/(landing)/solutions/components/featu
  * document draft retold for file routing, file history, parse runs, and
  * agent-written reports.
  */
+/** Shared meta + JSON-LD description for the Files page — one string, zero drift. */
+export const FILES_PAGE_DESCRIPTION =
+  'Files is the file storage for AI agents and teams in Sim. Upload, create, and share in one store — agents read files as inputs and write outputs back.'
+
 const FILES_CONFIG: SolutionsPageConfig = {
   module: 'Files',
   path: '/files',
+  seoDescription: FILES_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Files',
     heading: 'One file store for your team and every agent in Sim.',
     description:
-      'Upload, create, and share in Files, the file store in Sim, the open-source AI workspace. Agents read files as inputs, produce files as outputs, and share them with your team in one place.',
+      'Files is the file storage for teams and every AI agent in Sim, the open-source AI workspace. Upload, create, and share — agents read files as inputs and produce new files as outputs.',
     summary:
-      'Files is the file store in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Teams upload, create, and share files in one place, and Sim agents read those files as inputs, parse them, and produce new files as outputs shared with everyone.',
+      'Files is the file storage for teams and AI agents in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Teams upload, create, and share files, and agents read them as inputs, parse them, and produce new files as outputs.',
     visual: (
       <PlatformHeroVisual>
         <FilesHeroLoop />

--- a/apps/sim/app/(landing)/files/files.tsx
+++ b/apps/sim/app/(landing)/files/files.tsx
@@ -28,9 +28,9 @@ import { DocumentDraftGraphic } from '@/app/(landing)/solutions/components/featu
  * document draft retold for file routing, file history, parse runs, and
  * agent-written reports.
  */
-/** Shared meta + JSON-LD description for the Files page — one string, zero drift. */
+/** Shared meta + JSON-LD description for the Files page (one string, zero drift). */
 export const FILES_PAGE_DESCRIPTION =
-  'Files is the file storage for AI agents and teams in Sim. Upload, create, and share in one store — agents read files as inputs and write outputs back.'
+  'Files is the file storage for AI agents and teams in Sim. Upload, create, and share in one store, and agents read files as inputs and write outputs back.'
 
 const FILES_CONFIG: SolutionsPageConfig = {
   module: 'Files',
@@ -40,7 +40,7 @@ const FILES_CONFIG: SolutionsPageConfig = {
     eyebrow: 'Files',
     heading: 'One file store for your team and every agent in Sim.',
     description:
-      'Files is the file storage for teams and every AI agent in Sim, the open-source AI workspace. Upload, create, and share — agents read files as inputs and produce new files as outputs.',
+      'Files is the file storage for teams and every AI agent in Sim, the open-source AI workspace. Upload, create, and share. Agents read files as inputs and produce new files as outputs.',
     summary:
       'Files is the file storage for teams and AI agents in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Teams upload, create, and share files, and agents read them as inputs, parse them, and produce new files as outputs.',
     visual: (

--- a/apps/sim/app/(landing)/files/page.tsx
+++ b/apps/sim/app/(landing)/files/page.tsx
@@ -1,15 +1,13 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import Files from '@/app/(landing)/files/files'
+import Files, { FILES_PAGE_DESCRIPTION } from '@/app/(landing)/files/files'
 
 export const revalidate = 3600
 
-const TITLE = 'Files | One File Store for Teams and Agents in Sim, the AI Workspace'
-const DESCRIPTION =
-  'Files is the file store in Sim, the open-source AI workspace. Upload, create, and share files in one place — agents read them as inputs and produce them as outputs.'
+const TITLE = 'File Storage for AI Agents and Your Team | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: FILES_PAGE_DESCRIPTION,
   path: '/files',
   keywords:
     'AI workspace, file store for AI agents, shared file storage, AI agents read files, agents generate files, document parsing agents, AI file management, open-source AI workspace',

--- a/apps/sim/app/(landing)/knowledge/knowledge.tsx
+++ b/apps/sim/app/(landing)/knowledge/knowledge.tsx
@@ -31,14 +31,19 @@ import { KnowledgeAnswerGraphic } from '@/app/(landing)/solutions/components/fea
  * to the platform page's (`WebPage` + `BreadcrumbList` +
  * `WebApplication`), so the feature-tile treatment is SEO-neutral.
  */
+/** Shared meta + JSON-LD description for the Knowledge Base page — one string, zero drift. */
+export const KNOWLEDGE_PAGE_DESCRIPTION =
+  'Give AI agents a knowledge base in Sim. Upload docs, sync Notion, Google Drive, and Confluence, and get answers grounded in your data — with citations.'
+
 const KNOWLEDGE_CONFIG: SolutionsPageConfig = {
   module: 'Knowledge Base',
   path: '/knowledge',
+  seoDescription: KNOWLEDGE_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Knowledge Base',
-    heading: "Give your agents memory of your company's data in Sim.",
+    heading: 'The knowledge base that gives AI agents memory of your data.',
     description:
-      "Knowledge Base is your agents' memory in Sim, the open-source AI workspace. Upload docs, sync sources like Notion and Google Drive, and get answers grounded in your own data, with citations.",
+      "Knowledge Base is your agents' memory in Sim, the open-source AI workspace. Upload docs, sync sources like Notion and Google Drive, and get answers grounded in your data — with citations.",
     summary:
       'Knowledge Base is the agent-memory module in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Teams upload docs or sync sources like Notion, Google Drive, and Confluence, and every agent answers from that data with citations, kept fresh automatically.',
     visual: (

--- a/apps/sim/app/(landing)/knowledge/knowledge.tsx
+++ b/apps/sim/app/(landing)/knowledge/knowledge.tsx
@@ -41,7 +41,7 @@ const KNOWLEDGE_CONFIG: SolutionsPageConfig = {
   seoDescription: KNOWLEDGE_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Knowledge Base',
-    heading: 'The knowledge base that gives AI agents memory of your data.',
+    heading: "Give AI agents memory of your data with Sim's knowledge base.",
     description:
       "Knowledge Base is your agents' memory in Sim, the open-source AI workspace. Upload docs, sync sources like Notion and Google Drive, and get answers grounded in your data, with citations.",
     summary:

--- a/apps/sim/app/(landing)/knowledge/knowledge.tsx
+++ b/apps/sim/app/(landing)/knowledge/knowledge.tsx
@@ -31,9 +31,9 @@ import { KnowledgeAnswerGraphic } from '@/app/(landing)/solutions/components/fea
  * to the platform page's (`WebPage` + `BreadcrumbList` +
  * `WebApplication`), so the feature-tile treatment is SEO-neutral.
  */
-/** Shared meta + JSON-LD description for the Knowledge Base page — one string, zero drift. */
+/** Shared meta + JSON-LD description for the Knowledge Base page (one string, zero drift). */
 export const KNOWLEDGE_PAGE_DESCRIPTION =
-  'Give AI agents a knowledge base in Sim. Upload docs, sync Notion, Google Drive, and Confluence, and get answers grounded in your data — with citations.'
+  'Give AI agents a knowledge base in Sim. Upload docs, sync Notion, Google Drive, and Confluence, and get answers grounded in your data, with citations.'
 
 const KNOWLEDGE_CONFIG: SolutionsPageConfig = {
   module: 'Knowledge Base',
@@ -43,7 +43,7 @@ const KNOWLEDGE_CONFIG: SolutionsPageConfig = {
     eyebrow: 'Knowledge Base',
     heading: 'The knowledge base that gives AI agents memory of your data.',
     description:
-      "Knowledge Base is your agents' memory in Sim, the open-source AI workspace. Upload docs, sync sources like Notion and Google Drive, and get answers grounded in your data — with citations.",
+      "Knowledge Base is your agents' memory in Sim, the open-source AI workspace. Upload docs, sync sources like Notion and Google Drive, and get answers grounded in your data, with citations.",
     summary:
       'Knowledge Base is the agent-memory module in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Teams upload docs or sync sources like Notion, Google Drive, and Confluence, and every agent answers from that data with citations, kept fresh automatically.',
     visual: (
@@ -73,7 +73,7 @@ const KNOWLEDGE_CONFIG: SolutionsPageConfig = {
           visual: (
             <KnowledgeAnswerGraphic
               question='What is our refund policy for annual plans?'
-              answer='Annual plans are refunded pro-rata within 30 days of renewal — after that, the remaining term converts to account credit.'
+              answer='Annual plans are refunded pro-rata within 30 days of renewal. After that, the remaining term converts to account credit.'
               sourceLabel='Billing policy'
               sourceDetail='Cited from your knowledge base'
             />
@@ -160,7 +160,7 @@ const KNOWLEDGE_CONFIG: SolutionsPageConfig = {
         {
           title: 'One memory for every agent',
           description:
-            'Every agent in Sim reads from the same knowledge base — in Chat, in workflows, and in deployed agents — so answers stay consistent.',
+            'Every agent in Sim reads from the same knowledge base, in Chat, in workflows, and in deployed agents, so answers stay consistent.',
           featureTileTone: 'dark',
           featureTileDescriptionTone: 'soft',
           visual: (

--- a/apps/sim/app/(landing)/knowledge/page.tsx
+++ b/apps/sim/app/(landing)/knowledge/page.tsx
@@ -1,15 +1,13 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import Knowledge from '@/app/(landing)/knowledge/knowledge'
+import Knowledge, { KNOWLEDGE_PAGE_DESCRIPTION } from '@/app/(landing)/knowledge/knowledge'
 
 export const revalidate = 3600
 
-const TITLE = 'Knowledge Base | Agent Memory in Sim, the AI Workspace'
-const DESCRIPTION =
-  "Knowledge Base is your agents' memory in Sim, the open-source AI workspace. Upload docs, sync sources like Notion and Google Drive, and get answers grounded in your own data, with citations."
+const TITLE = 'Knowledge Base for AI Agents: Memory & Citations | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: KNOWLEDGE_PAGE_DESCRIPTION,
   path: '/knowledge',
   keywords:
     'AI workspace, knowledge base for AI agents, agent memory, ground AI answers in company data, sync documents to AI agents, AI answers with citations, open-source AI workspace',

--- a/apps/sim/app/(landing)/logs/logs.tsx
+++ b/apps/sim/app/(landing)/logs/logs.tsx
@@ -33,16 +33,21 @@ import { LogsHeroLoop } from '@/app/(landing)/logs/components/logs-hero-loop'
  * to the platform page's (`WebPage` + `BreadcrumbList` +
  * `WebApplication`), so the feature-tile treatment is SEO-neutral.
  */
+/** Shared meta + JSON-LD description for the Logs page — one string, zero drift. */
+export const LOGS_PAGE_DESCRIPTION =
+  'Sim gives teams AI agent observability — trace every run step by step, search and filter across runs, and catch failures with alerts.'
+
 const LOGS_CONFIG: SolutionsPageConfig = {
   module: 'Logs',
   path: '/logs',
+  seoDescription: LOGS_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Logs',
-    heading: 'Trace every agent decision, block by block, in Sim.',
+    heading: 'Trace every agent run with full observability in Sim.',
     description:
-      'Logs give teams full visibility into every run in Sim, the open-source AI workspace. Follow each agent run block by block, filter and search across every run, and catch failures the moment they happen.',
+      'Logs is the AI agent observability layer in Sim, the open-source AI workspace. Follow each run block by block, search across every run, and catch failures with alerts.',
     summary:
-      'Logs is the visibility layer in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Sim records every agent run block by block, so teams trace each decision, tool call, and output, filter and search across every run, and catch failures with alerts.',
+      'Logs is the AI agent observability layer in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Sim records every step of every run, so teams trace each decision, tool call, and output, and catch failures with alerts.',
     visual: (
       <PlatformHeroVisual>
         <LogsHeroLoop />
@@ -54,13 +59,13 @@ const LOGS_CONFIG: SolutionsPageConfig = {
       id: 'trace',
       title: 'See exactly what every agent did.',
       subtitle:
-        'Sim records every agent run block by block, so teams can follow each decision, tool call, and output on one timeline.',
+        'Sim records every step of every agent run, so teams can follow each decision, tool call, and output on one timeline.',
       cta: { label: 'Explore Logs in Sim', href: '/signup' },
       cards: [
         {
           title: 'Trace runs block by block',
           description:
-            'Sim captures every step of a run, each block, tool call, and model response with its duration, so no agent decision is a black box.',
+            'Sim captures every step of a run — each block, tool call, and model response, with its duration.',
           featureTileTone: 'dark',
           featureTileDescriptionTone: 'soft',
           visual: <RunTraceGraphic />,
@@ -135,13 +140,13 @@ const LOGS_CONFIG: SolutionsPageConfig = {
         {
           title: 'Filter to the runs that matter',
           description:
-            'Search and filter every run in Sim by workflow, status, trigger, and time, so one failure is never buried under a thousand successes.',
+            'Search and filter every run in Sim by workflow, status, trigger, and time, so failed runs surface fast.',
           visual: <FilterRunsGraphic />,
         },
         {
           title: 'Debug with full context',
           description:
-            'Sim snapshots each run, so teams open a failed run with its inputs, outputs, and trace intact and see exactly which block broke.',
+            'Sim snapshots each run, so teams open a failed run with inputs, outputs, and trace intact and see which block broke.',
           visual: (
             <StagingGraphic
               title='Nightly data sync'

--- a/apps/sim/app/(landing)/logs/logs.tsx
+++ b/apps/sim/app/(landing)/logs/logs.tsx
@@ -33,9 +33,9 @@ import { LogsHeroLoop } from '@/app/(landing)/logs/components/logs-hero-loop'
  * to the platform page's (`WebPage` + `BreadcrumbList` +
  * `WebApplication`), so the feature-tile treatment is SEO-neutral.
  */
-/** Shared meta + JSON-LD description for the Logs page — one string, zero drift. */
+/** Shared meta + JSON-LD description for the Logs page (one string, zero drift). */
 export const LOGS_PAGE_DESCRIPTION =
-  'Sim gives teams AI agent observability — trace every run step by step, search and filter across runs, and catch failures with alerts.'
+  'Sim gives teams AI agent observability: trace every run step by step, search and filter across runs, and catch failures with alerts.'
 
 const LOGS_CONFIG: SolutionsPageConfig = {
   module: 'Logs',
@@ -65,7 +65,7 @@ const LOGS_CONFIG: SolutionsPageConfig = {
         {
           title: 'Trace runs block by block',
           description:
-            'Sim captures every step of a run — each block, tool call, and model response, with its duration.',
+            'Sim captures every step of a run: each block, tool call, and model response, with its duration.',
           featureTileTone: 'dark',
           featureTileDescriptionTone: 'soft',
           visual: <RunTraceGraphic />,

--- a/apps/sim/app/(landing)/logs/page.tsx
+++ b/apps/sim/app/(landing)/logs/page.tsx
@@ -1,18 +1,16 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import Logs from '@/app/(landing)/logs/logs'
+import Logs, { LOGS_PAGE_DESCRIPTION } from '@/app/(landing)/logs/logs'
 
 export const revalidate = 3600
 
-const TITLE = 'Logs | Trace Every Agent Run in Sim, the AI Workspace'
-const DESCRIPTION =
-  'Logs is the visibility layer in Sim, the open-source AI workspace. Trace every agent run block by block, filter and search across runs, and catch failures with alerts.'
+const TITLE = 'AI Agent Observability & Logs: Trace Every Run | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: LOGS_PAGE_DESCRIPTION,
   path: '/logs',
   keywords:
-    'AI workspace, AI agent logs, agent observability, trace agent runs, LLM run logs, AI agent monitoring, workflow run history, open-source AI agent platform',
+    'AI agent observability, AI workspace, AI agent logs, trace agent runs, LLM run logs, AI agent monitoring, workflow run history, open-source AI agent platform',
 })
 
 export default function Page() {

--- a/apps/sim/app/(landing)/page.tsx
+++ b/apps/sim/app/(landing)/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { SITE_URL } from '@/lib/core/utils/urls'
+import { HOME_PAGE_DESCRIPTION } from '@/app/(landing)/components/home-structured-data'
 import Landing from '@/app/(landing)/landing'
 
 export const revalidate = 3600
@@ -9,8 +10,7 @@ export const metadata: Metadata = {
   title: {
     absolute: 'Sim, The AI Workspace | Build, Deploy & Manage AI Agents',
   },
-  description:
-    'Sim is the open-source AI workspace where teams build, deploy, and manage AI agents across 1,000+ integrations and every major LLM.',
+  description: HOME_PAGE_DESCRIPTION,
   keywords:
     'AI workspace, AI agent builder, AI agent workflow builder, build AI agents, visual workflow builder, open-source AI agent platform, AI agents, agentic workflows, LLM orchestration, AI automation, knowledge base, workflow builder, AI integrations, SOC2 compliant, enterprise AI',
   authors: [{ name: 'Sim' }],
@@ -23,8 +23,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: 'Sim, The AI Workspace | Build, Deploy & Manage AI Agents',
-    description:
-      'Sim is the open-source AI workspace where teams build, deploy, and manage AI agents. Connect 1,000+ integrations and every major LLM to create agents that automate real work, visually, conversationally, or with code.',
+    description: HOME_PAGE_DESCRIPTION,
     type: 'website',
     url: SITE_URL,
     siteName: 'Sim',
@@ -44,8 +43,7 @@ export const metadata: Metadata = {
     site: '@simdotai',
     creator: '@simdotai',
     title: 'Sim, The AI Workspace | Build, Deploy & Manage AI Agents',
-    description:
-      'Sim is the open-source AI workspace where teams build, deploy, and manage AI agents. Connect 1,000+ integrations and every major LLM to create agents that automate real work.',
+    description: HOME_PAGE_DESCRIPTION,
     images: {
       url: '/logo/426-240/reverse/small.png',
       alt: 'Sim, The AI Workspace for Teams',

--- a/apps/sim/app/(landing)/scheduled-tasks/page.tsx
+++ b/apps/sim/app/(landing)/scheduled-tasks/page.tsx
@@ -1,15 +1,15 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import ScheduledTasks from '@/app/(landing)/scheduled-tasks/scheduled-tasks'
+import ScheduledTasks, {
+  SCHEDULED_TASKS_PAGE_DESCRIPTION,
+} from '@/app/(landing)/scheduled-tasks/scheduled-tasks'
 
 export const revalidate = 3600
 
-const TITLE = 'Scheduled Tasks | Run Agents on a Cadence in Sim, the AI Workspace'
-const DESCRIPTION =
-  'Scheduled Tasks runs your AI agents on a cadence in Sim, the open-source AI workspace. Schedule any workflow from 15-minute intervals to monthly or custom cron, timezone-aware, with every run traced.'
+const TITLE = 'Schedule AI Agents: Cron & Recurring Runs | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: SCHEDULED_TASKS_PAGE_DESCRIPTION,
   path: '/scheduled-tasks',
   keywords:
     'AI workspace, scheduled AI agents, cron AI workflows, recurring agent runs, AI task scheduler, schedule workflow automation, open-source AI agent platform, agentic workflows',

--- a/apps/sim/app/(landing)/scheduled-tasks/scheduled-tasks.tsx
+++ b/apps/sim/app/(landing)/scheduled-tasks/scheduled-tasks.tsx
@@ -32,9 +32,9 @@ import { DocumentDraftGraphic } from '@/app/(landing)/solutions/components/featu
  * The JSON-LD emitted by {@link SolutionsPage} is structurally identical to
  * the workflows page's (`WebPage` + `BreadcrumbList` + `WebApplication`).
  */
-/** Shared meta + JSON-LD description for the Scheduled Tasks page — one string, zero drift. */
+/** Shared meta + JSON-LD description for the Scheduled Tasks page (one string, zero drift). */
 export const SCHEDULED_TASKS_PAGE_DESCRIPTION =
-  'Schedule AI agents in Sim to run every 15 minutes, daily, monthly, or on a custom cron — timezone-aware, with every run traced on the calendar.'
+  'Schedule AI agents in Sim to run every 15 minutes, daily, monthly, or on a custom cron, timezone-aware, with every run traced on the calendar.'
 
 const SCHEDULED_TASKS_CONFIG: SolutionsPageConfig = {
   module: 'Scheduled Tasks',
@@ -44,7 +44,7 @@ const SCHEDULED_TASKS_CONFIG: SolutionsPageConfig = {
     eyebrow: 'Scheduled Tasks',
     heading: 'Schedule AI agents to run on their own.',
     description:
-      'Scheduled Tasks is the scheduler in Sim, the open-source AI workspace. Run any agent every 15 minutes, daily, monthly, or on a custom cron — timezone-aware, every run traced.',
+      'Scheduled Tasks is the scheduler in Sim, the open-source AI workspace. Run any agent every 15 minutes, daily, monthly, or on a custom cron, timezone-aware, with every run traced.',
     summary:
       'Scheduled Tasks is the scheduler in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Teams schedule any workflow to run every 15 minutes, daily, weekly, monthly, or on a custom cron in your timezone, and every run lands on the calendar with full history.',
     visual: (

--- a/apps/sim/app/(landing)/scheduled-tasks/scheduled-tasks.tsx
+++ b/apps/sim/app/(landing)/scheduled-tasks/scheduled-tasks.tsx
@@ -32,16 +32,21 @@ import { DocumentDraftGraphic } from '@/app/(landing)/solutions/components/featu
  * The JSON-LD emitted by {@link SolutionsPage} is structurally identical to
  * the workflows page's (`WebPage` + `BreadcrumbList` + `WebApplication`).
  */
+/** Shared meta + JSON-LD description for the Scheduled Tasks page — one string, zero drift. */
+export const SCHEDULED_TASKS_PAGE_DESCRIPTION =
+  'Schedule AI agents in Sim to run every 15 minutes, daily, monthly, or on a custom cron — timezone-aware, with every run traced on the calendar.'
+
 const SCHEDULED_TASKS_CONFIG: SolutionsPageConfig = {
   module: 'Scheduled Tasks',
   path: '/scheduled-tasks',
+  seoDescription: SCHEDULED_TASKS_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Scheduled Tasks',
-    heading: 'Set agents to run on a schedule, and let the work happen on its own.',
+    heading: 'Schedule AI agents to run on their own.',
     description:
-      'Scheduled Tasks runs your agents on a cadence in Sim, the open-source AI workspace. Pick a time from every 15 minutes to monthly or write a cron, timezone-aware, with every run traced.',
+      'Scheduled Tasks is the scheduler in Sim, the open-source AI workspace. Run any agent every 15 minutes, daily, monthly, or on a custom cron — timezone-aware, every run traced.',
     summary:
-      'Scheduled Tasks is the scheduler in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Put any workflow on a cadence, from 15-minute intervals to daily, weekly, and monthly runs or custom cron, timezone-aware, then watch every scheduled run land on the workspace calendar with full run history.',
+      'Scheduled Tasks is the scheduler in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Teams schedule any workflow to run every 15 minutes, daily, weekly, monthly, or on a custom cron in your timezone, and every run lands on the calendar with full history.',
     visual: (
       <PlatformHeroVisual>
         <ScheduledTasksCalendarLoop />
@@ -51,7 +56,7 @@ const SCHEDULED_TASKS_CONFIG: SolutionsPageConfig = {
   rows: [
     {
       id: 'schedule',
-      title: 'Put any agent on a cadence.',
+      title: 'Put any agent on a schedule.',
       subtitle:
         'Sim turns a workflow into a scheduled task with one trigger, from 15-minute intervals to monthly closes, in your timezone.',
       cta: { label: 'Schedule your first agent', href: '/signup' },
@@ -132,7 +137,7 @@ const SCHEDULED_TASKS_CONFIG: SolutionsPageConfig = {
         {
           title: 'Keep it running',
           description:
-            'Schedules stay live in production. Pause, resume, or retune the cadence without redeploying.',
+            'Schedules stay live in production. Pause, resume, or retune the timing without redeploying.',
           featureTileTone: 'dark',
           featureTileDescriptionTone: 'soft',
           visual: (

--- a/apps/sim/app/(landing)/solutions/compliance/compliance.tsx
+++ b/apps/sim/app/(landing)/solutions/compliance/compliance.tsx
@@ -25,16 +25,21 @@ import { DocumentDraftGraphic } from '@/app/(landing)/solutions/components/featu
  * framework monitoring, policy review) - so the page shares the enterprise
  * design language without any new visual vocabulary.
  */
+/** Meta description shared between the page metadata and the page JSON-LD. */
+export const COMPLIANCE_PAGE_DESCRIPTION =
+  'AI agents for compliance teams: automate evidence collection, control monitoring, and audit reports. Built in Sim, the open-source AI workspace.'
+
 const COMPLIANCE_CONFIG: SolutionsPageConfig = {
   module: 'Compliance',
   path: '/solutions/compliance',
+  seoDescription: COMPLIANCE_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Compliance',
-    heading: 'Automate evidence, control checks, and audit reports with Sim agents.',
+    heading: 'Automate evidence, control checks, and audit reports with AI agents in Sim.',
     description:
-      'Compliance teams build AI agents in Sim, the open-source AI workspace, that monitor controls and assemble a clean, defensible record, keeping the organization continuously audit-ready instead of scrambling once a year.',
+      'Sim is the open-source AI workspace where compliance teams build AI agents for evidence collection and control monitoring. Stay audit-ready year-round, across 1,000+ integrations.',
     summary:
-      'Sim is the open-source AI workspace where compliance teams build, deploy, and manage AI agents that automate evidence collection, control monitoring, and reporting, keeping the organization continuously audit-ready across 1,000+ integrations.',
+      'Sim is the open-source AI workspace where compliance teams build, deploy, and manage AI agents for evidence collection, control monitoring, and audit reports. Agents keep the organization audit-ready year-round across 1,000+ integrations.',
     visual: (
       <PlatformHeroVisual>
         <ComplianceHeroLoop />

--- a/apps/sim/app/(landing)/solutions/compliance/page.tsx
+++ b/apps/sim/app/(landing)/solutions/compliance/page.tsx
@@ -1,15 +1,15 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import ComplianceSolution from '@/app/(landing)/solutions/compliance/compliance'
+import ComplianceSolution, {
+  COMPLIANCE_PAGE_DESCRIPTION,
+} from '@/app/(landing)/solutions/compliance/compliance'
 
 export const revalidate = 3600
 
-const TITLE = 'AI Agents for Continuous Compliance & Audit | Sim'
-const DESCRIPTION =
-  'Compliance teams use Sim, the open-source AI workspace, to build and deploy AI agents that automate evidence collection, control monitoring, and reporting.'
+const TITLE = 'AI Agents for Compliance: Evidence & Audit Reports | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: COMPLIANCE_PAGE_DESCRIPTION,
   path: '/solutions/compliance',
   keywords:
     'AI workspace, AI agents for compliance, compliance automation, evidence collection, control monitoring, audit readiness, open-source AI agent platform',

--- a/apps/sim/app/(landing)/solutions/components/feature-graphics/knowledge-answer-graphic.tsx
+++ b/apps/sim/app/(landing)/solutions/components/feature-graphics/knowledge-answer-graphic.tsx
@@ -46,7 +46,7 @@ interface KnowledgeAnswerGraphicProps {
 
 export function KnowledgeAnswerGraphic({
   question = 'How do I reset my SSO password?',
-  answer = 'Head to id.acme.com, choose "Forgot password", and follow the email link — no ticket needed.',
+  answer = 'Head to id.acme.com, choose "Forgot password", and follow the email link. No ticket needed.',
   sourceLabel = 'IT handbook',
   sourceDetail = 'Answered from your docs',
 }: KnowledgeAnswerGraphicProps = {}) {

--- a/apps/sim/app/(landing)/solutions/engineering/engineering.tsx
+++ b/apps/sim/app/(landing)/solutions/engineering/engineering.tsx
@@ -25,16 +25,21 @@ import { EngineeringHeroLoop } from '@/app/(landing)/solutions/engineering/compo
  * CI/CD deploys, runbook docs) - so the page shares the enterprise design
  * language without any new visual vocabulary.
  */
+/** Meta description shared between the page metadata and the page JSON-LD. */
+export const ENGINEERING_PAGE_DESCRIPTION =
+  'AI agents for engineering teams: automate code review, on-call triage, and documentation. Built in Sim, the open-source AI workspace.'
+
 const ENGINEERING_CONFIG: SolutionsPageConfig = {
   module: 'Engineering',
   path: '/solutions/engineering',
+  seoDescription: ENGINEERING_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Engineering',
-    heading: 'Automate code review, on-call, and docs with Sim agents.',
+    heading: 'Automate code review, on-call, and docs with AI agents in Sim.',
     description:
-      'Engineering teams build AI agents in Sim, the open-source AI workspace, wired into GitHub, CI/CD, and 1,000+ integrations, visually, conversationally, or with code.',
+      'Sim is the open-source AI workspace where engineering teams build AI agents for code review, on-call, and docs. Agents wire into GitHub, CI/CD, and 1,000+ integrations across the software lifecycle.',
     summary:
-      'Sim is the open-source AI workspace where engineering teams build, deploy, and manage AI agents across the software lifecycle, automating code review, on-call triage, and documentation, wired into GitHub, CI/CD, and 1,000+ integrations.',
+      'Sim is the open-source AI workspace where engineering teams build, deploy, and manage AI agents for code review, on-call triage, and documentation. Agents wire into GitHub, CI/CD, and 1,000+ integrations across the software lifecycle.',
     visual: (
       <PlatformHeroVisual>
         <EngineeringHeroLoop />

--- a/apps/sim/app/(landing)/solutions/engineering/page.tsx
+++ b/apps/sim/app/(landing)/solutions/engineering/page.tsx
@@ -1,15 +1,15 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import EngineeringSolution from '@/app/(landing)/solutions/engineering/engineering'
+import EngineeringSolution, {
+  ENGINEERING_PAGE_DESCRIPTION,
+} from '@/app/(landing)/solutions/engineering/engineering'
 
 export const revalidate = 3600
 
-const TITLE = 'AI Agents for Code Review & On-Call | Sim'
-const DESCRIPTION =
-  'Engineering teams use Sim, the open-source AI workspace, to build and deploy AI agents that automate code review, on-call triage, and documentation.'
+const TITLE = 'AI Agents for Engineering: Code Review & On-Call | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: ENGINEERING_PAGE_DESCRIPTION,
   path: '/solutions/engineering',
   keywords:
     'AI workspace, AI agents for engineering, automated code review, on-call automation, CI/CD agents, developer automation, open-source AI agent platform',

--- a/apps/sim/app/(landing)/solutions/finance/finance.tsx
+++ b/apps/sim/app/(landing)/solutions/finance/finance.tsx
@@ -24,16 +24,21 @@ import { FinanceHeroLoop } from '@/app/(landing)/solutions/finance/components/fi
  * routing, approval gates, spend monitoring, the finance audit ledger),
  * plus one finance-specific vignette, the reconciliation match ledger.
  */
+/** Meta description shared between the page metadata and the page JSON-LD. */
+export const FINANCE_PAGE_DESCRIPTION =
+  'AI agents for finance teams: automate invoice processing, reconciliation, and financial reporting. Built in Sim, the open-source AI workspace.'
+
 const FINANCE_CONFIG: SolutionsPageConfig = {
   module: 'Finance',
   path: '/solutions/finance',
+  seoDescription: FINANCE_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Finance',
-    heading: 'Automate invoice processing, reconciliation, and close with Sim agents.',
+    heading: 'Automate invoice processing, reconciliation, and close with AI agents in Sim.',
     description:
-      'Finance teams build AI agents in Sim, the open-source AI workspace, with human approvals, anomaly detection, and full audit trails, across 1,000+ integrations and every major LLM.',
+      'Sim is the open-source AI workspace where finance teams build AI agents for invoice processing, reconciliation, and close. Human approvals, anomaly detection, and full audit trails guard every run.',
     summary:
-      'Sim is the open-source AI workspace where finance teams build, deploy, and manage AI agents that automate reconciliation, invoice processing, and reporting, with human approvals, anomaly detection, and full audit trails across 1,000+ integrations.',
+      'Sim is the open-source AI workspace where finance teams build, deploy, and manage AI agents for invoice processing, reconciliation, and financial reporting. Agents run with human approvals, anomaly detection, and full audit trails across 1,000+ integrations.',
     visual: (
       <PlatformHeroVisual>
         <FinanceHeroLoop />

--- a/apps/sim/app/(landing)/solutions/finance/page.tsx
+++ b/apps/sim/app/(landing)/solutions/finance/page.tsx
@@ -1,15 +1,15 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import FinanceSolution from '@/app/(landing)/solutions/finance/finance'
+import FinanceSolution, {
+  FINANCE_PAGE_DESCRIPTION,
+} from '@/app/(landing)/solutions/finance/finance'
 
 export const revalidate = 3600
 
-const TITLE = 'AI Agents for Invoice Processing & Reconciliation | Sim'
-const DESCRIPTION =
-  'Finance teams use Sim, the open-source AI workspace, to build and deploy AI agents that automate reconciliation, invoice processing, and reporting.'
+const TITLE = 'AI Agents for Finance: Invoicing & Reconciliation | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: FINANCE_PAGE_DESCRIPTION,
   path: '/solutions/finance',
   keywords:
     'AI workspace, AI agents for finance, finance automation, invoice processing, account reconciliation, financial reporting, open-source AI agent platform',

--- a/apps/sim/app/(landing)/solutions/hr/hr.tsx
+++ b/apps/sim/app/(landing)/solutions/hr/hr.tsx
@@ -26,16 +26,21 @@ import { HrHeroLoop } from '@/app/(landing)/solutions/hr/components/hr-hero-loop
  * systems, a benefits answer grounded in the team's docs, offer-letter
  * drafting, PTO approvals, surveys, and people reports.
  */
+/** Meta description shared between the page metadata and the page JSON-LD. */
+export const HR_PAGE_DESCRIPTION =
+  'AI agents for HR teams: automate onboarding, employee questions, and approvals. Built in Sim, the open-source AI workspace.'
+
 const HR_CONFIG: SolutionsPageConfig = {
   module: 'HR',
   path: '/solutions/hr',
+  seoDescription: HR_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'HR',
-    heading: 'Automate onboarding, employee questions, and approvals with Sim agents.',
+    heading: 'Automate onboarding, employee questions, and approvals with AI agents in Sim.',
     description:
-      'HR teams build AI agents in Sim, the open-source AI workspace, wired into your HRIS and 1,000+ integrations, so the team spends time on people, not paperwork.',
+      'Sim is the open-source AI workspace where HR teams build AI agents for onboarding, employee questions, and approvals. Agents wire into your HRIS and 1,000+ integrations to keep people operations moving.',
     summary:
-      'Sim is the open-source AI workspace where HR teams build, deploy, and manage AI agents that automate onboarding, employee questions, and approvals, connecting your HRIS and 1,000+ integrations so the team focuses on people, not paperwork.',
+      'Sim is the open-source AI workspace where HR teams build, deploy, and manage AI agents for onboarding, employee questions, and approvals. Agents connect your HRIS and 1,000+ integrations so people operations keep moving.',
     visual: (
       <PlatformHeroVisual>
         <HrHeroLoop />

--- a/apps/sim/app/(landing)/solutions/hr/page.tsx
+++ b/apps/sim/app/(landing)/solutions/hr/page.tsx
@@ -1,15 +1,13 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import HrSolution from '@/app/(landing)/solutions/hr/hr'
+import HrSolution, { HR_PAGE_DESCRIPTION } from '@/app/(landing)/solutions/hr/hr'
 
 export const revalidate = 3600
 
-const TITLE = 'AI Agents for Onboarding & People Operations | Sim'
-const DESCRIPTION =
-  'HR teams use Sim, the open-source AI workspace, to build and deploy AI agents that automate onboarding, employee questions, and approvals.'
+const TITLE = 'AI Agents for HR: Onboarding & Employee Operations | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: HR_PAGE_DESCRIPTION,
   path: '/solutions/hr',
   keywords:
     'AI workspace, AI agents for HR, HR automation, employee onboarding, people operations, HRIS automation, open-source AI agent platform',

--- a/apps/sim/app/(landing)/solutions/it/it.tsx
+++ b/apps/sim/app/(landing)/solutions/it/it.tsx
@@ -25,16 +25,21 @@ import { ItHeroLoop } from '@/app/(landing)/solutions/it/components/it-hero-loop
  * runbooks, infrastructure monitors) - so the page shares the enterprise
  * design language without any new visual vocabulary.
  */
+/** Meta description shared between the page metadata and the page JSON-LD. */
+export const IT_PAGE_DESCRIPTION =
+  'AI agents for IT teams: automate ticket triage, access provisioning, and infrastructure monitoring. Built in Sim, the open-source AI workspace.'
+
 const IT_CONFIG: SolutionsPageConfig = {
   module: 'IT',
   path: '/solutions/it',
+  seoDescription: IT_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'IT',
-    heading: 'Automate ticket triage, access, and monitoring with Sim agents.',
+    heading: 'Automate ticket triage, access, and monitoring with AI agents in Sim.',
     description:
-      'IT teams build AI agents in Sim, the open-source AI workspace, with the governance, access controls, and audit trails IT needs, across 1,000+ integrations and every major LLM.',
+      'Sim is the open-source AI workspace where IT teams build AI agents for ticket triage, access, and monitoring. Agents run with governance, access controls, and audit trails across 1,000+ integrations.',
     summary:
-      'Sim is the open-source AI workspace where IT teams build, deploy, and manage AI agents that automate ticket triage, access provisioning, and infrastructure monitoring, connecting 1,000+ integrations and every major LLM under IT-grade governance.',
+      'Sim is the open-source AI workspace where IT teams build, deploy, and manage AI agents for ticket triage, access provisioning, and infrastructure monitoring. Agents run with IT-grade governance and audit trails across 1,000+ integrations and every major LLM.',
     visual: (
       <PlatformHeroVisual>
         <ItHeroLoop />

--- a/apps/sim/app/(landing)/solutions/it/page.tsx
+++ b/apps/sim/app/(landing)/solutions/it/page.tsx
@@ -1,15 +1,13 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import ItSolution from '@/app/(landing)/solutions/it/it'
+import ItSolution, { IT_PAGE_DESCRIPTION } from '@/app/(landing)/solutions/it/it'
 
 export const revalidate = 3600
 
-const TITLE = 'AI Agents for Ticket Triage & Access | Sim'
-const DESCRIPTION =
-  'IT teams use Sim, the open-source AI workspace, to build and deploy AI agents that automate ticket triage, access provisioning, and monitoring.'
+const TITLE = 'AI Agents for IT: Ticket Triage & Access Provisioning | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: IT_PAGE_DESCRIPTION,
   path: '/solutions/it',
   keywords:
     'AI workspace, IT automation, AI agents for IT, IT service desk automation, access provisioning, infrastructure monitoring, open-source AI agent platform',

--- a/apps/sim/app/(landing)/solutions/sales/page.tsx
+++ b/apps/sim/app/(landing)/solutions/sales/page.tsx
@@ -1,15 +1,13 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import SalesSolution from '@/app/(landing)/solutions/sales/sales'
+import SalesSolution, { SALES_PAGE_DESCRIPTION } from '@/app/(landing)/solutions/sales/sales'
 
 export const revalidate = 3600
 
-const TITLE = 'AI Agents for Lead Research & CRM Updates | Sim'
-const DESCRIPTION =
-  'Sales teams use Sim, the open-source AI workspace, to build and deploy AI agents that automate lead research, personalized outreach, and CRM updates.'
+const TITLE = 'AI Agents for Sales: Lead Research & CRM Updates | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: SALES_PAGE_DESCRIPTION,
   path: '/solutions/sales',
   keywords:
     'AI workspace, AI agents for sales, sales automation, lead research, CRM automation, pipeline reporting, open-source AI agent platform',

--- a/apps/sim/app/(landing)/solutions/sales/sales.tsx
+++ b/apps/sim/app/(landing)/solutions/sales/sales.tsx
@@ -27,16 +27,21 @@ import { SalesHeroLoop } from '@/app/(landing)/solutions/sales/components/sales-
  * outreach drafting, CRM stage updates, meeting prep, and the pipeline
  * digest.
  */
+/** Meta description shared between the page metadata and the page JSON-LD. */
+export const SALES_PAGE_DESCRIPTION =
+  'AI agents for sales teams: automate lead research, personalized outreach, and CRM updates. Built in Sim, the open-source AI workspace.'
+
 const SALES_CONFIG: SolutionsPageConfig = {
   module: 'Sales',
   path: '/solutions/sales',
+  seoDescription: SALES_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Sales',
-    heading: 'Automate lead research, outreach, and CRM updates with Sim agents.',
+    heading: 'Automate lead research, outreach, and CRM updates with AI agents in Sim.',
     description:
-      'Sales teams build AI agents in Sim, the open-source AI workspace, wired into Salesforce, HubSpot, and 1,000+ integrations, so reps spend their time selling, not updating records.',
+      'Sim is the open-source AI workspace where sales teams build AI agents for lead research, outreach, and CRM updates. Agents wire into Salesforce, HubSpot, and 1,000+ integrations to keep the pipeline current.',
     summary:
-      'Sim is the open-source AI workspace where sales teams build, deploy, and manage AI agents that automate lead research, personalized outreach, and CRM updates, wired into Salesforce, HubSpot, and 1,000+ integrations so the pipeline stays current and reps spend their time selling.',
+      'Sim is the open-source AI workspace where sales teams build, deploy, and manage AI agents for lead research, personalized outreach, and CRM updates. Agents wire into Salesforce, HubSpot, and 1,000+ integrations so the pipeline stays current.',
     visual: (
       <PlatformHeroVisual>
         <SalesHeroLoop />

--- a/apps/sim/app/(landing)/tables/page.tsx
+++ b/apps/sim/app/(landing)/tables/page.tsx
@@ -1,18 +1,16 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import Tables from '@/app/(landing)/tables/tables'
+import Tables, { TABLES_PAGE_DESCRIPTION } from '@/app/(landing)/tables/tables'
 
 export const revalidate = 3600
 
-const TITLE = 'Tables | Structured Data for Agents in Sim, the AI Workspace'
-const DESCRIPTION =
-  'Tables is the database built into Sim, the open-source AI workspace. Store, query, and wire structured data into agent runs — records, enrichments, and state between runs.'
+const TITLE = 'AI Agent Database: Tables for Structured Data | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: TABLES_PAGE_DESCRIPTION,
   path: '/tables',
   keywords:
-    'AI workspace, built-in database, structured data for AI agents, AI agent memory, data enrichment, agent state between runs, open-source AI agent platform, tables for agents',
+    'AI agent database, AI workspace, built-in database, structured data for AI agents, AI agent memory, data enrichment, agent state between runs, open-source AI agent platform, tables for agents',
 })
 
 export default function Page() {

--- a/apps/sim/app/(landing)/tables/tables.tsx
+++ b/apps/sim/app/(landing)/tables/tables.tsx
@@ -32,16 +32,21 @@ import { TablesHeroLoop } from '@/app/(landing)/tables/components/tables-hero-lo
  * to the platform page's (`WebPage` + `BreadcrumbList` +
  * `WebApplication`), so the switch to feature tiles is SEO-neutral.
  */
+/** Shared meta + JSON-LD description for the Tables page — one string, zero drift. */
+export const TABLES_PAGE_DESCRIPTION =
+  'Tables is the AI agent database built into Sim. Store leads, tickets, and invoices as rows agents read and write, and carry state from one run to the next.'
+
 const TABLES_CONFIG: SolutionsPageConfig = {
   module: 'Tables',
   path: '/tables',
+  seoDescription: TABLES_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Tables',
-    heading: 'Power agents with structured data in Sim.',
+    heading: 'Give AI agents a database built into Sim.',
     description:
-      'Tables is the database built into Sim, the open-source AI workspace. Store the records agents read and write, let enrichments fill empty cells, and carry state from one run to the next.',
+      'Tables is the database built into Sim, the open-source AI workspace. Store the records agents read and write, fill empty cells with enrichments, and keep state between runs.',
     summary:
-      'Tables is the built-in database in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Teams store records agents read and write, run enrichments that fill cells automatically, query rows from agent logic, and keep state between runs, all in one workspace.',
+      'Tables is the AI agent database built into Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Teams store records agents read and write, run enrichments that fill cells automatically, query rows from agent logic, and keep state between runs, all in one workspace.',
     visual: (
       <PlatformHeroVisual>
         <TablesHeroLoop />
@@ -53,7 +58,7 @@ const TABLES_CONFIG: SolutionsPageConfig = {
       id: 'records',
       title: 'Give agents structured data to act on.',
       subtitle:
-        'Sim stores the records agents work with, leads, tickets, and invoices, as tables that live in the same workspace as the agents themselves.',
+        'Sim stores the records agents work with — leads, tickets, invoices — as tables in the same workspace as the agents.',
       cta: { label: 'Explore Tables', href: '/signup' },
       cards: [
         {

--- a/apps/sim/app/(landing)/tables/tables.tsx
+++ b/apps/sim/app/(landing)/tables/tables.tsx
@@ -32,7 +32,7 @@ import { TablesHeroLoop } from '@/app/(landing)/tables/components/tables-hero-lo
  * to the platform page's (`WebPage` + `BreadcrumbList` +
  * `WebApplication`), so the switch to feature tiles is SEO-neutral.
  */
-/** Shared meta + JSON-LD description for the Tables page — one string, zero drift. */
+/** Shared meta + JSON-LD description for the Tables page (one string, zero drift). */
 export const TABLES_PAGE_DESCRIPTION =
   'Tables is the AI agent database built into Sim. Store leads, tickets, and invoices as rows agents read and write, and carry state from one run to the next.'
 
@@ -58,7 +58,7 @@ const TABLES_CONFIG: SolutionsPageConfig = {
       id: 'records',
       title: 'Give agents structured data to act on.',
       subtitle:
-        'Sim stores the records agents work with — leads, tickets, invoices — as tables in the same workspace as the agents.',
+        'Sim stores the leads, tickets, and invoices agents work with as tables in the same workspace as the agents.',
       cta: { label: 'Explore Tables', href: '/signup' },
       cards: [
         {

--- a/apps/sim/app/(landing)/workflows/page.tsx
+++ b/apps/sim/app/(landing)/workflows/page.tsx
@@ -1,18 +1,16 @@
 import { buildLandingMetadata } from '@/lib/landing/seo'
-import Workflows from '@/app/(landing)/workflows/workflows'
+import Workflows, { WORKFLOWS_PAGE_DESCRIPTION } from '@/app/(landing)/workflows/workflows'
 
 export const revalidate = 3600
 
-const TITLE = 'Workflows | The Visual Builder in Sim, the AI Workspace'
-const DESCRIPTION =
-  'Workflows is the visual builder in Sim, the open-source AI workspace. Connect blocks, every major LLM, and 1,000+ integrations into agent logic.'
+const TITLE = 'AI Workflow Builder for Agents and Teams | Sim'
 
 export const metadata = buildLandingMetadata({
   title: TITLE,
-  description: DESCRIPTION,
+  description: WORKFLOWS_PAGE_DESCRIPTION,
   path: '/workflows',
   keywords:
-    'AI workspace, visual workflow builder, build AI agents, AI agent workflow builder, LLM orchestration, AI integrations, open-source AI agent platform, agentic workflows',
+    'AI workflow builder, AI workspace, visual workflow builder, build AI agents, AI agent workflow builder, LLM orchestration, AI integrations, open-source AI agent platform, agentic workflows',
 })
 
 export default function Page() {

--- a/apps/sim/app/(landing)/workflows/workflows.tsx
+++ b/apps/sim/app/(landing)/workflows/workflows.tsx
@@ -34,9 +34,9 @@ import { WorkflowsEditorLoop } from '@/app/(landing)/workflows/components/workfl
  * to the platform page's (`WebPage` + `BreadcrumbList` +
  * `WebApplication`), so the switch to feature tiles is SEO-neutral.
  */
-/** Shared meta + JSON-LD description for the Workflows page — one string, zero drift. */
+/** Shared meta + JSON-LD description for the Workflows page (one string, zero drift). */
 export const WORKFLOWS_PAGE_DESCRIPTION =
-  "Sim's AI workflow builder connects blocks, every major LLM, and 1,000+ integrations into agents — build Slack bots and data pipelines visually or in code."
+  "Sim's AI workflow builder connects blocks, every major LLM, and 1,000+ integrations into agents. Build Slack bots and data pipelines visually or in code."
 
 const WORKFLOWS_CONFIG: SolutionsPageConfig = {
   module: 'Workflows',
@@ -119,7 +119,7 @@ const WORKFLOWS_CONFIG: SolutionsPageConfig = {
           visual: (
             <KnowledgeAnswerGraphic
               question='@sim how do refunds work for annual plans?'
-              answer='Annual plans are refunded pro-rata — the refund workflow checks the policy, computes the credit, and files it in Zendesk automatically.'
+              answer='Annual plans are refunded pro-rata. The refund workflow checks the policy, computes the credit, and files it in Zendesk automatically.'
               sourceLabel='Support playbook'
               sourceDetail='Answered in #support'
             />

--- a/apps/sim/app/(landing)/workflows/workflows.tsx
+++ b/apps/sim/app/(landing)/workflows/workflows.tsx
@@ -34,16 +34,21 @@ import { WorkflowsEditorLoop } from '@/app/(landing)/workflows/components/workfl
  * to the platform page's (`WebPage` + `BreadcrumbList` +
  * `WebApplication`), so the switch to feature tiles is SEO-neutral.
  */
+/** Shared meta + JSON-LD description for the Workflows page — one string, zero drift. */
+export const WORKFLOWS_PAGE_DESCRIPTION =
+  "Sim's AI workflow builder connects blocks, every major LLM, and 1,000+ integrations into agents — build Slack bots and data pipelines visually or in code."
+
 const WORKFLOWS_CONFIG: SolutionsPageConfig = {
   module: 'Workflows',
   path: '/workflows',
+  seoDescription: WORKFLOWS_PAGE_DESCRIPTION,
   hero: {
     eyebrow: 'Workflows',
-    heading: 'Build Slack bots, compliance agents, and data pipelines in Sim.',
+    heading: 'Build AI agent workflows visually in Sim.',
     description:
-      'Connect blocks, every major LLM, and 1,000+ integrations into agent logic, the visual builder in Sim, the open-source AI workspace. Build visually, conversationally, or with code.',
+      'Workflows is the visual AI workflow builder in Sim, the open-source AI workspace. Connect blocks, every major LLM, and 1,000+ integrations into Slack bots, compliance agents, and data pipelines.',
     summary:
-      'Workflows is the visual builder in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Wire blocks, every major LLM, and 1,000+ integrations into agent logic, then deploy and run it without leaving Sim, visually, conversationally, or with code.',
+      'Workflows is the visual AI workflow builder in Sim, the open-source AI workspace where teams build, deploy, and manage AI agents. Teams wire blocks, every major LLM, and 1,000+ integrations into agent logic, then deploy and trace every run without leaving Sim.',
     visual: (
       <PlatformHeroVisual>
         <WorkflowsEditorLoop />


### PR DESCRIPTION
## Summary
- Rewrite hero copy on all 12 platform/solutions pages to a definitional, keyword-first pattern — kills the 23–31-word clause-stacked template sentence ("[X] teams build AI agents in Sim, the open-source AI workspace, [modifiers], [tail]") and all rhetorical tail clauses; every hero sentence is now ≤20 words
- Retarget metadata to real queries: platform titles lead with the searchable category ("AI Workflow Builder…", "Knowledge Base for AI Agents…", "AI Agent Database…", "AI Agent Observability…", "Schedule AI Agents…") instead of bare module names; solutions titles gain their segment noun (Sales/Engineering/IT/Compliance/Finance/HR); all titles ≤60 chars ending "| Sim", all descriptions 120–155 chars with the keyword inside the first 120
- Fix H1s: home drops the constitution-banned "agentic workflows" for "building AI agents"; enterprise H1 now names Sim and says "AI workspace" (was "The AI Agent Platform…"); platform H1s carry their category term; solutions H1s end "…with AI agents in Sim"
- Structured data: new `seoDescription` config field shares one constant per page between the meta description and JSON-LD `WebPage.description` (kills the 13-page drift); `offersFreeTier: false` on enterprise removes the misleading $0 Offer; "Mothership" removed from the home featureList (→ "Chat"); home meta/OG/Twitter/JSON-LD descriptions unified to one string; "| Sim AI" → "| Sim"
- Footer: platform module links now point at the local landing pages instead of docs.sim.ai (internal link equity), Files/Logs/Scheduled Tasks added, "Mothership" label → "Chat"

## Type of Change
- [x] Improvement

## Testing
Tested manually — typecheck + biome clean; all 14 routes rendered and titles/descriptions/H1s extracted from live HTML and measured by script (lengths, uniqueness, keyword placement); JSON-LD spot-checked; enterprise offer suppression verified

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)