### PR TITLE
improvement(workflows): stop writing placeholder workflow descriptions

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -144,7 +144,7 @@ export function Home({ chatId, userName, userId }: HomeProps) {
           filename: `${seed.workflowName}.json`,
           workspaceId,
           nameOverride: seed.workflowName,
-          descriptionOverride: seed.workflowDescription || 'Imported from landing template',
+          descriptionOverride: seed.workflowDescription || undefined,
           createWorkflow: async ({ name, description, workspaceId }) => {
             return requestJson(createWorkflowContract, {
               body: {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/api-info-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/api-info-modal.tsx
@@ -17,6 +17,7 @@ import {
 } from '@sim/emcn'
 import { getErrorMessage } from '@sim/utils/errors'
 import { useParams } from 'next/navigation'
+import { getMeaningfulWorkflowDescription } from '@/lib/mcp/workflow-tool-schema'
 import { normalizeInputFormatValue } from '@/lib/workflows/input-format'
 import { isInputDefinitionTrigger } from '@/lib/workflows/triggers/input-definition-triggers'
 import type { InputFormatField } from '@/lib/workflows/types'
@@ -89,14 +90,9 @@ export function ApiInfoModal({ open, onOpenChange, workflowId }: ApiInfoModalPro
 
   useEffect(() => {
     if (open) {
-      const normalizedDesc = workflowMetadata?.description?.toLowerCase().trim()
-      const isDefaultDescription =
-        !workflowMetadata?.description ||
-        workflowMetadata.description === workflowMetadata.name ||
-        normalizedDesc === 'new workflow' ||
-        normalizedDesc === 'your first workflow - start building here!'
-
-      const initialDescription = isDefaultDescription ? '' : workflowMetadata?.description || ''
+      const initialDescription =
+        getMeaningfulWorkflowDescription(workflowMetadata?.description, workflowMetadata?.name) ??
+        ''
       setDescription(initialDescription)
       initialDescriptionRef.current = initialDescription
 
@@ -181,7 +177,7 @@ export function ApiInfoModal({ open, onOpenChange, workflowId }: ApiInfoModalPro
         await updateWorkflowMutation.mutateAsync({
           workspaceId,
           workflowId,
-          metadata: { description: description.trim() || 'New workflow' },
+          metadata: { description: description.trim() },
         })
       }
 

--- a/apps/sim/hooks/queries/workflows.ts
+++ b/apps/sim/hooks/queries/workflows.ts
@@ -175,7 +175,7 @@ export function useCreateWorkflow() {
         body: {
           id,
           name: name || generateCreativeWorkflowName(),
-          description: description || 'New workflow',
+          description,
           workspaceId,
           folderId: folderId || null,
           sortOrder,
@@ -226,7 +226,7 @@ export function useCreateWorkflow() {
         name: variables.name || generateCreativeWorkflowName(),
         lastModified: new Date(),
         createdAt: new Date(),
-        description: variables.description || 'New workflow',
+        description: variables.description ?? '',
         workspaceId: variables.workspaceId,
         folderId: variables.folderId || null,
         sortOrder,

--- a/apps/sim/lib/workflows/operations/import-export.test.ts
+++ b/apps/sim/lib/workflows/operations/import-export.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it, vi } from 'vitest'
 
 vi.unmock('@/blocks/registry')
 
+vi.mock('@/lib/api/client/request', () => ({
+  requestJson: vi.fn().mockResolvedValue({}),
+}))
+
 import {
   extractWorkflowName,
   parseWorkflowJson,
+  persistImportedWorkflow,
   sanitizePathSegment,
 } from '@/lib/workflows/operations/import-export'
 
@@ -131,6 +136,67 @@ describe('workflow import/export parsing', () => {
       type: 'knowledge-base-selector',
       value: 'kb-uuid-123',
     })
+  })
+})
+
+describe('persistImportedWorkflow description handling', () => {
+  function buildContent(description?: string) {
+    const state = createLegacyState()
+    return JSON.stringify({
+      data: {
+        version: '1.0',
+        workflow: { name: 'Imported Workflow' },
+        state: {
+          ...state,
+          metadata: { name: 'Imported Workflow', description },
+        },
+      },
+    })
+  }
+
+  async function importWithContent(content: string, descriptionOverride?: string) {
+    const createWorkflow = vi.fn().mockResolvedValue({ id: 'wf-1' })
+    await persistImportedWorkflow({
+      content,
+      filename: 'imported-workflow.json',
+      workspaceId: 'ws-1',
+      descriptionOverride,
+      createWorkflow,
+    })
+    return createWorkflow.mock.calls[0][0].description as string
+  }
+
+  it('scrubs placeholder metadata descriptions to an empty string', async () => {
+    expect(await importWithContent(buildContent('New workflow'))).toBe('')
+    expect(
+      await importWithContent(buildContent('Your first workflow - start building here!'))
+    ).toBe('')
+  })
+
+  it('scrubs name-equal metadata descriptions to an empty string', async () => {
+    expect(await importWithContent(buildContent('Imported Workflow'))).toBe('')
+  })
+
+  it('preserves meaningful metadata descriptions', async () => {
+    expect(await importWithContent(buildContent('Syncs leads from HubSpot to Slack'))).toBe(
+      'Syncs leads from HubSpot to Slack'
+    )
+  })
+
+  it('uses an empty string when no description is present', async () => {
+    expect(await importWithContent(buildContent(undefined))).toBe('')
+  })
+
+  it('prefers a meaningful override over metadata', async () => {
+    expect(
+      await importWithContent(buildContent('Metadata description'), 'Override description')
+    ).toBe('Override description')
+  })
+
+  it('falls back to meaningful metadata when the override is a placeholder', async () => {
+    expect(await importWithContent(buildContent('Metadata description'), 'New workflow')).toBe(
+      'Metadata description'
+    )
   })
 })
 

--- a/apps/sim/lib/workflows/operations/import-export.ts
+++ b/apps/sim/lib/workflows/operations/import-export.ts
@@ -679,10 +679,9 @@ export async function persistImportedWorkflow({
   const createdWorkflow = await createWorkflow({
     name: workflowName,
     description:
-      getMeaningfulWorkflowDescription(
-        descriptionOverride || workflowData.metadata?.description,
-        workflowName
-      ) ?? '',
+      getMeaningfulWorkflowDescription(descriptionOverride, workflowName) ??
+      getMeaningfulWorkflowDescription(workflowData.metadata?.description, workflowName) ??
+      '',
     workspaceId,
     folderId,
     sortOrder,

--- a/apps/sim/lib/workflows/operations/import-export.ts
+++ b/apps/sim/lib/workflows/operations/import-export.ts
@@ -677,7 +677,7 @@ export async function persistImportedWorkflow({
 
   const createdWorkflow = await createWorkflow({
     name: workflowName,
-    description: descriptionOverride || workflowData.metadata?.description || 'Imported from JSON',
+    description: descriptionOverride || workflowData.metadata?.description || '',
     workspaceId,
     folderId,
     sortOrder,

--- a/apps/sim/lib/workflows/operations/import-export.ts
+++ b/apps/sim/lib/workflows/operations/import-export.ts
@@ -11,6 +11,7 @@ import {
   type WorkflowStateContractInput,
   workflowVariablesContract,
 } from '@/lib/api/contracts/workflows'
+import { getMeaningfulWorkflowDescription } from '@/lib/mcp/workflow-tool-schema'
 import { migrateSubblockIds } from '@/lib/workflows/migrations/subblock-migrations'
 import {
   type ExportWorkflowState,
@@ -677,7 +678,11 @@ export async function persistImportedWorkflow({
 
   const createdWorkflow = await createWorkflow({
     name: workflowName,
-    description: descriptionOverride || workflowData.metadata?.description || '',
+    description:
+      getMeaningfulWorkflowDescription(
+        descriptionOverride || workflowData.metadata?.description,
+        workflowName
+      ) ?? '',
     workspaceId,
     folderId,
     sortOrder,


### PR DESCRIPTION
## Summary
- Stop writing filler workflow descriptions everywhere: the create-workflow hook no longer defaults to `New workflow` (server contract default of `''` applies), JSON imports no longer write `Imported from JSON`, and landing-template seeds no longer write `Imported from landing template`
- Make the API-info modal description field an honest passthrough: reuse the shared `getMeaningfulWorkflowDescription` scrubber (same one the MCP serve layer and deploy tools use) instead of a hand-rolled masking heuristic, and save the trimmed value as-is instead of re-writing `New workflow` when cleared
- Legacy rows containing the old filler still display as blank and get cleaned up on the next save; the downstream scrubbers stay in place for existing data
- Fixes the mismatch where the user never saw the description but the agent context was fed a meaningless `New workflow` literal for every UI-created workflow

## Type of Change
- [x] Improvement

## Testing
Typecheck, biome, and `check:api-validation` pass; no tests reference the removed filler strings

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)