### PR TITLE
fix(ci): run Build App on the larger runner in GitHub mode

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -194,9 +194,11 @@ jobs:
   # harmless), but the Turbo cache gets its own key: with a shared key, only
   # the last committer's new entries survive each run, so the test and build
   # Turbo entries would evict each other nondeterministically.
+  # Same next build as the app image, so it needs the same larger runner in
+  # GitHub mode: it peaks ~21.9 GB and SIGKILLs on the free 16 GB ones.
   build:
     name: Build App
-    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-latest' }}
+    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-8vcpu-ubuntu-2404' || 'linux-x64-8-core' }}
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Summary
Follow-up to #5814. Tonight's live `CI_PROVIDER=github` run caught the one job I missed.

The app is built twice: once inside Docker for the deployable image (`Build AMD64 (app)`, already routed to `linux-x64-8-core` in #5814) and once outside Docker as a parallel check (`Build App` in `test-build.yml`). Same `next build`, same ~21.9 GB peak — but `Build App` was still on a free 16 GB runner and SIGKILLed:

```
error: script "build" was terminated by signal SIGKILL (Forced quit)
```

That failure blocked `Migrate DB` and `Promote Images`, so staging never deployed the merge commit.

`Lint and Test` stays on free `ubuntu-latest` — it passed on GitHub-hosted with 13,589 tests and doesn't run the Next build.

## Why unconditional rather than fork-guarded
`test-build.yml` runs on PRs including forks, so a paid runner here is exposed to fork traffic in a way the push-only image jobs aren't. That's acceptable: this repo requires maintainer approval for fork-PR workflows (verified — fork PRs #5801/#5791 sit at `action_required`), so nobody can trigger spend by opening a PR. An approved fork PR costs ~$0.15 instead of $0, and it executes no code it wasn't already going to execute on a free runner. Public IP is disabled on the runner, so GitHub's fixed-IP warning doesn't apply. A fork guard would have added a conditional and made outside contributors' PRs fail with a confusing OOM.

Costs nothing in normal operation — Blacksmith is unchanged.

## Testing
- `actionlint` clean, `bun run lint:check` 19/19
- Evidence from run 29877014793: `Build AMD64 (app)` succeeded on `linux-x64-8-core` while `Build App` SIGKILLed on `ubuntu-latest` in the same run — same build, only the runner differed
- Memory requirement measured directly: 21,883 MB peak on a 32 GB runner; free 16 GB runners fail at every heap ceiling (4096/6144/8192 all died at ~15.9 GB)

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)