### PR TITLE
fix(billing): standardize credit-usage summary font to proportional figures

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/billing/components/credit-usage-section/credit-usage-section.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/billing/components/credit-usage-section/credit-usage-section.tsx
@@ -26,7 +26,7 @@ export function CreditUsageSection({
     <SettingsSection label='Credit usage'>
       <div className='flex items-center justify-between px-2'>
         <div className='flex flex-col justify-center gap-[1px]'>
-          <span className='text-[var(--text-body)] text-sm tabular-nums'>
+          <span className='text-[var(--text-body)] text-sm'>
             {isPending || isError ? '—' : formatCreditsLabel(totalCredits ?? 0)}
           </span>
           <span className='text-[var(--text-muted)] text-caption'>Last 30 days</span>


### PR DESCRIPTION
## Summary
- The "Credit usage" summary glance in Billing settings rendered its total (e.g. `285,857 credits`) with `tabular-nums`, which activates the `season` font's monospaced tabular-figure glyphs — a uniform-width digit set that visibly reads as a different font from the adjacent proportional letters and the rest of the UI.
- Dropped `tabular-nums` from that standalone summary span so the digits use `season`'s proportional figures and match surrounding text. The aligned-column credit costs in the usage-log list keep `tabular-nums` (correct there — numbers are stacked in a column).

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)