### PR TITLE
fix(csp): allow X (Twitter) conversion pixel domains on hosted

### DIFF
--- a/apps/sim/lib/core/security/csp.ts
+++ b/apps/sim/lib/core/security/csp.ts
@@ -66,6 +66,9 @@ const STATIC_SCRIPT_SRC = [
         'https://*.hs-analytics.net',
         'https://*.hscollectedforms.net',
         'https://*.hs-banner.com',
+        // X (Twitter) conversion pixel (landing pages) — the base code injects
+        // uwt.js as a <script> tag from static.ads-twitter.com
+        'https://static.ads-twitter.com',
       ]
     : []),
 ] as const
@@ -106,6 +109,10 @@ const STATIC_CONNECT_SRC = [
         // The visitor beacon itself is an image pixel (img-src, already
         // permitted below), not a connect-src request.
         'https://*.hscollectedforms.net',
+        // X (Twitter) conversion pixel — uwt.js sends conversion beacons here
+        // via fetch/sendBeacon. The t.co image-pixel fallback is already
+        // covered by the `https:` wildcard in img-src.
+        'https://analytics.twitter.com',
       ]
     : []),
 ] as const


### PR DESCRIPTION
## Summary
- The X (Twitter) conversion pixel injected on hosted landing pages tries to load `uwt.js` from `static.ads-twitter.com`, but that domain isn't in the CSP `script-src`, so the browser blocks it — the pixel never loads and every landing pageview logs a CSP violation.
- Add `https://static.ads-twitter.com` to `script-src` so `uwt.js` loads.
- Add `https://analytics.twitter.com` to `connect-src` so the pixel's conversion beacons (fetch/sendBeacon) can fire. The `t.co` image-pixel fallback is already covered by the `https:` wildcard in `img-src`.
- Both additions are gated behind `isHosted`, matching where the pixel `<Script>` is injected. Restores X ad conversion tracking and clears the console error.

## Type of Change
- [x] Bug fix

## Testing
Verified the live `www.sim.ai` CSP header lacked the ads-twitter/analytics.twitter domains; confirmed the injected pixel base code targets those domains. All 28 CSP tests pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)