### PR TITLE
improvement(ci): promote superseded first-attempt runs forward

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,19 +298,21 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
 
-      # Re-running this job from an old run would retag the deploy tags back
-      # to that run's commit and immediately trigger a production deploy of
-      # stale code. Only promote while this commit is still the branch head;
-      # when superseded, skip cleanly — the newer run's promotion covers it.
+      # Deploy-tag moves must be monotonic: a re-run of an old run must never
+      # retag latest/staging back to stale code. A superseded first-attempt
+      # run still promotes — the ci-<ref> concurrency group executes runs
+      # serially in commit order, so an ancestor of head is a forward deploy.
       - name: Guard against stale promotion
         id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          HEAD_SHA="$(git ls-remote "https://github.com/${{ github.repository }}.git" "refs/heads/${GITHUB_REF_NAME}" | cut -f1)"
-          if [ "$HEAD_SHA" != "${{ github.sha }}" ]; then
-            echo "::warning::Skipping promotion of ${{ github.sha }}: ${GITHUB_REF_NAME} has moved to ${HEAD_SHA}. Moving the deploy tags to this commit would deploy stale code; push a revert commit to roll back instead."
-            echo "fresh=false" >> $GITHUB_OUTPUT
-          else
+          STATUS="$(gh api "repos/${{ github.repository }}/compare/${{ github.sha }}...${GITHUB_REF_NAME}" --jq '.status' || echo "unknown")"
+          if [ "$STATUS" = "identical" ] || { [ "$STATUS" = "ahead" ] && [ "${{ github.run_attempt }}" = "1" ]; }; then
             echo "fresh=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Skipping promotion of ${{ github.sha }} (branch compare: ${STATUS}, attempt ${{ github.run_attempt }}). Moving the deploy tags here could deploy stale code; push a revert commit to roll back instead."
+            echo "fresh=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Promote images to deploy tags
@@ -419,18 +421,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Same protection as promote-images: a re-run of an old run must not
-      # move the public latest tags back to a stale commit. Immutable tags
-      # (sha and version) are still published — only latest moves are gated.
+      # Same monotonic guard as promote-images, applied to the public latest
+      # tags only — immutable sha and version tags are always published.
       - name: Guard against stale latest tags
         id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          HEAD_SHA="$(git ls-remote "https://github.com/${{ github.repository }}.git" "refs/heads/${GITHUB_REF_NAME}" | cut -f1)"
-          if [ "$HEAD_SHA" != "${{ github.sha }}" ]; then
-            echo "::warning::${GITHUB_REF_NAME} has moved to ${HEAD_SHA}; publishing immutable tags for ${{ github.sha }} but skipping the latest tags."
-            echo "fresh=false" >> $GITHUB_OUTPUT
-          else
+          STATUS="$(gh api "repos/${{ github.repository }}/compare/${{ github.sha }}...${GITHUB_REF_NAME}" --jq '.status' || echo "unknown")"
+          if [ "$STATUS" = "identical" ] || { [ "$STATUS" = "ahead" ] && [ "${{ github.run_attempt }}" = "1" ]; }; then
             echo "fresh=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Publishing immutable tags for ${{ github.sha }} but skipping the latest tags (branch compare: ${STATUS}, attempt ${{ github.run_attempt }})."
+            echo "fresh=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Publish tags and manifests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,7 @@ jobs:
     needs: [promote-images, build-ghcr-arm64, detect-version]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
+      contents: read
       packages: write
     strategy:
       matrix:


### PR DESCRIPTION
## Problem

Cursor Bugbot finding on #5712 ([discussion](https://github.com/simstudioai/sim/pull/5712#discussion_r3598409487)): the stale-promotion guard skips moving deploy tags whenever the run's commit is no longer the branch head, assuming the newer run will promote. But if commit A passes its gate and was superseded mid-run by commit B, and **B then fails lint/tests/migrate**, B never promotes — and A was skipped too. `latest`/`staging` stay on pre-A code with no automatic recovery until another push.

## Fix

Sharpen the guard from "head only" to "monotonic forward":

- **Commit == branch head** → promote (unchanged)
- **First-attempt run, commit is an ancestor of head** (checked via the GitHub compare API) → **promote forward**. This is always safe: the `ci-<ref>` concurrency group serializes runs per branch, so a superseded first-attempt run executes before its successor — nothing newer can have promoted first.
- **Re-run (`run_attempt > 1`) of a superseded commit** → skip with a warning. This is the actual rollback hazard the guard exists for: re-running an old run must not retag deploy tags back to stale code.
- **Commit not an ancestor of head** (force-push) or compare API failure → skip (fail safe).

Same semantics applied to both guards (`promote-images` ECR deploy tags, `create-ghcr-manifests` GHCR latest tags). Immutable sha/version tags remain ungated by the guard, as before.

## Failure-mode table

| Scenario | Before | After |
|---|---|---|
| A passes, superseded by B, B passes | B deploys (A skipped, covered by B) | same |
| A passes, superseded by B, **B fails** | **nothing deploys (stuck pre-A)** | **A deploys** |
| Re-run old run on moved branch | skipped | skipped |
| Re-run of current head (transient retry) | promotes | promotes |
| Force-pushed-away commit | skipped | skipped |