### PR TITLE
fix(emails): keep custom whitelabel logos at their original height

### DIFF
--- a/apps/sim/components/emails/components/email-layout.tsx
+++ b/apps/sim/components/emails/components/email-layout.tsx
@@ -54,9 +54,8 @@ export function EmailLayout({
           <Section style={baseStyles.header}>
             <Img
               src={brand.logoUrl || `${baseUrl}/brand/color/email/wordmark.png`}
-              height='41'
-              {...(hasCustomLogo ? {} : { width: '68' })}
               alt={brand.name}
+              {...(hasCustomLogo ? { height: '34' } : { height: '41', width: '68' })}
               style={hasCustomLogo ? { display: 'block', width: 'auto' } : { display: 'block' }}
             />
           </Section>


### PR DESCRIPTION
## Summary
- Follow-up to #5802. That PR bumped the header logo height from `34` → `41` to fit the newly padded default wordmark, but the `height` prop was applied unconditionally — so **configured custom/whitelabel logos** (`brand.logoUrl`) also inherited the `41px` height and rendered oversized.
- Make `height` conditional alongside `width`: custom logos keep their original `height='34'` (width auto); only the default padded wordmark uses `41×68`.

This is the P1 Greptile flagged on #5802 before it was merged.

## Type of Change
- [x] Bug fix

## Testing
Verified the JSX branches: `hasCustomLogo` → `height='34'` only; default → `height='41' width='68'`. Lint clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)