### PR TITLE
 v0.7.39: mcp oauth hardening, chat perf improvements

### DIFF
--- a/apps/sim/app/api/mcp/servers/[id]/refresh/route.test.ts
+++ b/apps/sim/app/api/mcp/servers/[id]/refresh/route.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment node
+ */
+import type { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockClearCache, mockDiscoverServerTools, mockSelect, mockUpdateSet } = vi.hoisted(() => ({
+  mockClearCache: vi.fn(),
+  mockDiscoverServerTools: vi.fn(),
+  mockSelect: vi.fn(),
+  mockUpdateSet: vi.fn(),
+}))
+
+vi.mock('@sim/db', () => ({
+  db: {
+    select: mockSelect,
+    update: vi.fn().mockReturnValue({ set: mockUpdateSet }),
+  },
+}))
+
+vi.mock('@/lib/core/utils/with-route-handler', () => ({
+  withRouteHandler: (handler: unknown) => handler,
+}))
+
+vi.mock('@/lib/mcp/middleware', () => ({
+  withMcpAuth:
+    () =>
+    (
+      handler: (
+        request: NextRequest,
+        context: { userId: string; workspaceId: string; requestId: string },
+        routeContext: { params: Promise<{ id: string }> }
+      ) => Promise<Response>
+    ) =>
+    (request: NextRequest, routeContext: { params: Promise<{ id: string }> }) =>
+      handler(
+        request,
+        { userId: 'user-1', workspaceId: 'workspace-1', requestId: 'request-1' },
+        routeContext
+      ),
+}))
+
+vi.mock('@/lib/mcp/service', () => ({
+  mcpService: {
+    clearCache: mockClearCache,
+    discoverServerTools: mockDiscoverServerTools,
+  },
+}))
+
+import { POST } from '@/app/api/mcp/servers/[id]/refresh/route'
+
+const initialServer = {
+  id: 'server-1',
+  workspaceId: 'workspace-1',
+  name: 'OAuth Server',
+  url: 'https://example.com/mcp',
+  connectionStatus: 'connected',
+  lastError: null,
+  lastConnected: new Date('2026-01-01T00:00:00.000Z'),
+  toolCount: 4,
+  statusConfig: { consecutiveFailures: 0, lastSuccessfulDiscovery: null },
+}
+
+const persistedServer = {
+  ...initialServer,
+  connectionStatus: 'disconnected',
+  lastError: null,
+  toolCount: 0,
+}
+
+function selectRows(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  }
+}
+
+describe('MCP server refresh route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSelect.mockReturnValueOnce(selectRows([initialServer]))
+    mockUpdateSet.mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([persistedServer]) }),
+    })
+  })
+
+  it('preserves the service-persisted OAuth pending status', async () => {
+    mockDiscoverServerTools.mockRejectedValueOnce(new Error('OAuth authorization required'))
+
+    const request = new Request('http://localhost/api/mcp/servers/server-1/refresh', {
+      method: 'POST',
+    }) as NextRequest
+    const response = await POST(request, { params: Promise.resolve({ id: 'server-1' }) })
+    const body = await response.json()
+
+    expect(body.data).toEqual(
+      expect.objectContaining({
+        status: 'disconnected',
+        error: null,
+      })
+    )
+    expect(mockUpdateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ connectionStatus: expect.anything() })
+    )
+  })
+
+  it('reports the discovery failure when status persistence leaves a stale connected row', async () => {
+    const reflectedSecret = 'Bearer reflected-static-token'
+    mockDiscoverServerTools.mockRejectedValueOnce(
+      new Error(`Upstream reflected ${reflectedSecret}`)
+    )
+    mockUpdateSet.mockReturnValueOnce({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([initialServer]),
+      }),
+    })
+
+    const request = new Request('http://localhost/api/mcp/servers/server-1/refresh', {
+      method: 'POST',
+    }) as NextRequest
+    const response = await POST(request, { params: Promise.resolve({ id: 'server-1' }) })
+    const body = await response.json()
+
+    expect(body.data).toEqual(
+      expect.objectContaining({
+        status: 'disconnected',
+        error: 'Internal server error',
+        workflowsUpdated: 0,
+      })
+    )
+    expect(JSON.stringify(body)).not.toContain(reflectedSecret)
+    expect(mockClearCache).not.toHaveBeenCalled()
+  })
+
+  it('preserves a connected status from a newer successful discovery', async () => {
+    mockDiscoverServerTools.mockRejectedValueOnce(new Error('Connection failed'))
+    const newerSuccessfulServer = {
+      ...initialServer,
+      lastConnected: new Date(Date.now() + 60_000),
+      toolCount: 7,
+    }
+    mockUpdateSet.mockReturnValueOnce({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([newerSuccessfulServer]),
+      }),
+    })
+
+    const request = new Request('http://localhost/api/mcp/servers/server-1/refresh', {
+      method: 'POST',
+    }) as NextRequest
+    const response = await POST(request, { params: Promise.resolve({ id: 'server-1' }) })
+    const body = await response.json()
+
+    expect(body.data).toEqual(
+      expect.objectContaining({
+        status: 'connected',
+        error: null,
+        toolCount: 7,
+        workflowsUpdated: 0,
+      })
+    )
+    expect(mockClearCache).toHaveBeenCalledWith('workspace-1')
+  })
+})

--- a/apps/sim/app/api/mcp/servers/[id]/refresh/route.test.ts
+++ b/apps/sim/app/api/mcp/servers/[id]/refresh/route.test.ts
@@ -164,4 +164,37 @@ describe('MCP server refresh route', () => {
     )
     expect(mockClearCache).toHaveBeenCalledWith('workspace-1')
   })
+
+  it('does not 500 when workflow sync fails after a successful discovery', async () => {
+    mockDiscoverServerTools.mockResolvedValueOnce([
+      {
+        name: 'search',
+        description: 'Search tool',
+        inputSchema: {},
+        serverId: 'server-1',
+        serverName: 'OAuth Server',
+      },
+    ])
+    // The route's server lookup consumes the first select (beforeEach). The sync's
+    // workflow select is left unmocked, so it throws — exercising the guard that
+    // keeps a secondary sync failure from turning a successful refresh into a 500.
+    mockUpdateSet.mockReturnValueOnce({
+      where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([initialServer]) }),
+    })
+
+    const request = new Request('http://localhost/api/mcp/servers/server-1/refresh', {
+      method: 'POST',
+    }) as NextRequest
+    const response = await POST(request, { params: Promise.resolve({ id: 'server-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.data).toEqual(
+      expect.objectContaining({
+        status: 'connected',
+        workflowsUpdated: 0,
+        updatedWorkflowIds: [],
+      })
+    )
+  })
 })

--- a/apps/sim/app/api/mcp/servers/[id]/refresh/route.ts
+++ b/apps/sim/app/api/mcp/servers/[id]/refresh/route.ts
@@ -1,7 +1,7 @@
 import { db } from '@sim/db'
 import { mcpServers, workflow, workflowBlocks } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
-import { toError } from '@sim/utils/errors'
+import { getErrorMessage, toError } from '@sim/utils/errors'
 import { truncate } from '@sim/utils/string'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import type { NextRequest } from 'next/server'
@@ -209,13 +209,22 @@ export const POST = withRouteHandler(
         }
 
         if (discoveryError === null) {
-          syncResult = await syncToolSchemasToWorkflows(
-            workspaceId,
-            serverId,
-            discoveredTools,
-            requestId,
-            { url: server.url ?? undefined, name: server.name ?? undefined }
-          )
+          try {
+            syncResult = await syncToolSchemasToWorkflows(
+              workspaceId,
+              serverId,
+              discoveredTools,
+              requestId,
+              { url: server.url ?? undefined, name: server.name ?? undefined }
+            )
+          } catch (error) {
+            // Discovery already persisted status and cached tools; a workflow-sync
+            // failure is a secondary propagation and must not fail the refresh with
+            // a 500. Surface it as zero workflows updated instead.
+            logger.warn(`[${requestId}] Tool schema sync failed after successful discovery`, {
+              error: getErrorMessage(error),
+            })
+          }
         }
 
         const now = new Date()

--- a/apps/sim/app/api/mcp/servers/[id]/refresh/route.ts
+++ b/apps/sim/app/api/mcp/servers/[id]/refresh/route.ts
@@ -2,6 +2,7 @@ import { db } from '@sim/db'
 import { mcpServers, workflow, workflowBlocks } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
+import { truncate } from '@sim/utils/string'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import type { NextRequest } from 'next/server'
 import { mcpServerIdParamsSchema } from '@/lib/api/contracts/mcp'
@@ -9,8 +10,9 @@ import { validationErrorResponse } from '@/lib/api/server'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { withMcpAuth } from '@/lib/mcp/middleware'
 import { mcpService } from '@/lib/mcp/service'
-import type { McpServerStatusConfig, McpTool, McpToolSchema } from '@/lib/mcp/types'
+import type { McpTool, McpToolSchema } from '@/lib/mcp/types'
 import {
+  categorizeError,
   createMcpErrorResponse,
   createMcpSuccessResponse,
   MCP_TOOL_CORE_PARAMS,
@@ -184,17 +186,10 @@ export const POST = withRouteHandler(
           )
         }
 
-        let connectionStatus: 'connected' | 'disconnected' | 'error' = 'error'
-        let toolCount = 0
-        let lastError: string | null = null
         let syncResult: SyncResult = { updatedCount: 0, updatedWorkflowIds: [] }
         let discoveredTools: McpTool[] = []
-
-        const currentStatusConfig: McpServerStatusConfig =
-          (server.statusConfig as McpServerStatusConfig | null) ?? {
-            consecutiveFailures: 0,
-            lastSuccessfulDiscovery: null,
-          }
+        let discoveryError: string | null = null
+        const discoveryStartedAt = new Date()
 
         try {
           discoveredTools = await mcpService.discoverServerTools(
@@ -203,10 +198,17 @@ export const POST = withRouteHandler(
             workspaceId,
             true
           )
-          connectionStatus = 'connected'
-          toolCount = discoveredTools.length
-          logger.info(`[${requestId}] Discovered ${toolCount} tools from server ${serverId}`)
+          logger.info(
+            `[${requestId}] Discovered ${discoveredTools.length} tools from server ${serverId}`
+          )
+        } catch (error) {
+          discoveryError = truncate(categorizeError(error).message, 200, '')
+          logger.warn(`[${requestId}] Failed to connect to server ${serverId}`, {
+            error: discoveryError,
+          })
+        }
 
+        if (discoveryError === null) {
           syncResult = await syncToolSchemasToWorkflows(
             workspaceId,
             serverId,
@@ -214,37 +216,44 @@ export const POST = withRouteHandler(
             requestId,
             { url: server.url ?? undefined, name: server.name ?? undefined }
           )
-        } catch (error) {
-          connectionStatus = 'error'
-          lastError =
-            error instanceof Error
-              ? error.message.split('\n')[0].slice(0, 200)
-              : 'Connection failed'
-          logger.warn(`[${requestId}] Failed to connect to server ${serverId}:`, error)
         }
 
         const now = new Date()
-        const newStatusConfig =
-          connectionStatus === 'connected'
-            ? { consecutiveFailures: 0, lastSuccessfulDiscovery: now.toISOString() }
-            : {
-                consecutiveFailures: currentStatusConfig.consecutiveFailures + 1,
-                lastSuccessfulDiscovery: currentStatusConfig.lastSuccessfulDiscovery,
-              }
 
         const [refreshedServer] = await db
           .update(mcpServers)
           .set({
             lastToolsRefresh: now,
-            connectionStatus,
-            lastError,
-            lastConnected: connectionStatus === 'connected' ? now : server.lastConnected,
-            toolCount,
-            statusConfig: newStatusConfig,
             updatedAt: now,
           })
-          .where(eq(mcpServers.id, serverId))
-          .returning()
+          .where(
+            and(
+              eq(mcpServers.id, serverId),
+              eq(mcpServers.workspaceId, workspaceId),
+              isNull(mcpServers.deletedAt)
+            )
+          )
+          .returning({
+            connectionStatus: mcpServers.connectionStatus,
+            lastConnected: mcpServers.lastConnected,
+            lastError: mcpServers.lastError,
+            toolCount: mcpServers.toolCount,
+          })
+
+        let connectionStatus = refreshedServer?.connectionStatus ?? 'error'
+        let lastError = refreshedServer ? refreshedServer.lastError : discoveryError
+        const toolCount = refreshedServer?.toolCount ?? discoveredTools.length
+
+        if (discoveryError !== null && connectionStatus === 'connected') {
+          const newerSuccessWonRace =
+            refreshedServer?.lastConnected != null &&
+            refreshedServer.lastConnected > discoveryStartedAt
+
+          if (!newerSuccessWonRace) {
+            connectionStatus = 'disconnected'
+            lastError = discoveryError
+          }
+        }
 
         if (connectionStatus === 'connected') {
           await mcpService.clearCache(workspaceId)

--- a/apps/sim/app/api/mcp/servers/test-connection/route.test.ts
+++ b/apps/sim/app/api/mcp/servers/test-connection/route.test.ts
@@ -1,0 +1,228 @@
+/**
+ * @vitest-environment node
+ */
+import { createMockRequest, loggerMock } from '@sim/testing'
+import type { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockClientOptions,
+  mockConnect,
+  mockDetectMcpAuthType,
+  mockDisconnect,
+  mockListTools,
+  mockResolveMcpConfigEnvVars,
+  mockValidateMcpServerSsrf,
+  MockMcpSsrfError,
+} = vi.hoisted(() => ({
+  mockClientOptions: vi.fn(),
+  mockConnect: vi.fn(),
+  mockDetectMcpAuthType: vi.fn(),
+  mockDisconnect: vi.fn(),
+  mockListTools: vi.fn(),
+  mockResolveMcpConfigEnvVars: vi.fn(),
+  mockValidateMcpServerSsrf: vi.fn(),
+  MockMcpSsrfError: class extends Error {},
+}))
+
+vi.mock('@/lib/core/utils/with-route-handler', () => ({
+  withRouteHandler: (handler: unknown) => handler,
+}))
+
+vi.mock('@/lib/mcp/client', () => ({
+  McpClient: class {
+    constructor(options: unknown) {
+      mockClientOptions(options)
+    }
+
+    static getVersionInfo() {
+      return { preferred: '2025-06-18', supported: ['2025-06-18'] }
+    }
+
+    connect = mockConnect
+    disconnect = mockDisconnect
+    listTools = mockListTools
+
+    getNegotiatedVersion() {
+      return '2025-06-18'
+    }
+  },
+}))
+
+vi.mock('@/lib/mcp/domain-check', () => ({
+  McpDnsResolutionError: class extends Error {},
+  McpDomainNotAllowedError: class extends Error {},
+  McpSsrfError: MockMcpSsrfError,
+  validateMcpDomain: vi.fn(),
+  validateMcpServerSsrf: mockValidateMcpServerSsrf,
+}))
+
+vi.mock('@/lib/mcp/middleware', () => ({
+  mcpBodyReadErrorResponse: vi.fn(() => null),
+  readMcpJsonBodyWithLimit: (request: NextRequest) => request.json(),
+  withMcpAuth:
+    () =>
+    (
+      handler: (
+        request: NextRequest,
+        context: { userId: string; workspaceId: string; requestId: string }
+      ) => Promise<Response>
+    ) =>
+    (request: NextRequest) =>
+      handler(request, {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        requestId: 'request-1',
+      }),
+}))
+
+vi.mock('@/lib/mcp/oauth', () => ({
+  detectMcpAuthType: mockDetectMcpAuthType,
+}))
+
+vi.mock('@/lib/mcp/resolve-config', () => ({
+  resolveMcpConfigEnvVars: mockResolveMcpConfigEnvVars,
+}))
+
+import { POST } from '@/app/api/mcp/servers/test-connection/route'
+
+const mockLogger = vi.mocked(loggerMock.createLogger).mock.results.at(-1)?.value
+
+function createTestRequest(headers: Record<string, string> = {}) {
+  return createMockRequest(
+    'POST',
+    {
+      name: 'Dual Auth Server',
+      transport: 'streamable-http',
+      url: 'https://example.com/mcp',
+      headers,
+      timeout: 10000,
+    },
+    {},
+    'http://localhost/api/mcp/servers/test-connection'
+  )
+}
+
+describe('MCP server test-connection route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDetectMcpAuthType.mockResolvedValue('oauth')
+    mockValidateMcpServerSsrf.mockResolvedValue('203.0.113.10')
+    mockResolveMcpConfigEnvVars.mockImplementation(async (config: unknown) => ({
+      config,
+      missingVars: [],
+    }))
+    mockConnect.mockResolvedValue(undefined)
+    mockListTools.mockResolvedValue([])
+    mockDisconnect.mockResolvedValue(undefined)
+  })
+
+  it('tests configured bearer headers before treating OAuth discovery as mandatory', async () => {
+    const response = await POST(createTestRequest({ Authorization: 'Bearer static-api-token' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.data).toEqual(
+      expect.objectContaining({ success: true, authType: 'headers', toolCount: 0 })
+    )
+    expect(mockDetectMcpAuthType).not.toHaveBeenCalled()
+    expect(mockClientOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          headers: { Authorization: 'Bearer static-api-token' },
+        }),
+      })
+    )
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a header-auth failure when the configured token is rejected', async () => {
+    mockConnect.mockRejectedValueOnce(new Error('HTTP 401: Unauthorized'))
+
+    const response = await POST(createTestRequest({ Authorization: 'Bearer invalid-static-token' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.data).toEqual(
+      expect.objectContaining({
+        success: false,
+        authType: 'headers',
+        error: 'HTTP 401: Unauthorized',
+      })
+    )
+    expect(mockDetectMcpAuthType).not.toHaveBeenCalled()
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+    expect(mockDisconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not expose configured credentials echoed by an upstream error', async () => {
+    const token = 'opaque-static-token'
+    mockConnect.mockRejectedValueOnce(new Error(`Upstream rejected ${token}`))
+
+    const response = await POST(createTestRequest({ Authorization: `Bearer ${token}` }))
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.data).toEqual(
+      expect.objectContaining({ success: false, authType: 'headers', error: 'Connection failed' })
+    )
+    expect(mockLogger).toBeDefined()
+    expect(JSON.stringify(mockLogger?.warn.mock.calls)).not.toContain(token)
+  })
+
+  it('preserves OAuth discovery when no static headers are configured', async () => {
+    const response = await POST(createTestRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.data).toEqual(
+      expect.objectContaining({ success: false, authRequired: true, authType: 'oauth' })
+    )
+    expect(mockDetectMcpAuthType).toHaveBeenCalledWith('https://example.com/mcp', '203.0.113.10')
+    expect(mockClientOptions).not.toHaveBeenCalled()
+  })
+
+  it('preserves OAuth discovery when only supplemental headers are configured', async () => {
+    const response = await POST(createTestRequest({ 'X-Sim-Via': 'workflow' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.data).toEqual(
+      expect.objectContaining({ success: false, authRequired: true, authType: 'oauth' })
+    )
+    expect(mockDetectMcpAuthType).toHaveBeenCalledWith('https://example.com/mcp', '203.0.113.10')
+    expect(mockClientOptions).not.toHaveBeenCalled()
+  })
+
+  it('blocks an env-resolved private URL before forwarding configured credentials', async () => {
+    const token = 'private-static-token'
+    mockResolveMcpConfigEnvVars.mockResolvedValueOnce({
+      config: {
+        id: 'test-request-1',
+        name: 'Dual Auth Server',
+        transport: 'streamable-http',
+        url: 'http://127.0.0.1/mcp',
+        headers: { Authorization: `Bearer ${token}` },
+        timeout: 10000,
+        retries: 1,
+        enabled: true,
+      },
+      missingVars: [],
+    })
+    mockValidateMcpServerSsrf.mockImplementation(async (url: string) => {
+      if (url === 'http://127.0.0.1/mcp') {
+        throw new MockMcpSsrfError('Private network targets are not allowed')
+      }
+      return '203.0.113.10'
+    })
+
+    const response = await POST(createTestRequest({ Authorization: `Bearer ${token}` }))
+    const responseText = await response.text()
+
+    expect(response.status).toBe(403)
+    expect(responseText).not.toContain(token)
+    expect(mockValidateMcpServerSsrf).toHaveBeenNthCalledWith(2, 'http://127.0.0.1/mcp')
+    expect(mockClientOptions).not.toHaveBeenCalled()
+    expect(mockDetectMcpAuthType).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/app/api/mcp/servers/test-connection/route.ts
+++ b/apps/sim/app/api/mcp/servers/test-connection/route.ts
@@ -1,6 +1,5 @@
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
-import { truncate } from '@sim/utils/string'
 import type { NextRequest } from 'next/server'
 import { mcpServerTestBodySchema } from '@/lib/api/contracts/mcp'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
@@ -50,17 +49,35 @@ interface TestConnectionResult {
 }
 
 /**
- * Extracts a user-friendly error message from connection errors.
- * Keeps diagnostic info (timeout, DNS, HTTP status) but strips
- * verbose internals (Zod details, full response bodies, stack traces).
+ * Maps connection failures to allowlisted messages. Upstream response bodies
+ * may echo configured credentials, so arbitrary error text must not reach API
+ * responses or logs.
  */
 function sanitizeConnectionError(error: unknown): string {
   if (!(error instanceof Error)) {
     return 'Unknown connection error'
   }
 
-  const firstLine = error.message.split('\n')[0]
-  return truncate(firstLine, 200)
+  const message = error.message.toLowerCase()
+  if (message.includes('timeout') || message.includes('timed out')) {
+    return 'Connection timed out'
+  }
+  if (message.includes('401') || message.includes('unauthorized')) {
+    return 'HTTP 401: Unauthorized'
+  }
+  if (message.includes('403') || message.includes('forbidden')) {
+    return 'HTTP 403: Forbidden'
+  }
+  if (message.includes('enotfound') || message.includes('could not resolve')) {
+    return 'MCP server hostname could not be resolved'
+  }
+  if (message.includes('econnrefused') || message.includes('connection refused')) {
+    return 'Connection refused'
+  }
+  if (message.includes('certificate') || message.includes('tls') || message.includes('ssl')) {
+    return 'TLS connection failed'
+  }
+  return 'Connection failed'
 }
 
 /**
@@ -172,8 +189,14 @@ export const POST = withRouteHandler(
 
       const result: TestConnectionResult = { success: false }
 
-      // Skip unauth connect when the server returns an RFC 9728 OAuth challenge.
-      if (testConfig.url) {
+      /** An explicit static Bearer token takes precedence over optional OAuth discovery. */
+      const hasStaticBearerToken = Object.entries(testConfig.headers ?? {}).some(
+        ([name, value]) =>
+          name.toLowerCase() === 'authorization' && /^Bearer\s+\S+/i.test(value.trim())
+      )
+      if (hasStaticBearerToken) {
+        result.authType = 'headers'
+      } else if (testConfig.url) {
         const detectedAuthType = await detectMcpAuthType(testConfig.url, resolvedIP)
         if (detectedAuthType === 'oauth') {
           result.authRequired = true
@@ -199,8 +222,8 @@ export const POST = withRouteHandler(
           const tools = await client.listTools()
           result.toolCount = tools.length
           result.success = true
-        } catch (toolError) {
-          logger.warn(`[${requestId}] Connection established but could not list tools:`, toolError)
+        } catch {
+          logger.warn(`[${requestId}] Connection established but could not list tools`)
           result.success = false
           result.error = 'Connection established but could not list tools'
           result.warnings = result.warnings || []
@@ -224,16 +247,15 @@ export const POST = withRouteHandler(
           capabilities: result.supportedCapabilities,
         })
       } catch (error) {
-        logger.warn(`[${requestId}] MCP server test failed:`, error)
-
         result.success = false
         result.error = sanitizeConnectionError(error)
+        logger.warn(`[${requestId}] MCP server test failed`, { error: result.error })
       } finally {
         if (client) {
           try {
             await client.disconnect()
-          } catch (disconnectError) {
-            logger.debug(`[${requestId}] Test client disconnect error (expected):`, disconnectError)
+          } catch {
+            logger.debug(`[${requestId}] Test client disconnect error (expected)`)
           }
         }
       }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -11,7 +11,7 @@ import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-markup'
 import '@sim/emcn/components/code/code.css'
-import { Checkbox, CopyCodeButton, cn, highlight, languages } from '@sim/emcn'
+import { Checkbox, CopyCodeButton, cn, languages, highlight as prismHighlight } from '@sim/emcn'
 import { decodeVfsSegmentSafe } from '@/lib/copilot/vfs/path-utils'
 import { extractTextContent } from '@/lib/core/utils/react-node-text'
 import { ContextMentionIcon } from '@/app/workspace/[workspaceId]/home/components/context-mention-icon'
@@ -161,6 +161,38 @@ function fileIconLabel(ref: string, fallback: string): string {
   return fallback
 }
 
+/**
+ * Bounded LRU cache for Prism highlight output. Chat rows are virtualized, so a
+ * message re-highlights every time it scrolls back into view; a component
+ * `useMemo` would not survive the unmount, so the cache lives at module scope.
+ * Output for an unregistered language is never cached — it renders through the
+ * JavaScript fallback, so caching it would keep serving that stale render if the
+ * real grammar registers later in the session.
+ */
+const HIGHLIGHT_CACHE_LIMIT = 512
+const highlightCache = new Map<string, string>()
+
+function highlight(code: string, language: string): string {
+  const resolved = LANG_ALIASES[language] || language || 'javascript'
+  const grammar = languages[resolved]
+  if (!grammar) return prismHighlight(code, languages.javascript, resolved)
+
+  const key = `${resolved}\n${code}`
+  const cached = highlightCache.get(key)
+  if (cached !== undefined) {
+    highlightCache.delete(key)
+    highlightCache.set(key, cached)
+    return cached
+  }
+  const html = prismHighlight(code, grammar, resolved)
+  highlightCache.set(key, html)
+  if (highlightCache.size > HIGHLIGHT_CACHE_LIMIT) {
+    const oldest = highlightCache.keys().next().value
+    if (oldest !== undefined) highlightCache.delete(oldest)
+  }
+  return html
+}
+
 const MARKDOWN_COMPONENTS = {
   table({ children }: { children?: React.ReactNode }) {
     return (
@@ -207,9 +239,7 @@ const MARKDOWN_COMPONENTS = {
       )
     }
 
-    const resolved = LANG_ALIASES[language] || language || 'javascript'
-    const grammar = languages[resolved] || languages.javascript
-    const html = highlight(codeString.trimEnd(), grammar, resolved)
+    const html = highlight(codeString.trimEnd(), language)
 
     return (
       <div className='not-prose my-6 overflow-hidden rounded-lg border border-[var(--divider)]'>
@@ -412,9 +442,9 @@ function ChatContentInner({
    * position (`E`/`qe` in streamdown 2.5), so a re-parse of unchanged content
    * without the animate plugin bails at every unoverridden element (`p`,
    * `strong`, `tr`, headings, …) and leaves the stale per-char span DOM in
-   * place. Every instance renders through the streaming parser (see
-   * `streamingTree` below) so the remount only sheds the spans, never
-   * re-interprets the markdown.
+   * place. The settled instance keeps the streaming parser (`parserTree`
+   * below) so the remount only sheds the spans, never re-interprets the
+   * markdown.
    *
    * The drain is deliberately one-way: a stream that resumes afterwards
    * (reconnect/continuation) reveals paced but unfaded, because re-arming
@@ -459,18 +489,19 @@ function ChatContentInner({
   }, [isRevealing, animationDrained, streamedThisSession])
 
   /**
-   * Every mount renders through the streaming parser (remend +
-   * incomplete-markdown repair + block-split) — `mode='static'` is never used.
-   * The two pipelines parse edge-case markdown differently (unbalanced fences,
-   * list continuation across blocks), so a message you watched stream would
-   * render subtly differently from the same message reloaded from the DB; one
-   * pipeline makes in-session and refreshed renders byte-identical. The rows
-   * are virtualized, so only visible messages pay the block-split mount cost.
-   * `streamingTree` (the remount key and animation props) still drops at
-   * drain, so a settled instance re-renders through the SAME parser minus the
-   * per-word animation spans — identical pixels.
+   * `parserTree` (drives `mode`) stays latched for the mount's life: streaming
+   * mode is the only one that applies remend/incomplete-markdown repair and
+   * block-split parsing, so a settled message must KEEP the streaming parser —
+   * swapping to `mode='static'` at drain re-parses the same source through a
+   * different pipeline (no remend, whole-doc parse) and visibly flashes on any
+   * reply with unbalanced markdown. `streamingTree` (drives the remount key
+   * and animation props) additionally drops at drain, so the settled instance
+   * re-renders through the SAME parser minus the per-word animation spans —
+   * byte-identical pixels. Only never-streamed mounts (reloaded history)
+   * render static.
    */
-  const streamingTree = (isRevealing || streamedThisSession) && !animationDrained
+  const parserTree = isRevealing || streamedThisSession
+  const streamingTree = parserTree && !animationDrained
 
   /**
    * One-way fade cutoff (see {@link FADE_MAX_REVEALED_CHARS}). Latched so a
@@ -573,6 +604,7 @@ function ChatContentInner({
             >
               <Streamdown
                 key={streamingTree ? 'stream' : 'settled'}
+                mode={parserTree ? undefined : 'static'}
                 animated={fadeActive ? STREAM_ANIMATION : false}
                 isAnimating={streamingTree}
                 components={MARKDOWN_COMPONENTS}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -10,10 +10,13 @@ import {
   adminParsers,
   adminUrlKeys,
 } from '@/app/workspace/[workspaceId]/settings/components/admin/search-params'
+import { useRecentImpersonations } from '@/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations'
 import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
 import {
+  type AdminUser,
   useAdminUsers,
+  useAdminUsersByEmails,
   useBanUser,
   useImpersonateUser,
   useSetUserRole,
@@ -24,6 +27,16 @@ import { useImportWorkflow } from '@/hooks/queries/workflows'
 import { clearUserData } from '@/stores'
 
 const PAGE_SIZE = 20 as const
+
+const USER_TABLE_HEADER = (
+  <div className='flex items-center gap-3 px-3 pb-1 text-[var(--text-tertiary)] text-caption'>
+    <span className='w-[170px]'>Name</span>
+    <span className='flex-1'>Email</span>
+    <span className='w-[60px]'>Role</span>
+    <span className='w-[55px]'>Status</span>
+    <span className='w-[200px] text-right'>Actions</span>
+  </div>
+)
 
 const MOTHERSHIP_ENV_OPTIONS: { value: MothershipEnvironment; label: string }[] = [
   { value: 'default', label: 'Default' },
@@ -43,6 +56,8 @@ export function Admin() {
   const banUser = useBanUser()
   const unbanUser = useUnbanUser()
   const impersonateUser = useImpersonateUser()
+  const { recentEmails, recordImpersonation } = useRecentImpersonations()
+  const { data: recentUsers } = useAdminUsersByEmails(recentEmails)
 
   const [workflowId, setWorkflowId] = useState('')
   const [targetWorkspaceId, setTargetWorkspaceId] = useState('')
@@ -94,7 +109,7 @@ export function Admin() {
     }
   }
 
-  const handleImpersonate = (userId: string) => {
+  const handleImpersonate = (userId: string, email: string) => {
     setImpersonationGuardError(null)
     if (session?.user?.role !== 'admin') {
       setImpersonatingUserId(null)
@@ -111,6 +126,7 @@ export function Admin() {
           setImpersonatingUserId(null)
         },
         onSuccess: async () => {
+          recordImpersonation(email)
           await clearUserData()
           window.location.assign('/workspace')
         },
@@ -156,6 +172,119 @@ export function Admin() {
     impersonateUser.variables,
     impersonatingUserId,
   ])
+
+  const renderUserRow = (u: AdminUser) => (
+    <div key={u.id} className='flex flex-col gap-2 px-3 py-2 text-small'>
+      <div className='flex items-center gap-3'>
+        <span className='w-[170px] truncate text-[var(--text-primary)]'>{u.name || '—'}</span>
+        <span className='flex-1 truncate text-[var(--text-secondary)]'>{u.email}</span>
+        <span className='w-[60px]'>
+          <Badge variant={u.role === 'admin' ? 'blue' : 'gray'}>{u.role || 'user'}</Badge>
+        </span>
+        <span className='w-[55px]'>
+          {u.banned ? <Badge variant='red'>Banned</Badge> : <Badge variant='green'>Active</Badge>}
+        </span>
+        <span className='flex w-[200px] justify-end gap-1'>
+          {u.id !== session?.user?.id && (
+            <>
+              <Button
+                variant='active'
+                className='h-[28px] px-2 text-caption'
+                onClick={() => handleImpersonate(u.id, u.email)}
+                disabled={pendingUserIds.has(u.id)}
+              >
+                {impersonatingUserId === u.id ||
+                (impersonateUser.isPending &&
+                  (impersonateUser.variables as { userId?: string } | undefined)?.userId === u.id)
+                  ? 'Switching...'
+                  : 'Impersonate'}
+              </Button>
+              <Button
+                variant='active'
+                className='h-[28px] px-2 text-caption'
+                onClick={() => {
+                  setUserRole.reset()
+                  setUserRole.mutate({
+                    userId: u.id,
+                    role: u.role === 'admin' ? 'user' : 'admin',
+                  })
+                }}
+                disabled={pendingUserIds.has(u.id)}
+              >
+                {u.role === 'admin' ? 'Demote' : 'Promote'}
+              </Button>
+              {u.banned ? (
+                <Button
+                  variant='active'
+                  className='h-[28px] px-2 text-caption'
+                  onClick={() => {
+                    unbanUser.reset()
+                    unbanUser.mutate({ userId: u.id })
+                  }}
+                  disabled={pendingUserIds.has(u.id)}
+                >
+                  Unban
+                </Button>
+              ) : (
+                <Button
+                  variant='active'
+                  className={cn(
+                    'h-[28px] px-2 text-caption',
+                    banUserId === u.id ? 'text-[var(--text-primary)]' : 'text-[var(--text-error)]'
+                  )}
+                  onClick={() => {
+                    if (banUserId === u.id) {
+                      setBanUserId(null)
+                      setBanReason('')
+                    } else {
+                      setBanUserId(u.id)
+                      setBanReason('')
+                    }
+                  }}
+                  disabled={pendingUserIds.has(u.id)}
+                >
+                  {banUserId === u.id ? 'Cancel' : 'Ban'}
+                </Button>
+              )}
+            </>
+          )}
+        </span>
+      </div>
+      {banUserId === u.id && !u.banned && (
+        <div className='flex items-center gap-2 pl-[170px]'>
+          <ChipInput
+            value={banReason}
+            onChange={(e) => setBanReason(e.target.value)}
+            placeholder='Reason (optional)'
+            className='flex-1'
+          />
+          <Button
+            variant='primary'
+            className='h-[28px] px-3 text-caption'
+            onClick={() => {
+              banUser.reset()
+              banUser.mutate(
+                {
+                  userId: u.id,
+                  ...(banReason.trim() ? { banReason: banReason.trim() } : {}),
+                },
+                {
+                  onSuccess: () => {
+                    setBanUserId(null)
+                    setBanReason('')
+                  },
+                }
+              )
+            }}
+            disabled={pendingUserIds.has(u.id)}
+          >
+            Confirm Ban
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+
   return (
     <SettingsPanel>
       <div className='flex flex-col gap-4'>
@@ -275,149 +404,16 @@ export function Admin() {
           </p>
         )}
 
-        {searchQuery.length > 0 && usersData && (
+        {searchQuery.length > 0 && usersData ? (
           <>
             <div className='flex flex-col gap-0.5'>
-              <div className='flex items-center gap-3 border-[var(--border-secondary)] border-b px-3 py-2 text-[var(--text-tertiary)] text-caption'>
-                <span className='w-[200px]'>Name</span>
-                <span className='flex-1'>Email</span>
-                <span className='w-[80px]'>Role</span>
-                <span className='w-[80px]'>Status</span>
-                <span className='w-[250px] text-right'>Actions</span>
-              </div>
+              {USER_TABLE_HEADER}
 
               {usersData.users.length === 0 && (
                 <SettingsEmptyState variant='inline'>No users found.</SettingsEmptyState>
               )}
 
-              {usersData.users.map((u) => (
-                <div
-                  key={u.id}
-                  className={cn(
-                    'flex flex-col gap-2 px-3 py-2 text-small',
-                    'border-[var(--border-secondary)] border-b last:border-b-0'
-                  )}
-                >
-                  <div className='flex items-center gap-3'>
-                    <span className='w-[200px] truncate text-[var(--text-primary)]'>
-                      {u.name || '—'}
-                    </span>
-                    <span className='flex-1 truncate text-[var(--text-secondary)]'>{u.email}</span>
-                    <span className='w-[80px]'>
-                      <Badge variant={u.role === 'admin' ? 'blue' : 'gray'}>
-                        {u.role || 'user'}
-                      </Badge>
-                    </span>
-                    <span className='w-[80px]'>
-                      {u.banned ? (
-                        <Badge variant='red'>Banned</Badge>
-                      ) : (
-                        <Badge variant='green'>Active</Badge>
-                      )}
-                    </span>
-                    <span className='flex w-[250px] justify-end gap-1'>
-                      {u.id !== session?.user?.id && (
-                        <>
-                          <Button
-                            variant='active'
-                            className='h-[28px] px-2 text-caption'
-                            onClick={() => handleImpersonate(u.id)}
-                            disabled={pendingUserIds.has(u.id)}
-                          >
-                            {impersonatingUserId === u.id ||
-                            (impersonateUser.isPending &&
-                              (impersonateUser.variables as { userId?: string } | undefined)
-                                ?.userId === u.id)
-                              ? 'Switching...'
-                              : 'Impersonate'}
-                          </Button>
-                          <Button
-                            variant='active'
-                            className='h-[28px] px-2 text-caption'
-                            onClick={() => {
-                              setUserRole.reset()
-                              setUserRole.mutate({
-                                userId: u.id,
-                                role: u.role === 'admin' ? 'user' : 'admin',
-                              })
-                            }}
-                            disabled={pendingUserIds.has(u.id)}
-                          >
-                            {u.role === 'admin' ? 'Demote' : 'Promote'}
-                          </Button>
-                          {u.banned ? (
-                            <Button
-                              variant='active'
-                              className='h-[28px] px-2 text-caption'
-                              onClick={() => {
-                                unbanUser.reset()
-                                unbanUser.mutate({ userId: u.id })
-                              }}
-                              disabled={pendingUserIds.has(u.id)}
-                            >
-                              Unban
-                            </Button>
-                          ) : (
-                            <Button
-                              variant='active'
-                              className={cn(
-                                'h-[28px] px-2 text-caption',
-                                banUserId === u.id
-                                  ? 'text-[var(--text-primary)]'
-                                  : 'text-[var(--text-error)]'
-                              )}
-                              onClick={() => {
-                                if (banUserId === u.id) {
-                                  setBanUserId(null)
-                                  setBanReason('')
-                                } else {
-                                  setBanUserId(u.id)
-                                  setBanReason('')
-                                }
-                              }}
-                              disabled={pendingUserIds.has(u.id)}
-                            >
-                              {banUserId === u.id ? 'Cancel' : 'Ban'}
-                            </Button>
-                          )}
-                        </>
-                      )}
-                    </span>
-                  </div>
-                  {banUserId === u.id && !u.banned && (
-                    <div className='flex items-center gap-2 pl-[200px]'>
-                      <ChipInput
-                        value={banReason}
-                        onChange={(e) => setBanReason(e.target.value)}
-                        placeholder='Reason (optional)'
-                        className='flex-1'
-                      />
-                      <Button
-                        variant='primary'
-                        className='h-[28px] px-3 text-caption'
-                        onClick={() => {
-                          banUser.reset()
-                          banUser.mutate(
-                            {
-                              userId: u.id,
-                              ...(banReason.trim() ? { banReason: banReason.trim() } : {}),
-                            },
-                            {
-                              onSuccess: () => {
-                                setBanUserId(null)
-                                setBanReason('')
-                              },
-                            }
-                          )
-                        }}
-                        disabled={pendingUserIds.has(u.id)}
-                      >
-                        Confirm Ban
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              ))}
+              {usersData.users.map((u) => renderUserRow(u))}
             </div>
 
             {totalPages > 1 && (
@@ -450,6 +446,15 @@ export function Admin() {
               </div>
             )}
           </>
+        ) : (
+          searchQuery.length === 0 &&
+          recentUsers &&
+          recentUsers.length > 0 && (
+            <div className='flex flex-col gap-0.5'>
+              {USER_TABLE_HEADER}
+              {recentUsers.map((u) => renderUserRow(u))}
+            </div>
+          )
         )}
       </div>
     </SettingsPanel>

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations.ts
@@ -1,0 +1,34 @@
+import { useCallback, useState } from 'react'
+import { RECENT_IMPERSONATIONS_STORAGE_KEY } from '@/stores'
+
+const MAX_RECENT = 5
+
+function readRecentEmails(): string[] {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(RECENT_IMPERSONATIONS_STORAGE_KEY) ?? '[]')
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((e): e is string => typeof e === 'string').slice(0, MAX_RECENT)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Last {@link MAX_RECENT} emails the admin impersonated, most recent first,
+ * persisted in localStorage on this browser.
+ */
+export function useRecentImpersonations() {
+  const [recentEmails, setRecentEmails] = useState<string[]>(() => readRecentEmails())
+
+  const recordImpersonation = useCallback((email: string) => {
+    const next = [email, ...readRecentEmails().filter((e) => e !== email)].slice(0, MAX_RECENT)
+    try {
+      localStorage.setItem(RECENT_IMPERSONATIONS_STORAGE_KEY, JSON.stringify(next))
+    } catch {
+      /* best-effort: recording must never block the impersonation transition */
+    }
+    setRecentEmails(next)
+  }, [])
+
+  return { recentEmails, recordImpersonation }
+}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
@@ -23,6 +23,8 @@ import {
   mcpServerIdParam,
   mcpServerIdUrlKeys,
 } from '@/app/workspace/[workspaceId]/settings/[section]/search-params'
+import { getRefreshActionState } from '@/app/workspace/[workspaceId]/settings/components/mcp/refresh-action-state'
+import { getServerToolsLabel } from '@/app/workspace/[workspaceId]/settings/components/mcp/server-tools-label'
 import { RowActionsMenu } from '@/app/workspace/[workspaceId]/settings/components/row-actions-menu'
 import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
@@ -61,16 +63,6 @@ function formatTransportLabel(transport: string): string {
     .join('-')
 }
 
-function formatToolsLabel(tools: McpTool[], connectionStatus?: string): string {
-  if (connectionStatus === 'error') {
-    return 'Unable to connect'
-  }
-  const count = tools.length
-  const plural = count !== 1 ? 's' : ''
-  const names = count > 0 ? `: ${tools.map((t) => t.name).join(', ')}` : ''
-  return `${count} tool${plural}${names}`
-}
-
 interface ServerListItemProps {
   canManage: boolean
   server: McpServer
@@ -93,8 +85,9 @@ function ServerListItem({
   onViewDetails,
 }: ServerListItemProps) {
   const transportLabel = formatTransportLabel(server.transport || 'http')
-  const toolsLabel = formatToolsLabel(tools, server.connectionStatus)
-  const isError = server.connectionStatus === 'error'
+  const toolsLabel = getServerToolsLabel(tools, server.connectionStatus, server.lastError)
+  const hasConnectionIssue =
+    server.connectionStatus === 'error' || server.connectionStatus === 'disconnected'
 
   return (
     <div className='flex items-center justify-between gap-3'>
@@ -108,7 +101,7 @@ function ServerListItem({
         <p
           className={cn(
             'truncate text-sm',
-            isError ? 'text-[var(--text-error)]' : 'text-[var(--text-muted)]'
+            hasConnectionIssue ? 'text-[var(--text-error)]' : 'text-[var(--text-muted)]'
           )}
         >
           {isRefreshing
@@ -312,19 +305,11 @@ export function MCP() {
   }
 
   useEffect(() => {
-    if (!refreshServerMutation.isSuccess) return
+    if (!refreshServerMutation.isSuccess && !refreshServerMutation.isError) return
     const timeout = window.setTimeout(() => refreshServerMutation.reset(), 3000)
     return () => window.clearTimeout(timeout)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mutation object is unstable; isSuccess flag is the trigger
-  }, [refreshServerMutation.isSuccess])
-
-  const refreshingServerId = refreshServerMutation.isPending
-    ? refreshServerMutation.variables?.serverId
-    : null
-  const refreshedServerId = refreshServerMutation.isSuccess
-    ? refreshServerMutation.variables?.serverId
-    : null
-  const refreshedWorkflowsUpdated = refreshServerMutation.data?.workflowsUpdated
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mutation object is unstable; status flags are the triggers
+  }, [refreshServerMutation.isSuccess, refreshServerMutation.isError])
 
   const editingServer = editingServerId
     ? (servers.find((s) => s.id === editingServerId) as McpServer | undefined)
@@ -389,15 +374,12 @@ export function MCP() {
   if (selectedServer) {
     const { server, tools } = selectedServer
     const transportLabel = formatTransportLabel(server.transport || 'http')
-
-    const refreshLabel =
-      refreshingServerId === server.id
-        ? 'Refreshing...'
-        : refreshedServerId === server.id
-          ? refreshedWorkflowsUpdated
-            ? `Synced (${refreshedWorkflowsUpdated} workflow${refreshedWorkflowsUpdated === 1 ? '' : 's'})`
-            : 'Refreshed'
-          : 'Refresh tools'
+    const isCurrentRefresh = refreshServerMutation.variables?.serverId === server.id
+    const refreshAction = getRefreshActionState({
+      mutationStatus: isCurrentRefresh ? refreshServerMutation.status : 'idle',
+      connectionStatus: isCurrentRefresh ? refreshServerMutation.data?.status : undefined,
+      workflowsUpdated: isCurrentRefresh ? refreshServerMutation.data?.workflowsUpdated : undefined,
+    })
 
     return (
       <SettingsPanel
@@ -407,9 +389,10 @@ export function MCP() {
           canEdit
             ? [
                 {
-                  text: refreshLabel,
+                  text: refreshAction.text,
+                  textTone: refreshAction.textTone,
                   onSelect: () => handleRefreshServer(server.id),
-                  disabled: refreshingServerId === server.id || refreshedServerId === server.id,
+                  disabled: refreshAction.disabled,
                 },
                 {
                   text: 'Edit',
@@ -438,11 +421,11 @@ export function MCP() {
               </div>
             )}
 
-            {server.connectionStatus === 'error' && (
+            {server.connectionStatus !== 'connected' && (
               <div className='flex flex-col gap-2'>
                 <span className='text-[var(--text-muted)] text-caption'>Status</span>
                 <p className='text-[var(--text-error)] text-sm'>
-                  {server.lastError || 'Unable to connect'}
+                  {getServerToolsLabel([], server.connectionStatus, server.lastError)}
                 </p>
               </div>
             )}
@@ -664,7 +647,10 @@ export function MCP() {
                   tools={tools}
                   isDeleting={deletingServers.has(server.id)}
                   isLoadingTools={isLoadingTools}
-                  isRefreshing={refreshingServerId === server.id}
+                  isRefreshing={
+                    refreshServerMutation.isPending &&
+                    refreshServerMutation.variables?.serverId === server.id
+                  }
                   onRemove={() => handleRemoveServer(server.id)}
                   onViewDetails={() => handleViewDetails(server.id)}
                 />

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { Badge, Button, Chip, ChipConfirmModal, cn, Tooltip } from '@sim/emcn'
+import { Badge, Button, Chip, ChipConfirmModal, cn, Tooltip, toast } from '@sim/emcn'
 import { ArrowLeft } from '@sim/emcn/icons'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
@@ -224,6 +224,7 @@ export function MCP() {
       logger.info(`Removed MCP server: ${serverId}`)
     } catch (error) {
       logger.error('Failed to remove MCP server:', error)
+      toast.error('Failed to remove MCP server', { description: getErrorMessage(error) })
     } finally {
       setDeletingServers((prev) => {
         const newSet = new Set(prev)
@@ -301,6 +302,7 @@ export function MCP() {
       }
     } catch (error) {
       logger.error('Failed to refresh MCP server:', error)
+      toast.error('Failed to refresh MCP server', { description: getErrorMessage(error) })
     }
   }
 

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/refresh-action-state.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/refresh-action-state.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { getRefreshActionState } from '@/app/workspace/[workspaceId]/settings/components/mcp/refresh-action-state'
+
+describe('getRefreshActionState', () => {
+  it.each(['error', 'disconnected'] as const)(
+    'shows a retryable red-text Failed state when refresh returns %s',
+    (status) => {
+      expect(
+        getRefreshActionState({
+          mutationStatus: 'success',
+          connectionStatus: status,
+          workflowsUpdated: 0,
+        })
+      ).toEqual({
+        text: 'Failed',
+        textTone: 'error',
+        disabled: false,
+      })
+    }
+  )
+
+  it('shows Failed when the refresh request itself rejects', () => {
+    expect(
+      getRefreshActionState({
+        mutationStatus: 'error',
+      })
+    ).toEqual({
+      text: 'Failed',
+      textTone: 'error',
+      disabled: false,
+    })
+  })
+
+  it('preserves successful refresh feedback', () => {
+    expect(
+      getRefreshActionState({
+        mutationStatus: 'success',
+        connectionStatus: 'connected',
+        workflowsUpdated: 2,
+      })
+    ).toEqual({
+      text: 'Synced (2 workflows)',
+      textTone: undefined,
+      disabled: true,
+    })
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/refresh-action-state.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/refresh-action-state.ts
@@ -1,0 +1,37 @@
+import type { MutationStatus } from '@tanstack/react-query'
+import type { RefreshMcpServerResult } from '@/lib/api/contracts/mcp'
+import type { SettingsAction } from '@/app/workspace/[workspaceId]/settings/components/settings-header/settings-header'
+
+interface RefreshActionStateInput {
+  mutationStatus: MutationStatus
+  connectionStatus?: RefreshMcpServerResult['status']
+  workflowsUpdated?: number
+}
+
+type RefreshActionState = Pick<SettingsAction, 'text' | 'textTone' | 'disabled'>
+
+export function getRefreshActionState({
+  mutationStatus,
+  connectionStatus,
+  workflowsUpdated,
+}: RefreshActionStateInput): RefreshActionState {
+  if (mutationStatus === 'pending') {
+    return { text: 'Refreshing...', textTone: undefined, disabled: true }
+  }
+
+  if (
+    mutationStatus === 'error' ||
+    (mutationStatus === 'success' && connectionStatus !== 'connected')
+  ) {
+    return { text: 'Failed', textTone: 'error', disabled: false }
+  }
+
+  if (mutationStatus === 'success') {
+    const text = workflowsUpdated
+      ? `Synced (${workflowsUpdated} workflow${workflowsUpdated === 1 ? '' : 's'})`
+      : 'Refreshed'
+    return { text, textTone: undefined, disabled: true }
+  }
+
+  return { text: 'Refresh tools', textTone: undefined, disabled: false }
+}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/server-tools-label.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/server-tools-label.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { getServerToolsLabel } from '@/app/workspace/[workspaceId]/settings/components/mcp/server-tools-label'
+
+describe('getServerToolsLabel', () => {
+  it('shows the persisted server error for errored connections', () => {
+    expect(getServerToolsLabel([], 'error', 'MCP error -32001: Request timed out')).toBe(
+      'MCP error -32001: Request timed out'
+    )
+  })
+
+  it('falls back when an errored connection has no persisted error', () => {
+    expect(getServerToolsLabel([], 'error', null)).toBe('Unable to connect')
+  })
+
+  it('shows a disconnected state when OAuth was not completed', () => {
+    expect(getServerToolsLabel([], 'disconnected', null)).toBe('Not Connected')
+  })
+
+  it('shows the persisted error for disconnected connections', () => {
+    expect(getServerToolsLabel([], 'disconnected', 'Request timed out')).toBe('Request timed out')
+  })
+
+  it('continues showing discovered tools for healthy connections', () => {
+    expect(getServerToolsLabel([{ name: 'search' }], 'connected', null)).toBe('1 tool: search')
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/server-tools-label.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/server-tools-label.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from '@/lib/api/contracts/mcp'
+
+interface NamedTool {
+  name: string
+}
+
+export function getServerToolsLabel(
+  tools: NamedTool[],
+  connectionStatus?: McpServer['connectionStatus'],
+  lastError?: McpServer['lastError']
+): string {
+  if (connectionStatus === 'error') {
+    return lastError?.trim() || 'Unable to connect'
+  }
+
+  if (connectionStatus === 'disconnected') {
+    return lastError?.trim() || 'Not Connected'
+  }
+
+  const count = tools.length
+  const plural = count !== 1 ? 's' : ''
+  const names = count > 0 ? `: ${tools.map((tool) => tool.name).join(', ')}` : ''
+  return `${count} tool${plural}${names}`
+}

--- a/apps/sim/components/settings/settings-header.tsx
+++ b/apps/sim/components/settings/settings-header.tsx
@@ -19,6 +19,7 @@ const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : us
 
 export interface SettingsAction {
   text: string
+  textTone?: 'error'
   icon?: ComponentType<{ className?: string }>
   variant?: 'primary' | 'destructive'
   active?: boolean
@@ -69,6 +70,7 @@ function computeSignature(config: SettingsHeaderConfig): string {
     back: config.back ? [config.back.text, config.back.icon ? 1 : 0] : null,
     actions: config.actions?.map((action) => [
       action.text,
+      action.textTone ?? '',
       action.variant ?? '',
       action.active ?? false,
       action.disabled ?? false,
@@ -155,7 +157,11 @@ export function SettingsHeaderShell({ children }: { children: ReactNode }) {
                 }
                 disabled={action.disabled}
               >
-                {action.text}
+                {action.textTone === 'error' ? (
+                  <span className='text-[var(--text-error)]'>{action.text}</span>
+                ) : (
+                  action.text
+                )}
               </Chip>
             )
             return action.tooltip ? (

--- a/apps/sim/hooks/queries/admin-users.ts
+++ b/apps/sim/hooks/queries/admin-users.ts
@@ -12,9 +12,10 @@ export const adminUserKeys = {
   lists: () => [...adminUserKeys.all, 'list'] as const,
   list: (offset: number, limit: number, searchQuery: string) =>
     [...adminUserKeys.lists(), offset, limit, searchQuery] as const,
+  byEmails: (emails: string[]) => [...adminUserKeys.lists(), 'byEmails', emails] as const,
 }
 
-interface AdminUser {
+export interface AdminUser {
   id: string
   name: string
   email: string
@@ -79,6 +80,41 @@ async function fetchAdminUsers(
     users: (data?.users ?? []).map(mapUser),
     total: data?.total ?? 0,
   }
+}
+
+async function fetchAdminUsersByEmails(
+  emails: string[],
+  signal?: AbortSignal
+): Promise<AdminUser[]> {
+  const results = await Promise.all(
+    emails.map(async (email) => {
+      const { data, error } = await client.admin.listUsers(
+        {
+          query: {
+            limit: 1,
+            filterField: 'email',
+            filterValue: email,
+            filterOperator: 'eq',
+          },
+        },
+        { signal }
+      )
+      if (error) throw new Error(error.message ?? 'Failed to fetch user')
+      const user = (data?.users ?? [])[0]
+      return user ? mapUser(user) : null
+    })
+  )
+  return results.filter((u): u is AdminUser => u !== null)
+}
+
+/** Resolves each email to its exact-match user; unmatched emails are dropped. */
+export function useAdminUsersByEmails(emails: string[]) {
+  return useQuery({
+    queryKey: adminUserKeys.byEmails(emails),
+    queryFn: ({ signal }) => fetchAdminUsersByEmails(emails, signal),
+    enabled: emails.length > 0,
+    staleTime: ADMIN_USER_LIST_STALE_TIME,
+  })
 }
 
 export function useAdminUsers(offset: number, limit: number, searchQuery: string) {

--- a/apps/sim/hooks/queries/mcp.test.tsx
+++ b/apps/sim/hooks/queries/mcp.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, type ReactNode } from 'react'
+import { sleep } from '@sim/utils/helpers'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockRequestJson } = vi.hoisted(() => ({
+  mockRequestJson: vi.fn(),
+}))
+
+vi.mock('@/lib/api/client/request', () => ({
+  requestJson: mockRequestJson,
+}))
+
+import {
+  discoverMcpToolsContract,
+  listMcpServersContract,
+  type McpServer,
+} from '@/lib/api/contracts/mcp'
+import { useForceRefreshMcpTools, useMcpServers, useMcpToolsQuery } from '@/hooks/queries/mcp'
+
+const WORKSPACE_ID = 'workspace-1'
+
+function server(id: string, overrides: Partial<McpServer> = {}): McpServer {
+  return {
+    id,
+    workspaceId: WORKSPACE_ID,
+    name: id,
+    transport: 'streamable-http',
+    url: `https://${id}.example.com/mcp`,
+    enabled: true,
+    connectionStatus: 'connected',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function renderHookWithClient<T>(useHook: () => T): {
+  getResult: () => T
+  unmount: () => void
+} {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const container = document.createElement('div')
+  const root: Root = createRoot(container)
+  let result: T | undefined
+
+  function Probe() {
+    result = useHook()
+    return null
+  }
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+
+  act(() => {
+    root.render(
+      <Wrapper>
+        <Probe />
+      </Wrapper>
+    )
+  })
+
+  return {
+    getResult: () => {
+      if (result === undefined) throw new Error('Hook result is not ready')
+      return result
+    },
+    unmount: () => act(() => root.unmount()),
+  }
+}
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve()
+      await sleep(1)
+    }
+  })
+}
+
+function mockServers(servers: McpServer[]) {
+  mockRequestJson.mockImplementation(async (contract) => {
+    if (contract === listMcpServersContract) {
+      return { success: true, data: { servers } }
+    }
+    if (contract === discoverMcpToolsContract) {
+      return { success: true, data: { tools: [], totalCount: 0, byServer: {} } }
+    }
+    throw new Error('Unexpected MCP request')
+  })
+}
+
+describe('useMcpToolsQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not auto-discover disconnected or errored OAuth servers', async () => {
+    mockServers([
+      server('oauth-disconnected', { authType: 'oauth', connectionStatus: 'disconnected' }),
+      server('oauth-error', { authType: 'oauth', connectionStatus: 'error' }),
+    ])
+
+    const { unmount } = renderHookWithClient(() => useMcpToolsQuery(WORKSPACE_ID))
+    await flush()
+
+    expect(mockRequestJson).toHaveBeenCalledTimes(1)
+    expect(mockRequestJson).toHaveBeenCalledWith(
+      listMcpServersContract,
+      expect.objectContaining({ query: { workspaceId: WORKSPACE_ID } })
+    )
+
+    unmount()
+  })
+
+  it('continues discovering connected OAuth and disconnected non-OAuth servers', async () => {
+    mockServers([
+      server('oauth-connected', { authType: 'oauth', connectionStatus: 'connected' }),
+      server('headers-disconnected', { authType: 'headers', connectionStatus: 'disconnected' }),
+    ])
+
+    const { unmount } = renderHookWithClient(() => useMcpToolsQuery(WORKSPACE_ID))
+    await flush()
+
+    expect(mockRequestJson).toHaveBeenCalledTimes(3)
+    expect(mockRequestJson).toHaveBeenCalledWith(
+      discoverMcpToolsContract,
+      expect.objectContaining({
+        query: { workspaceId: WORKSPACE_ID, serverId: 'oauth-connected' },
+      })
+    )
+    expect(mockRequestJson).toHaveBeenCalledWith(
+      discoverMcpToolsContract,
+      expect.objectContaining({
+        query: { workspaceId: WORKSPACE_ID, serverId: 'headers-disconnected' },
+      })
+    )
+
+    unmount()
+  })
+
+  it('refreshes the server list after a connected OAuth discovery fails', async () => {
+    let serverListRequests = 0
+    mockRequestJson.mockImplementation(async (contract) => {
+      if (contract === listMcpServersContract) {
+        serverListRequests++
+        const connectionStatus = serverListRequests === 1 ? 'connected' : 'disconnected'
+        return {
+          success: true,
+          data: {
+            servers: [server('oauth-server', { authType: 'oauth', connectionStatus })],
+          },
+        }
+      }
+      if (contract === discoverMcpToolsContract) {
+        throw new Error('OAuth authorization required')
+      }
+      throw new Error('Unexpected MCP request')
+    })
+
+    const { unmount } = renderHookWithClient(() => useMcpToolsQuery(WORKSPACE_ID))
+    await flush()
+
+    expect(serverListRequests).toBe(2)
+    expect(
+      mockRequestJson.mock.calls.filter(([contract]) => contract === discoverMcpToolsContract)
+    ).toHaveLength(1)
+
+    unmount()
+  })
+
+  it('does not force-refresh disconnected OAuth servers', async () => {
+    mockServers([
+      server('oauth-disconnected', { authType: 'oauth', connectionStatus: 'disconnected' }),
+      server('headers-connected', { authType: 'headers', connectionStatus: 'connected' }),
+    ])
+
+    const { getResult, unmount } = renderHookWithClient(() => ({
+      servers: useMcpServers(WORKSPACE_ID),
+      refresh: useForceRefreshMcpTools(),
+    }))
+    await flush()
+
+    await act(async () => {
+      await getResult().refresh.mutateAsync(WORKSPACE_ID)
+    })
+
+    const discoveryCalls = mockRequestJson.mock.calls.filter(
+      ([contract]) => contract === discoverMcpToolsContract
+    )
+    expect(discoveryCalls).toHaveLength(1)
+    expect(discoveryCalls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        query: { workspaceId: WORKSPACE_ID, refresh: true, serverId: 'headers-connected' },
+      })
+    )
+
+    unmount()
+  })
+})

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -125,20 +125,31 @@ async function fetchMcpTools(
   }
 }
 
+function isServerEligibleForDiscovery(server: McpServer, workspaceId: string): boolean {
+  return (
+    server.enabled &&
+    server.workspaceId === workspaceId &&
+    (server.authType !== 'oauth' || server.connectionStatus === 'connected')
+  )
+}
+
 /**
  * Workspace aggregate derived from N parallel per-server queries via
  * `useQueries`. One slow server cannot block the others.
  */
 export function useMcpToolsQuery(workspaceId: string) {
+  const queryClient = useQueryClient()
   const { data: servers, isLoading: serversLoading } = useMcpServers(workspaceId)
 
-  // Skip disabled rows (would 404 → negative-cache) and rows from a previous
-  // workspace (keepPreviousData on useMcpServers).
+  /**
+   * Skip disabled rows, rows retained from a previous workspace, and OAuth rows
+   * that require explicit authorization before discovery can succeed.
+   */
   const serverIds = useMemo(
     () =>
       servers
         ? servers
-            .filter((s) => s.enabled && s.workspaceId === workspaceId)
+            .filter((server) => isServerEligibleForDiscovery(server, workspaceId))
             .map((s) => s.id)
             .sort()
         : [],
@@ -148,8 +159,17 @@ export function useMcpToolsQuery(workspaceId: string) {
   const results = useQueries({
     queries: serverIds.map((serverId) => ({
       queryKey: mcpKeys.serverToolsList(workspaceId, serverId),
-      queryFn: ({ signal }: { signal?: AbortSignal }) =>
-        fetchMcpTools(workspaceId, false, signal, serverId),
+      queryFn: async ({ signal }: { signal?: AbortSignal }) => {
+        try {
+          return await fetchMcpTools(workspaceId, false, signal, serverId)
+        } catch (error) {
+          await queryClient.invalidateQueries(
+            { queryKey: mcpKeys.serversList(workspaceId) },
+            { cancelRefetch: false }
+          )
+          throw error
+        }
+      },
       enabled: !!workspaceId,
       retry: false,
       staleTime: MCP_SERVER_TOOLS_STALE_TIME,
@@ -203,7 +223,9 @@ export function useForceRefreshMcpTools() {
     mutationFn: async (workspaceId: string) => {
       const allServers =
         queryClient.getQueryData<McpServer[]>(mcpKeys.serversList(workspaceId)) ?? []
-      const servers = allServers.filter((s) => s.enabled && s.workspaceId === workspaceId)
+      const servers = allServers.filter((server) =>
+        isServerEligibleForDiscovery(server, workspaceId)
+      )
       const results = await Promise.allSettled(
         servers.map(async (server) => {
           const tools = await fetchMcpTools(workspaceId, true, undefined, server.id)

--- a/apps/sim/lib/mcp/client.test.ts
+++ b/apps/sim/lib/mcp/client.test.ts
@@ -3,6 +3,20 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { mockLogger, mockSdkConnect } = vi.hoisted(() => ({
+  mockLogger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  mockSdkConnect: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@sim/logger', () => ({
+  createLogger: () => mockLogger,
+}))
+
 /**
  * Capture the notification handler registered via `client.setNotificationHandler()`.
  * This lets us simulate the MCP SDK delivering a `tools/list_changed` notification.
@@ -14,7 +28,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
     class {
       constructor() {
         Object.assign(this, {
-          connect: vi.fn().mockResolvedValue(undefined),
+          connect: mockSdkConnect,
           close: vi.fn().mockResolvedValue(undefined),
           getServerVersion: vi.fn().mockReturnValue('2025-06-18'),
           getServerCapabilities: vi.fn().mockReturnValue({ tools: { listChanged: true } }),
@@ -65,6 +79,7 @@ describe('McpClient notification handler', () => {
   beforeEach(() => {
     capturedNotificationHandler = null
     vi.clearAllMocks()
+    mockSdkConnect.mockResolvedValue(undefined)
   })
 
   it('fires onToolsChanged when a notification arrives while connected', async () => {
@@ -113,6 +128,99 @@ describe('McpClient notification handler', () => {
     await client.connect()
 
     expect(capturedNotificationHandler).toBeNull()
+  })
+
+  it('uses the server connection timeout for the initialize request', async () => {
+    const client = new McpClient({
+      config: { ...createConfig(), timeout: 12_345 },
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await client.connect()
+
+    expect(mockSdkConnect).toHaveBeenCalledWith(expect.anything(), { timeout: 12_345 })
+  })
+
+  it('normalizes invalid connection timeouts before calling the SDK', async () => {
+    const client = new McpClient({
+      config: { ...createConfig(), timeout: -1 },
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await client.connect()
+
+    expect(mockSdkConnect).toHaveBeenCalledWith(expect.anything(), { timeout: 30_000 })
+  })
+
+  it('logs connection diagnostics without header values', async () => {
+    const client = new McpClient({
+      config: {
+        ...createConfig(),
+        authType: 'headers',
+        headers: { Authorization: 'Bearer do-not-log', 'X-API-Key': 'also-secret' },
+        timeout: 12_345,
+      },
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await client.connect()
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('Successfully connected'),
+      expect.objectContaining({
+        authType: 'headers',
+        headerNames: ['Authorization', 'X-API-Key'],
+        hasUnresolvedEnvRefs: false,
+        phase: 'initialize',
+        outcome: 'connected',
+        timeoutMs: 12_345,
+      })
+    )
+    expect(JSON.stringify(mockLogger.info.mock.calls)).not.toContain('do-not-log')
+    expect(JSON.stringify(mockLogger.info.mock.calls)).not.toContain('also-secret')
+  })
+
+  it('classifies initialize timeouts in connection diagnostics', async () => {
+    mockSdkConnect.mockRejectedValueOnce(new Error('MCP error -32001: Request timed out'))
+    const client = new McpClient({
+      config: {
+        ...createConfig(),
+        headers: { Authorization: 'Bearer do-not-log' },
+      },
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await expect(client.connect()).rejects.toThrow('Request timed out')
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to connect'),
+      expect.objectContaining({
+        phase: 'initialize',
+        outcome: 'timeout',
+        timeoutMs: 30_000,
+        error: expect.objectContaining({
+          name: 'Error',
+        }),
+      })
+    )
+    expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain('do-not-log')
+  })
+
+  it('does not log opaque credentials echoed by MCP errors', async () => {
+    const secret = 'opaque-credential-without-a-known-prefix'
+    mockSdkConnect.mockRejectedValueOnce(new Error(`Upstream rejected ${secret}`))
+    const client = new McpClient({
+      config: {
+        ...createConfig(),
+        authType: 'headers',
+        headers: { 'X-Custom-Credential': secret },
+      },
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await expect(client.connect()).rejects.toThrow('Upstream rejected')
+
+    expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain(secret)
   })
 
   it('passes configured headers for OAuth transports as well as header auth transports', () => {

--- a/apps/sim/lib/mcp/client.test.ts
+++ b/apps/sim/lib/mcp/client.test.ts
@@ -3,7 +3,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockLogger, mockSdkConnect } = vi.hoisted(() => ({
+const { mockLogger, mockSdkConnect, mockSdkListTools } = vi.hoisted(() => ({
   mockLogger: {
     debug: vi.fn(),
     error: vi.fn(),
@@ -11,6 +11,7 @@ const { mockLogger, mockSdkConnect } = vi.hoisted(() => ({
     warn: vi.fn(),
   },
   mockSdkConnect: vi.fn().mockResolvedValue(undefined),
+  mockSdkListTools: vi.fn().mockResolvedValue({ tools: [] }),
 }))
 
 vi.mock('@sim/logger', () => ({
@@ -37,7 +38,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
             .mockImplementation((_schema: unknown, handler: () => Promise<void>) => {
               capturedNotificationHandler = handler
             }),
-          listTools: vi.fn().mockResolvedValue({ tools: [] }),
+          listTools: mockSdkListTools,
         })
       }
     }
@@ -63,6 +64,7 @@ vi.mock('@/lib/core/execution-limits', () => ({
 }))
 
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { getMaxExecutionTimeout } from '@/lib/core/execution-limits'
 import { McpClient } from './client'
 import type { McpClientOptions, McpServerConfig } from './types'
 
@@ -80,6 +82,10 @@ describe('McpClient notification handler', () => {
     capturedNotificationHandler = null
     vi.clearAllMocks()
     mockSdkConnect.mockResolvedValue(undefined)
+    mockSdkListTools.mockResolvedValue({ tools: [] })
+    // clearAllMocks resets call history but not implementations; re-establish the
+    // default so a per-test override can't bleed into later tests.
+    vi.mocked(getMaxExecutionTimeout).mockReturnValue(30_000)
   })
 
   it('fires onToolsChanged when a notification arrives while connected', async () => {
@@ -150,6 +156,42 @@ describe('McpClient notification handler', () => {
     await client.connect()
 
     expect(mockSdkConnect).toHaveBeenCalledWith(expect.anything(), { timeout: 30_000 })
+  })
+
+  it('bounds tools/list with an idle timeout, hard cap, and progress reset', async () => {
+    const client = new McpClient({
+      config: createConfig(),
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await client.connect()
+    await client.listTools()
+
+    expect(mockSdkListTools).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        timeout: 30_000,
+        maxTotalTimeout: 60_000,
+        resetTimeoutOnProgress: true,
+        onprogress: expect.any(Function),
+      })
+    )
+  })
+
+  it('clamps a configured tools/list timeout to the absolute discovery ceiling', async () => {
+    vi.mocked(getMaxExecutionTimeout).mockReturnValue(120_000)
+    const client = new McpClient({
+      config: { ...createConfig(), timeout: 300_000 },
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await client.connect()
+    await client.listTools()
+
+    expect(mockSdkListTools).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ timeout: 60_000, maxTotalTimeout: 60_000 })
+    )
   })
 
   it('logs connection diagnostics without header values', async () => {

--- a/apps/sim/lib/mcp/client.ts
+++ b/apps/sim/lib/mcp/client.ts
@@ -104,6 +104,14 @@ export class McpClient {
         capabilities: {},
       }
     )
+
+    // Observe out-of-band transport errors the SDK would otherwise drop silently.
+    this.client.onerror = (error) => {
+      logger.warn(`MCP transport error for ${this.config.name}`, {
+        serverId: this.config.id,
+        error: sanitizeForLogging(getErrorMessage(error, 'Unknown transport error'), 200),
+      })
+    }
   }
 
   /**
@@ -217,9 +225,31 @@ export class McpClient {
       throw new McpConnectionError('Not connected to server', this.config.name)
     }
 
+    const configuredTimeout = this.config.timeout
+    // Idle timeout honors the per-server config but never exceeds the absolute
+    // discovery ceiling, so tools/list can't hang the UI past that cap.
+    const idleTimeoutMs = Math.min(
+      configuredTimeout !== undefined && Number.isFinite(configuredTimeout) && configuredTimeout > 0
+        ? Math.floor(configuredTimeout)
+        : MCP_CLIENT_CONSTANTS.LIST_TOOLS_TIMEOUT_MS,
+      getMaxExecutionTimeout(),
+      MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_TOTAL_TIMEOUT_MS
+    )
+    const maxTotalTimeoutMs = MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_TOTAL_TIMEOUT_MS
+
     try {
       const result: ListToolsResult = await this.client.listTools(undefined, {
-        timeout: MCP_CLIENT_CONSTANTS.LIST_TOOLS_TIMEOUT_MS,
+        // resetTimeoutOnProgress only takes effect when onprogress is supplied.
+        timeout: idleTimeoutMs,
+        maxTotalTimeout: maxTotalTimeoutMs,
+        resetTimeoutOnProgress: true,
+        onprogress: (progress) => {
+          logger.debug(`Tool discovery progress from ${this.config.name}`, {
+            serverId: this.config.id,
+            progress: progress.progress,
+            total: progress.total,
+          })
+        },
       })
 
       if (!result.tools || !Array.isArray(result.tools)) {

--- a/apps/sim/lib/mcp/client.ts
+++ b/apps/sim/lib/mcp/client.ts
@@ -9,9 +9,10 @@ import {
   ToolListChangedNotificationSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import { createLogger } from '@sim/logger'
-import { getErrorMessage } from '@sim/utils/errors'
+import { describeError, getErrorMessage } from '@sim/utils/errors'
 import { getMaxExecutionTimeout } from '@/lib/core/execution-limits'
 import { createPinnedFetch } from '@/lib/core/security/input-validation.server'
+import { sanitizeForLogging } from '@/lib/core/security/redaction'
 import { McpOauthRedirectRequired } from '@/lib/mcp/oauth'
 import {
   type McpClientOptions,
@@ -29,8 +30,29 @@ import {
   type McpVersionInfo,
 } from '@/lib/mcp/types'
 import { MCP_CLIENT_CONSTANTS } from '@/lib/mcp/utils'
+import { createEnvVarPattern } from '@/executor/utils/reference-validation'
 
 const logger = createLogger('McpClient')
+
+type ConnectionOutcome =
+  | 'started'
+  | 'connected'
+  | 'authorization_required'
+  | 'timeout'
+  | 'unauthorized'
+  | 'cancelled'
+  | 'error'
+
+function classifyConnectionOutcome(error: unknown): ConnectionOutcome {
+  if (error instanceof McpOauthRedirectRequired || error instanceof UnauthorizedError) {
+    return 'authorization_required'
+  }
+  const message = getErrorMessage(error, '').toLowerCase()
+  if (message.includes('connection attempt cancelled')) return 'cancelled'
+  if (message.includes('timeout') || message.includes('timed out')) return 'timeout'
+  if (message.includes('401') || message.includes('unauthorized')) return 'unauthorized'
+  return 'error'
+}
 
 interface McpClientConnectOptions {
   isCancelled?: () => boolean
@@ -90,10 +112,34 @@ export class McpClient {
    * for `notifications/tools/list_changed` after connecting.
    */
   async connect(options: McpClientConnectOptions = {}): Promise<void> {
-    logger.info(`Connecting to MCP server: ${this.config.name} (${this.config.transport})`)
+    const startedAt = Date.now()
+    const configuredTimeout = this.config.timeout
+    const timeoutMs =
+      configuredTimeout !== undefined && Number.isFinite(configuredTimeout) && configuredTimeout > 0
+        ? Math.min(Math.floor(configuredTimeout), getMaxExecutionTimeout())
+        : MCP_CLIENT_CONSTANTS.CLIENT_TIMEOUT
+    const headerNames = Object.keys(this.config.headers ?? {}).sort()
+    const hasUnresolvedEnvRefs = [
+      this.config.url ?? '',
+      ...Object.values(this.config.headers ?? {}),
+    ].some((value) => createEnvVarPattern().test(value))
+    const diagnostics = {
+      serverId: this.config.id,
+      authType: this.config.authType ?? (headerNames.length > 0 ? 'headers' : 'none'),
+      headerNames,
+      hasUnresolvedEnvRefs,
+      phase: 'initialize',
+      timeoutMs,
+    }
+    logger.info(`Connecting to MCP server: ${this.config.name} (${this.config.transport})`, {
+      ...diagnostics,
+      outcome: 'started' satisfies ConnectionOutcome,
+    })
 
     try {
-      await this.client.connect(this.transport)
+      await this.client.connect(this.transport, {
+        timeout: timeoutMs,
+      })
       if (options.isCancelled?.()) {
         await this.client.close().catch((error) => {
           logger.warn(`Error closing cancelled connection to ${this.config.name}:`, error)
@@ -116,17 +162,34 @@ export class McpClient {
 
       const serverVersion = this.client.getServerVersion()
       logger.info(`Successfully connected to MCP server: ${this.config.name}`, {
+        ...diagnostics,
+        durationMs: Date.now() - startedAt,
+        outcome: 'connected' satisfies ConnectionOutcome,
         protocolVersion: serverVersion,
       })
     } catch (error) {
       this.isConnected = false
-      if (error instanceof McpOauthRedirectRequired || error instanceof UnauthorizedError) {
+      const errorMessage = getErrorMessage(error, 'Unknown error')
+      const describedError = describeError(error)
+      const outcome = classifyConnectionOutcome(error)
+      logger.error(`Failed to connect to MCP server ${this.config.name}`, {
+        ...diagnostics,
+        durationMs: Date.now() - startedAt,
+        error: {
+          name: sanitizeForLogging(describedError.name, 100),
+          code: describedError.code ? sanitizeForLogging(describedError.code, 100) : undefined,
+          errno: describedError.errno ? sanitizeForLogging(describedError.errno, 100) : undefined,
+          syscall: describedError.syscall
+            ? sanitizeForLogging(describedError.syscall, 100)
+            : undefined,
+        },
+        outcome,
+      })
+      if (outcome === 'authorization_required') {
         this.connectionStatus.lastError = undefined
         throw error
       }
-      const errorMessage = getErrorMessage(error, 'Unknown error')
       this.connectionStatus.lastError = errorMessage
-      logger.error(`Failed to connect to MCP server ${this.config.name}:`, error)
       throw new McpConnectionError(errorMessage, this.config.name)
     }
   }

--- a/apps/sim/lib/mcp/service.test.ts
+++ b/apps/sim/lib/mcp/service.test.ts
@@ -400,7 +400,11 @@ describe('McpService.discoverTools per-server caching', () => {
 
   it('successful discoverServerTools clears the negative cache', async () => {
     mockGetWorkspaceServersRows.mockResolvedValue([dbRow('mcp-a', 'A')])
-    mockListTools.mockRejectedValueOnce(new Error('Request timed out'))
+    // A timeout is transient/retryable, so it must fail every attempt to reach
+    // the persisted-failure path.
+    mockListTools
+      .mockRejectedValueOnce(new Error('Request timed out'))
+      .mockRejectedValueOnce(new Error('Request timed out'))
 
     await expect(mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)).rejects.toThrow(
       'Request timed out'
@@ -450,7 +454,9 @@ describe('McpService.discoverTools per-server caching', () => {
         statusConfig: { consecutiveFailures: 0, lastSuccessfulDiscovery: null },
       }),
     ])
-    mockListTools.mockRejectedValueOnce(new Error('Request timed out'))
+    mockListTools
+      .mockRejectedValueOnce(new Error('Request timed out'))
+      .mockRejectedValueOnce(new Error('Request timed out'))
 
     await expect(mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)).rejects.toThrow(
       'Request timed out'
@@ -459,10 +465,23 @@ describe('McpService.discoverTools per-server caching', () => {
     expect(mockUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         connectionStatus: 'disconnected',
-        lastError: 'Request timed out',
+        // Raw SDK timeout text is mapped to a user-facing message before persisting.
+        lastError: 'The MCP server took too long to respond and timed out',
         statusConfig: { consecutiveFailures: 1, lastSuccessfulDiscovery: null },
       })
     )
+  })
+
+  it('retries a transient tools/list timeout and succeeds on the second attempt', async () => {
+    mockGetWorkspaceServersRows.mockResolvedValue([dbRow('mcp-a', 'A')])
+    mockListTools
+      .mockRejectedValueOnce(new Error('Request timed out'))
+      .mockResolvedValueOnce([tool('a1', 'mcp-a')])
+
+    const tools = await mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)
+
+    expect(tools.map((t) => t.name)).toEqual(['a1'])
+    expect(mockListTools).toHaveBeenCalledTimes(2)
   })
 
   it('persists and negative-caches per-server UnauthorizedError for headers auth', async () => {

--- a/apps/sim/lib/mcp/service.test.ts
+++ b/apps/sim/lib/mcp/service.test.ts
@@ -1,6 +1,9 @@
 /**
  * @vitest-environment node
  */
+
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
+import { loggerMock } from '@sim/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -14,16 +17,19 @@ const {
   mockValidateSsrf,
   mockIsDomainAllowed,
   mockCacheAdapter,
+  mockUpdateSet,
+  mockUpdateReturning,
 } = vi.hoisted(() => {
   const mockListTools = vi.fn()
   const mockConnect = vi.fn()
   const mockDisconnect = vi.fn()
+  const mockUpdateReturning = vi.fn().mockResolvedValue([{ id: 'server-1' }])
   // In-memory cache adapter so the service never touches the real Redis the
   // local .env points at (unreachable in CI/sandbox → hangs). Honors TTL via
   // an expiry timestamp so negative-cache assertions behave like production.
   const cacheStore = new Map<string, { tools: unknown[]; expiry: number }>()
   const mockCacheAdapter = {
-    get: async (key: string) => {
+    get: vi.fn(async (key: string) => {
       const entry = cacheStore.get(key)
       if (!entry) return null
       if (entry.expiry <= Date.now()) {
@@ -31,16 +37,16 @@ const {
         return null
       }
       return entry
-    },
-    set: async (key: string, tools: unknown[], ttlMs: number) => {
+    }),
+    set: vi.fn(async (key: string, tools: unknown[], ttlMs: number) => {
       cacheStore.set(key, { tools, expiry: Date.now() + ttlMs })
-    },
-    delete: async (key: string) => {
+    }),
+    delete: vi.fn(async (key: string) => {
       cacheStore.delete(key)
-    },
-    clear: async () => {
+    }),
+    clear: vi.fn(async () => {
       cacheStore.clear()
-    },
+    }),
     dispose: () => {},
   }
   return {
@@ -67,6 +73,10 @@ const {
     mockValidateDomain: vi.fn(),
     mockValidateSsrf: vi.fn(),
     mockIsDomainAllowed: vi.fn(() => true),
+    mockUpdateReturning,
+    mockUpdateSet: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: mockUpdateReturning }),
+    }),
   }
 })
 
@@ -80,13 +90,12 @@ vi.mock('@sim/db', () => {
     })
     return thenable
   }
-  const setter = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
   return {
     db: {
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({ where }),
       }),
-      update: vi.fn().mockReturnValue({ set: setter }),
+      update: vi.fn().mockReturnValue({ set: mockUpdateSet }),
       insert: vi.fn(),
       delete: vi.fn(),
     },
@@ -125,6 +134,8 @@ vi.mock('@/lib/mcp/storage', () => ({
 
 import { mcpService } from '@/lib/mcp/service'
 import { McpOauthAuthorizationRequiredError } from '@/lib/mcp/types'
+
+const mockLogger = vi.mocked(loggerMock.createLogger).mock.results.at(-1)?.value
 
 const WORKSPACE_ID = 'workspace-test'
 const USER_ID = 'user-test'
@@ -173,6 +184,8 @@ describe('McpService.discoverTools per-server caching', () => {
     )
     mockConnect.mockResolvedValue(undefined)
     mockDisconnect.mockResolvedValue(undefined)
+    mockUpdateReturning.mockReset()
+    mockUpdateReturning.mockResolvedValue([{ id: 'server-1' }])
     // The McpService singleton holds cache state across imports.
     await mcpService.clearCache()
   })
@@ -321,6 +334,70 @@ describe('McpService.discoverTools per-server caching', () => {
     expect(mockListTools).not.toHaveBeenCalled()
   })
 
+  it('persists and negative-caches UnauthorizedError for a headers-auth server', async () => {
+    const reflectedCredential = 'Bearer static-secret-for-bulk-discovery'
+    mockGetWorkspaceServersRows.mockResolvedValue([
+      dbRow('mcp-a', 'A', {
+        statusConfig: { consecutiveFailures: 0, lastSuccessfulDiscovery: null },
+      }),
+    ])
+    mockListTools.mockRejectedValueOnce(
+      new UnauthorizedError(`Rejected Authorization: ${reflectedCredential}`)
+    )
+
+    const first = await mcpService.discoverTools(USER_ID, WORKSPACE_ID)
+    expect(first).toEqual([])
+
+    await vi.waitFor(() => {
+      expect(mockUpdateSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connectionStatus: 'disconnected',
+          lastError: 'Authentication failed',
+          statusConfig: { consecutiveFailures: 1, lastSuccessfulDiscovery: null },
+        })
+      )
+      expect(mockCacheAdapter.set).toHaveBeenCalledWith(
+        `workspace:${WORKSPACE_ID}:server:mcp-a:failure`,
+        [],
+        expect.any(Number)
+      )
+    })
+    expect(JSON.stringify(mockUpdateSet.mock.calls)).not.toContain(reflectedCredential)
+    expect(JSON.stringify(mockCacheAdapter.set.mock.calls)).not.toContain(reflectedCredential)
+    expect(JSON.stringify(mockLogger?.warn.mock.calls)).not.toContain(reflectedCredential)
+
+    mockListTools.mockClear()
+    const second = await mcpService.discoverTools(USER_ID, WORKSPACE_ID)
+    expect(second).toEqual([])
+    expect(mockListTools).not.toHaveBeenCalled()
+  })
+
+  it('keeps UnauthorizedError soft-pending for an OAuth server', async () => {
+    mockGetWorkspaceServersRows.mockResolvedValue([dbRow('mcp-a', 'A', { authType: 'oauth' })])
+    mockResolveEnvVars.mockRejectedValue(new UnauthorizedError('OAuth token rejected'))
+
+    const first = await mcpService.discoverTools(USER_ID, WORKSPACE_ID)
+    expect(first).toEqual([])
+
+    await vi.waitFor(() => {
+      expect(mockUpdateSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connectionStatus: 'disconnected',
+          lastError: null,
+        })
+      )
+    })
+    expect(mockCacheAdapter.set).not.toHaveBeenCalledWith(
+      `workspace:${WORKSPACE_ID}:server:mcp-a:failure`,
+      [],
+      expect.any(Number)
+    )
+
+    mockResolveEnvVars.mockClear()
+    await mcpService.discoverTools(USER_ID, WORKSPACE_ID)
+    expect(mockResolveEnvVars).toHaveBeenCalledTimes(1)
+  })
+
   it('successful discoverServerTools clears the negative cache', async () => {
     mockGetWorkspaceServersRows.mockResolvedValue([dbRow('mcp-a', 'A')])
     mockListTools.mockRejectedValueOnce(new Error('Request timed out'))
@@ -365,5 +442,138 @@ describe('McpService.discoverTools per-server caching', () => {
     const after = await mcpService.discoverTools(USER_ID, WORKSPACE_ID)
     expect(after.map((t) => t.name)).toEqual(['a1'])
     expect(mockListTools).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists a per-server discovery failure before rethrowing it', async () => {
+    mockGetWorkspaceServersRows.mockResolvedValue([
+      dbRow('mcp-a', 'A', {
+        statusConfig: { consecutiveFailures: 0, lastSuccessfulDiscovery: null },
+      }),
+    ])
+    mockListTools.mockRejectedValueOnce(new Error('Request timed out'))
+
+    await expect(mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)).rejects.toThrow(
+      'Request timed out'
+    )
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionStatus: 'disconnected',
+        lastError: 'Request timed out',
+        statusConfig: { consecutiveFailures: 1, lastSuccessfulDiscovery: null },
+      })
+    )
+  })
+
+  it('persists and negative-caches per-server UnauthorizedError for headers auth', async () => {
+    const reflectedCredential = 'Bearer static-secret-for-server-discovery'
+    mockGetWorkspaceServersRows.mockResolvedValue([
+      dbRow('mcp-a', 'A', {
+        statusConfig: { consecutiveFailures: 0, lastSuccessfulDiscovery: null },
+      }),
+    ])
+    mockListTools.mockRejectedValueOnce(
+      new UnauthorizedError(`Rejected Authorization: ${reflectedCredential}`)
+    )
+
+    await expect(mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)).rejects.toThrow(
+      reflectedCredential
+    )
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionStatus: 'disconnected',
+        lastError: 'Authentication failed',
+        statusConfig: { consecutiveFailures: 1, lastSuccessfulDiscovery: null },
+      })
+    )
+    expect(JSON.stringify(mockUpdateSet.mock.calls)).not.toContain(reflectedCredential)
+    expect(JSON.stringify(mockCacheAdapter.set.mock.calls)).not.toContain(reflectedCredential)
+    expect(JSON.stringify(mockLogger?.warn.mock.calls)).not.toContain(reflectedCredential)
+
+    mockListTools.mockClear()
+    await expect(mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)).rejects.toThrow(
+      'cooldown'
+    )
+    expect(mockListTools).not.toHaveBeenCalled()
+  })
+
+  it('keeps per-server UnauthorizedError soft-pending for OAuth auth', async () => {
+    mockGetWorkspaceServersRows.mockResolvedValue([dbRow('mcp-a', 'A', { authType: 'oauth' })])
+    mockResolveEnvVars.mockRejectedValue(new UnauthorizedError('OAuth token rejected'))
+
+    await expect(mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)).rejects.toThrow(
+      'OAuth token rejected'
+    )
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionStatus: 'disconnected',
+        lastError: null,
+      })
+    )
+    expect(mockCacheAdapter.set).not.toHaveBeenCalledWith(
+      `workspace:${WORKSPACE_ID}:server:mcp-a:failure`,
+      [],
+      expect.any(Number)
+    )
+
+    mockResolveEnvVars.mockClear()
+    await expect(mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)).rejects.toThrow(
+      'OAuth token rejected'
+    )
+    expect(mockResolveEnvVars).toHaveBeenCalledTimes(1)
+  })
+
+  it('promotes the persisted server status to error on the third consecutive failure', async () => {
+    mockGetWorkspaceServersRows.mockResolvedValue([
+      dbRow('mcp-a', 'A', {
+        statusConfig: { consecutiveFailures: 2, lastSuccessfulDiscovery: null },
+      }),
+    ])
+    mockListTools.mockRejectedValueOnce(new Error('Connection refused'))
+
+    await expect(mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)).rejects.toThrow(
+      'Connection refused'
+    )
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionStatus: 'error',
+        statusConfig: { consecutiveFailures: 3, lastSuccessfulDiscovery: null },
+      })
+    )
+  })
+
+  it('persists OAuth-required discovery as disconnected without a failure error', async () => {
+    mockGetWorkspaceServersRows.mockResolvedValue([dbRow('mcp-a', 'A')])
+    mockListTools.mockRejectedValueOnce(new McpOauthAuthorizationRequiredError('mcp-a', 'A'))
+
+    await expect(mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)).rejects.toThrow(
+      'OAuth authorization required'
+    )
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionStatus: 'disconnected',
+        lastError: null,
+      })
+    )
+  })
+
+  it('does not negative-cache a failure older than a successful discovery', async () => {
+    mockGetWorkspaceServersRows.mockResolvedValue([dbRow('mcp-a', 'A')])
+    mockListTools.mockRejectedValueOnce(new Error('Older request failed'))
+    mockUpdateReturning.mockResolvedValueOnce([])
+
+    await expect(mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)).rejects.toThrow(
+      'Older request failed'
+    )
+
+    mockListTools.mockResolvedValueOnce([tool('a1', 'mcp-a')])
+    const tools = await mcpService.discoverServerTools(USER_ID, 'mcp-a', WORKSPACE_ID)
+
+    expect(tools.map((tool) => tool.name)).toEqual(['a1'])
+    expect(mockListTools).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/sim/lib/mcp/service.ts
+++ b/apps/sim/lib/mcp/service.ts
@@ -1,10 +1,12 @@
 import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
 import { StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { db } from '@sim/db'
 import { mcpServers } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
 import { sleep } from '@sim/utils/helpers'
+import { backoffWithJitter } from '@sim/utils/retry'
 import { and, eq, isNull, lte, or } from 'drizzle-orm'
 import { isTest } from '@/lib/core/config/env-flags'
 import { generateRequestId } from '@/lib/core/utils/request'
@@ -85,7 +87,43 @@ function getDiscoveryFailureMessage(
   if (authType !== 'oauth' && error instanceof UnauthorizedError) {
     return 'Authentication failed'
   }
+  if (isTimeoutError(error)) {
+    return 'The MCP server took too long to respond and timed out'
+  }
   return getErrorMessage(error, fallback)
+}
+
+function isTimeoutError(error: unknown): boolean {
+  if (error instanceof McpError && error.code === ErrorCode.RequestTimeout) {
+    return true
+  }
+  return getErrorMessage(error, '').toLowerCase().includes('timed out')
+}
+
+/** Transient failures a read-only `tools/list` may safely retry (idempotent, unlike `tools/call`); excludes OAuth and terminal 4xx. */
+function isRetryableDiscoveryError(error: unknown): boolean {
+  if (isTimeoutError(error)) return true
+  if (error instanceof McpError) {
+    return error.code === ErrorCode.ConnectionClosed
+  }
+  if (error instanceof StreamableHTTPError) {
+    // 404/400 = stale session (retry re-initializes); 429/5xx = transient upstream.
+    const code = error.code
+    return (
+      code === 404 ||
+      code === 400 ||
+      code === 429 ||
+      (typeof code === 'number' && code >= 500 && code <= 599)
+    )
+  }
+  const message = getErrorMessage(error, '').toLowerCase()
+  return (
+    message.includes('econnreset') ||
+    message.includes('socket hang up') ||
+    message.includes('etimedout') ||
+    message.includes('fetch failed') ||
+    message.includes('network')
+  )
 }
 
 class McpService {
@@ -772,12 +810,12 @@ class McpService {
           await client.disconnect()
         }
       } catch (error) {
-        if (this.isSessionError(error) && attempt < maxRetries - 1) {
+        if (isRetryableDiscoveryError(error) && attempt < maxRetries - 1) {
           logger.warn(
-            `[${requestId}] Session error discovering tools from server ${serverId}, retrying (attempt ${attempt + 1}):`,
+            `[${requestId}] Transient error discovering tools from server ${serverId}, retrying (attempt ${attempt + 1}):`,
             error
           )
-          await sleep(100)
+          await sleep(backoffWithJitter(attempt + 1, null, { baseMs: 250, maxMs: 2000 }))
           continue
         }
         // Drop positive cache so a follow-up doesn't return stale tools.

--- a/apps/sim/lib/mcp/service.ts
+++ b/apps/sim/lib/mcp/service.ts
@@ -5,7 +5,7 @@ import { mcpServers } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
 import { sleep } from '@sim/utils/helpers'
-import { and, eq, isNull } from 'drizzle-orm'
+import { and, eq, isNull, lte, or } from 'drizzle-orm'
 import { isTest } from '@/lib/core/config/env-flags'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { McpClient } from '@/lib/mcp/client'
@@ -65,6 +65,28 @@ type DiscoveryOutcome =
   // originalError preserves the type so markServerUnhealthy's instanceof
   // exemption survives the getErrorMessage call.
   | { kind: 'error'; message: string; originalError: unknown }
+
+type ServerStatusUpdate =
+  | { outcome: 'connected'; toolCount: number }
+  | { outcome: 'failed'; error: string; discoveryStartedAt?: Date }
+
+function isOauthAuthorizationError(error: unknown, authType: McpServerConfig['authType']): boolean {
+  return (
+    error instanceof McpOauthAuthorizationRequiredError ||
+    (authType === 'oauth' && error instanceof UnauthorizedError)
+  )
+}
+
+function getDiscoveryFailureMessage(
+  error: unknown,
+  authType: McpServerConfig['authType'],
+  fallback: string
+): string {
+  if (authType !== 'oauth' && error instanceof UnauthorizedError) {
+    return 'Authentication failed'
+  }
+  return getErrorMessage(error, fallback)
+}
 
 class McpService {
   private cacheAdapter: McpCacheStorageAdapter
@@ -311,11 +333,30 @@ class McpService {
   private async updateServerStatus(
     serverId: string,
     workspaceId: string,
-    success: boolean,
-    error?: string,
-    toolCount?: number
-  ): Promise<void> {
+    update: ServerStatusUpdate
+  ): Promise<boolean> {
     try {
+      const now = new Date()
+
+      if (update.outcome === 'connected') {
+        await db
+          .update(mcpServers)
+          .set({
+            connectionStatus: 'connected',
+            lastConnected: now,
+            lastError: null,
+            toolCount: update.toolCount,
+            lastToolsRefresh: now,
+            statusConfig: {
+              consecutiveFailures: 0,
+              lastSuccessfulDiscovery: now.toISOString(),
+            },
+            updatedAt: now,
+          })
+          .where(eq(mcpServers.id, serverId))
+        return true
+      }
+
       const [currentServer] = await db
         .select({ statusConfig: mcpServers.statusConfig })
         .from(mcpServers)
@@ -337,49 +378,42 @@ class McpService {
         lastSuccessfulDiscovery: storedConfig?.lastSuccessfulDiscovery ?? null,
       }
 
-      const now = new Date()
+      const newFailures = currentConfig.consecutiveFailures + 1
+      const isErrorState = newFailures >= MCP_CONSTANTS.MAX_CONSECUTIVE_FAILURES
 
-      if (success) {
-        await db
-          .update(mcpServers)
-          .set({
-            connectionStatus: 'connected',
-            lastConnected: now,
-            lastError: null,
-            toolCount: toolCount ?? 0,
-            lastToolsRefresh: now,
-            statusConfig: {
-              consecutiveFailures: 0,
-              lastSuccessfulDiscovery: now.toISOString(),
-            },
-            updatedAt: now,
-          })
-          .where(eq(mcpServers.id, serverId))
-      } else {
-        const newFailures = currentConfig.consecutiveFailures + 1
-        const isErrorState = newFailures >= MCP_CONSTANTS.MAX_CONSECUTIVE_FAILURES
-
-        await db
-          .update(mcpServers)
-          .set({
-            connectionStatus: isErrorState ? 'error' : 'disconnected',
-            lastError: error || 'Unknown error',
-            statusConfig: {
-              consecutiveFailures: newFailures,
-              lastSuccessfulDiscovery: currentConfig.lastSuccessfulDiscovery,
-            },
-            updatedAt: now,
-          })
-          .where(eq(mcpServers.id, serverId))
-
-        if (isErrorState) {
-          logger.warn(
-            `Server ${serverId} marked as error after ${newFailures} consecutive failures`
+      const updatedServers = await db
+        .update(mcpServers)
+        .set({
+          connectionStatus: isErrorState ? 'error' : 'disconnected',
+          lastError: update.error || 'Unknown error',
+          statusConfig: {
+            consecutiveFailures: newFailures,
+            lastSuccessfulDiscovery: currentConfig.lastSuccessfulDiscovery,
+          },
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(mcpServers.id, serverId),
+            eq(mcpServers.workspaceId, workspaceId),
+            isNull(mcpServers.deletedAt),
+            update.discoveryStartedAt
+              ? or(
+                  isNull(mcpServers.lastConnected),
+                  lte(mcpServers.lastConnected, update.discoveryStartedAt)
+                )
+              : undefined
           )
-        }
+        )
+        .returning({ id: mcpServers.id })
+
+      if (isErrorState && updatedServers.length > 0) {
+        logger.warn(`Server ${serverId} marked as error after ${newFailures} consecutive failures`)
       }
+      return updatedServers.length > 0
     } catch (err) {
       logger.error(`Failed to update server status for ${serverId}:`, err)
+      return false
     }
   }
 
@@ -390,9 +424,10 @@ class McpService {
   private async markServerUnhealthy(
     workspaceId: string,
     serverId: string,
-    error: unknown
+    error: unknown,
+    authType: McpServerConfig['authType']
   ): Promise<void> {
-    if (error instanceof McpOauthAuthorizationRequiredError || error instanceof UnauthorizedError) {
+    if (isOauthAuthorizationError(error, authType)) {
       return
     }
     try {
@@ -403,6 +438,40 @@ class McpService {
       )
     } catch (err) {
       logger.warn(`Failed to write failure cache for server ${serverId}:`, err)
+    }
+  }
+
+  private async markServerOauthPending(
+    serverId: string,
+    workspaceId: string,
+    discoveryStartedAt?: Date
+  ): Promise<boolean> {
+    try {
+      const updatedServers = await db
+        .update(mcpServers)
+        .set({
+          connectionStatus: 'disconnected',
+          lastError: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(mcpServers.id, serverId),
+            eq(mcpServers.workspaceId, workspaceId),
+            isNull(mcpServers.deletedAt),
+            discoveryStartedAt
+              ? or(
+                  isNull(mcpServers.lastConnected),
+                  lte(mcpServers.lastConnected, discoveryStartedAt)
+                )
+              : undefined
+          )
+        )
+        .returning({ id: mcpServers.id })
+      return updatedServers.length > 0
+    } catch (error) {
+      logger.warn(`Failed to mark OAuth server ${serverId} disconnected:`, error)
+      return false
     }
   }
 
@@ -429,6 +498,7 @@ class McpService {
     forceRefresh = false
   ): Promise<McpTool[]> {
     const requestId = generateRequestId()
+    const discoveryStartedAt = new Date()
 
     try {
       logger.info(`[${requestId}] Discovering MCP tools for workspace ${workspaceId}`)
@@ -479,15 +549,12 @@ class McpService {
               await client.disconnect()
             }
           } catch (error) {
-            if (
-              error instanceof McpOauthAuthorizationRequiredError ||
-              error instanceof UnauthorizedError
-            ) {
+            if (isOauthAuthorizationError(error, config.authType)) {
               return { kind: 'oauth-pending' }
             }
             return {
               kind: 'error',
-              message: getErrorMessage(error, 'Unknown error'),
+              message: getDiscoveryFailureMessage(error, config.authType, 'Unknown error'),
               originalError: error,
             }
           }
@@ -516,7 +583,10 @@ class McpService {
           fetchedCount++
           allTools.push(...outcome.tools)
           deferredSideEffects.push(
-            this.updateServerStatus(server.id, workspaceId, true, undefined, outcome.tools.length)
+            this.updateServerStatus(server.id, workspaceId, {
+              outcome: 'connected',
+              toolCount: outcome.tools.length,
+            })
           )
           cacheWrites.push(
             this.cacheAdapter
@@ -536,18 +606,9 @@ class McpService {
           // Mark disconnected so the UI surfaces the re-auth button.
           logger.info(`[${requestId}] Skipping server ${server.name}: OAuth authorization pending`)
           deferredSideEffects.push(
-            db
-              .update(mcpServers)
-              .set({
-                connectionStatus: 'disconnected',
-                lastError: null,
-                updatedAt: new Date(),
-              })
-              .where(eq(mcpServers.id, server.id))
-              .then(() => undefined)
-              .catch((err) => {
-                logger.warn(`[${requestId}] Failed to mark server ${server.id} disconnected:`, err)
-              })
+            this.markServerOauthPending(server.id, workspaceId, discoveryStartedAt).then(
+              () => undefined
+            )
           )
           return
         }
@@ -561,13 +622,26 @@ class McpService {
           `[${requestId}] Failed to discover tools from server ${server.name}: ${outcome.message}`
         )
         deferredSideEffects.push(
-          this.updateServerStatus(server.id, workspaceId, false, outcome.message),
-          this.markServerUnhealthy(workspaceId, server.id, outcome.originalError),
-          this.cacheAdapter
-            .delete(serverCacheKey(workspaceId, server.id))
-            .catch((err) =>
-              logger.warn(`[${requestId}] Cache delete failed for ${server.name}:`, err)
-            )
+          this.updateServerStatus(server.id, workspaceId, {
+            outcome: 'failed',
+            error: outcome.message,
+            discoveryStartedAt,
+          }).then(async (statusApplied) => {
+            if (!statusApplied) return
+            await Promise.allSettled([
+              this.markServerUnhealthy(
+                workspaceId,
+                server.id,
+                outcome.originalError,
+                server.authType
+              ),
+              this.cacheAdapter
+                .delete(serverCacheKey(workspaceId, server.id))
+                .catch((err) =>
+                  logger.warn(`[${requestId}] Cache delete failed for ${server.name}:`, err)
+                ),
+            ])
+          })
         )
       })
 
@@ -636,6 +710,7 @@ class McpService {
     forceRefresh: boolean
   ): Promise<McpTool[]> {
     const requestId = generateRequestId()
+    const discoveryStartedAt = new Date()
     const maxRetries = 2
 
     if (!forceRefresh) {
@@ -658,6 +733,7 @@ class McpService {
     }
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
+      let authType: McpServerConfig['authType']
       try {
         logger.info(
           `[${requestId}] Discovering tools from server ${serverId} for user ${userId}${attempt > 0 ? ` (attempt ${attempt + 1})` : ''}`
@@ -667,6 +743,7 @@ class McpService {
         if (!config) {
           throw new Error(`Server ${serverId} not found or not accessible`)
         }
+        authType = config.authType
 
         const { config: resolvedConfig, resolvedIP } = await this.resolveConfigEnvVars(
           config,
@@ -685,7 +762,10 @@ class McpService {
                 logger.warn(`[${requestId}] Cache write failed for ${config.name}:`, err)
               ),
             this.clearServerFailure(workspaceId, serverId),
-            this.updateServerStatus(serverId, workspaceId, true, undefined, tools.length),
+            this.updateServerStatus(serverId, workspaceId, {
+              outcome: 'connected',
+              toolCount: tools.length,
+            }),
           ])
           return tools
         } finally {
@@ -701,14 +781,23 @@ class McpService {
           continue
         }
         // Drop positive cache so a follow-up doesn't return stale tools.
-        await Promise.allSettled([
-          this.cacheAdapter
-            .delete(serverCacheKey(workspaceId, serverId))
-            .catch((err) =>
-              logger.warn(`[${requestId}] Cache delete failed for ${serverId}:`, err)
-            ),
-          this.markServerUnhealthy(workspaceId, serverId, error),
-        ])
+        const statusApplied = isOauthAuthorizationError(error, authType)
+          ? await this.markServerOauthPending(serverId, workspaceId, discoveryStartedAt)
+          : await this.updateServerStatus(serverId, workspaceId, {
+              outcome: 'failed',
+              error: getDiscoveryFailureMessage(error, authType, 'Connection failed'),
+              discoveryStartedAt,
+            })
+        if (statusApplied) {
+          await Promise.allSettled([
+            this.cacheAdapter
+              .delete(serverCacheKey(workspaceId, serverId))
+              .catch((err) =>
+                logger.warn(`[${requestId}] Cache delete failed for ${serverId}:`, err)
+              ),
+            this.markServerUnhealthy(workspaceId, serverId, error, authType),
+          ])
+        }
         throw error
       }
     }
@@ -747,10 +836,7 @@ class McpService {
             error: undefined,
           })
         } catch (error) {
-          if (
-            error instanceof McpOauthAuthorizationRequiredError ||
-            error instanceof UnauthorizedError
-          ) {
+          if (isOauthAuthorizationError(error, config.authType)) {
             summaries.push({
               id: config.id,
               name: config.name,
@@ -771,7 +857,7 @@ class McpService {
             status: 'error',
             toolCount: 0,
             lastSeen: undefined,
-            error: getErrorMessage(error, 'Connection failed'),
+            error: getDiscoveryFailureMessage(error, config.authType, 'Connection failed'),
           })
         }
       }

--- a/apps/sim/lib/mcp/utils.ts
+++ b/apps/sim/lib/mcp/utils.ts
@@ -51,7 +51,10 @@ export function sanitizeHeaders(
 export const MCP_CLIENT_CONSTANTS = {
   CLIENT_TIMEOUT: DEFAULT_EXECUTION_TIMEOUT_MS,
   AUTO_REFRESH_INTERVAL: 5 * 60 * 1000,
-  LIST_TOOLS_TIMEOUT_MS: 10_000,
+  /** Idle timeout for tools/list (gap between progress events); raised from 10s toward the SDK's 60s default. */
+  LIST_TOOLS_TIMEOUT_MS: 30_000,
+  /** Hard ceiling for tools/list regardless of progress (SDK maxTotalTimeout safeguard). */
+  LIST_TOOLS_MAX_TOTAL_TIMEOUT_MS: 60_000,
   FAILURE_CACHE_TTL_MS: 120_000,
 } as const
 

--- a/apps/sim/stores/index.ts
+++ b/apps/sim/stores/index.ts
@@ -12,6 +12,9 @@ import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 const logger = createLogger('Stores')
 
+/** localStorage key for the admin recent-impersonations list; kept through clearUserData. */
+export const RECENT_IMPERSONATIONS_STORAGE_KEY = 'recent-impersonations'
+
 /**
  * Reset all Zustand stores and React Query caches to initial state.
  */
@@ -50,8 +53,7 @@ export async function clearUserData(): Promise<void> {
   try {
     resetAllStores()
 
-    // Clear localStorage except for essential app settings
-    const keysToKeep = ['next-favicon', 'theme']
+    const keysToKeep = ['next-favicon', 'theme', RECENT_IMPERSONATIONS_STORAGE_KEY]
     const keysToRemove = Object.keys(localStorage).filter((key) => !keysToKeep.includes(key))
     keysToRemove.forEach((key) => localStorage.removeItem(key))
 


### PR DESCRIPTION
- **fix(mcp): recover cleanly from OAuth failures (#5595)**
- **feat(admin): show recently impersonated users in admin panel (#5750)**
- **perf(mothership): restore static markdown parse for settled chat messages (#5751)**
- **improvement(mcp): align tool discovery timeouts and retries with MCP protocol standard (#5753)**