### PR TITLE
fix(mcp): keep a legacy server row from blanking the whole server list

### DIFF
--- a/apps/sim/ee/workspace-forking/lib/copy/copy-resources.ts
+++ b/apps/sim/ee/workspace-forking/lib/copy/copy-resources.ts
@@ -395,6 +395,9 @@ export async function copyForkResourceContainers(
         createdBy: userId,
         url: typeof row.url === 'string' ? rewriteEnv(row.url) : row.url,
         headers,
+        // Normalize legacy `http`/`sse` transports to the only supported value so a
+        // forked row never carries a transport the API contract would reject.
+        transport: 'streamable-http',
         connectionStatus: 'disconnected',
         lastConnected: null,
         lastError: null,

--- a/apps/sim/lib/api/contracts/mcp.ts
+++ b/apps/sim/lib/api/contracts/mcp.ts
@@ -26,7 +26,12 @@ const optionalNumberFromNullableSchema = z.preprocess(
 
 const optionalConnectionStatusFromNullableSchema = z.preprocess(
   (value) => (value === null ? undefined : value),
-  z.enum(['connected', 'disconnected', 'error']).optional()
+  // `connection_status` is a free-text column; tolerate an off-enum value as undefined
+  // rather than failing the whole list's validation.
+  z
+    .enum(['connected', 'disconnected', 'error'])
+    .optional()
+    .catch(undefined)
 )
 
 const optionalHeadersFromNullableSchema = z.preprocess(
@@ -35,6 +40,16 @@ const optionalHeadersFromNullableSchema = z.preprocess(
 )
 
 export const mcpTransportSchema = z.enum(['streamable-http'])
+
+/**
+ * Transport as read back from storage. The `transport` column is free text, and
+ * rows predating the Streamable HTTP consolidation (or copied verbatim by an
+ * older fork) may still hold legacy `http`/`sse` values. Every server is operated
+ * over Streamable HTTP regardless, so any non-canonical value normalizes to the
+ * supported transport — this stops a single legacy row from failing the entire
+ * server list's response validation.
+ */
+const mcpTransportResponseSchema = mcpTransportSchema.catch('streamable-http')
 
 export const mcpAuthTypeSchema = z.enum(['none', 'headers', 'oauth'])
 
@@ -98,8 +113,10 @@ export const mcpServerSchema = z
     workspaceId: z.string(),
     name: z.string(),
     description: optionalStringFromNullableSchema,
-    transport: mcpTransportSchema,
-    authType: mcpAuthTypeSchema.optional(),
+    transport: mcpTransportResponseSchema,
+    // Response-side tolerance: `auth_type` is a free-text column, so a value outside
+    // the enum normalizes to undefined rather than failing the whole list's validation.
+    authType: mcpAuthTypeSchema.optional().catch(undefined),
     url: optionalStringFromNullableSchema,
     timeout: optionalNumberFromNullableSchema,
     retries: optionalNumberFromNullableSchema,

--- a/apps/sim/lib/mcp/orchestration/server-lifecycle.test.ts
+++ b/apps/sim/lib/mcp/orchestration/server-lifecycle.test.ts
@@ -14,13 +14,19 @@ import {
 } from '@sim/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockClearCache, mockOauthCredsChanged, mockRevokeOauthTokens, mockEvictServerConnections } =
-  vi.hoisted(() => ({
-    mockClearCache: vi.fn(),
-    mockOauthCredsChanged: vi.fn(),
-    mockRevokeOauthTokens: vi.fn(),
-    mockEvictServerConnections: vi.fn(),
-  }))
+const {
+  mockClearCache,
+  mockOauthCredsChanged,
+  mockRevokeOauthTokens,
+  mockEvictServerConnections,
+  mockGenerateMcpServerId,
+} = vi.hoisted(() => ({
+  mockClearCache: vi.fn(),
+  mockOauthCredsChanged: vi.fn(),
+  mockRevokeOauthTokens: vi.fn(),
+  mockEvictServerConnections: vi.fn(),
+  mockGenerateMcpServerId: vi.fn(),
+}))
 
 vi.mock('@sim/audit', () => auditMock)
 vi.mock('@sim/db', () => ({
@@ -52,10 +58,11 @@ vi.mock('@/lib/mcp/service', () => ({
     evictServerConnections: mockEvictServerConnections,
   },
 }))
-vi.mock('@/lib/mcp/utils', () => ({ generateMcpServerId: vi.fn() }))
+vi.mock('@/lib/mcp/utils', () => ({ generateMcpServerId: mockGenerateMcpServerId }))
 vi.mock('@/lib/posthog/server', () => posthogServerMock)
 
 import {
+  performCreateMcpServer,
   performDeleteMcpServer,
   performUpdateMcpServer,
 } from '@/lib/mcp/orchestration/server-lifecycle'
@@ -146,6 +153,42 @@ describe('MCP server lifecycle orchestration', () => {
       })
     )
     // ...and revoke the now-orphaned OAuth tokens rather than leaving them stored and valid.
+    expect(mockRevokeOauthTokens).toHaveBeenCalledWith('server-1')
+  })
+
+  it('resets to disconnected when a create/upsert flips an existing OAuth server to headers', async () => {
+    mockGenerateMcpServerId.mockReturnValue('server-1')
+    dbChainMockFns.limit.mockResolvedValueOnce([
+      {
+        id: 'server-1',
+        deletedAt: null,
+        url: 'https://example.com/mcp',
+        authType: 'oauth',
+        oauthClientId: 'client-1',
+        oauthClientSecret: 'secret-1',
+      },
+    ])
+
+    const result = await performCreateMcpServer({
+      workspaceId: 'workspace-1',
+      userId: 'user-1',
+      name: 'Example',
+      url: 'https://example.com/mcp',
+      authType: 'headers',
+    })
+
+    expect(result.success).toBe(true)
+    // Upsert must mirror the update path: an auth-type flip resets to disconnected and clears the
+    // stale error instead of optimistically marking the server connected.
+    expect(dbChainMockFns.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authType: 'headers',
+        connectionStatus: 'disconnected',
+        lastConnected: null,
+        lastError: null,
+      })
+    )
+    // ...and revoke the now-orphaned OAuth tokens.
     expect(mockRevokeOauthTokens).toHaveBeenCalledWith('server-1')
   })
 

--- a/apps/sim/lib/mcp/orchestration/server-lifecycle.ts
+++ b/apps/sim/lib/mcp/orchestration/server-lifecycle.ts
@@ -169,7 +169,10 @@ export async function performCreateMcpServer(
         currentEncryptedClientSecret: existingServer.oauthClientSecret,
       })
       const isRevival = existingServer.deletedAt !== null
-      const shouldClearOauth = urlChanged || credsChanged || isRevival
+      const authTypeChanged = existingServer.authType !== resolvedAuthType
+      // Turning OAuth off orphans its tokens; revoke and delete them, mirroring the update path.
+      const oauthDisabled = existingServer.authType === 'oauth' && resolvedAuthType !== 'oauth'
+      const shouldClearOauth = urlChanged || credsChanged || isRevival || oauthDisabled
 
       if (shouldClearOauth) await revokeMcpOauthTokens(serverId)
 
@@ -191,9 +194,13 @@ export async function performCreateMcpServer(
           deletedAt: null,
         }
         if (resolvedAuthType === 'oauth') {
-          if (shouldClearOauth) {
+          // A flip to OAuth (headers→OAuth carries no tokens to clear) or an OAuth URL/creds
+          // change leaves no valid session: reset to disconnected so the UI shows
+          // "authorization required" instead of a stale connected state until the flow completes.
+          if (authTypeChanged || shouldClearOauth) {
             updateValues.connectionStatus = 'disconnected'
             updateValues.lastConnected = null
+            updateValues.lastError = null
           }
         } else {
           updateValues.connectionStatus = 'connected'

--- a/apps/sim/lib/mcp/orchestration/server-lifecycle.ts
+++ b/apps/sim/lib/mcp/orchestration/server-lifecycle.ts
@@ -193,16 +193,16 @@ export async function performCreateMcpServer(
           updatedAt: new Date(),
           deletedAt: null,
         }
-        if (resolvedAuthType === 'oauth') {
-          // A flip to OAuth (headers→OAuth carries no tokens to clear) or an OAuth URL/creds
-          // change leaves no valid session: reset to disconnected so the UI shows
-          // "authorization required" instead of a stale connected state until the flow completes.
-          if (authTypeChanged || shouldClearOauth) {
-            updateValues.connectionStatus = 'disconnected'
-            updateValues.lastConnected = null
-            updateValues.lastError = null
-          }
-        } else {
+        if (authTypeChanged || (shouldClearOauth && resolvedAuthType === 'oauth')) {
+          // An auth-type flip, or an OAuth URL/creds change, invalidates any prior connection:
+          // reset to disconnected and clear the stale error so the UI never shows
+          // connected-with-error until re-discovery. Mirrors performUpdateMcpServer.
+          updateValues.connectionStatus = 'disconnected'
+          updateValues.lastConnected = null
+          updateValues.lastError = null
+        } else if (resolvedAuthType !== 'oauth') {
+          // A non-OAuth (re-)registration with unchanged auth optimistically marks the server
+          // reachable; discovery corrects it if the endpoint is unhealthy.
           updateValues.connectionStatus = 'connected'
           updateValues.lastConnected = new Date()
         }

--- a/apps/sim/lib/mcp/service.ts
+++ b/apps/sim/lib/mcp/service.ts
@@ -760,11 +760,20 @@ class McpService {
           return
         }
         if (outcome.kind === 'oauth-pending') {
-          // Mark disconnected so the UI surfaces the re-auth button.
+          // Mark disconnected so the UI surfaces the re-auth button, and drop the positive
+          // tool cache so a follow-up force-refresh can't serve tools for a server that now
+          // needs re-auth (mirrors the single-server discovery path).
           logger.info(`[${requestId}] Skipping server ${server.name}: OAuth authorization pending`)
           deferredSideEffects.push(
             this.markServerOauthPending(server.id, workspaceId, discoveryStartedAt).then(
-              () => undefined
+              async (statusApplied) => {
+                if (!statusApplied) return
+                await this.cacheAdapter
+                  .delete(serverCacheKey(workspaceId, server.id))
+                  .catch((err) =>
+                    logger.warn(`[${requestId}] Cache delete failed for ${server.name}:`, err)
+                  )
+              }
             )
           )
           return


### PR DESCRIPTION
## Summary
- The MCP server-list response validated `transport`/`authType`/`connectionStatus` with strict enums, but those are free-text DB columns that can hold legacy values (e.g. `transport` `http`/`sse` from before the streamable-http consolidation). Because the client strict-parses the whole `z.array(...)` with `retry:false`, one off-enum row blanked the entire workspace's MCP list ("Response failed contract validation").
- Found live in prod: 13 active rows (`sse`/`http`) across 11 workspaces. Same class as #5593, which only covered `consecutiveFailures`.
- Fix: response-side `.catch()` tolerance on all three strict-enum-over-free-text columns (request bodies stay strict) — `transport` → `streamable-http`, `authType`/`connectionStatus` → `undefined`. Uses Zod's built-in `.catch()`, matching the existing pattern in `contracts/admin.ts`.
- Stop the workspace-fork copy from propagating legacy `transport` values (the still-active vector that regenerated bad rows).
- Bundled two correctness fixes found in the same MCP audit: create/upsert path now resets connection status on a headers→OAuth flip (mirrors the update path, kills a false "connected" state); bulk discovery now drops the positive tool cache on OAuth-pending (mirrors the single-server path, no stale tools after re-auth).
- Data backfill of the 13 legacy rows handled separately.

## Type of Change
- [x] Bug fix

## Testing
- 149 tests pass across `lib/api/contracts`, `app/api/mcp/servers`, `lib/mcp`, and `ee/workspace-forking`; typecheck, Biome, and `check:api-validation` all clean.
- Runtime-verified: bad response values coerce (no throw), valid values pass through, and create/test request bodies still reject invalid `transport`.

## Follow-up (not in this PR)
- Optional durable hardening: per-row isolation at the list route (drop+log a malformed row) as a backstop for any *future* strict field. The three `.catch()`es close the entire present class, so this is future-proofing only.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)