### PR TITLE
fix(docker): require auth secrets in prod and Ollama Compose files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -209,7 +209,7 @@ To use local models with Sim:
    ollama pull gemma3:4b
    ```
 
-2. Start Sim with local model support:
+2. Start Sim with local model support (generate the persistent `.env` from the Quick Start above first — the Ollama Compose file requires the same secrets and refuses to start without them):
 
    ```bash
    # With NVIDIA GPU support

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -165,11 +165,35 @@ After running this command, open [http://localhost:3000/](http://localhost:3000/
 git clone https://github.com/<your-username>/sim.git
 cd sim
 
+# Generate persistent secrets once (the file is ignored by Git)
+(
+  set -euC
+  if [ -e .env ]; then
+    echo 'Refusing to overwrite existing .env' >&2
+    exit 1
+  fi
+  umask 077
+  better_auth_secret=$(openssl rand -hex 32)
+  encryption_key=$(openssl rand -hex 32)
+  api_encryption_key=$(openssl rand -hex 32)
+  internal_api_secret=$(openssl rand -hex 32)
+  cat > .env << EOF
+BETTER_AUTH_SECRET=$better_auth_secret
+ENCRYPTION_KEY=$encryption_key
+API_ENCRYPTION_KEY=$api_encryption_key
+INTERNAL_API_SECRET=$internal_api_secret
+EOF
+)
+
 # Start Sim
 docker compose -f docker-compose.prod.yml up -d
 ```
 
 Access the application at [http://localhost:3000/](http://localhost:3000/)
+
+Back up this `.env` file separately in a secured secret store; do not bundle it with database
+backups. Do not regenerate the values when restarting an existing installation: changing encryption
+keys can make stored secrets unreadable, and changing `BETTER_AUTH_SECRET` invalidates sessions.
 
 #### Using Local Models
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -195,6 +195,14 @@ Back up this `.env` file separately in a secured secret store; do not bundle it 
 backups. Do not regenerate the values when restarting an existing installation: changing encryption
 keys can make stored secrets unreadable, and changing `BETTER_AUTH_SECRET` invalidates sessions.
 
+Already have a `.env` (for example from an install that predates these required secrets)? The block above refuses to overwrite it. Add only the missing secrets instead — this preserves every existing value:
+
+```bash
+for key in BETTER_AUTH_SECRET ENCRYPTION_KEY API_ENCRYPTION_KEY INTERNAL_API_SECRET; do
+  grep -q "^${key}=" .env || printf '%s=%s\n' "$key" "$(openssl rand -hex 32)" >> .env
+done
+```
+
 #### Using Local Models
 
 To use local models with Sim:

--- a/README.md
+++ b/README.md
@@ -79,10 +79,35 @@ Docker must be installed and running. Use `-p, --port <port>` to run Sim on a di
 
 ```bash
 git clone https://github.com/simstudioai/sim.git && cd sim
+
+# Generate persistent secrets once (the file is ignored by Git)
+(
+  set -euC
+  if [ -e .env ]; then
+    echo 'Refusing to overwrite existing .env' >&2
+    exit 1
+  fi
+  umask 077
+  better_auth_secret=$(openssl rand -hex 32)
+  encryption_key=$(openssl rand -hex 32)
+  api_encryption_key=$(openssl rand -hex 32)
+  internal_api_secret=$(openssl rand -hex 32)
+  cat > .env << EOF
+BETTER_AUTH_SECRET=$better_auth_secret
+ENCRYPTION_KEY=$encryption_key
+API_ENCRYPTION_KEY=$api_encryption_key
+INTERNAL_API_SECRET=$internal_api_secret
+EOF
+)
+
 docker compose -f docker-compose.prod.yml up -d
 ```
 
 Open [http://localhost:3000](http://localhost:3000)
+
+Back up the generated `.env` file separately in a secured secret store; do not bundle it with
+database backups. Replacing its encryption keys can make stored secrets unreadable, while replacing
+`BETTER_AUTH_SECRET` invalidates existing sessions.
 
 Sim also supports local models via [Ollama](https://ollama.ai) and [vLLM](https://docs.vllm.ai/). See the [Docker self-hosting docs](https://docs.sim.ai/self-hosting/docker) for setup details.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Back up the generated `.env` file separately in a secured secret store; do not b
 database backups. Replacing its encryption keys can make stored secrets unreadable, while replacing
 `BETTER_AUTH_SECRET` invalidates existing sessions.
 
+Already have a `.env` (for example from an earlier install that predates these required secrets)? The block above refuses to overwrite it. Add only the missing secrets instead — this preserves every existing value:
+
+```bash
+for key in BETTER_AUTH_SECRET ENCRYPTION_KEY API_ENCRYPTION_KEY INTERNAL_API_SECRET; do
+  grep -q "^${key}=" .env || printf '%s=%s\n' "$key" "$(openssl rand -hex 32)" >> .env
+done
+```
+
 Sim also supports local models via [Ollama](https://ollama.ai) and [vLLM](https://docs.vllm.ai/). See the [Docker self-hosting docs](https://docs.sim.ai/self-hosting/docker) for setup details.
 
 ### Manual Setup

--- a/apps/docs/content/docs/de/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/de/self-hosting/docker.mdx
@@ -9,28 +9,56 @@ import { Callout } from 'fumadocs-ui/components/callout'
 ## Schnellstart
 
 ```bash
-# Clone and start
+# Clone the repository
 git clone https://github.com/simstudioai/sim.git && cd sim
+
+# Generate persistent secrets once (.env is ignored by Git)
+(
+  set -euC
+  if [ -e .env ]; then
+    echo 'Refusing to overwrite existing .env' >&2
+    exit 1
+  fi
+  umask 077
+  better_auth_secret=$(openssl rand -hex 32)
+  encryption_key=$(openssl rand -hex 32)
+  api_encryption_key=$(openssl rand -hex 32)
+  internal_api_secret=$(openssl rand -hex 32)
+  cat > .env << EOF
+BETTER_AUTH_SECRET=$better_auth_secret
+ENCRYPTION_KEY=$encryption_key
+API_ENCRYPTION_KEY=$api_encryption_key
+INTERNAL_API_SECRET=$internal_api_secret
+EOF
+)
+
+# Start Sim
 docker compose -f docker-compose.prod.yml up -d
 ```
 
 Öffnen Sie [http://localhost:3000](http://localhost:3000)
 
+<Callout type="warning">
+  Sichern Sie die erzeugte `.env` separat in einem geschützten Secret-Speicher und nicht zusammen
+  mit Datenbanksicherungen. Erzeugen Sie diese Werte bei einem Neustart nicht neu. Geänderte
+  Verschlüsselungsschlüssel können gespeicherte Secrets unlesbar machen; ein geändertes
+  `BETTER_AUTH_SECRET` macht bestehende Sitzungen ungültig.
+</Callout>
+
 ## Produktionseinrichtung
 
 ### 1. Umgebung konfigurieren
 
-```bash
-# Generate secrets
-cat > .env << EOF
-DATABASE_URL=postgresql://postgres:postgres@db:5432/simstudio
-BETTER_AUTH_SECRET=$(openssl rand -hex 32)
-ENCRYPTION_KEY=$(openssl rand -hex 32)
-INTERNAL_API_SECRET=$(openssl rand -hex 32)
+Behalten Sie die beim Schnellstart erzeugten Secrets und ergänzen Sie die öffentliche URL in
+derselben `.env`-Datei:
+
+```dotenv
 NEXT_PUBLIC_APP_URL=https://sim.yourdomain.com
 BETTER_AUTH_URL=https://sim.yourdomain.com
-EOF
 ```
+
+Wenn Sie den Schnellstart übersprungen haben, führen Sie zuerst dessen Secret-Erzeugung aus.
+Ersetzen Sie niemals Verschlüsselungsschlüssel einer Installation, die bereits Daten enthält.
 
 ### 2. Dienste starten
 
@@ -124,6 +152,9 @@ docker compose -f docker-compose.ollama.yml exec ollama ollama pull llama3.2
 ### Externes Ollama
 
 Wenn Ollama auf Ihrem Host-Rechner läuft (nicht in Docker):
+
+Führen Sie zuerst den Schnellstart aus, damit die persistente `.env` vorhanden ist. Verwenden Sie
+dann die passende Host-URL:
 
 ```bash
 # macOS/Windows

--- a/apps/docs/content/docs/de/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/de/self-hosting/docker.mdx
@@ -135,6 +135,8 @@ sudo certbot --nginx -d sim.yourdomain.com
 
 ## Ollama
 
+Führen Sie zuerst den Schnellstart aus, damit die persistente `.env` mit Ihren Secrets vorhanden ist – die Ollama-Compose-Datei benötigt dieselben Secrets und startet ohne sie nicht.
+
 ```bash
 # With GPU
 docker compose -f docker-compose.ollama.yml --profile gpu --profile setup up -d

--- a/apps/docs/content/docs/de/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/de/self-hosting/docker.mdx
@@ -45,6 +45,14 @@ docker compose -f docker-compose.prod.yml up -d
   `BETTER_AUTH_SECRET` macht bestehende Sitzungen ungültig.
 </Callout>
 
+Sie haben bereits eine `.env` (z. B. aus einer Installation vor diesen erforderlichen Secrets)? Der obige Block überschreibt sie nicht. Ergänzen Sie stattdessen nur die fehlenden Secrets – vorhandene Werte bleiben erhalten:
+
+```bash
+for key in BETTER_AUTH_SECRET ENCRYPTION_KEY API_ENCRYPTION_KEY INTERNAL_API_SECRET; do
+  grep -q "^${key}=" .env || printf '%s=%s\n' "$key" "$(openssl rand -hex 32)" >> .env
+done
+```
+
 ## Produktionseinrichtung
 
 ### 1. Umgebung konfigurieren

--- a/apps/docs/content/docs/en/platform/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/en/platform/self-hosting/docker.mdx
@@ -46,6 +46,14 @@ Open [http://localhost:3000](http://localhost:3000)
   invalidates existing sessions.
 </Callout>
 
+Already have a `.env` (for example from an install that predates these required secrets)? The block above refuses to overwrite it. Add only the missing secrets instead — this preserves every existing value:
+
+```bash
+for key in BETTER_AUTH_SECRET ENCRYPTION_KEY API_ENCRYPTION_KEY INTERNAL_API_SECRET; do
+  grep -q "^${key}=" .env || printf '%s=%s\n' "$key" "$(openssl rand -hex 32)" >> .env
+done
+```
+
 ## Production Setup
 
 ### 1. Configure Environment

--- a/apps/docs/content/docs/en/platform/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/en/platform/self-hosting/docker.mdx
@@ -131,6 +131,8 @@ sudo certbot --nginx -d sim.yourdomain.com
 
 ## Ollama
 
+Complete Quick Start first so the persistent `.env` with your secrets exists — the Ollama Compose file requires the same secrets and refuses to start without them.
+
 ```bash
 # With GPU
 docker compose -f docker-compose.ollama.yml --profile gpu --profile setup up -d

--- a/apps/docs/content/docs/en/platform/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/en/platform/self-hosting/docker.mdx
@@ -10,28 +10,55 @@ import { FAQ } from '@/components/ui/faq'
 ## Quick Start
 
 ```bash
-# Clone and start
+# Clone the repository
 git clone https://github.com/simstudioai/sim.git && cd sim
+
+# Generate persistent secrets once (the file is ignored by Git)
+(
+  set -euC
+  if [ -e .env ]; then
+    echo 'Refusing to overwrite existing .env' >&2
+    exit 1
+  fi
+  umask 077
+  better_auth_secret=$(openssl rand -hex 32)
+  encryption_key=$(openssl rand -hex 32)
+  api_encryption_key=$(openssl rand -hex 32)
+  internal_api_secret=$(openssl rand -hex 32)
+  cat > .env << EOF
+BETTER_AUTH_SECRET=$better_auth_secret
+ENCRYPTION_KEY=$encryption_key
+API_ENCRYPTION_KEY=$api_encryption_key
+INTERNAL_API_SECRET=$internal_api_secret
+EOF
+)
+
+# Start Sim
 docker compose -f docker-compose.prod.yml up -d
 ```
 
 Open [http://localhost:3000](http://localhost:3000)
 
+<Callout type="warning">
+  Back up the generated `.env` file separately in a secured secret store; do not bundle it with
+  database backups. Do not regenerate these values when restarting an existing installation.
+  Changing encryption keys can make stored secrets unreadable, while changing `BETTER_AUTH_SECRET`
+  invalidates existing sessions.
+</Callout>
+
 ## Production Setup
 
 ### 1. Configure Environment
 
-```bash
-# Generate secrets
-cat > .env << EOF
-DATABASE_URL=postgresql://postgres:postgres@db:5432/simstudio
-BETTER_AUTH_SECRET=$(openssl rand -hex 32)
-ENCRYPTION_KEY=$(openssl rand -hex 32)
-INTERNAL_API_SECRET=$(openssl rand -hex 32)
+Keep the secrets generated during Quick Start and add your public URL to the same `.env` file:
+
+```dotenv
 NEXT_PUBLIC_APP_URL=https://sim.yourdomain.com
 BETTER_AUTH_URL=https://sim.yourdomain.com
-EOF
 ```
+
+If you skipped Quick Start, run its secret-generation step first. Never replace encryption keys for
+an installation that already has database data.
 
 ### 2. Start Services
 
@@ -121,6 +148,8 @@ docker compose -f docker-compose.ollama.yml exec ollama ollama pull llama3.2
 
 If Ollama runs on your host machine (not in Docker):
 
+Complete Quick Start first so the persistent `.env` exists, then use the appropriate host URL:
+
 ```bash
 # macOS/Windows
 OLLAMA_URL=http://host.docker.internal:11434 docker compose -f docker-compose.prod.yml up -d
@@ -158,4 +187,3 @@ docker compose -f docker-compose.prod.yml exec db pg_dump -U postgres simstudio 
   { question: "How do I back up and restore the database?", answer: "Back up with: docker compose -f docker-compose.prod.yml exec db pg_dump -U postgres simstudio > backup.sql. Restore with: docker compose -f docker-compose.prod.yml exec -T db psql -U postgres simstudio < backup.sql. The database data is persisted in a Docker volume named postgres_data." },
   { question: "Can I customize the PostgreSQL credentials?", answer: "Yes. The docker-compose.prod.yml uses environment variable defaults: POSTGRES_USER (default: postgres), POSTGRES_PASSWORD (default: postgres), POSTGRES_DB (default: simstudio), and POSTGRES_PORT (default: 5432). Set these in your .env file to override them." },
 ]} />
-

--- a/apps/docs/content/docs/es/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/es/self-hosting/docker.mdx
@@ -135,6 +135,8 @@ sudo certbot --nginx -d sim.yourdomain.com
 
 ## Ollama
 
+Completa primero el Inicio rápido para crear el `.env` persistente con tus secretos: el archivo Compose de Ollama requiere los mismos secretos y no se inicia sin ellos.
+
 ```bash
 # With GPU
 docker compose -f docker-compose.ollama.yml --profile gpu --profile setup up -d

--- a/apps/docs/content/docs/es/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/es/self-hosting/docker.mdx
@@ -45,6 +45,14 @@ Abre [http://localhost:3000](http://localhost:3000)
   guardados, y cambiar `BETTER_AUTH_SECRET` invalida las sesiones existentes.
 </Callout>
 
+¿Ya tienes un `.env` (por ejemplo, de una instalación anterior a estos secretos obligatorios)? El bloque anterior no lo sobrescribe. Añade solo los secretos que falten; así se conservan todos los valores existentes:
+
+```bash
+for key in BETTER_AUTH_SECRET ENCRYPTION_KEY API_ENCRYPTION_KEY INTERNAL_API_SECRET; do
+  grep -q "^${key}=" .env || printf '%s=%s\n' "$key" "$(openssl rand -hex 32)" >> .env
+done
+```
+
 ## Configuración de producción
 
 ### 1. Configurar entorno

--- a/apps/docs/content/docs/es/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/es/self-hosting/docker.mdx
@@ -9,28 +9,56 @@ import { Callout } from 'fumadocs-ui/components/callout'
 ## Inicio rápido
 
 ```bash
-# Clone and start
+# Clone the repository
 git clone https://github.com/simstudioai/sim.git && cd sim
+
+# Generate persistent secrets once (.env is ignored by Git)
+(
+  set -euC
+  if [ -e .env ]; then
+    echo 'Refusing to overwrite existing .env' >&2
+    exit 1
+  fi
+  umask 077
+  better_auth_secret=$(openssl rand -hex 32)
+  encryption_key=$(openssl rand -hex 32)
+  api_encryption_key=$(openssl rand -hex 32)
+  internal_api_secret=$(openssl rand -hex 32)
+  cat > .env << EOF
+BETTER_AUTH_SECRET=$better_auth_secret
+ENCRYPTION_KEY=$encryption_key
+API_ENCRYPTION_KEY=$api_encryption_key
+INTERNAL_API_SECRET=$internal_api_secret
+EOF
+)
+
+# Start Sim
 docker compose -f docker-compose.prod.yml up -d
 ```
 
 Abre [http://localhost:3000](http://localhost:3000)
 
+<Callout type="warning">
+  Guarda el archivo `.env` generado por separado en un almacén seguro de secretos; no lo incluyas
+  con las copias de seguridad de la base de datos. No vuelvas a generar estos valores al reiniciar
+  una instalación existente. Cambiar las claves de cifrado puede hacer ilegibles los secretos
+  guardados, y cambiar `BETTER_AUTH_SECRET` invalida las sesiones existentes.
+</Callout>
+
 ## Configuración de producción
 
 ### 1. Configurar entorno
 
-```bash
-# Generate secrets
-cat > .env << EOF
-DATABASE_URL=postgresql://postgres:postgres@db:5432/simstudio
-BETTER_AUTH_SECRET=$(openssl rand -hex 32)
-ENCRYPTION_KEY=$(openssl rand -hex 32)
-INTERNAL_API_SECRET=$(openssl rand -hex 32)
+Conserva los secretos generados durante el Inicio rápido y añade la URL pública al mismo archivo
+`.env`:
+
+```dotenv
 NEXT_PUBLIC_APP_URL=https://sim.yourdomain.com
 BETTER_AUTH_URL=https://sim.yourdomain.com
-EOF
 ```
+
+Si omitiste el Inicio rápido, ejecuta primero su paso de generación de secretos. No reemplaces las
+claves de cifrado de una instalación que ya tenga datos.
 
 ### 2. Iniciar servicios
 
@@ -124,6 +152,9 @@ docker compose -f docker-compose.ollama.yml exec ollama ollama pull llama3.2
 ### Ollama externo
 
 Si Ollama se ejecuta en tu máquina host (no en Docker):
+
+Completa primero el Inicio rápido para crear el `.env` persistente y después usa la URL de host
+adecuada:
 
 ```bash
 # macOS/Windows

--- a/apps/docs/content/docs/fr/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/fr/self-hosting/docker.mdx
@@ -45,6 +45,14 @@ Ouvrez [http://localhost:3000](http://localhost:3000)
   secrets stockés illisibles, et modifier `BETTER_AUTH_SECRET` invalide les sessions existantes.
 </Callout>
 
+Vous avez déjà un `.env` (par exemple d'une installation antérieure à ces secrets requis) ? Le bloc ci-dessus ne l'écrase pas. Ajoutez seulement les secrets manquants — les valeurs existantes sont préservées :
+
+```bash
+for key in BETTER_AUTH_SECRET ENCRYPTION_KEY API_ENCRYPTION_KEY INTERNAL_API_SECRET; do
+  grep -q "^${key}=" .env || printf '%s=%s\n' "$key" "$(openssl rand -hex 32)" >> .env
+done
+```
+
 ## Configuration de production
 
 ### 1. Configurer l'environnement

--- a/apps/docs/content/docs/fr/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/fr/self-hosting/docker.mdx
@@ -135,6 +135,8 @@ sudo certbot --nginx -d sim.yourdomain.com
 
 ## Ollama
 
+Effectuez d'abord le Démarrage rapide pour créer le `.env` persistant avec vos secrets : le fichier Compose d'Ollama requiert les mêmes secrets et ne démarre pas sans eux.
+
 ```bash
 # With GPU
 docker compose -f docker-compose.ollama.yml --profile gpu --profile setup up -d

--- a/apps/docs/content/docs/fr/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/fr/self-hosting/docker.mdx
@@ -9,28 +9,56 @@ import { Callout } from 'fumadocs-ui/components/callout'
 ## Démarrage rapide
 
 ```bash
-# Clone and start
+# Clone the repository
 git clone https://github.com/simstudioai/sim.git && cd sim
+
+# Generate persistent secrets once (.env is ignored by Git)
+(
+  set -euC
+  if [ -e .env ]; then
+    echo 'Refusing to overwrite existing .env' >&2
+    exit 1
+  fi
+  umask 077
+  better_auth_secret=$(openssl rand -hex 32)
+  encryption_key=$(openssl rand -hex 32)
+  api_encryption_key=$(openssl rand -hex 32)
+  internal_api_secret=$(openssl rand -hex 32)
+  cat > .env << EOF
+BETTER_AUTH_SECRET=$better_auth_secret
+ENCRYPTION_KEY=$encryption_key
+API_ENCRYPTION_KEY=$api_encryption_key
+INTERNAL_API_SECRET=$internal_api_secret
+EOF
+)
+
+# Start Sim
 docker compose -f docker-compose.prod.yml up -d
 ```
 
 Ouvrez [http://localhost:3000](http://localhost:3000)
 
+<Callout type="warning">
+  Sauvegardez le fichier `.env` généré séparément dans un gestionnaire de secrets sécurisé ; ne
+  l'incluez pas avec les sauvegardes de la base de données. Ne régénérez pas ces valeurs au
+  redémarrage d'une installation existante. Modifier les clés de chiffrement peut rendre les
+  secrets stockés illisibles, et modifier `BETTER_AUTH_SECRET` invalide les sessions existantes.
+</Callout>
+
 ## Configuration de production
 
 ### 1. Configurer l'environnement
 
-```bash
-# Generate secrets
-cat > .env << EOF
-DATABASE_URL=postgresql://postgres:postgres@db:5432/simstudio
-BETTER_AUTH_SECRET=$(openssl rand -hex 32)
-ENCRYPTION_KEY=$(openssl rand -hex 32)
-INTERNAL_API_SECRET=$(openssl rand -hex 32)
+Conservez les secrets générés lors du Démarrage rapide et ajoutez l'URL publique au même fichier
+`.env` :
+
+```dotenv
 NEXT_PUBLIC_APP_URL=https://sim.yourdomain.com
 BETTER_AUTH_URL=https://sim.yourdomain.com
-EOF
 ```
+
+Si vous avez ignoré le Démarrage rapide, exécutez d'abord son étape de génération des secrets. Ne
+remplacez jamais les clés de chiffrement d'une installation qui contient déjà des données.
 
 ### 2. Démarrer les services
 
@@ -124,6 +152,9 @@ docker compose -f docker-compose.ollama.yml exec ollama ollama pull llama3.2
 ### Ollama externe
 
 Si Ollama s'exécute sur votre machine hôte (pas dans Docker) :
+
+Effectuez d'abord le Démarrage rapide afin de créer le fichier `.env` persistant, puis utilisez
+l'URL d'hôte appropriée :
 
 ```bash
 # macOS/Windows

--- a/apps/docs/content/docs/ja/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/ja/self-hosting/docker.mdx
@@ -44,6 +44,14 @@ docker compose -f docker-compose.prod.yml up -d
   シークレットを読み取れなくなる可能性があり、`BETTER_AUTH_SECRET` を変更すると既存のセッションが無効になります。
 </Callout>
 
+すでに `.env` がある場合（これらの必須シークレット導入前のインストールなど）、上記のブロックは上書きしません。代わりに不足しているシークレットのみを追加してください。既存の値はすべて保持されます。
+
+```bash
+for key in BETTER_AUTH_SECRET ENCRYPTION_KEY API_ENCRYPTION_KEY INTERNAL_API_SECRET; do
+  grep -q "^${key}=" .env || printf '%s=%s\n' "$key" "$(openssl rand -hex 32)" >> .env
+done
+```
+
 ## 本番環境のセットアップ
 
 ### 1. 環境の設定

--- a/apps/docs/content/docs/ja/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/ja/self-hosting/docker.mdx
@@ -9,28 +9,54 @@ import { Callout } from 'fumadocs-ui/components/callout'
 ## クイックスタート
 
 ```bash
-# Clone and start
+# Clone the repository
 git clone https://github.com/simstudioai/sim.git && cd sim
+
+# Generate persistent secrets once (.env is ignored by Git)
+(
+  set -euC
+  if [ -e .env ]; then
+    echo 'Refusing to overwrite existing .env' >&2
+    exit 1
+  fi
+  umask 077
+  better_auth_secret=$(openssl rand -hex 32)
+  encryption_key=$(openssl rand -hex 32)
+  api_encryption_key=$(openssl rand -hex 32)
+  internal_api_secret=$(openssl rand -hex 32)
+  cat > .env << EOF
+BETTER_AUTH_SECRET=$better_auth_secret
+ENCRYPTION_KEY=$encryption_key
+API_ENCRYPTION_KEY=$api_encryption_key
+INTERNAL_API_SECRET=$internal_api_secret
+EOF
+)
+
+# Start Sim
 docker compose -f docker-compose.prod.yml up -d
 ```
 
 [http://localhost:3000](http://localhost:3000)を開く
 
+<Callout type="warning">
+  生成した `.env` はデータベースのバックアップに含めず、安全なシークレットストアに別途保管してください。
+  既存のインストールを再起動するときにこれらの値を再生成しないでください。暗号化キーを変更すると保存済みの
+  シークレットを読み取れなくなる可能性があり、`BETTER_AUTH_SECRET` を変更すると既存のセッションが無効になります。
+</Callout>
+
 ## 本番環境のセットアップ
 
 ### 1. 環境の設定
 
-```bash
-# Generate secrets
-cat > .env << EOF
-DATABASE_URL=postgresql://postgres:postgres@db:5432/simstudio
-BETTER_AUTH_SECRET=$(openssl rand -hex 32)
-ENCRYPTION_KEY=$(openssl rand -hex 32)
-INTERNAL_API_SECRET=$(openssl rand -hex 32)
+クイックスタートで生成したシークレットを維持し、同じ `.env` ファイルに公開 URL を追加します：
+
+```dotenv
 NEXT_PUBLIC_APP_URL=https://sim.yourdomain.com
 BETTER_AUTH_URL=https://sim.yourdomain.com
-EOF
 ```
+
+クイックスタートを省略した場合は、先にシークレット生成手順を実行してください。すでにデータがあるインストールの
+暗号化キーは決して置き換えないでください。
 
 ### 2. サービスの起動
 
@@ -124,6 +150,8 @@ docker compose -f docker-compose.ollama.yml exec ollama ollama pull llama3.2
 ### 外部Ollama
 
 Ollamaがホストマシン上で実行されている場合（Dockerではない）：
+
+最初にクイックスタートを完了して永続的な `.env` を作成し、その後で適切なホスト URL を使用してください：
 
 ```bash
 # macOS/Windows

--- a/apps/docs/content/docs/ja/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/ja/self-hosting/docker.mdx
@@ -133,6 +133,8 @@ sudo certbot --nginx -d sim.yourdomain.com
 
 ## Ollama
 
+先にクイックスタートを実行して、シークレットを含む永続的な `.env` を用意してください。Ollama の Compose ファイルは同じシークレットを必要とし、それらがないと起動しません。
+
 ```bash
 # With GPU
 docker compose -f docker-compose.ollama.yml --profile gpu --profile setup up -d

--- a/apps/docs/content/docs/zh/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/zh/self-hosting/docker.mdx
@@ -43,6 +43,14 @@ docker compose -f docker-compose.prod.yml up -d
   更改加密密钥可能会导致已存储的密钥无法读取，而更改 `BETTER_AUTH_SECRET` 会使现有会话失效。
 </Callout>
 
+已经有 `.env` 了吗（例如来自引入这些必需密钥之前的安装）？上面的代码块不会覆盖它。请改为仅添加缺失的密钥——这会保留所有现有值：
+
+```bash
+for key in BETTER_AUTH_SECRET ENCRYPTION_KEY API_ENCRYPTION_KEY INTERNAL_API_SECRET; do
+  grep -q "^${key}=" .env || printf '%s=%s\n' "$key" "$(openssl rand -hex 32)" >> .env
+done
+```
+
 ## 生产环境设置
 
 ### 1. 配置环境

--- a/apps/docs/content/docs/zh/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/zh/self-hosting/docker.mdx
@@ -9,28 +9,52 @@ import { Callout } from 'fumadocs-ui/components/callout'
 ## 快速开始
 
 ```bash
-# Clone and start
+# Clone the repository
 git clone https://github.com/simstudioai/sim.git && cd sim
+
+# Generate persistent secrets once (.env is ignored by Git)
+(
+  set -euC
+  if [ -e .env ]; then
+    echo 'Refusing to overwrite existing .env' >&2
+    exit 1
+  fi
+  umask 077
+  better_auth_secret=$(openssl rand -hex 32)
+  encryption_key=$(openssl rand -hex 32)
+  api_encryption_key=$(openssl rand -hex 32)
+  internal_api_secret=$(openssl rand -hex 32)
+  cat > .env << EOF
+BETTER_AUTH_SECRET=$better_auth_secret
+ENCRYPTION_KEY=$encryption_key
+API_ENCRYPTION_KEY=$api_encryption_key
+INTERNAL_API_SECRET=$internal_api_secret
+EOF
+)
+
+# Start Sim
 docker compose -f docker-compose.prod.yml up -d
 ```
 
 打开 [http://localhost:3000](http://localhost:3000)
 
+<Callout type="warning">
+  请将生成的 `.env` 单独备份到安全的密钥存储中，不要与数据库备份放在一起。重启现有安装时不要重新生成这些值。
+  更改加密密钥可能会导致已存储的密钥无法读取，而更改 `BETTER_AUTH_SECRET` 会使现有会话失效。
+</Callout>
+
 ## 生产环境设置
 
 ### 1. 配置环境
 
-```bash
-# Generate secrets
-cat > .env << EOF
-DATABASE_URL=postgresql://postgres:postgres@db:5432/simstudio
-BETTER_AUTH_SECRET=$(openssl rand -hex 32)
-ENCRYPTION_KEY=$(openssl rand -hex 32)
-INTERNAL_API_SECRET=$(openssl rand -hex 32)
+保留快速开始期间生成的密钥，并将公共 URL 添加到同一个 `.env` 文件中：
+
+```dotenv
 NEXT_PUBLIC_APP_URL=https://sim.yourdomain.com
 BETTER_AUTH_URL=https://sim.yourdomain.com
-EOF
 ```
+
+如果跳过了快速开始，请先运行其中的密钥生成步骤。切勿替换已经包含数据的安装所使用的加密密钥。
 
 ### 2. 启动服务
 
@@ -124,6 +148,8 @@ docker compose -f docker-compose.ollama.yml exec ollama ollama pull llama3.2
 ### 外部 Ollama
 
 如果 Ollama 在您的主机上运行（而不是在 Docker 中）：
+
+请先完成快速开始以创建持久化的 `.env`，然后使用相应的主机 URL：
 
 ```bash
 # macOS/Windows

--- a/apps/docs/content/docs/zh/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/zh/self-hosting/docker.mdx
@@ -131,6 +131,8 @@ sudo certbot --nginx -d sim.yourdomain.com
 
 ## Ollama
 
+请先完成快速开始，以生成包含密钥的持久 `.env` 文件——Ollama 的 Compose 文件需要相同的密钥，缺少时将无法启动。
+
 ```bash
 # With GPU
 docker compose -f docker-compose.ollama.yml --profile gpu --profile setup up -d

--- a/apps/sim/lib/core/config/docker-compose-secrets.test.ts
+++ b/apps/sim/lib/core/config/docker-compose-secrets.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { load } from 'js-yaml'
+import { describe, expect, it } from 'vitest'
+
+type ComposeService = {
+  environment?: string[]
+}
+
+type ComposeFile = {
+  services?: Record<string, ComposeService>
+}
+
+const composePath = new URL('../../../../../docker-compose.prod.yml', import.meta.url)
+const compose = load(readFileSync(composePath, 'utf8')) as ComposeFile
+
+function environmentValue(serviceName: string, variableName: string): string | undefined {
+  const prefix = `${variableName}=`
+  return compose.services?.[serviceName]?.environment
+    ?.find((entry) => entry.startsWith(prefix))
+    ?.slice(prefix.length)
+}
+
+describe('production Docker Compose secrets', () => {
+  it.each([
+    ['simstudio', 'BETTER_AUTH_SECRET'],
+    ['simstudio', 'ENCRYPTION_KEY'],
+    ['simstudio', 'INTERNAL_API_SECRET'],
+    ['realtime', 'BETTER_AUTH_SECRET'],
+    ['realtime', 'INTERNAL_API_SECRET'],
+  ])('requires %s to receive %s', (serviceName, variableName) => {
+    expect(environmentValue(serviceName, variableName)).toMatch(
+      new RegExp(`^\\$\\{${variableName}:\\?.+\\}$`)
+    )
+  })
+})

--- a/apps/sim/lib/core/config/docker-compose-secrets.test.ts
+++ b/apps/sim/lib/core/config/docker-compose-secrets.test.ts
@@ -10,26 +10,43 @@ type ComposeFile = {
   services?: Record<string, ComposeService>
 }
 
-const composePath = new URL('../../../../../docker-compose.prod.yml', import.meta.url)
-const compose = load(readFileSync(composePath, 'utf8')) as ComposeFile
+function loadCompose(fileName: string): ComposeFile {
+  const composePath = new URL(`../../../../../${fileName}`, import.meta.url)
+  return load(readFileSync(composePath, 'utf8')) as ComposeFile
+}
 
-function environmentValue(serviceName: string, variableName: string): string | undefined {
+function environmentValue(
+  compose: ComposeFile,
+  serviceName: string,
+  variableName: string
+): string | undefined {
   const prefix = `${variableName}=`
   return compose.services?.[serviceName]?.environment
     ?.find((entry) => entry.startsWith(prefix))
     ?.slice(prefix.length)
 }
 
-describe('production Docker Compose secrets', () => {
-  it.each([
-    ['simstudio', 'BETTER_AUTH_SECRET'],
-    ['simstudio', 'ENCRYPTION_KEY'],
-    ['simstudio', 'INTERNAL_API_SECRET'],
-    ['realtime', 'BETTER_AUTH_SECRET'],
-    ['realtime', 'INTERNAL_API_SECRET'],
-  ])('requires %s to receive %s', (serviceName, variableName) => {
-    expect(environmentValue(serviceName, variableName)).toMatch(
-      new RegExp(`^\\$\\{${variableName}:\\?.+\\}$`)
-    )
-  })
+const requiredSecrets: Array<[string, string, string]> = [
+  ['docker-compose.prod.yml', 'simstudio', 'BETTER_AUTH_SECRET'],
+  ['docker-compose.prod.yml', 'simstudio', 'ENCRYPTION_KEY'],
+  ['docker-compose.prod.yml', 'simstudio', 'INTERNAL_API_SECRET'],
+  ['docker-compose.prod.yml', 'realtime', 'BETTER_AUTH_SECRET'],
+  ['docker-compose.prod.yml', 'realtime', 'INTERNAL_API_SECRET'],
+  ['docker-compose.ollama.yml', 'simstudio', 'BETTER_AUTH_SECRET'],
+  ['docker-compose.ollama.yml', 'simstudio', 'ENCRYPTION_KEY'],
+  ['docker-compose.ollama.yml', 'simstudio', 'INTERNAL_API_SECRET'],
+  ['docker-compose.ollama.yml', 'realtime', 'BETTER_AUTH_SECRET'],
+  ['docker-compose.ollama.yml', 'realtime', 'INTERNAL_API_SECRET'],
+]
+
+describe('Docker Compose secrets', () => {
+  it.each(requiredSecrets)(
+    '%s requires %s to receive %s via mandatory interpolation',
+    (fileName, serviceName, variableName) => {
+      const compose = loadCompose(fileName)
+      expect(environmentValue(compose, serviceName, variableName)).toMatch(
+        new RegExp(`^\\$\\{${variableName}:\\?.+\\}$`)
+      )
+    }
+  )
 })

--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -16,8 +16,9 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-simstudio}
       - BETTER_AUTH_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-sim_auth_secret_$(openssl rand -hex 16)}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-$(openssl rand -hex 32)}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?Set BETTER_AUTH_SECRET in .env using openssl rand -hex 32}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env using openssl rand -hex 32}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?Set INTERNAL_API_SECRET in .env using openssl rand -hex 32}
       - COPILOT_API_KEY=${COPILOT_API_KEY}
       - SIM_AGENT_API_URL=${SIM_AGENT_API_URL}
       - OLLAMA_URL=http://ollama:11434
@@ -46,7 +47,8 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-simstudio}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:3000}
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-sim_auth_secret_$(openssl rand -hex 16)}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?Set BETTER_AUTH_SECRET in .env using openssl rand -hex 32}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?Set INTERNAL_API_SECRET in .env using openssl rand -hex 32}
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,10 +17,10 @@ services:
       # addition to NEXT_PUBLIC_APP_URL. Use when serving from multiple domains
       # (apex + www, alias hostnames, reverse-proxy IPs). Empty by default.
       - TRUSTED_ORIGINS=${TRUSTED_ORIGINS:-}
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?Set BETTER_AUTH_SECRET in .env using openssl rand -hex 32}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env using openssl rand -hex 32}
       - API_ENCRYPTION_KEY=${API_ENCRYPTION_KEY:-}
-      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?Set INTERNAL_API_SECRET in .env using openssl rand -hex 32}
       - REDIS_URL=${REDIS_URL:-}
       - COPILOT_API_KEY=${COPILOT_API_KEY}
       - SIM_AGENT_API_URL=${SIM_AGENT_API_URL}
@@ -60,8 +60,8 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-simstudio}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:3000}
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
-      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?Set BETTER_AUTH_SECRET in .env using openssl rand -hex 32}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?Set INTERNAL_API_SECRET in .env using openssl rand -hex 32}
       - REDIS_URL=${REDIS_URL:-}
     depends_on:
       db:


### PR DESCRIPTION
## Summary

Builds on #5801 (included as the first commit) and closes the remaining gap in that fix: the same first-user-signup failure still exists in `docker-compose.ollama.yml`, which many self-hosters use because it's the "try Sim with local models" path.

## Root cause (the part #5801 didn't cover)

`docker-compose.ollama.yml` fell back to broken secret defaults:

- `BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-sim_auth_secret_$(openssl rand -hex 16)}` and `ENCRYPTION_KEY=${ENCRYPTION_KEY:-$(openssl rand -hex 32)}` — **Docker Compose does not perform `$(...)` command substitution**, so these resolve to the *literal* strings, i.e. a fixed, shared, weak secret across every install. Worse, the `ENCRYPTION_KEY` literal (`$(openssl rand -hex 32)`, 22 chars) is under the 32-char minimum the app enforces (`z.string().min(32)`), so it fails env validation.
- `INTERNAL_API_SECRET` — required (`z.string().min(32)`) by **both** the app (`apps/sim/lib/core/config/env.ts`) and realtime (`apps/realtime/src/env.ts`) — was not passed at all, so the Ollama quick start couldn't sign up the first admin, exactly like the prod bug in #5625.

## Changes

- Mirror the prod hardening in `docker-compose.ollama.yml`: require `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, and `INTERNAL_API_SECRET` via mandatory `${VAR:?...}` interpolation, and add `INTERNAL_API_SECRET` to both `simstudio` and `realtime`.
- Extend the regression test to assert the mandatory-secret interpolation for **both** `docker-compose.prod.yml` and `docker-compose.ollama.yml`.
- Note the `.env` prerequisite in the Ollama section of the docs (en/de/es/fr/ja/zh) and CONTRIBUTING.

## Validation

- `vitest run lib/core/config/docker-compose-secrets.test.ts` — 10 passed (5 prod + 5 ollama; the test parses the real Compose files).
- `biome check` on the test file — passed.
- Both Compose files parse as valid YAML (loaded by the test via `js-yaml`).

## Credit

First commit is @brainx's original #5801. This PR supersedes it — merging this lands both fixes together.

Fixes #5625
