### PR TITLE
feat(providers): add Gemini 3.6 Flash and 3.5 Flash-Lite

### DIFF
--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -1444,6 +1444,46 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     color: '#4285F4',
     models: [
       {
+        id: 'gemini-3.6-flash',
+        pricing: {
+          input: 1.5,
+          cachedInput: 0.15,
+          output: 7.5,
+          updatedAt: '2026-07-21',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['minimal', 'low', 'medium', 'high'],
+            default: 'medium',
+          },
+          maxOutputTokens: 65536,
+        },
+        contextWindow: 1048576,
+        releaseDate: '2026-07-21',
+        recommended: true,
+      },
+      {
+        id: 'gemini-3.5-flash-lite',
+        pricing: {
+          input: 0.3,
+          cachedInput: 0.03,
+          output: 2.5,
+          updatedAt: '2026-07-21',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 2 },
+          thinking: {
+            levels: ['minimal', 'low', 'medium', 'high'],
+            default: 'minimal',
+          },
+          maxOutputTokens: 65536,
+        },
+        contextWindow: 1048576,
+        releaseDate: '2026-07-21',
+        speedOptimized: true,
+      },
+      {
         id: 'gemini-3.5-flash',
         pricing: {
           input: 1.5,
@@ -1461,7 +1501,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1048576,
         releaseDate: '2026-05-19',
-        recommended: true,
       },
       {
         id: 'gemini-3.1-pro-preview',


### PR DESCRIPTION
## Summary
- Add `gemini-3.6-flash` to the Google provider registry (input \$1.50/M, cached \$0.15/M, output \$7.50/M) and set it as the recommended Google flash model
- Add `gemini-3.5-flash-lite` (input \$0.30/M, cached \$0.03/M, output \$2.50/M), marked speed-optimized
- Move `recommended` from `gemini-3.5-flash` to `gemini-3.6-flash` (direct successor: better performance, 17% fewer output tokens)
- Pricing verified against Google's live API pricing docs; context window (1,048,576) and max output (65,536) match the rest of the Gemini 3.x flash family
- Excluded Gemini 3.5 Flash Cyber — limited-access via CodeMender, not a general API model

## Type of Change
- [x] New feature

## Testing
Tested manually — `bun run lint` passes; both models fall under the `google` provider so they're automatically hosted + billed.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)