### PR TITLE
fix(slack): allow empty status to clear the assistant status indicator

### DIFF
--- a/apps/docs/content/docs/en/integrations/slack.mdx
+++ b/apps/docs/content/docs/en/integrations/slack.mdx
@@ -815,7 +815,7 @@ Set or clear the assistant thread status indicator (the loading shimmer) on a Sl
 | `botToken` | string | No | Bot token for Custom Bot |
 | `channel` | string | Yes | Channel ID containing the assistant thread \(e.g., C1234567890 or D1234567890\) |
 | `threadTs` | string | Yes | Thread timestamp \(thread_ts\) of the assistant thread \(e.g., 1405894322.002768\) |
-| `status` | string | Yes | Status text to display, e.g. 'Working on it…'. Pass an empty string to clear. |
+| `status` | string | No | Status text to display, e.g. 'Working on it…'. Omit or pass an empty string to clear the status. |
 | `loadingMessages` | json | No | Optional list of messages to rotate through as an animated loading indicator \(max 10\). |
 
 #### Output

--- a/apps/sim/tools/slack/set_status.ts
+++ b/apps/sim/tools/slack/set_status.ts
@@ -71,9 +71,10 @@ export const slackSetStatusTool: ToolConfig<SlackSetStatusParams, SlackSetStatus
     },
     status: {
       type: 'string',
-      required: true,
+      required: false,
       visibility: 'user-or-llm',
-      description: "Status text to display, e.g. 'Working on it…'. Pass an empty string to clear.",
+      description:
+        "Status text to display, e.g. 'Working on it…'. Omit or pass an empty string to clear the status.",
     },
     loadingMessages: {
       type: 'json',

--- a/apps/sim/tools/slack/types.ts
+++ b/apps/sim/tools/slack/types.ts
@@ -794,7 +794,7 @@ export interface SlackGetThreadParams extends SlackBaseParams {
 export interface SlackSetStatusParams extends SlackBaseParams {
   channel: string
   threadTs: string
-  status: string
+  status?: string
   loadingMessages?: string[]
 }
 


### PR DESCRIPTION
## Summary
- `slack_set_status` declared `status` as `required: true` / `user-or-llm`, so the shared required-param validator (`tools/utils.ts`) treated an empty string as missing and threw "Status is required for Slack Set Assistant Status" — the empty-string-clear path documented in the tool's own description could never reach Slack
- Made `status` non-required so an omitted or empty value passes validation. The request body builder already sends `status: params.status ?? ''`, and Slack's `assistant.threads.setStatus` treats an empty `status` as "clear the status indicator"
- Updated the param description and `SlackSetStatusParams.status` to match
- Left the generic validator alone — empty-string-is-missing is correct for other tools; the fix is scoping this one param as optional. The Slack block's `status` subblock was already `required: false`

Note: the docs row in `apps/docs/content/docs/en/integrations/slack.mdx` is generated, but `bun run generate-docs` currently produces a broken result locally (truncates slack.mdx from 1873 to 15 lines, drops all MANUAL-CONTENT blocks, deletes the 13 `*-service-account.mdx` pages, and rewrites ~15 unrelated integration pages). I reverted that and hand-applied only the single table row a correct regen would emit. The generator looks like it is running against an incomplete registry — worth a separate look.

## Type of Change
- [x] Bug fix

## Testing
`bun run type-check` clean. `vitest run tools/utils.test.ts serializer/tests/dual-validation.test.ts` — 40 passed. `bun run lint` and `bun run check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
