### PR TITLE
improvement(chat): give wsres resource links the clickable chip treatment

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -241,7 +241,7 @@ const MARKDOWN_COMPONENTS = {
           className={cn(
             'text-[var(--text-primary)]',
             kind
-              ? 'not-prose inline-flex items-baseline gap-1 no-underline'
+              ? 'not-prose inline-flex items-baseline gap-1 rounded-[5px] bg-[var(--surface-5)] px-[5px] no-underline transition-colors hover-hover:bg-[var(--surface-6)]'
               : 'underline decoration-dashed underline-offset-4'
           )}
           onClick={(e) => {


### PR DESCRIPTION
## Summary
- `#wsres-` resource links in assistant chat messages had no visible affordance at rest — plain text + icon, only the cursor hinted they were clickable
- applied the canonical clickable-resource chip recipe from `WorkspaceResourceDisplay` (`special-tags.tsx`): `rounded-[5px] bg-[var(--surface-5)] px-[5px]` with `hover-hover:bg-[var(--surface-6)]` + `transition-colors`
- follow-up to #5718 — the same resource now renders identically through both markdown paths

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)