### PR TITLE
fix(mcp): keep the pooled connection warm on a request timeout

### DIFF
--- a/apps/sim/lib/mcp/service-pool.test.ts
+++ b/apps/sim/lib/mcp/service-pool.test.ts
@@ -171,6 +171,19 @@ describe('McpService connection reuse wiring', () => {
     expect(mockRelease).toHaveBeenCalledWith(false)
   })
 
+  it('keeps the pooled connection warm on a request timeout (does not retire the session)', async () => {
+    // A streamable-HTTP request timeout aborts only that request's stream; the session stays
+    // healthy for the next request, so a timeout must NOT poison the lease (matches every
+    // production MCP client and avoids a connect/stall/reconnect churn loop).
+    mockCallTool.mockRejectedValue(new Error('Request timed out'))
+
+    await expect(
+      mcpService.executeTool(USER_ID, 'server-1', { name: 'do', arguments: {} }, WORKSPACE_ID)
+    ).rejects.toThrow()
+
+    expect(mockRelease).not.toHaveBeenCalledWith(true)
+  })
+
   it('poisons the lease on an auth failure so a rotated credential is re-resolved', async () => {
     mockCallTool.mockRejectedValue(new UnauthorizedError('token rejected'))
 

--- a/apps/sim/lib/mcp/service.ts
+++ b/apps/sim/lib/mcp/service.ts
@@ -99,9 +99,16 @@ function isTimeoutError(error: unknown): boolean {
 /**
  * A pooled connection is dead and must be retired so the caller's retry rebuilds
  * fresh: a stale session (400/404), an auth failure (401 — a rotated/revoked
- * credential; the rebuild re-resolves it), a closed transport, a timeout (no
- * response — possibly wedged), or a reset socket. Benign tool/consent errors and
- * healthy upstream responses (429/5xx) keep the connection warm.
+ * credential; the rebuild re-resolves it), a closed transport, or a reset socket.
+ *
+ * A request timeout is deliberately NOT dead: streamable-HTTP aborts only that
+ * request's own POST stream, leaving the session healthy for the next request, so
+ * every production MCP client (SDK, OpenCode, LibreChat) rejects the request and
+ * keeps the connection rather than tearing it down. Retiring on a timeout instead
+ * forced a full reconnect on the next discovery — and a fresh connect can stall on
+ * our end far longer than a warm request — turning one slow response into a
+ * connect/stall/reconnect churn loop. Benign tool/consent errors and healthy
+ * upstream responses (429/5xx) also keep the connection warm.
  */
 function isDeadConnectionError(error: unknown): boolean {
   if (error instanceof UnauthorizedError) {
@@ -111,9 +118,6 @@ function isDeadConnectionError(error: unknown): boolean {
     return error.code === 404 || error.code === 400 || error.code === 401
   }
   if (error instanceof McpError && error.code === ErrorCode.ConnectionClosed) {
-    return true
-  }
-  if (isTimeoutError(error)) {
     return true
   }
   const message = getErrorMessage(error, '').toLowerCase()


### PR DESCRIPTION
## Summary
Empirically diagnosed (2h of staging logs + an A/B test), not guessed:

- **The server is fast.** A normal client (curl, HTTP/1.1 *and* HTTP/2, no IP pin) does MCP `initialize` to these servers in **~120 ms every time, first attempt included**.
- **Our client's first connect consistently hangs to our 30s timeout, then the retry connects in ~100 ms** — 6/6 in the logs. So it's a client-side first-connect stall, not server flakiness.
- The killer: `isDeadConnectionError` treated a **request timeout** as a *dead connection*, so one `tools/list` timeout **retired the whole pooled connection** → the next discovery reconnected and paid the first-connect stall again → a **connect/stall/reconnect churn loop**. This is what produced the intermittent "Failed to discover MCP tools" and disconnected states.

## Fix
Stop poisoning the lease on a request timeout. A streamable-HTTP request timeout aborts only that request's own POST stream; the session stays healthy for the next request. Only a real transport close / 404 (session gone) / socket reset retires the connection now.

This matches **every** production MCP client reviewed (MCP TypeScript SDK, OpenCode, LibreChat) — none retire a connection on a request timeout.

## Type of Change
- [x] Bug fix (resilience; removes connection churn)

## Testing
- New unit test: a request timeout keeps the pooled connection warm (never poisons the lease). Existing poison tests (404 / auth / reset → still retire) unchanged and green (7/7).
- Type-check + biome clean.

## Follow-ups (not in this PR)
- Reduce `tools/list` polling cadence (reference clients discover once + refresh on `list_changed`, not a 30s poll).
- Investigate the single-IP pin as the first-connect-stall cause (best practice: no client pins IPs) — strong circumstantial evidence but not yet directly reproduced; it touches an SSRF control, so it needs its own proof + careful change.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)