### PR TITLE
diag(mcp): per-request phase logging on the streamable-HTTP transport

### DIFF
--- a/apps/sim/lib/mcp/pinned-fetch.ts
+++ b/apps/sim/lib/mcp/pinned-fetch.ts
@@ -6,6 +6,7 @@ import { validateMcpServerSsrf } from '@/lib/mcp/domain-check'
 import { McpError } from '@/lib/mcp/types'
 
 const logger = createLogger('McpOauthFetch')
+const transportLogger = createLogger('McpTransportFetch')
 
 /** Pinned fetch for the live MCP transport, plus a handle to release its sockets. */
 export interface PinnedMcpFetch {
@@ -25,7 +26,42 @@ export interface PinnedMcpFetch {
  */
 export function createPinnedMcpFetch(resolvedIP: string): PinnedMcpFetch {
   const { fetch: pinnedFetch, dispatcher } = createPinnedFetchWithDispatcher(resolvedIP)
-  return { fetch: pinnedFetch, close: () => dispatcher.destroy() }
+  // Per-request phase logging: a stalled transport request (e.g. a first `initialize` that hangs
+  // to the client timeout) shows whether it stalls BEFORE response headers ("request" with no
+  // "response headers" = connect/request stall) or AFTER ("response headers" then the SDK's
+  // stream read stalls). Isolates the client-side first-connect stall.
+  const instrumentedFetch: typeof fetch = async (input, init) => {
+    const method = init?.method ?? (input instanceof Request ? input.method : 'GET')
+    const target =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input instanceof Request
+            ? input.url
+            : String(input)
+    const host = URL.canParse(target) ? new URL(target).host : target
+    const startedAt = Date.now()
+    transportLogger.info('MCP transport request', { host, method })
+    try {
+      const response = await pinnedFetch(input, init)
+      transportLogger.info('MCP transport response headers', {
+        host,
+        method,
+        status: response.status,
+        ttfbMs: Date.now() - startedAt,
+      })
+      return response
+    } catch (error) {
+      transportLogger.warn('MCP transport request failed', {
+        host,
+        method,
+        ms: Date.now() - startedAt,
+      })
+      throw error
+    }
+  }
+  return { fetch: instrumentedFetch, close: () => dispatcher.destroy() }
 }
 
 /**

--- a/apps/sim/lib/mcp/pinned-fetch.ts
+++ b/apps/sim/lib/mcp/pinned-fetch.ts
@@ -53,10 +53,14 @@ export function createPinnedMcpFetch(resolvedIP: string): PinnedMcpFetch {
       })
       return response
     } catch (error) {
+      const e = error as { name?: string; code?: string; cause?: { name?: string; code?: string } }
       transportLogger.warn('MCP transport request failed', {
         host,
         method,
         ms: Date.now() - startedAt,
+        errorName: e?.name,
+        errorCode: e?.code ?? e?.cause?.code,
+        causeName: e?.cause?.name,
       })
       throw error
     }


### PR DESCRIPTION
## Summary
- Adds per-request phase logging to the pinned MCP transport fetch (`createPinnedMcpFetch`), mirroring the OAuth guarded-fetch instrumentation that isolated the `/oauth/start` body stall.
- Logs each transport request (host + method), the **response headers with TTFB**, and failures.
- **Why:** the logs prove our client's *first* connect to these servers consistently hangs to the 30s client timeout while a normal client's `initialize` returns in ~120 ms — but we haven't isolated *where* it stalls. This logging shows whether the first connect hangs **before** response headers (connect/request phase) or **after** (the SDK's stream/body read) — the data needed to root-cause it before touching the single-IP-pin SSRF control.

## Type of Change
- [x] Diagnostic (temporary logging; no behavior change)

## Testing
Type-check + biome clean. No behavior change — wraps the existing pinned fetch with logging only.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)