### PR TITLE
improvement(markdown): bump bold weight to 650 in dark mode

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.css
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.css
@@ -105,6 +105,12 @@
   font-weight: 600;
 }
 
+/* Light-on-dark text renders perceptually heavier, compressing the bold/regular contrast —
+ * mirror the dark-mode bump the --font-weight-* tokens apply (e.g. semibold 500 → 550). */
+.dark .rich-markdown-prose strong {
+  font-weight: 650;
+}
+
 .rich-markdown-prose em {
   font-style: italic;
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -47,7 +47,7 @@ const PROSE_CLASSES = cn(
   'prose-li:text-base prose-li:leading-[25px] prose-li:text-[var(--text-primary)]',
   'prose-li:my-1',
   'prose-ul:my-4 prose-ol:my-4',
-  'prose-strong:font-[600] prose-strong:text-[var(--text-primary)]',
+  'prose-strong:font-[600] dark:prose-strong:font-[650] prose-strong:text-[var(--text-primary)]',
   'prose-a:text-[var(--text-primary)] prose-a:underline prose-a:decoration-dashed prose-a:underline-offset-4',
   'prose-hr:border-[var(--divider)] prose-hr:my-6',
   'prose-table:my-0'
@@ -163,7 +163,7 @@ function fileIconLabel(ref: string, fallback: string): string {
 const MARKDOWN_COMPONENTS = {
   table({ children }: { children?: React.ReactNode }) {
     return (
-      <div className='not-prose my-4 w-full overflow-x-auto [&_strong]:font-[600]'>
+      <div className='not-prose my-4 w-full overflow-x-auto [&_strong]:font-[600] dark:[&_strong]:font-[650]'>
         <table className='min-w-full border-collapse [&_tbody_tr:last-child_td]:border-b-0'>
           {children}
         </table>


### PR DESCRIPTION
## Summary
- reopens #5721 (branch was deleted which auto-closed it; GitHub refuses to reopen after a force-replace) — same change, rebased on latest staging
- bold text in the markdown renderers (Files .md preview + chat messages) was hard to distinguish from body text in dark mode — light-on-dark text renders perceptually heavier, compressing the 430→600 weight contrast
- bumped `strong` to 650 in dark mode only, mirroring how the `--font-weight-*` tokens already bump semibold 500→550 in dark mode; light mode stays at 600

## Type of Change
- [x] Improvement

## Testing
Tested manually against the running app

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)