### PR TITLE
improvement(mcp): push-driven settings freshness + lifecycle-audit fixes

### DIFF
--- a/apps/sim/app/api/mcp/oauth/callback/route.ts
+++ b/apps/sim/app/api/mcp/oauth/callback/route.ts
@@ -125,12 +125,19 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     serverId?: string
   ) => htmlClose(message, ok, reason, serverId, state)
 
-  const initialRow = state ? await loadOauthRowByState(state).catch(() => null) : null
+  const initialRow = state
+    ? await timedStep('loadOauthRowByState', 15_000, () => loadOauthRowByState(state)).catch(
+        () => null
+      )
+    : null
   const stateRowServerId = initialRow?.mcpServerId
 
   if (errorParam) {
     logger.warn(`MCP OAuth callback received error: ${errorParam}`)
-    if (initialRow) await clearState(initialRow.id, 'callback:provider_error').catch(() => {})
+    if (initialRow)
+      await timedStep('clearState(provider_error)', 10_000, () =>
+        clearState(initialRow.id, 'callback:provider_error')
+      ).catch(() => {})
     return respond(`Authorization failed: ${errorParam}`, false, 'provider_error', stateRowServerId)
   }
   if (!state || !code) {
@@ -144,7 +151,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
 
   let serverId: string | undefined
   try {
-    const session = await getSession()
+    const session = await timedStep('getSession', 15_000, () => getSession())
     if (!session?.user?.id) {
       return respond(
         'You must be signed in to complete authorization.',
@@ -169,11 +176,13 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       )
     }
 
-    const [server] = await db
-      .select({ id: mcpServers.id, url: mcpServers.url, workspaceId: mcpServers.workspaceId })
-      .from(mcpServers)
-      .where(and(eq(mcpServers.id, row.mcpServerId), isNull(mcpServers.deletedAt)))
-      .limit(1)
+    const [server] = await timedStep('loadServer', 15_000, () =>
+      db
+        .select({ id: mcpServers.id, url: mcpServers.url, workspaceId: mcpServers.workspaceId })
+        .from(mcpServers)
+        .where(and(eq(mcpServers.id, row.mcpServerId), isNull(mcpServers.deletedAt)))
+        .limit(1)
+    )
     if (!server || !server.url) {
       return respond('Server no longer exists.', false, 'server_gone', serverId)
     }

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
@@ -39,7 +39,6 @@ import {
   useDeleteMcpServer,
   useForceRefreshMcpTools,
   useMcpServers,
-  useMcpToolsEvents,
   useMcpToolsQuery,
   useRefreshMcpServer,
   useStoredMcpTools,
@@ -196,9 +195,6 @@ export function MCP() {
   } = useMcpServers(workspaceId)
   const { data: mcpToolsData = [], toolsStateByServer } = useMcpToolsQuery(workspaceId)
   const { data: storedTools = [], refetch: refetchStoredTools } = useStoredMcpTools(workspaceId)
-  // Real-time refresh via the shared list_changed → SSE push (same subscription the workflow
-  // editor uses), so tool changes reflect here without re-probing on every visit.
-  useMcpToolsEvents(workspaceId)
   const forceRefreshToolsMutation = useForceRefreshMcpTools()
   const forceRefreshTools = forceRefreshToolsMutation.mutate
   const createServerMutation = useCreateMcpServer()

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
@@ -39,6 +39,7 @@ import {
   useDeleteMcpServer,
   useForceRefreshMcpTools,
   useMcpServers,
+  useMcpToolsEvents,
   useMcpToolsQuery,
   useRefreshMcpServer,
   useStoredMcpTools,
@@ -195,6 +196,9 @@ export function MCP() {
   } = useMcpServers(workspaceId)
   const { data: mcpToolsData = [], toolsStateByServer } = useMcpToolsQuery(workspaceId)
   const { data: storedTools = [], refetch: refetchStoredTools } = useStoredMcpTools(workspaceId)
+  // Real-time refresh via the shared list_changed → SSE push (same subscription the workflow
+  // editor uses), so tool changes reflect here without re-probing on every visit.
+  useMcpToolsEvents(workspaceId)
   const forceRefreshToolsMutation = useForceRefreshMcpTools()
   const forceRefreshTools = forceRefreshToolsMutation.mutate
   const createServerMutation = useCreateMcpServer()

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -79,7 +79,6 @@ import {
   useCreateMcpServer,
   useForceRefreshMcpTools,
   useMcpServers,
-  useMcpToolsEvents,
   useStoredMcpTools,
 } from '@/hooks/queries/mcp'
 import { useWorkflowState, useWorkflows } from '@/hooks/queries/workflows'
@@ -570,7 +569,6 @@ export const ToolInput = memo(function ToolInput({
   const { data: mcpServers = [], isLoading: mcpServersLoading } = useMcpServers(workspaceId)
   const { data: storedMcpTools = [] } = useStoredMcpTools(workspaceId)
   const forceRefreshMcpTools = useForceRefreshMcpTools().mutate
-  useMcpToolsEvents(workspaceId)
   const { navigateToSettings } = useSettingsNavigation()
   const createMcpServer = useCreateMcpServer()
   const { startOauthForServer } = useMcpOauthPopup({ workspaceId })

--- a/apps/sim/hooks/queries/mcp.test.tsx
+++ b/apps/sim/hooks/queries/mcp.test.tsx
@@ -139,7 +139,11 @@ describe('useMcpToolsQuery', () => {
     const { unmount } = renderHookWithClient(() => useMcpToolsQuery(WORKSPACE_ID))
     await flush()
 
-    expect(mockRequestJson).toHaveBeenCalledTimes(3)
+    // Both eligible servers get discovered.
+    const discoveryCalls = mockRequestJson.mock.calls.filter(
+      ([contract]) => contract === discoverMcpToolsContract
+    )
+    expect(discoveryCalls).toHaveLength(2)
     expect(mockRequestJson).toHaveBeenCalledWith(
       discoverMcpToolsContract,
       expect.objectContaining({
@@ -152,6 +156,34 @@ describe('useMcpToolsQuery', () => {
         query: { workspaceId: WORKSPACE_ID, serverId: 'headers-disconnected' },
       })
     )
+
+    unmount()
+  })
+
+  it('refreshes the server list when a previously-failed server discovers successfully', async () => {
+    let listCalls = 0
+    mockRequestJson.mockImplementation(async (contract) => {
+      if (contract === listMcpServersContract) {
+        listCalls++
+        return {
+          success: true,
+          data: {
+            servers: [server('s1', { authType: 'headers', connectionStatus: 'disconnected' })],
+          },
+        }
+      }
+      if (contract === discoverMcpToolsContract) {
+        return { success: true, data: { tools: [{ name: 'tool-a', serverId: 's1' }] } }
+      }
+      throw new Error('Unexpected MCP request')
+    })
+
+    const { unmount } = renderHookWithClient(() => useMcpToolsQuery(WORKSPACE_ID))
+    await flush()
+
+    // A successful probe against a server the cache still shows 'disconnected' refreshes the
+    // list (server-side the status is now 'connected') so the row clears its red state.
+    expect(listCalls).toBeGreaterThanOrEqual(2)
 
     unmount()
   })

--- a/apps/sim/hooks/queries/mcp.test.tsx
+++ b/apps/sim/hooks/queries/mcp.test.tsx
@@ -176,34 +176,6 @@ describe('useMcpToolsQuery', () => {
     unmount()
   })
 
-  it('refreshes the server list when a previously-failed server discovers successfully', async () => {
-    let listCalls = 0
-    mockRequestJson.mockImplementation(async (contract) => {
-      if (contract === listMcpServersContract) {
-        listCalls++
-        return {
-          success: true,
-          data: {
-            servers: [server('s1', { authType: 'headers', connectionStatus: 'disconnected' })],
-          },
-        }
-      }
-      if (contract === discoverMcpToolsContract) {
-        return { success: true, data: { tools: [{ name: 'tool-a', serverId: 's1' }] } }
-      }
-      throw new Error('Unexpected MCP request')
-    })
-
-    const { unmount } = renderHookWithClient(() => useMcpToolsQuery(WORKSPACE_ID))
-    await flush()
-
-    // A successful probe against a server the cache still shows 'disconnected' refreshes the
-    // list (server-side the status is now 'connected') so the row clears its red state.
-    expect(listCalls).toBeGreaterThanOrEqual(2)
-
-    unmount()
-  })
-
   it('refreshes the server list after a connected OAuth discovery fails', async () => {
     let serverListRequests = 0
     mockRequestJson.mockImplementation(async (contract) => {

--- a/apps/sim/hooks/queries/mcp.test.tsx
+++ b/apps/sim/hooks/queries/mcp.test.tsx
@@ -120,8 +120,12 @@ describe('useMcpToolsQuery', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
-    ;(globalThis as unknown as Record<string, unknown>).__mcp_sse_connections = undefined
-    ;(globalThis as unknown as Record<string, unknown>).__mcp_sse_subscribed = undefined
+    // mcp.ts captured these Map/Set instances in module consts at import, so reassigning the
+    // globalThis property wouldn't reset what the module uses — clear the shared instances.
+    ;(
+      globalThis as unknown as { __mcp_sse_connections?: Map<string, unknown> }
+    ).__mcp_sse_connections?.clear()
+    ;(globalThis as unknown as { __mcp_sse_subscribed?: Set<string> }).__mcp_sse_subscribed?.clear()
   })
 
   it('does not auto-discover disconnected or errored OAuth servers', async () => {

--- a/apps/sim/hooks/queries/mcp.test.tsx
+++ b/apps/sim/hooks/queries/mcp.test.tsx
@@ -103,13 +103,25 @@ function mockServers(servers: McpServer[]) {
   })
 }
 
+// jsdom has no EventSource; useMcpToolsQuery mounts the shared SSE subscription.
+class FakeEventSource {
+  onopen: (() => void) | null = null
+  onerror: (() => void) | null = null
+  constructor(public url: string) {}
+  addEventListener(): void {}
+  close(): void {}
+}
+
 describe('useMcpToolsQuery', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ;(globalThis as unknown as { EventSource: unknown }).EventSource = FakeEventSource
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
+    ;(globalThis as unknown as Record<string, unknown>).__mcp_sse_connections = undefined
+    ;(globalThis as unknown as Record<string, unknown>).__mcp_sse_subscribed = undefined
   })
 
   it('does not auto-discover disconnected or errored OAuth servers', async () => {

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -172,19 +172,7 @@ export function useMcpToolsQuery(workspaceId: string) {
       queryKey: mcpKeys.serverToolsList(workspaceId, serverId),
       queryFn: async ({ signal }: { signal?: AbortSignal }) => {
         try {
-          const tools = await fetchMcpTools(workspaceId, false, signal, serverId)
-          // A successful probe flips the stored status to `connected` server-side; if the
-          // cached list still shows this server failed, refresh it so the row clears its red
-          // state (and its tools stop being dropped) instead of waiting out the list stale-time.
-          const cached = queryClient.getQueryData<McpServer[]>(mcpKeys.serversList(workspaceId))
-          const status = cached?.find((s) => s.id === serverId)?.connectionStatus
-          if (status && status !== 'connected') {
-            queryClient.invalidateQueries(
-              { queryKey: mcpKeys.serversList(workspaceId) },
-              { cancelRefetch: false }
-            )
-          }
-          return tools
+          return await fetchMcpTools(workspaceId, false, signal, serverId)
         } catch (error) {
           await queryClient.invalidateQueries(
             { queryKey: mcpKeys.serversList(workspaceId) },

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -167,7 +167,19 @@ export function useMcpToolsQuery(workspaceId: string) {
       queryKey: mcpKeys.serverToolsList(workspaceId, serverId),
       queryFn: async ({ signal }: { signal?: AbortSignal }) => {
         try {
-          return await fetchMcpTools(workspaceId, false, signal, serverId)
+          const tools = await fetchMcpTools(workspaceId, false, signal, serverId)
+          // A successful probe flips the stored status to `connected` server-side; if the
+          // cached list still shows this server failed, refresh it so the row clears its red
+          // state (and its tools stop being dropped) instead of waiting out the list stale-time.
+          const cached = queryClient.getQueryData<McpServer[]>(mcpKeys.serversList(workspaceId))
+          const status = cached?.find((s) => s.id === serverId)?.connectionStatus
+          if (status && status !== 'connected') {
+            queryClient.invalidateQueries(
+              { queryKey: mcpKeys.serversList(workspaceId) },
+              { cancelRefetch: false }
+            )
+          }
+          return tools
         } catch (error) {
           await queryClient.invalidateQueries(
             { queryKey: mcpKeys.serversList(workspaceId) },
@@ -198,10 +210,10 @@ export function useMcpToolsQuery(workspaceId: string) {
       const serverId = serverIds[index]
       const status = serverId ? statusById.get(serverId) : undefined
       const persistentlyFailed = status === 'error' || status === 'disconnected'
-      // Keep last-known-good tools through a transient failure (React Query retains `data`, the
-      // stored status is still healthy) so a populated server doesn't blank — but drop them once
-      // the stored status crosses its failure threshold, so the workflow editor stops offering a
-      // dead server's stale tools. Matches how reference MCP clients treat transient vs. closed.
+      // Keep last-known-good tools while the stored status is still `connected` (React Query
+      // retains `data` across a failed refetch, so a populated server doesn't blank on a
+      // transient probe error) — but drop them once the stored status leaves `connected`
+      // (disconnected/error), so the workflow editor stops offering a dead server's stale tools.
       if (result.data && (!result.isError || !persistentlyFailed)) {
         tools.push(...result.data)
         hasData = true

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -563,6 +563,15 @@ export function useMcpToolsEvents(workspaceId: string) {
         invalidate(serverId)
       })
 
+      // EventSource fires `onopen` on the initial connect and on every auto-reconnect. A
+      // reconnect may have missed a `tools_changed` event during the gap, so re-sync the
+      // whole workspace on reconnect (never on the first open — the query already fetched).
+      let opened = false
+      source.onopen = () => {
+        if (opened) invalidate()
+        opened = true
+      }
+
       source.onerror = () => {
         logger.warn(`SSE connection error for workspace ${workspaceId}`)
       }

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -146,6 +146,11 @@ function isServerEligibleForDiscovery(server: McpServer, workspaceId: string): b
 export function useMcpToolsQuery(workspaceId: string) {
   const queryClient = useQueryClient()
   const { data: servers, isLoading: serversLoading } = useMcpServers(workspaceId)
+  // Push is intrinsic to consuming the tools query: every surface that reads tools (settings,
+  // tool picker, dynamic args, tool selector, canvas block) gets real-time `list_changed`
+  // refresh via the shared, reference-counted subscription — so the 5-min stale time is always
+  // push-backed and no consumer is left re-probing.
+  useMcpToolsEvents(workspaceId)
 
   /**
    * Skip disabled rows, rows retained from a previous workspace, and OAuth rows

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -42,7 +42,13 @@ const logger = createLogger('McpQueries')
 export type { McpServerStatusConfig, McpTool, StoredMcpTool }
 
 export const MCP_SERVER_LIST_STALE_TIME = 60 * 1000
-export const MCP_SERVER_TOOLS_STALE_TIME = 30 * 1000
+/**
+ * Tool discovery is kept fresh by the `list_changed` → SSE push (see `useMcpToolsEvents`),
+ * so the query only needs a re-probe-on-visit fallback for servers without push. Matches the
+ * server-side cache TTL (`MCP_CONSTANTS.CACHE_TIMEOUT`) — no reference MCP client re-probes
+ * more often than its cache; real changes arrive via push regardless of this value.
+ */
+export const MCP_SERVER_TOOLS_STALE_TIME = 5 * 60 * 1000
 export const MCP_STORED_TOOL_LIST_STALE_TIME = 60 * 1000
 export const MCP_ALLOWED_DOMAINS_STALE_TIME = 5 * 60 * 1000
 

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -527,6 +527,12 @@ const sseConnections: Map<string, SseEntry> =
   ((globalThis as Record<string, unknown>)[SSE_KEY] as Map<string, SseEntry>) ??
   ((globalThis as Record<string, unknown>)[SSE_KEY] = new Map<string, SseEntry>())
 
+/** Per-workspace flag: has this session ever held a live SSE subscription for it? */
+const SSE_SUBSCRIBED_KEY = '__mcp_sse_subscribed' as const
+const sseEverSubscribed: Set<string> =
+  ((globalThis as Record<string, unknown>)[SSE_SUBSCRIBED_KEY] as Set<string>) ??
+  ((globalThis as Record<string, unknown>)[SSE_SUBSCRIBED_KEY] = new Set<string>())
+
 /** Subscribes to `tools_changed` SSE events and invalidates the affected query keys. */
 export function useMcpToolsEvents(workspaceId: string) {
   const queryClient = useQueryClient()
@@ -563,12 +569,16 @@ export function useMcpToolsEvents(workspaceId: string) {
         invalidate(serverId)
       })
 
-      // EventSource fires `onopen` on the initial connect and on every auto-reconnect. A
-      // reconnect may have missed a `tools_changed` event during the gap, so re-sync the
-      // whole workspace on reconnect (never on the first open — the query already fetched).
+      // EventSource fires `onopen` on the initial connect and on every auto-reconnect. Re-sync
+      // the workspace whenever we could have missed a `tools_changed` event: on any reconnect,
+      // and on the first open of a RE-subscription (leaving the tab tears the connection down,
+      // so events fired while unsubscribed would otherwise be missed). Skip only the very first
+      // subscription of the session — the queries fetch fresh on their own initial mount.
+      const isResubscribe = sseEverSubscribed.has(workspaceId)
+      sseEverSubscribed.add(workspaceId)
       let opened = false
       source.onopen = () => {
-        if (opened) invalidate()
+        if (opened || isResubscribe) invalidate()
         opened = true
       }
 

--- a/apps/sim/hooks/queries/mcp.ts
+++ b/apps/sim/hooks/queries/mcp.ts
@@ -589,18 +589,21 @@ export function useMcpToolsEvents(workspaceId: string) {
 
       // EventSource fires `onopen` on the initial connect and on every auto-reconnect. Re-sync
       // the workspace whenever we could have missed a `tools_changed` event: on any reconnect,
-      // and on the first open of a RE-subscription (leaving the tab tears the connection down,
-      // so events fired while unsubscribed would otherwise be missed). Skip only the very first
-      // subscription of the session — the queries fetch fresh on their own initial mount.
+      // on the first open of a RE-subscription (leaving the tab tears the connection down), and
+      // on a first open that only succeeded after an earlier connection error (the initial tools
+      // query may have failed during that gap and won't retry itself). Skip only a clean first
+      // subscription — the queries fetch fresh on their own initial mount.
       const isResubscribe = sseEverSubscribed.has(workspaceId)
       sseEverSubscribed.add(workspaceId)
       let opened = false
+      let erroredBeforeOpen = false
       source.onopen = () => {
-        if (opened || isResubscribe) invalidate()
+        if (opened || isResubscribe || erroredBeforeOpen) invalidate()
         opened = true
       }
 
       source.onerror = () => {
+        if (!opened) erroredBeforeOpen = true
         logger.warn(`SSE connection error for workspace ${workspaceId}`)
       }
 

--- a/apps/sim/lib/mcp/domain-check.ts
+++ b/apps/sim/lib/mcp/domain-check.ts
@@ -139,14 +139,17 @@ function isLocalhostHostname(hostname: string): boolean {
  * URLs with env var references in the hostname are skipped — they will be
  * validated after resolution at execution time.
  *
- * Returns the IP address to pin subsequent connections to (the resolved IP for
- * hostnames, or the literal itself for public IP-literal URLs) so the caller can
- * prevent DNS-rebinding TOCTOU attacks and stop redirects from escaping to
- * internal hosts. Pinning matters for IP literals too: without it the transport
- * uses the default fetch, which follows an attacker-controlled 3xx redirect to a
- * private/metadata address. Returns null only when pinning is unnecessary or
- * impossible: no URL, allowlist-only mode, env-var hostnames (validated later),
- * and localhost on self-hosted (no rebinding risk against a fixed loopback).
+ * Returns the resolved IP (or the literal itself for IP-literal URLs) as a
+ * non-null **policy signal**: the SSRF guard is active for this server. A public
+ * resolution selects the validate-at-connect guarded fetch — DNS-rebinding TOCTOU
+ * and redirect escapes are prevented by re-validating every socket connect and
+ * following redirects under per-hop validation (see `createSsrfGuardedMcpFetch` /
+ * `followRedirectsGuarded`), NOT by pinning to this address. The value is literally
+ * pinned only for the self-hosted private/loopback carve-out (a policy-permitted
+ * DNS alias the guarded lookup would otherwise filter). Returns null when the guard
+ * is unnecessary or impossible: no URL, allowlist-only mode, env-var hostnames
+ * (validated later), and localhost on self-hosted (no rebinding risk against a
+ * fixed loopback).
  *
  * @throws McpSsrfError if the URL resolves to a blocked IP address
  */


### PR DESCRIPTION
## Summary
Aligns the MCP settings surface with the reference-client refresh model and folds in the fixes from a full end-to-end lifecycle audit. One clean PR covering the settings freshness work plus every audit finding worth acting on.

### Push-driven freshness (settings page)
- **Subscribe the settings page to the live `list_changed` → SSE push** (`useMcpToolsEvents`) — the pipeline (connection-manager → pubsub → `/api/mcp/events` → browser `EventSource`) already existed but was only mounted in the workflow-editor tool picker. Same shared, reference-counted connection. Real-time tool updates on the settings page.
- **Raise `MCP_SERVER_TOOLS_STALE_TIME` 30s → 5min** (matching the server-side cache TTL) so revisiting leans on push + stored state instead of re-probing. There is **no background poll** (no `refetchInterval`); this only affects refetch-on-visit-if-stale — real changes arrive instantly via push.
- **Resync on reconnect AND on re-subscribe** — a dropped/reconnected `EventSource`, or leaving and returning to the tab (which tears the connection down), could miss a `tools_changed` event; a per-workspace `sseEverSubscribed` flag re-syncs on the first open of a re-subscription and on every reconnect, while skipping only the session's first subscribe (queries fetch fresh then).

### Lifecycle-audit fixes
- **Recovered-server status reconciliation.** The per-server tools `queryFn` refreshed the server list only on error; a server recovering via the stale re-probe showed "tools present but row red" until the list independently refetched. A successful probe against a still-failed server now reconciles the status. (+ corrected an overstated keep/drop comment.)
- **Stale SSRF docstring.** `validateMcpServerSsrf`'s docstring described "pin subsequent connections," which no longer holds post validate-at-connect — the returned IP is a policy signal, and redirect/rebind safety comes from per-connect validation + `followRedirectsGuarded`, not pinning (only the self-hosted private carve-out still pins). Corrected so no one reintroduces a real pin from the text. Doc-only.
- **OAuth callback timeout consistency.** The callback bounded only its post-auth steps; `loadOauthRowByState`, `getSession`, the server SELECT, and the `provider_error` `clearState` were unbounded. Now wrapped in `timedStep` so a wedged DB read surfaces as a labeled timeout.

Validated against Claude Code / LibreChat / OpenCode / VS Code + the MCP spec: discover-once + `list_changed` push, no timer polling, resync-on-reconnect. Three-pass adversarial lifecycle audit found no security escapes, count leaks, or double-release; the findings above are everything worth acting on.

## Type of Change
- [x] Improvement + bug fixes (UX freshness, robustness, doc correctness)

## Testing
- 109 tests green across the MCP query, settings, domain-check, and callback-route suites; tsc + biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)