### PR TITLE
fix(mcp): retire pooled connections after consecutive request timeouts

### DIFF
--- a/apps/sim/lib/mcp/connection-pool.test.ts
+++ b/apps/sim/lib/mcp/connection-pool.test.ts
@@ -83,6 +83,50 @@ describe('McpConnectionPool', () => {
     expect(client.disconnect).not.toHaveBeenCalled()
   })
 
+  it('keeps the connection after a single timeout release', async () => {
+    const client = makeFakeClient()
+    const create = vi.fn(async () => client)
+
+    const lease = await pool.acquire(params('s1:w1:u1', create))
+    await lease.release(false, true)
+    await borrow(pool, params('s1:w1:u1', create))
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(client.disconnect).not.toHaveBeenCalled()
+  })
+
+  it('retires the connection after consecutive timeouts (circuit breaker)', async () => {
+    const client = makeFakeClient()
+    const replacement = makeFakeClient()
+    const create = vi.fn<() => Promise<McpClient>>()
+    create.mockResolvedValueOnce(client)
+    create.mockResolvedValue(replacement)
+
+    const l1 = await pool.acquire(params('s1:w1:u1', create))
+    await l1.release(false, true)
+    const l2 = await pool.acquire(params('s1:w1:u1', create))
+    await l2.release(false, true)
+
+    expect(client.disconnect).toHaveBeenCalledTimes(1)
+    const l3 = await pool.acquire(params('s1:w1:u1', create))
+    expect(l3.client).toBe(replacement)
+    await l3.release()
+  })
+
+  it('resets the timeout count on a healthy release', async () => {
+    const client = makeFakeClient()
+    const create = vi.fn(async () => client)
+
+    const l1 = await pool.acquire(params('s1:w1:u1', create))
+    await l1.release(false, true)
+    await borrow(pool, params('s1:w1:u1', create)) // healthy — resets the count
+    const l3 = await pool.acquire(params('s1:w1:u1', create))
+    await l3.release(false, true) // first of a new streak, not the second strike
+
+    expect(client.disconnect).not.toHaveBeenCalled()
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
   it('dedups concurrent creates into a single connect (single-flight)', async () => {
     let resolveCreate: ((client: McpClient) => void) | undefined
     const created = new Promise<McpClient>((resolve) => {

--- a/apps/sim/lib/mcp/connection-pool.ts
+++ b/apps/sim/lib/mcp/connection-pool.ts
@@ -32,6 +32,14 @@ const logger = createLogger('McpConnectionPool')
 const MAX_POOL_SIZE = 100
 /** Max lifetime; on expiry the pinned SSRF `resolvedIP` re-resolves. */
 const MAX_CONNECTION_AGE_MS = 10 * 60 * 1000
+/**
+ * Circuit breaker: retire a connection after this many CONSECUTIVE request
+ * timeouts. One timeout is a slow request and keeps the session (retiring on
+ * every timeout causes connect/stall/reconnect churn); repeated timeouts with
+ * no success in between indicate a half-open transport the liveness ping
+ * hasn't caught yet. A healthy release resets the count.
+ */
+const MAX_CONSECUTIVE_TIMEOUTS = 2
 const LIVENESS_TTL_MS = 60 * 1000
 const LIVENESS_PING_TIMEOUT_MS = 5 * 1000
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000
@@ -46,10 +54,14 @@ export interface AcquireParams {
   create: () => Promise<McpClient>
 }
 
-/** A borrowed connection. `release(poison)` must be called exactly once; pass `poison: true` to retire on failure. */
+/**
+ * A borrowed connection. `release(poison, sawTimeout)` must be called exactly once:
+ * `poison: true` retires immediately (dead-connection error); `sawTimeout: true`
+ * counts toward the consecutive-timeout circuit breaker without retiring on its own.
+ */
 export interface ConnectionLease {
   client: McpClient
-  release: (poison?: boolean) => Promise<void>
+  release: (poison?: boolean, sawTimeout?: boolean) => Promise<void>
 }
 
 interface PoolEntry {
@@ -60,6 +72,7 @@ interface PoolEntry {
   lastActivityAt: number
   lastLivenessCheckAt: number
   borrowers: number
+  consecutiveTimeouts: number
   retired: boolean
   closing: boolean
 }
@@ -95,7 +108,10 @@ export class McpConnectionPool {
     while (entry.closing) entry = await this.resolveEntry(params)
     entry.borrowers++
     entry.lastActivityAt = Date.now()
-    return { client: entry.client, release: (poison) => this.release(entry, poison ?? false) }
+    return {
+      client: entry.client,
+      release: (poison, sawTimeout) => this.release(entry, poison ?? false, sawTimeout ?? false),
+    }
   }
 
   private async resolveEntry(params: AcquireParams): Promise<PoolEntry> {
@@ -162,6 +178,7 @@ export class McpConnectionPool {
         lastActivityAt: now,
         lastLivenessCheckAt: now,
         borrowers: 0,
+        consecutiveTimeouts: 0,
         retired: false,
         closing: false,
       }
@@ -194,9 +211,17 @@ export class McpConnectionPool {
     return record.promise
   }
 
-  private async release(entry: PoolEntry, poison: boolean): Promise<void> {
+  private async release(entry: PoolEntry, poison: boolean, sawTimeout: boolean): Promise<void> {
     entry.borrowers = Math.max(0, entry.borrowers - 1)
     entry.lastActivityAt = Date.now()
+    if (sawTimeout) {
+      entry.consecutiveTimeouts++
+      if (entry.consecutiveTimeouts >= MAX_CONSECUTIVE_TIMEOUTS) {
+        this.retire(entry, `${entry.consecutiveTimeouts} consecutive request timeouts`)
+      }
+    } else if (!poison) {
+      entry.consecutiveTimeouts = 0
+    }
     if (poison) this.retire(entry, 'poisoned by failed operation')
     await this.closeIfIdle(entry)
   }

--- a/apps/sim/lib/mcp/service-pool.test.ts
+++ b/apps/sim/lib/mcp/service-pool.test.ts
@@ -134,7 +134,7 @@ describe('McpService connection reuse wiring', () => {
       expect.objectContaining({ key: `server-1:${WORKSPACE_ID}:${USER_ID}`, serverId: 'server-1' })
     )
     expect(mockCallTool).toHaveBeenCalledTimes(1)
-    expect(mockRelease).toHaveBeenCalledWith(false)
+    expect(mockRelease).toHaveBeenCalledWith(false, false)
     expect(poolClient.disconnect).not.toHaveBeenCalled()
     // A pool hit must not re-resolve env vars (acquire never invoked `create`).
     expect(mockResolveEnvVars).not.toHaveBeenCalled()
@@ -158,7 +158,7 @@ describe('McpService connection reuse wiring', () => {
       mcpService.executeTool(USER_ID, 'server-1', { name: 'do', arguments: {} }, WORKSPACE_ID)
     ).rejects.toThrow()
 
-    expect(mockRelease).toHaveBeenCalledWith(true)
+    expect(mockRelease).toHaveBeenCalledWith(true, false)
   })
 
   it('keeps the pooled connection warm on a benign (non-connection) tool error', async () => {
@@ -168,20 +168,22 @@ describe('McpService connection reuse wiring', () => {
       mcpService.executeTool(USER_ID, 'server-1', { name: 'do', arguments: {} }, WORKSPACE_ID)
     ).rejects.toThrow()
 
-    expect(mockRelease).toHaveBeenCalledWith(false)
+    expect(mockRelease).toHaveBeenCalledWith(false, false)
   })
 
   it('keeps the pooled connection warm on a request timeout (does not retire the session)', async () => {
     // A streamable-HTTP request timeout aborts only that request's stream; the session stays
     // healthy for the next request, so a timeout must NOT poison the lease (matches every
-    // production MCP client and avoids a connect/stall/reconnect churn loop).
+    // production MCP client and avoids a connect/stall/reconnect churn loop). It DOES report
+    // sawTimeout so the pool's consecutive-timeout circuit breaker can retire a half-open
+    // transport after repeated strikes.
     mockCallTool.mockRejectedValue(new Error('Request timed out'))
 
     await expect(
       mcpService.executeTool(USER_ID, 'server-1', { name: 'do', arguments: {} }, WORKSPACE_ID)
     ).rejects.toThrow()
 
-    expect(mockRelease).not.toHaveBeenCalledWith(true)
+    expect(mockRelease).toHaveBeenCalledWith(false, true)
   })
 
   it('poisons the lease on an auth failure so a rotated credential is re-resolved', async () => {
@@ -191,7 +193,7 @@ describe('McpService connection reuse wiring', () => {
       mcpService.executeTool(USER_ID, 'server-1', { name: 'do', arguments: {} }, WORKSPACE_ID)
     ).rejects.toThrow()
 
-    expect(mockRelease).toHaveBeenCalledWith(true)
+    expect(mockRelease).toHaveBeenCalledWith(true, false)
   })
 
   it('retries and recovers when a rotated credential causes a one-off auth failure', async () => {
@@ -209,7 +211,7 @@ describe('McpService connection reuse wiring', () => {
     expect(result).toEqual({ content: [] })
     expect(mockCallTool).toHaveBeenCalledTimes(2)
     // First attempt poisoned the stale lease; the retry re-acquired a fresh one.
-    expect(mockRelease).toHaveBeenCalledWith(true)
+    expect(mockRelease).toHaveBeenCalledWith(true, false)
     expect(mockAcquire).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/sim/lib/mcp/service-pool.test.ts
+++ b/apps/sim/lib/mcp/service-pool.test.ts
@@ -186,6 +186,21 @@ describe('McpService connection reuse wiring', () => {
     expect(mockRelease).toHaveBeenCalledWith(false, true)
   })
 
+  it('classifies an AbortSignal.timeout-shaped TimeoutError as a timeout for the breaker', async () => {
+    // DOMException name 'TimeoutError' with a message that lacks "timed out".
+    mockCallTool.mockRejectedValue(
+      Object.assign(new Error('The operation was aborted due to timeout'), {
+        name: 'TimeoutError',
+      })
+    )
+
+    await expect(
+      mcpService.executeTool(USER_ID, 'server-1', { name: 'do', arguments: {} }, WORKSPACE_ID)
+    ).rejects.toThrow()
+
+    expect(mockRelease).toHaveBeenCalledWith(false, true)
+  })
+
   it('poisons the lease on an auth failure so a rotated credential is re-resolved', async () => {
     mockCallTool.mockRejectedValue(new UnauthorizedError('token rejected'))
 

--- a/apps/sim/lib/mcp/service.ts
+++ b/apps/sim/lib/mcp/service.ts
@@ -93,6 +93,12 @@ function isTimeoutError(error: unknown): boolean {
   if (error instanceof McpError && error.code === ErrorCode.RequestTimeout) {
     return true
   }
+  // AbortSignal.timeout / undici surface a DOMException named TimeoutError whose
+  // message ("The operation was aborted due to timeout") lacks "timed out".
+  const e = error as { name?: string; cause?: { name?: string } } | null
+  if (e?.name === 'TimeoutError' || e?.cause?.name === 'TimeoutError') {
+    return true
+  }
   return getErrorMessage(error, '').toLowerCase().includes('timed out')
 }
 

--- a/apps/sim/lib/mcp/service.ts
+++ b/apps/sim/lib/mcp/service.ts
@@ -425,13 +425,17 @@ class McpService {
         create,
       })
       let poison = false
+      let sawTimeout = false
       try {
         return await fn(lease.client)
       } catch (error) {
         poison = isDeadConnectionError(error)
+        // A lone timeout keeps the session; the pool's circuit breaker retires it
+        // after consecutive timeouts with no healthy request in between.
+        sawTimeout = isTimeoutError(error)
         throw error
       } finally {
-        await lease.release(poison)
+        await lease.release(poison, sawTimeout)
       }
     }
 


### PR DESCRIPTION
## Summary
- Follow-up to #5817, closing the P2 raised there ("Timed-Out Transport Remains Reusable"): a *genuinely half-open* transport could keep serving repeated 30s timeouts until the pool's liveness ping caught it.
- Adds a consecutive-timeout **circuit breaker** to the pool: a lone request timeout still keeps the session warm (retiring on every timeout is what caused the connect/stall/reconnect churn #5817 fixed), but **two consecutive timeouts with no healthy request in between retire the connection**. Any healthy release resets the count.
- `withServerClient` now reports `sawTimeout` on release; dead-connection errors still poison immediately, benign errors still keep the connection warm.
- Matches the LibreChat pattern (circuit breaker counts connection-level failures, not single request timeouts); the MCP SDK/OpenCode behavior for a lone timeout is unchanged.

## Type of Change
- [x] Bug fix (resilience hardening)

## Testing
- 3 new pool tests: lone timeout keeps the connection; consecutive timeouts retire it (fresh connection on next acquire); healthy release resets the streak.
- Service test updated: timeout release reports `(poison=false, sawTimeout=true)`.
- All 25 pool + service-pool tests green; tsc + biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)