### PR TITLE
improvement(blocks): name the integration in every suggested-action template title

### DIFF
--- a/apps/sim/blocks/blocks/amplitude.ts
+++ b/apps/sim/blocks/blocks/amplitude.ts
@@ -1176,7 +1176,7 @@ export const AmplitudeBlockMeta = {
   templates: [
     {
       icon: AmplitudeIcon,
-      title: 'Product analytics digest',
+      title: 'Amplitude product analytics digest',
       prompt:
         'Create a scheduled weekly workflow that pulls key product metrics from Amplitude — active users, event segmentation for top events, and revenue — generates an executive summary with week-over-week trends, and posts it to Slack.',
       modules: ['scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/apollo.ts
+++ b/apps/sim/blocks/blocks/apollo.ts
@@ -1379,7 +1379,7 @@ export const ApolloBlockMeta = {
   templates: [
     {
       icon: Users,
-      title: 'Lead enrichment pipeline',
+      title: 'Apollo lead enrichment',
       prompt:
         'Build a workflow that watches my leads table for new entries, enriches each lead with company size, funding, tech stack, and decision-maker contacts using Apollo and web search, then updates the table with the enriched information.',
       modules: ['tables', 'agent', 'workflows'],
@@ -1388,7 +1388,7 @@ export const ApolloBlockMeta = {
     },
     {
       icon: ApolloIcon,
-      title: 'Prospect researcher',
+      title: 'Apollo prospect researcher',
       prompt:
         'Create an agent that takes a company name, deep-researches them across the web and Apollo, finds key decision-makers, recent news, funding rounds, and pain points, then compiles a prospect brief I can review before outreach.',
       modules: ['agent', 'files', 'workflows'],
@@ -1397,7 +1397,7 @@ export const ApolloBlockMeta = {
     },
     {
       icon: ApolloIcon,
-      title: 'ICP account builder',
+      title: 'Apollo ICP account builder',
       prompt:
         'Build a workflow that runs an Apollo organization search for accounts matching my ideal customer profile — industry, headcount, and tech stack — creates each as an Apollo account, and writes the new target list to a table for the SDR team.',
       modules: ['tables', 'agent', 'workflows'],
@@ -1406,7 +1406,7 @@ export const ApolloBlockMeta = {
     },
     {
       icon: Users,
-      title: 'Buying committee mapper',
+      title: 'Apollo buying committee mapper',
       prompt:
         'Create a workflow that takes a target account, runs an Apollo people search across the relevant titles, enriches each contact with verified email and role, and writes a mapped buying committee to a table so reps know exactly who to engage.',
       modules: ['tables', 'agent', 'workflows'],
@@ -1415,7 +1415,7 @@ export const ApolloBlockMeta = {
     },
     {
       icon: ApolloIcon,
-      title: 'Inbound lead enricher to HubSpot',
+      title: 'Apollo enrichment to HubSpot',
       prompt:
         'Build a workflow that on a new inbound signup enriches the person and their company with Apollo, scores fit against my ICP, and creates or updates the matching contact and company in HubSpot with the enriched fields.',
       modules: ['agent', 'workflows'],
@@ -1425,7 +1425,7 @@ export const ApolloBlockMeta = {
     },
     {
       icon: ApolloIcon,
-      title: 'Pipeline opportunity tracker',
+      title: 'Apollo pipeline tracker',
       prompt:
         'Create a scheduled workflow that searches Apollo opportunities by stage, summarizes new and at-risk deals with an agent, logs the snapshot to a pipeline table, and posts a daily deal-movement digest to the sales Slack channel.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -1435,7 +1435,7 @@ export const ApolloBlockMeta = {
     },
     {
       icon: Users,
-      title: 'CRM contact freshness sweep',
+      title: 'Apollo contact freshness sweep',
       prompt:
         'Build a scheduled workflow that pulls contacts from my CRM, bulk-enriches them through Apollo to refresh titles, emails, and company data, and bulk-updates the records so the database stays accurate for outbound.',
       modules: ['scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/ashby.ts
+++ b/apps/sim/blocks/blocks/ashby.ts
@@ -1037,7 +1037,7 @@ export const AshbyBlockMeta = {
     },
     {
       icon: AshbyIcon,
-      title: 'Interview note logger',
+      title: 'Ashby interview note logger',
       prompt:
         'Build a workflow that runs after every interview is logged in your meeting tool, summarizes the transcript, scores the candidate against the job requirements, creates a structured note on the matching Ashby candidate, and notifies the hiring manager in Slack.',
       modules: ['agent', 'workflows'],
@@ -1047,7 +1047,7 @@ export const AshbyBlockMeta = {
     },
     {
       icon: AshbyIcon,
-      title: 'Stage-change responder',
+      title: 'Ashby stage-change responder',
       prompt:
         'Create a workflow that detects when an Ashby application moves into a new stage, sends the candidate a stage-appropriate email, prepares the interviewer brief in a file, and updates a recruiting tracking table so coordinators always know who is next.',
       modules: ['tables', 'files', 'agent', 'workflows'],
@@ -1066,7 +1066,7 @@ export const AshbyBlockMeta = {
     },
     {
       icon: AshbyIcon,
-      title: 'Candidate research enricher',
+      title: 'Ashby candidate enricher',
       prompt:
         'Create a workflow that takes new Ashby candidates, researches each across LinkedIn and the web for relevant background, writes a structured profile summary onto the candidate as an Ashby note, and updates a recruiting table with research links.',
       modules: ['tables', 'agent', 'workflows'],
@@ -1076,7 +1076,7 @@ export const AshbyBlockMeta = {
     },
     {
       icon: AshbyIcon,
-      title: 'Offer ready brief',
+      title: 'Ashby offer-ready brief',
       prompt:
         'Build a workflow that runs when an Ashby application reaches the offer stage, gathers compensation benchmarks, interview feedback, and candidate priorities, drafts an offer brief file for the hiring manager, and Slacks the people team to start the offer process.',
       modules: ['agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/buffer.ts
+++ b/apps/sim/blocks/blocks/buffer.ts
@@ -369,7 +369,7 @@ export const BufferBlockMeta = {
   templates: [
     {
       icon: BufferIcon,
-      title: 'Blog post to social queue',
+      title: 'Buffer blog-to-social queue',
       prompt:
         'Build a workflow that takes a blog post URL and summary, writes a short social caption for it, and adds a Buffer post to the queue for each connected channel returned by Get Channels.',
       modules: ['agent', 'workflows'],
@@ -378,7 +378,7 @@ export const BufferBlockMeta = {
     },
     {
       icon: BufferIcon,
-      title: 'Weekly content calendar',
+      title: 'Buffer weekly content calendar',
       prompt:
         "Create a workflow that reads next week's content calendar from a table and creates a custom-scheduled Buffer post for each row with its channel, caption, and publish time, then writes the new post IDs back to the table.",
       modules: ['tables', 'agent', 'workflows'],
@@ -387,7 +387,7 @@ export const BufferBlockMeta = {
     },
     {
       icon: BufferIcon,
-      title: 'Image post from generated art',
+      title: 'Buffer post from generated art',
       prompt:
         'Build a workflow that generates an on-brand image with an AI image model, writes a matching caption, and creates a Buffer post with the image attached, scheduled for tomorrow morning.',
       modules: ['agent', 'files', 'workflows'],
@@ -396,7 +396,7 @@ export const BufferBlockMeta = {
     },
     {
       icon: BufferIcon,
-      title: 'Failed post alert to Slack',
+      title: 'Buffer failed-post alert to Slack',
       prompt:
         'Create a scheduled workflow that lists Buffer posts with status error, and for each failed post sends a Slack alert with the channel, the post text, and the publishing error message so the team can fix and reschedule it.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -406,7 +406,7 @@ export const BufferBlockMeta = {
     },
     {
       icon: BufferIcon,
-      title: 'Daily queue health check',
+      title: 'Buffer daily queue health check',
       prompt:
         'Build a scheduled daily workflow that gets all Buffer channels, flags any with a paused queue or disconnected account, counts scheduled posts per channel for the next 3 days, and emails a digest highlighting channels with an empty queue.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -415,7 +415,7 @@ export const BufferBlockMeta = {
     },
     {
       icon: BufferIcon,
-      title: 'Capture ideas from Slack',
+      title: 'Buffer ideas from Slack',
       prompt:
         'Create a workflow triggered by a Slack message in the content-ideas channel that cleans up the message text and saves it as a Buffer idea with a short title so the marketing team can draft it later.',
       modules: ['agent', 'workflows'],
@@ -425,7 +425,7 @@ export const BufferBlockMeta = {
     },
     {
       icon: BufferIcon,
-      title: 'Product launch announcement',
+      title: 'Buffer launch announcement',
       prompt:
         'Build a workflow that takes launch notes, writes a tailored announcement per social network, and shares a Buffer post immediately on every connected channel, then reports the external links of the published posts.',
       modules: ['agent', 'workflows'],
@@ -434,7 +434,7 @@ export const BufferBlockMeta = {
     },
     {
       icon: BufferIcon,
-      title: 'Evergreen content recycler',
+      title: 'Buffer evergreen recycler',
       prompt:
         'Create a scheduled weekly workflow that lists Buffer posts sent more than 90 days ago, picks the top evergreen ones, refreshes their captions, and re-adds them to the queue as new posts.',
       modules: ['scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/calendly.ts
+++ b/apps/sim/blocks/blocks/calendly.ts
@@ -334,7 +334,7 @@ export const CalendlyBlockMeta = {
   templates: [
     {
       icon: CalendlyIcon,
-      title: 'Scheduling follow-up automator',
+      title: 'Calendly booking follow-up',
       prompt:
         'Build a workflow that monitors new Calendly bookings, researches each attendee and their company, prepares a pre-meeting brief with relevant context, and sends a personalized confirmation email with an agenda and any prep materials.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/clickhouse.ts
+++ b/apps/sim/blocks/blocks/clickhouse.ts
@@ -517,7 +517,7 @@ export const ClickHouseBlockMeta = {
     },
     {
       icon: Wrench,
-      title: 'Scheduled table maintenance',
+      title: 'Scheduled ClickHouse maintenance',
       prompt:
         'Create a scheduled workflow that runs OPTIMIZE TABLE on my high-write ClickHouse tables each night to merge parts, then reports the resulting part counts and storage size.',
       modules: ['scheduled', 'workflows'],
@@ -526,7 +526,7 @@ export const ClickHouseBlockMeta = {
     },
     {
       icon: TrashOutline,
-      title: 'Partition retention cleanup',
+      title: 'ClickHouse partition cleanup',
       prompt:
         'Build a scheduled workflow that enforces a retention policy on my ClickHouse events table: take an explicit cutoff date as input, list the table partitions, select only the partitions on that exact table whose range ends strictly before the cutoff, and drop just those. Never infer the cutoff and never drop a partition that is not clearly past it.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -535,7 +535,7 @@ export const ClickHouseBlockMeta = {
     },
     {
       icon: Bell,
-      title: 'Alert on long-running queries',
+      title: 'Alert on slow ClickHouse queries',
       prompt:
         'Create a scheduled workflow that lists ClickHouse running queries and posts a Slack alert for any whose elapsed time exceeds an explicit threshold I set, including the query_id, user, and elapsed time so a human can investigate and decide whether to intervene.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -554,7 +554,7 @@ export const ClickHouseBlockMeta = {
     },
     {
       icon: Server,
-      title: 'Weekly storage growth report',
+      title: 'ClickHouse storage growth report',
       prompt:
         'Create a scheduled workflow that collects ClickHouse table stats (rows and size on disk) each week, has an agent summarize the largest tables and fastest growth, and posts the report to Slack.',
       modules: ['scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/cloudflare.ts
+++ b/apps/sim/blocks/blocks/cloudflare.ts
@@ -1092,7 +1092,7 @@ export const CloudflareBlockMeta = {
     },
     {
       icon: CloudflareIcon,
-      title: 'Cache purge on deploy',
+      title: 'Cloudflare cache purge on deploy',
       prompt:
         'Build a workflow that fires when a Vercel deployment succeeds on production, purges the Cloudflare cache for the affected hostnames, verifies the new content is being served, and posts a confirmation message to Slack with the purged paths.',
       modules: ['agent', 'workflows'],
@@ -1102,7 +1102,7 @@ export const CloudflareBlockMeta = {
     },
     {
       icon: CloudflareIcon,
-      title: 'SSL and zone health check',
+      title: 'Cloudflare SSL and zone check',
       prompt:
         'Create a scheduled weekly workflow that inspects every Cloudflare zone for SSL certificate status, security level, and zone settings drift, logs findings to a table, and opens Linear tickets for any zones that need attention.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -1112,7 +1112,7 @@ export const CloudflareBlockMeta = {
     },
     {
       icon: CloudflareIcon,
-      title: 'DNS analytics digest',
+      title: 'Cloudflare DNS analytics digest',
       prompt:
         'Build a scheduled workflow that pulls Cloudflare DNS analytics for the top zones every Monday, identifies query spikes, anomalies, and surges in particular record types, and emails a written analysis to the platform team with traffic graphs and recommendations.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],
@@ -1121,7 +1121,7 @@ export const CloudflareBlockMeta = {
     },
     {
       icon: CloudflareIcon,
-      title: 'Zone provisioning workflow',
+      title: 'Cloudflare zone provisioning',
       prompt:
         'Create a workflow that accepts a domain name from a form, creates a new Cloudflare zone, sets opinionated default DNS records and zone settings, generates the nameserver instructions, and posts the setup summary to Slack so the team can finalize delegation.',
       modules: ['agent', 'workflows'],
@@ -1131,7 +1131,7 @@ export const CloudflareBlockMeta = {
     },
     {
       icon: CloudflareIcon,
-      title: 'DNS record bulk importer',
+      title: 'Cloudflare DNS bulk importer',
       prompt:
         'Build a workflow that reads a table of DNS records — name, type, content, TTL — validates each row, creates or updates the matching record in Cloudflare, and writes results back to the table so DNS changes are versioned and reviewable.',
       modules: ['tables', 'agent', 'workflows'],
@@ -1140,7 +1140,7 @@ export const CloudflareBlockMeta = {
     },
     {
       icon: CloudflareIcon,
-      title: 'Zone settings policy enforcer',
+      title: 'Cloudflare zone policy enforcer',
       prompt:
         'Create a scheduled workflow that reads a baseline of required Cloudflare zone settings from a knowledge base, compares it against every zone weekly, automatically reverts unauthorized changes, and emails a compliance report to security leadership.',
       modules: ['knowledge-base', 'scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/cloudformation.ts
+++ b/apps/sim/blocks/blocks/cloudformation.ts
@@ -751,7 +751,7 @@ export const CloudFormationBlockMeta = {
     },
     {
       icon: CloudFormationIcon,
-      title: 'Stack inventory builder',
+      title: 'CloudFormation stack inventory',
       prompt:
         'Build a scheduled weekly workflow that describes every CloudFormation stack, lists its resources, and writes a unified inventory of stacks, status, region, and resource counts into a tracking table so the platform team has a single source of truth.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -760,7 +760,7 @@ export const CloudFormationBlockMeta = {
     },
     {
       icon: CloudFormationIcon,
-      title: 'Template validator gate',
+      title: 'CloudFormation template validator',
       prompt:
         'Create a workflow triggered when a CloudFormation template is changed in a GitHub pull request. Pull the template, validate it via the CloudFormation API, summarize any syntax or structural errors, and post the validation result as a PR comment to block merges on broken templates.',
       modules: ['agent', 'workflows'],
@@ -770,7 +770,7 @@ export const CloudFormationBlockMeta = {
     },
     {
       icon: CloudFormationIcon,
-      title: 'Stack failure investigator',
+      title: 'CloudFormation failure investigator',
       prompt:
         'Build a scheduled workflow that polls CloudFormation stack events every few minutes, detects rollbacks and create-failed events, pulls the failure reason and recent events from the stack, summarizes the root cause, opens a Linear ticket with the diagnosis, and posts to the on-call Slack channel.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -780,7 +780,7 @@ export const CloudFormationBlockMeta = {
     },
     {
       icon: CloudFormationIcon,
-      title: 'Template archive and search',
+      title: 'CloudFormation template archive',
       prompt:
         'Create a scheduled workflow that retrieves the deployed template for every CloudFormation stack, stores each template as a versioned file in your files store, and updates a knowledge base so engineers can search infrastructure definitions in natural language.',
       modules: ['scheduled', 'files', 'knowledge-base', 'agent', 'workflows'],
@@ -789,7 +789,7 @@ export const CloudFormationBlockMeta = {
     },
     {
       icon: CloudFormationIcon,
-      title: 'Resource change report',
+      title: 'CloudFormation change report',
       prompt:
         'Build a scheduled weekly workflow that pulls CloudFormation stack events, summarizes resource creates, updates, and deletes across the account, classifies risky changes, and writes a written change report file for platform leadership review.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],
@@ -798,7 +798,7 @@ export const CloudFormationBlockMeta = {
     },
     {
       icon: CloudFormationIcon,
-      title: 'Pre-deploy drift gate',
+      title: 'CloudFormation pre-deploy drift gate',
       prompt:
         'Create a workflow that runs before a deploy, initiates drift detection on the target CloudFormation stack, polls until drift detection completes, and either approves the deploy or blocks it with a Slack alert explaining the drifted resources.',
       modules: ['agent', 'workflows'],
@@ -808,7 +808,7 @@ export const CloudFormationBlockMeta = {
     },
     {
       icon: CloudFormationIcon,
-      title: 'Change set approval pipeline',
+      title: 'CloudFormation change set approval',
       prompt:
         'Build a workflow that creates a CloudFormation change set for a stack update, describes the proposed resource changes, posts a summary to Slack for approval, and executes the change set only after an approver replies, otherwise deletes the change set.',
       modules: ['agent', 'workflows'],
@@ -818,7 +818,7 @@ export const CloudFormationBlockMeta = {
     },
     {
       icon: CloudFormationIcon,
-      title: 'Environment provisioner',
+      title: 'CloudFormation environment provisioner',
       prompt:
         'Create a workflow that takes an environment name and template parameters as input, creates a new CloudFormation stack for that environment, polls stack events until it reaches CREATE_COMPLETE or fails, and posts the stack outputs to Slack.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/confluence.ts
+++ b/apps/sim/blocks/blocks/confluence.ts
@@ -1608,7 +1608,7 @@ export const ConfluenceBlockMeta = {
   templates: [
     {
       icon: PagerDutyIcon,
-      title: 'Confluence incident coordinator',
+      title: 'PagerDuty incident coordinator',
       prompt:
         'Create a knowledge base connected to my Confluence or Notion with runbooks and incident procedures. Then build a workflow triggered by PagerDuty incidents that searches the runbooks, gathers related Datadog alerts, identifies the on-call rotation, and posts a comprehensive incident brief to Slack.',
       modules: ['knowledge-base', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/confluence.ts
+++ b/apps/sim/blocks/blocks/confluence.ts
@@ -1608,7 +1608,7 @@ export const ConfluenceBlockMeta = {
   templates: [
     {
       icon: PagerDutyIcon,
-      title: 'Incident response coordinator',
+      title: 'Confluence incident coordinator',
       prompt:
         'Create a knowledge base connected to my Confluence or Notion with runbooks and incident procedures. Then build a workflow triggered by PagerDuty incidents that searches the runbooks, gathers related Datadog alerts, identifies the on-call rotation, and posts a comprehensive incident brief to Slack.',
       modules: ['knowledge-base', 'agent', 'workflows'],
@@ -1618,7 +1618,7 @@ export const ConfluenceBlockMeta = {
     },
     {
       icon: ConfluenceIcon,
-      title: 'Knowledge base sync',
+      title: 'Confluence knowledge base sync',
       prompt:
         'Create a knowledge base connected to my Confluence workspace so all wiki pages are automatically synced and searchable. Then build a scheduled workflow that identifies stale pages not updated in 90 days and sends a Slack reminder to page owners to review them.',
       modules: ['knowledge-base', 'scheduled', 'agent', 'workflows'],
@@ -1628,7 +1628,7 @@ export const ConfluenceBlockMeta = {
     },
     {
       icon: Search,
-      title: 'Multi-source knowledge hub',
+      title: 'Confluence multi-source knowledge hub',
       prompt:
         'Create a knowledge base and connect it to Confluence, Notion, and Google Drive so all my company documentation is automatically synced, chunked, and embedded. Then deploy a Q&A agent that can answer questions across all sources with citations.',
       modules: ['knowledge-base', 'scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/cursor.ts
+++ b/apps/sim/blocks/blocks/cursor.ts
@@ -314,7 +314,7 @@ export const CursorBlockMeta = {
     },
     {
       icon: CursorIcon,
-      title: 'Test fix delegator',
+      title: 'Cursor test-fix delegator',
       prompt:
         'Build a workflow triggered by a failing GitHub Actions test run that extracts the failing test name and error, launches a targeted Cursor cloud agent to fix only that test, downloads the artifact diff when ready, and replies on the failed run with the proposed patch.',
       modules: ['agent', 'workflows'],
@@ -324,7 +324,7 @@ export const CursorBlockMeta = {
     },
     {
       icon: CursorIcon,
-      title: 'Refactor follow-up loop',
+      title: 'Cursor refactor follow-up loop',
       prompt:
         'Create a workflow that picks up review comments on a Cursor-authored pull request, formulates each comment as a follow-up instruction, sends them to the originating Cursor cloud agent, and waits for the updated diff before re-requesting review.',
       modules: ['agent', 'workflows'],
@@ -343,7 +343,7 @@ export const CursorBlockMeta = {
     },
     {
       icon: CursorIcon,
-      title: 'Stuck-agent cleaner',
+      title: 'Cursor stuck-agent cleaner',
       prompt:
         'Create a scheduled workflow that runs hourly, lists Cursor cloud agents, detects agents stuck in the same state longer than a configurable threshold, stops or deletes them based on rules, and posts a Slack report of the cleanup actions taken.',
       modules: ['scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/datadog.ts
+++ b/apps/sim/blocks/blocks/datadog.ts
@@ -840,7 +840,7 @@ export const DatadogBlockMeta = {
   templates: [
     {
       icon: DatadogIcon,
-      title: 'Infrastructure health report',
+      title: 'Datadog infra health report',
       prompt:
         'Create a scheduled daily workflow that queries Datadog for key infrastructure metrics — error rates, latency percentiles, CPU and memory usage — logs them to a table for trend tracking, and sends a morning Slack report highlighting any anomalies or degradations.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/devin.ts
+++ b/apps/sim/blocks/blocks/devin.ts
@@ -363,7 +363,7 @@ export const DevinBlockMeta = {
     },
     {
       icon: DevinIcon,
-      title: 'Documentation gap closer',
+      title: 'Devin documentation gap closer',
       prompt:
         'Create a workflow that scans a knowledge base of docs against the latest repo state, finds undocumented public APIs, opens a Devin session for each gap with a prompt to write documentation, and stores the produced markdown back into the knowledge base.',
       modules: ['knowledge-base', 'files', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/dub.ts
+++ b/apps/sim/blocks/blocks/dub.ts
@@ -1206,7 +1206,7 @@ export const DubBlockMeta = {
     },
     {
       icon: DubIcon,
-      title: 'Campaign link batcher',
+      title: 'Dub campaign link batcher',
       prompt:
         'Create a workflow that reads a table of campaign destinations, upserts a Dub short link for each row with consistent UTM tags, writes the resulting short URL back into the table, and posts a Slack confirmation summarizing how many links were created or refreshed.',
       modules: ['tables', 'agent', 'workflows'],
@@ -1226,7 +1226,7 @@ export const DubBlockMeta = {
     },
     {
       icon: DubIcon,
-      title: 'Short link hygiene auditor',
+      title: 'Dub link hygiene auditor',
       prompt:
         'Create a scheduled monthly workflow that lists all Dub links, checks each destination for 4xx and 5xx responses, flags broken links in a table, and emails the marketing team a remediation list so dead campaign links never go live.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -1235,7 +1235,7 @@ export const DubBlockMeta = {
     },
     {
       icon: DubIcon,
-      title: 'Outbound link personalizer',
+      title: 'Dub outbound link personalizer',
       prompt:
         'Build a workflow that reads a leads table, generates a per-lead Dub short link with the lead identifier in UTM and metadata, attaches the personalized link to the outreach email body, and tracks delivery in the table.',
       modules: ['tables', 'agent', 'workflows'],
@@ -1245,7 +1245,7 @@ export const DubBlockMeta = {
     },
     {
       icon: DubIcon,
-      title: 'Release announcement linker',
+      title: 'Dub release announcement linker',
       prompt:
         'Create a workflow triggered by a GitHub release that creates a Dub short link for the release notes URL, posts the short link to the marketing Slack channel, and stores the mapping of release tag to short link in a tracking table.',
       modules: ['tables', 'agent', 'workflows'],
@@ -1255,7 +1255,7 @@ export const DubBlockMeta = {
     },
     {
       icon: DubIcon,
-      title: 'Top-converting links report',
+      title: 'Dub top-converting links report',
       prompt:
         'Build a scheduled monthly workflow that pulls Dub analytics grouped by link, ranks top performers by leads and sales, identifies underperformers, writes a narrative report file with recommendations, and shares it with marketing leadership.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/elevenlabs.ts
+++ b/apps/sim/blocks/blocks/elevenlabs.ts
@@ -492,7 +492,7 @@ export const ElevenLabsBlockMeta = {
     },
     {
       icon: ElevenLabsIcon,
-      title: 'Customer voice greeting generator',
+      title: 'ElevenLabs voice greeting generator',
       prompt:
         'Create a workflow that reads a table of new enterprise customers, generates a personalized ElevenLabs voice greeting with their account manager voice, and emails the audio file to the customer on day one.',
       modules: ['tables', 'agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/firecrawl.ts
+++ b/apps/sim/blocks/blocks/firecrawl.ts
@@ -775,7 +775,7 @@ export const FirecrawlBlockMeta = {
   templates: [
     {
       icon: FirecrawlIcon,
-      title: 'Firecrawl SEO brief generator',
+      title: 'Firecrawl keyword brief generator',
       prompt:
         'Build a workflow that takes a target keyword, uses Firecrawl to scrape the top 10 ranking pages, analyzes their content structure and subtopics, then generates a detailed content brief with outline, word count target, questions to answer, and internal linking suggestions.',
       modules: ['agent', 'files', 'workflows'],
@@ -784,7 +784,7 @@ export const FirecrawlBlockMeta = {
     },
     {
       icon: FirecrawlIcon,
-      title: 'Firecrawl competitive intel monitor',
+      title: 'Firecrawl competitor change tracker',
       prompt:
         'Build a scheduled workflow that scrapes competitor websites, pricing pages, and changelog pages weekly using Firecrawl, compares against previous snapshots, summarizes any changes, logs them to a tracking table, and sends a Slack alert for major updates.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/firecrawl.ts
+++ b/apps/sim/blocks/blocks/firecrawl.ts
@@ -775,7 +775,7 @@ export const FirecrawlBlockMeta = {
   templates: [
     {
       icon: FirecrawlIcon,
-      title: 'SEO content brief generator',
+      title: 'Firecrawl SEO brief generator',
       prompt:
         'Build a workflow that takes a target keyword, uses Firecrawl to scrape the top 10 ranking pages, analyzes their content structure and subtopics, then generates a detailed content brief with outline, word count target, questions to answer, and internal linking suggestions.',
       modules: ['agent', 'files', 'workflows'],
@@ -784,7 +784,7 @@ export const FirecrawlBlockMeta = {
     },
     {
       icon: FirecrawlIcon,
-      title: 'Competitive intel monitor',
+      title: 'Firecrawl competitive intel monitor',
       prompt:
         'Build a scheduled workflow that scrapes competitor websites, pricing pages, and changelog pages weekly using Firecrawl, compares against previous snapshots, summarizes any changes, logs them to a tracking table, and sends a Slack alert for major updates.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/github.ts
+++ b/apps/sim/blocks/blocks/github.ts
@@ -1,5 +1,5 @@
 import { Calendar } from '@sim/emcn/icons'
-import { GithubIcon, NotionIcon } from '@/components/icons'
+import { GithubIcon } from '@/components/icons'
 import type { BlockConfig, BlockMeta } from '@/blocks/types'
 import { AuthMode, IntegrationType } from '@/blocks/types'
 import { createVersionedToolSelector } from '@/blocks/utils'
@@ -2166,7 +2166,7 @@ export const GitHubBlockMeta = {
       tags: ['engineering', 'product', 'reporting', 'content'],
     },
     {
-      icon: NotionIcon,
+      icon: GithubIcon,
       title: 'GitHub docs auto-updater',
       prompt:
         'Create a knowledge base connected to my GitHub repository so code and docs stay synced. Then build a scheduled weekly workflow that detects API changes, compares them against the knowledge base to find outdated documentation, and either updates Notion pages directly or creates Linear tickets for the needed changes.',

--- a/apps/sim/blocks/blocks/github.ts
+++ b/apps/sim/blocks/blocks/github.ts
@@ -2149,7 +2149,7 @@ export const GitHubBlockMeta = {
   templates: [
     {
       icon: GithubIcon,
-      title: 'PR review assistant',
+      title: 'GitHub PR review assistant',
       prompt:
         'Create a knowledge base connected to my GitHub repo so it stays synced with my style guide and coding standards. Then build a workflow that reviews new pull requests against it, checks for common issues and security vulnerabilities, and posts a review comment with specific suggestions.',
       modules: ['knowledge-base', 'agent', 'workflows'],
@@ -2158,7 +2158,7 @@ export const GitHubBlockMeta = {
     },
     {
       icon: GithubIcon,
-      title: 'Changelog generator',
+      title: 'GitHub changelog generator',
       prompt:
         'Build a scheduled workflow that runs every Friday, pulls all merged PRs from GitHub for the week, categorizes changes as features, fixes, or improvements, and generates a user-facing changelog document with clear descriptions.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],
@@ -2167,7 +2167,7 @@ export const GitHubBlockMeta = {
     },
     {
       icon: NotionIcon,
-      title: 'Documentation auto-updater',
+      title: 'GitHub docs auto-updater',
       prompt:
         'Create a knowledge base connected to my GitHub repository so code and docs stay synced. Then build a scheduled weekly workflow that detects API changes, compares them against the knowledge base to find outdated documentation, and either updates Notion pages directly or creates Linear tickets for the needed changes.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -2186,7 +2186,7 @@ export const GitHubBlockMeta = {
     },
     {
       icon: GithubIcon,
-      title: 'Release notes drafter',
+      title: 'GitHub release notes drafter',
       prompt:
         'Build a workflow triggered when a GitHub release tag is created. Pull every merged pull request and commit since the previous tag, group them by feature, fix, and chore, draft customer-facing release notes, and post the draft as a comment on the release for final approval.',
       modules: ['agent', 'workflows'],
@@ -2195,7 +2195,7 @@ export const GitHubBlockMeta = {
     },
     {
       icon: Calendar,
-      title: 'Weekly team digest',
+      title: 'GitHub weekly team digest',
       prompt:
         "Build a scheduled workflow that runs every Friday, pulls the week's GitHub commits, closed Linear issues, and key Slack conversations, then emails a formatted weekly summary to the team.",
       modules: ['scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/gmail.ts
+++ b/apps/sim/blocks/blocks/gmail.ts
@@ -1,5 +1,5 @@
 import { ClipboardList } from '@sim/emcn/icons'
-import { GmailIcon, LemlistIcon } from '@/components/icons'
+import { GmailIcon } from '@/components/icons'
 import { getScopesForService } from '@/lib/oauth/utils'
 import type { BlockConfig, BlockMeta } from '@/blocks/types'
 import { AuthMode, IntegrationType } from '@/blocks/types'
@@ -659,7 +659,7 @@ export const GmailBlockMeta = {
       featured: true,
     },
     {
-      icon: LemlistIcon,
+      icon: GmailIcon,
       title: 'Gmail outbound sequence builder',
       prompt:
         'Build a workflow that reads leads from my table, researches each prospect and their company on the web, writes a personalized cold email tailored to their role and pain points, and sends it via Gmail. Schedule it to run daily to process new leads automatically.',

--- a/apps/sim/blocks/blocks/gmail.ts
+++ b/apps/sim/blocks/blocks/gmail.ts
@@ -649,7 +649,7 @@ export const GmailBlockMeta = {
   templates: [
     {
       icon: GmailIcon,
-      title: 'Auto-reply agent',
+      title: 'Gmail auto-reply agent',
       prompt:
         'Create a workflow that reads my Gmail inbox, identifies emails that need a response, and drafts contextual replies for each one. Schedule it to run every hour.',
       image: '/templates/gmail-agent-dark.png',
@@ -660,7 +660,7 @@ export const GmailBlockMeta = {
     },
     {
       icon: LemlistIcon,
-      title: 'Outbound sequence builder',
+      title: 'Gmail outbound sequence builder',
       prompt:
         'Build a workflow that reads leads from my table, researches each prospect and their company on the web, writes a personalized cold email tailored to their role and pain points, and sends it via Gmail. Schedule it to run daily to process new leads automatically.',
       modules: ['tables', 'agent', 'workflows'],
@@ -669,7 +669,7 @@ export const GmailBlockMeta = {
     },
     {
       icon: GmailIcon,
-      title: 'Email knowledge search',
+      title: 'Gmail knowledge search',
       prompt:
         'Create a knowledge base connected to my Gmail so all my emails are automatically synced, chunked, and searchable. Then build an agent I can ask things like "what did Sarah say about the pricing proposal?" or "find the contract John sent last month" and get instant answers with the original email cited.',
       modules: ['knowledge-base', 'agent'],
@@ -678,7 +678,7 @@ export const GmailBlockMeta = {
     },
     {
       icon: GmailIcon,
-      title: 'Email triage assistant',
+      title: 'Gmail triage assistant',
       prompt:
         'Build a workflow that scans my Gmail inbox every hour, categorizes emails by urgency and type (action needed, FYI, follow-up), drafts replies for routine messages, and sends me a prioritized summary in Slack so I only open what matters. Schedule it to run hourly.',
       modules: ['agent', 'scheduled', 'workflows'],
@@ -688,7 +688,7 @@ export const GmailBlockMeta = {
     },
     {
       icon: ClipboardList,
-      title: 'Invoice processor',
+      title: 'Gmail invoice processor',
       prompt:
         'Build a workflow that processes invoice PDFs from Gmail, extracts vendor name, amount, due date, and line items, then logs everything to a tracking table and sends a Slack alert for invoices due within 7 days.',
       modules: ['files', 'tables', 'agent', 'workflows'],
@@ -719,7 +719,7 @@ export const GmailBlockMeta = {
 
     {
       icon: GmailIcon,
-      title: 'Save incoming emails to Notion databases',
+      title: 'Gmail to Notion email capture',
       prompt:
         'Build a workflow that monitors Gmail for incoming emails, extracts structured data from each one, and stores it as a Notion database entry — useful for lead capture, support tickets, and meeting scheduling.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/gong.ts
+++ b/apps/sim/blocks/blocks/gong.ts
@@ -1333,7 +1333,7 @@ export const GongBlockMeta = {
   templates: [
     {
       icon: GongIcon,
-      title: 'Sales call analyzer',
+      title: 'Gong sales call analyzer',
       prompt:
         'Build a workflow that pulls call transcripts from Gong after each sales call, identifies key objections raised, action items promised, and competitor mentions, updates the deal record in my CRM, and posts a call summary with next steps to the Slack deal channel.',
       modules: ['agent', 'tables', 'workflows'],

--- a/apps/sim/blocks/blocks/google_calendar.ts
+++ b/apps/sim/blocks/blocks/google_calendar.ts
@@ -1,4 +1,4 @@
-import { GoogleCalendarIcon, TwilioIcon } from '@/components/icons'
+import { GoogleCalendarIcon } from '@/components/icons'
 import { getScopesForService } from '@/lib/oauth/utils'
 import type { BlockConfig, BlockMeta } from '@/blocks/types'
 import { AuthMode, IntegrationType } from '@/blocks/types'
@@ -1008,7 +1008,7 @@ export const GoogleCalendarBlockMeta = {
       featured: true,
     },
     {
-      icon: TwilioIcon,
+      icon: GoogleCalendarIcon,
       title: 'Calendar SMS appointment reminders',
       prompt:
         'Create a scheduled workflow that checks Google Calendar each morning for appointments in the next 24 hours, and sends an SMS reminder to each attendee via Twilio with the meeting time, location, and any prep notes.',

--- a/apps/sim/blocks/blocks/google_calendar.ts
+++ b/apps/sim/blocks/blocks/google_calendar.ts
@@ -998,7 +998,7 @@ export const GoogleCalendarBlockMeta = {
   templates: [
     {
       icon: GoogleCalendarIcon,
-      title: 'Meeting prep agent',
+      title: 'Calendar meeting prep agent',
       prompt:
         'Create an agent that checks my Google Calendar each morning, researches every attendee and topic on the web, and prepares a brief for each meeting so I walk in fully prepared. Schedule it to run every weekday morning.',
       image: '/templates/meeting-prep-dark.png',
@@ -1009,7 +1009,7 @@ export const GoogleCalendarBlockMeta = {
     },
     {
       icon: TwilioIcon,
-      title: 'SMS appointment reminders',
+      title: 'Calendar SMS appointment reminders',
       prompt:
         'Create a scheduled workflow that checks Google Calendar each morning for appointments in the next 24 hours, and sends an SMS reminder to each attendee via Twilio with the meeting time, location, and any prep notes.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -1029,7 +1029,7 @@ export const GoogleCalendarBlockMeta = {
     },
     {
       icon: GoogleCalendarIcon,
-      title: 'Daily agenda digest',
+      title: 'Calendar daily agenda digest',
       prompt:
         'Create a scheduled weekday workflow that lists my Google Calendar events for the day, summarizes them with attendee context and prep notes, and posts a clean morning agenda to Slack.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -1039,7 +1039,7 @@ export const GoogleCalendarBlockMeta = {
     },
     {
       icon: GoogleCalendarIcon,
-      title: 'Interview scheduling coordinator',
+      title: 'Calendar interview scheduler',
       prompt:
         "Build a workflow that when a candidate reaches the interview stage finds open slots across the panel's Google Calendars, creates the interview event with the video link, invites everyone, and emails the candidate the confirmation.",
       modules: ['agent', 'workflows'],
@@ -1049,7 +1049,7 @@ export const GoogleCalendarBlockMeta = {
     },
     {
       icon: GoogleCalendarIcon,
-      title: 'Meeting-load weekly report',
+      title: 'Calendar meeting-load weekly report',
       prompt:
         'Create a scheduled weekly workflow that lists Google Calendar events for the team, computes total meeting hours and recurring-meeting load per person, writes the breakdown to a table, and flags anyone over the focus-time threshold.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/google_docs.ts
+++ b/apps/sim/blocks/blocks/google_docs.ts
@@ -638,7 +638,7 @@ export const GoogleDocsBlockMeta = {
     },
     {
       icon: GoogleDocsIcon,
-      title: 'Weekly report writer',
+      title: 'Google Docs weekly report',
       prompt:
         'Create a scheduled weekly workflow that reads metrics from my tables, writes a narrative status report with an agent, and appends the new section to a running Google Docs document so leadership has one living record.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/google_drive.ts
+++ b/apps/sim/blocks/blocks/google_drive.ts
@@ -1546,7 +1546,7 @@ export const GoogleDriveBlockMeta = {
   templates: [
     {
       icon: BookOpen,
-      title: 'Personal knowledge assistant',
+      title: 'Google Drive knowledge assistant',
       prompt:
         'Create a knowledge base and connect it to my Google Drive, Notion, or Obsidian so all my notes, docs, and articles are automatically synced and embedded. Then build an agent that I can ask anything — it should answer with citations and deploy as a chat endpoint.',
       modules: ['knowledge-base', 'agent'],

--- a/apps/sim/blocks/blocks/google_drive.ts
+++ b/apps/sim/blocks/blocks/google_drive.ts
@@ -1546,7 +1546,7 @@ export const GoogleDriveBlockMeta = {
   templates: [
     {
       icon: BookOpen,
-      title: 'Google Drive knowledge assistant',
+      title: 'Google Drive personal notes assistant',
       prompt:
         'Create a knowledge base and connect it to my Google Drive, Notion, or Obsidian so all my notes, docs, and articles are automatically synced and embedded. Then build an agent that I can ask anything — it should answer with citations and deploy as a chat endpoint.',
       modules: ['knowledge-base', 'agent'],

--- a/apps/sim/blocks/blocks/google_pagespeed.ts
+++ b/apps/sim/blocks/blocks/google_pagespeed.ts
@@ -181,7 +181,7 @@ export const GooglePagespeedBlockMeta = {
     },
     {
       icon: GooglePagespeedIcon,
-      title: 'Core Web Vitals release gate',
+      title: 'PageSpeed CWV release gate',
       prompt:
         'Create a workflow triggered after a marketing-site deploy that runs Google PageSpeed Insights on the key landing pages for both mobile and desktop, compares Core Web Vitals against the prior baseline, and posts a pass/fail summary to Slack with the specific metrics that regressed.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/google_translate.ts
+++ b/apps/sim/blocks/blocks/google_translate.ts
@@ -232,7 +232,7 @@ export const GoogleTranslateBlockMeta = {
     },
     {
       icon: GoogleTranslateIcon,
-      title: 'Google Translate support replier',
+      title: 'Google Translate Intercom replier',
       prompt:
         'Build a workflow that detects the language of a new Intercom message, translates it to the agent language with Google Translate, drafts a reply, then translates the reply back before sending.',
       modules: ['agent', 'workflows'],
@@ -272,7 +272,7 @@ export const GoogleTranslateBlockMeta = {
     },
     {
       icon: GoogleTranslateIcon,
-      title: 'Google Translate support replies',
+      title: 'Google Translate ticket auto-reply',
       prompt:
         "Build a workflow that on a new support ticket detects the customer's language with Google Translate, translates the message to English for the agent, drafts a reply, then translates the response back into the customer's language before sending.",
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/google_translate.ts
+++ b/apps/sim/blocks/blocks/google_translate.ts
@@ -232,7 +232,7 @@ export const GoogleTranslateBlockMeta = {
     },
     {
       icon: GoogleTranslateIcon,
-      title: 'Multilingual support replier',
+      title: 'Google Translate support replier',
       prompt:
         'Build a workflow that detects the language of a new Intercom message, translates it to the agent language with Google Translate, drafts a reply, then translates the reply back before sending.',
       modules: ['agent', 'workflows'],
@@ -272,7 +272,7 @@ export const GoogleTranslateBlockMeta = {
     },
     {
       icon: GoogleTranslateIcon,
-      title: 'Multilingual support replies',
+      title: 'Google Translate support replies',
       prompt:
         "Build a workflow that on a new support ticket detects the customer's language with Google Translate, translates the message to English for the agent, drafts a reply, then translates the response back into the customer's language before sending.",
       modules: ['agent', 'workflows'],
@@ -281,7 +281,7 @@ export const GoogleTranslateBlockMeta = {
     },
     {
       icon: GoogleTranslateIcon,
-      title: 'Slack channel translator',
+      title: 'Google Translate Slack translator',
       prompt:
         "Create a workflow that watches an international Slack channel, detects non-English messages with Google Translate, translates them to the team's language, and posts the translation in a thread so everyone stays in the loop.",
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/greenhouse.ts
+++ b/apps/sim/blocks/blocks/greenhouse.ts
@@ -427,7 +427,7 @@ export const GreenhouseBlockMeta = {
   templates: [
     {
       icon: GreenhouseIcon,
-      title: 'Recruiting pipeline automator',
+      title: 'Greenhouse pipeline monitor',
       prompt:
         'Build a scheduled workflow that syncs open jobs and candidates from Greenhouse to a tracking table daily, flags candidates who have been in the same stage for more than 5 days, and sends a Slack summary to hiring managers with pipeline stats and bottlenecks.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/greptile.ts
+++ b/apps/sim/blocks/blocks/greptile.ts
@@ -203,7 +203,7 @@ export const GreptileBlockMeta = {
   templates: [
     {
       icon: SlackIcon,
-      title: 'Slack code Q&A bot',
+      title: 'Greptile Slack Q&A bot',
       prompt:
         'Build a workflow that monitors a Slack channel for code questions, routes them to Greptile against the relevant repository, and replies in-thread with the answer and the cited files.',
       modules: ['agent', 'workflows'],
@@ -213,7 +213,7 @@ export const GreptileBlockMeta = {
     },
     {
       icon: GreptileIcon,
-      title: 'Onboarding codebase explainer',
+      title: 'Greptile onboarding explainer',
       prompt:
         'Create a workflow where a new engineer asks how a part of the codebase works, Greptile answers against the indexed repository with cited files, and the explanation is saved to a Google Doc.',
       modules: ['agent', 'files', 'workflows'],
@@ -223,7 +223,7 @@ export const GreptileBlockMeta = {
     },
     {
       icon: ClipboardList,
-      title: 'PR review with codebase context',
+      title: 'Greptile PR review context',
       prompt:
         'Build a workflow that takes a pull request, asks Greptile how the changed code interacts with the rest of the repository, and writes a review comment summarizing impact and risks with cited files.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/greptile.ts
+++ b/apps/sim/blocks/blocks/greptile.ts
@@ -1,5 +1,5 @@
 import { ClipboardList } from '@sim/emcn/icons'
-import { GreptileIcon, SlackIcon } from '@/components/icons'
+import { GreptileIcon } from '@/components/icons'
 import type { BlockConfig, BlockMeta } from '@/blocks/types'
 import { AuthMode, IntegrationType } from '@/blocks/types'
 import type { GreptileResponse } from '@/tools/greptile/types'
@@ -202,7 +202,7 @@ export const GreptileBlockMeta = {
   url: 'https://www.greptile.com',
   templates: [
     {
-      icon: SlackIcon,
+      icon: GreptileIcon,
       title: 'Greptile Slack Q&A bot',
       prompt:
         'Build a workflow that monitors a Slack channel for code questions, routes them to Greptile against the relevant repository, and replies in-thread with the answer and the cited files.',

--- a/apps/sim/blocks/blocks/hubspot.ts
+++ b/apps/sim/blocks/blocks/hubspot.ts
@@ -1656,7 +1656,7 @@ export const HubSpotBlockMeta = {
     },
     {
       icon: HubspotIcon,
-      title: 'Win/loss analyzer',
+      title: 'HubSpot win/loss analyzer',
       prompt:
         'Build a workflow that pulls closed deals from HubSpot each week, analyzes patterns in wins vs losses — deal size, industry, sales cycle length, objections — and generates a report file with actionable insights on what to change. Schedule it to run every Monday.',
       modules: ['agent', 'files', 'scheduled', 'workflows'],

--- a/apps/sim/blocks/blocks/huggingface.ts
+++ b/apps/sim/blocks/blocks/huggingface.ts
@@ -136,7 +136,7 @@ export const HuggingFaceBlockMeta = {
     },
     {
       icon: HuggingFaceIcon,
-      title: 'Open-source sentiment scorer',
+      title: 'Hugging Face sentiment scorer',
       prompt:
         'Create a workflow that scores customer feedback with a Hugging Face chat model, writes sentiment and score columns back to the table, and pings Slack on a sudden negative spike.',
       modules: ['tables', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/intercom.ts
+++ b/apps/sim/blocks/blocks/intercom.ts
@@ -1743,7 +1743,7 @@ export const IntercomBlockMeta = {
   templates: [
     {
       icon: IntercomIcon,
-      title: 'Customer feedback analyzer',
+      title: 'Intercom feedback analyzer',
       prompt:
         'Build a scheduled workflow that pulls support tickets and conversations from Intercom daily, categorizes them by theme and sentiment, tracks trends in a table, and sends a weekly Slack report highlighting the top feature requests and pain points.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/jira.ts
+++ b/apps/sim/blocks/blocks/jira.ts
@@ -1472,7 +1472,7 @@ export const JiraBlockMeta = {
     },
     {
       icon: JiraIcon,
-      title: 'Sprint report generator',
+      title: 'Jira sprint report generator',
       prompt:
         'Create a scheduled workflow that runs at the end of each sprint, pulls all completed, in-progress, and blocked Jira tickets, calculates velocity and carry-over, and generates a sprint summary document with charts and trends to share with the team.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/jupyter.ts
+++ b/apps/sim/blocks/blocks/jupyter.ts
@@ -379,7 +379,7 @@ export const JupyterBlockMeta = {
     },
     {
       icon: JupyterIcon,
-      title: 'Notebook directory sync report',
+      title: 'Jupyter directory sync report',
       prompt:
         'Build a workflow that lists the contents of a Jupyter server directory and writes a summary of files and notebooks to a Table.',
       modules: ['tables', 'workflows'],
@@ -388,7 +388,7 @@ export const JupyterBlockMeta = {
     },
     {
       icon: JupyterIcon,
-      title: 'Read notebook and summarize',
+      title: 'Summarize a Jupyter notebook',
       prompt:
         'Build a workflow that reads a Jupyter notebook, has an agent summarize its cells, and sends the summary in Chat.',
       modules: ['agent', 'workflows'],
@@ -406,7 +406,7 @@ export const JupyterBlockMeta = {
     },
     {
       icon: JupyterIcon,
-      title: 'Archive and clean up notebooks',
+      title: 'Archive Jupyter notebooks',
       prompt:
         'Build a scheduled workflow that copies old notebooks on a Jupyter server into an archive directory, then deletes the originals.',
       modules: ['scheduled', 'workflows'],

--- a/apps/sim/blocks/blocks/linear.ts
+++ b/apps/sim/blocks/blocks/linear.ts
@@ -2636,7 +2636,7 @@ export const LinearBlockMeta = {
     },
     {
       icon: SlackIcon,
-      title: 'Meeting notes to action items',
+      title: 'Meeting notes to Linear tasks',
       prompt:
         'Create a workflow that takes meeting notes or a transcript, extracts action items with owners and due dates, creates tasks in Linear or Asana for each one, and posts a summary to the relevant Slack channel.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/linear.ts
+++ b/apps/sim/blocks/blocks/linear.ts
@@ -1,4 +1,4 @@
-import { DevinIcon, LinearIcon, SlackIcon } from '@/components/icons'
+import { DevinIcon, LinearIcon } from '@/components/icons'
 import { getScopesForService } from '@/lib/oauth/utils'
 import type { BlockConfig, BlockMeta } from '@/blocks/types'
 import { AuthMode, IntegrationType } from '@/blocks/types'
@@ -2635,7 +2635,7 @@ export const LinearBlockMeta = {
       alsoIntegrations: ['devin'],
     },
     {
-      icon: SlackIcon,
+      icon: LinearIcon,
       title: 'Meeting notes to Linear tasks',
       prompt:
         'Create a workflow that takes meeting notes or a transcript, extracts action items with owners and due dates, creates tasks in Linear or Asana for each one, and posts a summary to the relevant Slack channel.',

--- a/apps/sim/blocks/blocks/mailchimp.ts
+++ b/apps/sim/blocks/blocks/mailchimp.ts
@@ -1467,7 +1467,7 @@ export const MailchimpBlockMeta = {
   templates: [
     {
       icon: Mail,
-      title: 'Newsletter curator',
+      title: 'Mailchimp newsletter curator',
       prompt:
         'Create a scheduled weekly workflow that scrapes my favorite industry news sites and blogs, picks the top stories relevant to my audience, writes summaries for each, and drafts a ready-to-send newsletter in Mailchimp.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/notion.ts
+++ b/apps/sim/blocks/blocks/notion.ts
@@ -1124,7 +1124,7 @@ export const NotionBlockMeta = {
   templates: [
     {
       icon: Send,
-      title: 'Customer support bot',
+      title: 'Notion customer support bot',
       prompt:
         'Create a knowledge base and connect it to my Notion or Google Docs so it stays synced with my product documentation automatically. Then build an agent that answers customer questions using it with sourced citations and deploy it as a chat endpoint.',
       modules: ['knowledge-base', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/perplexity.ts
+++ b/apps/sim/blocks/blocks/perplexity.ts
@@ -286,7 +286,7 @@ export const PerplexityBlockMeta = {
     },
     {
       icon: PerplexityIcon,
-      title: 'Multi-source research agent',
+      title: 'Perplexity multi-source research',
       prompt:
         'Create an agent that triangulates a topic across Perplexity, Exa, and Tavily, deduplicates findings, and produces a consensus brief with confidence scores per claim.',
       modules: ['agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/persona.ts
+++ b/apps/sim/blocks/blocks/persona.ts
@@ -569,7 +569,7 @@ export const PersonaBlockMeta = {
   templates: [
     {
       icon: PersonaIcon,
-      title: 'Customer onboarding identity verification',
+      title: 'Persona onboarding verification',
       prompt:
         'Build a workflow triggered when a new customer signs up that creates a Persona inquiry from our KYC template with their name and email pre-filled, generates a one-time verification link, and emails it to the customer.',
       modules: ['workflows', 'agent'],
@@ -579,7 +579,7 @@ export const PersonaBlockMeta = {
     },
     {
       icon: PersonaIcon,
-      title: 'Verification decision router',
+      title: 'Persona decision router',
       prompt:
         'Build a workflow that takes an inquiry ID, fetches the inquiry from Persona, and routes on its status: approved customers get a welcome email, needs-review inquiries post to a compliance Slack channel with a summary, and declined inquiries update our CRM.',
       modules: ['workflows', 'agent'],
@@ -589,7 +589,7 @@ export const PersonaBlockMeta = {
     },
     {
       icon: PersonaIcon,
-      title: 'Daily pending-review digest',
+      title: 'Persona pending-review digest',
       prompt:
         'Build a scheduled workflow that runs every morning, lists Persona inquiries with needs_review status from the last 24 hours, summarizes each one, and posts a digest to the compliance team in Slack.',
       modules: ['scheduled', 'workflows', 'agent'],
@@ -599,7 +599,7 @@ export const PersonaBlockMeta = {
     },
     {
       icon: PersonaIcon,
-      title: 'Watchlist screening on signup',
+      title: 'Persona watchlist screening',
       prompt:
         "Build a workflow that takes a new user's name and birthdate, runs a Persona watchlist report against them, polls until the report is ready, and creates a case in our tracking table if the report has a match.",
       modules: ['workflows', 'tables', 'agent'],
@@ -608,7 +608,7 @@ export const PersonaBlockMeta = {
     },
     {
       icon: PersonaIcon,
-      title: 'Bulk account import from CRM export',
+      title: 'Persona bulk account import',
       prompt:
         'Build a workflow that takes an uploaded CSV export of customers, imports them into Persona as accounts using the account importer, polls the importer status, and reports how many rows succeeded, errored, or were duplicates.',
       modules: ['files', 'workflows', 'agent'],
@@ -617,7 +617,7 @@ export const PersonaBlockMeta = {
     },
     {
       icon: PersonaIcon,
-      title: 'Compliance audit PDF archive',
+      title: 'Persona audit PDF archive',
       prompt:
         'Build a workflow that takes an approved inquiry ID, downloads the inquiry summary PDF from Persona, and uploads it to a compliance archive folder in Google Drive named by customer reference ID.',
       modules: ['workflows', 'files', 'agent'],
@@ -627,7 +627,7 @@ export const PersonaBlockMeta = {
     },
     {
       icon: PersonaIcon,
-      title: 'Manual review case triage agent',
+      title: 'Persona case triage agent',
       prompt:
         'Build an agent that lists open Persona cases, fetches the linked inquiry and verification details for each, drafts a recommended approve/decline decision with reasoning, and posts the triage summary to Slack for a human reviewer.',
       modules: ['agent', 'workflows'],
@@ -637,7 +637,7 @@ export const PersonaBlockMeta = {
     },
     {
       icon: PersonaIcon,
-      title: 'Re-verification campaign for stale accounts',
+      title: 'Persona re-verification campaign',
       prompt:
         'Build a scheduled workflow that lists Persona accounts, finds ones whose latest approved inquiry is older than a year, creates a new inquiry for each from our re-verification template, and emails customers a one-time verification link.',
       modules: ['scheduled', 'workflows', 'agent'],

--- a/apps/sim/blocks/blocks/postgresql.ts
+++ b/apps/sim/blocks/blocks/postgresql.ts
@@ -409,7 +409,7 @@ export const PostgreSQLBlockMeta = {
   templates: [
     {
       icon: PostgresIcon,
-      title: 'Ask your database in plain English',
+      title: 'Ask Postgres in plain English',
       prompt:
         'Build a workflow that takes a natural-language question, has an agent turn it into a PostgreSQL SELECT query, runs it against the database, and returns the resulting rows as a readable answer.',
       modules: ['agent', 'workflows'],
@@ -418,7 +418,7 @@ export const PostgreSQLBlockMeta = {
     },
     {
       icon: PostgresIcon,
-      title: 'Daily metrics digest to Slack',
+      title: 'Postgres metrics digest to Slack',
       prompt:
         'Create a scheduled workflow that queries key business metrics from PostgreSQL each morning, has an agent summarize the numbers and notable changes, and posts the digest to a Slack channel.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -428,7 +428,7 @@ export const PostgreSQLBlockMeta = {
     },
     {
       icon: PostgresIcon,
-      title: 'Document the schema',
+      title: 'Document your Postgres schema',
       prompt:
         'Build a workflow that introspects a PostgreSQL schema to list its tables, columns, keys, and indexes, then has an agent write plain-English documentation describing what each table holds.',
       modules: ['agent', 'workflows'],
@@ -437,7 +437,7 @@ export const PostgreSQLBlockMeta = {
     },
     {
       icon: PostgresIcon,
-      title: 'Upsert records into a table',
+      title: 'Upsert records into Postgres',
       prompt:
         'Create a workflow that takes incoming records, checks PostgreSQL for an existing row by key, then inserts a new row or updates the existing one so the table stays in sync without duplicates.',
       modules: ['agent', 'workflows'],
@@ -446,7 +446,7 @@ export const PostgreSQLBlockMeta = {
     },
     {
       icon: PostgresIcon,
-      title: 'Nightly stale-data cleanup',
+      title: 'Nightly Postgres data cleanup',
       prompt:
         'Build a scheduled workflow that deletes rows in PostgreSQL older than a retention cutoff and reports how many rows were removed, so tables stay lean on an interval.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -455,7 +455,7 @@ export const PostgreSQLBlockMeta = {
     },
     {
       icon: PostgresIcon,
-      title: 'Sync query results into a Sim table',
+      title: 'Postgres results to Sim table',
       prompt:
         'Create a scheduled workflow that runs a PostgreSQL query for the latest records and writes each row into a Sim table, so the data is available for downstream blocks without a live database call.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -464,7 +464,7 @@ export const PostgreSQLBlockMeta = {
     },
     {
       icon: PostgresIcon,
-      title: 'Alert on threshold breach',
+      title: 'Postgres threshold breach alert',
       prompt:
         'Build a scheduled workflow that queries a PostgreSQL count or aggregate, compares it to a threshold, and posts a Slack alert only when the value crosses the limit so the team hears about problems early.',
       modules: ['scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/rb2b.ts
+++ b/apps/sim/blocks/blocks/rb2b.ts
@@ -223,7 +223,7 @@ export const RB2BBlockMeta = {
   templates: [
     {
       icon: RB2BIcon,
-      title: 'Website visitor de-anonymizer',
+      title: 'RB2B visitor de-anonymizer',
       prompt:
         'Build a workflow that takes the IP addresses of anonymous website visitors, uses RB2B to resolve each IP to a hashed email and company domain, and writes the identified visitors into a table for the sales team.',
       modules: ['tables', 'agent', 'workflows'],
@@ -232,7 +232,7 @@ export const RB2BBlockMeta = {
     },
     {
       icon: RB2BIcon,
-      title: 'Visitor IP to LinkedIn profile',
+      title: 'RB2B IP to LinkedIn profile',
       prompt:
         'Create a workflow that resolves a visitor IP to a hashed email with RB2B, then enriches that hashed email into a LinkedIn profile and business profile so reps know exactly who visited.',
       modules: ['tables', 'agent', 'workflows'],
@@ -241,7 +241,7 @@ export const RB2BBlockMeta = {
     },
     {
       icon: RB2BIcon,
-      title: 'Hashed email enrichment pipeline',
+      title: 'RB2B hashed-email enrichment',
       prompt:
         'Build a workflow that reads hashed emails from a table, uses RB2B to enrich each into a full business profile with name, title, seniority, and company details, and writes the enriched records back to the row.',
       modules: ['tables', 'agent', 'workflows'],
@@ -250,7 +250,7 @@ export const RB2BBlockMeta = {
     },
     {
       icon: RB2BIcon,
-      title: 'LinkedIn to mobile phone finder',
+      title: 'RB2B LinkedIn phone finder',
       prompt:
         "Create a workflow that takes a list of LinkedIn profile slugs, uses RB2B to look up each prospect's mobile phone and best personal email, and writes a ready-to-contact table for outbound calling.",
       modules: ['tables', 'agent', 'workflows'],
@@ -259,7 +259,7 @@ export const RB2BBlockMeta = {
     },
     {
       icon: RB2BIcon,
-      title: 'Intent-to-CRM identity sync',
+      title: 'RB2B visitor-to-HubSpot sync',
       prompt:
         'Build a workflow that resolves visitor IPs to company domains with RB2B, enriches the matched person into a business profile, and creates or updates the matching contact and company in HubSpot.',
       modules: ['agent', 'workflows'],
@@ -269,7 +269,7 @@ export const RB2BBlockMeta = {
     },
     {
       icon: RB2BIcon,
-      title: 'High-intent visitor Slack alerts',
+      title: 'RB2B visitor Slack alerts',
       prompt:
         'Create a workflow that reads a list of website visitor IPs, uses RB2B to resolve each person and their company, and posts an alert with the identified LinkedIn profile and company to the sales Slack channel.',
       modules: ['agent', 'workflows'],
@@ -279,7 +279,7 @@ export const RB2BBlockMeta = {
     },
     {
       icon: RB2BIcon,
-      title: 'LinkedIn slug resolver',
+      title: 'RB2B LinkedIn slug resolver',
       prompt:
         'Build a workflow that takes a first name, last name, and company domain, uses RB2B LinkedIn slug search to resolve the matching profile, and enriches it into a business profile written to a prospect table.',
       modules: ['tables', 'agent', 'workflows'],
@@ -288,7 +288,7 @@ export const RB2BBlockMeta = {
     },
     {
       icon: RB2BIcon,
-      title: 'Account engagement freshness sweep',
+      title: 'RB2B engagement freshness sweep',
       prompt:
         'Create a scheduled workflow that runs my list of prospect emails through RB2B email-to-last-active-date lookups, flags recently active contacts, and logs the engagement snapshot to a table for prioritized follow-up.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/reddit.ts
+++ b/apps/sim/blocks/blocks/reddit.ts
@@ -1394,7 +1394,7 @@ export const RedditBlockMeta = {
   templates: [
     {
       icon: RedditIcon,
-      title: 'Social mention tracker',
+      title: 'Reddit mention tracker',
       prompt:
         'Create a scheduled workflow that monitors Reddit and X for mentions of my brand and competitors, scores each mention by sentiment and reach, logs them to a table, and sends a daily Slack digest of notable mentions.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/revenuecat.ts
+++ b/apps/sim/blocks/blocks/revenuecat.ts
@@ -523,7 +523,7 @@ export const RevenueCatBlockMeta = {
     },
     {
       icon: RevenueCatIcon,
-      title: 'Entitlement granter',
+      title: 'RevenueCat entitlement granter',
       prompt:
         'Create a workflow that listens for a customer-success approval — for example a Slack reaction or a row in a table — looks up the RevenueCat subscriber, grants a promotional entitlement with the right expiry, and logs the grant in an audit table for compliance.',
       modules: ['tables', 'agent', 'workflows'],
@@ -533,7 +533,7 @@ export const RevenueCatBlockMeta = {
     },
     {
       icon: RevenueCatIcon,
-      title: 'Failed renewal recovery',
+      title: 'RevenueCat renewal recovery',
       prompt:
         'Build a scheduled workflow that lists RevenueCat subscribers with failed renewals, segments them by plan and tenure, drafts a tailored win-back email, sends it via Gmail, and tracks recovery outcomes in a table with retry cadence rules.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -543,7 +543,7 @@ export const RevenueCatBlockMeta = {
     },
     {
       icon: RevenueCatIcon,
-      title: 'Subscriber attribute sync',
+      title: 'RevenueCat attribute sync',
       prompt:
         'Create a workflow that listens for changes in your customer table — like email, display name, or company — and updates the matching RevenueCat subscriber attributes so analytics and targeted offers always reflect the latest customer state.',
       modules: ['tables', 'agent', 'workflows'],
@@ -552,7 +552,7 @@ export const RevenueCatBlockMeta = {
     },
     {
       icon: RevenueCatIcon,
-      title: 'Trial expiry digest',
+      title: 'RevenueCat trial expiry digest',
       prompt:
         'Build a scheduled daily workflow that lists RevenueCat subscribers whose trials expire in the next three days, ranks them by engagement, drafts a personalized conversion nudge, and emails the success team a prioritized list to call.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -562,7 +562,7 @@ export const RevenueCatBlockMeta = {
     },
     {
       icon: RevenueCatIcon,
-      title: 'Google Play refund operator',
+      title: 'RevenueCat Google Play refund',
       prompt:
         'Create a workflow that takes a refund approval from a support ticket, calls the RevenueCat Google Play refund operation with the right transaction identifier, revokes access, posts the outcome back on the ticket, and logs the action in a compliance table.',
       modules: ['tables', 'agent', 'workflows'],
@@ -572,7 +572,7 @@ export const RevenueCatBlockMeta = {
     },
     {
       icon: RevenueCatIcon,
-      title: 'Offering performance report',
+      title: 'RevenueCat offering report',
       prompt:
         'Build a scheduled weekly workflow that pulls RevenueCat offerings and recent purchases, computes conversion rate per offering and per package, writes a narrative analysis file with recommendations, and Slacks growth leadership the top findings.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/rippling.ts
+++ b/apps/sim/blocks/blocks/rippling.ts
@@ -1499,7 +1499,7 @@ export const RipplingBlockMeta = {
     },
     {
       icon: RipplingIcon,
-      title: 'Org chart export and review',
+      title: 'Rippling org chart export',
       prompt:
         'Build a scheduled weekly workflow that pulls Rippling workers, departments, teams, and titles, writes an updated org chart file, diffs against last week to find structural changes, and Slacks people operations any unexpected moves for review.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],
@@ -1509,7 +1509,7 @@ export const RipplingBlockMeta = {
     },
     {
       icon: RipplingIcon,
-      title: 'Custom object data sync',
+      title: 'Rippling custom object sync',
       prompt:
         'Create a workflow that reads rows from a Sim table representing custom Rippling objects — perks, equipment, allowances — and upserts them into Rippling so HR can manage company-specific data with the same governance as core worker records.',
       modules: ['tables', 'agent', 'workflows'],
@@ -1518,7 +1518,7 @@ export const RipplingBlockMeta = {
     },
     {
       icon: RipplingIcon,
-      title: 'Team and title auditor',
+      title: 'Rippling team and title audit',
       prompt:
         'Build a scheduled monthly workflow that lists Rippling teams, titles, and job functions, flags duplicates, unused values, and inconsistent naming, writes a cleanup report file, and opens a Linear task for the people operations owner of each issue.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],
@@ -1528,7 +1528,7 @@ export const RipplingBlockMeta = {
     },
     {
       icon: RipplingIcon,
-      title: 'Manager change notifier',
+      title: 'Rippling manager change alerts',
       prompt:
         'Create a scheduled workflow that polls Rippling workers for manager reassignments, notifies the worker and the new manager via email, schedules a thirty-minute intro on Google Calendar, and logs the transition in a tracking table for HR visibility.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -1538,7 +1538,7 @@ export const RipplingBlockMeta = {
     },
     {
       icon: RipplingIcon,
-      title: 'Department headcount digest',
+      title: 'Rippling headcount digest',
       prompt:
         'Build a scheduled weekly workflow that pulls Rippling workers grouped by department and employment type, computes headcount, open requisitions, and growth versus the prior week, writes a narrative summary, and emails it to department heads.',
       modules: ['scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/rocketlane.ts
+++ b/apps/sim/blocks/blocks/rocketlane.ts
@@ -2886,7 +2886,7 @@ export const RocketlaneBlockMeta = {
   templates: [
     {
       icon: RocketlaneIcon,
-      title: 'Client onboarding kickoff',
+      title: 'Rocketlane onboarding kickoff',
       prompt:
         'Build a workflow that creates a Rocketlane project from an onboarding template for a new customer, assigns the implementation manager placeholder, adds the account team as members, and posts a kickoff summary with the project details to Slack.',
       modules: ['agent', 'workflows'],
@@ -2896,7 +2896,7 @@ export const RocketlaneBlockMeta = {
     },
     {
       icon: RocketlaneIcon,
-      title: 'Weekly project status digest',
+      title: 'Rocketlane status digest',
       prompt:
         'Create a scheduled weekly workflow that lists active Rocketlane projects with their status and due dates, summarizes progress and anything overdue per customer, and emails the digest to the delivery team every Monday morning.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -2906,7 +2906,7 @@ export const RocketlaneBlockMeta = {
     },
     {
       icon: RocketlaneIcon,
-      title: 'Overdue task escalation',
+      title: 'Rocketlane task escalation',
       prompt:
         'Build a scheduled daily workflow that lists Rocketlane tasks with a due date before today that are not complete, marks them at risk, and posts an escalation to Slack tagging each task name, project, and assignees.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -2916,7 +2916,7 @@ export const RocketlaneBlockMeta = {
     },
     {
       icon: RocketlaneIcon,
-      title: 'Time tracking rollup',
+      title: 'Rocketlane time rollup',
       prompt:
         'Create a scheduled weekly workflow that searches Rocketlane time entries for the past week, totals billable and non-billable minutes per project, and posts a formatted utilization rollup to Slack.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -2926,7 +2926,7 @@ export const RocketlaneBlockMeta = {
     },
     {
       icon: RocketlaneIcon,
-      title: 'Invoice payment monitor',
+      title: 'Rocketlane invoice monitor',
       prompt:
         'Build a scheduled workflow that lists Rocketlane invoices with an outstanding amount greater than zero and a due date in the past, pulls their payments, and emails the finance team a list of overdue invoices with amounts outstanding.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -2936,7 +2936,7 @@ export const RocketlaneBlockMeta = {
     },
     {
       icon: RocketlaneIcon,
-      title: 'Resource allocation report',
+      title: 'Rocketlane allocation report',
       prompt:
         'Create a workflow that lists Rocketlane resource allocations for the next two weeks, writes each member, project, and allocation range into a table, and flags team members who appear in overlapping allocations.',
       modules: ['tables', 'agent', 'workflows'],
@@ -2945,7 +2945,7 @@ export const RocketlaneBlockMeta = {
     },
     {
       icon: RocketlaneIcon,
-      title: 'Timesheet reminder',
+      title: 'Rocketlane timesheet reminder',
       prompt:
         'Build a scheduled Friday workflow that lists active Rocketlane team members, searches this week’s time entries per user, and sends a Slack reminder to anyone who has logged less than their expected hours.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -2955,7 +2955,7 @@ export const RocketlaneBlockMeta = {
     },
     {
       icon: RocketlaneIcon,
-      title: 'New project scaffolding',
+      title: 'Rocketlane project scaffolding',
       prompt:
         'Create a workflow that scaffolds a delivery project in Rocketlane: create the project, add Discovery, Implementation, and Go-live phases with dates, create kickoff tasks in each phase with assignees, and set up a shared space with a kickoff document.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/salesforce.ts
+++ b/apps/sim/blocks/blocks/salesforce.ts
@@ -1005,7 +1005,7 @@ export const SalesforceBlockMeta = {
   templates: [
     {
       icon: SalesforceIcon,
-      title: 'CRM knowledge search',
+      title: 'Salesforce knowledge search',
       prompt:
         'Create a knowledge base connected to my Salesforce account so all deals, contacts, notes, and activities are automatically synced and searchable. Then build an agent I can ask things like "what\'s the history with Acme Corp?" or "who was involved in the last enterprise deal?" and get instant answers with CRM record citations.',
       modules: ['knowledge-base', 'agent'],
@@ -1014,7 +1014,7 @@ export const SalesforceBlockMeta = {
     },
     {
       icon: SalesforceIcon,
-      title: 'Deal pipeline tracker',
+      title: 'Salesforce pipeline tracker',
       prompt:
         'Create a table with columns for deal name, stage, amount, close date, and next steps. Build a workflow that syncs open deals from Salesforce into this table daily, and sends me a Slack summary each morning of deals that need attention or are at risk of slipping.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],
@@ -1036,7 +1036,7 @@ export const SalesforceBlockMeta = {
     },
     {
       icon: SalesforceIcon,
-      title: 'Inbound lead router',
+      title: 'Salesforce lead router',
       prompt:
         'Build a workflow that triggers on new inbound form submissions, creates a Salesforce lead with the captured fields, runs a SOQL query to check for an existing account match, assigns the lead to the right owner, and posts the new lead with its score to Slack.',
       modules: ['agent', 'workflows'],
@@ -1065,7 +1065,7 @@ export const SalesforceBlockMeta = {
     },
     {
       icon: SalesforceIcon,
-      title: 'Closed-won onboarding kickoff',
+      title: 'Salesforce onboarding kickoff',
       prompt:
         'Create a workflow that watches Salesforce opportunities for stage changes to closed-won, pulls the related account and contacts, creates onboarding tasks for the CS owner, and writes a kickoff record into a tables-based project tracker.',
       modules: ['tables', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/sap_s4hana.ts
+++ b/apps/sim/blocks/blocks/sap_s4hana.ts
@@ -1271,7 +1271,7 @@ export const SapS4HanaBlockMeta = {
     },
     {
       icon: SapS4HanaIcon,
-      title: 'Purchase requisition router',
+      title: 'SAP purchase requisition router',
       prompt:
         'Build a workflow exposed to internal users as a form that captures purchase requisition details, classifies the request, creates the requisition in SAP S/4HANA via OData, posts the requisition number back to the requester, and logs the request in a tracking table.',
       modules: ['tables', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/sentry.ts
+++ b/apps/sim/blocks/blocks/sentry.ts
@@ -735,7 +735,7 @@ export const SentryBlockMeta = {
   templates: [
     {
       icon: Bug,
-      title: 'Bug triage agent',
+      title: 'Sentry bug triage agent',
       prompt:
         'Build an agent that monitors Sentry for new errors, automatically triages them by severity and affected users, creates Linear tickets for critical issues with full stack traces, and sends a Slack notification to the on-call channel.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/sentry.ts
+++ b/apps/sim/blocks/blocks/sentry.ts
@@ -735,7 +735,7 @@ export const SentryBlockMeta = {
   templates: [
     {
       icon: Bug,
-      title: 'Sentry bug triage agent',
+      title: 'Sentry on-call triage agent',
       prompt:
         'Build an agent that monitors Sentry for new errors, automatically triages them by severity and affected users, creates Linear tickets for critical issues with full stack traces, and sends a Slack notification to the on-call channel.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/sftp.ts
+++ b/apps/sim/blocks/blocks/sftp.ts
@@ -326,7 +326,7 @@ export const SftpBlockMeta = {
   templates: [
     {
       icon: Download,
-      title: 'Pull new files from a remote drop folder',
+      title: 'Pull new files from an SFTP folder',
       prompt:
         'Build a workflow that runs on a schedule, lists a remote SFTP drop folder, downloads any new files, and passes their contents into the workflow for processing.',
       modules: ['scheduled', 'files', 'workflows'],
@@ -344,7 +344,7 @@ export const SftpBlockMeta = {
     },
     {
       icon: Server,
-      title: 'Mirror a local export to a remote directory',
+      title: 'Mirror a local export to SFTP',
       prompt:
         'Build a workflow that lists a remote SFTP directory, compares it to the files produced by an earlier block, and uploads any missing files to keep the remote directory in sync.',
       modules: ['files', 'scheduled', 'workflows'],
@@ -353,7 +353,7 @@ export const SftpBlockMeta = {
     },
     {
       icon: TrashOutline,
-      title: 'Archive and delete old files on a schedule',
+      title: 'Archive and delete old SFTP files',
       prompt:
         'Build a workflow that runs nightly, lists an SFTP directory, downloads files older than a threshold to archive them, and then deletes the originals from the remote server.',
       modules: ['scheduled', 'files', 'workflows'],
@@ -372,7 +372,7 @@ export const SftpBlockMeta = {
     },
     {
       icon: Search,
-      title: 'Inventory a remote directory listing',
+      title: 'Inventory an SFTP directory',
       prompt:
         'Build a workflow that lists a remote SFTP directory with detailed metadata and records the file names, sizes, and timestamps for auditing.',
       modules: ['files', 'workflows', 'tables'],
@@ -381,7 +381,7 @@ export const SftpBlockMeta = {
     },
     {
       icon: File,
-      title: 'Write a manifest file to a remote server',
+      title: 'Write a manifest file to SFTP',
       prompt:
         'Build a workflow that assembles a manifest of processed records and creates a manifest.txt file on a remote SFTP path so downstream systems know the batch is ready.',
       modules: ['files', 'workflows'],
@@ -390,7 +390,7 @@ export const SftpBlockMeta = {
     },
     {
       icon: Download,
-      title: 'Download a remote file and summarize it',
+      title: 'Download an SFTP file and summarize it',
       prompt:
         'Build a workflow that downloads a file from an SFTP server and passes its contents to an agent that summarizes the key points.',
       modules: ['files', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/shopify.ts
+++ b/apps/sim/blocks/blocks/shopify.ts
@@ -1035,7 +1035,7 @@ export const ShopifyBlockMeta = {
   templates: [
     {
       icon: ShopifyIcon,
-      title: 'E-commerce order monitor',
+      title: 'Shopify order monitor',
       prompt:
         'Build a workflow that monitors Shopify orders, flags high-value or unusual orders for review, tracks fulfillment status in a table, and sends daily inventory and sales summaries to Slack with restock alerts when items run low.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],
@@ -1045,7 +1045,7 @@ export const ShopifyBlockMeta = {
     },
     {
       icon: ShopifyIcon,
-      title: 'Unpaid order recovery',
+      title: 'Shopify unpaid order recovery',
       prompt:
         'Build a scheduled workflow that lists Shopify orders left open and unpaid in the past day, drafts a personalized recovery email referencing the items, and sends it via Gmail while logging recovery attempts to a table.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -1055,7 +1055,7 @@ export const ShopifyBlockMeta = {
     },
     {
       icon: ShopifyIcon,
-      title: 'Low-stock restock alerter',
+      title: 'Shopify restock alerter',
       prompt:
         'Create a scheduled hourly workflow that lists Shopify inventory items, computes days-of-cover from recent sales velocity, flags SKUs below a configurable threshold, and posts a Slack alert to the operations channel with the variant, location, and recommended reorder quantity.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -1074,7 +1074,7 @@ export const ShopifyBlockMeta = {
     },
     {
       icon: ShopifyIcon,
-      title: 'Fulfillment status tracker',
+      title: 'Shopify fulfillment tracker',
       prompt:
         'Create a scheduled workflow that lists Shopify orders and their fulfillment status, updates a status table with shipped, in-transit, and delivered states, and proactively emails customers when their order misses an SLA so support gets ahead of the inquiry.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -1084,7 +1084,7 @@ export const ShopifyBlockMeta = {
     },
     {
       icon: ShopifyIcon,
-      title: 'Product launch publisher',
+      title: 'Shopify product launcher',
       prompt:
         'Build a workflow that takes a new product brief, creates the product in Shopify with variants and pricing, adds it to the right collection, drafts a launch announcement, and queues a Slack and email broadcast for marketing review before going live.',
       modules: ['agent', 'workflows'],
@@ -1094,7 +1094,7 @@ export const ShopifyBlockMeta = {
     },
     {
       icon: ShopifyIcon,
-      title: 'Order anomaly detector',
+      title: 'Shopify order anomaly detector',
       prompt:
         'Create a scheduled workflow that runs every fifteen minutes, lists recent Shopify orders, scores each for anomalies — high value, unusual destination, mismatched billing — flags suspects in a review queue table, and Slacks the operations team for hands-on inspection.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/slack.ts
+++ b/apps/sim/blocks/blocks/slack.ts
@@ -1,5 +1,5 @@
 import { BookOpen, ClipboardList, File, Table, Users } from '@sim/emcn/icons'
-import { GoogleTranslateIcon, GreptileIcon, LinearIcon, SlackIcon } from '@/components/icons'
+import { GoogleTranslateIcon, GreptileIcon, SlackIcon } from '@/components/icons'
 import { getScopesForService } from '@/lib/oauth/utils'
 import type { BlockConfig, BlockMeta, SubBlockConfig } from '@/blocks/types'
 import { AuthMode, IntegrationType } from '@/blocks/types'
@@ -2498,7 +2498,7 @@ export const SlackBlockMeta = {
       tags: ['support', 'sales', 'monitoring', 'analysis'],
     },
     {
-      icon: LinearIcon,
+      icon: SlackIcon,
       title: 'Slack incident postmortem writer',
       prompt:
         'Create a workflow that when triggered after an incident, pulls the Slack thread from the incident channel, gathers relevant Sentry errors and deployment logs, and drafts a structured postmortem with timeline, root cause, and action items.',

--- a/apps/sim/blocks/blocks/slack.ts
+++ b/apps/sim/blocks/blocks/slack.ts
@@ -2490,7 +2490,7 @@ export const SlackBlockMeta = {
     },
     {
       icon: Table,
-      title: 'Churn risk detector',
+      title: 'Slack churn risk alerts',
       prompt:
         'Create a workflow that monitors customer activity — support ticket frequency, response sentiment, usage patterns — scores each account for churn risk in a table, and triggers a Slack alert to the account team when a customer crosses the risk threshold.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],
@@ -2499,7 +2499,7 @@ export const SlackBlockMeta = {
     },
     {
       icon: LinearIcon,
-      title: 'Incident postmortem writer',
+      title: 'Slack incident postmortem writer',
       prompt:
         'Create a workflow that when triggered after an incident, pulls the Slack thread from the incident channel, gathers relevant Sentry errors and deployment logs, and drafts a structured postmortem with timeline, root cause, and action items.',
       modules: ['agent', 'files', 'workflows'],
@@ -2528,7 +2528,7 @@ export const SlackBlockMeta = {
     },
     {
       icon: File,
-      title: 'Automated narrative report',
+      title: 'Slack narrative report',
       prompt:
         'Build a scheduled workflow that pulls key data from my tables every week, analyzes trends and anomalies, and writes a narrative report — not just charts and numbers, but written insights explaining what changed, why it matters, and what to do next. Save it as a document and send a summary to Slack.',
       modules: ['tables', 'scheduled', 'agent', 'files', 'workflows'],
@@ -2537,7 +2537,7 @@ export const SlackBlockMeta = {
     },
     {
       icon: BookOpen,
-      title: 'Email digest curator',
+      title: 'Slack reading digest',
       prompt:
         'Create a scheduled daily workflow that searches the web for the latest articles, papers, and news on topics I care about, picks the top 5 most relevant pieces, writes a one-paragraph summary for each, and delivers a curated reading digest to my inbox or Slack.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],
@@ -2546,7 +2546,7 @@ export const SlackBlockMeta = {
     },
     {
       icon: ClipboardList,
-      title: 'Daily standup summary',
+      title: 'Slack standup summary',
       prompt:
         'Create a scheduled workflow that reads the #standup Slack channel each morning, summarizes what everyone is working on, identifies blockers, and posts a structured recap to a Google Docs document.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],
@@ -2556,7 +2556,7 @@ export const SlackBlockMeta = {
     },
     {
       icon: Users,
-      title: 'New hire onboarding automation',
+      title: 'Slack onboarding automation',
       prompt:
         "Build a workflow that when triggered with a new hire's info, creates their accounts, sends a personalized welcome message in Slack, schedules 1:1s with their team on Google Calendar, shares relevant onboarding docs from the knowledge base, and tracks completion in a table.",
       modules: ['knowledge-base', 'tables', 'agent', 'workflows'],
@@ -2566,7 +2566,7 @@ export const SlackBlockMeta = {
     },
     {
       icon: Table,
-      title: 'Customer 360 view',
+      title: 'Slack customer 360 alerts',
       prompt:
         'Create a comprehensive customer table that aggregates data from my CRM, support tickets, billing history, and product usage into a single unified view per customer. Schedule it to sync daily and send a Slack alert when any customer shows signs of trouble across multiple signals.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/smtp.ts
+++ b/apps/sim/blocks/blocks/smtp.ts
@@ -215,7 +215,7 @@ export const SmtpBlockMeta = {
   templates: [
     {
       icon: SmtpIcon,
-      title: 'Scheduled daily digest email',
+      title: 'SMTP daily digest email',
       prompt:
         'Build a scheduled workflow that gathers the day’s key updates, has an agent write a clean HTML summary, and sends it as a daily digest email to the team over SMTP.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -224,7 +224,7 @@ export const SmtpBlockMeta = {
     },
     {
       icon: SmtpIcon,
-      title: 'Alert email when a condition is met',
+      title: 'SMTP alert email on threshold',
       prompt:
         'Create a workflow that checks a metric or status, and when it crosses a threshold, sends an alert email over SMTP with the details and a clear subject so the on-call person notices immediately.',
       modules: ['agent', 'workflows'],
@@ -233,7 +233,7 @@ export const SmtpBlockMeta = {
     },
     {
       icon: SmtpIcon,
-      title: 'Email a generated report as an attachment',
+      title: 'SMTP report as attachment',
       prompt:
         'Build a workflow that generates a report file, then sends it as an email attachment over SMTP to the requested recipients with a short summary in the body.',
       modules: ['files', 'agent', 'workflows'],
@@ -242,7 +242,7 @@ export const SmtpBlockMeta = {
     },
     {
       icon: SmtpIcon,
-      title: 'Personalized outreach from a recipient table',
+      title: 'SMTP outreach from a table',
       prompt:
         'Create a workflow that reads a table of recipients, has an agent draft a personalized message for each row, and sends an individual email to every contact over SMTP with their name and details filled in.',
       modules: ['tables', 'agent', 'workflows'],
@@ -251,7 +251,7 @@ export const SmtpBlockMeta = {
     },
     {
       icon: SmtpIcon,
-      title: 'Form-submission auto-reply',
+      title: 'SMTP form-submission auto-reply',
       prompt:
         'Build a workflow that triggers on a new form submission and sends an automatic confirmation email over SMTP to the submitter, using their address as the recipient and a friendly reply-to.',
       modules: ['agent', 'workflows'],
@@ -260,7 +260,7 @@ export const SmtpBlockMeta = {
     },
     {
       icon: SmtpIcon,
-      title: 'Incident notification email',
+      title: 'SMTP incident notification',
       prompt:
         'Create a workflow that, when an incident is detected, sends a notification email over SMTP to a distribution list with the severity, impact, and next steps, cc’ing the stakeholders who need to be looped in.',
       modules: ['agent', 'workflows'],
@@ -269,7 +269,7 @@ export const SmtpBlockMeta = {
     },
     {
       icon: SmtpIcon,
-      title: 'Weekly summary email',
+      title: 'SMTP weekly summary email',
       prompt:
         'Build a scheduled workflow that compiles the week’s results into an HTML summary with an agent and emails it over SMTP to the team every Friday, with a link-friendly reply-to for follow-ups.',
       modules: ['scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/sportmonks.ts
+++ b/apps/sim/blocks/blocks/sportmonks.ts
@@ -2292,7 +2292,7 @@ export const SportmonksBlockMeta = {
   templates: [
     {
       icon: SportmonksIcon,
-      title: 'Daily football fixtures digest',
+      title: 'Sportmonks daily fixtures digest',
       prompt:
         "Build a scheduled daily workflow that fetches today's football fixtures from Sportmonks for the leagues I follow, summarizes the key matchups and kickoff times, and posts the digest to Slack.",
       modules: ['scheduled', 'agent', 'workflows'],
@@ -2302,7 +2302,7 @@ export const SportmonksBlockMeta = {
     },
     {
       icon: SportmonksIcon,
-      title: 'Live football score alerter',
+      title: 'Sportmonks live score alerter',
       prompt:
         'Create a scheduled workflow that polls Sportmonks inplay football scores, detects goals and status changes since the last run, and pings Slack with the updated scoreline for tracked matches.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -2312,7 +2312,7 @@ export const SportmonksBlockMeta = {
     },
     {
       icon: SportmonksIcon,
-      title: 'Weekly league standings report',
+      title: 'Sportmonks league standings report',
       prompt:
         'Build a scheduled weekly workflow that pulls the Sportmonks football standings and topscorers for a season, formats a league table with recent form, and emails the report to the group.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -2322,7 +2322,7 @@ export const SportmonksBlockMeta = {
     },
     {
       icon: SportmonksIcon,
-      title: 'Race weekend schedule digest',
+      title: 'Sportmonks race weekend digest',
       prompt:
         "Build a scheduled workflow that fetches this weekend's motorsport sessions from Sportmonks, summarizes the practice, qualifying, and race times, and posts the schedule to Slack.",
       modules: ['scheduled', 'agent', 'workflows'],
@@ -2332,7 +2332,7 @@ export const SportmonksBlockMeta = {
     },
     {
       icon: SportmonksIcon,
-      title: 'Motorsport championship tracker',
+      title: 'Sportmonks championship tracker',
       prompt:
         'Create a scheduled weekly workflow that pulls the Sportmonks motorsport driver and constructor standings for the current season, formats the championship tables, and emails them to the group.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -2342,7 +2342,7 @@ export const SportmonksBlockMeta = {
     },
     {
       icon: SportmonksIcon,
-      title: 'Pre-match odds snapshot',
+      title: 'Sportmonks pre-match odds snapshot',
       prompt:
         'Build a workflow that pulls Sportmonks pre-match odds for a fixture across selected bookmakers, computes the implied probability for each outcome, and writes the snapshot to a table.',
       modules: ['tables', 'agent', 'workflows'],
@@ -2351,7 +2351,7 @@ export const SportmonksBlockMeta = {
     },
     {
       icon: SportmonksIcon,
-      title: 'Live odds movement alerter',
+      title: 'Sportmonks live odds alerter',
       prompt:
         'Create a scheduled workflow that polls Sportmonks in-play odds for a fixture, detects sharp price moves since the last run, and pings Slack with the updated lines.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -2361,7 +2361,7 @@ export const SportmonksBlockMeta = {
     },
     {
       icon: SportmonksIcon,
-      title: 'Head-to-head match preview',
+      title: 'Sportmonks head-to-head preview',
       prompt:
         'Create a workflow that takes two team names, resolves them to IDs via Sportmonks football team search, pulls their head-to-head history and current standings, and writes a match preview file.',
       modules: ['agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/sqs.ts
+++ b/apps/sim/blocks/blocks/sqs.ts
@@ -190,7 +190,7 @@ export const SQSBlockMeta = {
     },
     {
       icon: SQSIcon,
-      title: 'SQS alert fan-out',
+      title: 'SQS alert enricher',
       prompt:
         'Create a workflow triggered by PagerDuty or Datadog alerts that classifies severity, decorates the payload with runbook context, and pushes the enriched alert to an Amazon SQS queue so multiple downstream notifiers and ticketing systems can consume it independently.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/sqs.ts
+++ b/apps/sim/blocks/blocks/sqs.ts
@@ -172,7 +172,7 @@ export const SQSBlockMeta = {
     },
     {
       icon: SQSIcon,
-      title: 'Dead-letter queue replayer',
+      title: 'SQS dead-letter replayer',
       prompt:
         'Create a scheduled workflow that runs every morning, scans a table of failed jobs, regenerates the original payload, and republishes each failed message to its Amazon SQS queue with retry metadata so transient failures are recovered automatically.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -190,7 +190,7 @@ export const SQSBlockMeta = {
     },
     {
       icon: SQSIcon,
-      title: 'Alert fan-out queue',
+      title: 'SQS alert fan-out',
       prompt:
         'Create a workflow triggered by PagerDuty or Datadog alerts that classifies severity, decorates the payload with runbook context, and pushes the enriched alert to an Amazon SQS queue so multiple downstream notifiers and ticketing systems can consume it independently.',
       modules: ['agent', 'workflows'],
@@ -200,7 +200,7 @@ export const SQSBlockMeta = {
     },
     {
       icon: SQSIcon,
-      title: 'Batch order processor',
+      title: 'SQS batch order queue',
       prompt:
         'Build a workflow that takes a list of orders from a table and queues each one as a separate Amazon SQS message for parallel downstream processing. Track each enqueued message ID in the table so you can correlate downstream results back to the originating row.',
       modules: ['tables', 'agent', 'workflows'],
@@ -209,7 +209,7 @@ export const SQSBlockMeta = {
     },
     {
       icon: SQSIcon,
-      title: 'Scheduled fan-out job',
+      title: 'Scheduled SQS fan-out',
       prompt:
         'Create a scheduled workflow that runs every fifteen minutes, queries pending items from a table, batches them, and pushes one Amazon SQS message per batch to your worker queue. Update the table with batch IDs and timestamps so reprocessing is deterministic.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -218,7 +218,7 @@ export const SQSBlockMeta = {
     },
     {
       icon: SQSIcon,
-      title: 'Cross-service notifier',
+      title: 'SQS cross-service notifier',
       prompt:
         'Build a workflow that listens for completed builds in your CI tool, composes a status payload with build metadata and artifact links, and sends the payload to an Amazon SQS queue so internal services like deploy, audit, and notification workers can react asynchronously.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/square.ts
+++ b/apps/sim/blocks/blocks/square.ts
@@ -883,7 +883,7 @@ export const SquareBlockMeta = {
   templates: [
     {
       icon: SquareIcon,
-      title: 'Daily sales summary',
+      title: 'Square daily sales summary',
       prompt:
         'Build a scheduled daily workflow that lists Square payments from the previous day across all locations, totals gross sales, refunds, and net revenue, writes the figures to a table for historical tracking, and posts a Slack summary with day-over-day trends.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -893,7 +893,7 @@ export const SquareBlockMeta = {
     },
     {
       icon: SquareIcon,
-      title: 'Refund pattern monitor',
+      title: 'Square refund pattern monitor',
       prompt:
         'Create a scheduled weekly workflow that lists Square payments and their refunds, classifies each refund by reason and location, flags any location with an unusually high refund rate, and emails finance a narrative report with recommended actions.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],
@@ -903,7 +903,7 @@ export const SquareBlockMeta = {
     },
     {
       icon: SquareIcon,
-      title: 'New customer welcome',
+      title: 'Square new customer welcome',
       prompt:
         'Build a workflow that takes a new Square customer, creates a welcome email tailored to their purchase, adds them to an onboarding tracking table, and posts a notification to the customer success Slack channel.',
       modules: ['tables', 'agent', 'workflows'],
@@ -913,7 +913,7 @@ export const SquareBlockMeta = {
     },
     {
       icon: SquareIcon,
-      title: 'Invoice chase automation',
+      title: 'Square invoice chase automation',
       prompt:
         'Create a scheduled workflow that lists Square invoices for a location, finds those that are unpaid past their due date, sends a polite reminder email per customer, and logs every chase action to a collections table.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -923,7 +923,7 @@ export const SquareBlockMeta = {
     },
     {
       icon: SquareIcon,
-      title: 'Catalog image enrichment',
+      title: 'Square catalog image enrichment',
       prompt:
         'Build a workflow that lists Square catalog items missing images, generates a product image for each one, uploads it as a catalog image attached to the item, and writes a report of which items were updated.',
       modules: ['agent', 'files', 'workflows'],
@@ -932,7 +932,7 @@ export const SquareBlockMeta = {
     },
     {
       icon: SquareIcon,
-      title: 'Low-stock reorder alerts',
+      title: 'Square low-stock reorder alerts',
       prompt:
         'Create a scheduled workflow that lists the Square catalog, identifies items flagged as low or out of stock, drafts a reorder summary grouped by supplier, and posts it to a Slack purchasing channel with the items and quantities to reorder.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -942,7 +942,7 @@ export const SquareBlockMeta = {
     },
     {
       icon: SquareIcon,
-      title: 'Customer purchase history lookup',
+      title: 'Square purchase history lookup',
       prompt:
         'Build a workflow that searches Square customers by email, pulls their orders and payments, summarizes lifetime spend and most-purchased items, and returns a concise profile the support team can use during a conversation.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/ssh.ts
+++ b/apps/sim/blocks/blocks/ssh.ts
@@ -609,7 +609,7 @@ export const SSHBlockMeta = {
   templates: [
     {
       icon: SshTerminalIcon,
-      title: 'Scheduled server health check to Slack',
+      title: 'SSH health check to Slack',
       prompt:
         'Every morning, SSH into the production server and run a health check command (uptime, load average, and free memory). Summarize stdout with an agent and post the result to the #ops Slack channel so the team starts the day knowing the box is healthy.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -638,7 +638,7 @@ export const SSHBlockMeta = {
     },
     {
       icon: ClipboardList,
-      title: 'Tail and summarize a remote log',
+      title: 'Summarize a remote log over SSH',
       prompt:
         'SSH into the server and read the last 200 lines of /var/log/app.log, then hand the content to an agent that summarizes recent errors and warnings into a short digest. Post the digest so on-call engineers can scan incidents at a glance.',
       modules: ['workflows', 'agent'],
@@ -648,7 +648,7 @@ export const SSHBlockMeta = {
     },
     {
       icon: Download,
-      title: 'Fetch a remote report file into the workflow',
+      title: 'Fetch a remote report over SSH',
       prompt:
         'Download a generated report file from the remote server via SSH and pass the resulting file output into the next step for processing or storage, so a nightly export on the box flows straight into the workflow.',
       modules: ['scheduled', 'files', 'workflows'],
@@ -657,7 +657,7 @@ export const SSHBlockMeta = {
     },
     {
       icon: Search,
-      title: 'Verify a command exists before running it',
+      title: 'Verify a command exists over SSH',
       prompt:
         'Before executing a maintenance step, use Check Command Exists over SSH to confirm a tool like docker or git is installed on the remote host. If the exists output is true, run the command; if not, report a clear message that the dependency is missing.',
       modules: ['workflows'],
@@ -666,7 +666,7 @@ export const SSHBlockMeta = {
     },
     {
       icon: File,
-      title: 'Push a config file and restart a service',
+      title: 'Push a config and restart over SSH',
       prompt:
         'Upload a rendered configuration file to the remote server via SSH, write it to the target path, then execute a command to restart the affected service. Confirm success from the exitCode and stderr outputs before finishing.',
       modules: ['workflows', 'agent'],

--- a/apps/sim/blocks/blocks/stripe.ts
+++ b/apps/sim/blocks/blocks/stripe.ts
@@ -1,4 +1,4 @@
-import { GoogleSheetsIcon, StripeIcon } from '@/components/icons'
+import { StripeIcon } from '@/components/icons'
 import type { BlockConfig, BlockMeta } from '@/blocks/types'
 import { AuthMode, IntegrationType } from '@/blocks/types'
 import type { StripeResponse } from '@/tools/stripe/types'
@@ -848,7 +848,7 @@ export const StripeBlockMeta = {
   url: 'https://stripe.com',
   templates: [
     {
-      icon: GoogleSheetsIcon,
+      icon: StripeIcon,
       title: 'Stripe weekly metrics report',
       prompt:
         'Build a scheduled workflow that pulls data from Stripe and my database every Monday, calculates key metrics like MRR, churn, new subscriptions, and failed payments, writes results to Google Sheets, and sends the team a Slack summary with week-over-week trends.',

--- a/apps/sim/blocks/blocks/stripe.ts
+++ b/apps/sim/blocks/blocks/stripe.ts
@@ -849,7 +849,7 @@ export const StripeBlockMeta = {
   templates: [
     {
       icon: GoogleSheetsIcon,
-      title: 'Weekly metrics report',
+      title: 'Stripe weekly metrics report',
       prompt:
         'Build a scheduled workflow that pulls data from Stripe and my database every Monday, calculates key metrics like MRR, churn, new subscriptions, and failed payments, writes results to Google Sheets, and sends the team a Slack summary with week-over-week trends.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -859,7 +859,7 @@ export const StripeBlockMeta = {
     },
     {
       icon: StripeIcon,
-      title: 'Revenue operations dashboard',
+      title: 'Stripe revenue dashboard',
       prompt:
         'Create a scheduled daily workflow that pulls payment data from Stripe, calculates MRR, net revenue, failed payments, and new subscriptions, logs everything to a table with historical tracking, and sends a daily Slack summary with trends and anomalies.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],
@@ -869,7 +869,7 @@ export const StripeBlockMeta = {
     },
     {
       icon: StripeIcon,
-      title: 'Failed payment recovery',
+      title: 'Stripe failed payment recovery',
       prompt:
         'Build a workflow that listens for Stripe failed-payment events, looks up the customer, classifies the failure reason, drafts a tailored recovery email and a Slack alert to the success team, and logs the attempt in a tracking table so recovery rate can be measured.',
       modules: ['tables', 'agent', 'workflows'],
@@ -879,7 +879,7 @@ export const StripeBlockMeta = {
     },
     {
       icon: StripeIcon,
-      title: 'Subscription churn flagger',
+      title: 'Stripe churn flagger',
       prompt:
         'Create a scheduled daily workflow that lists Stripe subscriptions canceled or scheduled for cancellation, enriches each customer with usage and support history, scores the churn risk, and logs the cohort to a table with recommended save plays for the success team.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -889,7 +889,7 @@ export const StripeBlockMeta = {
     },
     {
       icon: StripeIcon,
-      title: 'Invoice chase automation',
+      title: 'Stripe invoice chaser',
       prompt:
         'Build a scheduled workflow that lists Stripe invoices overdue by more than seven days, sends a polite chase email tailored to the customer history, escalates to a Slack alert at thirty days, and writes every action into a collections tracking table.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -899,7 +899,7 @@ export const StripeBlockMeta = {
     },
     {
       icon: StripeIcon,
-      title: 'New customer welcome flow',
+      title: 'Stripe customer welcome flow',
       prompt:
         'Create a workflow triggered when a new Stripe customer is created. Send a personalized welcome email, create their onboarding checklist in a table, schedule a follow-up meeting via Calendly, and post a Slack notification to the customer success channel.',
       modules: ['tables', 'agent', 'workflows'],
@@ -909,7 +909,7 @@ export const StripeBlockMeta = {
     },
     {
       icon: StripeIcon,
-      title: 'Refund pattern analyzer',
+      title: 'Stripe refund pattern analyzer',
       prompt:
         'Build a scheduled weekly workflow that lists Stripe charge and dispute events, classifies each refund or dispute by reason and product, identifies recurring patterns or fraud signals, writes a narrative report file, and Slacks finance with the top concerns and recommended actions.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/sts.ts
+++ b/apps/sim/blocks/blocks/sts.ts
@@ -527,7 +527,7 @@ export const STSBlockMeta = {
     },
     {
       icon: STSIcon,
-      title: 'CI/CD OIDC credential broker',
+      title: 'STS CI/CD OIDC credential broker',
       prompt:
         'Build a workflow that receives an OIDC token from a CI/CD pipeline (e.g. GitHub Actions), calls AWS STS assume role with web identity to mint short-lived deployment credentials, and writes the issuance to an audit log.',
       modules: ['agent', 'workflows'],
@@ -536,7 +536,7 @@ export const STSBlockMeta = {
     },
     {
       icon: STSIcon,
-      title: 'Enterprise SSO SAML role broker',
+      title: 'STS SAML SSO role broker',
       prompt:
         'Create a workflow that takes a SAML assertion from a corporate identity provider, calls AWS STS assume role with SAML to grant scoped temporary credentials, and logs the session details for compliance review.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/textract.ts
+++ b/apps/sim/blocks/blocks/textract.ts
@@ -494,7 +494,7 @@ export const TextractBlockMeta = {
     },
     {
       icon: TextractIcon,
-      title: 'Receipt OCR for expense reports',
+      title: 'Textract receipt OCR',
       prompt:
         'Build a workflow that processes Gmail attachments with AWS Textract, extracts vendor, date, total, and category, logs each receipt to an expense table, and tags reimbursable items.',
       modules: ['tables', 'files', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/thrive.ts
+++ b/apps/sim/blocks/blocks/thrive.ts
@@ -958,7 +958,7 @@ export const ThriveBlockMeta = {
     },
     {
       icon: ThriveIcon,
-      title: 'Compliance completion digest',
+      title: 'Thrive compliance digest',
       prompt:
         'Create a scheduled weekly workflow that lists Thrive enrolments for a compliance assignment, filters those still open or overdue, and posts a Slack summary to the people-ops channel.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -968,7 +968,7 @@ export const ThriveBlockMeta = {
     },
     {
       icon: ThriveIcon,
-      title: 'Sync leavers from HRIS',
+      title: 'Suspend leavers in Thrive',
       prompt:
         'Build a workflow that reads terminated employees from an HRIS export and suspends each matching user in Thrive with their end date, then logs the result to a table.',
       modules: ['tables', 'agent', 'workflows'],
@@ -977,7 +977,7 @@ export const ThriveBlockMeta = {
     },
     {
       icon: ThriveIcon,
-      title: 'Import historical completions',
+      title: 'Import completions into Thrive',
       prompt:
         'Create a workflow that reads a CSV of prior learning records and creates a completion in Thrive for each user and content item with the completion date.',
       modules: ['files', 'agent', 'workflows'],
@@ -986,7 +986,7 @@ export const ThriveBlockMeta = {
     },
     {
       icon: ThriveIcon,
-      title: 'Assign mandatory training to an audience',
+      title: 'Assign Thrive training to an audience',
       prompt:
         'Build a workflow that creates a Thrive content assignment for a chosen audience and primary content, sets a 30-day completion period, and reports how many learners were enrolled.',
       modules: ['agent', 'workflows'],
@@ -995,7 +995,7 @@ export const ThriveBlockMeta = {
     },
     {
       icon: ThriveIcon,
-      title: 'CPD shortfall report',
+      title: 'Thrive CPD shortfall report',
       prompt:
         'Create a scheduled monthly workflow that queries Thrive CPD user summaries for a date range, compares logged minutes against each audience CPD requirement, and emails managers a list of learners below target.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -1005,7 +1005,7 @@ export const ThriveBlockMeta = {
     },
     {
       icon: ThriveIcon,
-      title: 'Tag learners by skill',
+      title: 'Tag Thrive learners by skill',
       prompt:
         'Build a workflow that searches Thrive users by status, then adds skill tags and updates skill levels for each learner based on a mapping in a spreadsheet.',
       modules: ['agent', 'workflows'],
@@ -1015,7 +1015,7 @@ export const ThriveBlockMeta = {
     },
     {
       icon: ThriveIcon,
-      title: 'Trending content to Slack',
+      title: 'Thrive trending content to Slack',
       prompt:
         'Create a scheduled workflow that queries recently updated Thrive content and activity records, summarises the most engaged-with learning, and posts a weekly highlight to Slack.',
       modules: ['scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/typeform.ts
+++ b/apps/sim/blocks/blocks/typeform.ts
@@ -462,7 +462,7 @@ export const TypeformBlockMeta = {
   templates: [
     {
       icon: TypeformIcon,
-      title: 'Typeform response analyzer',
+      title: 'Typeform survey summarizer',
       prompt:
         'Create a workflow that pulls new Typeform responses daily, categorizes feedback by theme and sentiment, logs structured results to a table, and sends a Slack digest when a new batch of responses comes in with the key takeaways.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/typeform.ts
+++ b/apps/sim/blocks/blocks/typeform.ts
@@ -462,7 +462,7 @@ export const TypeformBlockMeta = {
   templates: [
     {
       icon: TypeformIcon,
-      title: 'Survey response analyzer',
+      title: 'Typeform response analyzer',
       prompt:
         'Create a workflow that pulls new Typeform responses daily, categorizes feedback by theme and sentiment, logs structured results to a table, and sends a Slack digest when a new batch of responses comes in with the key takeaways.',
       modules: ['tables', 'scheduled', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/uptimerobot.ts
+++ b/apps/sim/blocks/blocks/uptimerobot.ts
@@ -828,7 +828,7 @@ export const UptimeRobotBlockMeta = {
   templates: [
     {
       icon: UptimeRobotIcon,
-      title: 'Downtime alert to Slack',
+      title: 'UptimeRobot downtime alert to Slack',
       prompt:
         'Build a scheduled workflow that lists UptimeRobot incidents from the last hour, filters to ones that are still active, and posts a formatted Slack alert with the affected monitor name, cause, and how long it has been down.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -838,7 +838,7 @@ export const UptimeRobotBlockMeta = {
     },
     {
       icon: UptimeRobotIcon,
-      title: 'Auto-create monitors from a table',
+      title: 'UptimeRobot monitors from a table',
       prompt:
         'Create a workflow that reads a list of service URLs from a table and creates an HTTP UptimeRobot monitor for each one with a 5-minute interval, then writes the new monitor IDs back to the table.',
       modules: ['tables', 'agent', 'workflows'],
@@ -847,7 +847,7 @@ export const UptimeRobotBlockMeta = {
     },
     {
       icon: UptimeRobotIcon,
-      title: 'Incident to Linear ticket',
+      title: 'UptimeRobot incident to Linear',
       prompt:
         'Build a scheduled workflow that polls UptimeRobot for active incidents, and for any new incident creates a Linear ticket with the monitor name, cause, and root-cause URL, then posts the ticket link to Slack.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -857,7 +857,7 @@ export const UptimeRobotBlockMeta = {
     },
     {
       icon: UptimeRobotIcon,
-      title: 'Maintenance window scheduler',
+      title: 'UptimeRobot maintenance window',
       prompt:
         'Create a workflow that, before a planned deploy, creates a one-time UptimeRobot maintenance window covering the affected monitors for the next 30 minutes so alerts are suppressed during the rollout.',
       modules: ['agent', 'workflows'],
@@ -866,7 +866,7 @@ export const UptimeRobotBlockMeta = {
     },
     {
       icon: UptimeRobotIcon,
-      title: 'Daily uptime digest',
+      title: 'Daily UptimeRobot digest',
       prompt:
         'Build a scheduled daily workflow that lists all UptimeRobot monitors, summarizes how many are up versus down, lists any currently in a down state, and emails a morning availability digest to the on-call team.',
       modules: ['scheduled', 'agent', 'workflows'],
@@ -875,7 +875,7 @@ export const UptimeRobotBlockMeta = {
     },
     {
       icon: UptimeRobotIcon,
-      title: 'Status page publisher',
+      title: 'UptimeRobot status page',
       prompt:
         'Create a workflow that builds a public status page in UptimeRobot for a chosen set of monitors, uploads the company logo, and returns the public URL key so it can be shared.',
       modules: ['agent', 'files', 'workflows'],
@@ -884,7 +884,7 @@ export const UptimeRobotBlockMeta = {
     },
     {
       icon: UptimeRobotIcon,
-      title: 'Pause monitors during maintenance',
+      title: 'Pause UptimeRobot monitors',
       prompt:
         'Build a workflow that, when triggered, pauses a specific UptimeRobot monitor, waits for an upstream maintenance task to finish, then starts the monitor again and confirms it is back to a running state.',
       modules: ['agent', 'workflows'],
@@ -893,7 +893,7 @@ export const UptimeRobotBlockMeta = {
     },
     {
       icon: UptimeRobotIcon,
-      title: 'Onboard alert contacts',
+      title: 'Onboard UptimeRobot contacts',
       prompt:
         'Create a workflow that reads a list of team email addresses and adds each one as an UptimeRobot alert contact, then assigns them to the critical production monitors.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/vercel.ts
+++ b/apps/sim/blocks/blocks/vercel.ts
@@ -2057,7 +2057,7 @@ export const VercelBlockMeta = {
     },
     {
       icon: VercelIcon,
-      title: 'Preview deployment reviewer',
+      title: 'Vercel preview deploy reviewer',
       prompt:
         'Build a workflow that watches GitHub pull requests, finds the matching Vercel preview deployment, captures the preview URL, runs a smoke check against critical pages, and posts a status comment on the pull request with the preview link and any issues found.',
       modules: ['agent', 'workflows'],
@@ -2067,7 +2067,7 @@ export const VercelBlockMeta = {
     },
     {
       icon: VercelIcon,
-      title: 'Environment variable auditor',
+      title: 'Vercel env variable auditor',
       prompt:
         'Create a scheduled weekly workflow that pulls environment variables from every Vercel project, compares them to a reference list in a table, flags drift, missing keys, and stale values, and emails a remediation report to the platform team.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -2076,7 +2076,7 @@ export const VercelBlockMeta = {
     },
     {
       icon: VercelIcon,
-      title: 'Domain and DNS inventory',
+      title: 'Vercel domain and DNS inventory',
       prompt:
         'Build a scheduled workflow that lists every domain and DNS record across my Vercel account weekly, logs them into a tracking table, and sends a Slack diff of any added, removed, or modified records so DNS changes never go unnoticed.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -2086,7 +2086,7 @@ export const VercelBlockMeta = {
     },
     {
       icon: VercelIcon,
-      title: 'Project pause guard',
+      title: 'Vercel project pause guard',
       prompt:
         'Build a scheduled workflow that scans Vercel projects daily for low-traffic or stale candidates flagged in a table, pauses projects that meet the criteria, and Slacks a digest of paused and unpaused projects to the platform team for review.',
       modules: ['scheduled', 'tables', 'agent', 'workflows'],
@@ -2096,7 +2096,7 @@ export const VercelBlockMeta = {
     },
     {
       icon: VercelIcon,
-      title: 'Deploy log triage',
+      title: 'Vercel deploy log triage',
       prompt:
         'Create a workflow that fires after each Vercel deployment, fetches the build and runtime logs, classifies warnings and errors with an agent, groups recurring issues, and opens a Linear ticket per cluster so platform regressions get addressed early.',
       modules: ['agent', 'workflows'],
@@ -2106,7 +2106,7 @@ export const VercelBlockMeta = {
     },
     {
       icon: VercelIcon,
-      title: 'Failed deployment recovery',
+      title: 'Vercel failed deploy recovery',
       prompt:
         'Build a workflow that watches Vercel for failed production deployments, identifies the last known good production deployment, promotes it back to production for an instant rollback, and posts a Slack incident summary with the failure cause and rollback confirmation.',
       modules: ['agent', 'workflows'],

--- a/apps/sim/blocks/blocks/wordpress.ts
+++ b/apps/sim/blocks/blocks/wordpress.ts
@@ -1220,7 +1220,7 @@ export const WordPressBlockMeta = {
   templates: [
     {
       icon: WordpressIcon,
-      title: 'Blog auto-publisher',
+      title: 'WordPress blog auto-publisher',
       prompt:
         'Build a workflow that takes a draft document, optimizes it for SEO by researching target keywords, formats it for WordPress with proper headings and meta description, and publishes it as a draft post for final review.',
       modules: ['agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/workday.ts
+++ b/apps/sim/blocks/blocks/workday.ts
@@ -477,7 +477,7 @@ export const WorkdayBlockMeta = {
     },
     {
       icon: WorkdayIcon,
-      title: 'Pre-hire creation pipeline',
+      title: 'Workday pre-hire pipeline',
       prompt:
         'Create a workflow exposed as a form that captures candidate details from recruiters, validates required fields, creates a pre-hire record in Workday, returns the pre-hire identifier, and logs the submission in a recruiting tracking table.',
       modules: ['tables', 'agent', 'workflows'],
@@ -486,7 +486,7 @@ export const WorkdayBlockMeta = {
     },
     {
       icon: WorkdayIcon,
-      title: 'Job change orchestrator',
+      title: 'Workday job change orchestrator',
       prompt:
         'Build a workflow that watches a Sim table of approved promotions, transfers, and demotions, performs the Workday change-job action for each row, updates downstream tools and Slack channel membership, and writes the outcome back to the table for audit.',
       modules: ['tables', 'agent', 'workflows'],
@@ -496,7 +496,7 @@ export const WorkdayBlockMeta = {
     },
     {
       icon: WorkdayIcon,
-      title: 'Compensation review prep',
+      title: 'Workday comp review prep',
       prompt:
         'Create a scheduled workflow that pulls Workday workers and their current compensation, joins with a performance ratings table, drafts manager-by-manager compensation review packets as files, and emails each manager their packet ahead of the cycle.',
       modules: ['scheduled', 'tables', 'agent', 'files', 'workflows'],
@@ -506,7 +506,7 @@ export const WorkdayBlockMeta = {
     },
     {
       icon: WorkdayIcon,
-      title: 'Termination workflow',
+      title: 'Workday termination workflow',
       prompt:
         'Build a workflow triggered by an approved offboarding request that initiates the Workday Terminate Employee business process, deactivates downstream accounts, schedules an exit interview on Google Calendar, and writes a compliance record to an audit table.',
       modules: ['tables', 'agent', 'workflows'],
@@ -516,7 +516,7 @@ export const WorkdayBlockMeta = {
     },
     {
       icon: WorkdayIcon,
-      title: 'Org structure snapshot',
+      title: 'Workday org structure snapshot',
       prompt:
         'Create a scheduled weekly workflow that pulls Workday workers and organizations, builds an org chart file with departments and cost centers, diffs against last week to highlight structural changes, and emails the result to people leadership.',
       modules: ['scheduled', 'agent', 'files', 'workflows'],
@@ -525,7 +525,7 @@ export const WorkdayBlockMeta = {
     },
     {
       icon: WorkdayIcon,
-      title: 'Personal info update self-service',
+      title: 'Workday personal-info self-service',
       prompt:
         'Build a workflow exposed as a chat or form endpoint that takes employee-submitted personal info changes, validates the request, calls the Workday Update Personal Information action, confirms back to the employee, and logs the change in a people-operations audit table.',
       modules: ['tables', 'agent', 'workflows'],

--- a/apps/sim/blocks/blocks/youtube.ts
+++ b/apps/sim/blocks/blocks/youtube.ts
@@ -555,7 +555,7 @@ export const YouTubeBlockMeta = {
   templates: [
     {
       icon: YouTubeIcon,
-      title: 'Content repurposer',
+      title: 'YouTube content repurposer',
       prompt:
         'Build a workflow that takes a YouTube video URL, pulls the video details and description, researches the topic on the web for additional context, and generates a Twitter thread, LinkedIn post, and blog summary optimized for each platform.',
       modules: ['agent', 'files', 'workflows'],

--- a/apps/sim/blocks/blocks/zendesk.ts
+++ b/apps/sim/blocks/blocks/zendesk.ts
@@ -721,7 +721,7 @@ export const ZendeskBlockMeta = {
   templates: [
     {
       icon: ZendeskIcon,
-      title: 'Support ticket knowledge search',
+      title: 'Zendesk ticket knowledge search',
       prompt:
         'Create a knowledge base connected to my Zendesk account so all past tickets, resolutions, and agent notes are automatically synced and searchable. Then build an agent my support team can ask things like "how do we usually resolve the SSO login issue?" or "has anyone reported this billing bug before?" to find past solutions instantly.',
       modules: ['knowledge-base', 'agent'],


### PR DESCRIPTION
## Summary
- Home-screen **Suggested actions** rows render only an icon + the block template title, so titles that didn't name their integration (e.g. "Refund pattern monitor", "Fireflies CRM updater") were unidentifiable — you couldn't tell what the suggestion was for.
- Audited all 1,563 template titles: ~76% already named their integration ("Ahrefs keyword tracker"). Rewrote the **234** that didn't, across 63 block files, so each names its integration naturally in that block's existing "Brand + phrase" style ("Refund pattern monitor" → "Square refund pattern monitor").
- Fixed at the data layer, not with a display-side prefix: a prefix would double-name the 76% that already read correctly, and the catalog surfaces (integration detail page, landing `/integrations/[slug]`) already show the integration as page context. This keeps all three surfaces consistent.
- Titles-only change — no code, contract, or prompt changes. Titles that already identify the integration via a known abbreviation (JSM, PDL, Postgres) were left as-is.

## Type of Change
- [x] Bug fix

## Testing
Tested manually — re-scanned all titles (0 genuinely-nameless remain), `tsc --noEmit` clean, verified only `title:` lines changed and every rewrite reads accurately against its prompt.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)