### PR TITLE
fix(ux): balance question-card spacing and drop stray SMTP icon dot

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
@@ -232,8 +232,15 @@ const AssistantMessageRow = memo(function AssistantMessageRow({
     questionDismissed,
   })
 
+  // A visible question card (active or answered recap) sits 12px below the
+  // preceding prose (chat-content's `space-y-3`). The row's default `pb-6`
+  // would leave 24px underneath — asymmetric. Shrink the trailing gap to match
+  // so the card breathes equally top and bottom. Dismissed cards fall back to
+  // the normal message rhythm (they render the standard actions row instead).
+  const showsQuestionCard = endsWithQuestion && !questionDismissed
+
   return (
-    <div className={rowClassName}>
+    <div className={cn(rowClassName, showsQuestionCard && 'pb-3')}>
       <MessageContent
         blocks={blocks}
         fallbackContent={message.content}

--- a/apps/sim/components/icons.tsx
+++ b/apps/sim/components/icons.tsx
@@ -5737,7 +5737,6 @@ export function SmtpIcon(props: SVGProps<SVGSVGElement>) {
         strokeLinecap='round'
         strokeLinejoin='round'
       />
-      <circle cx='24' cy='6' r='4' fill='currentColor' stroke='none' />
     </svg>
   )
 }


### PR DESCRIPTION
## Summary
- Balance the spacing around Chat question cards: a visible question card (active or answered recap) now uses a 12px trailing gap (`pb-3`) instead of the row default (`pb-6`/`pb-4`), matching the 12px `space-y-3` gap above it so the card breathes equally top and bottom. Excludes dismissed cards, which fall back to the normal message rhythm + actions row.
- Remove the stray notification dot from the SMTP icon so it matches the rest of the emcn line-icons (the envelope path is now identical to the standard mail icon).

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)