### PR TITLE
fix(library): show full unambiguous dates on featured and related cards

### DIFF
--- a/apps/sim/app/(landing)/components/content-author-page/content-author-page.tsx
+++ b/apps/sim/app/(landing)/components/content-author-page/content-author-page.tsx
@@ -73,6 +73,7 @@ export function ContentAuthorPage({
                       month: 'short',
                       day: 'numeric',
                       year: 'numeric',
+                      timeZone: 'UTC',
                     })}
                   </span>
 
@@ -82,6 +83,7 @@ export function ContentAuthorPage({
                         month: 'short',
                         day: 'numeric',
                         year: 'numeric',
+                        timeZone: 'UTC',
                       })}
                     </span>
                     <h3 className='text-[var(--text-primary)] text-base leading-tight tracking-[-0.01em] lg:text-lg'>

--- a/apps/sim/app/(landing)/components/content-index-page/content-index-page.tsx
+++ b/apps/sim/app/(landing)/components/content-index-page/content-index-page.tsx
@@ -86,6 +86,7 @@ export function ContentIndexPage({
                             month: 'short',
                             day: 'numeric',
                             year: 'numeric',
+                            timeZone: 'UTC',
                           })}
                         </span>
                         <h3 className='text-[var(--text-primary)] text-lg leading-tight tracking-[-0.01em]'>
@@ -114,6 +115,7 @@ export function ContentIndexPage({
                       month: 'short',
                       day: 'numeric',
                       year: 'numeric',
+                      timeZone: 'UTC',
                     })}
                   </span>
 
@@ -123,6 +125,7 @@ export function ContentIndexPage({
                         month: 'short',
                         day: 'numeric',
                         year: 'numeric',
+                        timeZone: 'UTC',
                       })}
                     </span>
                     <h3 className='text-[var(--text-primary)] text-base leading-tight tracking-[-0.01em] lg:text-lg'>

--- a/apps/sim/app/(landing)/components/content-index-page/content-index-page.tsx
+++ b/apps/sim/app/(landing)/components/content-index-page/content-index-page.tsx
@@ -84,7 +84,8 @@ export function ContentIndexPage({
                         <span className='text-[var(--text-muted)] text-xs uppercase tracking-[0.1em]'>
                           {new Date(p.date).toLocaleDateString('en-US', {
                             month: 'short',
-                            year: '2-digit',
+                            day: 'numeric',
+                            year: 'numeric',
                           })}
                         </span>
                         <h3 className='text-[var(--text-primary)] text-lg leading-tight tracking-[-0.01em]'>

--- a/apps/sim/app/(landing)/components/content-post-page/content-post-page.tsx
+++ b/apps/sim/app/(landing)/components/content-post-page/content-post-page.tsx
@@ -83,6 +83,7 @@ export function ContentPostPage({
                   month: 'short',
                   day: 'numeric',
                   year: 'numeric',
+                  timeZone: 'UTC',
                 })}
               </time>
               <meta itemProp='dateModified' content={post.updated ?? post.date} />
@@ -154,6 +155,7 @@ export function ContentPostPage({
                           month: 'short',
                           day: 'numeric',
                           year: 'numeric',
+                          timeZone: 'UTC',
                         })}
                       </span>
                       <h3 className='text-[var(--text-primary)] text-lg leading-tight tracking-[-0.01em]'>

--- a/apps/sim/app/(landing)/components/content-post-page/content-post-page.tsx
+++ b/apps/sim/app/(landing)/components/content-post-page/content-post-page.tsx
@@ -152,7 +152,8 @@ export function ContentPostPage({
                       <span className='text-[var(--text-muted)] text-xs uppercase tracking-[0.1em]'>
                         {new Date(p.date).toLocaleDateString('en-US', {
                           month: 'short',
-                          year: '2-digit',
+                          day: 'numeric',
+                          year: 'numeric',
                         })}
                       </span>
                       <h3 className='text-[var(--text-primary)] text-lg leading-tight tracking-[-0.01em]'>


### PR DESCRIPTION
## Summary
- Featured cards on the Library/Blog index and the "more posts" cards on a post page rendered dates as `month + 2-digit year` — e.g. July 2026 showed as "JUL 26", which reads like a day (July 26th) rather than a year.
- Switched both to the same `month / day / year` format used by the list rows, post header, and author page (e.g. "Jul 13, 2026"), so dates are consistent and unambiguous everywhere.

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)