### PR TITLE
fix(chat): run block execution state loader

### DIFF
--- a/apps/sim/lib/workflows/executor/execution-state.test.ts
+++ b/apps/sim/lib/workflows/executor/execution-state.test.ts
@@ -148,7 +148,10 @@ describe('execution state lookup', () => {
     )
     mockMaterializeExecutionData
       .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({ executionState: EXECUTION_STATE })
+      .mockImplementationOnce(async (executionData: Record<string, unknown>) => {
+        const { traceStoreRef: _traceStoreRef, ...inlineValues } = executionData
+        return { executionState: EXECUTION_STATE, ...inlineValues }
+      })
 
     const result = await getLatestExecutionStateWithExecutionId('workflow-1')
 
@@ -160,7 +163,6 @@ describe('execution state lookup', () => {
     expect(mockMaterializeExecutionData).toHaveBeenNthCalledWith(
       1,
       {
-        executionState: null,
         traceStoreRef: { id: 'value-2' },
       },
       {

--- a/apps/sim/lib/workflows/executor/execution-state.ts
+++ b/apps/sim/lib/workflows/executor/execution-state.ts
@@ -142,8 +142,12 @@ export async function getLatestExecutionStateWithExecutionId(
       workflowId: row.workflowId,
       workspaceId: row.workspaceId,
       executionData: {
-        executionState: row.executionState,
-        [TRACE_STORE_REF_KEY]: row.traceStoreRef,
+        ...(row.executionState !== null && row.executionState !== undefined
+          ? { executionState: row.executionState }
+          : {}),
+        ...(row.traceStoreRef !== null && row.traceStoreRef !== undefined
+          ? { [TRACE_STORE_REF_KEY]: row.traceStoreRef }
+          : {}),
       },
     })
     if (state) return { executionId: row.executionId, state }


### PR DESCRIPTION
## Summary

Fix cross-turn chat run-from-block by preserving pointer-backed execution state during latest snapshot lookup.


## Type of Change
- [x] Bug fix


## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)