### PR TITLE
fix(mcp): open the OAuth popup synchronously and bound the start request

### DIFF
--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.test.tsx
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.test.tsx
@@ -180,7 +180,7 @@ describe('useMcpOauthPopup', () => {
     hook.unmount()
   })
 
-  it('keeps the row connecting when a reopen fails but a prior flow is still live', async () => {
+  it('clears the row when a reopen fails (the reopen blanked the prior window)', async () => {
     mockStartOauth.mockResolvedValueOnce({
       status: 'redirect',
       authorizationUrl: 'https://as.example/a?state=st-a',
@@ -195,14 +195,15 @@ describe('useMcpOauthPopup', () => {
     await flush()
     expect(hook.result().connectingServers.has('s1')).toBe(true)
 
-    // Reopen fails (e.g. popup blocked). The still-live prior flow must keep the row connecting
-    // rather than the failed attempt clearing it (deterministic reference counting).
-    mockStartOauth.mockRejectedValueOnce(new Error('Popup blocked'))
+    // Reopen fails after the named-window open already navigated the prior auth window to
+    // about:blank — the prior flow is moot (windowless), so BOTH it and the failed attempt
+    // clear, leaving the row idle with 'Connect with OAuth' immediately available.
+    mockStartOauth.mockRejectedValueOnce(new Error('start failed'))
     await act(async () => {
       await hook.result().startOauthForServer('s1')
     })
     await flush()
-    expect(hook.result().connectingServers.has('s1')).toBe(true)
+    expect(hook.result().connectingServers.has('s1')).toBe(false)
 
     hook.unmount()
   })

--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.test.tsx
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.test.tsx
@@ -79,6 +79,16 @@ async function flush() {
 describe('useMcpOauthPopup', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Popup-first: startOauthForServer opens a blank window synchronously.
+    window.open = vi.fn(
+      () =>
+        ({
+          close: vi.fn(),
+          focus: vi.fn(),
+          location: { replace: vi.fn() },
+          closed: false,
+        }) as unknown as Window
+    )
     // jsdom has no BroadcastChannel; the hook opens one on mount.
     class FakeBroadcastChannel {
       onmessage: ((event: MessageEvent) => void) | null = null
@@ -115,7 +125,11 @@ describe('useMcpOauthPopup', () => {
 
     // Settle the first flow so the guard clears.
     await act(async () => {
-      resolveStart({ status: 'redirect', popup: { closed: false }, state: 'state-1' })
+      resolveStart({
+        status: 'redirect',
+        authorizationUrl: 'https://as.example/a?state=state-1',
+        state: 'state-1',
+      })
     })
     await flush()
 
@@ -123,7 +137,11 @@ describe('useMcpOauthPopup', () => {
   })
 
   it('allows a fresh start after the previous one settles (reopen after abandon)', async () => {
-    mockStartOauth.mockResolvedValue({ status: 'redirect', popup: { closed: false }, state: 'st' })
+    mockStartOauth.mockResolvedValue({
+      status: 'redirect',
+      authorizationUrl: 'https://as.example/a?state=st',
+      state: 'st',
+    })
 
     const hook = renderHookWithClient(() => useMcpOauthPopup({ workspaceId: 'w1' }))
     await flush()
@@ -165,7 +183,7 @@ describe('useMcpOauthPopup', () => {
   it('keeps the row connecting when a reopen fails but a prior flow is still live', async () => {
     mockStartOauth.mockResolvedValueOnce({
       status: 'redirect',
-      popup: { closed: false },
+      authorizationUrl: 'https://as.example/a?state=st-a',
       state: 'st-a',
     })
     const hook = renderHookWithClient(() => useMcpOauthPopup({ workspaceId: 'w1' }))
@@ -186,6 +204,42 @@ describe('useMcpOauthPopup', () => {
     await flush()
     expect(hook.result().connectingServers.has('s1')).toBe(true)
 
+    hook.unmount()
+  })
+
+  it('does not issue the start request when the popup is blocked', async () => {
+    ;(window.open as ReturnType<typeof vi.fn>).mockReturnValue(null)
+    const hook = renderHookWithClient(() => useMcpOauthPopup({ workspaceId: 'w1' }))
+    await flush()
+
+    await act(async () => {
+      await hook.result().startOauthForServer('s1')
+    })
+    await flush()
+
+    expect(mockStartOauth).not.toHaveBeenCalled()
+    expect(hook.result().connectingServers.has('s1')).toBe(false)
+    hook.unmount()
+  })
+
+  it('opens the popup before the start request resolves (popup-first)', async () => {
+    const order: string[] = []
+    ;(window.open as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      order.push('open')
+      return { close: vi.fn(), focus: vi.fn(), location: { replace: vi.fn() } } as unknown as Window
+    })
+    mockStartOauth.mockImplementation(async () => {
+      order.push('start')
+      return { status: 'redirect', authorizationUrl: 'https://as.example/a?state=st', state: 'st' }
+    })
+    const hook = renderHookWithClient(() => useMcpOauthPopup({ workspaceId: 'w1' }))
+    await flush()
+
+    await act(async () => {
+      await hook.result().startOauthForServer('s1')
+    })
+
+    expect(order).toEqual(['open', 'start'])
     hook.unmount()
   })
 })

--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
@@ -194,6 +194,9 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
           navigated = window.open(authorizationUrl, `mcp-oauth-${serverId}`) !== null
         }
         if (!navigated) {
+          try {
+            popup.close()
+          } catch {}
           decConnecting(serverId)
           toast.error('Popup blocked. Please allow popups for this site and retry.')
           return

--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
@@ -50,9 +50,9 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
 
   // Per-server count of live authorization attempts; a row shows "Connecting…" / "Reopen
   // authorization" while its count > 0. Reference counting (not a boolean set) keeps the label
-  // deterministic across concurrent attempts: a reopen increments before the superseded flow
-  // decrements, so the count never dips to 0 mid-reopen (no flicker), and every attempt clears
-  // exactly once (never stuck).
+  // deterministic across concurrent attempts: a reopen retires the superseded flow and starts
+  // its own count within one batched update (no flicker), and every attempt clears exactly
+  // once (never stuck).
   const [connectingCounts, setConnectingCounts] = useState<Map<string, number>>(() => new Map())
   // OAuth `state` nonce -> { serverId, safety timeout }. `state` keys the BroadcastChannel
   // correlation: the callback echoes it on every result (even failures that resolve no serverId),

--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
@@ -168,14 +168,14 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
         return
       }
       popup.focus?.()
+      // Opening the shared named window just navigated ANY prior authorization window to
+      // about:blank, so prior flows for this server are moot regardless of how this attempt
+      // ends — retire them now (a failed start must not leave a windowless flow "connecting"
+      // for the 10-minute safety timeout).
+      retireFlows(serverId)
       incConnecting(serverId) // this attempt begins
       try {
         const result = await startOauth({ serverId, workspaceId })
-        // The replacement start succeeded (already-authorized, or a fresh authorization is
-        // underway), so retire any prior attempt for this server now — its result is moot and
-        // the server-side `state` it depended on has been overwritten. A *failed* start
-        // (below) leaves prior flows intact.
-        retireFlows(serverId)
         if (result.status === 'already_authorized') {
           try {
             popup.close()
@@ -185,11 +185,18 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
           return
         }
         const { authorizationUrl, state } = result
+        let navigated = true
         try {
           popup.location.replace(authorizationUrl)
         } catch {
           // A COOP-severed reused window can refuse scripted navigation; reopen by name.
-          window.open(authorizationUrl, `mcp-oauth-${serverId}`)
+          // This runs after the await, so it can itself be popup-blocked — check it.
+          navigated = window.open(authorizationUrl, `mcp-oauth-${serverId}`) !== null
+        }
+        if (!navigated) {
+          decConnecting(serverId)
+          toast.error('Popup blocked. Please allow popups for this site and retry.')
+          return
         }
         // Track the in-flight flow by its `state` nonce for the BroadcastChannel gate, bounded by
         // a safety timeout in case no result ever arrives (popup abandoned, or a callback the

--- a/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
+++ b/apps/sim/hooks/mcp/use-mcp-oauth-popup.ts
@@ -153,27 +153,55 @@ export function useMcpOauthPopup({ workspaceId }: UseMcpOauthPopupProps) {
       const starting = (startingRef.current ??= new Set())
       if (starting.has(serverId)) return
       starting.add(serverId)
+      // Popup-first: open (or, via the shared window name, reuse+focus) the popup
+      // SYNCHRONOUSLY inside the user's click so the browser's activation gate sees
+      // it. Opening after the /oauth/start await loses the activation and gets
+      // silently popup-blocked — the "pressed Connect and nothing happened" bug.
+      const popup = window.open(
+        'about:blank',
+        `mcp-oauth-${serverId}`,
+        'width=560,height=720,resizable=yes,scrollbars=yes'
+      )
+      if (!popup) {
+        starting.delete(serverId)
+        toast.error('Popup blocked. Please allow popups for this site and retry.')
+        return
+      }
+      popup.focus?.()
       incConnecting(serverId) // this attempt begins
       try {
         const result = await startOauth({ serverId, workspaceId })
-        // The replacement start succeeded (already-authorized, or a fresh popup opened), so retire
-        // any prior attempt for this server now — its result is moot and the server-side `state`
-        // it depended on has been overwritten. A *failed* start (below) leaves prior flows intact.
+        // The replacement start succeeded (already-authorized, or a fresh authorization is
+        // underway), so retire any prior attempt for this server now — its result is moot and
+        // the server-side `state` it depended on has been overwritten. A *failed* start
+        // (below) leaves prior flows intact.
         retireFlows(serverId)
         if (result.status === 'already_authorized') {
+          try {
+            popup.close()
+          } catch {}
           invalidateServer(serverId)
           decConnecting(serverId) // this attempt ends
           return
         }
+        const { authorizationUrl, state } = result
+        try {
+          popup.location.replace(authorizationUrl)
+        } catch {
+          // A COOP-severed reused window can refuse scripted navigation; reopen by name.
+          window.open(authorizationUrl, `mcp-oauth-${serverId}`)
+        }
         // Track the in-flight flow by its `state` nonce for the BroadcastChannel gate, bounded by
         // a safety timeout in case no result ever arrives (popup abandoned, or a callback the
         // client can't otherwise observe under COOP).
-        const { state } = result
         pendingFlowsRef.current.set(state, {
           serverId,
           timeout: window.setTimeout(() => settleFlow(state), OAUTH_FLOW_TIMEOUT_MS),
         })
       } catch (e) {
+        try {
+          popup.close()
+        } catch {}
         decConnecting(serverId) // this attempt ends; any prior flow keeps its own count
         logger.error('Failed to start MCP OAuth', e)
         toast.error(toError(e).message || 'Failed to start authorization')

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -310,7 +310,7 @@ export function useCreateMcpServer() {
  * correlate the eventual result back to this exact flow.
  */
 export type StartMcpOauthMutationResult =
-  | { status: 'redirect'; popup: Window; state: string }
+  | { status: 'redirect'; authorizationUrl: string; state: string }
   | { status: 'already_authorized' }
 
 export function useStartMcpOauth() {
@@ -319,6 +319,9 @@ export function useStartMcpOauth() {
       mutationFn: async ({ serverId, workspaceId }) => {
         const result = await requestJson(startMcpOauthContract, {
           query: { serverId, workspaceId },
+          // A stalled /oauth/start must settle so the caller can reset the connecting
+          // state and close its pre-opened popup instead of appearing bricked.
+          signal: AbortSignal.timeout(30_000),
         })
         if (result.status === 'already_authorized') return { status: 'already_authorized' }
 
@@ -332,15 +335,10 @@ export function useStartMcpOauth() {
         if (!state) {
           throw new Error('Authorization URL is missing the OAuth state parameter')
         }
-        const popup = window.open(
-          result.authorizationUrl,
-          `mcp-oauth-${serverId}`,
-          'width=560,height=720,resizable=yes,scrollbars=yes'
-        )
-        if (!popup) {
-          throw new Error('Popup blocked. Please allow popups for this site and retry.')
-        }
-        return { status: 'redirect', popup, state }
+        // The popup itself is opened SYNCHRONOUSLY by the caller inside the user's
+        // click (popup-first) — opening it here, after the network await, loses the
+        // user activation and gets silently popup-blocked.
+        return { status: 'redirect', authorizationUrl: result.authorizationUrl, state }
       },
     }
   )

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -317,12 +317,28 @@ export function useStartMcpOauth() {
   return useMutation<StartMcpOauthMutationResult, Error, { serverId: string; workspaceId: string }>(
     {
       mutationFn: async ({ serverId, workspaceId }) => {
-        const result = await requestJson(startMcpOauthContract, {
-          query: { serverId, workspaceId },
-          // A stalled /oauth/start must settle so the caller can reset the connecting
-          // state and close its pre-opened popup instead of appearing bricked.
-          signal: AbortSignal.timeout(30_000),
-        })
+        // A stalled /oauth/start must settle so the caller can reset the connecting
+        // state and close its pre-opened popup instead of appearing bricked.
+        // Feature-detect AbortSignal.timeout (Safari <16 lacks it) with a plain
+        // controller fallback.
+        let timeoutSignal: AbortSignal | undefined
+        let timeoutId: ReturnType<typeof setTimeout> | undefined
+        if (typeof AbortSignal.timeout === 'function') {
+          timeoutSignal = AbortSignal.timeout(30_000)
+        } else {
+          const controller = new AbortController()
+          timeoutId = setTimeout(() => controller.abort(new Error('Request timed out')), 30_000)
+          timeoutSignal = controller.signal
+        }
+        let result: Awaited<ReturnType<typeof requestJson<typeof startMcpOauthContract>>>
+        try {
+          result = await requestJson(startMcpOauthContract, {
+            query: { serverId, workspaceId },
+            signal: timeoutSignal,
+          })
+        } finally {
+          if (timeoutId !== undefined) clearTimeout(timeoutId)
+        }
         if (result.status === 'already_authorized') return { status: 'already_authorized' }
 
         const parsedUrl = new URL(result.authorizationUrl)


### PR DESCRIPTION
## Summary
Fixes the two reported OAuth UX failures (no popup after Add MCP; 'Reopen authorization window' pressing doing nothing):

- **Popup-first**: `window.open` previously ran **after** awaiting `/api/mcp/oauth/start`, outside the browser's user-activation window, so the popup was **silently blocked** — worst on the add-server flow (two awaits deep). The hook now opens `about:blank` **synchronously in the click** (named per server, so a re-click focuses/reuses an existing authorization window), navigates it once the start returns, and closes it on failure/`already_authorized`. A genuinely blocked popup shows a clear toast and skips the request entirely.
- **Bounded start**: `/oauth/start` had no client-side timeout, so a stalled start (the known transient body-stall) held the re-entrancy guard and the connecting label indefinitely — the button looked dead. The request is now bounded at 30s; on timeout the popup closes, the label resets to 'Connect with OAuth', and retry is immediately available.
- The mutation no longer opens windows (returns `authorizationUrl` + `state`); popup lifecycle lives in one place.

Residual note: the add-server auto-start still sits after the create request, so an extremely slow create+probe can still exceed the activation window — but it now degrades to a clear 'Popup blocked' toast and a clean, clickable 'Connect with OAuth' state instead of a stuck label.

## Type of Change
- [x] Bug fix (UX)

## Testing
- Hook tests updated + 2 new: popup opens before the start request resolves (popup-first ordering), and a blocked popup skips the request and leaves the row idle. 10/10 green; tsc + biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)