### PR TITLE
fix(chat): align resource mention icon spacing with mention chips

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -241,7 +241,7 @@ const MARKDOWN_COMPONENTS = {
           className={cn(
             'text-[var(--text-primary)]',
             kind
-              ? 'not-prose inline-flex items-center gap-[5px] no-underline'
+              ? 'not-prose inline-flex items-baseline gap-1 no-underline'
               : 'underline decoration-dashed underline-offset-4'
           )}
           onClick={(e) => {
@@ -261,7 +261,7 @@ const MARKDOWN_COMPONENTS = {
           {kind && ref && (
             <ContextMentionIcon
               context={{ kind, label: kind === 'file' ? fileIconLabel(ref, label) : label }}
-              className='size-[14px] flex-shrink-0 text-[var(--text-icon)]'
+              className='relative top-0.5 size-[12px] flex-shrink-0 text-[var(--text-icon)]'
             />
           )}
           {children}


### PR DESCRIPTION
## Summary
- `#wsres-` resource links in the /chat renderer used `items-center gap-[5px]` with a 14px icon, so icon-to-text spacing didn't match the mention chips in the input or sent user messages
- aligned them to the canonical mention recipe (`items-baseline gap-1`, 12px icon nudged `top-0.5`) used by `special-tags.tsx` and `user-message-content.tsx`

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)