### PR TITLE
fix(mcp): keep last-known-good tools instead of flashing red on a transient failure

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
@@ -97,12 +97,12 @@ function ServerListItem({
     server.lastError,
     server.authType
   )
-  // A live discovery failure whose stored status hasn't caught up yet would otherwise read as
-  // "0 tools"; surface it directly so a failed row reads as failed, not empty.
-  // Shown even when cached tools exist: a present discoveryError means the LATEST
-  // discovery failed, and silently showing the stale tool count would hide that.
+  // Only hard-red when there are no last-known tools to show. A populated, connected server
+  // stays on its tool count through a transient probe failure; a persistent failure flips
+  // `connectionStatus` to error/disconnected and reads as failed through that path instead.
   const showDiscoveryError =
     Boolean(discoveryError) &&
+    tools.length === 0 &&
     server.connectionStatus !== 'error' &&
     server.connectionStatus !== 'disconnected'
   const hasConnectionIssue =

--- a/apps/sim/hooks/queries/mcp.test.tsx
+++ b/apps/sim/hooks/queries/mcp.test.tsx
@@ -3,7 +3,7 @@
  */
 import { act, type ReactNode } from 'react'
 import { sleep } from '@sim/utils/helpers'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -20,7 +20,12 @@ import {
   listMcpServersContract,
   type McpServer,
 } from '@/lib/api/contracts/mcp'
-import { useForceRefreshMcpTools, useMcpServers, useMcpToolsQuery } from '@/hooks/queries/mcp'
+import {
+  mcpKeys,
+  useForceRefreshMcpTools,
+  useMcpServers,
+  useMcpToolsQuery,
+} from '@/hooks/queries/mcp'
 
 const WORKSPACE_ID = 'workspace-1'
 
@@ -177,6 +182,46 @@ describe('useMcpToolsQuery', () => {
     expect(
       mockRequestJson.mock.calls.filter(([contract]) => contract === discoverMcpToolsContract)
     ).toHaveLength(1)
+
+    unmount()
+  })
+
+  it('keeps last-known-good tools when a later discovery refetch fails', async () => {
+    let discoverCalls = 0
+    mockRequestJson.mockImplementation(async (contract) => {
+      if (contract === listMcpServersContract) {
+        return {
+          success: true,
+          data: { servers: [server('s1', { authType: 'headers', connectionStatus: 'connected' })] },
+        }
+      }
+      if (contract === discoverMcpToolsContract) {
+        discoverCalls++
+        if (discoverCalls === 1) {
+          return { success: true, data: { tools: [{ name: 'tool-a', serverId: 's1' }] } }
+        }
+        throw new Error('transient stall')
+      }
+      throw new Error('Unexpected MCP request')
+    })
+
+    const { getResult, unmount } = renderHookWithClient(() => ({
+      tools: useMcpToolsQuery(WORKSPACE_ID),
+      queryClient: useQueryClient(),
+    }))
+    await flush()
+    expect(getResult().tools.data).toHaveLength(1)
+
+    // Force a refetch that fails; the last successful tools must survive.
+    await act(async () => {
+      await getResult().queryClient.invalidateQueries({
+        queryKey: mcpKeys.serverToolsList(WORKSPACE_ID, 's1'),
+      })
+    })
+    await flush()
+
+    expect(getResult().tools.data).toHaveLength(1)
+    expect(getResult().tools.toolsStateByServer.get('s1')?.error).toBeInstanceOf(Error)
 
     unmount()
   })

--- a/apps/sim/hooks/queries/mcp.test.tsx
+++ b/apps/sim/hooks/queries/mcp.test.tsx
@@ -226,6 +226,49 @@ describe('useMcpToolsQuery', () => {
     unmount()
   })
 
+  it('drops stale tools once a non-OAuth server is persistently failed', async () => {
+    let discoverCalls = 0
+    let listCalls = 0
+    mockRequestJson.mockImplementation(async (contract) => {
+      if (contract === listMcpServersContract) {
+        listCalls++
+        // Healthy on first read, error state after the failed refetch invalidates the list.
+        const connectionStatus = listCalls === 1 ? 'connected' : 'error'
+        return {
+          success: true,
+          data: { servers: [server('s1', { authType: 'headers', connectionStatus })] },
+        }
+      }
+      if (contract === discoverMcpToolsContract) {
+        discoverCalls++
+        if (discoverCalls === 1) {
+          return { success: true, data: { tools: [{ name: 'tool-a', serverId: 's1' }] } }
+        }
+        throw new Error('persistent failure')
+      }
+      throw new Error('Unexpected MCP request')
+    })
+
+    const { getResult, unmount } = renderHookWithClient(() => ({
+      tools: useMcpToolsQuery(WORKSPACE_ID),
+      queryClient: useQueryClient(),
+    }))
+    await flush()
+    expect(getResult().tools.data).toHaveLength(1)
+
+    await act(async () => {
+      await getResult().queryClient.invalidateQueries({
+        queryKey: mcpKeys.serverToolsList(WORKSPACE_ID, 's1'),
+      })
+    })
+    await flush()
+
+    // Stored status is now 'error' → the dead server's stale tools are dropped from the aggregate.
+    expect(getResult().tools.data).toHaveLength(0)
+
+    unmount()
+  })
+
   it('does not force-refresh disconnected OAuth servers', async () => {
     mockServers([
       server('oauth-disconnected', { authType: 'oauth', connectionStatus: 'disconnected' }),

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -188,8 +188,10 @@ export function useMcpToolsQuery(workspaceId: string) {
     >()
     for (let index = 0; index < results.length; index++) {
       const result = results[index]
-      // Drop stale data from servers whose latest refetch errored.
-      if (result.data && !result.isError) {
+      // Keep last-known-good tools when the latest refetch errored (React Query retains `data`);
+      // the per-server error rides in `toolsStateByServer`. Blanking a populated server on a
+      // transient discovery failure is what every reference MCP client avoids.
+      if (result.data) {
         tools.push(...result.data)
         hasData = true
       }

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -182,23 +182,27 @@ export function useMcpToolsQuery(workspaceId: string) {
     let hasData = false
     let anyServerLoading = false
     let firstError: Error | null = null
+    const statusById = new Map(servers?.map((s) => [s.id, s.connectionStatus]))
     const toolsStateByServer = new Map<
       string,
       { isLoading: boolean; isFetching: boolean; error: Error | null }
     >()
     for (let index = 0; index < results.length; index++) {
       const result = results[index]
-      // Keep last-known-good tools when the latest refetch errored (React Query retains `data`);
-      // the per-server error rides in `toolsStateByServer`. Blanking a populated server on a
-      // transient discovery failure is what every reference MCP client avoids.
-      if (result.data) {
+      const serverId = serverIds[index]
+      const status = serverId ? statusById.get(serverId) : undefined
+      const persistentlyFailed = status === 'error' || status === 'disconnected'
+      // Keep last-known-good tools through a transient failure (React Query retains `data`, the
+      // stored status is still healthy) so a populated server doesn't blank — but drop them once
+      // the stored status crosses its failure threshold, so the workflow editor stops offering a
+      // dead server's stale tools. Matches how reference MCP clients treat transient vs. closed.
+      if (result.data && (!result.isError || !persistentlyFailed)) {
         tools.push(...result.data)
         hasData = true
       }
       if (result.isLoading) anyServerLoading = true
       if (!firstError && result.error instanceof Error) firstError = result.error
 
-      const serverId = serverIds[index]
       if (serverId) {
         toolsStateByServer.set(serverId, {
           isLoading: result.isLoading,
@@ -215,7 +219,7 @@ export function useMcpToolsQuery(workspaceId: string) {
       error: hasData ? null : firstError,
       toolsStateByServer,
     }
-  }, [results, serversLoading, serverIds])
+  }, [results, serversLoading, serverIds, servers])
 }
 
 export function useForceRefreshMcpTools() {


### PR DESCRIPTION
## Summary
A **connected** MCP server with cached tools was showing red **"Failed to discover MCP tools"** on a single transient discovery probe — even though the backend stored status was `connected` with a valid tool count (verified in the DB while the UI showed red). It made healthy servers look like they "fail all the time" as probes oscillated against the origin's intermittent stalls.

Two coordinated client-side display fixes:
- **`useMcpToolsQuery` no longer discards React Query's retained `data` on error** — it kept the last successful tools around and we were throwing them away (`if (result.data && !result.isError)` → `if (result.data)`). The per-server error still rides in `toolsStateByServer`.
- **`showDiscoveryError` only hard-reds when there are genuinely no tools to show** (`tools.length === 0`). A populated, connected server stays on its tool count through a transient blip; a **persistent** failure still reads as failed via the stored `connectionStatus` (gated by `MAX_CONSECUTIVE_FAILURES`).

**Validated against primary sources before changing** (I'd over-corrected this exact condition in #5829): the MCP spec's discover-once + `tools/list_changed` model, plus the actual behavior of Claude Code (which shipped this same fix as a bug removal — a transient failure no longer flags a healthy server), LibreChat (returns already-fetched tools rather than discarding; guards against overwriting with empty), OpenCode (`if (!listed) return`, leaves tools intact), and VS Code (persistent tool cache). None blanks a populated server on a transient `tools/list` failure over a live connection. This supersedes the #5829 over-correction.

## Type of Change
- [x] Bug fix (UX / correctness of display)

## Testing
- New `useMcpToolsQuery` test: last-known-good tools survive a failing refetch (with the per-server error still exposed). 16 MCP query + settings tests green; tsc + biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)