### PR TITLE
feat(admin): show recently impersonated users in admin panel

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -29,7 +29,7 @@ import { clearUserData } from '@/stores'
 const PAGE_SIZE = 20 as const
 
 const USER_TABLE_HEADER = (
-  <div className='flex items-center gap-3 border-[var(--border)] border-b px-3 py-2 text-[var(--text-tertiary)] text-caption'>
+  <div className='flex items-center gap-3 px-3 pb-1 text-[var(--text-tertiary)] text-caption'>
     <span className='w-[170px]'>Name</span>
     <span className='flex-1'>Email</span>
     <span className='w-[60px]'>Role</span>
@@ -174,13 +174,7 @@ export function Admin() {
   ])
 
   const renderUserRow = (u: AdminUser) => (
-    <div
-      key={u.id}
-      className={cn(
-        'flex flex-col gap-2 px-3 py-2 text-small',
-        'border-[var(--border)] border-b last:border-b-0'
-      )}
-    >
+    <div key={u.id} className='flex flex-col gap-2 px-3 py-2 text-small'>
       <div className='flex items-center gap-3'>
         <span className='w-[170px] truncate text-[var(--text-primary)]'>{u.name || '—'}</span>
         <span className='flex-1 truncate text-[var(--text-secondary)]'>{u.email}</span>

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -10,10 +10,13 @@ import {
   adminParsers,
   adminUrlKeys,
 } from '@/app/workspace/[workspaceId]/settings/components/admin/search-params'
+import { useRecentImpersonations } from '@/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations'
 import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
 import {
+  type AdminUser,
   useAdminUsers,
+  useAdminUsersByEmails,
   useBanUser,
   useImpersonateUser,
   useSetUserRole,
@@ -24,6 +27,16 @@ import { useImportWorkflow } from '@/hooks/queries/workflows'
 import { clearUserData } from '@/stores'
 
 const PAGE_SIZE = 20 as const
+
+const USER_TABLE_HEADER = (
+  <div className='flex items-center gap-3 border-[var(--border)] border-b px-3 py-2 text-[var(--text-tertiary)] text-caption'>
+    <span className='w-[170px]'>Name</span>
+    <span className='flex-1'>Email</span>
+    <span className='w-[60px]'>Role</span>
+    <span className='w-[55px]'>Status</span>
+    <span className='w-[200px] text-right'>Actions</span>
+  </div>
+)
 
 const MOTHERSHIP_ENV_OPTIONS: { value: MothershipEnvironment; label: string }[] = [
   { value: 'default', label: 'Default' },
@@ -43,6 +56,8 @@ export function Admin() {
   const banUser = useBanUser()
   const unbanUser = useUnbanUser()
   const impersonateUser = useImpersonateUser()
+  const { recentEmails, recordImpersonation } = useRecentImpersonations()
+  const { data: recentUsers } = useAdminUsersByEmails(recentEmails)
 
   const [workflowId, setWorkflowId] = useState('')
   const [targetWorkspaceId, setTargetWorkspaceId] = useState('')
@@ -94,7 +109,7 @@ export function Admin() {
     }
   }
 
-  const handleImpersonate = (userId: string) => {
+  const handleImpersonate = (userId: string, email: string) => {
     setImpersonationGuardError(null)
     if (session?.user?.role !== 'admin') {
       setImpersonatingUserId(null)
@@ -111,6 +126,7 @@ export function Admin() {
           setImpersonatingUserId(null)
         },
         onSuccess: async () => {
+          recordImpersonation(email)
           await clearUserData()
           window.location.assign('/workspace')
         },
@@ -156,6 +172,125 @@ export function Admin() {
     impersonateUser.variables,
     impersonatingUserId,
   ])
+
+  const renderUserRow = (u: AdminUser) => (
+    <div
+      key={u.id}
+      className={cn(
+        'flex flex-col gap-2 px-3 py-2 text-small',
+        'border-[var(--border)] border-b last:border-b-0'
+      )}
+    >
+      <div className='flex items-center gap-3'>
+        <span className='w-[170px] truncate text-[var(--text-primary)]'>{u.name || '—'}</span>
+        <span className='flex-1 truncate text-[var(--text-secondary)]'>{u.email}</span>
+        <span className='w-[60px]'>
+          <Badge variant={u.role === 'admin' ? 'blue' : 'gray'}>{u.role || 'user'}</Badge>
+        </span>
+        <span className='w-[55px]'>
+          {u.banned ? <Badge variant='red'>Banned</Badge> : <Badge variant='green'>Active</Badge>}
+        </span>
+        <span className='flex w-[200px] justify-end gap-1'>
+          {u.id !== session?.user?.id && (
+            <>
+              <Button
+                variant='active'
+                className='h-[28px] px-2 text-caption'
+                onClick={() => handleImpersonate(u.id, u.email)}
+                disabled={pendingUserIds.has(u.id)}
+              >
+                {impersonatingUserId === u.id ||
+                (impersonateUser.isPending &&
+                  (impersonateUser.variables as { userId?: string } | undefined)?.userId === u.id)
+                  ? 'Switching...'
+                  : 'Impersonate'}
+              </Button>
+              <Button
+                variant='active'
+                className='h-[28px] px-2 text-caption'
+                onClick={() => {
+                  setUserRole.reset()
+                  setUserRole.mutate({
+                    userId: u.id,
+                    role: u.role === 'admin' ? 'user' : 'admin',
+                  })
+                }}
+                disabled={pendingUserIds.has(u.id)}
+              >
+                {u.role === 'admin' ? 'Demote' : 'Promote'}
+              </Button>
+              {u.banned ? (
+                <Button
+                  variant='active'
+                  className='h-[28px] px-2 text-caption'
+                  onClick={() => {
+                    unbanUser.reset()
+                    unbanUser.mutate({ userId: u.id })
+                  }}
+                  disabled={pendingUserIds.has(u.id)}
+                >
+                  Unban
+                </Button>
+              ) : (
+                <Button
+                  variant='active'
+                  className={cn(
+                    'h-[28px] px-2 text-caption',
+                    banUserId === u.id ? 'text-[var(--text-primary)]' : 'text-[var(--text-error)]'
+                  )}
+                  onClick={() => {
+                    if (banUserId === u.id) {
+                      setBanUserId(null)
+                      setBanReason('')
+                    } else {
+                      setBanUserId(u.id)
+                      setBanReason('')
+                    }
+                  }}
+                  disabled={pendingUserIds.has(u.id)}
+                >
+                  {banUserId === u.id ? 'Cancel' : 'Ban'}
+                </Button>
+              )}
+            </>
+          )}
+        </span>
+      </div>
+      {banUserId === u.id && !u.banned && (
+        <div className='flex items-center gap-2 pl-[170px]'>
+          <ChipInput
+            value={banReason}
+            onChange={(e) => setBanReason(e.target.value)}
+            placeholder='Reason (optional)'
+            className='flex-1'
+          />
+          <Button
+            variant='primary'
+            className='h-[28px] px-3 text-caption'
+            onClick={() => {
+              banUser.reset()
+              banUser.mutate(
+                {
+                  userId: u.id,
+                  ...(banReason.trim() ? { banReason: banReason.trim() } : {}),
+                },
+                {
+                  onSuccess: () => {
+                    setBanUserId(null)
+                    setBanReason('')
+                  },
+                }
+              )
+            }}
+            disabled={pendingUserIds.has(u.id)}
+          >
+            Confirm Ban
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+
   return (
     <SettingsPanel>
       <div className='flex flex-col gap-4'>
@@ -275,149 +410,16 @@ export function Admin() {
           </p>
         )}
 
-        {searchQuery.length > 0 && usersData && (
+        {searchQuery.length > 0 && usersData ? (
           <>
             <div className='flex flex-col gap-0.5'>
-              <div className='flex items-center gap-3 border-[var(--border-secondary)] border-b px-3 py-2 text-[var(--text-tertiary)] text-caption'>
-                <span className='w-[200px]'>Name</span>
-                <span className='flex-1'>Email</span>
-                <span className='w-[80px]'>Role</span>
-                <span className='w-[80px]'>Status</span>
-                <span className='w-[250px] text-right'>Actions</span>
-              </div>
+              {USER_TABLE_HEADER}
 
               {usersData.users.length === 0 && (
                 <SettingsEmptyState variant='inline'>No users found.</SettingsEmptyState>
               )}
 
-              {usersData.users.map((u) => (
-                <div
-                  key={u.id}
-                  className={cn(
-                    'flex flex-col gap-2 px-3 py-2 text-small',
-                    'border-[var(--border-secondary)] border-b last:border-b-0'
-                  )}
-                >
-                  <div className='flex items-center gap-3'>
-                    <span className='w-[200px] truncate text-[var(--text-primary)]'>
-                      {u.name || '—'}
-                    </span>
-                    <span className='flex-1 truncate text-[var(--text-secondary)]'>{u.email}</span>
-                    <span className='w-[80px]'>
-                      <Badge variant={u.role === 'admin' ? 'blue' : 'gray'}>
-                        {u.role || 'user'}
-                      </Badge>
-                    </span>
-                    <span className='w-[80px]'>
-                      {u.banned ? (
-                        <Badge variant='red'>Banned</Badge>
-                      ) : (
-                        <Badge variant='green'>Active</Badge>
-                      )}
-                    </span>
-                    <span className='flex w-[250px] justify-end gap-1'>
-                      {u.id !== session?.user?.id && (
-                        <>
-                          <Button
-                            variant='active'
-                            className='h-[28px] px-2 text-caption'
-                            onClick={() => handleImpersonate(u.id)}
-                            disabled={pendingUserIds.has(u.id)}
-                          >
-                            {impersonatingUserId === u.id ||
-                            (impersonateUser.isPending &&
-                              (impersonateUser.variables as { userId?: string } | undefined)
-                                ?.userId === u.id)
-                              ? 'Switching...'
-                              : 'Impersonate'}
-                          </Button>
-                          <Button
-                            variant='active'
-                            className='h-[28px] px-2 text-caption'
-                            onClick={() => {
-                              setUserRole.reset()
-                              setUserRole.mutate({
-                                userId: u.id,
-                                role: u.role === 'admin' ? 'user' : 'admin',
-                              })
-                            }}
-                            disabled={pendingUserIds.has(u.id)}
-                          >
-                            {u.role === 'admin' ? 'Demote' : 'Promote'}
-                          </Button>
-                          {u.banned ? (
-                            <Button
-                              variant='active'
-                              className='h-[28px] px-2 text-caption'
-                              onClick={() => {
-                                unbanUser.reset()
-                                unbanUser.mutate({ userId: u.id })
-                              }}
-                              disabled={pendingUserIds.has(u.id)}
-                            >
-                              Unban
-                            </Button>
-                          ) : (
-                            <Button
-                              variant='active'
-                              className={cn(
-                                'h-[28px] px-2 text-caption',
-                                banUserId === u.id
-                                  ? 'text-[var(--text-primary)]'
-                                  : 'text-[var(--text-error)]'
-                              )}
-                              onClick={() => {
-                                if (banUserId === u.id) {
-                                  setBanUserId(null)
-                                  setBanReason('')
-                                } else {
-                                  setBanUserId(u.id)
-                                  setBanReason('')
-                                }
-                              }}
-                              disabled={pendingUserIds.has(u.id)}
-                            >
-                              {banUserId === u.id ? 'Cancel' : 'Ban'}
-                            </Button>
-                          )}
-                        </>
-                      )}
-                    </span>
-                  </div>
-                  {banUserId === u.id && !u.banned && (
-                    <div className='flex items-center gap-2 pl-[200px]'>
-                      <ChipInput
-                        value={banReason}
-                        onChange={(e) => setBanReason(e.target.value)}
-                        placeholder='Reason (optional)'
-                        className='flex-1'
-                      />
-                      <Button
-                        variant='primary'
-                        className='h-[28px] px-3 text-caption'
-                        onClick={() => {
-                          banUser.reset()
-                          banUser.mutate(
-                            {
-                              userId: u.id,
-                              ...(banReason.trim() ? { banReason: banReason.trim() } : {}),
-                            },
-                            {
-                              onSuccess: () => {
-                                setBanUserId(null)
-                                setBanReason('')
-                              },
-                            }
-                          )
-                        }}
-                        disabled={pendingUserIds.has(u.id)}
-                      >
-                        Confirm Ban
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              ))}
+              {usersData.users.map((u) => renderUserRow(u))}
             </div>
 
             {totalPages > 1 && (
@@ -450,6 +452,15 @@ export function Admin() {
               </div>
             )}
           </>
+        ) : (
+          searchQuery.length === 0 &&
+          recentUsers &&
+          recentUsers.length > 0 && (
+            <div className='flex flex-col gap-0.5'>
+              {USER_TABLE_HEADER}
+              {recentUsers.map((u) => renderUserRow(u))}
+            </div>
+          )
         )}
       </div>
     </SettingsPanel>

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations.ts
@@ -1,7 +1,5 @@
 import { useCallback, useState } from 'react'
-
-/** Survives clearUserData via the keysToKeep allowlist in @/stores. */
-export const RECENT_IMPERSONATIONS_STORAGE_KEY = 'recent-impersonations'
+import { RECENT_IMPERSONATIONS_STORAGE_KEY } from '@/stores'
 
 const MAX_RECENT = 5
 
@@ -24,7 +22,11 @@ export function useRecentImpersonations() {
 
   const recordImpersonation = useCallback((email: string) => {
     const next = [email, ...readRecentEmails().filter((e) => e !== email)].slice(0, MAX_RECENT)
-    localStorage.setItem(RECENT_IMPERSONATIONS_STORAGE_KEY, JSON.stringify(next))
+    try {
+      localStorage.setItem(RECENT_IMPERSONATIONS_STORAGE_KEY, JSON.stringify(next))
+    } catch {
+      /* best-effort: recording must never block the impersonation transition */
+    }
     setRecentEmails(next)
   }, [])
 

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react'
+
+/** Survives clearUserData via the keysToKeep allowlist in @/stores. */
+export const RECENT_IMPERSONATIONS_STORAGE_KEY = 'recent-impersonations'
+
+const MAX_RECENT = 5
+
+function readRecentEmails(): string[] {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(RECENT_IMPERSONATIONS_STORAGE_KEY) ?? '[]')
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((e): e is string => typeof e === 'string').slice(0, MAX_RECENT)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Last {@link MAX_RECENT} emails the admin impersonated, most recent first,
+ * persisted in localStorage on this browser.
+ */
+export function useRecentImpersonations() {
+  const [recentEmails, setRecentEmails] = useState<string[]>(() => readRecentEmails())
+
+  const recordImpersonation = useCallback((email: string) => {
+    const next = [email, ...readRecentEmails().filter((e) => e !== email)].slice(0, MAX_RECENT)
+    localStorage.setItem(RECENT_IMPERSONATIONS_STORAGE_KEY, JSON.stringify(next))
+    setRecentEmails(next)
+  }, [])
+
+  return { recentEmails, recordImpersonation }
+}

--- a/apps/sim/hooks/queries/admin-users.ts
+++ b/apps/sim/hooks/queries/admin-users.ts
@@ -91,20 +91,17 @@ async function fetchAdminUsersByEmails(
       const { data, error } = await client.admin.listUsers(
         {
           query: {
-            limit: 20,
-            searchField: 'email',
-            searchValue: email,
-            searchOperator: 'contains',
+            limit: 1,
+            filterField: 'email',
+            filterValue: email,
+            filterOperator: 'eq',
           },
         },
         { signal }
       )
       if (error) throw new Error(error.message ?? 'Failed to fetch user')
-      return (
-        (data?.users ?? [])
-          .map(mapUser)
-          .find((u) => u.email.toLowerCase() === email.toLowerCase()) ?? null
-      )
+      const user = (data?.users ?? [])[0]
+      return user ? mapUser(user) : null
     })
   )
   return results.filter((u): u is AdminUser => u !== null)

--- a/apps/sim/hooks/queries/admin-users.ts
+++ b/apps/sim/hooks/queries/admin-users.ts
@@ -91,7 +91,7 @@ async function fetchAdminUsersByEmails(
       const { data, error } = await client.admin.listUsers(
         {
           query: {
-            limit: 5,
+            limit: 20,
             searchField: 'email',
             searchValue: email,
             searchOperator: 'contains',

--- a/apps/sim/hooks/queries/admin-users.ts
+++ b/apps/sim/hooks/queries/admin-users.ts
@@ -12,9 +12,10 @@ export const adminUserKeys = {
   lists: () => [...adminUserKeys.all, 'list'] as const,
   list: (offset: number, limit: number, searchQuery: string) =>
     [...adminUserKeys.lists(), offset, limit, searchQuery] as const,
+  byEmails: (emails: string[]) => [...adminUserKeys.lists(), 'byEmails', emails] as const,
 }
 
-interface AdminUser {
+export interface AdminUser {
   id: string
   name: string
   email: string
@@ -79,6 +80,44 @@ async function fetchAdminUsers(
     users: (data?.users ?? []).map(mapUser),
     total: data?.total ?? 0,
   }
+}
+
+async function fetchAdminUsersByEmails(
+  emails: string[],
+  signal?: AbortSignal
+): Promise<AdminUser[]> {
+  const results = await Promise.all(
+    emails.map(async (email) => {
+      const { data, error } = await client.admin.listUsers(
+        {
+          query: {
+            limit: 5,
+            searchField: 'email',
+            searchValue: email,
+            searchOperator: 'contains',
+          },
+        },
+        { signal }
+      )
+      if (error) throw new Error(error.message ?? 'Failed to fetch user')
+      return (
+        (data?.users ?? [])
+          .map(mapUser)
+          .find((u) => u.email.toLowerCase() === email.toLowerCase()) ?? null
+      )
+    })
+  )
+  return results.filter((u): u is AdminUser => u !== null)
+}
+
+/** Resolves each email to its exact-match user; unmatched emails are dropped. */
+export function useAdminUsersByEmails(emails: string[]) {
+  return useQuery({
+    queryKey: adminUserKeys.byEmails(emails),
+    queryFn: ({ signal }) => fetchAdminUsersByEmails(emails, signal),
+    enabled: emails.length > 0,
+    staleTime: ADMIN_USER_LIST_STALE_TIME,
+  })
 }
 
 export function useAdminUsers(offset: number, limit: number, searchQuery: string) {

--- a/apps/sim/stores/index.ts
+++ b/apps/sim/stores/index.ts
@@ -2,7 +2,6 @@
 
 import { createLogger } from '@sim/logger'
 import { getQueryClient } from '@/app/_shell/providers/get-query-client'
-import { RECENT_IMPERSONATIONS_STORAGE_KEY } from '@/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations'
 import { environmentKeys } from '@/hooks/queries/environment'
 import { useExecutionStore } from '@/stores/execution'
 import { useMothershipDraftsStore } from '@/stores/mothership-drafts/store'
@@ -12,6 +11,9 @@ import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 const logger = createLogger('Stores')
+
+/** localStorage key for the admin recent-impersonations list; kept through clearUserData. */
+export const RECENT_IMPERSONATIONS_STORAGE_KEY = 'recent-impersonations'
 
 /**
  * Reset all Zustand stores and React Query caches to initial state.

--- a/apps/sim/stores/index.ts
+++ b/apps/sim/stores/index.ts
@@ -2,6 +2,7 @@
 
 import { createLogger } from '@sim/logger'
 import { getQueryClient } from '@/app/_shell/providers/get-query-client'
+import { RECENT_IMPERSONATIONS_STORAGE_KEY } from '@/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations'
 import { environmentKeys } from '@/hooks/queries/environment'
 import { useExecutionStore } from '@/stores/execution'
 import { useMothershipDraftsStore } from '@/stores/mothership-drafts/store'
@@ -50,8 +51,7 @@ export async function clearUserData(): Promise<void> {
   try {
     resetAllStores()
 
-    // Clear localStorage except for essential app settings
-    const keysToKeep = ['next-favicon', 'theme']
+    const keysToKeep = ['next-favicon', 'theme', RECENT_IMPERSONATIONS_STORAGE_KEY]
     const keysToRemove = Object.keys(localStorage).filter((key) => !keysToKeep.includes(key))
     keysToRemove.forEach((key) => localStorage.removeItem(key))
 


### PR DESCRIPTION
## Summary
- Track the last 5 impersonated users (emails only) in localStorage and show them as default rows in the admin User Management table
- Searching replaces the recents with search results; clearing the search brings them back
- Recents resolve to live user rows via a new `useAdminUsersByEmails` query (exact email match), so role/ban status is always current and all row actions work on them
- Allowlist the `recent-impersonations` key in `clearUserData` so impersonation switches/sign-outs don't wipe it
- Extract the user row + table header into shared render helpers; fix undefined `--border-secondary` token to `--border`; tighten Name/Role/Status/Actions column widths so Email doesn't truncate

## Type of Change
- [x] New feature

## Testing
Tested manually. Lint, type-check, and `check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)