### PR TITLE
fix(mcp): don't blank the MCP tools page when tool discovery fails

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
@@ -71,6 +71,7 @@ interface ServerListItemProps {
   isConnecting: boolean
   isLoadingTools?: boolean
   isRefreshing?: boolean
+  discoveryError?: string | null
   onRemove: () => void
   onViewDetails: () => void
   onAuthorize: () => void
@@ -84,6 +85,7 @@ function ServerListItem({
   isConnecting,
   isLoadingTools = false,
   isRefreshing = false,
+  discoveryError = null,
   onRemove,
   onViewDetails,
   onAuthorize,
@@ -95,8 +97,17 @@ function ServerListItem({
     server.lastError,
     server.authType
   )
+  // A live discovery failure whose stored status hasn't caught up yet would otherwise read as
+  // "0 tools"; surface it directly so a failed row reads as failed, not empty.
+  const showDiscoveryError =
+    Boolean(discoveryError) &&
+    tools.length === 0 &&
+    server.connectionStatus !== 'error' &&
+    server.connectionStatus !== 'disconnected'
   const hasConnectionIssue =
-    server.connectionStatus === 'error' || server.connectionStatus === 'disconnected'
+    server.connectionStatus === 'error' ||
+    server.connectionStatus === 'disconnected' ||
+    showDiscoveryError
 
   return (
     <div className='flex items-center justify-between gap-3'>
@@ -117,7 +128,9 @@ function ServerListItem({
             ? 'Refreshing...'
             : isLoadingTools && tools.length === 0
               ? 'Loading...'
-              : toolsLabel}
+              : showDiscoveryError
+                ? discoveryError
+                : toolsLabel}
         </p>
       </div>
       <div className='flex flex-shrink-0 items-center gap-1'>
@@ -390,6 +403,11 @@ export function MCP() {
   // (`toolsError`) must not blank the page — the servers still render, each row surfacing its
   // own discovery state via `toolsStateByServer`, with a non-blocking notice above the list.
   const listError = serversError
+  // Any per-server discovery failure — even a partial one where other servers succeeded (which
+  // suppresses the aggregate `toolsError`) — so the notice below still surfaces it.
+  const hasDiscoveryError =
+    Boolean(toolsError) ||
+    Array.from(toolsStateByServer.values()).some((state) => state.error != null)
   const hasServers = servers && servers.length > 0
   const showNoResults = searchTerm.trim() && filteredServers.length === 0 && servers.length > 0
 
@@ -661,7 +679,7 @@ export function MCP() {
           </SettingsEmptyState>
         ) : (
           <div className='flex flex-col gap-2'>
-            {toolsError && (
+            {hasDiscoveryError && (
               <p className='text-[var(--text-error)] text-xs leading-tight'>
                 {getErrorMessage(toolsError, 'Some tools could not be discovered')}
               </p>
@@ -686,6 +704,9 @@ export function MCP() {
                   isRefreshing={
                     refreshServerMutation.isPending &&
                     refreshServerMutation.variables?.serverId === server.id
+                  }
+                  discoveryError={
+                    serverToolsState?.error ? getErrorMessage(serverToolsState.error) : null
                   }
                   onRemove={() => handleRemoveServer(server.id)}
                   onViewDetails={() => handleViewDetails(server.id)}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
@@ -386,7 +386,10 @@ export function MCP() {
     return issues
   }
 
-  const error = toolsError || serversError
+  // Only a failure to load the server LIST replaces the list. A tool-discovery failure
+  // (`toolsError`) must not blank the page — the servers still render, each row surfacing its
+  // own discovery state via `toolsStateByServer`, with a non-blocking notice above the list.
+  const listError = serversError
   const hasServers = servers && servers.length > 0
   const showNoResults = searchTerm.trim() && filteredServers.length === 0 && servers.length > 0
 
@@ -646,10 +649,10 @@ export function MCP() {
             : []
         }
       >
-        {error ? (
+        {listError ? (
           <div className='flex h-full flex-col items-center justify-center gap-2'>
             <p className='text-[var(--text-error)] text-xs leading-tight'>
-              {getErrorMessage(error, 'Failed to load MCP servers')}
+              {getErrorMessage(listError, 'Failed to load MCP servers')}
             </p>
           </div>
         ) : serversLoading ? null : !hasServers ? (
@@ -658,6 +661,11 @@ export function MCP() {
           </SettingsEmptyState>
         ) : (
           <div className='flex flex-col gap-2'>
+            {toolsError && (
+              <p className='text-[var(--text-error)] text-xs leading-tight'>
+                {getErrorMessage(toolsError, 'Some tools could not be discovered')}
+              </p>
+            )}
             {filteredServers.map((server) => {
               if (!server?.id) return null
               const tools = toolsByServer[server.id] || []


### PR DESCRIPTION
## Summary
- A **tool-discovery** failure (one slow/failing server — e.g. a stalled streamable-HTTP transport timing out) replaced the **entire** MCP tools server list with a centered error banner, hiding every server including healthy/authorizable ones.
- Root cause: `const error = toolsError || serversError` gated the whole list, conflating a *tool-discovery* failure with a *server-list-load* failure. Either one blanked the page.
- Fix: gate the full-list replacement on **`serversError` only** (the list genuinely failing to load). When the servers loaded, always render the list — each row already surfaces its own discovery state via `toolsStateByServer` (per-row status), with a small **non-blocking notice** above the list when discovery had issues.
- This restores the per-server isolation intent: one bad server can't hide the others, and you can still act on the list (reconnect an OAuth server, retry, etc.).

## Type of Change
- [x] Bug fix (UX resilience)

## Testing
- Type-checks + biome clean.
- Audited the full discovery lifecycle (hook `useMcpToolsQuery` per-server `useQueries` isolation, the discover route, the service single/all-server paths, and every render state): page never blanks on a tool-discovery failure in any of loading / no-servers / servers+toolsError / serversError / detail-view; per-server isolation intact; no other code hides the list; no unused vars or regressions.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)