### PR TITLE
fix(billing): point enterprise Talk to sales at Cal.com instead of Typeform

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/upgrade/upgrade.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/upgrade/upgrade.tsx
@@ -37,7 +37,8 @@ import {
 } from '@/app/workspace/[workspaceId]/upgrade/search-params'
 import { useFullscreenOriginStore } from '@/stores/fullscreen-origin'
 
-const TYPEFORM_ENTERPRISE_URL = 'https://form.typeform.com/to/jqCO12pF' as const
+/** Enterprise "Talk to sales" books time with the sales team on Cal.com. */
+const SALES_CAL_URL = 'https://cal.com/team/sim/enterprise' as const
 
 /**
  * Props for {@link Upgrade}.
@@ -149,7 +150,7 @@ export function Upgrade({ workspaceId }: UpgradeProps) {
     const onClick = (): void => {
       switch (cta.intent) {
         case 'sales':
-          window.open(TYPEFORM_ENTERPRISE_URL, '_blank')
+          window.open(SALES_CAL_URL, '_blank', 'noopener,noreferrer')
           return
         case 'downgrade':
           void state.onUpgradeToOtherTier()


### PR DESCRIPTION
## Summary
- Enterprise "Talk to sales" CTA on the upgrade page now opens Emir's Cal.com booking link (`cal.com/emirkarabeg/sim-team`) instead of the Typeform demo-request form
- Removes the dead `TYPEFORM_ENTERPRISE_URL` constant; opens with `noopener,noreferrer`

## Type of Change
- [x] Bug fix

## Testing
Tested manually — Enterprise card CTA opens the Cal.com scheduler in a new tab.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)