### PR TITLE
fix(oauth): serialize version-guard date in slack fan-out sql

### DIFF
--- a/apps/sim/lib/oauth/slack.ts
+++ b/apps/sim/lib/oauth/slack.ts
@@ -77,7 +77,9 @@ export async function fanOutSlackTokenChain(
       and(
         installationFilter(teamId),
         since
-          ? sql`NOT EXISTS (SELECT 1 FROM ${account} sibling WHERE sibling.provider_id = 'slack' AND sibling.account_id LIKE ${`${teamId}-%`} AND sibling.updated_at > ${since})`
+          ? // Raw sql params skip drizzle's column mapping, and the driver
+            // rejects bare Date objects — serialize to ISO explicitly.
+            sql`NOT EXISTS (SELECT 1 FROM ${account} sibling WHERE sibling.provider_id = 'slack' AND sibling.account_id LIKE ${`${teamId}-%`} AND sibling.updated_at > ${since.toISOString()})`
           : undefined
       )
     )


### PR DESCRIPTION
## Summary
- The version-guarded Slack fan-out (#5723) passed a bare \`Date\` as a raw sql parameter; raw fragments skip drizzle's column mapping and the driver rejects Date instances (\`The "string" argument must be of type string or an instance of Buffer...\`), failing every guarded fan-out at runtime
- Serialize the guard timestamp to ISO explicitly in the fragment
- Caught in staging testing (run failed with the generic refresh error; CloudWatch showed the failed query). Verified end-to-end against a real database: guard timestamp keeps ms precision and the guarded fan-out updates all installation rows

## Type of Change
- [x] Bug fix

## Testing
Local repro script against a real Postgres reproduced the driver error pre-fix and passes post-fix (guarded fan-out writes all rows, chainVersion keeps millisecond precision). Unit suites pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)