### PR TITLE
fix(security): prefer IPv4 when pinning DB and 1Password connections

### DIFF
--- a/apps/sim/app/api/tools/onepassword/utils.test.ts
+++ b/apps/sim/app/api/tools/onepassword/utils.test.ts
@@ -54,16 +54,33 @@ describe('validateConnectServerUrl', () => {
     })
 
     it('blocks a hostname that resolves to a private IP', async () => {
-      mockDnsLookup.mockResolvedValue({ address: '10.1.2.3', family: 4 })
+      mockDnsLookup.mockResolvedValue([{ address: '10.1.2.3', family: 4 }])
       await expect(validateConnectServerUrl('https://connect.internal')).rejects.toThrow(
         'cannot point to a private or reserved IP address'
       )
     })
 
     it('allows a hostname that resolves to a public IP', async () => {
-      mockDnsLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 })
+      mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }])
       await expect(validateConnectServerUrl('https://connect.example.com')).resolves.toBe(
         '93.184.216.34'
+      )
+    })
+
+    it('prefers the IPv4 address for a dual-stack host (avoids unreachable IPv6 pin)', async () => {
+      mockDnsLookup.mockResolvedValue([
+        { address: '2606:4700::6810:85e5', family: 6 },
+        { address: '93.184.216.34', family: 4 },
+      ])
+      await expect(validateConnectServerUrl('https://connect.example.com')).resolves.toBe(
+        '93.184.216.34'
+      )
+    })
+
+    it('pins the sole IPv6 address for an IPv6-only host', async () => {
+      mockDnsLookup.mockResolvedValue([{ address: '2606:4700::6810:85e5', family: 6 }])
+      await expect(validateConnectServerUrl('https://connect.example.com')).resolves.toBe(
+        '2606:4700::6810:85e5'
       )
     })
   })
@@ -94,7 +111,7 @@ describe('validateConnectServerUrl', () => {
     })
 
     it('allows a hostname that resolves to a private IP', async () => {
-      mockDnsLookup.mockResolvedValue({ address: '10.1.2.3', family: 4 })
+      mockDnsLookup.mockResolvedValue([{ address: '10.1.2.3', family: 4 }])
       await expect(validateConnectServerUrl('https://connect.internal')).resolves.toBe('10.1.2.3')
     })
   })

--- a/apps/sim/app/api/tools/onepassword/utils.ts
+++ b/apps/sim/app/api/tools/onepassword/utils.ts
@@ -317,7 +317,10 @@ export async function validateConnectServerUrl(serverUrl: string): Promise<strin
 
   let address: string
   try {
-    ;({ address } = await dns.lookup(clean, { verbatim: true }))
+    // Prefer IPv4: pinning strips Happy Eyeballs' fallback, and a pinned IPv6 address hangs
+    // on IPv4-only egress (e.g. AWS NAT gateways).
+    const resolved = await dns.lookup(clean, { all: true, verbatim: true })
+    address = (resolved.find((entry) => entry.family === 4) ?? resolved[0]).address
   } catch (error) {
     connectLogger.warn('DNS lookup failed for 1Password Connect server URL', {
       hostname: clean,

--- a/apps/sim/lib/core/security/input-validation.server.ts
+++ b/apps/sim/lib/core/security/input-validation.server.ts
@@ -188,7 +188,10 @@ export async function validateDatabaseHost(
   }
 
   try {
-    const { address } = await dns.lookup(cleanHost, { verbatim: true })
+    // Prefer IPv4: pinning strips Happy Eyeballs' fallback, and a pinned IPv6 address hangs
+    // on IPv4-only egress (e.g. AWS NAT gateways).
+    const resolved = await dns.lookup(cleanHost, { all: true, verbatim: true })
+    const { address } = resolved.find((entry) => entry.family === 4) ?? resolved[0]
 
     if (isPrivateOrReservedIP(address) && !isPrivateDatabaseHostsAllowed) {
       logger.warn('Database host resolves to blocked IP address', {


### PR DESCRIPTION
## Summary
- Same class of bug fixed for MCP in #5798, applied to the other two pinned-resolution sites (flagged by both review passes on that PR).
- SSRF pinning forces each outbound connection to a **single resolved IP**, which strips Happy Eyeballs' IPv4 fallback. `dns.lookup(verbatim)` returns the **IPv6 address first** for dual-stack hosts, so a **dual-stack database host** or **1Password Connect server** gets pinned to IPv6 — **unreachable on IPv4-only egress** (AWS NAT gateways) and hangs until timeout.
- `validateDatabaseHost` and `validateConnectServerUrl` now resolve **all** addresses (`{ all: true, verbatim: true }`) and **prefer IPv4**; IPv6-only hosts still pin their sole address.

## Safety
- **SSRF unchanged**: the selected (IPv4-preferred) address is the exact one that gets validated (`isPrivateOrReservedIP` / `assertConnectIpAllowed`) and pinned — never a "validate A, connect B" split. Equal-or-stricter than before (a private IPv4 is now caught where it was previously masked by an IPv6 pick).
- No signature/threading changes.

## Type of Change
- [x] Bug fix

## Testing
- `lib/core/security` + all DB tool utils (postgresql/clickhouse/mysql) + onepassword suites green (617); tsc + biome clean.
- Added tests: dual-stack host prefers IPv4; IPv6-only host pins its sole address (onepassword). `validateDatabaseHost` uses the identical expression, covered by the domain-check test in #5798.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)