### PR TITLE
Add settings navigation acceptance contracts

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/settings-sidebar/settings-sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/settings-sidebar/settings-sidebar.tsx
@@ -57,6 +57,11 @@ export function SettingsSidebar({
   const showDiscardDialog = pendingLeave !== null
 
   const [hasOverflowTop, setHasOverflowTop] = useState(false)
+  const [isHydrated, setIsHydrated] = useState(false)
+
+  useEffect(() => {
+    setIsHydrated(true)
+  }, [])
 
   const { data: session } = useSession()
   const hostContext = useWorkspaceHostContext()
@@ -265,7 +270,12 @@ export function SettingsSidebar({
         )}
       >
         <SidebarTooltip label='Back' enabled={showCollapsedTooltips}>
-          <button type='button' onClick={handleBack} className={chipVariants({ fullWidth: true })}>
+          <button
+            type='button'
+            disabled={!isHydrated}
+            onClick={handleBack}
+            className={chipVariants({ fullWidth: true })}
+          >
             <div className='flex size-[16px] flex-shrink-0 items-center justify-center text-[var(--text-icon)]'>
               <ChevronDown className='size-[10px] rotate-90' />
             </div>
@@ -276,6 +286,8 @@ export function SettingsSidebar({
 
       {/* Settings sections */}
       <div
+        role='navigation'
+        aria-label='Workspace settings sections'
         ref={isCollapsed ? undefined : scrollContainerRef}
         className={cn(
           'flex flex-1 flex-col overflow-y-auto overflow-x-hidden border-t pt-1.5 transition-colors duration-150',
@@ -337,6 +349,9 @@ export function SettingsSidebar({
                     ) : (
                       <button
                         type='button'
+                        disabled={!isHydrated}
+                        aria-label={item.label}
+                        aria-current={active ? 'page' : undefined}
                         className={itemClassName}
                         onMouseEnter={() => handlePrefetch(item.id)}
                         onFocus={() => handlePrefetch(item.id)}

--- a/apps/sim/components/settings/settings-sidebar.tsx
+++ b/apps/sim/components/settings/settings-sidebar.tsx
@@ -63,6 +63,11 @@ export function SettingsSidebar<Section extends SettingsSection>({
   const cancelLeave = useSettingsDirtyStore((state) => state.cancelLeave)
   const pendingLeave = useSettingsDirtyStore((state) => state.pendingLeave)
   const [hasOverflowTop, setHasOverflowTop] = useState(false)
+  const [isHydrated, setIsHydrated] = useState(false)
+
+  useEffect(() => {
+    setIsHydrated(true)
+  }, [])
 
   useEffect(() => {
     const container = scrollContainerRef.current
@@ -85,6 +90,7 @@ export function SettingsSidebar<Section extends SettingsSection>({
         <SidebarTooltip label='Back' enabled={showCollapsedTooltips}>
           <button
             type='button'
+            disabled={!isHydrated}
             onClick={() => requestLeave(() => router.push(backHref))}
             className={chipVariants({ fullWidth: true })}
           >
@@ -130,6 +136,9 @@ export function SettingsSidebar<Section extends SettingsSection>({
                       >
                         <button
                           type='button'
+                          disabled={!isHydrated}
+                          aria-label={item.label}
+                          aria-current={active ? 'page' : undefined}
                           className={chipVariants({ active, fullWidth: true })}
                           onClick={() => {
                             if (active) return

--- a/apps/sim/e2e/README.md
+++ b/apps/sim/e2e/README.md
@@ -99,6 +99,38 @@ new database, Stripe fake, app, realtime process, and browser run:
 bun run test:e2e -- --reuse-build --project=hosted-billing-chromium-navigation
 ```
 
+## Settings navigation contracts
+
+Step 3 owns three literal acceptance datasets in
+`e2e/settings/navigation/contracts.ts`: canonical sidebar sections, special
+route outcomes, and representative persona visibility. They are intentionally
+independent of production navigation metadata. When product copy, routes, or
+visibility change, update the product and these expectations together rather
+than generating expectations from the implementation.
+
+Run only the navigation contracts during local iteration:
+
+```bash
+bun run test:e2e -- --reuse-build \
+  --project=hosted-billing-chromium-navigation --no-deps \
+  e2e/settings/navigation
+```
+
+The complete navigation project includes foundation safety and unauthenticated
+smoke coverage. On the Step 3 reference run, one worker completed its 123 tests
+in 1.7 minutes and the cache-hit orchestrator in 5 minutes 10 seconds. Two
+workers completed the same retry-free project in 55.3 seconds and the
+cache-hit orchestrator in 4 minutes 25 seconds, so the project retains two
+workers. Foundation coverage passed in both measurements. The final
+post-review dependency chain passed all 139 navigation, workflow, persona, and
+isolation tests in 1.3 minutes of Playwright time.
+
+The full chain's isolated browser contexts share a loopback address, so the E2E
+app raises Better Auth's generic request ceiling without disabling its limiter.
+That override fails closed unless the exact hosted E2E profile, E2E auth origin,
+and loopback `sim_e2e_*` database are all present; normal deployments retain
+Better Auth's defaults.
+
 The cache lives under ignored `e2e/.cache/builds/`. A hit requires matching
 source contents (including uncommitted/untracked files), build/public profile,
 Node/Bun/Next versions, platform, `BUILD_ID`, and the cached artifact checksum.

--- a/apps/sim/e2e/settings/navigation/canonical-navigation.spec.ts
+++ b/apps/sim/e2e/settings/navigation/canonical-navigation.spec.ts
@@ -1,0 +1,99 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from '../../fixtures/persona-test'
+import { absoluteE2eUrl, readinessLocator, resolveContractPath } from './contract-resolver'
+import { type SectionContract, sectionContracts } from './contracts'
+
+for (const literalContract of sectionContracts) {
+  const contract: SectionContract = literalContract
+  test(`${contract.contractId} is reachable through its sidebar contract`, async ({
+    contextForPersona,
+    personaManifest,
+  }) => {
+    const context = await contextForPersona(contract.driver.personaKey)
+    const page = await context.newPage()
+    const targetPath = resolveContractPath(personaManifest, contract.pathTemplate, contract.driver)
+    const startingPath = resolveStartingPath(contract, personaManifest)
+
+    await page.goto(absoluteE2eUrl(startingPath))
+
+    const targetButton = page.getByRole('button', { name: contract.label, exact: true })
+    await expect(targetButton).toBeVisible()
+
+    const successfulResponse = contract.successfulResponse
+      ? page.waitForResponse((response) => {
+          const url = new URL(response.url())
+          return url.pathname === contract.successfulResponse?.path && response.status() === 200
+        })
+      : null
+    await targetButton.click()
+    await expect(page).toHaveURL(absoluteE2eUrl(targetPath))
+    if (successfulResponse) {
+      const response = await successfulResponse
+      if (contract.successfulResponse?.expectedJson !== undefined) {
+        await expect(response.json()).resolves.toEqual(contract.successfulResponse.expectedJson)
+      }
+    }
+
+    await assertCanonicalSettingsPage(page, contract, targetPath)
+  })
+}
+
+async function assertCanonicalSettingsPage(
+  page: Page,
+  contract: SectionContract,
+  targetPath: string
+): Promise<void> {
+  await expect(page).toHaveURL(absoluteE2eUrl(targetPath))
+  await expect(
+    page.getByRole('heading', { name: contract.heading, level: 1, exact: true }),
+    `${contract.contractId} heading changed; update the literal navigation contract intentionally`
+  ).toBeVisible()
+  await expect(
+    page.getByText(contract.description, { exact: true }),
+    `${contract.contractId} description changed; update the literal navigation contract intentionally`
+  ).toBeVisible()
+  await expect(readinessLocator(page, contract.readiness)).toBeVisible()
+  await expect(page.getByRole('button', { name: contract.label, exact: true })).toHaveAttribute(
+    'aria-current',
+    'page'
+  )
+  await expect(
+    page.getByRole('heading', { name: 'Failed to load settings', exact: true })
+  ).toHaveCount(0)
+  await expect(
+    page.getByRole('heading', { name: 'Something went wrong', exact: true })
+  ).toHaveCount(0)
+  await expect(
+    page.getByRole('heading', { name: 'Settings unavailable', exact: true })
+  ).toHaveCount(0)
+  await expect(page.getByRole('heading', { name: 'Setting unavailable', exact: true })).toHaveCount(
+    0
+  )
+}
+
+function resolveStartingPath(
+  contract: SectionContract,
+  manifest: Parameters<typeof resolveContractPath>[0]
+): string {
+  if (contract.plane === 'account') {
+    return contract.sectionId === 'general'
+      ? '/account/settings/api-keys'
+      : '/account/settings/general'
+  }
+
+  if (contract.plane === 'organization') {
+    const section = contract.sectionId === 'members' ? 'access-control' : 'members'
+    return resolveContractPath(
+      manifest,
+      `/organization/{organizationId}/settings/${section}`,
+      contract.driver
+    )
+  }
+
+  const section = contract.sectionId === 'general' ? 'secrets' : 'general'
+  return resolveContractPath(
+    manifest,
+    `/workspace/{workspaceId}/settings/${section}`,
+    contract.driver
+  )
+}

--- a/apps/sim/e2e/settings/navigation/contract-integrity.spec.ts
+++ b/apps/sim/e2e/settings/navigation/contract-integrity.spec.ts
@@ -1,0 +1,215 @@
+import { expect, test } from '@playwright/test'
+import { createSettingsPersonaScenarios, SETTINGS_PERSONA_KEYS } from '../personas'
+import {
+  type AuthenticatedDriver,
+  personaVisibilityCases,
+  type RouteOutcome,
+  routeCases,
+  type SectionContract,
+  sectionContracts,
+} from './contracts'
+
+const scenario = createSettingsPersonaScenarios('navigation-contract').primary
+const personas = new Map(scenario.personas.map((persona) => [persona.key, persona]))
+const workspaces = new Map(scenario.workspaces.map((workspace) => [workspace.key, workspace]))
+const organizations = new Map(
+  scenario.organizations.map((organization) => [organization.key, organization])
+)
+
+test('navigation contracts have stable independent identities and paths', () => {
+  expectUnique(
+    sectionContracts.map(({ contractId }) => contractId),
+    'section contractId'
+  )
+  expectUnique(
+    sectionContracts.map(({ plane, sectionId }) => `${plane}/${sectionId}`),
+    'plane/sectionId'
+  )
+  expectUnique(
+    sectionContracts.map(({ pathTemplate }) => pathTemplate),
+    'canonical path'
+  )
+  expectUnique(
+    routeCases.map(({ caseId }) => caseId),
+    'route caseId'
+  )
+  expectUnique(
+    routeCases.map(({ pathTemplate }) => pathTemplate),
+    'route input path'
+  )
+  expectUnique(
+    personaVisibilityCases.map(({ caseId }) => caseId),
+    'visibility caseId'
+  )
+
+  const canonicalPaths = new Set(sectionContracts.map(({ pathTemplate }) => pathTemplate))
+  for (const routeCase of routeCases) {
+    const allowedCanonicalReuse =
+      routeCase.outcome.kind === 'organization-unavailable' ||
+      routeCase.outcome.kind === 'login-redirect'
+    expect(
+      canonicalPaths.has(routeCase.pathTemplate) && !allowedCanonicalReuse,
+      `${routeCase.caseId} must not duplicate a canonical sidebar path`
+    ).toBe(false)
+  }
+
+  for (const contract of sectionContracts) {
+    const sectionContract: SectionContract = contract
+    expect(contract.heading, `${contract.contractId} heading`).not.toBe('')
+    expect(contract.description, `${contract.contractId} description`).not.toBe('')
+    expect(contract.label, `${contract.contractId} label`).not.toBe('')
+    expect(contract.group, `${contract.contractId} group`).not.toBe('')
+    expect(contract.readiness, `${contract.contractId} readiness`).toBeTruthy()
+    if (sectionContract.successfulResponse) {
+      expect(sectionContract.successfulResponse.path, contract.contractId).toMatch(/^\/api\//)
+    }
+    assertPathBinding(contract.pathTemplate, contract.driver, contract.contractId)
+    assertDriverCanReachBinding(contract.driver, contract.contractId)
+  }
+})
+
+test('route and visibility drivers are coherent with the Step 2 scenario', () => {
+  const personaKeys = new Set<string>(SETTINGS_PERSONA_KEYS)
+  for (const routeCase of routeCases) {
+    const outcome: RouteOutcome = routeCase.outcome
+    expect(outcome.kind, `${routeCase.caseId} outcome`).toBeTruthy()
+    if (routeCase.driver === 'unauthenticated') {
+      expect(outcome.kind, routeCase.caseId).toBe('login-redirect')
+      expect(
+        routeCase.pathTemplate,
+        `${routeCase.caseId} literal unauthenticated path`
+      ).not.toMatch(/\{[^}]+\}/)
+      continue
+    }
+    expect(outcome.kind, routeCase.caseId).not.toBe('login-redirect')
+    expect(personaKeys.has(routeCase.driver.personaKey), routeCase.caseId).toBe(true)
+    assertPathBinding(routeCase.pathTemplate, routeCase.driver, routeCase.caseId)
+    if (outcome.kind === 'render') {
+      expect(outcome.preserveInputUrl, routeCase.caseId).toBe(true)
+      if (outcome.successfulResponse) {
+        expect(outcome.successfulResponse.path, routeCase.caseId).toMatch(/^\/api\//)
+        expect(outcome.readiness, `${routeCase.caseId} response readiness`).toBeTruthy()
+      }
+    }
+    if (outcome.kind === 'redirect') {
+      assertPathBinding(outcome.pathTemplate, routeCase.driver, `${routeCase.caseId} redirect`)
+      if (outcome.successfulResponse) {
+        expect(outcome.successfulResponse.path, routeCase.caseId).toMatch(/^\/api\//)
+      }
+      if (!outcome.pathTemplate.includes('/settings')) {
+        expect(outcome.readiness, `${routeCase.caseId} destination readiness`).toBeTruthy()
+        expect(outcome.successfulResponse, `${routeCase.caseId} destination response`).toBeTruthy()
+      }
+    }
+    if (outcome.kind === 'organization-unavailable') {
+      assertUnavailableDriver(routeCase.driver, routeCase.caseId, routeCase.pathTemplate)
+    } else {
+      assertDriverCanReachBinding(routeCase.driver, routeCase.caseId)
+    }
+  }
+
+  for (const visibilityCase of personaVisibilityCases) {
+    assertDriverCanReachBinding(visibilityCase.driver, visibilityCase.caseId)
+    assertPathBinding(
+      visibilityCase.plane === 'account'
+        ? '/account/settings/{section}'
+        : `/${visibilityCase.plane}/{${visibilityCase.plane}Id}/settings/{section}`,
+      visibilityCase.driver,
+      visibilityCase.caseId
+    )
+    const visibleSectionIds = new Set<string>(visibilityCase.expectedVisibleSectionIds)
+    expect(visibilityCase.expectedVisibleSectionIds, visibilityCase.caseId).toContain(
+      visibilityCase.representativeSectionId
+    )
+    expect(
+      visibilityCase.importantHiddenSectionIds.filter((sectionId) =>
+        visibleSectionIds.has(sectionId)
+      ),
+      `${visibilityCase.caseId} visible/hidden overlap`
+    ).toEqual([])
+    expect(visibilityCase.expectedVisibleLabels, `${visibilityCase.caseId} visible labels`).toEqual(
+      visibilityCase.expectedVisibleSectionIds.map((sectionId) =>
+        sectionLabel(visibilityCase.plane, sectionId, visibilityCase.caseId)
+      )
+    )
+    expect(visibilityCase.importantHiddenLabels, `${visibilityCase.caseId} hidden labels`).toEqual(
+      visibilityCase.importantHiddenSectionIds.map((sectionId) =>
+        sectionLabel(visibilityCase.plane, sectionId, visibilityCase.caseId)
+      )
+    )
+  }
+})
+
+function assertPathBinding(pathTemplate: string, driver: AuthenticatedDriver, label: string): void {
+  const needsOrganization = pathTemplate.includes('{organizationId}')
+  const needsWorkspace = pathTemplate.includes('{workspaceId}')
+  expect(needsOrganization && needsWorkspace, `${label} dynamic path ambiguity`).toBe(false)
+  if (!needsOrganization && !needsWorkspace) {
+    expect(driver.binding, `${label} unexpected resource binding`).toBeUndefined()
+    return
+  }
+  expect(driver.binding?.resourceKind, `${label} resource binding kind`).toBe(
+    needsOrganization ? 'organization' : 'workspace'
+  )
+  expect(driver.binding?.worldKey, `${label} world binding`).toBe('settings-primary')
+}
+
+function sectionLabel(plane: string, sectionId: string, caseId: string): string {
+  const contract = sectionContracts.find(
+    (candidate) => candidate.plane === plane && candidate.sectionId === sectionId
+  )
+  expect(contract, `${caseId} ${plane}/${sectionId} section contract`).toBeTruthy()
+  return contract?.label ?? ''
+}
+
+function assertDriverCanReachBinding(driver: AuthenticatedDriver, label: string): void {
+  const persona = personas.get(driver.personaKey)
+  expect(persona, `${label} persona`).toBeTruthy()
+  if (!driver.binding) return
+
+  if (driver.binding.resourceKind === 'workspace') {
+    expect(workspaces.has(driver.binding.resourceKey), `${label} workspace binding`).toBe(true)
+    const expectation = persona?.workspaces.find(
+      ({ workspaceKey }) => workspaceKey === driver.binding?.resourceKey
+    )
+    expect(expectation, `${label} persona workspace expectation`).toBeTruthy()
+    expect(expectation?.access, `${label} workspace access`).not.toBe('none')
+    return
+  }
+
+  expect(organizations.has(driver.binding.resourceKey), `${label} organization binding`).toBe(true)
+  const membership = scenario.organizationMemberships.find(
+    ({ organizationKey, userKey }) =>
+      organizationKey === driver.binding?.resourceKey && userKey === persona?.userKey
+  )
+  expect(membership, `${label} organization membership`).toBeTruthy()
+}
+
+function assertUnavailableDriver(
+  driver: AuthenticatedDriver,
+  label: string,
+  pathTemplate: string
+): void {
+  const persona = personas.get(driver.personaKey)
+  const binding = driver.binding
+  expect(persona, `${label} persona`).toBeTruthy()
+  expect(binding?.resourceKind, `${label} organization binding`).toBe('organization')
+  const membership = scenario.organizationMemberships.find(
+    ({ organizationKey, userKey }) =>
+      organizationKey === binding?.resourceKey && userKey === persona?.userKey
+  )
+
+  if (label === 'organization-non-member-layout-unavailable') {
+    expect(membership, `${label} requires non-membership`).toBeUndefined()
+    return
+  }
+  expect(membership, `${label} requires organization membership`).toBeTruthy()
+  if (!pathTemplate.endsWith('/unavailable')) {
+    expect(membership?.role, `${label} requires insufficient organization role`).toBe('member')
+  }
+}
+
+function expectUnique(values: readonly string[], label: string): void {
+  const duplicates = values.filter((value, index) => values.indexOf(value) !== index)
+  expect(duplicates, `duplicate ${label}`).toEqual([])
+}

--- a/apps/sim/e2e/settings/navigation/contract-resolver.ts
+++ b/apps/sim/e2e/settings/navigation/contract-resolver.ts
@@ -1,0 +1,83 @@
+import type { Locator, Page } from '@playwright/test'
+import type { ScenarioManifest } from '../../fixtures/e2e-world'
+import type { AuthenticatedDriver, DynamicResourceBinding, SemanticReadiness } from './contracts'
+
+const DYNAMIC_SEGMENTS = {
+  organization: '{organizationId}',
+  workspace: '{workspaceId}',
+} as const
+
+export function resolveContractPath(
+  manifest: ScenarioManifest,
+  pathTemplate: string,
+  driver?: AuthenticatedDriver
+): string {
+  const binding = driver?.binding
+  const requiresOrganization = pathTemplate.includes(DYNAMIC_SEGMENTS.organization)
+  const requiresWorkspace = pathTemplate.includes(DYNAMIC_SEGMENTS.workspace)
+
+  if (!requiresOrganization && !requiresWorkspace) {
+    if (binding) {
+      throw new Error(`Static contract path must not declare a dynamic binding: ${pathTemplate}`)
+    }
+    return pathTemplate
+  }
+  if (!binding) throw new Error(`Dynamic contract path is missing a binding: ${pathTemplate}`)
+
+  const expectedKind = requiresOrganization ? 'organization' : 'workspace'
+  if (binding.resourceKind !== expectedKind) {
+    throw new Error(
+      `Contract path expects ${expectedKind}, received ${binding.resourceKind}: ${pathTemplate}`
+    )
+  }
+
+  const resourceId = resolveBoundResourceId(manifest, binding)
+  return pathTemplate.replace(
+    DYNAMIC_SEGMENTS[binding.resourceKind],
+    encodeURIComponent(resourceId)
+  )
+}
+
+export function resolveBoundResourceId(
+  manifest: ScenarioManifest,
+  binding: DynamicResourceBinding
+): string {
+  const world = manifest.worlds[binding.worldKey]
+  if (!world) throw new Error(`Unknown contract world: ${binding.worldKey}`)
+  const resources =
+    binding.resourceKind === 'organization' ? world.organizationIds : world.workspaceIds
+  const resourceId = resources[binding.resourceKey]
+  if (!resourceId) {
+    throw new Error(
+      `Unknown ${binding.resourceKind} contract resource "${binding.resourceKey}" in world "${binding.worldKey}"`
+    )
+  }
+  return resourceId
+}
+
+export function readinessLocator(page: Page, readiness: SemanticReadiness): Locator {
+  switch (readiness.kind) {
+    case 'button':
+      return page.getByRole('button', { name: readiness.name, exact: true })
+    case 'link':
+      return page.getByRole('link', { name: readiness.name, exact: true })
+    case 'textbox':
+      return page.getByRole('textbox', { name: readiness.name, exact: true })
+    case 'switch':
+      return page.getByRole('switch', { name: readiness.name, exact: true })
+    case 'tab':
+      return page.getByRole('tab', { name: readiness.name, exact: true })
+    case 'text':
+      return page.getByText(readiness.value, { exact: true })
+  }
+}
+
+export function requiredBaseUrl(): string {
+  const value = process.env.E2E_BASE_URL
+  if (!value) throw new Error('Missing navigation contract environment value: E2E_BASE_URL')
+  return value
+}
+
+export function absoluteE2eUrl(pathname: string): string {
+  return new URL(pathname, requiredBaseUrl()).toString()
+}

--- a/apps/sim/e2e/settings/navigation/contracts.ts
+++ b/apps/sim/e2e/settings/navigation/contracts.ts
@@ -1,0 +1,1060 @@
+import type { SettingsPersonaKey } from '../personas'
+
+export type SettingsPlane = 'account' | 'organization' | 'workspace'
+export type WorldKey = 'settings-primary'
+
+export interface DynamicResourceBinding {
+  worldKey: WorldKey
+  resourceKind: 'organization' | 'workspace'
+  resourceKey: string
+}
+
+export interface AuthenticatedDriver {
+  personaKey: SettingsPersonaKey
+  binding?: DynamicResourceBinding
+}
+
+export type SemanticReadiness =
+  | { kind: 'button'; name: string }
+  | { kind: 'link'; name: string }
+  | { kind: 'textbox'; name: string }
+  | { kind: 'switch'; name: string }
+  | { kind: 'tab'; name: string }
+  | { kind: 'text'; value: string }
+
+export interface SuccessfulResponse {
+  path: string
+  expectedJson?: unknown
+}
+
+export interface SectionContract {
+  contractId: string
+  plane: SettingsPlane
+  sectionId: string
+  group: string
+  label: string
+  pathTemplate: string
+  heading: string
+  description: string
+  readiness: SemanticReadiness
+  successfulResponse?: SuccessfulResponse
+  driver: AuthenticatedDriver
+  activeSidebarItem: boolean
+}
+
+export type RouteOutcome =
+  | {
+      kind: 'render'
+      heading: string
+      description: string
+      preserveInputUrl: boolean
+      successfulResponse?: SuccessfulResponse
+      readiness?: SemanticReadiness
+    }
+  | {
+      kind: 'redirect'
+      pathTemplate: string
+      successfulResponse?: SuccessfulResponse
+      readiness?: SemanticReadiness
+    }
+  | { kind: 'login-redirect' }
+  | { kind: 'not-found' }
+  | { kind: 'organization-unavailable'; presentation: 'layout' | 'embedded'; title: string }
+
+export interface RouteCase {
+  caseId: string
+  pathTemplate: string
+  driver: AuthenticatedDriver | 'unauthenticated'
+  outcome: RouteOutcome
+}
+
+export interface PersonaVisibilityCase {
+  caseId: string
+  plane: SettingsPlane
+  driver: AuthenticatedDriver
+  expectedVisibleSectionIds: readonly string[]
+  expectedVisibleLabels: readonly string[]
+  importantHiddenSectionIds: readonly string[]
+  importantHiddenLabels: readonly string[]
+  representativeSectionId: string
+  representativeLabel: string
+}
+
+const primaryWorkspace = (
+  personaKey: SettingsPersonaKey,
+  resourceKey: string
+): AuthenticatedDriver => ({
+  personaKey,
+  binding: {
+    worldKey: 'settings-primary',
+    resourceKind: 'workspace',
+    resourceKey,
+  },
+})
+
+const primaryOrganization = (
+  personaKey: SettingsPersonaKey,
+  resourceKey: string
+): AuthenticatedDriver => ({
+  personaKey,
+  binding: {
+    worldKey: 'settings-primary',
+    resourceKind: 'organization',
+    resourceKey,
+  },
+})
+
+const platformAccount = { personaKey: 'platformAdmin' } as const satisfies AuthenticatedDriver
+const platformWorkspace = primaryWorkspace('platformAdmin', 'platform-admin-workspace')
+const maxWorkspace = primaryWorkspace('personalMaxOwner', 'personal-max-workspace')
+const enterpriseWorkspace = primaryWorkspace('enterpriseOrganizationAdmin', 'enterprise-workspace')
+const enterpriseOrganization = primaryOrganization(
+  'enterpriseOrganizationAdmin',
+  'enterprise-organization'
+)
+const lapsedOrganization = primaryOrganization('freeOrganizationOwner', 'lapsed-organization')
+const foreignEnterpriseOrganization = primaryOrganization(
+  'personalFreeOwner',
+  'enterprise-organization'
+)
+const teamOrganizationMember = primaryOrganization('workspaceReadMember', 'team-organization')
+
+export const sectionContracts = [
+  {
+    contractId: 'account-general',
+    plane: 'account',
+    sectionId: 'general',
+    group: 'account',
+    label: 'General',
+    pathTemplate: '/account/settings/general',
+    heading: 'General',
+    description: 'Manage your profile, appearance, and preferences.',
+    readiness: { kind: 'button', name: 'Change profile picture' },
+    driver: platformAccount,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'account-billing',
+    plane: 'account',
+    sectionId: 'billing',
+    group: 'account',
+    label: 'Billing',
+    pathTemplate: '/account/settings/billing',
+    heading: 'Billing',
+    description: 'Manage your personal plan, usage, and invoices.',
+    readiness: { kind: 'link', name: 'Explore personal plans' },
+    driver: platformAccount,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'account-api-keys',
+    plane: 'account',
+    sectionId: 'api-keys',
+    group: 'developer',
+    label: 'Sim API keys',
+    pathTemplate: '/account/settings/api-keys',
+    heading: 'Sim API keys',
+    description: 'Create and manage your personal Sim API keys.',
+    readiness: { kind: 'button', name: 'Create API key' },
+    driver: platformAccount,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'account-copilot',
+    plane: 'account',
+    sectionId: 'copilot',
+    group: 'developer',
+    label: 'Chat keys',
+    pathTemplate: '/account/settings/copilot',
+    heading: 'Chat keys',
+    description: 'Manage the model-provider keys that power Chat.',
+    readiness: { kind: 'button', name: 'Create API key' },
+    driver: platformAccount,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'account-admin',
+    plane: 'account',
+    sectionId: 'admin',
+    group: 'platform',
+    label: 'Admin',
+    pathTemplate: '/account/settings/admin',
+    heading: 'Admin',
+    description: 'Superuser administration and workspace tools.',
+    readiness: { kind: 'switch', name: 'Super admin mode' },
+    driver: platformAccount,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'account-mothership',
+    plane: 'account',
+    sectionId: 'mothership',
+    group: 'platform',
+    label: 'Mothership',
+    pathTemplate: '/account/settings/mothership',
+    heading: 'Mothership',
+    description: 'Internal Sim operations and license management.',
+    readiness: { kind: 'button', name: 'Overview' },
+    driver: platformAccount,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'organization-members',
+    plane: 'organization',
+    sectionId: 'members',
+    group: 'organization',
+    label: 'Members',
+    pathTemplate: '/organization/{organizationId}/settings/members',
+    heading: 'Members',
+    description: 'Manage organization members, roles, and seats.',
+    readiness: { kind: 'button', name: 'Invite' },
+    driver: enterpriseOrganization,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'organization-billing',
+    plane: 'organization',
+    sectionId: 'billing',
+    group: 'organization',
+    label: 'Billing',
+    pathTemplate: '/organization/{organizationId}/settings/billing',
+    heading: 'Billing',
+    description: 'Manage the organization plan, usage, and invoices.',
+    readiness: { kind: 'button', name: 'Explore organization plans' },
+    successfulResponse: {
+      path: '/api/billing/invoices',
+      expectedJson: { success: true, invoices: [], hasMore: false },
+    },
+    driver: lapsedOrganization,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'organization-access-control',
+    plane: 'organization',
+    sectionId: 'access-control',
+    group: 'security',
+    label: 'Access control',
+    pathTemplate: '/organization/{organizationId}/settings/access-control',
+    heading: 'Access control',
+    description: 'Manage permission groups across your organization.',
+    readiness: { kind: 'button', name: 'Create group' },
+    driver: enterpriseOrganization,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'organization-audit-logs',
+    plane: 'organization',
+    sectionId: 'audit-logs',
+    group: 'security',
+    label: 'Audit logs',
+    pathTemplate: '/organization/{organizationId}/settings/audit-logs',
+    heading: 'Audit logs',
+    description: 'Review activity and changes across your organization.',
+    readiness: { kind: 'textbox', name: 'Search audit logs...' },
+    driver: enterpriseOrganization,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'organization-sso',
+    plane: 'organization',
+    sectionId: 'sso',
+    group: 'security',
+    label: 'Single sign-on',
+    pathTemplate: '/organization/{organizationId}/settings/sso',
+    heading: 'Single sign-on',
+    description: 'Configure single sign-on for your organization.',
+    readiness: { kind: 'text', value: 'Provider Type' },
+    driver: enterpriseOrganization,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'organization-data-retention',
+    plane: 'organization',
+    sectionId: 'data-retention',
+    group: 'enterprise',
+    label: 'Data retention',
+    pathTemplate: '/organization/{organizationId}/settings/data-retention',
+    heading: 'Data retention',
+    description:
+      'Control data retention windows and PII redaction. Workspaces without an override inherit the organization defaults.',
+    readiness: { kind: 'button', name: 'Add override' },
+    driver: enterpriseOrganization,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'organization-data-drains',
+    plane: 'organization',
+    sectionId: 'data-drains',
+    group: 'enterprise',
+    label: 'Data drains',
+    pathTemplate: '/organization/{organizationId}/settings/data-drains',
+    heading: 'Data drains',
+    description: 'Stream your logs and events to external destinations.',
+    readiness: { kind: 'button', name: 'New drain' },
+    driver: enterpriseOrganization,
+    activeSidebarItem: true,
+  },
+  {
+    contractId: 'organization-whitelabeling',
+    plane: 'organization',
+    sectionId: 'whitelabeling',
+    group: 'enterprise',
+    label: 'Whitelabeling',
+    pathTemplate: '/organization/{organizationId}/settings/whitelabeling',
+    heading: 'Whitelabeling',
+    description: 'Customize your workspace branding and appearance.',
+    readiness: { kind: 'text', value: 'Brand Identity' },
+    driver: enterpriseOrganization,
+    activeSidebarItem: true,
+  },
+  ...[
+    [
+      'workspace-general',
+      'general',
+      'account',
+      'General',
+      'Manage your profile, appearance, and preferences.',
+      { kind: 'button', name: 'Change profile picture' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-secrets',
+      'secrets',
+      'account',
+      'Secrets',
+      'Store environment variables for your workflows.',
+      { kind: 'textbox', name: 'Search secrets...' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-access-control',
+      'access-control',
+      'enterprise',
+      'Access control',
+      'Manage permission groups across your organization.',
+      { kind: 'button', name: 'Create group' },
+      enterpriseWorkspace,
+    ],
+    [
+      'workspace-custom-blocks',
+      'custom-blocks',
+      'enterprise',
+      'Custom blocks',
+      'Publish workflows as reusable blocks for your organization.',
+      {
+        kind: 'text',
+        value: 'Custom blocks require an Enterprise plan. Contact your admin to enable them.',
+      },
+      enterpriseWorkspace,
+      {
+        path: '/api/custom-blocks',
+        expectedJson: { enabled: false, customBlocks: [] },
+      },
+    ],
+    [
+      'workspace-audit-logs',
+      'audit-logs',
+      'enterprise',
+      'Audit logs',
+      'Review activity and changes across your organization.',
+      { kind: 'textbox', name: 'Search audit logs...' },
+      enterpriseWorkspace,
+    ],
+    [
+      'workspace-apikeys',
+      'apikeys',
+      'system',
+      'Sim API keys',
+      'Create and manage API keys for the Sim API.',
+      { kind: 'button', name: 'Create API key' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-byok',
+      'byok',
+      'system',
+      'BYOK',
+      'Bring your own model-provider API keys.',
+      { kind: 'textbox', name: 'Search providers' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-billing',
+      'billing',
+      'subscription',
+      'Billing',
+      'Manage your plan, pricing, and invoices.',
+      { kind: 'link', name: 'Explore personal plans' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-teammates',
+      'teammates',
+      'subscription',
+      'Teammates',
+      'Manage your teammates in this workspace.',
+      { kind: 'textbox', name: 'Search teammates...' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-organization',
+      'organization',
+      'subscription',
+      'Organization',
+      "Manage your organization's members and seats.",
+      { kind: 'button', name: 'Invite' },
+      enterpriseWorkspace,
+    ],
+    [
+      'workspace-sso',
+      'sso',
+      'enterprise',
+      'Single sign-on',
+      'Configure single sign-on for your organization.',
+      { kind: 'text', value: 'Provider Type' },
+      enterpriseWorkspace,
+    ],
+    [
+      'workspace-whitelabeling',
+      'whitelabeling',
+      'enterprise',
+      'Whitelabeling',
+      'Customize your workspace branding and appearance.',
+      { kind: 'text', value: 'Brand Identity' },
+      enterpriseWorkspace,
+    ],
+    [
+      'workspace-copilot',
+      'copilot',
+      'system',
+      'Chat keys',
+      'Manage the model-provider keys that power Chat.',
+      { kind: 'button', name: 'Create API key' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-forks',
+      'forks',
+      'enterprise',
+      'Workspace Forks',
+      'Fork this workspace and sync changes with its parent.',
+      { kind: 'textbox', name: 'Search forks...' },
+      enterpriseWorkspace,
+    ],
+    [
+      'workspace-mcp',
+      'mcp',
+      'tools',
+      'MCP tools',
+      'Connect MCP servers and use their tools in workflows.',
+      { kind: 'button', name: 'Add server' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-custom-tools',
+      'custom-tools',
+      'tools',
+      'Custom tools',
+      'Create and manage custom tools for your agents.',
+      { kind: 'button', name: 'Add tool' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-workflow-mcp-servers',
+      'workflow-mcp-servers',
+      'tools',
+      'MCP servers',
+      'Expose your workflows as tools on an MCP server.',
+      { kind: 'button', name: 'Add server' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-inbox',
+      'inbox',
+      'system',
+      'Sim mailer',
+      'Trigger and process workflows from incoming email.',
+      { kind: 'switch', name: 'Enable email inbox' },
+      maxWorkspace,
+    ],
+    [
+      'workspace-admin',
+      'admin',
+      'superuser',
+      'Admin',
+      'Superuser administration and workspace tools.',
+      { kind: 'switch', name: 'Super admin mode' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-data-retention',
+      'data-retention',
+      'enterprise',
+      'Data retention',
+      'Control data retention windows and PII redaction. Workspaces without an override inherit the organization defaults.',
+      { kind: 'button', name: 'Add override' },
+      enterpriseWorkspace,
+    ],
+    [
+      'workspace-data-drains',
+      'data-drains',
+      'enterprise',
+      'Data drains',
+      'Stream your logs and events to external destinations.',
+      { kind: 'button', name: 'New drain' },
+      enterpriseWorkspace,
+    ],
+    [
+      'workspace-mothership',
+      'mothership',
+      'superuser',
+      'Mothership',
+      'Internal Sim operations and license management.',
+      { kind: 'button', name: 'Overview' },
+      platformWorkspace,
+    ],
+    [
+      'workspace-recently-deleted',
+      'recently-deleted',
+      'system',
+      'Recently deleted',
+      'Restore items deleted in the last 30 days.',
+      { kind: 'textbox', name: 'Search deleted items...' },
+      platformWorkspace,
+    ],
+  ].map(
+    ([contractId, sectionId, group, label, description, readiness, driver, successfulResponse]) =>
+      ({
+        contractId,
+        plane: 'workspace',
+        sectionId,
+        group,
+        label,
+        pathTemplate: `/workspace/{workspaceId}/settings/${sectionId}`,
+        heading: label,
+        description,
+        readiness,
+        successfulResponse,
+        driver,
+        activeSidebarItem: true,
+      }) as SectionContract
+  ),
+] as const satisfies readonly SectionContract[]
+
+export const routeCases = [
+  {
+    caseId: 'account-base',
+    pathTemplate: '/account/settings',
+    driver: platformAccount,
+    outcome: { kind: 'redirect', pathTemplate: '/account/settings/general' },
+  },
+  {
+    caseId: 'organization-base',
+    pathTemplate: '/organization/{organizationId}/settings',
+    driver: enterpriseOrganization,
+    outcome: {
+      kind: 'redirect',
+      pathTemplate: '/organization/{organizationId}/settings/members',
+    },
+  },
+  {
+    caseId: 'workspace-base',
+    pathTemplate: '/workspace/{workspaceId}/settings',
+    driver: platformWorkspace,
+    outcome: {
+      kind: 'redirect',
+      pathTemplate: '/workspace/{workspaceId}/settings/general',
+    },
+  },
+  {
+    caseId: 'account-api-keys-alias',
+    pathTemplate: '/account/settings/apikeys',
+    driver: platformAccount,
+    outcome: {
+      kind: 'render',
+      heading: 'Sim API keys',
+      description: 'Create and manage your personal Sim API keys.',
+      preserveInputUrl: true,
+    },
+  },
+  {
+    caseId: 'organization-members-alias',
+    pathTemplate: '/organization/{organizationId}/settings/organization',
+    driver: enterpriseOrganization,
+    outcome: {
+      kind: 'render',
+      heading: 'Members',
+      description: 'Manage organization members, roles, and seats.',
+      preserveInputUrl: true,
+    },
+  },
+  {
+    caseId: 'workspace-billing-alias',
+    pathTemplate: '/workspace/{workspaceId}/settings/subscription',
+    driver: platformWorkspace,
+    outcome: {
+      kind: 'render',
+      heading: 'Billing',
+      description: 'Manage your plan, pricing, and invoices.',
+      preserveInputUrl: true,
+    },
+  },
+  {
+    caseId: 'workspace-organization-alias',
+    pathTemplate: '/workspace/{workspaceId}/settings/team',
+    driver: enterpriseWorkspace,
+    outcome: {
+      kind: 'render',
+      heading: 'Organization',
+      description: "Manage your organization's members and seats.",
+      preserveInputUrl: true,
+    },
+  },
+  {
+    caseId: 'workspace-api-keys-alias',
+    pathTemplate: '/workspace/{workspaceId}/settings/api-keys',
+    driver: platformWorkspace,
+    outcome: {
+      kind: 'render',
+      heading: 'Sim API keys',
+      description: 'Create and manage API keys for the Sim API.',
+      preserveInputUrl: true,
+    },
+  },
+  {
+    caseId: 'workspace-integrations-redirect',
+    pathTemplate: '/workspace/{workspaceId}/settings/integrations',
+    driver: platformWorkspace,
+    outcome: {
+      kind: 'redirect',
+      pathTemplate: '/workspace/{workspaceId}/integrations',
+      successfulResponse: {
+        path: '/api/credentials',
+        expectedJson: { credentials: [] },
+      },
+      readiness: { kind: 'textbox', name: 'Search integrations...' },
+    },
+  },
+  {
+    caseId: 'workspace-skills-redirect',
+    pathTemplate: '/workspace/{workspaceId}/settings/skills',
+    driver: platformWorkspace,
+    outcome: {
+      kind: 'redirect',
+      pathTemplate: '/workspace/{workspaceId}/skills',
+      successfulResponse: {
+        path: '/api/skills',
+      },
+      readiness: { kind: 'text', value: 'connect-integration' },
+    },
+  },
+  {
+    caseId: 'account-credit-usage',
+    pathTemplate: '/account/settings/billing/credit-usage',
+    driver: platformAccount,
+    outcome: {
+      kind: 'render',
+      heading: 'Credit usage',
+      description: 'Every credit-consuming event behind your usage.',
+      preserveInputUrl: true,
+      successfulResponse: { path: '/api/users/me/usage-logs' },
+      readiness: { kind: 'text', value: 'No credit usage in this period.' },
+    },
+  },
+  {
+    caseId: 'workspace-credit-usage',
+    pathTemplate: '/workspace/{workspaceId}/settings/billing/credit-usage',
+    driver: platformWorkspace,
+    outcome: {
+      kind: 'render',
+      heading: 'Credit usage',
+      description: 'Every credit-consuming event behind your usage.',
+      preserveInputUrl: true,
+      successfulResponse: { path: '/api/users/me/usage-logs' },
+      readiness: { kind: 'text', value: 'No credit usage in this period.' },
+    },
+  },
+  {
+    caseId: 'organization-non-member-layout-unavailable',
+    pathTemplate: '/organization/{organizationId}/settings/members',
+    driver: foreignEnterpriseOrganization,
+    outcome: {
+      kind: 'organization-unavailable',
+      presentation: 'layout',
+      title: 'Settings unavailable',
+    },
+  },
+  {
+    caseId: 'organization-member-section-unavailable',
+    pathTemplate: '/organization/{organizationId}/settings/billing',
+    driver: teamOrganizationMember,
+    outcome: {
+      kind: 'organization-unavailable',
+      presentation: 'embedded',
+      title: 'Settings unavailable',
+    },
+  },
+  {
+    caseId: 'organization-explicit-unavailable',
+    pathTemplate: '/organization/{organizationId}/settings/unavailable',
+    driver: teamOrganizationMember,
+    outcome: {
+      kind: 'organization-unavailable',
+      presentation: 'embedded',
+      title: 'Settings unavailable',
+    },
+  },
+  {
+    caseId: 'unauthenticated-account',
+    pathTemplate: '/account/settings/general',
+    driver: 'unauthenticated',
+    outcome: { kind: 'login-redirect' },
+  },
+  {
+    caseId: 'unauthenticated-organization',
+    pathTemplate: '/organization/unauthenticated-organization/settings/members',
+    driver: 'unauthenticated',
+    outcome: { kind: 'login-redirect' },
+  },
+  {
+    caseId: 'unauthenticated-workspace',
+    pathTemplate: '/workspace/unauthenticated-workspace/settings/general',
+    driver: 'unauthenticated',
+    outcome: { kind: 'login-redirect' },
+  },
+  ...(['account', 'organization', 'workspace'] as const).map((plane) => {
+    const driver =
+      plane === 'account'
+        ? platformAccount
+        : plane === 'organization'
+          ? teamOrganizationMember
+          : platformWorkspace
+    const pathTemplate =
+      plane === 'account'
+        ? '/account/settings/not-a-section'
+        : plane === 'organization'
+          ? '/organization/{organizationId}/settings/not-a-section'
+          : '/workspace/{workspaceId}/settings/not-a-section'
+    return {
+      caseId: `${plane}-unknown-section`,
+      pathTemplate,
+      driver,
+      outcome: { kind: 'not-found' },
+    } satisfies RouteCase
+  }),
+] as const satisfies readonly RouteCase[]
+
+export const personaVisibilityCases = [
+  {
+    caseId: 'account-personal-paid-owner',
+    plane: 'account',
+    driver: { personaKey: 'personalPaidOwner' },
+    expectedVisibleSectionIds: ['general', 'billing', 'api-keys', 'copilot'],
+    expectedVisibleLabels: ['General', 'Billing', 'Sim API keys', 'Chat keys'],
+    importantHiddenSectionIds: ['admin', 'mothership'],
+    importantHiddenLabels: ['Admin', 'Mothership'],
+    representativeSectionId: 'api-keys',
+    representativeLabel: 'Sim API keys',
+  },
+  {
+    caseId: 'account-platform-admin',
+    plane: 'account',
+    driver: platformAccount,
+    expectedVisibleSectionIds: ['general', 'billing', 'api-keys', 'copilot', 'admin', 'mothership'],
+    expectedVisibleLabels: [
+      'General',
+      'Billing',
+      'Sim API keys',
+      'Chat keys',
+      'Admin',
+      'Mothership',
+    ],
+    importantHiddenSectionIds: [],
+    importantHiddenLabels: [],
+    representativeSectionId: 'api-keys',
+    representativeLabel: 'Sim API keys',
+  },
+  {
+    caseId: 'organization-enterprise-admin',
+    plane: 'organization',
+    driver: enterpriseOrganization,
+    expectedVisibleSectionIds: [
+      'members',
+      'billing',
+      'access-control',
+      'audit-logs',
+      'sso',
+      'data-retention',
+      'data-drains',
+      'whitelabeling',
+    ],
+    expectedVisibleLabels: [
+      'Members',
+      'Billing',
+      'Access control',
+      'Audit logs',
+      'Single sign-on',
+      'Data retention',
+      'Data drains',
+      'Whitelabeling',
+    ],
+    importantHiddenSectionIds: [],
+    importantHiddenLabels: [],
+    representativeSectionId: 'access-control',
+    representativeLabel: 'Access control',
+  },
+  {
+    caseId: 'organization-free-owner',
+    plane: 'organization',
+    driver: lapsedOrganization,
+    expectedVisibleSectionIds: ['members', 'billing'],
+    expectedVisibleLabels: ['Members', 'Billing'],
+    importantHiddenSectionIds: ['access-control', 'audit-logs', 'sso', 'data-retention'],
+    importantHiddenLabels: ['Access control', 'Audit logs', 'Single sign-on', 'Data retention'],
+    representativeSectionId: 'members',
+    representativeLabel: 'Members',
+  },
+  {
+    caseId: 'organization-read-member',
+    plane: 'organization',
+    driver: teamOrganizationMember,
+    expectedVisibleSectionIds: ['members'],
+    expectedVisibleLabels: ['Members'],
+    importantHiddenSectionIds: ['billing', 'access-control', 'audit-logs'],
+    importantHiddenLabels: ['Billing', 'Access control', 'Audit logs'],
+    representativeSectionId: 'members',
+    representativeLabel: 'Members',
+  },
+  {
+    caseId: 'workspace-personal-paid-owner',
+    plane: 'workspace',
+    driver: primaryWorkspace('personalPaidOwner', 'personal-paid-workspace'),
+    expectedVisibleSectionIds: [
+      'general',
+      'secrets',
+      'custom-tools',
+      'mcp',
+      'billing',
+      'teammates',
+      'apikeys',
+      'workflow-mcp-servers',
+      'byok',
+      'copilot',
+      'inbox',
+      'recently-deleted',
+    ],
+    expectedVisibleLabels: [
+      'General',
+      'Secrets',
+      'Custom tools',
+      'MCP tools',
+      'Billing',
+      'Teammates',
+      'Sim API keys',
+      'MCP servers',
+      'BYOK',
+      'Chat keys',
+      'Sim mailer',
+      'Recently deleted',
+    ],
+    importantHiddenSectionIds: ['organization', 'access-control', 'admin'],
+    importantHiddenLabels: ['Organization', 'Access control', 'Admin'],
+    representativeSectionId: 'secrets',
+    representativeLabel: 'Secrets',
+  },
+  {
+    caseId: 'workspace-enterprise-admin',
+    plane: 'workspace',
+    driver: enterpriseWorkspace,
+    expectedVisibleSectionIds: [
+      'general',
+      'secrets',
+      'custom-tools',
+      'mcp',
+      'billing',
+      'teammates',
+      'organization',
+      'apikeys',
+      'workflow-mcp-servers',
+      'byok',
+      'copilot',
+      'inbox',
+      'recently-deleted',
+      'access-control',
+      'audit-logs',
+      'forks',
+      'sso',
+      'data-retention',
+      'data-drains',
+      'whitelabeling',
+      'custom-blocks',
+    ],
+    expectedVisibleLabels: [
+      'General',
+      'Secrets',
+      'Custom tools',
+      'MCP tools',
+      'Billing',
+      'Teammates',
+      'Organization',
+      'Sim API keys',
+      'MCP servers',
+      'BYOK',
+      'Chat keys',
+      'Sim mailer',
+      'Recently deleted',
+      'Access control',
+      'Audit logs',
+      'Workspace Forks',
+      'Single sign-on',
+      'Data retention',
+      'Data drains',
+      'Whitelabeling',
+      'Custom blocks',
+    ],
+    importantHiddenSectionIds: ['admin', 'mothership'],
+    importantHiddenLabels: ['Admin', 'Mothership'],
+    representativeSectionId: 'access-control',
+    representativeLabel: 'Access control',
+  },
+  {
+    caseId: 'workspace-free-organization-owner',
+    plane: 'workspace',
+    driver: primaryWorkspace('freeOrganizationOwner', 'lapsed-organization-workspace'),
+    expectedVisibleSectionIds: [
+      'general',
+      'secrets',
+      'custom-tools',
+      'mcp',
+      'billing',
+      'teammates',
+      'apikeys',
+      'workflow-mcp-servers',
+      'byok',
+      'copilot',
+      'inbox',
+      'recently-deleted',
+    ],
+    expectedVisibleLabels: [
+      'General',
+      'Secrets',
+      'Custom tools',
+      'MCP tools',
+      'Billing',
+      'Teammates',
+      'Sim API keys',
+      'MCP servers',
+      'BYOK',
+      'Chat keys',
+      'Sim mailer',
+      'Recently deleted',
+    ],
+    importantHiddenSectionIds: ['organization', 'access-control', 'admin'],
+    importantHiddenLabels: ['Organization', 'Access control', 'Admin'],
+    representativeSectionId: 'secrets',
+    representativeLabel: 'Secrets',
+  },
+  {
+    caseId: 'workspace-read-member',
+    plane: 'workspace',
+    driver: primaryWorkspace('workspaceReadMember', 'team-workspace'),
+    expectedVisibleSectionIds: [
+      'general',
+      'secrets',
+      'custom-tools',
+      'mcp',
+      'teammates',
+      'apikeys',
+      'workflow-mcp-servers',
+      'byok',
+      'copilot',
+      'inbox',
+      'recently-deleted',
+    ],
+    expectedVisibleLabels: [
+      'General',
+      'Secrets',
+      'Custom tools',
+      'MCP tools',
+      'Teammates',
+      'Sim API keys',
+      'MCP servers',
+      'BYOK',
+      'Chat keys',
+      'Sim mailer',
+      'Recently deleted',
+    ],
+    importantHiddenSectionIds: ['billing', 'organization', 'access-control', 'forks'],
+    importantHiddenLabels: ['Billing', 'Organization', 'Access control', 'Workspace Forks'],
+    representativeSectionId: 'secrets',
+    representativeLabel: 'Secrets',
+  },
+  {
+    caseId: 'workspace-permission-group-restricted',
+    plane: 'workspace',
+    driver: primaryWorkspace('permissionGroupRestricted', 'enterprise-workspace'),
+    expectedVisibleSectionIds: [
+      'general',
+      'teammates',
+      'workflow-mcp-servers',
+      'byok',
+      'copilot',
+      'recently-deleted',
+      'custom-blocks',
+    ],
+    expectedVisibleLabels: [
+      'General',
+      'Teammates',
+      'MCP servers',
+      'BYOK',
+      'Chat keys',
+      'Recently deleted',
+      'Custom blocks',
+    ],
+    importantHiddenSectionIds: ['secrets', 'custom-tools', 'mcp', 'apikeys', 'inbox'],
+    importantHiddenLabels: ['Secrets', 'Custom tools', 'MCP tools', 'Sim API keys', 'Sim mailer'],
+    representativeSectionId: 'teammates',
+    representativeLabel: 'Teammates',
+  },
+  {
+    caseId: 'workspace-platform-admin',
+    plane: 'workspace',
+    driver: platformWorkspace,
+    expectedVisibleSectionIds: [
+      'general',
+      'secrets',
+      'custom-tools',
+      'mcp',
+      'billing',
+      'teammates',
+      'apikeys',
+      'workflow-mcp-servers',
+      'byok',
+      'copilot',
+      'inbox',
+      'recently-deleted',
+      'admin',
+      'mothership',
+    ],
+    expectedVisibleLabels: [
+      'General',
+      'Secrets',
+      'Custom tools',
+      'MCP tools',
+      'Billing',
+      'Teammates',
+      'Sim API keys',
+      'MCP servers',
+      'BYOK',
+      'Chat keys',
+      'Sim mailer',
+      'Recently deleted',
+      'Admin',
+      'Mothership',
+    ],
+    importantHiddenSectionIds: ['organization', 'access-control', 'custom-blocks'],
+    importantHiddenLabels: ['Organization', 'Access control', 'Custom blocks'],
+    representativeSectionId: 'admin',
+    representativeLabel: 'Admin',
+  },
+] as const satisfies readonly PersonaVisibilityCase[]

--- a/apps/sim/e2e/settings/navigation/history.spec.ts
+++ b/apps/sim/e2e/settings/navigation/history.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test } from '../../fixtures/persona-test'
+import { absoluteE2eUrl, resolveBoundResourceId } from './contract-resolver'
+
+const PLATFORM_WORKSPACE_BINDING = {
+  worldKey: 'settings-primary',
+  resourceKind: 'workspace',
+  resourceKey: 'platform-admin-workspace',
+} as const
+
+test('workspace section replacement keeps browser Back pointed at the pre-settings page', async ({
+  contextForPersona,
+  personaManifest,
+}) => {
+  const context = await contextForPersona('platformAdmin')
+  const page = await context.newPage()
+  const workspaceId = resolveBoundResourceId(personaManifest, PLATFORM_WORKSPACE_BINDING)
+  const homePath = `/workspace/${encodeURIComponent(workspaceId)}/home`
+
+  await page.goto(absoluteE2eUrl(`${homePath}?from=navigation-history`))
+  await page.getByRole('link', { name: 'Settings', exact: true }).click()
+  await expect(page).toHaveURL(
+    absoluteE2eUrl(`/workspace/${encodeURIComponent(workspaceId)}/settings/general`)
+  )
+  await expect
+    .poll(() => page.evaluate(() => sessionStorage.getItem('settings-return-url')))
+    .toBe(homePath)
+
+  await page.getByRole('button', { name: 'Secrets', exact: true }).click()
+  await expect(page).toHaveURL(
+    absoluteE2eUrl(`/workspace/${encodeURIComponent(workspaceId)}/settings/secrets`)
+  )
+  await page.getByRole('button', { name: 'Sim API keys', exact: true }).click()
+  await expect(page).toHaveURL(
+    absoluteE2eUrl(`/workspace/${encodeURIComponent(workspaceId)}/settings/apikeys`)
+  )
+
+  await page.goBack()
+  await expect(page).toHaveURL(absoluteE2eUrl(`${homePath}?from=navigation-history`))
+})
+
+test('workspace app Back consumes the pathname-only return target', async ({
+  contextForPersona,
+  personaManifest,
+}) => {
+  const context = await contextForPersona('platformAdmin')
+  const page = await context.newPage()
+  const workspaceId = resolveBoundResourceId(personaManifest, PLATFORM_WORKSPACE_BINDING)
+  const homePath = `/workspace/${encodeURIComponent(workspaceId)}/home`
+
+  await page.goto(absoluteE2eUrl(`${homePath}?ignored=query`))
+  await page.getByRole('link', { name: 'Settings', exact: true }).click()
+  await page.getByRole('button', { name: 'Secrets', exact: true }).click()
+  await page.getByRole('button', { name: 'Back', exact: true }).click()
+
+  await expect(page).toHaveURL(absoluteE2eUrl(homePath))
+  await expect
+    .poll(() => page.evaluate(() => sessionStorage.getItem('settings-return-url')))
+    .toBeNull()
+})
+
+test('direct workspace settings entry falls back to workspace home', async ({
+  contextForPersona,
+  personaManifest,
+}) => {
+  const context = await contextForPersona('platformAdmin')
+  const page = await context.newPage()
+  const workspaceId = resolveBoundResourceId(personaManifest, PLATFORM_WORKSPACE_BINDING)
+  const workspacePrefix = `/workspace/${encodeURIComponent(workspaceId)}`
+
+  await page.goto(absoluteE2eUrl(`${workspacePrefix}/settings/general`))
+  await page.getByRole('button', { name: 'Back', exact: true }).click()
+
+  await expect(page).toHaveURL(absoluteE2eUrl(`${workspacePrefix}/home`))
+})
+
+for (const standaloneCase of [
+  {
+    name: 'account',
+    personaKey: 'platformAdmin',
+    entryPath: '/account/settings/general',
+    binding: PLATFORM_WORKSPACE_BINDING,
+  },
+  {
+    name: 'organization',
+    personaKey: 'enterpriseOrganizationAdmin',
+    entryPath: '/organization/{organizationId}/settings/members',
+    binding: {
+      worldKey: 'settings-primary',
+      resourceKind: 'workspace',
+      resourceKey: 'enterprise-workspace',
+    } as const,
+    organizationBinding: {
+      worldKey: 'settings-primary',
+      resourceKind: 'organization',
+      resourceKey: 'enterprise-organization',
+    } as const,
+  },
+] as const) {
+  test(`${standaloneCase.name} Back reaches the resolved workspace destination`, async ({
+    contextForPersona,
+    personaManifest,
+  }) => {
+    const context = await contextForPersona(standaloneCase.personaKey)
+    const page = await context.newPage()
+    const workspaceId = resolveBoundResourceId(personaManifest, standaloneCase.binding)
+    let entryPath: string = standaloneCase.entryPath
+    if ('organizationBinding' in standaloneCase && standaloneCase.organizationBinding) {
+      entryPath = entryPath.replace(
+        '{organizationId}',
+        encodeURIComponent(
+          resolveBoundResourceId(personaManifest, standaloneCase.organizationBinding)
+        )
+      )
+    }
+
+    await page.goto(absoluteE2eUrl(entryPath))
+    const expectedUrl = absoluteE2eUrl(`/workspace/${encodeURIComponent(workspaceId)}/home`)
+    const backButton = page.getByRole('button', { name: 'Back', exact: true })
+    await backButton.click()
+    await expect(page).toHaveURL(expectedUrl)
+  })
+}

--- a/apps/sim/e2e/settings/navigation/persona-visibility.spec.ts
+++ b/apps/sim/e2e/settings/navigation/persona-visibility.spec.ts
@@ -1,0 +1,124 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from '../../fixtures/persona-test'
+import { absoluteE2eUrl, resolveBoundResourceId, resolveContractPath } from './contract-resolver'
+import { type PersonaVisibilityCase, personaVisibilityCases } from './contracts'
+
+for (const visibilityCase of personaVisibilityCases) {
+  test(`${visibilityCase.caseId} exposes its complete sidebar set`, async ({
+    contextForPersona,
+    personaManifest,
+  }) => {
+    const context = await contextForPersona(visibilityCase.driver.personaKey)
+    const page = await context.newPage()
+    const initialPath = initialVisibilityPath(visibilityCase, personaManifest)
+
+    if (visibilityCase.plane === 'workspace') {
+      const workspaceId = resolveBoundResourceId(personaManifest, requiredBinding(visibilityCase))
+      const gateResponses = [
+        waitForSuccessfulPath(page, '/api/permission-groups/user'),
+        waitForSuccessfulPath(page, '/api/settings/allowed-integrations'),
+        waitForSuccessfulPath(page, `/api/workspaces/${encodeURIComponent(workspaceId)}/inbox`),
+        waitForSuccessfulPath(
+          page,
+          `/api/workspaces/${encodeURIComponent(workspaceId)}/fork/availability`
+        ),
+      ]
+      await Promise.all([page.goto(absoluteE2eUrl(initialPath)), ...gateResponses])
+    } else {
+      await page.goto(absoluteE2eUrl(initialPath))
+    }
+
+    const sidebar = page.getByRole('complementary', {
+      name:
+        visibilityCase.plane === 'account'
+          ? 'Account settings navigation'
+          : visibilityCase.plane === 'organization'
+            ? 'Organization settings navigation'
+            : 'Workspace sidebar',
+    })
+    await expect(sidebar).toBeVisible()
+    const sectionNavigation =
+      visibilityCase.plane === 'workspace'
+        ? sidebar.getByRole('navigation', { name: 'Workspace settings sections' })
+        : sidebar
+    await expect(sectionNavigation).toBeVisible()
+    await expect
+      .poll(
+        async () => {
+          const buttons = await sectionNavigation.getByRole('button').all()
+          const labels = await Promise.all(
+            buttons.map((button) => button.getAttribute('aria-label'))
+          )
+          return labels.filter((label): label is string => label !== null)
+        },
+        { message: `${visibilityCase.caseId} visible sidebar order` }
+      )
+      .toEqual([...visibilityCase.expectedVisibleLabels])
+
+    for (const hiddenLabel of visibilityCase.importantHiddenLabels) {
+      await expect(sidebar.getByRole('button', { name: hiddenLabel, exact: true })).toHaveCount(0)
+    }
+
+    const representative = sidebar.getByRole('button', {
+      name: visibilityCase.representativeLabel,
+      exact: true,
+    })
+    await expect(representative).toBeVisible()
+    const expectedUrl = absoluteE2eUrl(representativePath(visibilityCase, personaManifest))
+    if (page.url() !== expectedUrl) await representative.click()
+    await expect(page).toHaveURL(expectedUrl)
+  })
+}
+
+function waitForSuccessfulPath(page: Page, pathname: string) {
+  return page.waitForResponse((response) => {
+    const url = new URL(response.url())
+    return url.pathname === pathname && response.status() === 200
+  })
+}
+
+function initialVisibilityPath(
+  visibilityCase: PersonaVisibilityCase,
+  manifest: Parameters<typeof resolveContractPath>[0]
+): string {
+  if (visibilityCase.plane === 'account') return '/account/settings/general'
+  if (visibilityCase.plane === 'organization') {
+    return resolveContractPath(
+      manifest,
+      '/organization/{organizationId}/settings/members',
+      visibilityCase.driver
+    )
+  }
+  return resolveContractPath(
+    manifest,
+    '/workspace/{workspaceId}/settings/general',
+    visibilityCase.driver
+  )
+}
+
+function representativePath(
+  visibilityCase: PersonaVisibilityCase,
+  manifest: Parameters<typeof resolveContractPath>[0]
+): string {
+  if (visibilityCase.plane === 'account') {
+    return `/account/settings/${visibilityCase.representativeSectionId}`
+  }
+  if (visibilityCase.plane === 'organization') {
+    return resolveContractPath(
+      manifest,
+      `/organization/{organizationId}/settings/${visibilityCase.representativeSectionId}`,
+      visibilityCase.driver
+    )
+  }
+  return resolveContractPath(
+    manifest,
+    `/workspace/{workspaceId}/settings/${visibilityCase.representativeSectionId}`,
+    visibilityCase.driver
+  )
+}
+
+function requiredBinding(visibilityCase: PersonaVisibilityCase) {
+  const binding = visibilityCase.driver.binding
+  if (!binding) throw new Error(`${visibilityCase.caseId} requires a dynamic resource binding`)
+  return binding
+}

--- a/apps/sim/e2e/settings/navigation/route-cases.spec.ts
+++ b/apps/sim/e2e/settings/navigation/route-cases.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '../../fixtures/persona-test'
+import { absoluteE2eUrl, readinessLocator, resolveContractPath } from './contract-resolver'
+import { type RouteOutcome, routeCases } from './contracts'
+
+for (const routeCase of routeCases.filter((candidate) => candidate.driver !== 'unauthenticated')) {
+  test(`${routeCase.caseId} matches its route outcome`, async ({
+    contextForPersona,
+    personaManifest,
+  }) => {
+    const context = await contextForPersona(routeCase.driver.personaKey)
+    const page = await context.newPage()
+    const inputPath = resolveContractPath(personaManifest, routeCase.pathTemplate, routeCase.driver)
+    const outcome: RouteOutcome = routeCase.outcome
+    const responseExpectation =
+      outcome.kind === 'render' || outcome.kind === 'redirect'
+        ? outcome.successfulResponse
+        : undefined
+    const successfulResponse = responseExpectation
+      ? page.waitForResponse((candidate) => {
+          const url = new URL(candidate.url())
+          return url.pathname === responseExpectation.path && candidate.status() === 200
+        })
+      : null
+    const response = await page.goto(absoluteE2eUrl(inputPath))
+    if (successfulResponse) {
+      const apiResponse = await successfulResponse
+      if (responseExpectation?.expectedJson !== undefined) {
+        await expect(apiResponse.json()).resolves.toEqual(responseExpectation.expectedJson)
+      }
+    }
+
+    switch (outcome.kind) {
+      case 'render':
+        await expect(page).toHaveURL(absoluteE2eUrl(inputPath))
+        await expect(
+          page.getByRole('heading', {
+            name: outcome.heading,
+            level: 1,
+            exact: true,
+          })
+        ).toBeVisible()
+        await expect(page.getByText(outcome.description, { exact: true })).toBeVisible()
+        if (outcome.readiness) {
+          await expect(readinessLocator(page, outcome.readiness)).toBeVisible()
+        }
+        break
+      case 'redirect': {
+        const expectedPath = resolveContractPath(
+          personaManifest,
+          outcome.pathTemplate,
+          routeCase.driver
+        )
+        await expect(page).toHaveURL(absoluteE2eUrl(expectedPath))
+        expect(response?.ok(), `${routeCase.caseId} redirect destination response`).toBe(true)
+        if (outcome.readiness) {
+          const destinationReadiness = readinessLocator(page, outcome.readiness)
+          await expect(destinationReadiness).toBeVisible()
+          await expect(destinationReadiness).toBeEnabled()
+        }
+        break
+      }
+      case 'not-found':
+        expect(response?.status(), `${routeCase.caseId} must use the real 404 boundary`).toBe(404)
+        break
+      case 'organization-unavailable':
+        await expect(
+          page.getByRole('heading', {
+            name: outcome.title,
+            level: 1,
+            exact: true,
+          })
+        ).toBeVisible()
+        await expect(page).toHaveURL(absoluteE2eUrl(inputPath))
+        await expect(
+          page.getByRole('complementary', { name: 'Organization settings navigation' })
+        ).toHaveCount(outcome.presentation === 'embedded' ? 1 : 0)
+        break
+    }
+  })
+}

--- a/apps/sim/e2e/settings/smoke/unauthenticated.spec.ts
+++ b/apps/sim/e2e/settings/smoke/unauthenticated.spec.ts
@@ -1,8 +1,14 @@
 import { expect, test } from '../../fixtures/browser-test'
+import { routeCases } from '../navigation/contracts'
 
-test('protected settings redirect unauthenticated users to login', async ({ page }) => {
-  await page.goto('/account/settings/general')
+for (const routeCase of routeCases.filter((candidate) => candidate.driver === 'unauthenticated')) {
+  test(`${routeCase.caseId} redirects to login without return state`, async ({ page }) => {
+    await page.goto(routeCase.pathTemplate)
 
-  await expect(page).toHaveURL(/\/login(?:\?|$)/)
-  await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible()
-})
+    await expect(page).toHaveURL(/\/login(?:\?|$)/)
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible()
+    await expect
+      .poll(() => page.evaluate(() => sessionStorage.getItem('settings-return-url')))
+      .toBeNull()
+  })
+}

--- a/apps/sim/ee/custom-blocks/components/custom-blocks.tsx
+++ b/apps/sim/ee/custom-blocks/components/custom-blocks.tsx
@@ -53,9 +53,11 @@ export function CustomBlocks() {
 
   if (!canManage) {
     return (
-      <SettingsEmptyState>
-        Custom blocks require an Enterprise plan. Contact your admin to enable them.
-      </SettingsEmptyState>
+      <SettingsPanel>
+        <SettingsEmptyState>
+          Custom blocks require an Enterprise plan. Contact your admin to enable them.
+        </SettingsEmptyState>
+      </SettingsPanel>
     )
   }
 

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -54,7 +54,11 @@ import {
 import { pauseProSubscriptionForOrgCoverage } from '@/lib/billing/organizations/membership'
 import { isPro, isTeam } from '@/lib/billing/plan-helpers'
 import { getPlans, resolvePlanFromStripeSubscription } from '@/lib/billing/plans'
-import { buildStripeClientConfig } from '@/lib/billing/stripe-client-config'
+import {
+  buildStripeClientConfig,
+  isGuardedE2eDatabaseUrl,
+  STRIPE_E2E_PROFILE,
+} from '@/lib/billing/stripe-client-config'
 import { syncSeatsFromStripeQuantity } from '@/lib/billing/validation/seat-management'
 import { handleAbandonedCheckout } from '@/lib/billing/webhooks/checkout'
 import { handleChargeDispute, handleDisputeClosed } from '@/lib/billing/webhooks/disputes'
@@ -192,8 +196,16 @@ if (validStripeKey) {
   stripeClient = new Stripe(validStripeKey, buildStripeClientConfig(env))
 }
 
+const usesGuardedE2eAuthRateLimit =
+  env.E2E_PROFILE === STRIPE_E2E_PROFILE &&
+  env.BETTER_AUTH_URL === 'http://e2e.sim.ai:3000' &&
+  isGuardedE2eDatabaseUrl(env.DATABASE_URL)
+
 export const auth = betterAuth({
   baseURL: getBaseUrl(),
+  // Full browser contracts intentionally exercise many isolated sessions from loopback.
+  // Keep Better Auth's limiter enabled while raising only the hermetic profile's ceiling.
+  ...(usesGuardedE2eAuthRateLimit ? { rateLimit: { max: 10_000 } } : {}),
   trustedOrigins: [
     getBaseUrl(),
     ...(env.NEXT_PUBLIC_SOCKET_URL ? [env.NEXT_PUBLIC_SOCKET_URL] : []),

--- a/apps/sim/lib/billing/stripe-client-config.test.ts
+++ b/apps/sim/lib/billing/stripe-client-config.test.ts
@@ -19,6 +19,9 @@ const guardedEnvironment: StripeClientConfigEnvironment = {
 describe('isGuardedE2eDatabaseUrl', () => {
   it('accepts only loopback sim_e2e databases', () => {
     expect(isGuardedE2eDatabaseUrl(guardedEnvironment.DATABASE_URL)).toBe(true)
+    expect(isGuardedE2eDatabaseUrl('postgresql://sim:sim@[::1]:5432/sim_e2e_config_test')).toBe(
+      true
+    )
     expect(isGuardedE2eDatabaseUrl('postgresql://db.example.com/sim_e2e_config_test')).toBe(false)
     expect(isGuardedE2eDatabaseUrl('postgresql://127.0.0.1/sim')).toBe(false)
   })

--- a/apps/sim/lib/billing/stripe-client-config.test.ts
+++ b/apps/sim/lib/billing/stripe-client-config.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildStripeClientConfig,
+  isGuardedE2eDatabaseUrl,
   STRIPE_API_VERSION,
   STRIPE_E2E_PROFILE,
   type StripeClientConfigEnvironment,
@@ -14,6 +15,14 @@ const guardedEnvironment: StripeClientConfigEnvironment = {
   STRIPE_API_BASE_URL: 'http://127.0.0.1:12111',
   STRIPE_SECRET_KEY: 'sk_test_e2e_config',
 }
+
+describe('isGuardedE2eDatabaseUrl', () => {
+  it('accepts only loopback sim_e2e databases', () => {
+    expect(isGuardedE2eDatabaseUrl(guardedEnvironment.DATABASE_URL)).toBe(true)
+    expect(isGuardedE2eDatabaseUrl('postgresql://db.example.com/sim_e2e_config_test')).toBe(false)
+    expect(isGuardedE2eDatabaseUrl('postgresql://127.0.0.1/sim')).toBe(false)
+  })
+})
 
 describe('buildStripeClientConfig', () => {
   it('preserves the normal Stripe configuration without an override', () => {

--- a/apps/sim/lib/billing/stripe-client-config.ts
+++ b/apps/sim/lib/billing/stripe-client-config.ts
@@ -52,7 +52,7 @@ export function isGuardedE2eDatabaseUrl(databaseUrl: string | undefined): boolea
 
 function isLoopbackHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase()
-  if (normalized === 'localhost') return true
+  if (normalized === 'localhost' || normalized === '::1' || normalized === '[::1]') return true
 
   const octets = normalized.split('.')
   return (

--- a/apps/sim/lib/billing/stripe-client-config.ts
+++ b/apps/sim/lib/billing/stripe-client-config.ts
@@ -41,6 +41,15 @@ function hasLoopbackDatabaseHostname(databaseUrl: string | undefined): boolean {
   }
 }
 
+export function isGuardedE2eDatabaseUrl(databaseUrl: string | undefined): boolean {
+  const databaseName = getDatabaseName(databaseUrl)
+  return (
+    databaseName !== null &&
+    E2E_DATABASE_NAME_PATTERN.test(databaseName) &&
+    hasLoopbackDatabaseHostname(databaseUrl)
+  )
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase()
   if (normalized === 'localhost') return true

--- a/apps/sim/playwright.config.ts
+++ b/apps/sim/playwright.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
         '**/settings/smoke/unauthenticated.spec.ts',
         '**/settings/navigation/**/*.spec.ts',
       ],
-      workers: 1,
+      workers: 2,
     },
     {
       name: 'hosted-billing-chromium-workflows',


### PR DESCRIPTION
## Summary
- add independent canonical-section, special-route, and persona-visibility contracts for account, organization, and unified workspace settings
- cover sidebar navigation, aliases, redirects, 404/unavailable states, credit usage, complete representative visibility, and browser/app Back behavior
- add semantic active-state and hydration-safe settings controls, strict API readiness checks, and two-worker navigation execution
- guard the E2E-only Better Auth request ceiling behind the exact profile, origin, and loopback `sim_e2e_*` database invariants

## Verification
- `bun run type-check`
- targeted Biome checks for all changed files
- affected Vitest suites: 28 tests passed
- complete retry-free E2E dependency chain: 139 tests passed in 1.3m Playwright time
- two independent Claude/GPT review rounds completed with no remaining actionable findings