### PR TITLE
fix(mcp): follow tools/list pagination instead of silently truncating

### DIFF
--- a/apps/sim/lib/mcp/client.test.ts
+++ b/apps/sim/lib/mcp/client.test.ts
@@ -248,6 +248,32 @@ describe('McpClient notification handler', () => {
     expect(tools.map((t) => t.name)).toEqual(['a'])
   })
 
+  it('keeps an empty partial (does not throw) when page one succeeds but a later page fails', async () => {
+    // Page one is valid but empty with a cursor; page two fails. Page one succeeded, so
+    // discovery must not fail the server — it returns [] rather than throwing.
+    mockSdkListTools
+      .mockResolvedValueOnce({ tools: [], nextCursor: 'c1' })
+      .mockRejectedValueOnce(new Error('page 2 blew up'))
+    const client = new McpClient({
+      config: createConfig(),
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await client.connect()
+    await expect(client.listTools()).resolves.toEqual([])
+  })
+
+  it('throws when the very first page fails', async () => {
+    mockSdkListTools.mockRejectedValueOnce(new Error('page 1 blew up'))
+    const client = new McpClient({
+      config: createConfig(),
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await client.connect()
+    await expect(client.listTools()).rejects.toThrow()
+  })
+
   it('logs connection diagnostics without header values', async () => {
     const client = new McpClient({
       config: {

--- a/apps/sim/lib/mcp/client.test.ts
+++ b/apps/sim/lib/mcp/client.test.ts
@@ -177,7 +177,7 @@ describe('McpClient notification handler', () => {
       undefined,
       expect.objectContaining({
         timeout: 30_000,
-        maxTotalTimeout: 60_000,
+        maxTotalTimeout: expect.any(Number),
         resetTimeoutOnProgress: true,
         onprogress: expect.any(Function),
       })
@@ -196,8 +196,56 @@ describe('McpClient notification handler', () => {
 
     expect(mockSdkListTools).toHaveBeenCalledWith(
       undefined,
-      expect.objectContaining({ timeout: 60_000, maxTotalTimeout: 60_000 })
+      expect.objectContaining({ timeout: 60_000, maxTotalTimeout: expect.any(Number) })
     )
+  })
+
+  it('follows nextCursor pagination and aggregates all pages', async () => {
+    mockSdkListTools
+      .mockResolvedValueOnce({ tools: [{ name: 'a' }, { name: 'b' }], nextCursor: 'c1' })
+      .mockResolvedValueOnce({ tools: [{ name: 'c' }], nextCursor: 'c2' })
+      .mockResolvedValueOnce({ tools: [{ name: 'd' }] })
+    const client = new McpClient({
+      config: createConfig(),
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await client.connect()
+    const tools = await client.listTools()
+
+    expect(tools.map((t) => t.name)).toEqual(['a', 'b', 'c', 'd'])
+    expect(mockSdkListTools).toHaveBeenNthCalledWith(2, { cursor: 'c1' }, expect.anything())
+    expect(mockSdkListTools).toHaveBeenNthCalledWith(3, { cursor: 'c2' }, expect.anything())
+  })
+
+  it('stops paginating when the server repeats a cursor (loop guard)', async () => {
+    mockSdkListTools.mockResolvedValue({ tools: [{ name: 'x' }], nextCursor: 'same' })
+    const client = new McpClient({
+      config: createConfig(),
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await client.connect()
+    const tools = await client.listTools()
+
+    // Page 1 sets cursor 'same'; page 2 returns 'same' again → guard stops. Not 50 pages.
+    expect(mockSdkListTools).toHaveBeenCalledTimes(2)
+    expect(tools).toHaveLength(2)
+  })
+
+  it('returns partial tools when a later page fails', async () => {
+    mockSdkListTools
+      .mockResolvedValueOnce({ tools: [{ name: 'a' }], nextCursor: 'c1' })
+      .mockRejectedValueOnce(new Error('page 2 blew up'))
+    const client = new McpClient({
+      config: createConfig(),
+      securityPolicy: { requireConsent: false, auditLevel: 'basic' },
+    })
+
+    await client.connect()
+    const tools = await client.listTools()
+
+    expect(tools.map((t) => t.name)).toEqual(['a'])
   })
 
   it('logs connection diagnostics without header values', async () => {

--- a/apps/sim/lib/mcp/client.ts
+++ b/apps/sim/lib/mcp/client.ts
@@ -280,14 +280,17 @@ export class McpClient {
     // and aggregate wall-clock — plus a repeated-cursor guard, since a page cap
     // alone can't stop a server that returns a fresh cursor with no new tools.
     const deadline = startedAt + maxTotalTimeoutMs
+    const maxPages = MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_PAGES
     const tools: McpTool[] = []
     const seenCursors = new Set<string>()
     let cursor: string | undefined
     let bytes = 0
+    let pagesFetched = 0
     let truncated: string | undefined
+    let reachedEnd = false
 
     try {
-      for (let page = 0; page < MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_PAGES; page++) {
+      for (let page = 0; page < maxPages; page++) {
         const remainingMs = deadline - Date.now()
         if (remainingMs <= 0) {
           truncated = 'aggregate timeout'
@@ -309,9 +312,11 @@ export class McpClient {
             },
           }
         )
+        pagesFetched++
 
         if (!result.tools || !Array.isArray(result.tools)) {
           logger.warn(`Invalid tools response from server ${this.config.name}:`, result)
+          reachedEnd = true
           break
         }
 
@@ -320,7 +325,7 @@ export class McpClient {
             truncated = 'tool count'
             break
           }
-          bytes += JSON.stringify(tool).length
+          bytes += Buffer.byteLength(JSON.stringify(tool), 'utf8')
           if (bytes > MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_BYTES) {
             truncated = 'byte size'
             break
@@ -336,7 +341,10 @@ export class McpClient {
         if (truncated) break
 
         const next = result.nextCursor
-        if (!next) break // missing/empty cursor = end of results (spec)
+        if (!next) {
+          reachedEnd = true
+          break // missing/empty cursor = end of results (spec)
+        }
         if (seenCursors.has(next)) {
           truncated = 'repeated cursor'
           break
@@ -345,12 +353,15 @@ export class McpClient {
         cursor = next
       }
 
-      if (truncated || seenCursors.size >= MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_PAGES - 1) {
+      // The loop can exhaust `maxPages` with a cursor still pending — that's a page-cap
+      // truncation, distinct from a natural end (`reachedEnd`) or an explicit budget hit.
+      if (!truncated && !reachedEnd) truncated = 'page cap'
+      if (truncated) {
         logger.warn(`Tool discovery truncated for server ${this.config.name}`, {
           serverId: this.config.id,
-          reason: truncated ?? 'page cap',
+          reason: truncated,
           toolsCollected: tools.length,
-          pagesFetched: seenCursors.size + 1,
+          pagesFetched,
         })
       }
 
@@ -362,13 +373,14 @@ export class McpClient {
         durationMs: Date.now() - startedAt,
         idleTimeoutMs,
         maxTotalTimeoutMs,
-        pagesFetched: seenCursors.size + 1,
+        pagesFetched,
         toolsCollected: tools.length,
         sessionIdPresent: Boolean(this.transport.sessionId),
         error: getMcpSafeErrorDiagnostics(error),
       })
-      // Partial results from earlier pages are still useful; only fail if page one failed.
-      if (tools.length > 0) return tools
+      // At least one page succeeded → keep its (possibly empty) partial result rather than
+      // failing discovery and marking the server unhealthy; only a page-one failure throws.
+      if (pagesFetched > 0) return tools
       throw error
     }
   }

--- a/apps/sim/lib/mcp/client.ts
+++ b/apps/sim/lib/mcp/client.ts
@@ -5,7 +5,6 @@ import {
   LATEST_PROTOCOL_VERSION,
   type ListToolsResult,
   SUPPORTED_PROTOCOL_VERSIONS,
-  type Tool,
   ToolListChangedNotificationSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import { createLogger } from '@sim/logger'
@@ -275,33 +274,87 @@ export class McpClient {
     const maxTotalTimeoutMs = MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_TOTAL_TIMEOUT_MS
     const startedAt = Date.now()
 
-    try {
-      const result: ListToolsResult = await this.client.listTools(undefined, {
-        // resetTimeoutOnProgress only takes effect when onprogress is supplied.
-        timeout: idleTimeoutMs,
-        maxTotalTimeout: maxTotalTimeoutMs,
-        resetTimeoutOnProgress: true,
-        onprogress: (progress) => {
-          logger.debug(`Tool discovery progress from ${this.config.name}`, {
-            serverId: this.config.id,
-            progress: progress.progress,
-            total: progress.total,
-          })
-        },
-      })
+    // The SDK's `listTools()` returns a single page; a server that paginates via
+    // `nextCursor` would otherwise be silently truncated to page one. Follow the
+    // cursor, bounded by four independent budgets — pages, tool count, byte size,
+    // and aggregate wall-clock — plus a repeated-cursor guard, since a page cap
+    // alone can't stop a server that returns a fresh cursor with no new tools.
+    const deadline = startedAt + maxTotalTimeoutMs
+    const tools: McpTool[] = []
+    const seenCursors = new Set<string>()
+    let cursor: string | undefined
+    let bytes = 0
+    let truncated: string | undefined
 
-      if (!result.tools || !Array.isArray(result.tools)) {
-        logger.warn(`Invalid tools response from server ${this.config.name}:`, result)
-        return []
+    try {
+      for (let page = 0; page < MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_PAGES; page++) {
+        const remainingMs = deadline - Date.now()
+        if (remainingMs <= 0) {
+          truncated = 'aggregate timeout'
+          break
+        }
+        const result: ListToolsResult = await this.client.listTools(
+          cursor ? { cursor } : undefined,
+          {
+            // resetTimeoutOnProgress only takes effect when onprogress is supplied.
+            timeout: Math.min(idleTimeoutMs, remainingMs),
+            maxTotalTimeout: remainingMs,
+            resetTimeoutOnProgress: true,
+            onprogress: (progress) => {
+              logger.debug(`Tool discovery progress from ${this.config.name}`, {
+                serverId: this.config.id,
+                progress: progress.progress,
+                total: progress.total,
+              })
+            },
+          }
+        )
+
+        if (!result.tools || !Array.isArray(result.tools)) {
+          logger.warn(`Invalid tools response from server ${this.config.name}:`, result)
+          break
+        }
+
+        for (const tool of result.tools) {
+          if (tools.length >= MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_TOOLS) {
+            truncated = 'tool count'
+            break
+          }
+          bytes += JSON.stringify(tool).length
+          if (bytes > MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_BYTES) {
+            truncated = 'byte size'
+            break
+          }
+          tools.push({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema as McpTool['inputSchema'],
+            serverId: this.config.id,
+            serverName: this.config.name,
+          })
+        }
+        if (truncated) break
+
+        const next = result.nextCursor
+        if (!next) break // missing/empty cursor = end of results (spec)
+        if (seenCursors.has(next)) {
+          truncated = 'repeated cursor'
+          break
+        }
+        seenCursors.add(next)
+        cursor = next
       }
 
-      return result.tools.map((tool: Tool) => ({
-        name: tool.name,
-        description: tool.description,
-        inputSchema: tool.inputSchema as McpTool['inputSchema'],
-        serverId: this.config.id,
-        serverName: this.config.name,
-      }))
+      if (truncated || seenCursors.size >= MCP_CLIENT_CONSTANTS.LIST_TOOLS_MAX_PAGES - 1) {
+        logger.warn(`Tool discovery truncated for server ${this.config.name}`, {
+          serverId: this.config.id,
+          reason: truncated ?? 'page cap',
+          toolsCollected: tools.length,
+          pagesFetched: seenCursors.size + 1,
+        })
+      }
+
+      return tools
     } catch (error) {
       logger.error(`Failed to list tools from server ${this.config.name}`, {
         serverId: this.config.id,
@@ -309,9 +362,13 @@ export class McpClient {
         durationMs: Date.now() - startedAt,
         idleTimeoutMs,
         maxTotalTimeoutMs,
+        pagesFetched: seenCursors.size + 1,
+        toolsCollected: tools.length,
         sessionIdPresent: Boolean(this.transport.sessionId),
         error: getMcpSafeErrorDiagnostics(error),
       })
+      // Partial results from earlier pages are still useful; only fail if page one failed.
+      if (tools.length > 0) return tools
       throw error
     }
   }

--- a/apps/sim/lib/mcp/utils.ts
+++ b/apps/sim/lib/mcp/utils.ts
@@ -55,6 +55,12 @@ export const MCP_CLIENT_CONSTANTS = {
   LIST_TOOLS_TIMEOUT_MS: 30_000,
   /** Hard ceiling for tools/list regardless of progress (SDK maxTotalTimeout safeguard). */
   LIST_TOOLS_MAX_TOTAL_TIMEOUT_MS: 60_000,
+  /** Max `tools/list` pages followed via `nextCursor` before truncating (see fetch loop). */
+  LIST_TOOLS_MAX_PAGES: 50,
+  /** Max tools aggregated across all pages before truncating. */
+  LIST_TOOLS_MAX_TOOLS: 1000,
+  /** Max total tool-payload bytes aggregated across all pages before truncating. */
+  LIST_TOOLS_MAX_BYTES: 5 * 1024 * 1024,
   FAILURE_CACHE_TTL_MS: 120_000,
 } as const
 


### PR DESCRIPTION
## Summary
- The MCP SDK's `listTools()` returns a **single page**. A server that paginates its tool list via `nextCursor` was **silently truncated to page one** — its later tools just never appeared, with no error.
- Now follows the cursor, bounded by four independent budgets — **50 pages / 1000 tools / 5 MB / 60 s aggregate wall-clock** — plus a **repeated-cursor guard** (a page cap alone can't stop a server that returns a fresh cursor with zero new tools forever within budget). Caps live in `MCP_CLIENT_CONSTANTS`.
- **Partial results are kept**: if a later page fails, the tools already collected are returned; only a page-one failure throws. Truncation is logged with the reason.
- Matches LibreChat's capped-cursor-loop pattern; grounded in the MCP pagination spec (missing `nextCursor` = end of results, opaque cursors).

Deliberately scoped to pagination only. Legacy HTTP+SSE transport fallback is a separate, larger change (restructures the connect path + a real header-auth-on-SSE-GET footgun + needs a real legacy-SSE server to validate against) — recommended as its own PR, not bundled here.

## Type of Change
- [x] Bug fix (silent truncation)

## Testing
- 3 new client tests: multi-page aggregation across `nextCursor`, repeated-cursor loop guard stops early, later-page failure returns partial results. All 19 client tests green; tsc + biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)