### PR TITLE
feat(chat): favicon external links with secure link-preview tooltips

### DIFF
--- a/apps/sim/app/api/link-preview/route.ts
+++ b/apps/sim/app/api/link-preview/route.ts
@@ -2,6 +2,7 @@ import { createHash } from 'crypto'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
 import { truncate } from '@sim/utils/string'
+import * as cheerio from 'cheerio'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import type { LinkPreview } from '@/lib/api/contracts/link-preview'
@@ -24,51 +25,24 @@ const CACHE_TTL_SECONDS = 24 * 60 * 60
 const NEGATIVE_CACHE_TTL_SECONDS = 60 * 60
 const CACHE_KEY_PREFIX = 'link-preview:v1:'
 
-function decodeHtmlEntities(value: string): string {
-  return value
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#0?39;/g, "'")
-    .replace(/&#x27;/gi, "'")
-    .replace(/&nbsp;/g, ' ')
-}
-
 /**
- * Content of a `<meta>` tag matched by `property` or `name`, handling either
- * attribute order. Only the document head matters for previews, so callers
- * pass a head-truncated HTML string.
+ * Parses preview metadata from the document head. Only the head matters for
+ * previews, so the input is truncated at `<body>` before parsing; cheerio
+ * handles attribute order, quoting, and entity decoding.
  */
-function metaContent(html: string, key: string): string | null {
-  const attr = `(?:property|name)=["']${key}["']`
-  const content = `content=(?:"([^"]*)"|'([^']*)')`
-  const patterns = [
-    new RegExp(`<meta[^>]*${attr}[^>]*${content}`, 'i'),
-    new RegExp(`<meta[^>]*${content}[^>]*${attr}`, 'i'),
-  ]
-  for (const pattern of patterns) {
-    const match = html.match(pattern)
-    const value = match?.[1] ?? match?.[2]
-    if (value) return decodeHtmlEntities(value).trim() || null
-  }
-  return null
-}
-
 function parsePreview(html: string): LinkPreview {
   const bodyIndex = html.search(/<body[\s>]/i)
-  const head = bodyIndex === -1 ? html : html.slice(0, bodyIndex)
+  const $ = cheerio.load(bodyIndex === -1 ? html : html.slice(0, bodyIndex))
 
-  const titleTag = head.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1]
+  const meta = (key: string): string | null => {
+    const value = $(`meta[property="${key}"], meta[name="${key}"]`).first().attr('content')
+    return value?.trim() || null
+  }
+
   const title =
-    metaContent(head, 'og:title') ??
-    metaContent(head, 'twitter:title') ??
-    (titleTag ? decodeHtmlEntities(titleTag).trim() || null : null)
-  const description =
-    metaContent(head, 'og:description') ??
-    metaContent(head, 'twitter:description') ??
-    metaContent(head, 'description')
-  const siteName = metaContent(head, 'og:site_name')
+    meta('og:title') ?? meta('twitter:title') ?? ($('title').first().text().trim() || null)
+  const description = meta('og:description') ?? meta('twitter:description') ?? meta('description')
+  const siteName = meta('og:site_name')
 
   if (!title && !description && !siteName) return null
   return {

--- a/apps/sim/app/api/link-preview/route.ts
+++ b/apps/sim/app/api/link-preview/route.ts
@@ -26,13 +26,12 @@ const NEGATIVE_CACHE_TTL_SECONDS = 60 * 60
 const CACHE_KEY_PREFIX = 'link-preview:v1:'
 
 /**
- * Parses preview metadata from the document head. Only the head matters for
- * previews, so the input is truncated at `<body>` before parsing; cheerio
- * handles attribute order, quoting, and entity decoding.
+ * Parses preview metadata from the fetched document (already capped at
+ * MAX_RESPONSE_BYTES); cheerio handles attribute order, quoting, and entity
+ * decoding.
  */
 function parsePreview(html: string): LinkPreview {
-  const bodyIndex = html.search(/<body[\s>]/i)
-  const $ = cheerio.load(bodyIndex === -1 ? html : html.slice(0, bodyIndex))
+  const $ = cheerio.load(html)
 
   const meta = (key: string): string | null => {
     const value = $(`meta[property="${key}"], meta[name="${key}"]`).first().attr('content')
@@ -54,7 +53,6 @@ function parsePreview(html: string): LinkPreview {
 
 async function fetchPreview(url: string): Promise<LinkPreview> {
   const response = await secureFetchWithValidation(url, {
-    allowHttp: true,
     timeout: FETCH_TIMEOUT_MS,
     maxRedirects: MAX_REDIRECTS,
     maxResponseBytes: MAX_RESPONSE_BYTES,
@@ -83,6 +81,10 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const parsed = await parseRequest(getLinkPreviewContract, request, {})
   if (!parsed.success) return parsed.response
   const { url } = parsed.data.query
+
+  if (!url.startsWith('https://')) {
+    return NextResponse.json({ preview: null })
+  }
 
   const redis = getRedisClient()
   const cacheKey = `${CACHE_KEY_PREFIX}${createHash('sha256').update(url).digest('hex')}`

--- a/apps/sim/app/api/link-preview/route.ts
+++ b/apps/sim/app/api/link-preview/route.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto'
 import { createLogger } from '@sim/logger'
+import { getErrorMessage } from '@sim/utils/errors'
 import { truncate } from '@sim/utils/string'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
@@ -126,7 +127,10 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   try {
     preview = await fetchPreview(url)
   } catch (error) {
-    logger.info('Link preview fetch failed; returning null preview', { url, error })
+    logger.info('Link preview fetch failed; returning null preview', {
+      host: new URL(url).hostname,
+      error: getErrorMessage(error, 'unknown error').replaceAll(url, '[url]'),
+    })
   }
 
   if (redis) {

--- a/apps/sim/app/api/link-preview/route.ts
+++ b/apps/sim/app/api/link-preview/route.ts
@@ -1,0 +1,134 @@
+import { createLogger } from '@sim/logger'
+import { truncate } from '@sim/utils/string'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import type { LinkPreview } from '@/lib/api/contracts/link-preview'
+import { getLinkPreviewContract } from '@/lib/api/contracts/link-preview'
+import { parseRequest } from '@/lib/api/server'
+import { getSession } from '@/lib/auth'
+import { getRedisClient } from '@/lib/core/config/redis'
+import { secureFetchWithValidation } from '@/lib/core/security/input-validation.server'
+import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+
+const logger = createLogger('LinkPreviewAPI')
+
+const FETCH_TIMEOUT_MS = 5000
+const MAX_RESPONSE_BYTES = 256 * 1024
+const MAX_REDIRECTS = 3
+const TITLE_MAX_CHARS = 200
+const DESCRIPTION_MAX_CHARS = 300
+const CACHE_TTL_SECONDS = 24 * 60 * 60
+const NEGATIVE_CACHE_TTL_SECONDS = 60 * 60
+const CACHE_KEY_PREFIX = 'link-preview:v1:'
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&nbsp;/g, ' ')
+}
+
+/**
+ * Content of a `<meta>` tag matched by `property` or `name`, handling either
+ * attribute order. Only the document head matters for previews, so callers
+ * pass a head-truncated HTML string.
+ */
+function metaContent(html: string, key: string): string | null {
+  const attr = `(?:property|name)=["']${key}["']`
+  const patterns = [
+    new RegExp(`<meta[^>]*${attr}[^>]*content=["']([^"']*)["']`, 'i'),
+    new RegExp(`<meta[^>]*content=["']([^"']*)["'][^>]*${attr}`, 'i'),
+  ]
+  for (const pattern of patterns) {
+    const match = html.match(pattern)
+    if (match?.[1]) return decodeHtmlEntities(match[1]).trim() || null
+  }
+  return null
+}
+
+function parsePreview(html: string): LinkPreview {
+  const bodyIndex = html.search(/<body[\s>]/i)
+  const head = bodyIndex === -1 ? html : html.slice(0, bodyIndex)
+
+  const titleTag = head.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1]
+  const title =
+    metaContent(head, 'og:title') ??
+    metaContent(head, 'twitter:title') ??
+    (titleTag ? decodeHtmlEntities(titleTag).trim() || null : null)
+  const description =
+    metaContent(head, 'og:description') ??
+    metaContent(head, 'twitter:description') ??
+    metaContent(head, 'description')
+  const siteName = metaContent(head, 'og:site_name')
+
+  if (!title && !description && !siteName) return null
+  return {
+    title: title ? truncate(title, TITLE_MAX_CHARS) : null,
+    description: description ? truncate(description, DESCRIPTION_MAX_CHARS) : null,
+    siteName: siteName ? truncate(siteName, TITLE_MAX_CHARS) : null,
+  }
+}
+
+async function fetchPreview(url: string): Promise<LinkPreview> {
+  const response = await secureFetchWithValidation(url, {
+    timeout: FETCH_TIMEOUT_MS,
+    maxRedirects: MAX_REDIRECTS,
+    maxResponseBytes: MAX_RESPONSE_BYTES,
+    headers: {
+      'User-Agent': 'Simbot/1.0 (+https://sim.ai)',
+      Accept: 'text/html,application/xhtml+xml',
+    },
+  })
+  if (response.status < 200 || response.status >= 300) return null
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.includes('text/html') && !contentType.includes('application/xhtml+xml')) {
+    return null
+  }
+  return parsePreview(await response.text())
+}
+
+export const GET = withRouteHandler(async (request: NextRequest) => {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const parsed = await parseRequest(getLinkPreviewContract, request, {})
+  if (!parsed.success) return parsed.response
+  const { url } = parsed.data.query
+
+  const redis = getRedisClient()
+  const cacheKey = `${CACHE_KEY_PREFIX}${url}`
+  if (redis) {
+    try {
+      const cached = await redis.get(cacheKey)
+      if (cached !== null) {
+        return NextResponse.json({ preview: JSON.parse(cached) })
+      }
+    } catch (error) {
+      logger.warn('Link preview cache read failed', { error })
+    }
+  }
+
+  let preview: LinkPreview = null
+  try {
+    preview = await fetchPreview(url)
+  } catch (error) {
+    logger.info('Link preview fetch failed; returning null preview', { url, error })
+  }
+
+  if (redis) {
+    const ttl = preview ? CACHE_TTL_SECONDS : NEGATIVE_CACHE_TTL_SECONDS
+    try {
+      await redis.set(cacheKey, JSON.stringify(preview), 'EX', ttl)
+    } catch (error) {
+      logger.warn('Link preview cache write failed', { error })
+    }
+  }
+
+  return NextResponse.json({ preview })
+})

--- a/apps/sim/app/api/link-preview/route.ts
+++ b/apps/sim/app/api/link-preview/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { createLogger } from '@sim/logger'
 import { truncate } from '@sim/utils/string'
 import type { NextRequest } from 'next/server'
@@ -7,6 +8,7 @@ import { getLinkPreviewContract } from '@/lib/api/contracts/link-preview'
 import { parseRequest } from '@/lib/api/server'
 import { getSession } from '@/lib/auth'
 import { getRedisClient } from '@/lib/core/config/redis'
+import { enforceUserRateLimit } from '@/lib/core/rate-limiter/route-helpers'
 import { secureFetchWithValidation } from '@/lib/core/security/input-validation.server'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 
@@ -39,13 +41,15 @@ function decodeHtmlEntities(value: string): string {
  */
 function metaContent(html: string, key: string): string | null {
   const attr = `(?:property|name)=["']${key}["']`
+  const content = `content=(?:"([^"]*)"|'([^']*)')`
   const patterns = [
-    new RegExp(`<meta[^>]*${attr}[^>]*content=["']([^"']*)["']`, 'i'),
-    new RegExp(`<meta[^>]*content=["']([^"']*)["'][^>]*${attr}`, 'i'),
+    new RegExp(`<meta[^>]*${attr}[^>]*${content}`, 'i'),
+    new RegExp(`<meta[^>]*${content}[^>]*${attr}`, 'i'),
   ]
   for (const pattern of patterns) {
     const match = html.match(pattern)
-    if (match?.[1]) return decodeHtmlEntities(match[1]).trim() || null
+    const value = match?.[1] ?? match?.[2]
+    if (value) return decodeHtmlEntities(value).trim() || null
   }
   return null
 }
@@ -75,6 +79,7 @@ function parsePreview(html: string): LinkPreview {
 
 async function fetchPreview(url: string): Promise<LinkPreview> {
   const response = await secureFetchWithValidation(url, {
+    allowHttp: true,
     timeout: FETCH_TIMEOUT_MS,
     maxRedirects: MAX_REDIRECTS,
     maxResponseBytes: MAX_RESPONSE_BYTES,
@@ -97,12 +102,15 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const rateLimited = await enforceUserRateLimit('link-preview', session.user.id)
+  if (rateLimited) return rateLimited
+
   const parsed = await parseRequest(getLinkPreviewContract, request, {})
   if (!parsed.success) return parsed.response
   const { url } = parsed.data.query
 
   const redis = getRedisClient()
-  const cacheKey = `${CACHE_KEY_PREFIX}${url}`
+  const cacheKey = `${CACHE_KEY_PREFIX}${createHash('sha256').update(url).digest('hex')}`
   if (redis) {
     try {
       const cached = await redis.get(cacheKey)

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -182,7 +182,7 @@ function ExternalLinkTooltip({ href, hostname }: ExternalLinkTooltipProps) {
   const { data } = useLinkPreview(href)
   const preview = data?.preview
 
-  if (!preview?.title && !preview?.description) {
+  if (!preview) {
     return <span className='break-all'>{href}</span>
   }
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -11,8 +11,9 @@ import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-markup'
 import '@sim/emcn/components/code/code.css'
-import { Checkbox, CopyCodeButton, cn, highlight, languages } from '@sim/emcn'
+import { Checkbox, CopyCodeButton, cn, highlight, languages, Tooltip } from '@sim/emcn'
 import { decodeVfsSegmentSafe } from '@/lib/copilot/vfs/path-utils'
+import { faviconUrl } from '@/lib/core/utils/favicon'
 import { extractTextContent } from '@/lib/core/utils/react-node-text'
 import { ContextMentionIcon } from '@/app/workspace/[workspaceId]/home/components/context-mention-icon'
 import {
@@ -22,6 +23,7 @@ import {
   SpecialTags,
 } from '@/app/workspace/[workspaceId]/home/components/message-content/components/special-tags'
 import type { ChatContextKind, MothershipResource } from '@/app/workspace/[workspaceId]/home/types'
+import { useLinkPreview } from '@/hooks/queries/link-preview'
 import { useSmoothText } from '@/hooks/use-smooth-text'
 import { sanitizeChatDisplayContent } from './chat-sanitize'
 
@@ -160,6 +162,55 @@ function fileIconLabel(ref: string, fallback: string): string {
   return fallback
 }
 
+/** Hides a favicon img that failed to load so the link degrades to plain text. */
+function hideBrokenFavicon(e: React.SyntheticEvent<HTMLImageElement>): void {
+  e.currentTarget.style.display = 'none'
+}
+
+interface ExternalLinkTooltipProps {
+  href: string
+  hostname: string
+}
+
+/**
+ * OG-metadata card for an external link's tooltip. Rendered only while the
+ * tooltip is open (Radix lazy-mounts content), so the preview request fires on
+ * hover intent; until metadata arrives — or when the site has none — it shows
+ * the destination URL.
+ */
+function ExternalLinkTooltip({ href, hostname }: ExternalLinkTooltipProps) {
+  const { data } = useLinkPreview(href)
+  const preview = data?.preview
+
+  if (!preview?.title && !preview?.description) {
+    return <span className='break-all'>{href}</span>
+  }
+
+  return (
+    <span className='flex flex-col gap-0.5'>
+      {preview.title && <span className='font-medium'>{preview.title}</span>}
+      {preview.description && (
+        <span className='line-clamp-2 text-[var(--text-muted)]'>{preview.description}</span>
+      )}
+      <span className='text-[var(--text-muted)]'>{preview.siteName ?? hostname}</span>
+    </span>
+  )
+}
+
+/**
+ * Hostname for an external http(s) link, used to fetch its favicon. Returns
+ * null for relative, anchor, mailto, and unparsable hrefs so those keep the
+ * plain underlined treatment.
+ */
+function externalLinkHostname(href?: string): string | null {
+  if (!href || !/^https?:\/\//i.test(href)) return null
+  try {
+    return new URL(href).hostname
+  } catch {
+    return null
+  }
+}
+
 const MARKDOWN_COMPONENTS = {
   table({ children }: { children?: React.ReactNode }) {
     return (
@@ -266,6 +317,34 @@ const MARKDOWN_COMPONENTS = {
           )}
           {children}
         </a>
+      )
+    }
+    const hostname = externalLinkHostname(href)
+    if (hostname && href) {
+      return (
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <a
+              href={href}
+              className='not-prose group text-[var(--text-primary)] no-underline'
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              <img
+                src={faviconUrl(hostname, 32)}
+                alt=''
+                className='relative top-[0.5px] mr-[2px] inline size-[12px] rounded-[3px]'
+                onError={hideBrokenFavicon}
+              />
+              <span className='underline decoration-[color:var(--text-muted)] underline-offset-4 transition-colors group-hover:decoration-[color:var(--text-primary)]'>
+                {children}
+              </span>
+            </a>
+          </Tooltip.Trigger>
+          <Tooltip.Content side='top'>
+            <ExternalLinkTooltip href={href} hostname={hostname} />
+          </Tooltip.Content>
+        </Tooltip.Root>
       )
     }
     return (

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -11,9 +11,8 @@ import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-markup'
 import '@sim/emcn/components/code/code.css'
-import { Checkbox, CopyCodeButton, cn, highlight, languages, Tooltip } from '@sim/emcn'
+import { Checkbox, CopyCodeButton, cn, highlight, languages } from '@sim/emcn'
 import { decodeVfsSegmentSafe } from '@/lib/copilot/vfs/path-utils'
-import { faviconUrl } from '@/lib/core/utils/favicon'
 import { extractTextContent } from '@/lib/core/utils/react-node-text'
 import { ContextMentionIcon } from '@/app/workspace/[workspaceId]/home/components/context-mention-icon'
 import {
@@ -23,9 +22,9 @@ import {
   SpecialTags,
 } from '@/app/workspace/[workspaceId]/home/components/message-content/components/special-tags'
 import type { ChatContextKind, MothershipResource } from '@/app/workspace/[workspaceId]/home/types'
-import { useLinkPreview } from '@/hooks/queries/link-preview'
 import { useSmoothText } from '@/hooks/use-smooth-text'
 import { sanitizeChatDisplayContent } from './chat-sanitize'
+import { ExternalLink, externalLinkHostname } from './external-link'
 
 const LANG_ALIASES: Record<string, string> = {
   js: 'javascript',
@@ -162,55 +161,6 @@ function fileIconLabel(ref: string, fallback: string): string {
   return fallback
 }
 
-/** Hides a favicon img that failed to load so the link degrades to plain text. */
-function hideBrokenFavicon(e: React.SyntheticEvent<HTMLImageElement>): void {
-  e.currentTarget.style.display = 'none'
-}
-
-interface ExternalLinkTooltipProps {
-  href: string
-  hostname: string
-}
-
-/**
- * OG-metadata card for an external link's tooltip. Rendered only while the
- * tooltip is open (Radix lazy-mounts content), so the preview request fires on
- * hover intent; until metadata arrives — or when the site has none — it shows
- * the destination URL.
- */
-function ExternalLinkTooltip({ href, hostname }: ExternalLinkTooltipProps) {
-  const { data } = useLinkPreview(href)
-  const preview = data?.preview
-
-  if (!preview) {
-    return <span className='break-all'>{href}</span>
-  }
-
-  return (
-    <span className='flex flex-col gap-0.5'>
-      {preview.title && <span className='font-medium'>{preview.title}</span>}
-      {preview.description && (
-        <span className='line-clamp-2 text-[var(--text-muted)]'>{preview.description}</span>
-      )}
-      <span className='text-[var(--text-muted)]'>{preview.siteName ?? hostname}</span>
-    </span>
-  )
-}
-
-/**
- * Hostname for an external http(s) link, used to fetch its favicon. Returns
- * null for relative, anchor, mailto, and unparsable hrefs so those keep the
- * plain underlined treatment.
- */
-function externalLinkHostname(href?: string): string | null {
-  if (!href || !/^https?:\/\//i.test(href)) return null
-  try {
-    return new URL(href).hostname
-  } catch {
-    return null
-  }
-}
-
 const MARKDOWN_COMPONENTS = {
   table({ children }: { children?: React.ReactNode }) {
     return (
@@ -322,29 +272,9 @@ const MARKDOWN_COMPONENTS = {
     const hostname = externalLinkHostname(href)
     if (hostname && href) {
       return (
-        <Tooltip.Root>
-          <Tooltip.Trigger asChild>
-            <a
-              href={href}
-              className='not-prose group text-[var(--text-primary)] no-underline'
-              target='_blank'
-              rel='noopener noreferrer'
-            >
-              <img
-                src={faviconUrl(hostname, 32)}
-                alt=''
-                className='relative top-[0.5px] mr-[2px] inline size-[12px] rounded-[3px]'
-                onError={hideBrokenFavicon}
-              />
-              <span className='underline decoration-[color:var(--text-muted)] underline-offset-4 transition-colors group-hover:decoration-[color:var(--text-primary)]'>
-                {children}
-              </span>
-            </a>
-          </Tooltip.Trigger>
-          <Tooltip.Content side='top'>
-            <ExternalLinkTooltip href={href} hostname={hostname} />
-          </Tooltip.Content>
-        </Tooltip.Root>
+        <ExternalLink href={href} hostname={hostname}>
+          {children}
+        </ExternalLink>
       )
     }
     return (

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -277,6 +277,13 @@ const MARKDOWN_COMPONENTS = {
         </ExternalLink>
       )
     }
+    if (href?.startsWith('mailto:')) {
+      return (
+        <a href={href} className='not-prose text-[var(--text-primary)] no-underline'>
+          {children}
+        </a>
+      )
+    }
     return (
       <a
         href={href}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/external-link.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/external-link.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { Tooltip } from '@sim/emcn'
+import { faviconUrl } from '@/lib/core/utils/favicon'
+import { useLinkPreview } from '@/hooks/queries/link-preview'
+
+/** Hides a favicon img that failed to load so the link degrades to plain text. */
+function hideBrokenFavicon(e: React.SyntheticEvent<HTMLImageElement>): void {
+  e.currentTarget.style.display = 'none'
+}
+
+/**
+ * Hostname for an external http(s) link, used to fetch its favicon. Returns
+ * null for relative, anchor, mailto, and unparsable hrefs so those keep the
+ * plain underlined treatment.
+ */
+export function externalLinkHostname(href?: string): string | null {
+  if (!href || !/^https?:\/\//i.test(href)) return null
+  try {
+    return new URL(href).hostname
+  } catch {
+    return null
+  }
+}
+
+interface ExternalLinkProps {
+  href: string
+  hostname: string
+  children?: React.ReactNode
+}
+
+/**
+ * Favicon + quiet-underline external link with an OG-preview tooltip. The
+ * preview query fires when the link renders, so metadata is normally cached
+ * (client and server side) before the first hover; the tooltip shows the
+ * destination URL until metadata arrives or when the site has none.
+ */
+export function ExternalLink({ href, hostname, children }: ExternalLinkProps) {
+  const { data } = useLinkPreview(href)
+  const preview = data?.preview
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>
+        <a
+          href={href}
+          className='not-prose group text-[var(--text-primary)] no-underline'
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          <img
+            src={faviconUrl(hostname, 32)}
+            alt=''
+            className='relative top-[0.5px] mr-[2px] inline size-[12px] rounded-[3px]'
+            onError={hideBrokenFavicon}
+          />
+          <span className='underline decoration-[color:var(--text-muted)] underline-offset-4 transition-colors group-hover:decoration-[color:var(--text-primary)]'>
+            {children}
+          </span>
+        </a>
+      </Tooltip.Trigger>
+      <Tooltip.Content>
+        {preview ? (
+          <span className='flex flex-col gap-0.5'>
+            {preview.title && <span className='font-medium'>{preview.title}</span>}
+            {preview.description && (
+              <span className='line-clamp-2 text-[var(--text-muted)]'>{preview.description}</span>
+            )}
+            <span className='text-[var(--text-muted)]'>{preview.siteName ?? hostname}</span>
+          </span>
+        ) : (
+          <span className='break-all'>{href}</span>
+        )}
+      </Tooltip.Content>
+    </Tooltip.Root>
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/external-link.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/external-link.tsx
@@ -33,10 +33,12 @@ interface ExternalLinkProps {
  * Favicon + quiet-underline external link with an OG-preview tooltip. The
  * preview query fires when the link renders, so metadata is normally cached
  * (client and server side) before the first hover; the tooltip shows the
- * destination URL until metadata arrives or when the site has none.
+ * destination URL until metadata arrives or when the site has none. Previews
+ * are https-only — plain-http links keep the URL tooltip, since fetching them
+ * server-side would reach the URL validator's self-host loopback exception.
  */
 export function ExternalLink({ href, hostname, children }: ExternalLinkProps) {
-  const { data } = useLinkPreview(href)
+  const { data } = useLinkPreview(href.startsWith('https://') ? href : undefined)
   const preview = data?.preview
 
   return (

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/cells/cell-render.tsx
@@ -4,6 +4,7 @@ import type React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { Badge, Checkbox, cn, Tooltip } from '@sim/emcn'
 import { parse } from 'tldts'
+import { faviconUrl } from '@/lib/core/utils/favicon'
 import type { RowExecutionMetadata } from '@/lib/table'
 import { StatusBadge } from '@/app/workspace/[workspaceId]/logs/utils'
 import { storageToDisplay } from '../../../utils'
@@ -368,7 +369,7 @@ export function CellRender({ kind, isEditing }: CellRenderProps): React.ReactEle
       return (
         <span className={cn('flex min-w-0 items-center gap-1.5', isEditing && 'invisible')}>
           <img
-            src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(kind.domain)}&sz=16`}
+            src={faviconUrl(kind.domain, 16)}
             alt=''
             width={12}
             height={12}

--- a/apps/sim/hooks/queries/link-preview.ts
+++ b/apps/sim/hooks/queries/link-preview.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query'
+import { requestJson } from '@/lib/api/client/request'
+import { getLinkPreviewContract, type LinkPreviewResponse } from '@/lib/api/contracts/link-preview'
+
+/** Previews are near-immutable page metadata; the server also caches for 24h. */
+export const LINK_PREVIEW_STALE_TIME = 60 * 60 * 1000
+
+export const linkPreviewKeys = {
+  all: ['link-preview'] as const,
+  details: () => [...linkPreviewKeys.all, 'detail'] as const,
+  detail: (url?: string) => [...linkPreviewKeys.details(), url ?? ''] as const,
+}
+
+async function fetchLinkPreview(url: string, signal?: AbortSignal): Promise<LinkPreviewResponse> {
+  return requestJson(getLinkPreviewContract, { query: { url }, signal })
+}
+
+/**
+ * OG metadata for an external URL, fetched through the SSRF-hardened
+ * `/api/link-preview` proxy. Mount the consuming component lazily (e.g. inside
+ * a tooltip that renders on open) so the request only fires on intent.
+ */
+export function useLinkPreview(url?: string) {
+  return useQuery({
+    queryKey: linkPreviewKeys.detail(url),
+    queryFn: ({ signal }) => fetchLinkPreview(url as string, signal),
+    enabled: Boolean(url),
+    staleTime: LINK_PREVIEW_STALE_TIME,
+    retry: false,
+  })
+}

--- a/apps/sim/hooks/queries/link-preview.ts
+++ b/apps/sim/hooks/queries/link-preview.ts
@@ -17,8 +17,10 @@ async function fetchLinkPreview(url: string, signal?: AbortSignal): Promise<Link
 
 /**
  * OG metadata for an external URL, fetched through the SSRF-hardened
- * `/api/link-preview` proxy. Mount the consuming component lazily (e.g. inside
- * a tooltip that renders on open) so the request only fires on intent.
+ * `/api/link-preview` proxy. Fires when the consuming component renders so the
+ * preview is normally cached before the user hovers; results are long-lived
+ * (client staleTime + 24h server-side Redis cache) and failures are not
+ * retried.
  */
 export function useLinkPreview(url?: string) {
   return useQuery({

--- a/apps/sim/lib/api/contracts/link-preview.ts
+++ b/apps/sim/lib/api/contracts/link-preview.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+import { defineRouteContract } from '@/lib/api/contracts/types'
+
+export const linkPreviewQuerySchema = z.object({
+  url: z
+    .string()
+    .trim()
+    .min(1, 'url is required')
+    .max(2048, 'url must be 2048 characters or less')
+    .url('url must be a valid URL'),
+})
+
+export const linkPreviewResponseSchema = z.object({
+  preview: z
+    .object({
+      title: z.string().nullable(),
+      description: z.string().nullable(),
+      siteName: z.string().nullable(),
+    })
+    .nullable(),
+})
+
+export type LinkPreviewQuery = z.input<typeof linkPreviewQuerySchema>
+export type LinkPreviewResponse = z.output<typeof linkPreviewResponseSchema>
+export type LinkPreview = LinkPreviewResponse['preview']
+
+export const getLinkPreviewContract = defineRouteContract({
+  method: 'GET',
+  path: '/api/link-preview',
+  query: linkPreviewQuerySchema,
+  response: { mode: 'json', schema: linkPreviewResponseSchema },
+})

--- a/apps/sim/lib/core/utils/favicon.ts
+++ b/apps/sim/lib/core/utils/favicon.ts
@@ -1,0 +1,9 @@
+/**
+ * URL for a domain's favicon via Google's favicon service.
+ *
+ * @param domain - Bare hostname (e.g. `x.com`), not a full URL
+ * @param size - Requested pixel size; request 2x the display size for retina
+ */
+export function faviconUrl(domain: string, size: number): string {
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=${size}`
+}

--- a/scripts/check-api-validation-contracts.ts
+++ b/scripts/check-api-validation-contracts.ts
@@ -9,8 +9,8 @@ const QUERY_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/queries')
 const SELECTOR_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/selectors')
 
 const BASELINE = {
-  totalRoutes: 963,
-  zodRoutes: 963,
+  totalRoutes: 964,
+  zodRoutes: 964,
   nonZodRoutes: 0,
 } as const
 


### PR DESCRIPTION
## Summary
- external http(s) links in chat responses now render with the site's favicon (Google s2 service, 2x fetched, 12px, optically aligned to cap height) + a quiet solid underline in `--text-muted` that darkens to `--text-primary` on hover — replaces the harsh dashed underline; mailto/anchor/relative links keep the old treatment
- hovering a link shows an OG-metadata preview tooltip (title / description / site name) via a new contract-bound `GET /api/link-preview` route: session-gated, fetches through the existing SSRF toolkit (`secureFetchWithValidation` — DNS-pinned, private-IP blocked) with 5s timeout, 3-redirect cap, 256KB response cap, head-only OG parsing, and Redis caching (24h positive / 1h negative); any failure returns a null preview and the tooltip falls back to the URL
- preview requests fire only on hover intent (Radix lazy-mounts tooltip content) through a new `useLinkPreview` React Query hook
- consolidated the favicon URL into a shared `faviconUrl()` helper, now used by both chat and the tables URL cell (previously inline there)
- bumped the api-validation route-count baseline 963→964 for the new route

## Type of Change
- [x] New feature

## Testing
Tested manually against the running app (favicon alignment across 10 sites, preview tooltips, 401 unauthenticated, bot-blocked-site fallback)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)