### PR TITLE
fix(ui): tuck notification stack below modal and dropdown menus

### DIFF
--- a/apps/sim/app/_styles/globals.css
+++ b/apps/sim/app/_styles/globals.css
@@ -22,13 +22,16 @@
   --auth-primary-btn-hover-border: #e0e0e0;
   --auth-primary-btn-hover-text: #000000;
 
-  /* z-index scale. Transient poppers (menus, selects, popovers, tooltips, toasts)
-     sit above --z-modal so they stay clickable over the semi-transparent overlay. */
+  /* z-index scale. The toast/notification stack is ambient: it sits above page
+     content but BELOW the modal and the transient poppers (menus, selects,
+     popovers, tooltips), so an open modal or dropdown menu is never occluded by
+     a background notification. Poppers sit above --z-modal so they stay
+     clickable over the modal's semi-transparent overlay. */
   --z-dropdown: 100;
+  --z-toast: 150;
   --z-modal: 200;
   --z-popover: 300;
   --z-tooltip: 400;
-  --z-toast: 500;
 
   /* Shadow scale */
   --shadow-subtle: 0 2px 4px 0 rgba(0, 0, 0, 0.08);


### PR DESCRIPTION
## Summary
- Notifications (toasts) were rendering on top of open modals and the workspace dropdown menu because `--z-toast` (500) sat above `--z-modal` (200) and `--z-popover` (300) in the shared z-index scale
- Moved the toast/notification layer to `--z-toast: 150` so it's ambient: above page content and editor drawers (`--z-dropdown: 100`), but below the modal and every transient popper (menus, selects, popovers, tooltips)
- Single-token change in `globals.css` — all toasts, modals, and dropdown menus consume these tokens as the single source of truth, so no component code changes

## Type of Change
- [x] Bug fix

## Testing
Traced every `--z-toast`, `--z-modal`, and `--z-popover` consumer: the toast stack and modal are both portaled to `document.body` (shared stacking context, so pure z compares), and the workspace switcher uses `DropdownMenu` (`--z-popover`, 300). Verified the only other `--z-toast` consumers — the landing skip-link (still above the `z-50` navbar) and an off-screen drag ghost — are unaffected at 150.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)