### PR TITLE
fix(sidebar): align workspace header loading-state spacing with chip geometry

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   Chip,
   ChipConfirmModal,
+  chipGeometryClass,
   chipVariants,
   cn,
   DropdownMenu,
@@ -644,7 +645,8 @@ function WorkspaceHeaderImpl({
           type='button'
           aria-label='Switch workspace'
           className={cn(
-            'mx-0.5 h-[30px] items-center gap-2 rounded-lg px-2',
+            chipGeometryClass,
+            'mx-0.5',
             isCollapsed ? 'flex' : 'inline-flex min-w-0 max-w-full'
           )}
           title={activeWorkspace?.name}


### PR DESCRIPTION
## Summary
- The disabled/loading workspace header button hand-rolled its chrome with `gap-2` (8px), while the loaded state renders through `chipVariants()` whose canonical geometry is `gap-1.5` (6px) — so the icon-to-name spacing visibly shifted 2px when the workspace list finished loading
- Replace the hand-rolled class list with the design system's `chipGeometryClass` (exported for exactly this case: matching chip shape without inheriting hover/cursor chrome), keeping the `mx-0.5` and collapsed/expanded flex handling

## Type of Change
- [x] Bug fix

## Testing
Verified empirically against the emcn tokens (`chipContentGap = 'gap-1.5'` vs the hand-rolled `gap-2`); typecheck and lint pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)