### PR TITLE
feat(triggers): service-account credentials in the hubspot trigger

### DIFF
--- a/apps/docs/content/docs/en/integrations/hubspot-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/hubspot-service-account.mdx
@@ -116,7 +116,7 @@ The access token is bearer credentials for your entire portal, limited only by i
 
 ## Using the Service Account in Workflows
 
-Add a HubSpot block to your workflow. In the credential dropdown, your HubSpot service account appears alongside any OAuth credentials. Select it and configure the block as you normally would.
+Add a HubSpot block or the HubSpot CRM Trigger to your workflow. In the credential dropdown, your HubSpot service account appears alongside any OAuth credentials. Select it and configure the block as you normally would. For the polling trigger, a service account is often the better choice — the token never expires and keeps working even if the person who connected it leaves the portal.
 
 {/* TODO(screenshot): HubSpot block in a workflow with the HubSpot service account selected as the credential */}
 

--- a/apps/sim/app/api/credentials/route.ts
+++ b/apps/sim/app/api/credentials/route.ts
@@ -27,6 +27,7 @@ import {
   ServiceAccountSecretError,
   verifyAndBuildServiceAccountSecret,
 } from '@/lib/credentials/service-account-secret'
+import { isTokenServiceAccountProviderId } from '@/lib/credentials/token-service-accounts/descriptors'
 import { TokenServiceAccountValidationError } from '@/lib/credentials/token-service-accounts/errors'
 import { getServiceConfigByProviderId } from '@/lib/oauth'
 import { SLACK_CUSTOM_BOT_PROVIDER_ID } from '@/lib/oauth/types'
@@ -432,6 +433,19 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           {
             code: 'duplicate_display_name',
             error: `A Slack bot named "${resolvedDisplayName}" already exists in this workspace. Give this bot a different name.`,
+          },
+          { status: 409 }
+        )
+      }
+
+      // Token service-account creates always carry a fresh token that must be
+      // stored — falling through to the existing-credential path would return
+      // the old credential as success and silently drop the submitted token.
+      if (resolvedProviderId && isTokenServiceAccountProviderId(resolvedProviderId)) {
+        return NextResponse.json(
+          {
+            code: 'duplicate_display_name',
+            error: `A credential named "${resolvedDisplayName}" already exists in this workspace. Give this one a different name.`,
           },
           { status: 409 }
         )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/credential-selector/credential-selector.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/credential-selector/credential-selector.tsx
@@ -106,10 +106,10 @@ export function CredentialSelector({
     if (credentialKind === 'custom-bot') {
       return rawCredentials.filter((cred) => cred.type === 'service_account')
     }
-    return isTriggerMode
+    return isTriggerMode && !subBlock.allowServiceAccounts
       ? rawCredentials.filter((cred) => cred.type !== 'service_account')
       : rawCredentials
-  }, [rawCredentials, isTriggerMode, credentialKind])
+  }, [rawCredentials, isTriggerMode, credentialKind, subBlock.allowServiceAccounts])
 
   const selectedCredential = useMemo(
     () => credentials.find((cred) => cred.id === selectedId),

--- a/apps/sim/blocks/types.ts
+++ b/apps/sim/blocks/types.ts
@@ -372,6 +372,13 @@ export interface SubBlockConfig {
    * connect row opens the custom-bot setup modal instead of the OAuth flow.
    */
   credentialKind?: 'custom-bot'
+  /**
+   * Opts a trigger-mode `oauth-input` selector into listing service-account
+   * credentials, which are otherwise excluded in trigger mode. Set only when the
+   * trigger's server-side polling path can resolve the provider's service-account
+   * token (see `resolveOAuthCredential` in `@/lib/webhooks/polling/utils`).
+   */
+  allowServiceAccounts?: boolean
   // Selector properties — declarative mapping to a SelectorKey
   selectorKey?: SelectorKey
   selectorAllowSearch?: boolean

--- a/apps/sim/lib/webhooks/polling/utils.ts
+++ b/apps/sim/lib/webhooks/polling/utils.ts
@@ -7,6 +7,7 @@ import {
   getOAuthToken,
   refreshAccessTokenIfNeeded,
   resolveOAuthAccountId,
+  resolveServiceAccountToken,
 } from '@/app/api/auth/oauth/utils'
 import { MAX_CONSECUTIVE_FAILURES } from '@/triggers/constants'
 
@@ -202,6 +203,13 @@ export async function resolveOAuthCredential(
       throw new Error(
         `Failed to resolve OAuth account for credential ${credentialId}, webhook ${webhookData.id}`
       )
+    }
+    if (resolved.credentialType === 'service_account' && resolved.credentialId) {
+      const { accessToken: serviceAccountToken } = await resolveServiceAccountToken(
+        resolved.credentialId,
+        resolved.providerId
+      )
+      return serviceAccountToken
     }
     const rows = await db.select().from(account).where(eq(account.id, resolved.accountId)).limit(1)
     if (!rows.length) {

--- a/apps/sim/triggers/hubspot/poller.ts
+++ b/apps/sim/triggers/hubspot/poller.ts
@@ -61,6 +61,7 @@ export const hubspotPollingTrigger: TriggerConfig = {
       description: 'Connect a HubSpot account so Sim can poll your CRM on your behalf.',
       serviceId: 'hubspot',
       requiredScopes: getScopesForService('hubspot'),
+      allowServiceAccounts: true,
       required: true,
       mode: 'trigger',
     },


### PR DESCRIPTION
## Summary
- Staging's #5682 shipped HubSpot (and 11 other) token-paste service accounts while this PR was in review, superseding the provider work here — this PR is now rebased on it and carries only what #5682 doesn't have:
- HubSpot CRM Trigger accepts service-account credentials: the polling credential resolver (`resolveOAuthCredential`) resolves `service_account` credentials via `resolveServiceAccountToken`, and a new `allowServiceAccounts` subblock flag opts the trigger's credential picker into listing them (enabled on the HubSpot poller)
- 409 `duplicate_display_name` on token service-account create collisions (all 12 providers): previously a name match fell through to the existing-credential path and silently dropped the submitted token; the token modal already maps this code to a friendly message
- Docs: note trigger support on the HubSpot service-account page

## Type of Change
- [x] New feature

## Testing
Tested manually. `lint`, `tsc`, and `check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)