### PR TITLE
refactor(security): ipaddr-free @sim/security/hostnames sub-export (removes urls.ts loopback dup)

### DIFF
--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import { createLogger } from '@sim/logger'
+import { isLoopbackHostname } from '@sim/security/hostnames'
 import { getErrorMessage } from '@sim/utils/errors'
 import {
   keepPreviousData,
@@ -26,7 +27,6 @@ import {
   testMcpServerConnectionContract,
   updateMcpServerContract,
 } from '@/lib/api/contracts/mcp'
-import { isLoopbackHostname } from '@/lib/core/utils/urls'
 import { sanitizeForHttp, sanitizeHeaders } from '@/lib/mcp/shared'
 import type {
   McpAuthType,

--- a/apps/sim/lib/core/utils/urls.ts
+++ b/apps/sim/lib/core/utils/urls.ts
@@ -1,3 +1,4 @@
+import { isLoopbackHostname } from '@sim/security/hostnames'
 import { env, getEnv } from '@/lib/core/config/env'
 import { isProd } from '@/lib/core/config/env-flags'
 
@@ -103,17 +104,6 @@ export function getEmailDomain(): string {
 
 const DEFAULT_SOCKET_URL = 'http://localhost:3002'
 const DEFAULT_OLLAMA_URL = 'http://localhost:11434'
-export const LOCALHOST_HOSTNAMES: ReadonlySet<string> = new Set([
-  'localhost',
-  '127.0.0.1',
-  '[::1]',
-  '::1',
-])
-
-export function isLoopbackHostname(hostname: string): boolean {
-  return LOCALHOST_HOSTNAMES.has(hostname)
-}
-
 /**
  * Parses a comma-separated list of origins (e.g. from a `TRUSTED_ORIGINS` env
  * var) into a deduped array of normalized origins. Invalid entries are dropped.
@@ -152,7 +142,7 @@ export function parseOriginList(
 export function isLocalhostUrl(url: string): boolean {
   try {
     const { hostname } = new URL(url)
-    return LOCALHOST_HOSTNAMES.has(hostname)
+    return isLoopbackHostname(hostname)
   } catch {
     return false
   }
@@ -208,7 +198,7 @@ export function getSocketUrl(): string {
   if (explicit) return explicit
 
   const browserOrigin = getBrowserOrigin()
-  if (browserOrigin && !LOCALHOST_HOSTNAMES.has(new URL(browserOrigin).hostname)) {
+  if (browserOrigin && !isLoopbackHostname(new URL(browserOrigin).hostname)) {
     return browserOrigin
   }
 

--- a/apps/sim/lib/mcp/oauth/probe.ts
+++ b/apps/sim/lib/mcp/oauth/probe.ts
@@ -1,8 +1,8 @@
 import { extractWWWAuthenticateParams } from '@modelcontextprotocol/sdk/client/auth.js'
 import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { createLogger } from '@sim/logger'
+import { isLoopbackHostname } from '@sim/security/hostnames'
 import { createPinnedFetch } from '@/lib/core/security/input-validation.server'
-import { isLoopbackHostname } from '@/lib/core/utils/urls'
 import { createSsrfGuardedMcpFetch } from '@/lib/mcp/pinned-fetch'
 import type { McpAuthType } from '@/lib/mcp/types'
 

--- a/apps/sim/lib/mcp/oauth/url-validation.ts
+++ b/apps/sim/lib/mcp/oauth/url-validation.ts
@@ -1,4 +1,4 @@
-import { isLoopbackHostname } from '@/lib/core/utils/urls'
+import { isLoopbackHostname } from '@sim/security/hostnames'
 
 export class McpOauthInsecureUrlError extends Error {
   constructor(url: string) {

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -26,6 +26,10 @@
       "types": "./src/hmac.ts",
       "default": "./src/hmac.ts"
     },
+    "./hostnames": {
+      "types": "./src/hostnames.ts",
+      "default": "./src/hostnames.ts"
+    },
     "./ssrf": {
       "types": "./src/ssrf.ts",
       "default": "./src/ssrf.ts"

--- a/packages/security/src/hostnames.test.ts
+++ b/packages/security/src/hostnames.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { isLoopbackHostname, unwrapIpv6Brackets } from './hostnames'
+
+describe('isLoopbackHostname', () => {
+  it('matches localhost and the loopback literals, brackets optional', () => {
+    expect(isLoopbackHostname('localhost')).toBe(true)
+    expect(isLoopbackHostname('127.0.0.1')).toBe(true)
+    expect(isLoopbackHostname('::1')).toBe(true)
+    expect(isLoopbackHostname('[::1]')).toBe(true)
+  })
+
+  it('does not match other loopback-range IPs or public hosts (exact-set only)', () => {
+    expect(isLoopbackHostname('127.0.0.5')).toBe(false)
+    expect(isLoopbackHostname('example.com')).toBe(false)
+    expect(isLoopbackHostname('10.0.0.1')).toBe(false)
+  })
+})
+
+describe('unwrapIpv6Brackets', () => {
+  it('strips brackets from IPv6 authorities', () => {
+    expect(unwrapIpv6Brackets('[::1]')).toBe('::1')
+    expect(unwrapIpv6Brackets('[2606:4700::1111]')).toBe('2606:4700::1111')
+  })
+
+  it('leaves bare hostnames untouched', () => {
+    expect(unwrapIpv6Brackets('example.com')).toBe('example.com')
+    expect(unwrapIpv6Brackets('127.0.0.1')).toBe('127.0.0.1')
+  })
+})

--- a/packages/security/src/hostnames.ts
+++ b/packages/security/src/hostnames.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure host-string helpers with no `ipaddr.js` dependency, so client bundles can
+ * share them without pulling the IP library. The ipaddr-backed classification
+ * lives in `./ssrf`, which re-exports these for its own consumers.
+ */
+
+/**
+ * Strips the brackets the WHATWG URL parser puts around IPv6 authorities so the
+ * result can be matched or handed to an IP classifier directly.
+ */
+export function unwrapIpv6Brackets(host: string): string {
+  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
+}
+
+/**
+ * Loopback host identifiers permitted to use plain HTTP: `localhost` and the
+ * canonical loopback IP literals. Compared after stripping IPv6 brackets.
+ */
+const LOOPBACK_HOSTNAMES: ReadonlySet<string> = new Set(['localhost', '127.0.0.1', '::1'])
+
+/**
+ * True when a host (name or IP literal, IPv6 brackets optional) is loopback by
+ * exact match — `localhost`, `127.0.0.1`, or `::1`. For full-range loopback-IP
+ * classification (e.g. `127.0.0.5`) use `isLoopbackIp` from `./ssrf`.
+ */
+export function isLoopbackHostname(host: string): boolean {
+  return LOOPBACK_HOSTNAMES.has(unwrapIpv6Brackets(host))
+}

--- a/packages/security/src/ssrf.test.ts
+++ b/packages/security/src/ssrf.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  isLoopbackHostname,
-  isLoopbackIp,
-  isPrivateIp,
-  isPrivateIpHost,
-  unwrapIpv6Brackets,
-} from './ssrf'
+import { isLoopbackIp, isPrivateIp, isPrivateIpHost, unwrapIpv6Brackets } from './ssrf'
 
 describe('isPrivateIp', () => {
   describe('IPv4 private/reserved ranges', () => {
@@ -179,32 +173,5 @@ describe('isLoopbackIp', () => {
     expect(isLoopbackIp('169.254.169.254')).toBe(false)
     expect(isLoopbackIp('not-an-ip')).toBe(false)
     expect(isLoopbackIp('localhost')).toBe(false)
-  })
-})
-
-describe('isLoopbackHostname', () => {
-  it('matches localhost and the loopback literals, brackets optional', () => {
-    expect(isLoopbackHostname('localhost')).toBe(true)
-    expect(isLoopbackHostname('127.0.0.1')).toBe(true)
-    expect(isLoopbackHostname('::1')).toBe(true)
-    expect(isLoopbackHostname('[::1]')).toBe(true)
-  })
-
-  it('does not match other loopback-range IPs or public hosts (exact-set only)', () => {
-    expect(isLoopbackHostname('127.0.0.5')).toBe(false)
-    expect(isLoopbackHostname('example.com')).toBe(false)
-    expect(isLoopbackHostname('10.0.0.1')).toBe(false)
-  })
-})
-
-describe('unwrapIpv6Brackets', () => {
-  it('strips brackets from IPv6 authorities', () => {
-    expect(unwrapIpv6Brackets('[::1]')).toBe('::1')
-    expect(unwrapIpv6Brackets('[2606:4700::1111]')).toBe('2606:4700::1111')
-  })
-
-  it('leaves bare hostnames untouched', () => {
-    expect(unwrapIpv6Brackets('example.com')).toBe('example.com')
-    expect(unwrapIpv6Brackets('127.0.0.1')).toBe('127.0.0.1')
   })
 })

--- a/packages/security/src/ssrf.ts
+++ b/packages/security/src/ssrf.ts
@@ -1,12 +1,9 @@
 import * as ipaddr from 'ipaddr.js'
+import { unwrapIpv6Brackets } from './hostnames'
 
-/**
- * Strips the brackets the WHATWG URL parser puts around IPv6 authorities so the
- * result can be handed straight to {@link isPrivateIp} / {@link isIpLiteral}.
- */
-export function unwrapIpv6Brackets(host: string): string {
-  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
-}
+// Re-export the pure host helpers so existing `@sim/security/ssrf` consumers
+// keep one import site; client code that must avoid ipaddr imports `./hostnames`.
+export { isLoopbackHostname, unwrapIpv6Brackets } from './hostnames'
 
 /**
  * True when the (bracket-free) host is an IP literal rather than a DNS name —
@@ -27,21 +24,6 @@ export function isLoopbackIp(ip: string): boolean {
   } catch {
     return false
   }
-}
-
-/**
- * Loopback host identifiers permitted to use plain HTTP: `localhost` and the
- * canonical loopback IP literals. Compared after stripping IPv6 brackets.
- */
-const LOOPBACK_HOSTNAMES: ReadonlySet<string> = new Set(['localhost', '127.0.0.1', '::1'])
-
-/**
- * True when a host (name or IP literal, IPv6 brackets optional) is loopback by
- * exact match — `localhost`, `127.0.0.1`, or `::1`. For full-range loopback-IP
- * classification (e.g. `127.0.0.5`) use {@link isLoopbackIp}.
- */
-export function isLoopbackHostname(host: string): boolean {
-  return LOOPBACK_HOSTNAMES.has(unwrapIpv6Brackets(host))
 }
 
 /**


### PR DESCRIPTION
## What

Follow-up to #5784 (the SSRF hardening PR, now merged). Completes the `@sim/security/ssrf` consolidation by splitting the **pure** host helpers into an ipaddr-free sub-export so the last duplicate can be removed.

`unwrapIpv6Brackets` + `isLoopbackHostname` never touch `ipaddr.js`, but they lived in `@sim/security/ssrf` whose top line is `import * as ipaddr from 'ipaddr.js'`. That's why `apps/sim/lib/core/utils/urls.ts` — which is pulled into client bundles — kept its **own** copy of `isLoopbackHostname` (importing the ssrf one would have dragged `ipaddr.js` into the browser).

### Change
- New **`@sim/security/hostnames`** — pure, zero-dependency: `unwrapIpv6Brackets`, `isLoopbackHostname`.
- `ssrf.ts` imports `unwrapIpv6Brackets` from it and **re-exports both**, so every existing `@sim/security/ssrf` consumer (desktop + server) is unchanged.
- `urls.ts` drops its local `LOCALHOST_HOSTNAMES` set + `isLoopbackHostname`, and its three client importers (`hooks/queries/mcp`, `mcp/oauth/probe`, `mcp/oauth/url-validation`) now use the single shared definition — **no `ipaddr.js` in the client bundle**.
- Tests for the pure helpers moved to `hostnames.test.ts`.

Behavior is equivalent for every reachable `url.hostname` input (bracketed IPv6 `[::1]` → stripped `::1`; `localhost`/`127.0.0.1` unchanged) — verified by direct execution.

## Testing
`@sim/security` 106 · affected sim suites (urls + mcp/oauth) 45 · type-check (security + full `apps/sim`) · `check:boundaries` · `check:utils` · `check:api-validation:strict` · Biome — all green.
