### PR TITLE
perf(mothership): restore static markdown parse for settled chat messages

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -10,8 +10,9 @@ import 'prismjs/components/prism-typescript'
 import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-markup'
+import type { Grammar } from 'prismjs'
 import '@sim/emcn/components/code/code.css'
-import { Checkbox, CopyCodeButton, cn, highlight, languages } from '@sim/emcn'
+import { Checkbox, CopyCodeButton, cn, languages, highlight as prismHighlight } from '@sim/emcn'
 import { decodeVfsSegmentSafe } from '@/lib/copilot/vfs/path-utils'
 import { extractTextContent } from '@/lib/core/utils/react-node-text'
 import { ContextMentionIcon } from '@/app/workspace/[workspaceId]/home/components/context-mention-icon'
@@ -159,6 +160,31 @@ function fileIconLabel(ref: string, fallback: string): string {
     if (decoded.includes('.')) return decoded
   }
   return fallback
+}
+
+/**
+ * Bounded LRU cache for Prism highlight output. Chat rows are virtualized, so a
+ * message re-highlights every time it scrolls back into view; a component
+ * `useMemo` would not survive the unmount, so the cache lives at module scope.
+ */
+const HIGHLIGHT_CACHE_LIMIT = 512
+const highlightCache = new Map<string, string>()
+
+function highlight(code: string, grammar: Grammar | undefined, language: string): string {
+  const key = `${language}\n${code}`
+  const cached = highlightCache.get(key)
+  if (cached !== undefined) {
+    highlightCache.delete(key)
+    highlightCache.set(key, cached)
+    return cached
+  }
+  const html = prismHighlight(code, grammar, language)
+  highlightCache.set(key, html)
+  if (highlightCache.size > HIGHLIGHT_CACHE_LIMIT) {
+    const oldest = highlightCache.keys().next().value
+    if (oldest !== undefined) highlightCache.delete(oldest)
+  }
+  return html
 }
 
 const MARKDOWN_COMPONENTS = {
@@ -412,9 +438,9 @@ function ChatContentInner({
    * position (`E`/`qe` in streamdown 2.5), so a re-parse of unchanged content
    * without the animate plugin bails at every unoverridden element (`p`,
    * `strong`, `tr`, headings, …) and leaves the stale per-char span DOM in
-   * place. Every instance renders through the streaming parser (see
-   * `streamingTree` below) so the remount only sheds the spans, never
-   * re-interprets the markdown.
+   * place. The settled instance keeps the streaming parser (`parserTree`
+   * below) so the remount only sheds the spans, never re-interprets the
+   * markdown.
    *
    * The drain is deliberately one-way: a stream that resumes afterwards
    * (reconnect/continuation) reveals paced but unfaded, because re-arming
@@ -459,18 +485,19 @@ function ChatContentInner({
   }, [isRevealing, animationDrained, streamedThisSession])
 
   /**
-   * Every mount renders through the streaming parser (remend +
-   * incomplete-markdown repair + block-split) — `mode='static'` is never used.
-   * The two pipelines parse edge-case markdown differently (unbalanced fences,
-   * list continuation across blocks), so a message you watched stream would
-   * render subtly differently from the same message reloaded from the DB; one
-   * pipeline makes in-session and refreshed renders byte-identical. The rows
-   * are virtualized, so only visible messages pay the block-split mount cost.
-   * `streamingTree` (the remount key and animation props) still drops at
-   * drain, so a settled instance re-renders through the SAME parser minus the
-   * per-word animation spans — identical pixels.
+   * `parserTree` (drives `mode`) stays latched for the mount's life: streaming
+   * mode is the only one that applies remend/incomplete-markdown repair and
+   * block-split parsing, so a settled message must KEEP the streaming parser —
+   * swapping to `mode='static'` at drain re-parses the same source through a
+   * different pipeline (no remend, whole-doc parse) and visibly flashes on any
+   * reply with unbalanced markdown. `streamingTree` (drives the remount key
+   * and animation props) additionally drops at drain, so the settled instance
+   * re-renders through the SAME parser minus the per-word animation spans —
+   * byte-identical pixels. Only never-streamed mounts (reloaded history)
+   * render static.
    */
-  const streamingTree = (isRevealing || streamedThisSession) && !animationDrained
+  const parserTree = isRevealing || streamedThisSession
+  const streamingTree = parserTree && !animationDrained
 
   /**
    * One-way fade cutoff (see {@link FADE_MAX_REVEALED_CHARS}). Latched so a
@@ -573,6 +600,7 @@ function ChatContentInner({
             >
               <Streamdown
                 key={streamingTree ? 'stream' : 'settled'}
+                mode={parserTree ? undefined : 'static'}
                 animated={fadeActive ? STREAM_ANIMATION : false}
                 isAnimating={streamingTree}
                 components={MARKDOWN_COMPONENTS}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -10,7 +10,6 @@ import 'prismjs/components/prism-typescript'
 import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-markup'
-import type { Grammar } from 'prismjs'
 import '@sim/emcn/components/code/code.css'
 import { Checkbox, CopyCodeButton, cn, languages, highlight as prismHighlight } from '@sim/emcn'
 import { decodeVfsSegmentSafe } from '@/lib/copilot/vfs/path-utils'
@@ -166,19 +165,26 @@ function fileIconLabel(ref: string, fallback: string): string {
  * Bounded LRU cache for Prism highlight output. Chat rows are virtualized, so a
  * message re-highlights every time it scrolls back into view; a component
  * `useMemo` would not survive the unmount, so the cache lives at module scope.
+ * Output for an unregistered language is never cached — it renders through the
+ * JavaScript fallback, so caching it would keep serving that stale render if the
+ * real grammar registers later in the session.
  */
 const HIGHLIGHT_CACHE_LIMIT = 512
 const highlightCache = new Map<string, string>()
 
-function highlight(code: string, grammar: Grammar | undefined, language: string): string {
-  const key = `${language}\n${code}`
+function highlight(code: string, language: string): string {
+  const resolved = LANG_ALIASES[language] || language || 'javascript'
+  const grammar = languages[resolved]
+  if (!grammar) return prismHighlight(code, languages.javascript, resolved)
+
+  const key = `${resolved}\n${code}`
   const cached = highlightCache.get(key)
   if (cached !== undefined) {
     highlightCache.delete(key)
     highlightCache.set(key, cached)
     return cached
   }
-  const html = prismHighlight(code, grammar, language)
+  const html = prismHighlight(code, grammar, resolved)
   highlightCache.set(key, html)
   if (highlightCache.size > HIGHLIGHT_CACHE_LIMIT) {
     const oldest = highlightCache.keys().next().value
@@ -233,9 +239,7 @@ const MARKDOWN_COMPONENTS = {
       )
     }
 
-    const resolved = LANG_ALIASES[language] || language || 'javascript'
-    const grammar = languages[resolved] || languages.javascript
-    const html = highlight(codeString.trimEnd(), grammar, resolved)
+    const html = highlight(codeString.trimEnd(), language)
 
     return (
       <div className='not-prose my-6 overflow-hidden rounded-lg border border-[var(--divider)]'>


### PR DESCRIPTION
## Summary
- Chat scroll got laggy after the mothership v0.8 merge (#5410), which removed `mode='static'` from the chat markdown renderer. Every message then rendered through Streamdown's streaming parser — remend + incomplete-markdown repair + per-block re-parse, running the rehype raw/sanitize/harden chain once **per block**.
- Because chat rows are virtualized, every up/down scroll remounts the messages crossing the overscan boundary and re-pays that N-block cost. That's the lag.
- Restore `mode='static'` for never-streamed mounts (reloaded history, or an in-session message scrolled out of the virtualized window and back): one whole-document parse instead of streaming's per-block re-parse. A completed message needs no incomplete-markdown repair, so static is the correct — and much cheaper — mode.
- In-session streaming is unchanged: it keeps the streaming parser for its mount life, so there's no drain re-parse flash.
- Cache Prism highlight output in a module-level bounded LRU (512, LRU eviction) so a code block re-highlights at most once across the unmount/remount virtualization does on scroll — a component `useMemo` would not survive the unmount.

## Root cause
Verified by commit archaeology + reading `streamdown@2.5.0`'s compiled parser: `mode: 'static'` renders the whole message in one `ReactMarkdown` pass and skips `parseIncompleteMarkdown`; `mode: 'streaming'` splits into N blocks and renders each as its own `ReactMarkdown` subtree, running the expensive `rehype-raw` chain per block.

## Type of Change
- [x] Bug fix (performance regression)

## Testing
- `tsc` clean (0 errors), biome clean, 108/108 message-content tests pass.
- `/cleanup` (8 parallel quality passes: effects, state, memo, callback, react-query, url-state, emcn, comments) returned zero findings.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
