### PR TITLE
fix(mcp): pin outbound connections to IPv4 to avoid unreachable-IPv6 hangs

### DIFF
--- a/apps/sim/lib/core/security/input-validation.server.ts
+++ b/apps/sim/lib/core/security/input-validation.server.ts
@@ -105,7 +105,12 @@ export async function validateUrlWithDNS(
   }
 
   try {
-    const { address } = await dns.lookup(cleanHostname, { verbatim: true })
+    // Prefer IPv4: the resolved address is pinned by the caller, which removes Happy
+    // Eyeballs' IPv4 fallback. On an IPv4-only egress (e.g. AWS NAT gateways) a pinned
+    // IPv6 address from a dual-stack host is unreachable and hangs until timeout, so pick
+    // an IPv4 address when the host has one; IPv6-only hosts still pin their sole address.
+    const resolved = await dns.lookup(cleanHostname, { all: true, verbatim: true })
+    const { address } = resolved.find((entry) => entry.family === 4) ?? resolved[0]
 
     const resolvedIsLoopback =
       ipaddr.isValid(address) &&

--- a/apps/sim/lib/core/security/input-validation.server.ts
+++ b/apps/sim/lib/core/security/input-validation.server.ts
@@ -105,10 +105,8 @@ export async function validateUrlWithDNS(
   }
 
   try {
-    // Prefer IPv4: the resolved address is pinned by the caller, which removes Happy
-    // Eyeballs' IPv4 fallback. On an IPv4-only egress (e.g. AWS NAT gateways) a pinned
-    // IPv6 address from a dual-stack host is unreachable and hangs until timeout, so pick
-    // an IPv4 address when the host has one; IPv6-only hosts still pin their sole address.
+    // Prefer IPv4: pinning strips Happy Eyeballs' fallback, and a pinned IPv6 address hangs
+    // on IPv4-only egress (e.g. AWS NAT gateways). See validateMcpServerSsrf.
     const resolved = await dns.lookup(cleanHostname, { all: true, verbatim: true })
     const { address } = resolved.find((entry) => entry.family === 4) ?? resolved[0]
 

--- a/apps/sim/lib/mcp/domain-check.test.ts
+++ b/apps/sim/lib/mcp/domain-check.test.ts
@@ -364,12 +364,31 @@ describe('validateMcpServerSsrf', () => {
   })
 
   it('returns resolved IP for URLs that resolve to public IPs', async () => {
-    mockDnsLookup.mockResolvedValue({ address: '93.184.216.34' })
+    mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }])
     await expect(validateMcpServerSsrf('https://example.com/mcp')).resolves.toBe('93.184.216.34')
   })
 
+  it('prefers IPv4 over IPv6 for a dual-stack host (verbatim returns IPv6 first)', async () => {
+    // Cloudflare-fronted hosts resolve IPv6-first; pinning that IPv6 hangs on an IPv4-only
+    // egress. The guard must pin the reachable IPv4 instead.
+    mockDnsLookup.mockResolvedValue([
+      { address: '2606:4700:3037::ac43:cc5f', family: 6 },
+      { address: '104.21.22.105', family: 4 },
+    ])
+    await expect(validateMcpServerSsrf('https://app.withgauge.com/mcp')).resolves.toBe(
+      '104.21.22.105'
+    )
+  })
+
+  it('pins the sole IPv6 address for an IPv6-only host', async () => {
+    mockDnsLookup.mockResolvedValue([{ address: '2606:4700:3037::ac43:cc5f', family: 6 }])
+    await expect(validateMcpServerSsrf('https://ipv6-only.example/mcp')).resolves.toBe(
+      '2606:4700:3037::ac43:cc5f'
+    )
+  })
+
   it('returns resolved IP for HTTP URLs on non-localhost hosts', async () => {
-    mockDnsLookup.mockResolvedValue({ address: '93.184.216.34' })
+    mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }])
     await expect(validateMcpServerSsrf('http://example.com:3000/mcp')).resolves.toBe(
       '93.184.216.34'
     )
@@ -405,12 +424,12 @@ describe('validateMcpServerSsrf', () => {
   })
 
   it('throws McpSsrfError for URLs resolving to private IPs', async () => {
-    mockDnsLookup.mockResolvedValue({ address: '10.0.0.5' })
+    mockDnsLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }])
     await expect(validateMcpServerSsrf('https://internal.corp/mcp')).rejects.toThrow(McpSsrfError)
   })
 
   it('throws McpSsrfError for URLs resolving to link-local IPs', async () => {
-    mockDnsLookup.mockResolvedValue({ address: '169.254.169.254' })
+    mockDnsLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }])
     await expect(validateMcpServerSsrf('https://metadata.internal/latest')).rejects.toThrow(
       McpSsrfError
     )
@@ -424,7 +443,7 @@ describe('validateMcpServerSsrf', () => {
   })
 
   it('returns resolved IP for URLs resolving to loopback on self-hosted (localhost alias)', async () => {
-    mockDnsLookup.mockResolvedValue({ address: '127.0.0.1' })
+    mockDnsLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }])
     await expect(validateMcpServerSsrf('http://my-local-alias:3000/mcp')).resolves.toBe('127.0.0.1')
   })
 
@@ -450,14 +469,14 @@ describe('validateMcpServerSsrf', () => {
     })
 
     it('rejects URLs resolving to loopback on hosted', async () => {
-      mockDnsLookup.mockResolvedValue({ address: '127.0.0.1' })
+      mockDnsLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }])
       await expect(validateMcpServerSsrf('http://my-local-alias:3000/mcp')).rejects.toThrow(
         McpSsrfError
       )
     })
 
     it('returns resolved IP for public IP resolutions on hosted', async () => {
-      mockDnsLookup.mockResolvedValue({ address: '93.184.216.34' })
+      mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }])
       await expect(validateMcpServerSsrf('https://example.com/mcp')).resolves.toBe('93.184.216.34')
     })
 
@@ -483,7 +502,7 @@ describe('validateMcpServerSsrf', () => {
     })
 
     it('still blocks DNS resolutions to private IPs on hosted (regression)', async () => {
-      mockDnsLookup.mockResolvedValue({ address: '10.0.0.5' })
+      mockDnsLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }])
       await expect(validateMcpServerSsrf('https://internal.corp/mcp')).rejects.toThrow(McpSsrfError)
     })
 
@@ -508,7 +527,7 @@ describe('validateMcpServerSsrf', () => {
     })
 
     it('returns resolved loopback IP for DNS aliases (caller pins)', async () => {
-      mockDnsLookup.mockResolvedValue({ address: '127.0.0.1' })
+      mockDnsLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }])
       await expect(validateMcpServerSsrf('http://my-local-alias/mcp')).resolves.toBe('127.0.0.1')
     })
   })

--- a/apps/sim/lib/mcp/domain-check.ts
+++ b/apps/sim/lib/mcp/domain-check.ts
@@ -185,11 +185,8 @@ export async function validateMcpServerSsrf(url: string | undefined): Promise<st
 
   let address: string
   try {
-    // Prefer IPv4. The caller pins the connection to this single address, which strips
-    // Happy Eyeballs' IPv4 fallback — and common deploy egresses (AWS NAT gateways) are
-    // IPv4-only, so pinning a dual-stack host's IPv6 address (which `verbatim` returns
-    // first for Cloudflare-fronted hosts) connects into a void and hangs until timeout.
-    // IPv6-only hosts still pin their sole address.
+    // Prefer IPv4: pinning strips Happy Eyeballs' fallback, and a pinned IPv6 address
+    // (which `verbatim` returns first for dual-stack hosts) hangs on IPv4-only egress.
     const resolved = await dns.lookup(cleanHostname, { all: true, verbatim: true })
     address = (resolved.find((entry) => entry.family === 4) ?? resolved[0]).address
   } catch (error) {

--- a/apps/sim/lib/mcp/domain-check.ts
+++ b/apps/sim/lib/mcp/domain-check.ts
@@ -185,8 +185,13 @@ export async function validateMcpServerSsrf(url: string | undefined): Promise<st
 
   let address: string
   try {
-    const lookup = await dns.lookup(cleanHostname, { verbatim: true })
-    address = lookup.address
+    // Prefer IPv4. The caller pins the connection to this single address, which strips
+    // Happy Eyeballs' IPv4 fallback — and common deploy egresses (AWS NAT gateways) are
+    // IPv4-only, so pinning a dual-stack host's IPv6 address (which `verbatim` returns
+    // first for Cloudflare-fronted hosts) connects into a void and hangs until timeout.
+    // IPv6-only hosts still pin their sole address.
+    const resolved = await dns.lookup(cleanHostname, { all: true, verbatim: true })
+    address = (resolved.find((entry) => entry.family === 4) ?? resolved[0]).address
   } catch (error) {
     logger.warn('DNS lookup failed for MCP server URL', {
       hostname,


### PR DESCRIPTION
## The real root cause (empirically confirmed)

The MCP "connecting forever" / tool-discovery 30s timeouts in **production** — affecting Gauge, Exa, and PlanetScale alike — were caused by **IP-family pinning**, not OAuth or HTTP/2 (which the earlier PRs fixed but were different layers).

The chain, every link verified against production:
1. SSRF protection pins each outbound connection to a **single resolved IP** (`createPinnedLookup`), which **strips Happy Eyeballs' IPv4 fallback**.
2. `dns.lookup(host, { verbatim: true })` returns the **IPv6 address first** for Cloudflare-fronted dual-stack hosts — verified: `app.withgauge.com` → `2606:4700:…`, `api.exa.ai` → `2606:4700:…`.
3. Production's app subnets have **zero IPv6 egress** — no IPv6 CIDR, IPv4-only via NAT Gateway (AWS NAT Gateways are IPv4-only). Verified on both subnets + route tables.
4. So the connection pinned to IPv6 **connects into a void and hangs → the SDK's 30s timeout fires** (`AbortError`, `durationMs=30002`). **Intermittent** because the resolver rotates A/AAAA order (works on retry when it picks IPv4).

This explains everything that didn't add up: why **#5797 (h1.1) didn't fix it** (protocol-independent), and why it **never reproduced locally** (dev machines have IPv6 egress).

Empirical proof (undici, pinned lookup):
```
pin IPv6-blackhole ONLY (current behavior)   → FAIL after 8001ms (TimeoutError)   ← the prod hang
prefer IPv4 / include IPv4 in the set        → status 200 in ~600ms               ← reachable
```

## Fix
At both pinned-resolution sites — `validateMcpServerSsrf` (MCP) and `validateUrlWithDNS` (providers / A2A / SMTP, same latent bug) — resolve **all** addresses (`{ all: true, verbatim: true }`) and **prefer an IPv4 address**; IPv6-only hosts still pin their sole address. This keeps the single-IP pinning API and threading untouched (near-zero blast radius) and **SSRF validation of the pinned IP is unchanged**.

Verified end-to-end: `app.withgauge.com` and `api.exa.ai` now pin their IPv4 address instead of the unreachable IPv6.

## Type of Change
- [x] Bug fix

## Testing
- Full `lib/mcp` suite green (374); `lib/core/security` green; tsc + biome clean.
- Added tests: dual-stack host prefers IPv4; IPv6-only host pins its sole address.
- The definitive confirmation is re-testing on staging/prod once deployed.

## Note
A fuller fix (pin the *validated set* of all resolved IPs and let undici do Happy Eyeballs, so it's egress-agnostic) is a good follow-up, but it threads `string → string[]` through ~10 security-critical sites; preferring IPv4 fixes the confirmed bug now with minimal risk.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)