### PR TITLE
diag(mcp): comprehensive HTTP logging for OAuth + streamable-HTTP transport

### DIFF
--- a/apps/sim/lib/mcp/client.test.ts
+++ b/apps/sim/lib/mcp/client.test.ts
@@ -381,6 +381,9 @@ describe('McpClient notification handler', () => {
       {
         authProvider,
         requestInit: { headers: { 'X-Sim-Via': 'workflow' } },
+        // The transport fetch is always wrapped for diagnostics (a no-op passthrough
+        // under test); it defaults to globalThis.fetch when the server isn't pinned.
+        fetch: expect.any(Function),
       }
     )
   })

--- a/apps/sim/lib/mcp/client.ts
+++ b/apps/sim/lib/mcp/client.ts
@@ -12,6 +12,7 @@ import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
 import { getMaxExecutionTimeout } from '@/lib/core/execution-limits'
 import { getMcpSafeErrorDiagnostics } from '@/lib/mcp/error-diagnostics'
+import { withMcpHttpDiagnostics } from '@/lib/mcp/http-diagnostics'
 import { McpOauthRedirectRequired } from '@/lib/mcp/oauth'
 import { createPinnedMcpFetch } from '@/lib/mcp/pinned-fetch'
 import {
@@ -101,7 +102,7 @@ export class McpClient {
     this.transport = new StreamableHTTPClientTransport(new URL(this.config.url), {
       authProvider: useOauth ? this.authProvider : undefined,
       requestInit: { headers: this.config.headers },
-      ...(pinned ? { fetch: pinned.fetch } : {}),
+      ...(pinned ? { fetch: withMcpHttpDiagnostics(pinned.fetch, 'transport') } : {}),
     })
 
     this.client = new Client(

--- a/apps/sim/lib/mcp/client.ts
+++ b/apps/sim/lib/mcp/client.ts
@@ -102,7 +102,9 @@ export class McpClient {
     this.transport = new StreamableHTTPClientTransport(new URL(this.config.url), {
       authProvider: useOauth ? this.authProvider : undefined,
       requestInit: { headers: this.config.headers },
-      ...(pinned ? { fetch: withMcpHttpDiagnostics(pinned.fetch, 'transport') } : {}),
+      // Wrap whether pinned or not (SDK's default is globalThis.fetch, so passing it is
+      // behavior-neutral) so the diagnostic also covers unpinned/allowlisted servers.
+      fetch: withMcpHttpDiagnostics(pinned?.fetch ?? globalThis.fetch, 'transport'),
     })
 
     this.client = new Client(

--- a/apps/sim/lib/mcp/http-diagnostics.ts
+++ b/apps/sim/lib/mcp/http-diagnostics.ts
@@ -1,0 +1,152 @@
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { createLogger } from '@sim/logger'
+import { sanitizeForLogging } from '@/lib/core/security/redaction'
+import { getMcpSafeErrorDiagnostics } from '@/lib/mcp/error-diagnostics'
+
+const logger = createLogger('McpHttpDiag')
+
+const MAX_LOGGED_CHUNKS = 40
+const PREVIEW_CHARS = 500
+
+/**
+ * TEMPORARY diagnostic for the MCP OAuth + streamable-HTTP transport HTTP layer.
+ * Enabled by default; set `MCP_HTTP_DIAGNOSTICS=false` to silence. Remove once the
+ * Gauge `initialize` hang is root-caused.
+ *
+ * Safety: request bodies and the OAuth token-response body carry the authorization
+ * code / access / refresh tokens, so they are NEVER logged. Only the *transport*
+ * response body — MCP JSON-RPC protocol messages, which contain no credentials — is
+ * streamed and logged, and every logged value passes through `sanitizeForLogging`.
+ */
+function diagnosticsEnabled(): boolean {
+  if (process.env.NODE_ENV === 'test' || process.env.VITEST) return false
+  return process.env.MCP_HTTP_DIAGNOSTICS !== 'false'
+}
+
+function requestUrl(input: string | URL | Request): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.href
+  return input.url
+}
+
+/**
+ * Wraps a `FetchLike` so every request/response in the MCP OAuth or transport flow is
+ * logged with timing. `phase` distinguishes the two so the transport `initialize` — the
+ * suspected hang — can be traced chunk-by-chunk while OAuth bodies stay unlogged.
+ */
+export function withMcpHttpDiagnostics(
+  fetchFn: FetchLike,
+  phase: 'oauth' | 'transport'
+): FetchLike {
+  if (!diagnosticsEnabled()) return fetchFn
+
+  return async (input, init) => {
+    const url = requestUrl(input as string | URL | Request)
+    const method = init?.method ?? 'GET'
+    const reqHeaders = new Headers((init?.headers as HeadersInit | undefined) ?? undefined)
+    const startedAt = Date.now()
+
+    logger.info('request', {
+      phase,
+      method,
+      url,
+      hasAuth: reqHeaders.has('authorization'),
+      accept: reqHeaders.get('accept') ?? undefined,
+    })
+
+    let res: Response
+    try {
+      res = (await fetchFn(input, init)) as Response
+    } catch (error) {
+      logger.warn('fetch rejected', {
+        phase,
+        method,
+        url,
+        ms: Date.now() - startedAt,
+        error: getMcpSafeErrorDiagnostics(error),
+      })
+      throw error
+    }
+
+    const contentType = res.headers.get('content-type') ?? ''
+    const safeHeaders: Record<string, string> = {}
+    for (const [name, value] of res.headers.entries()) {
+      const lower = name.toLowerCase()
+      safeHeaders[name] =
+        lower === 'set-cookie' || lower === 'authorization' || lower === 'www-authenticate'
+          ? '<omitted>'
+          : sanitizeForLogging(value, 200)
+    }
+
+    logger.info('response', {
+      phase,
+      method,
+      url,
+      status: res.status,
+      contentType,
+      mcpSessionId: res.headers.get('mcp-session-id') ? 'present' : 'absent',
+      headerMs: Date.now() - startedAt,
+      headers: safeHeaders,
+    })
+
+    // Only the transport body is safe to log (MCP protocol JSON, no credentials).
+    if (phase !== 'transport' || !res.body) return res
+
+    let logBranch: ReadableStream<Uint8Array>
+    let passBranch: ReadableStream<Uint8Array>
+    try {
+      ;[logBranch, passBranch] = res.body.tee()
+    } catch {
+      return res
+    }
+
+    void (async () => {
+      const reader = logBranch.getReader()
+      const decoder = new TextDecoder()
+      let chunks = 0
+      let bytes = 0
+      try {
+        for (;;) {
+          const { done, value } = await reader.read()
+          if (done) {
+            logger.info('transport body complete', {
+              phase,
+              url,
+              chunks,
+              bytes,
+              ms: Date.now() - startedAt,
+            })
+            break
+          }
+          chunks += 1
+          bytes += value.byteLength
+          if (chunks <= MAX_LOGGED_CHUNKS) {
+            logger.info('transport body chunk', {
+              phase,
+              url,
+              chunk: chunks,
+              size: value.byteLength,
+              ms: Date.now() - startedAt,
+              preview: sanitizeForLogging(decoder.decode(value, { stream: true }), PREVIEW_CHARS),
+            })
+          }
+        }
+      } catch (error) {
+        logger.warn('transport body read error', {
+          phase,
+          url,
+          chunks,
+          bytes,
+          ms: Date.now() - startedAt,
+          error: getMcpSafeErrorDiagnostics(error),
+        })
+      }
+    })()
+
+    return new Response(passBranch, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+    })
+  }
+}

--- a/apps/sim/lib/mcp/http-diagnostics.ts
+++ b/apps/sim/lib/mcp/http-diagnostics.ts
@@ -1,6 +1,7 @@
 import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { createLogger } from '@sim/logger'
 import { sanitizeForLogging } from '@/lib/core/security/redaction'
+import { sanitizeUrlForLog } from '@/lib/core/utils/logging'
 import { getMcpSafeErrorDiagnostics } from '@/lib/mcp/error-diagnostics'
 
 const logger = createLogger('McpHttpDiag')
@@ -28,15 +29,8 @@ function diagnosticsEnabled(): boolean {
   return process.env.MCP_HTTP_DIAGNOSTICS !== 'false'
 }
 
-/** Origin + path only — query values can carry `code`/`token`/`api_key`, so they're dropped. */
-function safeUrl(input: string | URL | Request): string {
-  const raw = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-  try {
-    const u = new URL(raw)
-    return u.search ? `${u.origin}${u.pathname}?<redacted>` : `${u.origin}${u.pathname}`
-  } catch {
-    return '<unparseable-url>'
-  }
+function rawUrl(input: string | URL | Request): string {
+  return typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
 }
 
 /**
@@ -65,7 +59,7 @@ export function withMcpHttpDiagnostics(
   if (!diagnosticsEnabled()) return fetchFn
 
   return async (input, init) => {
-    const url = safeUrl(input as string | URL | Request)
+    const url = sanitizeUrlForLog(rawUrl(input as string | URL | Request))
     const method = init?.method ?? 'GET'
     const reqHeaders = new Headers((init?.headers as HeadersInit | undefined) ?? undefined)
     const startedAt = Date.now()
@@ -113,8 +107,18 @@ export function withMcpHttpDiagnostics(
       return res
     }
 
+    // Cancel the detached log reader when the caller aborts (e.g. the SDK's 30s
+    // initialize timeout — exactly the hang we're tracing) so this tee branch can't
+    // keep the response stream / connection alive after the SDK has given up.
+    const signal = init?.signal
     void (async () => {
       const reader = logBranch.getReader()
+      const cancelReader = () => void reader.cancel().catch(() => {})
+      if (signal?.aborted) {
+        cancelReader()
+        return
+      }
+      signal?.addEventListener('abort', cancelReader, { once: true })
       const decoder = new TextDecoder()
       let chunks = 0
       let bytes = 0
@@ -150,6 +154,8 @@ export function withMcpHttpDiagnostics(
           ms: Date.now() - startedAt,
           error: getMcpSafeErrorDiagnostics(error),
         })
+      } finally {
+        signal?.removeEventListener('abort', cancelReader)
       }
     })()
 

--- a/apps/sim/lib/mcp/http-diagnostics.ts
+++ b/apps/sim/lib/mcp/http-diagnostics.ts
@@ -1,5 +1,6 @@
 import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { createLogger } from '@sim/logger'
+import { sanitizeForLogging } from '@/lib/core/security/redaction'
 import { getMcpSafeErrorDiagnostics } from '@/lib/mcp/error-diagnostics'
 
 const logger = createLogger('McpHttpDiag')
@@ -69,7 +70,7 @@ export function withMcpHttpDiagnostics(
     const reqHeaders = new Headers((init?.headers as HeadersInit | undefined) ?? undefined)
     const startedAt = Date.now()
 
-    logger.info('request', {
+    logger.warn('request', {
       phase,
       method,
       url,
@@ -91,7 +92,7 @@ export function withMcpHttpDiagnostics(
       throw error
     }
 
-    logger.info('response', {
+    logger.warn('response', {
       phase,
       method,
       url,
@@ -121,7 +122,7 @@ export function withMcpHttpDiagnostics(
         for (;;) {
           const { done, value } = await reader.read()
           if (done) {
-            logger.info('initialize body complete', {
+            logger.warn('initialize body complete', {
               url,
               chunks,
               bytes,
@@ -132,12 +133,12 @@ export function withMcpHttpDiagnostics(
           chunks += 1
           bytes += value.byteLength
           if (chunks <= MAX_LOGGED_CHUNKS) {
-            logger.info('initialize body chunk', {
+            logger.warn('initialize body chunk', {
               url,
               chunk: chunks,
               size: value.byteLength,
               ms: Date.now() - startedAt,
-              preview: decoder.decode(value, { stream: true }).slice(0, PREVIEW_CHARS),
+              preview: sanitizeForLogging(decoder.decode(value, { stream: true }), PREVIEW_CHARS),
             })
           }
         }

--- a/apps/sim/lib/mcp/http-diagnostics.ts
+++ b/apps/sim/lib/mcp/http-diagnostics.ts
@@ -34,12 +34,20 @@ function rawUrl(input: string | URL | Request): string {
 }
 
 /**
+ * The `initialize` request is a small fixed structure (protocolVersion, capabilities,
+ * clientInfo). This length gate lets us skip parsing large `tools/call` payloads —
+ * which can be multi-MB — entirely, keeping the check off the hot path.
+ */
+const MAX_INIT_BODY_CHARS = 4096
+
+/**
  * True only when the request body is an MCP `initialize` JSON-RPC message. Used to
  * scope response-body logging to the initialize handshake and nothing else — token
  * requests (form-encoded) and tool calls (`method: 'tools/call'`) both fail this.
+ * Large bodies are rejected by length before any parse (see {@link MAX_INIT_BODY_CHARS}).
  */
 function isInitializeRequest(body: unknown): boolean {
-  if (typeof body !== 'string') return false
+  if (typeof body !== 'string' || body.length > MAX_INIT_BODY_CHARS) return false
   try {
     return (JSON.parse(body) as { method?: unknown })?.method === 'initialize'
   } catch {

--- a/apps/sim/lib/mcp/http-diagnostics.ts
+++ b/apps/sim/lib/mcp/http-diagnostics.ts
@@ -1,6 +1,5 @@
 import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { createLogger } from '@sim/logger'
-import { sanitizeForLogging } from '@/lib/core/security/redaction'
 import { getMcpSafeErrorDiagnostics } from '@/lib/mcp/error-diagnostics'
 
 const logger = createLogger('McpHttpDiag')
@@ -13,26 +12,50 @@ const PREVIEW_CHARS = 500
  * Enabled by default; set `MCP_HTTP_DIAGNOSTICS=false` to silence. Remove once the
  * Gauge `initialize` hang is root-caused.
  *
- * Safety: request bodies and the OAuth token-response body carry the authorization
- * code / access / refresh tokens, so they are NEVER logged. Only the *transport*
- * response body — MCP JSON-RPC protocol messages, which contain no credentials — is
- * streamed and logged, and every logged value passes through `sanitizeForLogging`.
+ * Secret-safety (the wrapped transport fetch also carries in-transport OAuth
+ * refresh/registration, and every tool result):
+ * - Request and OAuth response bodies are NEVER logged.
+ * - The only response body streamed is the one whose REQUEST is an MCP `initialize`
+ *   JSON-RPC call — which excludes token/refresh responses AND `tools/call` results
+ *   (tool output can be PII/file contents/credentials). The `initialize` result is
+ *   protocol metadata only (serverInfo, capabilities), no credentials.
+ * - URLs are logged origin+path only; query strings (`?code=`, `?token=`, …) are
+ *   redacted. Sensitive headers (authorization/cookie/www-authenticate) are omitted.
  */
 function diagnosticsEnabled(): boolean {
   if (process.env.NODE_ENV === 'test' || process.env.VITEST) return false
   return process.env.MCP_HTTP_DIAGNOSTICS !== 'false'
 }
 
-function requestUrl(input: string | URL | Request): string {
-  if (typeof input === 'string') return input
-  if (input instanceof URL) return input.href
-  return input.url
+/** Origin + path only — query values can carry `code`/`token`/`api_key`, so they're dropped. */
+function safeUrl(input: string | URL | Request): string {
+  const raw = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+  try {
+    const u = new URL(raw)
+    return u.search ? `${u.origin}${u.pathname}?<redacted>` : `${u.origin}${u.pathname}`
+  } catch {
+    return '<unparseable-url>'
+  }
+}
+
+/**
+ * True only when the request body is an MCP `initialize` JSON-RPC message. Used to
+ * scope response-body logging to the initialize handshake and nothing else — token
+ * requests (form-encoded) and tool calls (`method: 'tools/call'`) both fail this.
+ */
+function isInitializeRequest(body: unknown): boolean {
+  if (typeof body !== 'string') return false
+  try {
+    return (JSON.parse(body) as { method?: unknown })?.method === 'initialize'
+  } catch {
+    return false
+  }
 }
 
 /**
  * Wraps a `FetchLike` so every request/response in the MCP OAuth or transport flow is
- * logged with timing. `phase` distinguishes the two so the transport `initialize` — the
- * suspected hang — can be traced chunk-by-chunk while OAuth bodies stay unlogged.
+ * logged with timing. Only the `initialize` response body is streamed (see secret-safety
+ * note above) — that's the suspected hang.
  */
 export function withMcpHttpDiagnostics(
   fetchFn: FetchLike,
@@ -41,7 +64,7 @@ export function withMcpHttpDiagnostics(
   if (!diagnosticsEnabled()) return fetchFn
 
   return async (input, init) => {
-    const url = requestUrl(input as string | URL | Request)
+    const url = safeUrl(input as string | URL | Request)
     const method = init?.method ?? 'GET'
     const reqHeaders = new Headers((init?.headers as HeadersInit | undefined) ?? undefined)
     const startedAt = Date.now()
@@ -68,29 +91,18 @@ export function withMcpHttpDiagnostics(
       throw error
     }
 
-    const contentType = res.headers.get('content-type') ?? ''
-    const safeHeaders: Record<string, string> = {}
-    for (const [name, value] of res.headers.entries()) {
-      const lower = name.toLowerCase()
-      safeHeaders[name] =
-        lower === 'set-cookie' || lower === 'authorization' || lower === 'www-authenticate'
-          ? '<omitted>'
-          : sanitizeForLogging(value, 200)
-    }
-
     logger.info('response', {
       phase,
       method,
       url,
       status: res.status,
-      contentType,
+      contentType: res.headers.get('content-type') ?? '',
       mcpSessionId: res.headers.get('mcp-session-id') ? 'present' : 'absent',
       headerMs: Date.now() - startedAt,
-      headers: safeHeaders,
     })
 
-    // Only the transport body is safe to log (MCP protocol JSON, no credentials).
-    if (phase !== 'transport' || !res.body) return res
+    // Stream-log ONLY the initialize handshake response — never OAuth bodies or tool results.
+    if (phase !== 'transport' || !isInitializeRequest(init?.body) || !res.body) return res
 
     let logBranch: ReadableStream<Uint8Array>
     let passBranch: ReadableStream<Uint8Array>
@@ -109,8 +121,7 @@ export function withMcpHttpDiagnostics(
         for (;;) {
           const { done, value } = await reader.read()
           if (done) {
-            logger.info('transport body complete', {
-              phase,
+            logger.info('initialize body complete', {
               url,
               chunks,
               bytes,
@@ -121,19 +132,17 @@ export function withMcpHttpDiagnostics(
           chunks += 1
           bytes += value.byteLength
           if (chunks <= MAX_LOGGED_CHUNKS) {
-            logger.info('transport body chunk', {
-              phase,
+            logger.info('initialize body chunk', {
               url,
               chunk: chunks,
               size: value.byteLength,
               ms: Date.now() - startedAt,
-              preview: sanitizeForLogging(decoder.decode(value, { stream: true }), PREVIEW_CHARS),
+              preview: decoder.decode(value, { stream: true }).slice(0, PREVIEW_CHARS),
             })
           }
         }
       } catch (error) {
-        logger.warn('transport body read error', {
-          phase,
+        logger.warn('initialize body read error', {
           url,
           chunks,
           bytes,

--- a/apps/sim/lib/mcp/oauth/auth.ts
+++ b/apps/sim/lib/mcp/oauth/auth.ts
@@ -1,4 +1,5 @@
 import { auth, type OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
+import { withMcpHttpDiagnostics } from '@/lib/mcp/http-diagnostics'
 import { createSsrfGuardedMcpFetch } from '@/lib/mcp/pinned-fetch'
 
 type McpAuthOptions = Parameters<typeof auth>[1]
@@ -15,5 +16,8 @@ export function mcpAuthGuarded(
   provider: OAuthClientProvider,
   options: McpAuthOptions
 ): ReturnType<typeof auth> {
-  return auth(provider, { ...options, fetchFn: options.fetchFn ?? createSsrfGuardedMcpFetch() })
+  return auth(provider, {
+    ...options,
+    fetchFn: withMcpHttpDiagnostics(options.fetchFn ?? createSsrfGuardedMcpFetch(), 'oauth'),
+  })
 }


### PR DESCRIPTION
## Summary
Temporary diagnostic to **empirically root-cause the Gauge MCP `initialize` hang** in one shot — no more incremental probes. Wraps both MCP HTTP layers with logging:
- **OAuth phase** (discovery / DCR / token / refresh / revoke): logs request `method`/`url`/`hasAuth`, and response `status`/`content-type`/`mcp-session-id`/safe-headers/timing. **Bodies are never logged** (they carry the auth code + access/refresh tokens).
- **Transport phase** (streamable-HTTP `initialize`): same request/response logging **plus the response body streamed chunk-by-chunk with timing**. MCP protocol JSON carries no credentials, so this is safe — and it's exactly what tells us whether Gauge returns SSE-that-stalls (our fix) vs never-sends-the-result (Gauge's bug) vs fast JSON.

So a **single authorize** produces the full HTTP conversation with Gauge, end to end.

## Why this (context)
Prior work fixed the OAuth hang (#5776) and confirmed: OAuth completes, Gauge accepts the token (`sessionIdPresent: true`), then the **authenticated `initialize` result never arrives → 30s timeout → retry loop = "loads forever."** Gauge `/mcp` is healthy unauthenticated over h1.1 **and** h2 (incl. Sim's exact pinned dispatcher), so pinning/h2/connection are ruled out. This logging closes the last unknown: what Gauge actually sends for the authenticated `initialize`.

## Safety
- **No secrets logged**: request bodies and OAuth token-response bodies (which contain tokens) are never read; only the transport body (MCP JSON-RPC) is streamed, and every logged value passes through `sanitizeForLogging`. `authorization`/`set-cookie`/`www-authenticate` headers are omitted.
- **Opt-out**: on by default; `MCP_HTTP_DIAGNOSTICS=false` silences it. **Disabled under test** so unit tests are unaffected.
- **Bounded**: caps logged chunks (40) and preview length (500 chars).
- Behavior-preserving: the transport body is `tee()`'d and passed through untouched; if `tee()` fails it returns the original response.

## Type of Change
- [x] Diagnostic (temporary; to be reverted once root-caused)

## Testing
Full `lib/mcp` + `app/api/mcp` suite: 432 passing. Typecheck, lint, `check:utils` clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)