### PR TITLE
fix(emcn): remove brand-accent focus ring from TagInput default variant

### DIFF
--- a/packages/emcn/src/components/tag-input/tag-input.tsx
+++ b/packages/emcn/src/components/tag-input/tag-input.tsx
@@ -50,8 +50,10 @@ import { Tooltip } from '../tooltip/tooltip'
  *
  * @remarks
  * - `default` matches the standard Input component styling for consistent height.
+ *   Like `ChipInput`, it shows no focus ring — the surface stays calm and the
+ *   caret carries focus.
  * - `block` matches the multi-row "Description" textarea pattern: larger radius,
- *   top-aligned items, taller min-height, and no focus ring — for use inside
+ *   top-aligned items, and taller min-height — for use inside
  *   form sections where the tag input visually pairs with textarea fields.
  *   Uses `content-start` so wrapped flex lines pack tightly at `h-5` (20px) row
  *   pitch instead of being stretched by the `min-h-[112px]` floor; unused
@@ -64,7 +66,7 @@ const tagInputVariants = cva(
     variants: {
       variant: {
         default:
-          'items-center rounded-sm py-1.5 focus-within:outline-none focus-within:ring-1 focus-within:ring-[var(--brand-accent)] dark:bg-[var(--surface-5)]',
+          'items-center rounded-sm py-1.5 focus-within:outline-none dark:bg-[var(--surface-5)]',
         block:
           'min-h-[112px] content-start items-start rounded-lg py-2 focus-within:outline-none dark:bg-[var(--surface-4)]',
       },


### PR DESCRIPTION
## Summary
- Remove the green `--brand-accent` focus ring from `TagInput`'s `default` variant so it matches the canonical chip chrome — `ChipInput` shows no focus ring, and `TagInput`'s `block` variant already omits it
- Fixes the green outline on the "Allowed emails" field in the Share file modal (and any other default-variant `TagInput`)
- Update the variant TSDoc since "no focus ring" is no longer a block-only differentiator

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)