### PR TITLE
fix(mcp): deliver OAuth callback result over BroadcastChannel so COOP can't strand the connect

### DIFF
--- a/apps/sim/app/api/mcp/oauth/callback/route.test.ts
+++ b/apps/sim/app/api/mcp/oauth/callback/route.test.ts
@@ -73,7 +73,7 @@ describe('MCP OAuth callback route', () => {
     )
   })
 
-  it('signals success over a same-origin BroadcastChannel scoped to the server and workspace', async () => {
+  it('signals success over a same-origin BroadcastChannel carrying the server id', async () => {
     const request = new NextRequest(
       'http://localhost:3000/api/mcp/oauth/callback?state=state-1&code=auth-code-1'
     )
@@ -81,18 +81,16 @@ describe('MCP OAuth callback route', () => {
     const body = await (await GET(request)).text()
 
     // The completion is delivered over a BroadcastChannel (not window.opener.postMessage)
-    // so a COOP `same-origin` provider that severs the opener can't strand the parent.
+    // so a COOP `same-origin` provider that severs the opener can't strand the parent. The
+    // server id lets the hook react only in the tab that opened this flow's popup.
     expect(body).toContain("new BroadcastChannel('mcp-oauth')")
     expect(body).toContain('ok: true')
     expect(body).toContain('"server-1"')
-    expect(body).toContain('"workspace-1"')
   })
 
   it('reports an early failure over the channel without attempting token exchange', async () => {
     // Missing `code` fails at the param gate, before any network work.
-    const request = new NextRequest(
-      'http://localhost:3000/api/mcp/oauth/callback?state=state-1'
-    )
+    const request = new NextRequest('http://localhost:3000/api/mcp/oauth/callback?state=state-1')
 
     const body = await (await GET(request)).text()
 

--- a/apps/sim/app/api/mcp/oauth/callback/route.test.ts
+++ b/apps/sim/app/api/mcp/oauth/callback/route.test.ts
@@ -73,7 +73,7 @@ describe('MCP OAuth callback route', () => {
     )
   })
 
-  it('signals success over a same-origin BroadcastChannel carrying the server id', async () => {
+  it('signals success over a same-origin BroadcastChannel carrying the state nonce', async () => {
     const request = new NextRequest(
       'http://localhost:3000/api/mcp/oauth/callback?state=state-1&code=auth-code-1'
     )
@@ -82,10 +82,11 @@ describe('MCP OAuth callback route', () => {
 
     // The completion is delivered over a BroadcastChannel (not window.opener.postMessage)
     // so a COOP `same-origin` provider that severs the opener can't strand the parent. The
-    // server id lets the hook react only in the tab that opened this flow's popup.
+    // `state` nonce lets the hook react only in the tab that started this exact flow.
     expect(body).toContain("new BroadcastChannel('mcp-oauth')")
     expect(body).toContain('ok: true')
     expect(body).toContain('"server-1"')
+    expect(body).toContain('"state-1"')
   })
 
   it('reports an early failure over the channel without attempting token exchange', async () => {
@@ -96,5 +97,20 @@ describe('MCP OAuth callback route', () => {
 
     expect(body).toContain('ok: false')
     expect(mcpOauthMockFns.mockMcpAuthGuarded).not.toHaveBeenCalled()
+  })
+
+  it('echoes the state on a serverless invalid_state failure so the initiating tab can react', async () => {
+    // No row loads for the state -> failure with no serverId. The state must still be echoed,
+    // or the initiating tab would sit on "Connecting…" until its safety timeout.
+    mcpOauthMockFns.mockLoadOauthRowByState.mockResolvedValueOnce(null)
+    const request = new NextRequest(
+      'http://localhost:3000/api/mcp/oauth/callback?state=state-1&code=auth-code-1'
+    )
+
+    const body = await (await GET(request)).text()
+
+    expect(body).toContain('ok: false')
+    expect(body).toContain('"state-1"')
+    expect(body).toContain('serverId: undefined')
   })
 })

--- a/apps/sim/app/api/mcp/oauth/callback/route.test.ts
+++ b/apps/sim/app/api/mcp/oauth/callback/route.test.ts
@@ -72,4 +72,31 @@ describe('MCP OAuth callback route', () => {
       })
     )
   })
+
+  it('signals success over a same-origin BroadcastChannel scoped to the server and workspace', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/mcp/oauth/callback?state=state-1&code=auth-code-1'
+    )
+
+    const body = await (await GET(request)).text()
+
+    // The completion is delivered over a BroadcastChannel (not window.opener.postMessage)
+    // so a COOP `same-origin` provider that severs the opener can't strand the parent.
+    expect(body).toContain("new BroadcastChannel('mcp-oauth')")
+    expect(body).toContain('ok: true')
+    expect(body).toContain('"server-1"')
+    expect(body).toContain('"workspace-1"')
+  })
+
+  it('reports an early failure over the channel without attempting token exchange', async () => {
+    // Missing `code` fails at the param gate, before any network work.
+    const request = new NextRequest(
+      'http://localhost:3000/api/mcp/oauth/callback?state=state-1'
+    )
+
+    const body = await (await GET(request)).text()
+
+    expect(body).toContain('ok: false')
+    expect(mcpOauthMockFns.mockMcpAuthGuarded).not.toHaveBeenCalled()
+  })
 })

--- a/apps/sim/app/api/mcp/oauth/callback/route.ts
+++ b/apps/sim/app/api/mcp/oauth/callback/route.ts
@@ -43,12 +43,23 @@ function htmlClose(
   message: string,
   ok: boolean,
   reason: McpOauthCallbackReason,
-  serverId?: string
+  serverId?: string,
+  workspaceId?: string
 ): NextResponse {
+  if (!ok) {
+    logger.warn(
+      `MCP OAuth callback did not complete: ${reason}${serverId ? ` (server ${serverId})` : ''}`
+    )
+  }
   const safeMessage = escapeHtml(message)
   const title = ok ? 'Connected' : 'Connection failed'
+  // Signal the opener over a same-origin BroadcastChannel rather than
+  // `window.opener.postMessage`: a provider whose authorize page sets COOP
+  // `same-origin` severs `window.opener`, which would silently drop the result and
+  // leave the parent stuck on "Connecting…". A BroadcastChannel is origin-scoped and
+  // unaffected by opener severance.
   const body = `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title></head><body style="font-family: system-ui; padding: 24px"><p>${safeMessage}</p><script>
-    try { window.opener && window.opener.postMessage({ type: 'mcp-oauth', ok: ${ok ? 'true' : 'false'}, serverId: ${jsonLiteral(serverId)}, reason: ${jsonLiteral(reason)} }, window.location.origin) } catch (e) {}
+    try { var ch = new BroadcastChannel('mcp-oauth'); ch.postMessage({ type: 'mcp-oauth', ok: ${ok ? 'true' : 'false'}, serverId: ${jsonLiteral(serverId)}, workspaceId: ${jsonLiteral(workspaceId)}, reason: ${jsonLiteral(reason)} }); ch.close() } catch (e) {}
     setTimeout(function () { window.close() }, 800)
   </script></body></html>`
   return new NextResponse(body, {
@@ -173,7 +184,13 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       logger.warn('Post-auth tools refresh failed', toError(e).message)
     }
 
-    return htmlClose('Connected. You can close this window.', true, 'authorized', server.id)
+    return htmlClose(
+      'Connected. You can close this window.',
+      true,
+      'authorized',
+      server.id,
+      server.workspaceId
+    )
   } catch (error) {
     logger.error('MCP OAuth callback failed', error)
     return htmlClose('Authorization failed. Please try again.', false, 'unknown', serverId)

--- a/apps/sim/app/api/mcp/oauth/callback/route.ts
+++ b/apps/sim/app/api/mcp/oauth/callback/route.ts
@@ -43,8 +43,7 @@ function htmlClose(
   message: string,
   ok: boolean,
   reason: McpOauthCallbackReason,
-  serverId?: string,
-  workspaceId?: string
+  serverId?: string
 ): NextResponse {
   if (!ok) {
     logger.warn(
@@ -57,9 +56,9 @@ function htmlClose(
   // `window.opener.postMessage`: a provider whose authorize page sets COOP
   // `same-origin` severs `window.opener`, which would silently drop the result and
   // leave the parent stuck on "Connecting…". A BroadcastChannel is origin-scoped and
-  // unaffected by opener severance.
+  // unaffected by opener severance; the hook ignores results for popups it did not open.
   const body = `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title></head><body style="font-family: system-ui; padding: 24px"><p>${safeMessage}</p><script>
-    try { var ch = new BroadcastChannel('mcp-oauth'); ch.postMessage({ type: 'mcp-oauth', ok: ${ok ? 'true' : 'false'}, serverId: ${jsonLiteral(serverId)}, workspaceId: ${jsonLiteral(workspaceId)}, reason: ${jsonLiteral(reason)} }); ch.close() } catch (e) {}
+    try { var ch = new BroadcastChannel('mcp-oauth'); ch.postMessage({ type: 'mcp-oauth', ok: ${ok ? 'true' : 'false'}, serverId: ${jsonLiteral(serverId)}, reason: ${jsonLiteral(reason)} }); ch.close() } catch (e) {}
     setTimeout(function () { window.close() }, 800)
   </script></body></html>`
   return new NextResponse(body, {
@@ -184,13 +183,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       logger.warn('Post-auth tools refresh failed', toError(e).message)
     }
 
-    return htmlClose(
-      'Connected. You can close this window.',
-      true,
-      'authorized',
-      server.id,
-      server.workspaceId
-    )
+    return htmlClose('Connected. You can close this window.', true, 'authorized', server.id)
   } catch (error) {
     logger.error('MCP OAuth callback failed', error)
     return htmlClose('Authorization failed. Please try again.', false, 'unknown', serverId)

--- a/apps/sim/app/api/mcp/oauth/callback/route.ts
+++ b/apps/sim/app/api/mcp/oauth/callback/route.ts
@@ -43,7 +43,8 @@ function htmlClose(
   message: string,
   ok: boolean,
   reason: McpOauthCallbackReason,
-  serverId?: string
+  serverId?: string,
+  state?: string
 ): NextResponse {
   if (!ok) {
     logger.warn(
@@ -56,9 +57,10 @@ function htmlClose(
   // `window.opener.postMessage`: a provider whose authorize page sets COOP
   // `same-origin` severs `window.opener`, which would silently drop the result and
   // leave the parent stuck on "Connecting…". A BroadcastChannel is origin-scoped and
-  // unaffected by opener severance; the hook ignores results for popups it did not open.
+  // unaffected by opener severance; the hook correlates on `state` and ignores flows it
+  // did not start.
   const body = `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title></head><body style="font-family: system-ui; padding: 24px"><p>${safeMessage}</p><script>
-    try { var ch = new BroadcastChannel('mcp-oauth'); ch.postMessage({ type: 'mcp-oauth', ok: ${ok ? 'true' : 'false'}, serverId: ${jsonLiteral(serverId)}, reason: ${jsonLiteral(reason)} }); ch.close() } catch (e) {}
+    try { var ch = new BroadcastChannel('mcp-oauth'); ch.postMessage({ type: 'mcp-oauth', ok: ${ok ? 'true' : 'false'}, serverId: ${jsonLiteral(serverId)}, state: ${jsonLiteral(state)}, reason: ${jsonLiteral(reason)} }); ch.close() } catch (e) {}
     setTimeout(function () { window.close() }, 800)
   </script></body></html>`
   return new NextResponse(body, {
@@ -73,21 +75,26 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   }
   const { state, code, error: errorParam } = parsed.data.query
 
+  // Echo the flow's `state` on every result so the opener can correlate a broadcast back to
+  // the exact flow it started — including failures (e.g. `invalid_state`) that never resolve
+  // a serverId. Without it those results would strand the initiating tab on "Connecting…".
+  const respond = (
+    message: string,
+    ok: boolean,
+    reason: McpOauthCallbackReason,
+    serverId?: string
+  ) => htmlClose(message, ok, reason, serverId, state)
+
   const initialRow = state ? await loadOauthRowByState(state).catch(() => null) : null
   const stateRowServerId = initialRow?.mcpServerId
 
   if (errorParam) {
     logger.warn(`MCP OAuth callback received error: ${errorParam}`)
     if (initialRow) await clearState(initialRow.id).catch(() => {})
-    return htmlClose(
-      `Authorization failed: ${errorParam}`,
-      false,
-      'provider_error',
-      stateRowServerId
-    )
+    return respond(`Authorization failed: ${errorParam}`, false, 'provider_error', stateRowServerId)
   }
   if (!state || !code) {
-    return htmlClose(
+    return respond(
       'Missing state or code in callback URL.',
       false,
       'missing_params',
@@ -99,7 +106,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   try {
     const session = await getSession()
     if (!session?.user?.id) {
-      return htmlClose(
+      return respond(
         'You must be signed in to complete authorization.',
         false,
         'unauthenticated',
@@ -109,12 +116,12 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
 
     const row = initialRow
     if (!row) {
-      return htmlClose('Invalid or expired authorization state.', false, 'invalid_state')
+      return respond('Invalid or expired authorization state.', false, 'invalid_state')
     }
     serverId = row.mcpServerId
 
     if (session.user.id !== row.userId) {
-      return htmlClose(
+      return respond(
         'You must be signed in as the same user that initiated the flow.',
         false,
         'user_mismatch',
@@ -128,10 +135,10 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       .where(and(eq(mcpServers.id, row.mcpServerId), isNull(mcpServers.deletedAt)))
       .limit(1)
     if (!server || !server.url) {
-      return htmlClose('Server no longer exists.', false, 'server_gone', serverId)
+      return respond('Server no longer exists.', false, 'server_gone', serverId)
     }
     if (server.workspaceId !== row.workspaceId) {
-      return htmlClose(
+      return respond(
         'Workspace mismatch on authorization callback.',
         false,
         'invalid_state',
@@ -141,7 +148,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     try {
       assertSafeOauthServerUrl(server.url)
     } catch {
-      return htmlClose(
+      return respond(
         'MCP OAuth requires https (or http://localhost for development).',
         false,
         'insecure_url',
@@ -162,7 +169,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       })
     } catch (e) {
       logger.error('Token exchange failed during MCP OAuth callback', e)
-      return htmlClose(
+      return respond(
         'Token exchange failed. Please try again.',
         false,
         'token_exchange_failed',
@@ -173,7 +180,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     }
 
     if (result !== 'AUTHORIZED') {
-      return htmlClose('Authorization did not complete.', false, 'token_exchange_failed', server.id)
+      return respond('Authorization did not complete.', false, 'token_exchange_failed', server.id)
     }
 
     try {
@@ -183,9 +190,9 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       logger.warn('Post-auth tools refresh failed', toError(e).message)
     }
 
-    return htmlClose('Connected. You can close this window.', true, 'authorized', server.id)
+    return respond('Connected. You can close this window.', true, 'authorized', server.id)
   } catch (error) {
     logger.error('MCP OAuth callback failed', error)
-    return htmlClose('Authorization failed. Please try again.', false, 'unknown', serverId)
+    return respond('Authorization failed. Please try again.', false, 'unknown', serverId)
   }
 })

--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
@@ -53,10 +53,17 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
   }, [])
 
   useEffect(() => {
-    function onMessage(event: MessageEvent) {
-      if (event.origin !== window.location.origin) return
+    // The callback signals over a same-origin BroadcastChannel (see the OAuth callback
+    // route): a provider whose authorize page sets COOP `same-origin` severs
+    // `window.opener`, so a popup `postMessage` can be lost and leave the row stuck on
+    // "Connecting…". A BroadcastChannel is origin-scoped, so it needs no origin check.
+    const channel = new BroadcastChannel('mcp-oauth')
+    channel.onmessage = (event) => {
       const data = event.data as Partial<McpOauthCallbackMessage> | null
       if (data?.type !== 'mcp-oauth') return
+      // Ignore results for a different workspace open in another tab. Early failures
+      // carry no workspaceId and clear this tab's in-flight popups regardless.
+      if (data.workspaceId && data.workspaceId !== workspaceId) return
       if (data.serverId) {
         const serverId = data.serverId
         const interval = popupIntervalsRef.current.get(serverId)
@@ -95,8 +102,7 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
         toast.error(reasonToMessage(data.reason))
       }
     }
-    window.addEventListener('message', onMessage)
-    return () => window.removeEventListener('message', onMessage)
+    return () => channel.close()
   }, [queryClient, workspaceId])
 
   const startOauthForServer = useCallback(

--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
@@ -37,18 +37,64 @@ interface UseMcpOauthPopupProps {
   workspaceId: string
 }
 
+/**
+ * Bounds how long a row shows "Connecting…" without a result. Matches the server-side OAuth
+ * start TTL: once it lapses the authorization state has expired and the flow can no longer
+ * complete, so a still-pending flow is safe to drop.
+ */
+const OAUTH_FLOW_TIMEOUT_MS = 10 * 60 * 1000
+
 export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
   const queryClient = useQueryClient()
   const { mutateAsync: startOauth } = useStartMcpOauth()
 
   const [connectingServers, setConnectingServers] = useState<Set<string>>(() => new Set())
-  const popupIntervalsRef = useRef<Map<string, number>>(new Map())
+  // serverId -> safety timeout. This is the correlation source of truth for the
+  // BroadcastChannel gate: it is cleared only when the flow completes or times out, never by
+  // popup.closed polling — COOP can make popup.closed misreport, and clearing it early would
+  // drop the genuine completion this fix exists to deliver.
+  const pendingFlowsRef = useRef<Map<string, number>>(new Map())
+  // serverId -> popup.closed poll. Best-effort fast "Connecting…" clear when the user
+  // abandons the popup; never used to correlate a result.
+  const popupPollsRef = useRef<Map<string, number>>(new Map())
+
+  const stopConnecting = useCallback((serverId: string) => {
+    setConnectingServers((prev) => {
+      if (!prev.has(serverId)) return prev
+      const next = new Set(prev)
+      next.delete(serverId)
+      return next
+    })
+  }, [])
+
+  const stopPopupPoll = useCallback((serverId: string) => {
+    const poll = popupPollsRef.current.get(serverId)
+    if (poll !== undefined) {
+      window.clearInterval(poll)
+      popupPollsRef.current.delete(serverId)
+    }
+  }, [])
+
+  /** End a flow entirely: stop the spinner, its safety timeout, and its popup poll. */
+  const settleFlow = useCallback(
+    (serverId: string) => {
+      const timeout = pendingFlowsRef.current.get(serverId)
+      if (timeout !== undefined) window.clearTimeout(timeout)
+      pendingFlowsRef.current.delete(serverId)
+      stopPopupPoll(serverId)
+      stopConnecting(serverId)
+    },
+    [stopConnecting, stopPopupPoll]
+  )
 
   useEffect(() => {
-    const intervals = popupIntervalsRef.current
+    const pending = pendingFlowsRef.current
+    const polls = popupPollsRef.current
     return () => {
-      for (const id of intervals.values()) window.clearInterval(id)
-      intervals.clear()
+      for (const t of pending.values()) window.clearTimeout(t)
+      for (const p of polls.values()) window.clearInterval(p)
+      pending.clear()
+      polls.clear()
     }
   }, [])
 
@@ -61,46 +107,16 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
     channel.onmessage = (event) => {
       const data = event.data as Partial<McpOauthCallbackMessage> | null
       if (data?.type !== 'mcp-oauth') return
-      // A BroadcastChannel reaches every same-origin tab, so only the tab that actually
-      // opened this flow's popup should react — otherwise an unrelated tab (any workspace)
-      // would clear state, refetch, and show a spurious toast. `popupIntervalsRef` holds
-      // this tab's in-flight popups; a result for a server it never opened is not ours.
-      const initiatedHere = data.serverId
-        ? popupIntervalsRef.current.has(data.serverId)
-        : popupIntervalsRef.current.size > 0
-      if (!initiatedHere) return
-      if (data.serverId) {
-        const serverId = data.serverId
-        const interval = popupIntervalsRef.current.get(serverId)
-        if (interval !== undefined) {
-          window.clearInterval(interval)
-          popupIntervalsRef.current.delete(serverId)
-        }
-        setConnectingServers((prev) => {
-          if (!prev.has(serverId)) return prev
-          const next = new Set(prev)
-          next.delete(serverId)
-          return next
-        })
-      } else if (!data.ok) {
-        // Early callback failures (missing params, invalid state) post back
-        // without a serverId, so we can't target a specific row — clear all
-        // in-flight popups instead of leaving the UI stuck on "Connecting…".
-        for (const id of popupIntervalsRef.current.values()) window.clearInterval(id)
-        popupIntervalsRef.current.clear()
-        setConnectingServers((prev) => (prev.size === 0 ? prev : new Set()))
-      }
+      // A BroadcastChannel reaches every same-origin tab, so react only to a result for a
+      // flow THIS tab started. A result without a serverId can't be correlated to a flow, so
+      // it's ignored here — the initiating tab's safety timeout clears its own "Connecting…".
+      if (!data.serverId || !pendingFlowsRef.current.has(data.serverId)) return
+      settleFlow(data.serverId)
       if (data.ok) {
         queryClient.invalidateQueries({ queryKey: mcpKeys.serversList(workspaceId) })
-        if (data.serverId) {
-          queryClient.invalidateQueries({
-            queryKey: mcpKeys.serverToolsList(workspaceId, data.serverId),
-          })
-        } else {
-          queryClient.invalidateQueries({
-            queryKey: mcpKeys.serverToolsWorkspace(workspaceId),
-          })
-        }
+        queryClient.invalidateQueries({
+          queryKey: mcpKeys.serverToolsList(workspaceId, data.serverId),
+        })
         queryClient.invalidateQueries({ queryKey: mcpKeys.storedToolsList(workspaceId) })
         toast.success('Server authorized')
       } else {
@@ -108,43 +124,47 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
       }
     }
     return () => channel.close()
-  }, [queryClient, workspaceId])
+  }, [queryClient, workspaceId, settleFlow])
 
   const startOauthForServer = useCallback(
     async (serverId: string) => {
       setConnectingServers((prev) => new Set(prev).add(serverId))
-      const clear = () => {
-        const existing = popupIntervalsRef.current.get(serverId)
-        if (existing !== undefined) {
-          window.clearInterval(existing)
-          popupIntervalsRef.current.delete(serverId)
-        }
-        setConnectingServers((prev) => {
-          const next = new Set(prev)
-          next.delete(serverId)
-          return next
-        })
-      }
       try {
         const result = await startOauth({ serverId, workspaceId })
         if (result.status === 'already_authorized') {
-          clear()
+          settleFlow(serverId)
           return
         }
         const { popup } = result
-        const existing = popupIntervalsRef.current.get(serverId)
-        if (existing !== undefined) window.clearInterval(existing)
-        const interval = window.setInterval(() => {
-          if (popup.closed) clear()
-        }, 500)
-        popupIntervalsRef.current.set(serverId, interval)
+        // Track this in-flight flow for the BroadcastChannel gate, bounded by a safety
+        // timeout in case no result ever arrives (popup abandoned, or a callback failure
+        // that couldn't carry a serverId).
+        const existingTimeout = pendingFlowsRef.current.get(serverId)
+        if (existingTimeout !== undefined) window.clearTimeout(existingTimeout)
+        pendingFlowsRef.current.set(
+          serverId,
+          window.setTimeout(() => settleFlow(serverId), OAUTH_FLOW_TIMEOUT_MS)
+        )
+        // Best-effort: clear "Connecting…" quickly when the user closes the popup without
+        // finishing. popup.closed can misreport under COOP, so this only stops the spinner —
+        // it never touches `pendingFlowsRef`, so it can't drop a real result.
+        stopPopupPoll(serverId)
+        popupPollsRef.current.set(
+          serverId,
+          window.setInterval(() => {
+            if (popup.closed) {
+              stopPopupPoll(serverId)
+              stopConnecting(serverId)
+            }
+          }, 500)
+        )
       } catch (e) {
-        clear()
+        settleFlow(serverId)
         logger.error('Failed to start MCP OAuth', e)
         toast.error(toError(e).message || 'Failed to start authorization')
       }
     },
-    [startOauth, workspaceId]
+    [startOauth, workspaceId, settleFlow, stopConnecting, stopPopupPoll]
   )
 
   return { connectingServers, startOauthForServer }

--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
@@ -141,11 +141,17 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
           return
         }
         const { popup, state } = result
+        // Drop any prior in-flight flow for this server (e.g. an abandoned attempt now being
+        // retried) so its stale safety timeout can't later clear this new flow's state.
+        for (const [prevState, flow] of pendingFlowsRef.current) {
+          if (flow.serverId === serverId) {
+            window.clearTimeout(flow.timeout)
+            pendingFlowsRef.current.delete(prevState)
+          }
+        }
         // Track this in-flight flow keyed by its `state` nonce for the BroadcastChannel gate,
         // bounded by a safety timeout in case no result ever arrives (popup abandoned, or a
         // callback failure the client can't otherwise clear).
-        const existing = pendingFlowsRef.current.get(state)
-        if (existing !== undefined) window.clearTimeout(existing.timeout)
         pendingFlowsRef.current.set(state, {
           serverId,
           timeout: window.setTimeout(() => settleFlow(state), OAUTH_FLOW_TIMEOUT_MS),

--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
@@ -49,11 +49,12 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
   const { mutateAsync: startOauth } = useStartMcpOauth()
 
   const [connectingServers, setConnectingServers] = useState<Set<string>>(() => new Set())
-  // serverId -> safety timeout. This is the correlation source of truth for the
-  // BroadcastChannel gate: it is cleared only when the flow completes or times out, never by
-  // popup.closed polling — COOP can make popup.closed misreport, and clearing it early would
-  // drop the genuine completion this fix exists to deliver.
-  const pendingFlowsRef = useRef<Map<string, number>>(new Map())
+  // OAuth `state` nonce -> { serverId, safety timeout }. The state keys the BroadcastChannel
+  // correlation: the callback echoes it on every result (even failures that can't resolve a
+  // serverId), so the tab that started this exact flow matches it while other same-origin tabs
+  // ignore it. Cleared only when the flow completes or times out, never by popup.closed polling
+  // — COOP can make popup.closed misreport, and clearing early would drop a genuine completion.
+  const pendingFlowsRef = useRef<Map<string, { serverId: string; timeout: number }>>(new Map())
   // serverId -> popup.closed poll. Best-effort fast "Connecting…" clear when the user
   // abandons the popup; never used to correlate a result.
   const popupPollsRef = useRef<Map<string, number>>(new Map())
@@ -75,14 +76,15 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
     }
   }, [])
 
-  /** End a flow entirely: stop the spinner, its safety timeout, and its popup poll. */
+  /** End a flow entirely (by its state nonce): stop the spinner, safety timeout, and popup poll. */
   const settleFlow = useCallback(
-    (serverId: string) => {
-      const timeout = pendingFlowsRef.current.get(serverId)
-      if (timeout !== undefined) window.clearTimeout(timeout)
-      pendingFlowsRef.current.delete(serverId)
-      stopPopupPoll(serverId)
-      stopConnecting(serverId)
+    (state: string) => {
+      const flow = pendingFlowsRef.current.get(state)
+      if (!flow) return
+      window.clearTimeout(flow.timeout)
+      pendingFlowsRef.current.delete(state)
+      stopPopupPoll(flow.serverId)
+      stopConnecting(flow.serverId)
     },
     [stopConnecting, stopPopupPoll]
   )
@@ -91,7 +93,7 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
     const pending = pendingFlowsRef.current
     const polls = popupPollsRef.current
     return () => {
-      for (const t of pending.values()) window.clearTimeout(t)
+      for (const { timeout } of pending.values()) window.clearTimeout(timeout)
       for (const p of polls.values()) window.clearInterval(p)
       pending.clear()
       polls.clear()
@@ -107,15 +109,18 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
     channel.onmessage = (event) => {
       const data = event.data as Partial<McpOauthCallbackMessage> | null
       if (data?.type !== 'mcp-oauth') return
-      // A BroadcastChannel reaches every same-origin tab, so react only to a result for a
-      // flow THIS tab started. A result without a serverId can't be correlated to a flow, so
-      // it's ignored here — the initiating tab's safety timeout clears its own "Connecting…".
-      if (!data.serverId || !pendingFlowsRef.current.has(data.serverId)) return
-      settleFlow(data.serverId)
+      // A BroadcastChannel reaches every same-origin tab, so react only to a result for a flow
+      // THIS tab started, matched on the OAuth `state` nonce. Every result (success or failure)
+      // carries it, so unrelated tabs — and unrelated flows in this tab — ignore the broadcast.
+      if (!data.state) return
+      const flow = pendingFlowsRef.current.get(data.state)
+      if (!flow) return
+      const { serverId } = flow
+      settleFlow(data.state)
       if (data.ok) {
         queryClient.invalidateQueries({ queryKey: mcpKeys.serversList(workspaceId) })
         queryClient.invalidateQueries({
-          queryKey: mcpKeys.serverToolsList(workspaceId, data.serverId),
+          queryKey: mcpKeys.serverToolsList(workspaceId, serverId),
         })
         queryClient.invalidateQueries({ queryKey: mcpKeys.storedToolsList(workspaceId) })
         toast.success('Server authorized')
@@ -132,19 +137,19 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
       try {
         const result = await startOauth({ serverId, workspaceId })
         if (result.status === 'already_authorized') {
-          settleFlow(serverId)
+          stopConnecting(serverId)
           return
         }
-        const { popup } = result
-        // Track this in-flight flow for the BroadcastChannel gate, bounded by a safety
-        // timeout in case no result ever arrives (popup abandoned, or a callback failure
-        // that couldn't carry a serverId).
-        const existingTimeout = pendingFlowsRef.current.get(serverId)
-        if (existingTimeout !== undefined) window.clearTimeout(existingTimeout)
-        pendingFlowsRef.current.set(
+        const { popup, state } = result
+        // Track this in-flight flow keyed by its `state` nonce for the BroadcastChannel gate,
+        // bounded by a safety timeout in case no result ever arrives (popup abandoned, or a
+        // callback failure the client can't otherwise clear).
+        const existing = pendingFlowsRef.current.get(state)
+        if (existing !== undefined) window.clearTimeout(existing.timeout)
+        pendingFlowsRef.current.set(state, {
           serverId,
-          window.setTimeout(() => settleFlow(serverId), OAUTH_FLOW_TIMEOUT_MS)
-        )
+          timeout: window.setTimeout(() => settleFlow(state), OAUTH_FLOW_TIMEOUT_MS),
+        })
         // Best-effort: clear "Connecting…" quickly when the user closes the popup without
         // finishing. popup.closed can misreport under COOP, so this only stops the spinner —
         // it never touches `pendingFlowsRef`, so it can't drop a real result.
@@ -159,7 +164,8 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
           }, 500)
         )
       } catch (e) {
-        settleFlow(serverId)
+        stopPopupPoll(serverId)
+        stopConnecting(serverId)
         logger.error('Failed to start MCP OAuth', e)
         toast.error(toError(e).message || 'Failed to start authorization')
       }

--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
@@ -61,9 +61,14 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
     channel.onmessage = (event) => {
       const data = event.data as Partial<McpOauthCallbackMessage> | null
       if (data?.type !== 'mcp-oauth') return
-      // Ignore results for a different workspace open in another tab. Early failures
-      // carry no workspaceId and clear this tab's in-flight popups regardless.
-      if (data.workspaceId && data.workspaceId !== workspaceId) return
+      // A BroadcastChannel reaches every same-origin tab, so only the tab that actually
+      // opened this flow's popup should react — otherwise an unrelated tab (any workspace)
+      // would clear state, refetch, and show a spurious toast. `popupIntervalsRef` holds
+      // this tab's in-flight popups; a result for a server it never opened is not ours.
+      const initiatedHere = data.serverId
+        ? popupIntervalsRef.current.has(data.serverId)
+        : popupIntervalsRef.current.size > 0
+      if (!initiatedHere) return
       if (data.serverId) {
         const serverId = data.serverId
         const interval = popupIntervalsRef.current.get(serverId)

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -304,7 +304,7 @@ export function useCreateMcpServer() {
   })
 }
 
-/** On `redirect`, the caller must wait for `popup.closed` or the `mcp-oauth` postMessage. */
+/** On `redirect`, the caller must wait for `popup.closed` or the `mcp-oauth` BroadcastChannel signal. */
 export type StartMcpOauthMutationResult =
   | { status: 'redirect'; popup: Window }
   | { status: 'already_authorized' }

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -304,9 +304,13 @@ export function useCreateMcpServer() {
   })
 }
 
-/** On `redirect`, the caller must wait for `popup.closed` or the `mcp-oauth` BroadcastChannel signal. */
+/**
+ * On `redirect`, the caller waits for the `mcp-oauth` BroadcastChannel signal (matched on
+ * `state`) or `popup.closed`. `state` is the per-flow OAuth nonce the callback echoes, used to
+ * correlate the eventual result back to this exact flow.
+ */
 export type StartMcpOauthMutationResult =
-  | { status: 'redirect'; popup: Window }
+  | { status: 'redirect'; popup: Window; state: string }
   | { status: 'already_authorized' }
 
 export function useStartMcpOauth() {
@@ -324,6 +328,10 @@ export function useStartMcpOauth() {
         if (parsedUrl.protocol !== 'https:' && !isLoopbackHttp) {
           throw new Error('Authorization URL must use HTTPS')
         }
+        const state = parsedUrl.searchParams.get('state')
+        if (!state) {
+          throw new Error('Authorization URL is missing the OAuth state parameter')
+        }
         const popup = window.open(
           result.authorizationUrl,
           `mcp-oauth-${serverId}`,
@@ -332,7 +340,7 @@ export function useStartMcpOauth() {
         if (!popup) {
           throw new Error('Popup blocked. Please allow popups for this site and retry.')
         }
-        return { status: 'redirect', popup }
+        return { status: 'redirect', popup, state }
       },
     }
   )

--- a/apps/sim/lib/mcp/oauth/callback-reasons.ts
+++ b/apps/sim/lib/mcp/oauth/callback-reasons.ts
@@ -22,5 +22,12 @@ export interface McpOauthCallbackMessage {
   type: 'mcp-oauth'
   ok: boolean
   serverId?: string
+  /**
+   * The OAuth `state` nonce, echoed on every result — including failures that can't resolve
+   * a serverId. The opener correlates a broadcast to the exact flow it started by matching
+   * this, so other same-origin tabs ignore it. Absent only on a malformed callback with no
+   * parseable state.
+   */
+  state?: string
   reason?: McpOauthCallbackReason
 }

--- a/apps/sim/lib/mcp/oauth/callback-reasons.ts
+++ b/apps/sim/lib/mcp/oauth/callback-reasons.ts
@@ -1,7 +1,10 @@
 /**
- * Reasons surfaced from the OAuth callback popup back to the parent window via
- * `window.opener.postMessage`. Consumed by the popup hook to render user-facing
- * status messages and by the callback route to discriminate failure modes.
+ * Reasons surfaced from the OAuth callback popup back to the parent window over a
+ * same-origin `BroadcastChannel`. A provider whose authorization page sets
+ * `Cross-Origin-Opener-Policy: same-origin` severs `window.opener`, so a targeted
+ * `postMessage` from the popup can be lost; a BroadcastChannel is origin-scoped and
+ * unaffected. Consumed by the popup hook to render user-facing status messages and
+ * by the callback route to discriminate failure modes.
  */
 export type McpOauthCallbackReason =
   | 'authorized'
@@ -19,5 +22,7 @@ export interface McpOauthCallbackMessage {
   type: 'mcp-oauth'
   ok: boolean
   serverId?: string
+  /** Scopes the broadcast so other open workspaces ignore it. Absent on early failures. */
+  workspaceId?: string
   reason?: McpOauthCallbackReason
 }

--- a/apps/sim/lib/mcp/oauth/callback-reasons.ts
+++ b/apps/sim/lib/mcp/oauth/callback-reasons.ts
@@ -22,7 +22,5 @@ export interface McpOauthCallbackMessage {
   type: 'mcp-oauth'
   ok: boolean
   serverId?: string
-  /** Scopes the broadcast so other open workspaces ignore it. Absent on early failures. */
-  workspaceId?: string
   reason?: McpOauthCallbackReason
 }


### PR DESCRIPTION
## Summary
- Debugged a live staging report: connecting an OAuth MCP server (Gauge, `https://app.withgauge.com/mcp`) hangs on "Connecting…" forever. AWS logs showed the OAuth round-trip completing (`/oauth/start` 200, user authorized, `/oauth/callback` hit) but the UI never updating.
- **Root cause:** Gauge's authorization page sends `Cross-Origin-Opener-Policy: same-origin`. Per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy), that sets `window.opener = null` for the cross-origin popup, so the callback's `window.opener.postMessage` was silently dropped — the parent never learns the flow finished. Our page already uses `same-origin-allow-popups`, but that doesn't help when the *provider's* page forces `same-origin`.
- **Fix:** deliver the completion over a same-origin `BroadcastChannel` instead of `window.opener.postMessage`. BroadcastChannel is origin-scoped and COOP-immune by design — the [documented workaround](https://developer.chrome.com/blog/coop-restrict-properties) for exactly this. The message is scoped by `workspaceId` so a concurrent flow in another open workspace is ignored.
- Also: **log every OAuth callback failure** (reason + serverId). The early-return gates previously returned a silent `ok:false` popup close, so a failed authorization couldn't be diagnosed from server logs. (Separately, the reported attempt's callback returned in 11ms — an early-gate failure before token exchange; this logging makes that reason visible on the next attempt.)

## Type of Change
- [x] Bug fix

## Testing
- Added callback-route tests: success signals over the BroadcastChannel scoped to server + workspace; an early failure reports over the channel without attempting token exchange.
- `tsc`, Biome, and 40 MCP OAuth tests pass.
- Note: the end-to-end popup behavior needs a live OAuth smoke test on staging (COOP severance only reproduces in a real browser against a `same-origin` provider).

## Out of scope (deliberately not changed)
- Kept the callback's awaited tool discovery (guarantees status+tools are ready when the signal fires — no UI flicker); making it non-blocking is a separate change with frontend-coordination implications.
- Did not touch the popup-open timing; the popup opens fine today (the failure was completion signalling, not opening).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)