### PR TITLE
improvement(workflow): zero-render drag-resize for panel, terminal, and output panel

### DIFF
--- a/apps/sim/app/_styles/globals.css
+++ b/apps/sim/app/_styles/globals.css
@@ -14,6 +14,7 @@
   --panel-width: 320px; /* PANEL_WIDTH.DEFAULT */
   --editor-connections-height: 172px; /* EDITOR_CONNECTIONS_HEIGHT.DEFAULT */
   --terminal-height: 206px; /* TERMINAL_HEIGHT.DEFAULT */
+  --output-panel-width: 560px; /* OUTPUT_PANEL_WIDTH.DEFAULT */
   --auth-primary-btn-bg: #ffffff;
   --auth-primary-btn-border: #ffffff;
   --auth-primary-btn-text: #000000;

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/hooks/use-panel-resize.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/hooks/use-panel-resize.ts
@@ -1,90 +1,40 @@
-import { useCallback, useEffect, useRef } from 'react'
-import { PANEL_WIDTH } from '@/stores/constants'
+import { useDragResize } from '@/hooks/use-drag-resize'
+import { CONTENT_WINDOW_GAP, PANEL_WIDTH } from '@/stores/constants'
 import { usePanelStore } from '@/stores/panel'
 
-/** Inset gap between the viewport edge and the content window */
-const CONTENT_WINDOW_GAP = 8
+/**
+ * Computes the clamped panel width for a pointer position. The maximum is
+ * floored at the minimum so a narrow viewport can never invert the clamp
+ * and force the panel below {@link PANEL_WIDTH.MIN}.
+ */
+function computePanelWidth(ev: PointerEvent): number {
+  const maxWidth = Math.max(PANEL_WIDTH.MIN, window.innerWidth * PANEL_WIDTH.MAX_PERCENTAGE)
+  const newWidth = window.innerWidth - CONTENT_WINDOW_GAP - ev.clientX
+  return Math.min(Math.max(newWidth, PANEL_WIDTH.MIN), maxWidth)
+}
+
+/**
+ * Applies the panel width per frame. The `--panel-width` CSS variable alone
+ * sizes `.panel-container`, so no React work happens during the drag.
+ */
+function applyPanelWidth(width: number): void {
+  document.documentElement.style.setProperty('--panel-width', `${width}px`)
+}
 
 /**
  * Handles panel drag-resize with zero React renders during the drag.
+ * The final width is committed to the store (one re-render + one
+ * localStorage write) when the drag ends.
  *
- * Mirrors the sidebar resize architecture (`use-sidebar-resize.ts`):
- *
- * pointerdown  → capture the pointer on the handle (so move/up keep arriving
- *                even when the cursor leaves the window)
- * pointermove  → write to --panel-width inside a requestAnimationFrame
- *                callback (the CSS variable alone sizes `.panel-container`,
- *                so no React work happens per frame)
- * pointerup    → cancel any pending RAF, tear down, persist the final width
- *                to Zustand once (one re-render + one localStorage write)
- *
- * The drag is torn down by `pointerup`, `pointercancel`, or window `blur`, so
- * an interrupted gesture can never leave the drag listeners or body cursor
- * stuck. A single-flight guard prevents stacking listeners across rapid
- * presses, and an unmount cleanup tears down a drag still in flight.
+ * @returns Pointer-down handler for the resize handle
  */
 export function usePanelResize() {
   const setPanelWidth = usePanelStore((s) => s.setPanelWidth)
-  const setIsResizing = usePanelStore((s) => s.setIsResizing)
-  const cleanupRef = useRef<(() => void) | null>(null)
 
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent<HTMLElement>) => {
-      if (cleanupRef.current) return
-
-      const handle = e.currentTarget
-      const pointerId = e.pointerId
-      setIsResizing(true)
-      document.body.style.cursor = 'ew-resize'
-      document.body.style.userSelect = 'none'
-      handle.setPointerCapture?.(pointerId)
-
-      let rafId: number | null = null
-
-      const onPointerMove = (ev: PointerEvent) => {
-        if (rafId !== null) cancelAnimationFrame(rafId)
-        rafId = requestAnimationFrame(() => {
-          const maxWidth = window.innerWidth * PANEL_WIDTH.MAX_PERCENTAGE
-          const newWidth = window.innerWidth - CONTENT_WINDOW_GAP - ev.clientX
-          const clamped = Math.min(Math.max(newWidth, PANEL_WIDTH.MIN), maxWidth)
-          document.documentElement.style.setProperty('--panel-width', `${clamped}px`)
-          rafId = null
-        })
-      }
-
-      const cleanup = () => {
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId)
-          rafId = null
-        }
-        document.body.style.cursor = ''
-        document.body.style.userSelect = ''
-        if (handle.hasPointerCapture?.(pointerId)) handle.releasePointerCapture(pointerId)
-        document.removeEventListener('pointermove', onPointerMove)
-        document.removeEventListener('pointerup', endDrag)
-        document.removeEventListener('pointercancel', endDrag)
-        window.removeEventListener('blur', endDrag)
-        cleanupRef.current = null
-      }
-
-      function endDrag() {
-        cleanup()
-        const raw = document.documentElement.style.getPropertyValue('--panel-width')
-        const finalWidth = Number.parseFloat(raw)
-        if (!Number.isNaN(finalWidth)) setPanelWidth(finalWidth)
-        setIsResizing(false)
-      }
-
-      cleanupRef.current = cleanup
-      document.addEventListener('pointermove', onPointerMove)
-      document.addEventListener('pointerup', endDrag)
-      document.addEventListener('pointercancel', endDrag)
-      window.addEventListener('blur', endDrag)
-    },
-    [setPanelWidth, setIsResizing]
-  )
-
-  useEffect(() => () => cleanupRef.current?.(), [])
-
-  return { handlePointerDown }
+  return useDragResize({
+    cursor: 'ew-resize',
+    compute: computePanelWidth,
+    apply: applyPanelWidth,
+    commit: setPanelWidth,
+  })
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/hooks/use-panel-resize.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/hooks/use-panel-resize.ts
@@ -1,5 +1,4 @@
-import { useCallback, useEffect } from 'react'
-import { useShallow } from 'zustand/react/shallow'
+import { useCallback, useEffect, useRef } from 'react'
 import { PANEL_WIDTH } from '@/stores/constants'
 import { usePanelStore } from '@/stores/panel'
 
@@ -7,63 +6,85 @@ import { usePanelStore } from '@/stores/panel'
 const CONTENT_WINDOW_GAP = 8
 
 /**
- * Custom hook to handle panel resize functionality.
- * Manages mouse events for resizing and enforces min/max width constraints.
- * Maximum width is capped at 40% of the viewport width for optimal layout.
+ * Handles panel drag-resize with zero React renders during the drag.
  *
- * @returns Resize state and handlers
+ * Mirrors the sidebar resize architecture (`use-sidebar-resize.ts`):
+ *
+ * pointerdown  → capture the pointer on the handle (so move/up keep arriving
+ *                even when the cursor leaves the window)
+ * pointermove  → write to --panel-width inside a requestAnimationFrame
+ *                callback (the CSS variable alone sizes `.panel-container`,
+ *                so no React work happens per frame)
+ * pointerup    → cancel any pending RAF, tear down, persist the final width
+ *                to Zustand once (one re-render + one localStorage write)
+ *
+ * The drag is torn down by `pointerup`, `pointercancel`, or window `blur`, so
+ * an interrupted gesture can never leave the drag listeners or body cursor
+ * stuck. A single-flight guard prevents stacking listeners across rapid
+ * presses, and an unmount cleanup tears down a drag still in flight.
  */
 export function usePanelResize() {
-  const { setPanelWidth, isResizing, setIsResizing } = usePanelStore(
-    useShallow((s) => ({
-      setPanelWidth: s.setPanelWidth,
-      isResizing: s.isResizing,
-      setIsResizing: s.setIsResizing,
-    }))
+  const setPanelWidth = usePanelStore((s) => s.setPanelWidth)
+  const setIsResizing = usePanelStore((s) => s.setIsResizing)
+  const cleanupRef = useRef<(() => void) | null>(null)
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      if (cleanupRef.current) return
+
+      const handle = e.currentTarget
+      const pointerId = e.pointerId
+      setIsResizing(true)
+      document.body.style.cursor = 'ew-resize'
+      document.body.style.userSelect = 'none'
+      handle.setPointerCapture?.(pointerId)
+
+      let rafId: number | null = null
+
+      const onPointerMove = (ev: PointerEvent) => {
+        if (rafId !== null) cancelAnimationFrame(rafId)
+        rafId = requestAnimationFrame(() => {
+          const maxWidth = window.innerWidth * PANEL_WIDTH.MAX_PERCENTAGE
+          const newWidth = window.innerWidth - CONTENT_WINDOW_GAP - ev.clientX
+          const clamped = Math.min(Math.max(newWidth, PANEL_WIDTH.MIN), maxWidth)
+          document.documentElement.style.setProperty('--panel-width', `${clamped}px`)
+          rafId = null
+        })
+      }
+
+      const cleanup = () => {
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId)
+          rafId = null
+        }
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+        if (handle.hasPointerCapture?.(pointerId)) handle.releasePointerCapture(pointerId)
+        document.removeEventListener('pointermove', onPointerMove)
+        document.removeEventListener('pointerup', endDrag)
+        document.removeEventListener('pointercancel', endDrag)
+        window.removeEventListener('blur', endDrag)
+        cleanupRef.current = null
+      }
+
+      function endDrag() {
+        cleanup()
+        const raw = document.documentElement.style.getPropertyValue('--panel-width')
+        const finalWidth = Number.parseFloat(raw)
+        if (!Number.isNaN(finalWidth)) setPanelWidth(finalWidth)
+        setIsResizing(false)
+      }
+
+      cleanupRef.current = cleanup
+      document.addEventListener('pointermove', onPointerMove)
+      document.addEventListener('pointerup', endDrag)
+      document.addEventListener('pointercancel', endDrag)
+      window.addEventListener('blur', endDrag)
+    },
+    [setPanelWidth, setIsResizing]
   )
 
-  /**
-   * Handles mouse down on resize handle
-   */
-  const handleMouseDown = useCallback(() => {
-    setIsResizing(true)
-  }, [setIsResizing])
+  useEffect(() => () => cleanupRef.current?.(), [])
 
-  /**
-   * Setup resize event listeners and body styles when resizing
-   * Cleanup is handled automatically by the effect's return function
-   */
-  useEffect(() => {
-    if (!isResizing) return
-
-    const handleMouseMove = (e: MouseEvent) => {
-      const newWidth = window.innerWidth - CONTENT_WINDOW_GAP - e.clientX
-      const maxWidth = window.innerWidth * PANEL_WIDTH.MAX_PERCENTAGE
-
-      if (newWidth >= PANEL_WIDTH.MIN && newWidth <= maxWidth) {
-        setPanelWidth(newWidth)
-      }
-    }
-
-    const handleMouseUp = () => {
-      setIsResizing(false)
-    }
-
-    document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', handleMouseUp)
-    document.body.style.cursor = 'ew-resize'
-    document.body.style.userSelect = 'none'
-
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', handleMouseUp)
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-    }
-  }, [isResizing, setPanelWidth, setIsResizing])
-
-  return {
-    isResizing,
-    handleMouseDown,
-  }
+  return { handlePointerDown }
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -122,11 +122,10 @@ export const Panel = memo(function Panel() {
 
   const panelRef = useRef<HTMLElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const { activeTab, setActiveTab, panelWidth, _hasHydrated, setHasHydrated } = usePanelStore(
+  const { activeTab, setActiveTab, _hasHydrated, setHasHydrated } = usePanelStore(
     useShallow((state) => ({
       activeTab: state.activeTab,
       setActiveTab: state.setActiveTab,
-      panelWidth: state.panelWidth,
       _hasHydrated: state._hasHydrated,
       setHasHydrated: state.setHasHydrated,
     }))
@@ -189,7 +188,7 @@ export const Panel = memo(function Panel() {
   const { handleRunWorkflow, handleCancelExecution, isExecuting } = useWorkflowExecution()
 
   // Panel resize hook
-  const { handleMouseDown } = usePanelResize()
+  const { handlePointerDown } = usePanelResize()
 
   /**
    * Opens subscription settings modal
@@ -932,7 +931,7 @@ export const Panel = memo(function Panel() {
         {/* Resize Handle */}
         <div
           className='absolute top-0 bottom-0 left-[-4px] z-20 w-[8px] cursor-ew-resize'
-          onMouseDown={handleMouseDown}
+          onPointerDown={handlePointerDown}
           role='separator'
           aria-orientation='vertical'
           aria-label='Resize panel'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/components/output-panel/output-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/components/output-panel/output-panel.tsx
@@ -77,12 +77,12 @@ const OutputCodeContent = React.memo(function OutputCodeContent({
 
 /**
  * Props for the OutputPanel component
- * Store-backed settings (wrapText, openOnRun, structuredView, outputPanelWidth)
+ * Store-backed settings (wrapText, openOnRun, structuredView)
  * are accessed directly from useTerminalStore to reduce prop drilling.
  */
 export interface OutputPanelProps {
   selectedEntry: ConsoleEntry
-  handleOutputPanelResizeMouseDown: (e: React.MouseEvent) => void
+  handleOutputPanelResizePointerDown: (e: React.PointerEvent<HTMLElement>) => void
   handleHeaderClick: () => void
   isExpanded: boolean
   expandToLastHeight: () => void
@@ -109,7 +109,7 @@ export interface OutputPanelProps {
  */
 export const OutputPanel = React.memo(function OutputPanel({
   selectedEntry,
-  handleOutputPanelResizeMouseDown,
+  handleOutputPanelResizePointerDown,
   handleHeaderClick,
   isExpanded,
   expandToLastHeight,
@@ -130,7 +130,6 @@ export const OutputPanel = React.memo(function OutputPanel({
   handleClearConsoleFromMenu,
 }: OutputPanelProps) {
   // Access store-backed settings directly to reduce prop drilling
-  const outputPanelWidth = useTerminalStore((state) => state.outputPanelWidth)
   const wrapText = useTerminalStore((state) => state.wrapText)
   const setWrapText = useTerminalStore((state) => state.setWrapText)
   const openOnRun = useTerminalStore((state) => state.openOnRun)
@@ -293,12 +292,12 @@ export const OutputPanel = React.memo(function OutputPanel({
     <>
       <div
         className='absolute top-0 right-0 bottom-0 flex flex-col border-[var(--border)] border-l bg-[var(--bg)]'
-        style={{ width: `${outputPanelWidth}px` }}
+        style={{ width: 'var(--output-panel-width)' }}
       >
         {/* Horizontal Resize Handle */}
         <div
           className='-ml-1 absolute top-0 bottom-0 left-0 z-20 w-[8px] cursor-ew-resize'
-          onMouseDown={handleOutputPanelResizeMouseDown}
+          onPointerDown={handleOutputPanelResizePointerDown}
           role='separator'
           aria-label='Resize output panel'
           aria-orientation='vertical'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/hooks/use-output-panel-resize.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/hooks/use-output-panel-resize.ts
@@ -1,49 +1,89 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { OUTPUT_PANEL_WIDTH, TERMINAL_BLOCK_COLUMN_WIDTH } from '@/stores/constants'
 import { useTerminalStore } from '@/stores/terminal'
 
+/**
+ * Handles the terminal output panel drag-resize with zero React renders
+ * during the drag.
+ *
+ * Mirrors the sidebar resize architecture (`use-sidebar-resize.ts`):
+ *
+ * pointerdown  → capture the pointer on the handle (so move/up keep arriving
+ *                even when the cursor leaves the window)
+ * pointermove  → write to --output-panel-width inside a requestAnimationFrame
+ *                callback (the CSS variable alone sizes the logs column via
+ *                `calc(100% - var(--output-panel-width))`)
+ * pointerup    → cancel any pending RAF, tear down, persist the final width
+ *                to Zustand once (one re-render + one localStorage write)
+ *
+ * The drag is torn down by `pointerup`, `pointercancel`, or window `blur`, so
+ * an interrupted gesture can never leave the drag listeners or body cursor
+ * stuck. A single-flight guard prevents stacking listeners across rapid
+ * presses, and an unmount cleanup tears down a drag still in flight.
+ */
 export function useOutputPanelResize() {
-  const setOutputPanelWidth = useTerminalStore((state) => state.setOutputPanelWidth)
-  const [isResizing, setIsResizing] = useState(false)
+  const setOutputPanelWidth = useTerminalStore((s) => s.setOutputPanelWidth)
+  const cleanupRef = useRef<(() => void) | null>(null)
 
-  const handleMouseDown = useCallback(() => {
-    setIsResizing(true)
-  }, [])
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      if (cleanupRef.current) return
 
-  useEffect(() => {
-    if (!isResizing) return
-
-    const handleMouseMove = (e: MouseEvent) => {
       const terminalEl = document.querySelector('[aria-label="Terminal"]')
       if (!terminalEl) return
 
-      const terminalRect = terminalEl.getBoundingClientRect()
-      const newWidth = terminalRect.right - e.clientX
-      const maxWidth = terminalRect.width - TERMINAL_BLOCK_COLUMN_WIDTH
-      const clampedWidth = Math.max(OUTPUT_PANEL_WIDTH.MIN, Math.min(newWidth, maxWidth))
+      const handle = e.currentTarget
+      const pointerId = e.pointerId
+      document.body.style.cursor = 'ew-resize'
+      document.body.style.userSelect = 'none'
+      handle.setPointerCapture?.(pointerId)
 
-      setOutputPanelWidth(clampedWidth)
-    }
+      let rafId: number | null = null
 
-    const handleMouseUp = () => {
-      setIsResizing(false)
-    }
+      const onPointerMove = (ev: PointerEvent) => {
+        if (rafId !== null) cancelAnimationFrame(rafId)
+        rafId = requestAnimationFrame(() => {
+          const terminalRect = terminalEl.getBoundingClientRect()
+          const newWidth = terminalRect.right - ev.clientX
+          const maxWidth = terminalRect.width - TERMINAL_BLOCK_COLUMN_WIDTH
+          const clamped = Math.max(OUTPUT_PANEL_WIDTH.MIN, Math.min(newWidth, maxWidth))
+          document.documentElement.style.setProperty('--output-panel-width', `${clamped}px`)
+          rafId = null
+        })
+      }
 
-    document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', handleMouseUp)
-    document.body.style.cursor = 'ew-resize'
-    document.body.style.userSelect = 'none'
+      const cleanup = () => {
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId)
+          rafId = null
+        }
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+        if (handle.hasPointerCapture?.(pointerId)) handle.releasePointerCapture(pointerId)
+        document.removeEventListener('pointermove', onPointerMove)
+        document.removeEventListener('pointerup', endDrag)
+        document.removeEventListener('pointercancel', endDrag)
+        window.removeEventListener('blur', endDrag)
+        cleanupRef.current = null
+      }
 
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', handleMouseUp)
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-    }
-  }, [isResizing, setOutputPanelWidth])
+      function endDrag() {
+        cleanup()
+        const raw = document.documentElement.style.getPropertyValue('--output-panel-width')
+        const finalWidth = Number.parseFloat(raw)
+        if (!Number.isNaN(finalWidth)) setOutputPanelWidth(finalWidth)
+      }
 
-  return {
-    isResizing,
-    handleMouseDown,
-  }
+      cleanupRef.current = cleanup
+      document.addEventListener('pointermove', onPointerMove)
+      document.addEventListener('pointerup', endDrag)
+      document.addEventListener('pointercancel', endDrag)
+      window.addEventListener('blur', endDrag)
+    },
+    [setOutputPanelWidth]
+  )
+
+  useEffect(() => () => cleanupRef.current?.(), [])
+
+  return { handlePointerDown }
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/hooks/use-output-panel-resize.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/hooks/use-output-panel-resize.ts
@@ -14,27 +14,27 @@ function applyOutputPanelWidth(width: number): void {
 
 /**
  * Handles the terminal output panel drag-resize with zero React renders
- * during the drag. The terminal rect is captured once on drag start (its
- * size cannot change mid-drag, and this keeps forced layout reads off the
- * per-move path). The final width is committed to the store (one re-render
- * + one localStorage write) when the drag ends.
+ * during the drag. The terminal element is captured once on drag start and
+ * its rect is re-read per frame (rAF-aligned, before the CSS-var write), so
+ * the clamp stays correct even if the terminal resizes mid-drag. The final
+ * width is committed to the store (one re-render + one localStorage write)
+ * when the drag ends.
  *
  * @returns Pointer-down handler for the resize handle
  */
 export function useOutputPanelResize() {
   const setOutputPanelWidth = useTerminalStore((s) => s.setOutputPanelWidth)
-  const terminalRectRef = useRef<DOMRect | null>(null)
+  const terminalElRef = useRef<Element | null>(null)
 
-  const captureTerminalRect = useCallback(() => {
-    const terminalEl = document.querySelector('[aria-label="Terminal"]')
-    if (!terminalEl) return false
-    terminalRectRef.current = terminalEl.getBoundingClientRect()
-    return true
+  const captureTerminalElement = useCallback(() => {
+    terminalElRef.current = document.querySelector('[aria-label="Terminal"]')
+    return terminalElRef.current !== null
   }, [])
 
   const computeOutputPanelWidth = useCallback((ev: PointerEvent) => {
-    const terminalRect = terminalRectRef.current
-    if (!terminalRect) return null
+    const terminalEl = terminalElRef.current
+    if (!terminalEl) return null
+    const terminalRect = terminalEl.getBoundingClientRect()
     const newWidth = terminalRect.right - ev.clientX
     const maxWidth = terminalRect.width - TERMINAL_BLOCK_COLUMN_WIDTH
     return Math.max(OUTPUT_PANEL_WIDTH.MIN, Math.min(newWidth, maxWidth))
@@ -45,6 +45,6 @@ export function useOutputPanelResize() {
     compute: computeOutputPanelWidth,
     apply: applyOutputPanelWidth,
     commit: setOutputPanelWidth,
-    onStart: captureTerminalRect,
+    onStart: captureTerminalElement,
   })
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/hooks/use-output-panel-resize.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/hooks/use-output-panel-resize.ts
@@ -1,89 +1,50 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useRef } from 'react'
+import { useDragResize } from '@/hooks/use-drag-resize'
 import { OUTPUT_PANEL_WIDTH, TERMINAL_BLOCK_COLUMN_WIDTH } from '@/stores/constants'
 import { useTerminalStore } from '@/stores/terminal'
 
 /**
+ * Applies the output panel width per frame. The `--output-panel-width` CSS
+ * variable alone sizes the output panel and its sibling logs column, so no
+ * React work happens during the drag.
+ */
+function applyOutputPanelWidth(width: number): void {
+  document.documentElement.style.setProperty('--output-panel-width', `${width}px`)
+}
+
+/**
  * Handles the terminal output panel drag-resize with zero React renders
- * during the drag.
+ * during the drag. The terminal rect is captured once on drag start (its
+ * size cannot change mid-drag, and this keeps forced layout reads off the
+ * per-move path). The final width is committed to the store (one re-render
+ * + one localStorage write) when the drag ends.
  *
- * Mirrors the sidebar resize architecture (`use-sidebar-resize.ts`):
- *
- * pointerdown  → capture the pointer on the handle (so move/up keep arriving
- *                even when the cursor leaves the window)
- * pointermove  → write to --output-panel-width inside a requestAnimationFrame
- *                callback (the CSS variable alone sizes the logs column via
- *                `calc(100% - var(--output-panel-width))`)
- * pointerup    → cancel any pending RAF, tear down, persist the final width
- *                to Zustand once (one re-render + one localStorage write)
- *
- * The drag is torn down by `pointerup`, `pointercancel`, or window `blur`, so
- * an interrupted gesture can never leave the drag listeners or body cursor
- * stuck. A single-flight guard prevents stacking listeners across rapid
- * presses, and an unmount cleanup tears down a drag still in flight.
+ * @returns Pointer-down handler for the resize handle
  */
 export function useOutputPanelResize() {
   const setOutputPanelWidth = useTerminalStore((s) => s.setOutputPanelWidth)
-  const cleanupRef = useRef<(() => void) | null>(null)
+  const terminalRectRef = useRef<DOMRect | null>(null)
 
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent<HTMLElement>) => {
-      if (cleanupRef.current) return
+  const captureTerminalRect = useCallback(() => {
+    const terminalEl = document.querySelector('[aria-label="Terminal"]')
+    if (!terminalEl) return false
+    terminalRectRef.current = terminalEl.getBoundingClientRect()
+    return true
+  }, [])
 
-      const terminalEl = document.querySelector('[aria-label="Terminal"]')
-      if (!terminalEl) return
+  const computeOutputPanelWidth = useCallback((ev: PointerEvent) => {
+    const terminalRect = terminalRectRef.current
+    if (!terminalRect) return null
+    const newWidth = terminalRect.right - ev.clientX
+    const maxWidth = terminalRect.width - TERMINAL_BLOCK_COLUMN_WIDTH
+    return Math.max(OUTPUT_PANEL_WIDTH.MIN, Math.min(newWidth, maxWidth))
+  }, [])
 
-      const handle = e.currentTarget
-      const pointerId = e.pointerId
-      document.body.style.cursor = 'ew-resize'
-      document.body.style.userSelect = 'none'
-      handle.setPointerCapture?.(pointerId)
-
-      let rafId: number | null = null
-
-      const onPointerMove = (ev: PointerEvent) => {
-        if (rafId !== null) cancelAnimationFrame(rafId)
-        rafId = requestAnimationFrame(() => {
-          const terminalRect = terminalEl.getBoundingClientRect()
-          const newWidth = terminalRect.right - ev.clientX
-          const maxWidth = terminalRect.width - TERMINAL_BLOCK_COLUMN_WIDTH
-          const clamped = Math.max(OUTPUT_PANEL_WIDTH.MIN, Math.min(newWidth, maxWidth))
-          document.documentElement.style.setProperty('--output-panel-width', `${clamped}px`)
-          rafId = null
-        })
-      }
-
-      const cleanup = () => {
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId)
-          rafId = null
-        }
-        document.body.style.cursor = ''
-        document.body.style.userSelect = ''
-        if (handle.hasPointerCapture?.(pointerId)) handle.releasePointerCapture(pointerId)
-        document.removeEventListener('pointermove', onPointerMove)
-        document.removeEventListener('pointerup', endDrag)
-        document.removeEventListener('pointercancel', endDrag)
-        window.removeEventListener('blur', endDrag)
-        cleanupRef.current = null
-      }
-
-      function endDrag() {
-        cleanup()
-        const raw = document.documentElement.style.getPropertyValue('--output-panel-width')
-        const finalWidth = Number.parseFloat(raw)
-        if (!Number.isNaN(finalWidth)) setOutputPanelWidth(finalWidth)
-      }
-
-      cleanupRef.current = cleanup
-      document.addEventListener('pointermove', onPointerMove)
-      document.addEventListener('pointerup', endDrag)
-      document.addEventListener('pointercancel', endDrag)
-      window.addEventListener('blur', endDrag)
-    },
-    [setOutputPanelWidth]
-  )
-
-  useEffect(() => () => cleanupRef.current?.(), [])
-
-  return { handlePointerDown }
+  return useDragResize({
+    cursor: 'ew-resize',
+    compute: computeOutputPanelWidth,
+    apply: applyOutputPanelWidth,
+    commit: setOutputPanelWidth,
+    onStart: captureTerminalRect,
+  })
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/hooks/use-terminal-resize.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/hooks/use-terminal-resize.ts
@@ -1,52 +1,99 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+import { TERMINAL_CONFIG } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/utils'
+import { TERMINAL_HEIGHT } from '@/stores/constants'
 import { useTerminalStore } from '@/stores/terminal'
-
-const MIN_HEIGHT = 30
-const MAX_HEIGHT_PERCENTAGE = 0.7
 
 /** Inset gap between the viewport edge and the content window */
 const CONTENT_WINDOW_GAP = 8
 
+/**
+ * Handles terminal drag-resize with (almost) zero React renders during the drag.
+ *
+ * Mirrors the sidebar resize architecture (`use-sidebar-resize.ts`):
+ *
+ * pointerdown  → capture the pointer on the handle (so move/up keep arriving
+ *                even when the cursor leaves the window)
+ * pointermove  → write to --terminal-height inside a requestAnimationFrame
+ *                callback (the CSS variable alone sizes `.terminal-container`).
+ *                The store is committed mid-drag only when the height crosses
+ *                the expanded threshold, so `isExpanded` subscribers (header
+ *                chevron, auto-open logic) still flip live.
+ * pointerup    → cancel any pending RAF, tear down, persist the final height
+ *                to Zustand once (one re-render + one localStorage write)
+ *
+ * The drag is torn down by `pointerup`, `pointercancel`, or window `blur`, so
+ * an interrupted gesture can never leave the drag listeners or body cursor
+ * stuck. A single-flight guard prevents stacking listeners across rapid
+ * presses, and an unmount cleanup tears down a drag still in flight.
+ */
 export function useTerminalResize() {
-  const setTerminalHeight = useTerminalStore((state) => state.setTerminalHeight)
-  const isResizing = useTerminalStore((state) => state.isResizing)
-  const setIsResizing = useTerminalStore((state) => state.setIsResizing)
+  const setTerminalHeight = useTerminalStore((s) => s.setTerminalHeight)
+  const setIsResizing = useTerminalStore((s) => s.setIsResizing)
+  const cleanupRef = useRef<(() => void) | null>(null)
 
-  const handleMouseDown = useCallback(() => {
-    setIsResizing(true)
-  }, [setIsResizing])
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      if (cleanupRef.current) return
 
-  useEffect(() => {
-    if (!isResizing) return
+      const handle = e.currentTarget
+      const pointerId = e.pointerId
+      setIsResizing(true)
+      document.body.style.cursor = 'ns-resize'
+      document.body.style.userSelect = 'none'
+      handle.setPointerCapture?.(pointerId)
 
-    const handleMouseMove = (e: MouseEvent) => {
-      const newHeight = window.innerHeight - CONTENT_WINDOW_GAP - e.clientY
-      const maxHeight = window.innerHeight * MAX_HEIGHT_PERCENTAGE
+      let rafId: number | null = null
 
-      if (newHeight >= MIN_HEIGHT && newHeight <= maxHeight) {
-        setTerminalHeight(newHeight)
+      const onPointerMove = (ev: PointerEvent) => {
+        if (rafId !== null) cancelAnimationFrame(rafId)
+        rafId = requestAnimationFrame(() => {
+          const maxHeight = window.innerHeight * TERMINAL_HEIGHT.MAX_PERCENTAGE
+          const newHeight = window.innerHeight - CONTENT_WINDOW_GAP - ev.clientY
+          const clamped = Math.min(Math.max(newHeight, TERMINAL_HEIGHT.MIN), maxHeight)
+          document.documentElement.style.setProperty('--terminal-height', `${clamped}px`)
+
+          const wasExpanded =
+            useTerminalStore.getState().terminalHeight > TERMINAL_CONFIG.NEAR_MIN_THRESHOLD
+          const nowExpanded = clamped > TERMINAL_CONFIG.NEAR_MIN_THRESHOLD
+          if (wasExpanded !== nowExpanded) setTerminalHeight(clamped)
+
+          rafId = null
+        })
       }
-    }
 
-    const handleMouseUp = () => {
-      setIsResizing(false)
-    }
+      const cleanup = () => {
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId)
+          rafId = null
+        }
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+        if (handle.hasPointerCapture?.(pointerId)) handle.releasePointerCapture(pointerId)
+        document.removeEventListener('pointermove', onPointerMove)
+        document.removeEventListener('pointerup', endDrag)
+        document.removeEventListener('pointercancel', endDrag)
+        window.removeEventListener('blur', endDrag)
+        cleanupRef.current = null
+      }
 
-    document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', handleMouseUp)
-    document.body.style.cursor = 'ns-resize'
-    document.body.style.userSelect = 'none'
+      function endDrag() {
+        cleanup()
+        const raw = document.documentElement.style.getPropertyValue('--terminal-height')
+        const finalHeight = Number.parseFloat(raw)
+        if (!Number.isNaN(finalHeight)) setTerminalHeight(finalHeight)
+        setIsResizing(false)
+      }
 
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', handleMouseUp)
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-    }
-  }, [isResizing, setTerminalHeight, setIsResizing])
+      cleanupRef.current = cleanup
+      document.addEventListener('pointermove', onPointerMove)
+      document.addEventListener('pointerup', endDrag)
+      document.addEventListener('pointercancel', endDrag)
+      window.addEventListener('blur', endDrag)
+    },
+    [setTerminalHeight, setIsResizing]
+  )
 
-  return {
-    isResizing,
-    handleMouseDown,
-  }
+  useEffect(() => () => cleanupRef.current?.(), [])
+
+  return { handlePointerDown }
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/hooks/use-terminal-resize.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/hooks/use-terminal-resize.ts
@@ -1,99 +1,48 @@
-import { useCallback, useEffect, useRef } from 'react'
 import { TERMINAL_CONFIG } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/utils'
-import { TERMINAL_HEIGHT } from '@/stores/constants'
+import { useDragResize } from '@/hooks/use-drag-resize'
+import { CONTENT_WINDOW_GAP, TERMINAL_HEIGHT } from '@/stores/constants'
 import { useTerminalStore } from '@/stores/terminal'
 
-/** Inset gap between the viewport edge and the content window */
-const CONTENT_WINDOW_GAP = 8
+/** Computes the clamped terminal height for a pointer position */
+function computeTerminalHeight(ev: PointerEvent): number {
+  const maxHeight = Math.max(
+    TERMINAL_HEIGHT.MIN,
+    window.innerHeight * TERMINAL_HEIGHT.MAX_PERCENTAGE
+  )
+  const newHeight = window.innerHeight - CONTENT_WINDOW_GAP - ev.clientY
+  return Math.min(Math.max(newHeight, TERMINAL_HEIGHT.MIN), maxHeight)
+}
 
 /**
- * Handles terminal drag-resize with (almost) zero React renders during the drag.
+ * Applies the terminal height per frame. The `--terminal-height` CSS
+ * variable alone sizes `.terminal-container`, so no React work happens on
+ * ordinary frames. The store is committed mid-drag only when the height
+ * crosses the expanded threshold, so `isExpanded` subscribers (header
+ * chevron, auto-open logic) still flip live during the drag.
+ */
+function applyTerminalHeight(height: number): void {
+  document.documentElement.style.setProperty('--terminal-height', `${height}px`)
+
+  const store = useTerminalStore.getState()
+  const wasExpanded = store.terminalHeight > TERMINAL_CONFIG.NEAR_MIN_THRESHOLD
+  const nowExpanded = height > TERMINAL_CONFIG.NEAR_MIN_THRESHOLD
+  if (wasExpanded !== nowExpanded) store.setTerminalHeight(height)
+}
+
+/**
+ * Handles terminal drag-resize with zero React renders during the drag
+ * (except at expanded-threshold crossings). The final height is committed
+ * to the store (one re-render + one localStorage write) when the drag ends.
  *
- * Mirrors the sidebar resize architecture (`use-sidebar-resize.ts`):
- *
- * pointerdown  → capture the pointer on the handle (so move/up keep arriving
- *                even when the cursor leaves the window)
- * pointermove  → write to --terminal-height inside a requestAnimationFrame
- *                callback (the CSS variable alone sizes `.terminal-container`).
- *                The store is committed mid-drag only when the height crosses
- *                the expanded threshold, so `isExpanded` subscribers (header
- *                chevron, auto-open logic) still flip live.
- * pointerup    → cancel any pending RAF, tear down, persist the final height
- *                to Zustand once (one re-render + one localStorage write)
- *
- * The drag is torn down by `pointerup`, `pointercancel`, or window `blur`, so
- * an interrupted gesture can never leave the drag listeners or body cursor
- * stuck. A single-flight guard prevents stacking listeners across rapid
- * presses, and an unmount cleanup tears down a drag still in flight.
+ * @returns Pointer-down handler for the resize handle
  */
 export function useTerminalResize() {
   const setTerminalHeight = useTerminalStore((s) => s.setTerminalHeight)
-  const setIsResizing = useTerminalStore((s) => s.setIsResizing)
-  const cleanupRef = useRef<(() => void) | null>(null)
 
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent<HTMLElement>) => {
-      if (cleanupRef.current) return
-
-      const handle = e.currentTarget
-      const pointerId = e.pointerId
-      setIsResizing(true)
-      document.body.style.cursor = 'ns-resize'
-      document.body.style.userSelect = 'none'
-      handle.setPointerCapture?.(pointerId)
-
-      let rafId: number | null = null
-
-      const onPointerMove = (ev: PointerEvent) => {
-        if (rafId !== null) cancelAnimationFrame(rafId)
-        rafId = requestAnimationFrame(() => {
-          const maxHeight = window.innerHeight * TERMINAL_HEIGHT.MAX_PERCENTAGE
-          const newHeight = window.innerHeight - CONTENT_WINDOW_GAP - ev.clientY
-          const clamped = Math.min(Math.max(newHeight, TERMINAL_HEIGHT.MIN), maxHeight)
-          document.documentElement.style.setProperty('--terminal-height', `${clamped}px`)
-
-          const wasExpanded =
-            useTerminalStore.getState().terminalHeight > TERMINAL_CONFIG.NEAR_MIN_THRESHOLD
-          const nowExpanded = clamped > TERMINAL_CONFIG.NEAR_MIN_THRESHOLD
-          if (wasExpanded !== nowExpanded) setTerminalHeight(clamped)
-
-          rafId = null
-        })
-      }
-
-      const cleanup = () => {
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId)
-          rafId = null
-        }
-        document.body.style.cursor = ''
-        document.body.style.userSelect = ''
-        if (handle.hasPointerCapture?.(pointerId)) handle.releasePointerCapture(pointerId)
-        document.removeEventListener('pointermove', onPointerMove)
-        document.removeEventListener('pointerup', endDrag)
-        document.removeEventListener('pointercancel', endDrag)
-        window.removeEventListener('blur', endDrag)
-        cleanupRef.current = null
-      }
-
-      function endDrag() {
-        cleanup()
-        const raw = document.documentElement.style.getPropertyValue('--terminal-height')
-        const finalHeight = Number.parseFloat(raw)
-        if (!Number.isNaN(finalHeight)) setTerminalHeight(finalHeight)
-        setIsResizing(false)
-      }
-
-      cleanupRef.current = cleanup
-      document.addEventListener('pointermove', onPointerMove)
-      document.addEventListener('pointerup', endDrag)
-      document.addEventListener('pointercancel', endDrag)
-      window.addEventListener('blur', endDrag)
-    },
-    [setTerminalHeight, setIsResizing]
-  )
-
-  useEffect(() => () => cleanupRef.current?.(), [])
-
-  return { handlePointerDown }
+  return useDragResize({
+    cursor: 'ns-resize',
+    compute: computeTerminalHeight,
+    apply: applyTerminalHeight,
+    commit: setTerminalHeight,
+  })
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/terminal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/terminal.tsx
@@ -720,8 +720,8 @@ export const Terminal = memo(function Terminal() {
 
   const [isPlaygroundEnabled] = useState(() => isTruthy(getEnv('NEXT_PUBLIC_ENABLE_PLAYGROUND')))
 
-  const { handleMouseDown } = useTerminalResize()
-  const { handleMouseDown: handleOutputPanelResizeMouseDown } = useOutputPanelResize()
+  const { handlePointerDown } = useTerminalResize()
+  const { handlePointerDown: handleOutputPanelResizePointerDown } = useOutputPanelResize()
 
   const {
     filters,
@@ -1301,7 +1301,7 @@ export const Terminal = memo(function Terminal() {
         {/* Resize Handle */}
         <div
           className='absolute top-[-4px] right-0 left-0 z-20 h-[8px] cursor-ns-resize'
-          onMouseDown={handleMouseDown}
+          onPointerDown={handlePointerDown}
           role='separator'
           aria-orientation='horizontal'
           aria-label='Resize terminal'
@@ -1311,7 +1311,7 @@ export const Terminal = memo(function Terminal() {
           {/* Left Section - Logs */}
           <div
             className={clsx('flex flex-col', !selectedEntry && 'flex-1')}
-            style={selectedEntry ? { width: `calc(100% - ${outputPanelWidth}px)` } : undefined}
+            style={selectedEntry ? { width: 'calc(100% - var(--output-panel-width))' } : undefined}
           >
             {/* Header */}
             <div
@@ -1497,7 +1497,7 @@ export const Terminal = memo(function Terminal() {
           {selectedEntry && (
             <OutputPanel
               selectedEntry={selectedEntry}
-              handleOutputPanelResizeMouseDown={handleOutputPanelResizeMouseDown}
+              handleOutputPanelResizePointerDown={handleOutputPanelResizePointerDown}
               handleHeaderClick={handleHeaderClick}
               isExpanded={isExpanded}
               expandToLastHeight={expandToLastHeight}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/terminal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/terminal.tsx
@@ -1255,6 +1255,10 @@ export const Terminal = memo(function Terminal() {
   /**
    * Adjust output panel width on resize.
    * Closes the output panel if there's not enough space for the minimum width.
+   * The clamp compares against the live `--output-panel-width` CSS variable
+   * (the visual width — during a drag it runs ahead of the store, which only
+   * commits on release) so a resize mid-drag can never stomp the drag with a
+   * stale store value; the store value is the fallback before any write.
    */
   useEffect(() => {
     const el = terminalRef.current
@@ -1271,7 +1275,11 @@ export const Terminal = memo(function Terminal() {
         return
       }
 
-      if (outputPanelWidth > maxWidth) {
+      const liveWidth = Number.parseFloat(
+        document.documentElement.style.getPropertyValue('--output-panel-width')
+      )
+      const currentWidth = Number.isNaN(liveWidth) ? outputPanelWidth : liveWidth
+      if (currentWidth > maxWidth) {
         setOutputPanelWidth(Math.max(maxWidth, MIN_OUTPUT_PANEL_WIDTH_PX))
       }
     }

--- a/apps/sim/hooks/use-drag-resize.ts
+++ b/apps/sim/hooks/use-drag-resize.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+interface UseDragResizeOptions {
+  /** Cursor applied to the document body for the duration of the drag */
+  cursor: 'ew-resize' | 'ns-resize'
+  /**
+   * Maps a pointer position to the clamped target dimension, or `null` to
+   * ignore the move. Runs on every pointermove, so it must stay cheap (no
+   * layout reads — capture rects in `onStart` instead).
+   */
+  compute: (ev: PointerEvent) => number | null
+  /**
+   * Applies per-frame visual feedback (typically a CSS variable write).
+   * Invoked inside requestAnimationFrame, at most once per frame.
+   */
+  apply: (value: number) => void
+  /**
+   * Persists the final value once when the drag ends. Not called when the
+   * pointer never moved (a plain click on the handle).
+   */
+  commit: (value: number) => void
+  /**
+   * Optional drag-start hook (e.g. capture an anchor rect, set a store flag).
+   * Return `false` to abort the drag before any listeners are attached.
+   */
+  onStart?: () => boolean | undefined
+  /** Optional drag-end hook, invoked after teardown and commit */
+  onEnd?: () => void
+}
+
+/**
+ * Shared drag-resize mechanism with zero React renders during the drag.
+ *
+ * Architecture (mirrors the sidebar's `use-sidebar-resize.ts`):
+ *
+ * pointerdown  → capture the pointer on the handle (so move/up keep arriving
+ *                even when the cursor leaves the window or crosses an iframe)
+ * pointermove  → `compute` the clamped value immediately (cheap math), then
+ *                `apply` it inside a requestAnimationFrame callback so DOM
+ *                writes align with the browser paint cycle
+ * pointerup    → cancel any pending RAF, tear down, and `commit` the last
+ *                computed value once — committing the tracked value (rather
+ *                than reading it back out of the DOM) means a fast
+ *                single-frame flick is never lost to a cancelled RAF
+ *
+ * The drag is torn down by `pointerup`/`pointercancel` of the captured
+ * pointer (other pointers are ignored, so a second touch cannot kill the
+ * gesture) or window `blur`, so an interrupted gesture can never leave the
+ * listeners or body cursor stuck. A single-flight guard prevents stacking
+ * listeners across rapid presses, and an unmount cleanup tears down a drag
+ * still in flight.
+ */
+export function useDragResize(options: UseDragResizeOptions) {
+  const cleanupRef = useRef<(() => void) | null>(null)
+  const optionsRef = useRef(options)
+
+  useEffect(() => {
+    optionsRef.current = options
+  }, [options])
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    if (cleanupRef.current) return
+    if (optionsRef.current.onStart?.() === false) return
+
+    const handle = e.currentTarget
+    const pointerId = e.pointerId
+    document.body.style.cursor = optionsRef.current.cursor
+    document.body.style.userSelect = 'none'
+    handle.setPointerCapture?.(pointerId)
+
+    let rafId: number | null = null
+    let pendingValue: number | null = null
+
+    const onPointerMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return
+      const value = optionsRef.current.compute(ev)
+      if (value === null) return
+      pendingValue = value
+      rafId ??= requestAnimationFrame(() => {
+        if (pendingValue !== null) optionsRef.current.apply(pendingValue)
+        rafId = null
+      })
+    }
+
+    const cleanup = () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      if (handle.hasPointerCapture?.(pointerId)) handle.releasePointerCapture(pointerId)
+      document.removeEventListener('pointermove', onPointerMove)
+      document.removeEventListener('pointerup', onPointerEnd)
+      document.removeEventListener('pointercancel', onPointerEnd)
+      window.removeEventListener('blur', endDrag)
+      cleanupRef.current = null
+    }
+
+    function endDrag() {
+      cleanup()
+      if (pendingValue !== null) optionsRef.current.commit(pendingValue)
+      optionsRef.current.onEnd?.()
+    }
+
+    function onPointerEnd(ev: PointerEvent) {
+      if (ev.pointerId !== pointerId) return
+      endDrag()
+    }
+
+    cleanupRef.current = cleanup
+    document.addEventListener('pointermove', onPointerMove)
+    document.addEventListener('pointerup', onPointerEnd)
+    document.addEventListener('pointercancel', onPointerEnd)
+    window.addEventListener('blur', endDrag)
+  }, [])
+
+  useEffect(() => () => cleanupRef.current?.(), [])
+
+  return { handlePointerDown }
+}

--- a/apps/sim/hooks/use-drag-resize.ts
+++ b/apps/sim/hooks/use-drag-resize.ts
@@ -5,8 +5,9 @@ interface UseDragResizeOptions {
   cursor: 'ew-resize' | 'ns-resize'
   /**
    * Maps a pointer position to the clamped target dimension, or `null` to
-   * ignore the move. Runs on every pointermove, so it must stay cheap (no
-   * layout reads — capture rects in `onStart` instead).
+   * ignore the move. Runs at most once per animation frame (before `apply`,
+   * so a layout read here happens against clean layout) and once more on
+   * release, so it may read layout but must stay cheap.
    */
   compute: (ev: PointerEvent) => number | null
   /**
@@ -20,8 +21,9 @@ interface UseDragResizeOptions {
    */
   commit: (value: number) => void
   /**
-   * Optional drag-start hook (e.g. capture an anchor rect, set a store flag).
-   * Return `false` to abort the drag before any listeners are attached.
+   * Optional drag-start hook (e.g. capture an anchor element, set a store
+   * flag). Return `false` to abort the drag before any listeners are
+   * attached.
    */
   onStart?: () => boolean | undefined
   /** Optional drag-end hook, invoked after teardown and commit */
@@ -35,13 +37,15 @@ interface UseDragResizeOptions {
  *
  * pointerdown  → capture the pointer on the handle (so move/up keep arriving
  *                even when the cursor leaves the window or crosses an iframe)
- * pointermove  → `compute` the clamped value immediately (cheap math), then
- *                `apply` it inside a requestAnimationFrame callback so DOM
- *                writes align with the browser paint cycle
- * pointerup    → cancel any pending RAF, tear down, and `commit` the last
- *                computed value once — committing the tracked value (rather
- *                than reading it back out of the DOM) means a fast
- *                single-frame flick is never lost to a cancelled RAF
+ * pointermove  → remember the latest pointer event and schedule a
+ *                requestAnimationFrame callback that `compute`s the clamped
+ *                value from it and `apply`s it, so both any layout read and
+ *                the DOM write align with the browser paint cycle
+ * pointerup    → tear down, `compute` the final value from the latest
+ *                pointer event, `apply` and `commit` it once — deriving the
+ *                final value from the event (rather than reading state back
+ *                out of the DOM) means a fast single-frame flick is never
+ *                lost to a cancelled RAF
  *
  * The drag is torn down by `pointerup`/`pointercancel` of the captured
  * pointer (other pointers are ignored, so a second touch cannot kill the
@@ -69,16 +73,16 @@ export function useDragResize(options: UseDragResizeOptions) {
     handle.setPointerCapture?.(pointerId)
 
     let rafId: number | null = null
-    let pendingValue: number | null = null
+    let lastEvent: PointerEvent | null = null
 
     const onPointerMove = (ev: PointerEvent) => {
       if (ev.pointerId !== pointerId) return
-      const value = optionsRef.current.compute(ev)
-      if (value === null) return
-      pendingValue = value
+      lastEvent = ev
       rafId ??= requestAnimationFrame(() => {
-        if (pendingValue !== null) optionsRef.current.apply(pendingValue)
         rafId = null
+        if (lastEvent === null) return
+        const value = optionsRef.current.compute(lastEvent)
+        if (value !== null) optionsRef.current.apply(value)
       })
     }
 
@@ -99,7 +103,13 @@ export function useDragResize(options: UseDragResizeOptions) {
 
     function endDrag() {
       cleanup()
-      if (pendingValue !== null) optionsRef.current.commit(pendingValue)
+      if (lastEvent !== null) {
+        const value = optionsRef.current.compute(lastEvent)
+        if (value !== null) {
+          optionsRef.current.apply(value)
+          optionsRef.current.commit(value)
+        }
+      }
       optionsRef.current.onEnd?.()
     }
 

--- a/apps/sim/stores/constants.ts
+++ b/apps/sim/stores/constants.ts
@@ -18,6 +18,9 @@ const API_ENDPOINTS = {
  * @see layout.tsx for pre-hydration script that reads localStorage
  */
 
+/** Inset gap in pixels between the viewport edge and the content window */
+export const CONTENT_WINDOW_GAP = 8
+
 /** Sidebar width constraints */
 export const SIDEBAR_WIDTH = {
   DEFAULT: 248,

--- a/apps/sim/stores/panel/store.ts
+++ b/apps/sim/stores/panel/store.ts
@@ -29,10 +29,6 @@ export const usePanelStore = create<PanelState>()(
           document.documentElement.removeAttribute('data-panel-active-tab')
         }
       },
-      isResizing: false,
-      setIsResizing: (isResizing) => {
-        set({ isResizing })
-      },
       _hasHydrated: false,
       setHasHydrated: (hasHydrated) => {
         set({ _hasHydrated: hasHydrated })
@@ -44,8 +40,8 @@ export const usePanelStore = create<PanelState>()(
        * Persist only the durable panel preferences. `activeTab` MUST be kept:
        * the blocking script in `app/layout.tsx` reads it from this persisted
        * `panel-state` entry to set `data-panel-active-tab` before hydration,
-       * preventing a tab flash. The transient `isResizing` drag flag and the
-       * `_hasHydrated` hydration marker are excluded.
+       * preventing a tab flash. The `_hasHydrated` hydration marker is
+       * excluded.
        */
       partialize: (state) => ({
         panelWidth: state.panelWidth,

--- a/apps/sim/stores/panel/types.ts
+++ b/apps/sim/stores/panel/types.ts
@@ -11,10 +11,6 @@ export interface PanelState {
   setPanelWidth: (width: number) => void
   activeTab: PanelTab
   setActiveTab: (tab: PanelTab) => void
-  /** Whether the panel is currently being resized */
-  isResizing: boolean
-  /** Updates the panel resize state */
-  setIsResizing: (isResizing: boolean) => void
   _hasHydrated: boolean
   setHasHydrated: (hasHydrated: boolean) => void
 }

--- a/apps/sim/stores/terminal/store.ts
+++ b/apps/sim/stores/terminal/store.ts
@@ -50,6 +50,11 @@ export const useTerminalStore = create<TerminalState>()(
       setOutputPanelWidth: (width) => {
         const clampedWidth = Math.max(OUTPUT_PANEL_WIDTH.MIN, width)
         set({ outputPanelWidth: clampedWidth })
+
+        // Update CSS variable for immediate visual feedback
+        if (typeof window !== 'undefined') {
+          document.documentElement.style.setProperty('--output-panel-width', `${clampedWidth}px`)
+        }
       },
       openOnRun: true,
       /**
@@ -107,14 +112,19 @@ export const useTerminalStore = create<TerminalState>()(
         structuredView: state.structuredView,
       }),
       /**
-       * Synchronizes the `--terminal-height` CSS custom property with the
-       * persisted store value after client-side rehydration.
+       * Synchronizes the `--terminal-height` and `--output-panel-width` CSS
+       * custom properties with the persisted store values after client-side
+       * rehydration.
        */
       onRehydrateStorage: () => (state) => {
         if (state && typeof window !== 'undefined') {
           document.documentElement.style.setProperty(
             '--terminal-height',
             `${state.terminalHeight}px`
+          )
+          document.documentElement.style.setProperty(
+            '--output-panel-width',
+            `${state.outputPanelWidth}px`
           )
         }
       },

--- a/apps/sim/stores/terminal/store.ts
+++ b/apps/sim/stores/terminal/store.ts
@@ -8,7 +8,6 @@ export const useTerminalStore = create<TerminalState>()(
     (set) => ({
       terminalHeight: TERMINAL_HEIGHT.DEFAULT,
       lastExpandedHeight: TERMINAL_HEIGHT.DEFAULT,
-      isResizing: false,
       /**
        * Updates the terminal height and synchronizes the CSS custom property.
        *
@@ -33,17 +32,10 @@ export const useTerminalStore = create<TerminalState>()(
           document.documentElement.style.setProperty('--terminal-height', `${clampedHeight}px`)
         }
       },
-      /**
-       * Updates the terminal resize state used to coordinate layout transitions.
-       *
-       * @param isResizing - True while the terminal is being resized via mouse drag.
-       */
-      setIsResizing: (isResizing) => {
-        set({ isResizing })
-      },
       outputPanelWidth: OUTPUT_PANEL_WIDTH.DEFAULT,
       /**
-       * Updates the output panel width, enforcing the minimum constraint.
+       * Updates the output panel width, enforcing the minimum constraint and
+       * synchronizing the `--output-panel-width` CSS custom property.
        *
        * @param width - Desired width in pixels for the output panel.
        */
@@ -51,7 +43,6 @@ export const useTerminalStore = create<TerminalState>()(
         const clampedWidth = Math.max(OUTPUT_PANEL_WIDTH.MIN, width)
         set({ outputPanelWidth: clampedWidth })
 
-        // Update CSS variable for immediate visual feedback
         if (typeof window !== 'undefined') {
           document.documentElement.style.setProperty('--output-panel-width', `${clampedWidth}px`)
         }
@@ -99,9 +90,8 @@ export const useTerminalStore = create<TerminalState>()(
     {
       name: 'terminal-state',
       /**
-       * Persist only the durable terminal UI preferences. The transient
-       * `isResizing` drag flag and the `_hasHydrated` hydration marker are
-       * excluded so they always start fresh on load.
+       * Persist only the durable terminal UI preferences. The `_hasHydrated`
+       * hydration marker is excluded so it always starts fresh on load.
        */
       partialize: (state) => ({
         terminalHeight: state.terminalHeight,

--- a/apps/sim/stores/terminal/types.ts
+++ b/apps/sim/stores/terminal/types.ts
@@ -21,21 +21,6 @@ export interface TerminalState {
   setWrapText: (wrap: boolean) => void
   structuredView: boolean
   setStructuredView: (structured: boolean) => void
-  /**
-   * Indicates whether the terminal is currently being resized via mouse drag.
-   *
-   * @remarks
-   * This flag is used by other workspace UI elements (e.g. notifications,
-   * diff controls) to temporarily disable position transitions while the
-   * terminal height is actively changing, avoiding janky animations.
-   */
-  isResizing: boolean
-  /**
-   * Updates the {@link TerminalState.isResizing} flag.
-   *
-   * @param isResizing - True while the terminal is being resized.
-   */
-  setIsResizing: (isResizing: boolean) => void
   _hasHydrated: boolean
   setHasHydrated: (hasHydrated: boolean) => void
 }


### PR DESCRIPTION
## Summary
- Resizing the editor panel and terminal on the workflow canvas got laggy on staging/prod — every mousemove dispatched a Zustand set with no rAF throttle, re-rendering the entire always-mounted panel tree (Chat/Editor/Toolbar) plus a synchronous zustand-persist localStorage write per move. `panel.tsx` subscribed to `panelWidth` it never rendered (the CSS var does all sizing). Local dev doesn't show it because there's no GTM/GA/PostHog on the main thread and no real-size chat/workflow data to re-render
- Ports the sidebar's proven drag pattern (#4354) to `use-panel-resize`, `use-terminal-resize`, and `use-output-panel-resize`: pointer capture on the handle, rAF-throttled writes to only the CSS variable during the drag (`--panel-width`, `--terminal-height`, new `--output-panel-width`), single store commit + localStorage write on pointerup
- Terminal still commits mid-drag when crossing the 40px expanded threshold so `isExpanded` subscribers (header chevron, auto-open) flip live exactly as before
- Output panel width moves from React inline style to the `--output-panel-width` CSS var (store setter + rehydration keep it synced, `:root` default matches `OUTPUT_PANEL_WIDTH.DEFAULT`)
- Drops the panel's unused `panelWidth` subscription; drags now survive releasing outside the window (`pointercancel`/`blur` teardown, same as the sidebar)

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)