### PR TITLE
improvement(mcp): trace OAuth state writes to diagnose invalid_state clobber

### DIFF
--- a/apps/sim/app/api/mcp/oauth/callback/route.ts
+++ b/apps/sim/app/api/mcp/oauth/callback/route.ts
@@ -90,7 +90,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
 
   if (errorParam) {
     logger.warn(`MCP OAuth callback received error: ${errorParam}`)
-    if (initialRow) await clearState(initialRow.id).catch(() => {})
+    if (initialRow) await clearState(initialRow.id, 'callback:provider_error').catch(() => {})
     return respond(`Authorization failed: ${errorParam}`, false, 'provider_error', stateRowServerId)
   }
   if (!state || !code) {
@@ -157,7 +157,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     }
 
     // Burn state before token exchange so a replayed callback cannot reuse it.
-    await clearState(row.id)
+    await clearState(row.id, 'callback:burn-before-exchange')
 
     const preregistered = await loadPreregisteredClient(server.id)
     const provider = new SimMcpOauthProvider({ row, preregistered })

--- a/apps/sim/lib/mcp/oauth/provider.ts
+++ b/apps/sim/lib/mcp/oauth/provider.ts
@@ -77,7 +77,7 @@ export class SimMcpOauthProvider implements OAuthClientProvider {
 
   async state(): Promise<string> {
     const state = generateId()
-    await saveState(this.row.id, state)
+    await saveState(this.row.id, state, 'provider.state')
     return state
   }
 
@@ -140,7 +140,7 @@ export class SimMcpOauthProvider implements OAuthClientProvider {
     }
     if (scope === 'all' || scope === 'verifier') {
       await clearVerifier(this.row.id)
-      await clearState(this.row.id)
+      await clearState(this.row.id, `invalidateCredentials:${scope}`)
       this.row.codeVerifier = null
     }
   }

--- a/apps/sim/lib/mcp/oauth/storage.ts
+++ b/apps/sim/lib/mcp/oauth/storage.ts
@@ -192,12 +192,13 @@ export async function saveCodeVerifier(rowId: string, verifier: string): Promise
     .where(eq(mcpServerOauth.id, rowId))
 }
 
-export async function saveState(rowId: string, state: string): Promise<void> {
+export async function saveState(rowId: string, state: string, context = 'unknown'): Promise<void> {
   const now = new Date()
   await db
     .update(mcpServerOauth)
     .set({ state: hashState(state), stateCreatedAt: now, updatedAt: now })
     .where(eq(mcpServerOauth.id, rowId))
+  logger.info('MCP OAuth authorization state saved', { rowId, context })
 }
 
 export async function clearTokens(rowId: string): Promise<void> {
@@ -221,11 +222,12 @@ export async function clearVerifier(rowId: string): Promise<void> {
     .where(eq(mcpServerOauth.id, rowId))
 }
 
-export async function clearState(rowId: string): Promise<void> {
+export async function clearState(rowId: string, context = 'unknown'): Promise<void> {
   await db
     .update(mcpServerOauth)
     .set({ state: null, stateCreatedAt: null, updatedAt: new Date() })
     .where(eq(mcpServerOauth.id, rowId))
+  logger.info('MCP OAuth authorization state cleared', { rowId, context })
 }
 
 /**


### PR DESCRIPTION
## Summary
- MCP OAuth (`app.withgauge.com/mcp` and others) fails on the callback with `invalid_state` ("Authorization expired"). Staging DB + logs confirm the authorization `state` is cleared ~5s after `/oauth/start` saves it, before the user authorizes — but `clearState` was **silent**, so the clobber never appeared in logs.
- Verified this is the *only* path that can null an existing row's `state`: `safeDecrypt` never touches `state` (it's a hash, not encrypted), and the discovery/connection paths short-circuit (`if (!row.tokens)`) before ever running the SDK `auth()` flow.
- Adds a caller `context` to `saveState`/`clearState` and logs every write, so the exact clobber source is pinned on the next repro — then the precise fix follows.

## Type of Change
- [x] Improvement (diagnostic instrumentation)

## Testing
Tested manually — lint, typecheck, and 29 OAuth unit tests pass. Instrumentation is behavior-preserving (optional param defaults to `unknown`).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)