### PR TITLE
feat(landing): X pixel conversion tracking on landing pages

### DIFF
--- a/apps/sim/app/(landing)/layout.tsx
+++ b/apps/sim/app/(landing)/layout.tsx
@@ -6,8 +6,17 @@ import { isHosted } from '@/lib/core/config/env-flags'
 import { SITE_URL } from '@/lib/core/utils/urls'
 import { LandingShell } from '@/app/(landing)/components'
 import { HubspotPageViewTracker } from '@/app/(landing)/hubspot-page-view-tracker'
+import { XPageViewTracker } from '@/app/(landing)/x-page-view-tracker'
 
 const HUBSPOT_SCRIPT_SRC = 'https://js-na2.hs-scripts.com/246720681.js' as const
+
+const X_PIXEL_ID = 'q5xbl' as const
+
+/** X (Twitter) conversion tracking base code — loads uwt.js and fires the initial PageView. */
+const X_PIXEL_BASE_CODE = `!function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+},s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
+a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+twq('config','${X_PIXEL_ID}');`
 
 /**
  * Route-group layout for the entire landing family - the home page, platform and
@@ -33,12 +42,16 @@ export default function LandingLayout({ children }: { children: ReactNode }) {
   return (
     <LandingShell>
       {children}
-      {/* HubSpot tracking — hosted only */}
+      {/* HubSpot + X pixel tracking — hosted only */}
       {isHosted && (
         <>
           <Script id='hs-script-loader' src={HUBSPOT_SCRIPT_SRC} strategy='afterInteractive' />
+          <Script id='x-pixel-base' strategy='afterInteractive'>
+            {X_PIXEL_BASE_CODE}
+          </Script>
           <Suspense fallback={null}>
             <HubspotPageViewTracker />
+            <XPageViewTracker />
           </Suspense>
         </>
       )}

--- a/apps/sim/app/(landing)/x-page-view-tracker.tsx
+++ b/apps/sim/app/(landing)/x-page-view-tracker.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { usePathname, useSearchParams } from 'next/navigation'
 
 declare global {
@@ -11,9 +11,7 @@ declare global {
 
 // next/script dedupes by id and never reloads on remount, so this must be
 // module-scope (not a ref) to survive LandingLayout unmounting/remounting.
-// Keyed by URL (not a boolean) so Strict Mode effect replays and same-URL
-// remounts never re-fire a PageView already counted for that URL.
-let lastTrackedUrl: string | null = null
+let hasTrackedInitialPageView = false
 
 /**
  * The X pixel base code only auto-tracks the first page load; LandingLayout
@@ -26,16 +24,21 @@ export function XPageViewTracker() {
   const searchParams = useSearchParams()
   const query = searchParams.toString()
 
+  // Instance-scoped (not module-scoped) so a Strict Mode replay of this
+  // mount's effect is skipped, while a fresh mount — returning to the landing
+  // layout from the app — starts empty and tracks the view again.
+  const lastTrackedUrlRef = useRef<string | null>(null)
+
   useEffect(() => {
     const url = query ? `${pathname}?${query}` : pathname
+    if (lastTrackedUrlRef.current === url) return
+    lastTrackedUrlRef.current = url
 
-    if (lastTrackedUrl === null) {
-      lastTrackedUrl = url
+    if (!hasTrackedInitialPageView) {
+      hasTrackedInitialPageView = true
       return
     }
-    if (url === lastTrackedUrl) return
 
-    lastTrackedUrl = url
     window.twq?.('config', 'q5xbl')
   }, [pathname, query])
 

--- a/apps/sim/app/(landing)/x-page-view-tracker.tsx
+++ b/apps/sim/app/(landing)/x-page-view-tracker.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
+
+declare global {
+  interface Window {
+    twq?: (...args: unknown[]) => void
+  }
+}
+
+// next/script dedupes by id and never reloads on remount, so this must be
+// module-scope (not a ref) to survive LandingLayout unmounting/remounting.
+let hasTrackedInitialPageView = false
+
+/**
+ * The X pixel base code only auto-tracks the first page load; LandingLayout
+ * persists across client-side navigations, so the pixel never sees the rest.
+ * Re-fires the pixel's PageView via `twq('config', ...)` on every navigation
+ * after the first.
+ */
+export function XPageViewTracker() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const query = searchParams.toString()
+
+  useEffect(() => {
+    if (!hasTrackedInitialPageView) {
+      hasTrackedInitialPageView = true
+      return
+    }
+
+    window.twq?.('config', 'q5xbl')
+  }, [pathname, query])
+
+  return null
+}

--- a/apps/sim/app/(landing)/x-page-view-tracker.tsx
+++ b/apps/sim/app/(landing)/x-page-view-tracker.tsx
@@ -11,7 +11,9 @@ declare global {
 
 // next/script dedupes by id and never reloads on remount, so this must be
 // module-scope (not a ref) to survive LandingLayout unmounting/remounting.
-let hasTrackedInitialPageView = false
+// Keyed by URL (not a boolean) so Strict Mode effect replays and same-URL
+// remounts never re-fire a PageView already counted for that URL.
+let lastTrackedUrl: string | null = null
 
 /**
  * The X pixel base code only auto-tracks the first page load; LandingLayout
@@ -25,11 +27,15 @@ export function XPageViewTracker() {
   const query = searchParams.toString()
 
   useEffect(() => {
-    if (!hasTrackedInitialPageView) {
-      hasTrackedInitialPageView = true
+    const url = query ? `${pathname}?${query}` : pathname
+
+    if (lastTrackedUrl === null) {
+      lastTrackedUrl = url
       return
     }
+    if (url === lastTrackedUrl) return
 
+    lastTrackedUrl = url
     window.twq?.('config', 'q5xbl')
   }, [pathname, query])
 


### PR DESCRIPTION
## Summary
- Adds the X (Twitter) conversion tracking base code (pixel `q5xbl`) to the landing layout, loaded via `next/script` `afterInteractive` and gated to hosted only — same pattern as the existing HubSpot loader
- Adds `XPageViewTracker` to re-fire the pixel's PageView on client-side navigations, since the landing layout persists across route changes and the base code only tracks the first load (mirrors `HubspotPageViewTracker`)

## Type of Change
- [x] New feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)