### PR TITLE
fix(settings): align recently-deleted icon colors with platform token

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/recently-deleted/recently-deleted.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/recently-deleted/recently-deleted.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { Chip, ChipInput, ChipModalTabs } from '@sim/emcn'
-import { Folder, Search, Workflow } from '@sim/emcn/icons'
+import { Search } from '@sim/emcn/icons'
 import { toError } from '@sim/utils/errors'
 import { formatDate } from '@sim/utils/formatting'
 import { useParams, useRouter } from 'next/navigation'
@@ -72,12 +72,12 @@ const SORT_OPTIONS: ColumnOption[] = [
   { id: 'type', label: 'Type' },
 ]
 
-const ICON_CLASS = 'size-5'
+const ICON_CLASS = 'size-5 shrink-0'
 
-const RESOURCE_TYPE_TO_MOTHERSHIP: Partial<
-  Record<Exclude<ResourceType, 'all'>, MothershipResourceType>
-> = {
+const RESOURCE_TYPE_TO_MOTHERSHIP: Record<Exclude<ResourceType, 'all'>, MothershipResourceType> = {
   workflow: 'workflow',
+  folder: 'folder',
+  workspace_folder: 'filefolder',
   table: 'table',
   knowledge: 'knowledgebase',
   file: 'file',
@@ -89,7 +89,6 @@ interface DeletedResource {
   type: Exclude<ResourceType, 'all'>
   deletedAt: Date
   workspaceId: string
-  color?: string
 }
 
 interface RestoredResourceEntry {
@@ -116,17 +115,7 @@ const TYPE_LABEL: Record<Exclude<ResourceType, 'all'>, string> = {
 }
 
 function ResourceIcon({ resource }: { resource: DeletedResource }) {
-  if (resource.type === 'workflow') {
-    return <Workflow className={`${ICON_CLASS} shrink-0 text-[var(--text-icon)]`} />
-  }
-
-  if (resource.type === 'folder' || resource.type === 'workspace_folder') {
-    const color = resource.color ?? '#6B7280'
-    return <Folder className={ICON_CLASS} style={{ color }} />
-  }
-
   const mothershipType = RESOURCE_TYPE_TO_MOTHERSHIP[resource.type]
-  if (!mothershipType) return null
   const config = RESOURCE_REGISTRY[mothershipType]
   return config.renderTabIcon(
     { type: mothershipType, id: resource.id, title: resource.name },
@@ -222,7 +211,6 @@ export function RecentlyDeleted() {
         type: 'folder',
         deletedAt: folder.archivedAt ? new Date(folder.archivedAt) : new Date(folder.updatedAt),
         workspaceId: folder.workspaceId,
-        color: folder.color,
       })
     }
 


### PR DESCRIPTION
## Summary
- Folder and file-folder icons in the Recently Deleted settings page rendered with a hardcoded inline color (`#6B7280` fallback) while every other row icon used `var(--text-icon)`, so folder rows looked visibly lighter/off-token
- Route all resource types through the shared `RESOURCE_REGISTRY` tab-icon renderers (which apply `text-[var(--text-icon)]`) instead of special-casing workflows and folders
- Remove the now-unused `color` plumbing on `DeletedResource` and the dead icon imports

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)