### PR TITLE
fix(auth): gate email-otp auto-signup behind DISABLE_EMAIL_SIGNUP

### DIFF
--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -768,6 +768,13 @@ export const auth = betterAuth({
   },
   emailAndPassword: {
     enabled: true,
+    /**
+     * Same flag that hides the email/password signup form (DISABLE_EMAIL_SIGNUP).
+     * Blocks /sign-up/email at the better-auth layer so ripping out the frontend
+     * form cannot be bypassed by calling the endpoint directly. Existing users
+     * can still sign in.
+     */
+    disableSignUp: isEmailSignupDisabled,
     requireEmailVerification: isEmailVerificationEnabled,
     /**
      * When someone signs up with an already-registered email, better-auth returns a
@@ -890,11 +897,6 @@ export const auth = betterAuth({
             message: 'Email/password authentication is disabled. Please use SSO to sign in.',
           })
       }
-
-      if (isEmailSignupDisabled && ctx.path.startsWith('/sign-up/email'))
-        throw new APIError('FORBIDDEN', {
-          message: 'Email sign-up is disabled. Please use Google, Microsoft, or GitHub.',
-        })
 
       const isSignIn = ctx.path.startsWith('/sign-in')
       const isSignUp = ctx.path.startsWith('/sign-up')
@@ -1039,6 +1041,14 @@ export const auth = betterAuth({
           throw error
         }
       },
+      /**
+       * Without this, /sign-in/email-otp auto-registers any unknown email —
+       * bypassing the signup gate entirely (no captcha, no /sign-up path).
+       * Gated by the same DISABLE_EMAIL_SIGNUP flag as the signup form; when
+       * set, better-auth also silently skips sending OTPs to unknown emails
+       * (enumeration-safe) while existing users keep OTP sign-in.
+       */
+      disableSignUp: isEmailSignupDisabled,
       sendVerificationOnSignUp: false,
       otpLength: 6, // Explicitly set the OTP length
       expiresIn: 15 * 60, // 15 minutes in seconds

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -1044,11 +1044,13 @@ export const auth = betterAuth({
       /**
        * Without this, /sign-in/email-otp auto-registers any unknown email —
        * bypassing the signup gate entirely (no captcha, no /sign-up path).
-       * Gated by the same DISABLE_EMAIL_SIGNUP flag as the signup form; when
-       * set, better-auth also silently skips sending OTPs to unknown emails
-       * (enumeration-safe) while existing users keep OTP sign-in.
+       * Gated by the same DISABLE_EMAIL_SIGNUP flag as the signup form (and by
+       * DISABLE_REGISTRATION, whose /sign-up path check has the same blind
+       * spot); when set, better-auth also silently skips sending OTPs to
+       * unknown emails (enumeration-safe) while existing users keep OTP
+       * sign-in.
        */
-      disableSignUp: isEmailSignupDisabled,
+      disableSignUp: isEmailSignupDisabled || isRegistrationDisabled,
       sendVerificationOnSignUp: false,
       otpLength: 6, // Explicitly set the OTP length
       expiresIn: 15 * 60, // 15 minutes in seconds


### PR DESCRIPTION
## Summary
- \`DISABLE_EMAIL_SIGNUP\` only blocked the \`/sign-up/email\` path, but better-auth's email-otp plugin auto-registers any unknown email on \`/sign-in/email-otp\` — so new accounts could still be created with the flag set
- Wire the same flag into better-auth's native \`disableSignUp\` option on both \`emailAndPassword\` and the \`emailOTP\` plugin, and drop the now-redundant path-string check in the before-hook
- With \`disableSignUp\` set, the OTP plugin also skips sending sign-in codes to unknown emails (enumeration-safe) while existing users keep OTP sign-in, email/password sign-in, and the verify-email flow unchanged; social/SSO signup is unaffected

## Type of Change
- [x] Bug fix

## Testing
Verified against better-auth 1.6.13 source: unknown-email OTP sign-in rejects instead of creating a user; existing-user OTP sign-in, email/password sign-in, and email verification paths unchanged. Typecheck and lint pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)