### PR TITLE
feat(access-control): per-group chat-deploy auth modes + polish

### DIFF
--- a/apps/sim/app/api/chat/manage/[id]/route.test.ts
+++ b/apps/sim/app/api/chat/manage/[id]/route.test.ts
@@ -20,8 +20,9 @@ import {
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockCheckChatAccess } = vi.hoisted(() => ({
+const { mockCheckChatAccess, mockValidateChatDeployAuth } = vi.hoisted(() => ({
   mockCheckChatAccess: vi.fn(),
+  mockValidateChatDeployAuth: vi.fn(),
 }))
 
 const mockCreateSuccessResponse = workflowsApiUtilsMockFns.mockCreateSuccessResponse
@@ -50,10 +51,20 @@ vi.mock('@/lib/core/utils/urls', () => ({
 vi.mock('@/app/api/chat/utils', () => ({
   checkChatAccess: mockCheckChatAccess,
 }))
+vi.mock('@/ee/access-control/utils/permission-check', () => {
+  class ChatDeployAuthNotAllowedError extends Error {
+    constructor() {
+      super('This chat authentication mode is not allowed based on your permission group settings')
+      this.name = 'ChatDeployAuthNotAllowedError'
+    }
+  }
+  return { validateChatDeployAuth: mockValidateChatDeployAuth, ChatDeployAuthNotAllowedError }
+})
 vi.mock('@/lib/workflows/persistence/utils', () => workflowsPersistenceUtilsMock)
 vi.mock('@/lib/workflows/orchestration', () => workflowsOrchestrationMock)
 
 import { DELETE, GET, PATCH } from '@/app/api/chat/manage/[id]/route'
+import { ChatDeployAuthNotAllowedError } from '@/ee/access-control/utils/permission-check'
 
 describe('Chat Edit API Route', () => {
   beforeEach(() => {
@@ -211,6 +222,34 @@ describe('Chat Edit API Route', () => {
       expect(data.id).toBe('chat-123')
       expect(data.chatUrl).toBe('http://localhost:3000/chat/test-chat')
       expect(data.message).toBe('Chat deployment updated successfully')
+    })
+
+    it('returns 403 when the updated auth type is blocked by the permission group', async () => {
+      authMockFns.mockGetSession.mockResolvedValue({
+        user: { id: 'user-id' },
+      })
+
+      mockCheckChatAccess.mockResolvedValue({
+        hasAccess: true,
+        chat: {
+          id: 'chat-123',
+          identifier: 'test-chat',
+          authType: 'public',
+          workflowId: 'workflow-123',
+        },
+        workspaceId: 'workspace-123',
+      })
+      mockValidateChatDeployAuth.mockRejectedValueOnce(new ChatDeployAuthNotAllowedError())
+
+      const req = new NextRequest('http://localhost:3000/api/chat/manage/chat-123', {
+        method: 'PATCH',
+        body: JSON.stringify({ authType: 'public' }),
+      })
+      const response = await PATCH(req, { params: Promise.resolve({ id: 'chat-123' }) })
+
+      expect(response.status).toBe(403)
+      expect(mockValidateChatDeployAuth).toHaveBeenCalledWith('user-id', 'workspace-123', 'public')
+      expect(dbChainMockFns.update).not.toHaveBeenCalled()
     })
 
     it('rejects the update without admitting a new deploy while an attempt is in flight', async () => {

--- a/apps/sim/app/api/chat/manage/[id]/route.test.ts
+++ b/apps/sim/app/api/chat/manage/[id]/route.test.ts
@@ -224,7 +224,7 @@ describe('Chat Edit API Route', () => {
       expect(data.message).toBe('Chat deployment updated successfully')
     })
 
-    it('returns 403 when the updated auth type is blocked by the permission group', async () => {
+    it('returns 403 when the updated auth type changes to a blocked mode', async () => {
       authMockFns.mockGetSession.mockResolvedValue({
         user: { id: 'user-id' },
       })
@@ -234,7 +234,7 @@ describe('Chat Edit API Route', () => {
         chat: {
           id: 'chat-123',
           identifier: 'test-chat',
-          authType: 'public',
+          authType: 'password',
           workflowId: 'workflow-123',
         },
         workspaceId: 'workspace-123',
@@ -250,6 +250,32 @@ describe('Chat Edit API Route', () => {
       expect(response.status).toBe(403)
       expect(mockValidateChatDeployAuth).toHaveBeenCalledWith('user-id', 'workspace-123', 'public')
       expect(dbChainMockFns.update).not.toHaveBeenCalled()
+    })
+
+    it('does not re-check the auth mode when it is unchanged (grandfathered)', async () => {
+      authMockFns.mockGetSession.mockResolvedValue({
+        user: { id: 'user-id' },
+      })
+
+      mockCheckChatAccess.mockResolvedValue({
+        hasAccess: true,
+        chat: {
+          id: 'chat-123',
+          identifier: 'test-chat',
+          authType: 'public',
+          workflowId: 'workflow-123',
+        },
+        workspaceId: 'workspace-123',
+      })
+
+      const req = new NextRequest('http://localhost:3000/api/chat/manage/chat-123', {
+        method: 'PATCH',
+        body: JSON.stringify({ authType: 'public', title: 'Renamed' }),
+      })
+      const response = await PATCH(req, { params: Promise.resolve({ id: 'chat-123' }) })
+
+      expect(response.status).toBe(200)
+      expect(mockValidateChatDeployAuth).not.toHaveBeenCalled()
     })
 
     it('rejects the update without admitting a new deploy while an attempt is in flight', async () => {

--- a/apps/sim/app/api/chat/manage/[id]/route.ts
+++ b/apps/sim/app/api/chat/manage/[id]/route.ts
@@ -23,6 +23,10 @@ import {
   createErrorResponse,
   createSuccessResponse,
 } from '@/app/api/workflows/utils'
+import {
+  ChatDeployAuthNotAllowedError,
+  validateChatDeployAuth,
+} from '@/ee/access-control/utils/permission-check'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 120
@@ -117,6 +121,17 @@ export const PATCH = withRouteHandler(
 
       if (workflowId && workflowId !== existingChat[0].workflowId) {
         return createErrorResponse('Changing the workflow of a chat deployment is not allowed', 400)
+      }
+
+      if (authType && chatWorkspaceId) {
+        try {
+          await validateChatDeployAuth(session.user.id, chatWorkspaceId, authType)
+        } catch (error) {
+          if (error instanceof ChatDeployAuthNotAllowedError) {
+            return createErrorResponse(error.message, 403)
+          }
+          throw error
+        }
       }
 
       if (identifier && identifier !== existingChat[0].identifier) {

--- a/apps/sim/app/api/chat/manage/[id]/route.ts
+++ b/apps/sim/app/api/chat/manage/[id]/route.ts
@@ -123,7 +123,10 @@ export const PATCH = withRouteHandler(
         return createErrorResponse('Changing the workflow of a chat deployment is not allowed', 400)
       }
 
-      if (authType && chatWorkspaceId) {
+      // Enforce the permission group's chat auth-mode allow-list only when the
+      // mode actually changes, so a grandfathered mode already saved on this chat
+      // can still be re-saved (e.g. a title-only edit) without a 403.
+      if (authType && authType !== existingChatRecord.authType && chatWorkspaceId) {
         try {
           await validateChatDeployAuth(session.user.id, chatWorkspaceId, authType)
         } catch (error) {

--- a/apps/sim/app/api/chat/route.test.ts
+++ b/apps/sim/app/api/chat/route.test.ts
@@ -16,8 +16,9 @@ import {
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockCheckWorkflowAccessForChatCreation } = vi.hoisted(() => ({
+const { mockCheckWorkflowAccessForChatCreation, mockValidateChatDeployAuth } = vi.hoisted(() => ({
   mockCheckWorkflowAccessForChatCreation: vi.fn(),
+  mockValidateChatDeployAuth: vi.fn(),
 }))
 
 const mockCreateSuccessResponse = workflowsApiUtilsMockFns.mockCreateSuccessResponse
@@ -32,6 +33,16 @@ vi.mock('@/app/api/chat/utils', () => ({
   checkWorkflowAccessForChatCreation: mockCheckWorkflowAccessForChatCreation,
 }))
 
+vi.mock('@/ee/access-control/utils/permission-check', () => {
+  class ChatDeployAuthNotAllowedError extends Error {
+    constructor() {
+      super('This chat authentication mode is not allowed based on your permission group settings')
+      this.name = 'ChatDeployAuthNotAllowedError'
+    }
+  }
+  return { validateChatDeployAuth: mockValidateChatDeployAuth, ChatDeployAuthNotAllowedError }
+})
+
 vi.mock('@/lib/workflows/orchestration', () => workflowsOrchestrationMock)
 
 vi.mock('@/lib/core/config/env', () =>
@@ -42,6 +53,7 @@ vi.mock('@/lib/core/config/env', () =>
 )
 
 import { GET, POST } from '@/app/api/chat/route'
+import { ChatDeployAuthNotAllowedError } from '@/ee/access-control/utils/permission-check'
 
 describe('Chat API Route', () => {
   beforeEach(() => {
@@ -235,6 +247,40 @@ describe('Chat API Route', () => {
           identifier: 'test-chat',
         })
       )
+    })
+
+    it('returns 403 when the chat auth type is blocked by the permission group', async () => {
+      authMockFns.mockGetSession.mockResolvedValue({
+        user: { id: 'user-id', email: 'user@example.com' },
+      })
+
+      const validData = {
+        workflowId: 'workflow-123',
+        identifier: 'test-chat',
+        title: 'Test Chat',
+        authType: 'public',
+        customizations: {
+          primaryColor: '#000000',
+          welcomeMessage: 'Hello',
+        },
+      }
+
+      dbChainMockFns.limit.mockResolvedValueOnce([])
+      mockCheckWorkflowAccessForChatCreation.mockResolvedValue({
+        hasAccess: true,
+        workflow: { userId: 'user-id', workspaceId: 'workspace-1', isDeployed: true },
+      })
+      mockValidateChatDeployAuth.mockRejectedValueOnce(new ChatDeployAuthNotAllowedError())
+
+      const req = new NextRequest('http://localhost:3000/api/chat', {
+        method: 'POST',
+        body: JSON.stringify(validData),
+      })
+      const response = await POST(req)
+
+      expect(response.status).toBe(403)
+      expect(mockValidateChatDeployAuth).toHaveBeenCalledWith('user-id', 'workspace-1', 'public')
+      expect(mockPerformChatDeploy).not.toHaveBeenCalled()
     })
 
     it('passes chat customizations and outputConfigs through in the API request shape', async () => {

--- a/apps/sim/app/api/chat/route.ts
+++ b/apps/sim/app/api/chat/route.ts
@@ -11,6 +11,10 @@ import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { performChatDeploy } from '@/lib/workflows/orchestration'
 import { checkWorkflowAccessForChatCreation } from '@/app/api/chat/utils'
 import { createErrorResponse, createSuccessResponse } from '@/app/api/workflows/utils'
+import {
+  ChatDeployAuthNotAllowedError,
+  validateChatDeployAuth,
+} from '@/ee/access-control/utils/permission-check'
 
 const logger = createLogger('ChatAPI')
 
@@ -99,6 +103,17 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
 
     if (!hasAccess || !workflowRecord) {
       return createErrorResponse('Workflow not found or access denied', 404)
+    }
+
+    if (workflowRecord.workspaceId) {
+      try {
+        await validateChatDeployAuth(session.user.id, workflowRecord.workspaceId, authType)
+      } catch (error) {
+        if (error instanceof ChatDeployAuthNotAllowedError) {
+          return createErrorResponse(error.message, 403)
+        }
+        throw error
+      }
     }
 
     const result = await performChatDeploy({

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
@@ -677,27 +677,20 @@ function AuthSelector({
   }
 
   const { config: permissionConfig } = usePermissionConfig()
+  const allowedAuthTypes = permissionConfig.allowedChatDeployAuthTypes
 
-  // SSO shows when the env flag is on, or when this chat is already saved as SSO,
-  // so an existing SSO mode is never dropped (and silently downgraded by the snap
-  // effect below) when the flag is off.
-  const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED')) || savedAuthType === 'sso'
-  const baseAuthOptions: AuthType[] = ssoEnabled
+  const ssoAvailable =
+    isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED')) ||
+    savedAuthType === 'sso' ||
+    (allowedAuthTypes?.includes('sso') ?? false)
+  const baseAuthOptions: AuthType[] = ssoAvailable
     ? ['public', 'password', 'email', 'sso']
     : ['public', 'password', 'email']
 
-  // Org access-control may restrict which auth modes are allowed (`null` = all).
-  // The route is the source of truth; this just hides disallowed options. Only a
-  // chat's already-saved mode is grandfathered (kept visible) — not the unsaved
-  // `public` default of a brand-new chat.
-  const allowedAuthTypes = permissionConfig.allowedChatDeployAuthTypes
   const authOptions = baseAuthOptions.filter(
     (type) => allowedAuthTypes === null || allowedAuthTypes.includes(type) || type === savedAuthType
   )
 
-  // If the current selection isn't offered (e.g. a new chat defaulting to a
-  // now-disallowed `public`), snap to the first allowed mode so the form can't
-  // submit a value the server will reject.
   useEffect(() => {
     if (authOptions.length > 0 && !authOptions.includes(authType)) {
       onAuthTypeChange(authOptions[0])

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
@@ -33,6 +33,7 @@ import {
   useUpdateChat,
 } from '@/hooks/queries/chats'
 import type { ChatDetail } from '@/hooks/queries/deployments'
+import { usePermissionConfig } from '@/hooks/use-permission-config'
 import { useIdentifierValidation } from './hooks'
 import {
   getPasswordHelperText,
@@ -671,10 +672,20 @@ function AuthSelector({
     }
   }
 
+  const { config: permissionConfig } = usePermissionConfig()
+
   const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED'))
-  const authOptions = ssoEnabled
-    ? (['public', 'password', 'email', 'sso'] as const)
-    : (['public', 'password', 'email'] as const)
+  const baseAuthOptions: AuthType[] = ssoEnabled
+    ? ['public', 'password', 'email', 'sso']
+    : ['public', 'password', 'email']
+
+  // Org access-control may restrict which auth modes are allowed (`null` = all).
+  // The route is the source of truth; this just hides disallowed options, keeping
+  // the current selection visible so the saved state always shows.
+  const allowedAuthTypes = permissionConfig.allowedChatDeployAuthTypes
+  const authOptions = baseAuthOptions.filter(
+    (type) => allowedAuthTypes === null || allowedAuthTypes.includes(type) || type === authType
+  )
 
   return (
     <div className='space-y-4'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
@@ -372,6 +372,7 @@ export function ChatDeploy({
           <AuthSelector
             key={`${existingChat?.id ?? 'new'}-${formInitCounter}`}
             authType={formData.authType}
+            savedAuthType={existingChat?.authType as AuthType | undefined}
             password={formData.password}
             emails={formData.emails}
             onAuthTypeChange={(type) => updateField('authType', type)}
@@ -584,6 +585,8 @@ function IdentifierInput({
 
 interface AuthSelectorProps {
   authType: AuthType
+  /** The persisted mode of an existing chat, kept selectable even if newly disallowed. */
+  savedAuthType?: AuthType
   password: string
   emails: string[]
   onAuthTypeChange: (type: AuthType) => void
@@ -603,6 +606,7 @@ const AUTH_LABELS: Record<AuthType, string> = {
 
 function AuthSelector({
   authType,
+  savedAuthType,
   password,
   emails,
   onAuthTypeChange,
@@ -680,12 +684,22 @@ function AuthSelector({
     : ['public', 'password', 'email']
 
   // Org access-control may restrict which auth modes are allowed (`null` = all).
-  // The route is the source of truth; this just hides disallowed options, keeping
-  // the current selection visible so the saved state always shows.
+  // The route is the source of truth; this just hides disallowed options. Only a
+  // chat's already-saved mode is grandfathered (kept visible) — not the unsaved
+  // `public` default of a brand-new chat.
   const allowedAuthTypes = permissionConfig.allowedChatDeployAuthTypes
   const authOptions = baseAuthOptions.filter(
-    (type) => allowedAuthTypes === null || allowedAuthTypes.includes(type) || type === authType
+    (type) => allowedAuthTypes === null || allowedAuthTypes.includes(type) || type === savedAuthType
   )
+
+  // If the current selection isn't offered (e.g. a new chat defaulting to a
+  // now-disallowed `public`), snap to the first allowed mode so the form can't
+  // submit a value the server will reject.
+  useEffect(() => {
+    if (authOptions.length > 0 && !authOptions.includes(authType)) {
+      onAuthTypeChange(authOptions[0])
+    }
+  }, [authOptions, authType, onAuthTypeChange])
 
   return (
     <div className='space-y-4'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
@@ -678,7 +678,10 @@ function AuthSelector({
 
   const { config: permissionConfig } = usePermissionConfig()
 
-  const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED'))
+  // SSO shows when the env flag is on, or when this chat is already saved as SSO,
+  // so an existing SSO mode is never dropped (and silently downgraded by the snap
+  // effect below) when the flag is off.
+  const ssoEnabled = isTruthy(getEnv('NEXT_PUBLIC_SSO_ENABLED')) || savedAuthType === 'sso'
   const baseAuthOptions: AuthType[] = ssoEnabled
     ? ['public', 'password', 'email', 'sso']
     : ['public', 'password', 'email']

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -79,6 +79,17 @@ const FILE_SHARE_AUTH_TYPE_OPTIONS: { value: ShareAuthType; label: string }[] = 
 ]
 const ALL_FILE_SHARE_AUTH_TYPES: ShareAuthType[] = FILE_SHARE_AUTH_TYPE_OPTIONS.map((o) => o.value)
 
+/** Chat-deployment auth modes an admin can allow/disallow. `null` config = all allowed. */
+const CHAT_DEPLOY_AUTH_TYPE_OPTIONS: { value: ShareAuthType; label: string }[] = [
+  { value: 'public', label: 'Public' },
+  { value: 'password', label: 'Password' },
+  { value: 'email', label: 'Email' },
+  { value: 'sso', label: 'SSO' },
+]
+const ALL_CHAT_DEPLOY_AUTH_TYPES: ShareAuthType[] = CHAT_DEPLOY_AUTH_TYPE_OPTIONS.map(
+  (o) => o.value
+)
+
 interface OrganizationMemberOption {
   userId: string
   user: {
@@ -503,7 +514,7 @@ function BlockToolRow({
           className='relative flex size-[16px] flex-shrink-0 items-center justify-center overflow-hidden rounded-sm'
           style={{ background: block.bgColor }}
         >
-          {BlockIcon && <BlockIcon className='!h-[10px] !w-[10px] text-white' />}
+          {BlockIcon && <BlockIcon className='!size-[9px] text-white' />}
         </div>
         <button
           type='button'
@@ -736,13 +747,6 @@ export function GroupDetail({
         category: 'Deploy Tabs',
         configKey: 'hideDeployChatbot' as const,
         hint: 'Hide the chatbot deployment option.',
-      },
-      {
-        id: 'hide-deploy-template',
-        label: 'Template',
-        category: 'Deploy Tabs',
-        configKey: 'hideDeployTemplate' as const,
-        hint: 'Hide the template publishing option.',
       },
       {
         id: 'disable-mcp',
@@ -1111,6 +1115,19 @@ export function GroupDetail({
       ...prev,
       allowedFileShareAuthTypes:
         values.length === ALL_FILE_SHARE_AUTH_TYPES.length ? null : (values as ShareAuthType[]),
+    }))
+  }, [])
+
+  const chatDeployAuthValue = useMemo(
+    () => editingConfig.allowedChatDeployAuthTypes ?? ALL_CHAT_DEPLOY_AUTH_TYPES,
+    [editingConfig.allowedChatDeployAuthTypes]
+  )
+
+  const setChatDeployAuthTypes = useCallback((values: string[]) => {
+    setEditingConfig((prev) => ({
+      ...prev,
+      allowedChatDeployAuthTypes:
+        values.length === ALL_CHAT_DEPLOY_AUTH_TYPES.length ? null : (values as ShareAuthType[]),
     }))
   }, [])
 
@@ -1495,10 +1512,10 @@ export function GroupDetail({
                           onCheckedChange={() => toggleIntegration(block.type)}
                         />
                         <div
-                          className='relative flex h-[16px] w-[16px] flex-shrink-0 items-center justify-center overflow-hidden rounded-sm'
+                          className='relative flex size-[16px] flex-shrink-0 items-center justify-center overflow-hidden rounded-sm'
                           style={{ background: block.bgColor }}
                         >
-                          {BlockIcon && <BlockIcon className='!h-[10px] !w-[10px] text-white' />}
+                          {BlockIcon && <BlockIcon className='!size-[9px] text-white' />}
                         </div>
                         <span className='truncate font-medium text-sm'>{block.name}</span>
                       </label>
@@ -1594,6 +1611,29 @@ export function GroupDetail({
                 </div>
               </SettingsSection>
             ))}
+            <SettingsSection label='Chat'>
+              <div
+                className={cn(
+                  'flex flex-col gap-1.5 px-2 pt-1',
+                  editingConfig.hideDeployChatbot && 'opacity-50'
+                )}
+              >
+                <span className='text-[var(--text-secondary)] text-xs'>
+                  Auth modes chat deployments may use
+                </span>
+                <ChipDropdown
+                  multiple
+                  showAllOption={false}
+                  allLabel='None'
+                  value={chatDeployAuthValue}
+                  onChange={setChatDeployAuthTypes}
+                  options={CHAT_DEPLOY_AUTH_TYPE_OPTIONS}
+                  disabled={editingConfig.hideDeployChatbot}
+                  matchTriggerWidth={false}
+                  className='w-[200px]'
+                />
+              </div>
+            </SettingsSection>
             <SettingsSection label='Files'>
               <div className='flex flex-col gap-1.5'>
                 <label

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -1111,6 +1111,10 @@ export function GroupDetail({
   )
 
   const setFileShareAuthTypes = useCallback((values: string[]) => {
+    // At least one mode must stay allowed while public sharing is enabled — an
+    // empty allow-list would silently block every share. To turn public sharing
+    // off entirely, uncheck Public Sharing instead.
+    if (values.length === 0) return
     setEditingConfig((prev) => ({
       ...prev,
       allowedFileShareAuthTypes:
@@ -1124,6 +1128,10 @@ export function GroupDetail({
   )
 
   const setChatDeployAuthTypes = useCallback((values: string[]) => {
+    // At least one mode must stay allowed while chat deploy is enabled — an empty
+    // allow-list would silently block every chat deployment. To turn chat deploy
+    // off entirely, use the Hide Chat toggle instead.
+    if (values.length === 0) return
     setEditingConfig((prev) => ({
       ...prev,
       allowedChatDeployAuthTypes:

--- a/apps/sim/ee/access-control/utils/permission-check.test.ts
+++ b/apps/sim/ee/access-control/utils/permission-check.test.ts
@@ -37,7 +37,7 @@ const {
     hideDeployApi: false,
     hideDeployMcp: false,
     hideDeployChatbot: false,
-    hideDeployTemplate: false,
+    allowedChatDeployAuthTypes: null,
   },
   mockGetAllowedIntegrationsFromEnv: vi.fn<() => string[] | null>(),
   mockIsOrganizationOnEnterprisePlan: vi.fn<() => Promise<boolean>>(),
@@ -134,6 +134,7 @@ vi.mock('@/blocks/registry', () => ({
 
 import {
   assertPermissionsAllowed,
+  ChatDeployAuthNotAllowedError,
   CustomToolsNotAllowedError,
   getUserPermissionConfig,
   IntegrationNotAllowedError,
@@ -144,6 +145,7 @@ import {
   SkillsNotAllowedError,
   ToolNotAllowedError,
   validateBlockType,
+  validateChatDeployAuth,
   validateMcpToolsAllowed,
   validateModelProvider,
   validatePublicFileSharing,
@@ -548,6 +550,38 @@ describe('validatePublicFileSharing', () => {
   it('no-ops when no auth type is provided (master switch only)', async () => {
     mockWorkspaceGroups.value = [{ config: { allowedFileShareAuthTypes: ['password'] } }]
     await validatePublicFileSharing('user-123', 'workspace-1')
+  })
+})
+
+describe('validateChatDeployAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWorkspaceGroups.value = []
+    mockDefaultGroup.value = []
+    mockGetAllowedIntegrationsFromEnv.mockReturnValue(null)
+    setEnterpriseOrgWorkspace()
+  })
+
+  it('throws when the auth type is not in the allow-list', async () => {
+    mockWorkspaceGroups.value = [{ config: { allowedChatDeployAuthTypes: ['password', 'sso'] } }]
+    await expect(
+      validateChatDeployAuth('user-123', 'workspace-1', 'public')
+    ).rejects.toBeInstanceOf(ChatDeployAuthNotAllowedError)
+  })
+
+  it('allows an auth type that is in the allow-list', async () => {
+    mockWorkspaceGroups.value = [{ config: { allowedChatDeployAuthTypes: ['password', 'sso'] } }]
+    await validateChatDeployAuth('user-123', 'workspace-1', 'password')
+  })
+
+  it('allows any auth type when the allow-list is null', async () => {
+    mockWorkspaceGroups.value = [{ config: { allowedChatDeployAuthTypes: null } }]
+    await validateChatDeployAuth('user-123', 'workspace-1', 'email')
+  })
+
+  it('no-ops when access control does not apply (non-enterprise)', async () => {
+    mockIsOrganizationOnEnterprisePlan.mockResolvedValue(false)
+    await validateChatDeployAuth('user-123', 'workspace-1', 'public')
   })
 })
 

--- a/apps/sim/ee/access-control/utils/permission-check.ts
+++ b/apps/sim/ee/access-control/utils/permission-check.ts
@@ -99,6 +99,13 @@ export class PublicFileSharingNotAllowedError extends Error {
   }
 }
 
+export class ChatDeployAuthNotAllowedError extends Error {
+  constructor() {
+    super('This chat authentication mode is not allowed based on your permission group settings')
+    this.name = 'ChatDeployAuthNotAllowedError'
+  }
+}
+
 /**
  * Merges the env allowlist into a permission config.
  * If `config` is null and no env allowlist is set, returns null.
@@ -291,6 +298,35 @@ export async function validatePublicFileSharing(
       authType,
     })
     throw new PublicFileSharingNotAllowedError()
+  }
+}
+
+/**
+ * Throws {@link ChatDeployAuthNotAllowedError} if the user's effective permission
+ * group for the workspace doesn't allow the chat deployment's `authType` (i.e. it
+ * isn't in the group's `allowedChatDeployAuthTypes` allow-list; `null` allows all).
+ * No-op when access control doesn't apply (non-enterprise / disabled), so
+ * non-governed orgs are unaffected.
+ */
+export async function validateChatDeployAuth(
+  userId: string,
+  workspaceId: string,
+  authType: ShareAuthType
+): Promise<void> {
+  const config = await getUserPermissionConfig(userId, workspaceId)
+  if (!config) {
+    return
+  }
+  if (
+    config.allowedChatDeployAuthTypes !== null &&
+    !config.allowedChatDeployAuthTypes.includes(authType)
+  ) {
+    logger.warn('Chat deploy auth type blocked by permission group', {
+      userId,
+      workspaceId,
+      authType,
+    })
+    throw new ChatDeployAuthNotAllowedError()
   }
 }
 

--- a/apps/sim/lib/api/contracts/permission-groups.ts
+++ b/apps/sim/lib/api/contracts/permission-groups.ts
@@ -28,7 +28,7 @@ export const permissionGroupFullConfigSchema = z.object({
   hideDeployApi: z.boolean(),
   hideDeployMcp: z.boolean(),
   hideDeployChatbot: z.boolean(),
-  hideDeployTemplate: z.boolean(),
+  allowedChatDeployAuthTypes: z.array(shareAuthTypeSchema).nullable(),
 })
 
 export const addPermissionGroupMemberBodySchema = z.object({

--- a/apps/sim/lib/copilot/tools/handlers/deployment/deploy.ts
+++ b/apps/sim/lib/copilot/tools/handlers/deployment/deploy.ts
@@ -406,7 +406,7 @@ export async function executeDeployChat(
 
     // Enforce the permission group's chat auth-mode allow-list, but only when the
     // mode actually changes (or on a first deploy) so an existing grandfathered
-    // mode can be re-saved. New/changed modes must be allowed.
+    // mode can be re-saved.
     if (workflowRecord.workspaceId && resolvedAuthType !== existingDeployment?.authType) {
       try {
         await validateChatDeployAuth(context.userId, workflowRecord.workspaceId, resolvedAuthType)

--- a/apps/sim/lib/copilot/tools/handlers/deployment/deploy.ts
+++ b/apps/sim/lib/copilot/tools/handlers/deployment/deploy.ts
@@ -22,6 +22,10 @@ import {
   performFullUndeploy,
 } from '@/lib/workflows/orchestration'
 import { checkChatAccess, checkWorkflowAccessForChatCreation } from '@/app/api/chat/utils'
+import {
+  ChatDeployAuthNotAllowedError,
+  validateChatDeployAuth,
+} from '@/ee/access-control/utils/permission-check'
 import { ensureWorkflowAccess } from '../access'
 import type { DeployApiParams, DeployChatParams, DeployMcpParams } from '../param-types'
 
@@ -399,6 +403,20 @@ export async function executeDeployChat(
       params.customizations?.imageUrl ||
       params.customizations?.iconUrl ||
       existingCustomizations.imageUrl
+
+    // Enforce the permission group's chat auth-mode allow-list, but only when the
+    // mode actually changes (or on a first deploy) so an existing grandfathered
+    // mode can be re-saved. New/changed modes must be allowed.
+    if (workflowRecord.workspaceId && resolvedAuthType !== existingDeployment?.authType) {
+      try {
+        await validateChatDeployAuth(context.userId, workflowRecord.workspaceId, resolvedAuthType)
+      } catch (error) {
+        if (error instanceof ChatDeployAuthNotAllowedError) {
+          return { success: false, error: error.message }
+        }
+        throw error
+      }
+    }
 
     const result = await performChatDeploy({
       workflowId,

--- a/apps/sim/lib/permission-groups/types.ts
+++ b/apps/sim/lib/permission-groups/types.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod'
 import type { ShareAuthType } from '@/lib/api/contracts/public-shares'
 
-/** Auth modes a public file share can use; admins may restrict the allowed subset. */
+/**
+ * Auth modes a public file share or a chat deployment can use; admins may
+ * restrict the allowed subset. The two surfaces share the same four modes.
+ */
 export const FILE_SHARE_AUTH_TYPES = ['public', 'password', 'email', 'sso'] as const
 
 export const PERMISSION_GROUP_CONSTRAINTS = {
@@ -41,7 +44,7 @@ export const permissionGroupConfigSchema = z.object({
   hideDeployApi: z.boolean().optional(),
   hideDeployMcp: z.boolean().optional(),
   hideDeployChatbot: z.boolean().optional(),
-  hideDeployTemplate: z.boolean().optional(),
+  allowedChatDeployAuthTypes: z.array(z.enum(FILE_SHARE_AUTH_TYPES)).nullable().optional(),
 })
 
 export interface PermissionGroupConfig {
@@ -79,7 +82,8 @@ export interface PermissionGroupConfig {
   hideDeployApi: boolean
   hideDeployMcp: boolean
   hideDeployChatbot: boolean
-  hideDeployTemplate: boolean
+  /** Allowed chat-deployment auth modes; `null` means all are allowed. */
+  allowedChatDeployAuthTypes: ShareAuthType[] | null
 }
 
 export const DEFAULT_PERMISSION_GROUP_CONFIG: PermissionGroupConfig = {
@@ -106,7 +110,7 @@ export const DEFAULT_PERMISSION_GROUP_CONFIG: PermissionGroupConfig = {
   hideDeployApi: false,
   hideDeployMcp: false,
   hideDeployChatbot: false,
-  hideDeployTemplate: false,
+  allowedChatDeployAuthTypes: null,
 }
 
 export function parsePermissionGroupConfig(config: unknown): PermissionGroupConfig {
@@ -150,6 +154,10 @@ export function parsePermissionGroupConfig(config: unknown): PermissionGroupConf
     hideDeployApi: typeof c.hideDeployApi === 'boolean' ? c.hideDeployApi : false,
     hideDeployMcp: typeof c.hideDeployMcp === 'boolean' ? c.hideDeployMcp : false,
     hideDeployChatbot: typeof c.hideDeployChatbot === 'boolean' ? c.hideDeployChatbot : false,
-    hideDeployTemplate: typeof c.hideDeployTemplate === 'boolean' ? c.hideDeployTemplate : false,
+    allowedChatDeployAuthTypes: Array.isArray(c.allowedChatDeployAuthTypes)
+      ? c.allowedChatDeployAuthTypes.filter((t): t is ShareAuthType =>
+          (FILE_SHARE_AUTH_TYPES as readonly string[]).includes(t as string)
+        )
+      : null,
   }
 }


### PR DESCRIPTION
## Summary
- Add a per-permission-group **"Auth modes chat deployments may use"** control in the Access Control group's Platform tab, mirroring the existing public-file-share auth-mode control. Admins can now restrict which chat auth modes are allowed (i.e. disable Public, Password, Email, or SSO).
- **Enforced server-side** on chat create (`POST /api/chat`) and update (`PATCH /api/chat/manage/[id]`) via a new `validateChatDeployAuth` (throws `ChatDeployAuthNotAllowedError` → 403), reusing the same `getUserPermissionConfig` resolver the file-share gate uses.
- The chat deploy modal's "Access control" options are filtered to the allowed set (the currently-saved mode stays visible so existing state always shows; the route remains the source of truth).
- Remove the dead **Template** deploy option (`hideDeployTemplate` had no consumer anywhere).
- Shrink the Access Control block permission icons (`size-[9px]`) so they no longer touch their tile borders, and normalize the tiles to the `size-[16px]` shorthand.

## Implementation notes
- New config field `allowedChatDeployAuthTypes` (`ShareAuthType[] | null`, `null` = all allowed) added to `permissionGroupConfigSchema`, `PermissionGroupConfig`, `DEFAULT_PERMISSION_GROUP_CONFIG`, `parsePermissionGroupConfig`, and the `permissionGroupFullConfigSchema` contract. No DB migration — config is a JSONB blob and the parser defaults the field for existing rows.
- Enforcement mirrors `validatePublicFileSharing`; no-ops for non-enterprise / access-control-disabled orgs.

## Type of Change
- [x] Feature + cleanup

## Testing
- Added unit tests for `validateChatDeployAuth` (allow-list hit/miss, `null` = all, non-enterprise no-op) and 403 enforcement tests on both chat create and update routes. Full suite: 87 passing.
- `tsc`, `biome`, and `check:api-validation` all clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)