### PR TITLE
improvement(url-state): platform-wide nuqs audit — migrate remaining view-state, codify conventions

### DIFF
--- a/.claude/rules/sim-url-state.md
+++ b/.claude/rules/sim-url-state.md
@@ -50,11 +50,13 @@ Co-locate a `search-params.ts` next to the feature. Export the parser map (and s
 
 Conventions:
 
-- `.withDefault(...)` on every parser so reads are non-null.
-- Filter / search / toggle / pagination options: `{ history: 'replace', shallow: true, clearOnDefault: true }` — clean URLs, no back-stack churn.
+- `.withDefault(...)` on every parser so reads are non-null. A deliberately **nullable** parser (dynamic default, custom-range-only dates, nullable sort) must carry a comment saying why.
+- Filter / search / toggle / pagination options: `{ history: 'replace', clearOnDefault: true }` — clean URLs, no back-stack churn. `shallow` defaults to `true` in nuqs; writing `shallow: true` explicitly is fine but not required.
 - Navigations that belong in browser history (changing folder, opening a deep-linked entity): `{ history: 'push' }`.
-- `shallow: false` **only** when a Server Component / loader must re-read the param.
-- Short, stable, **kebab-case** URL keys. Renaming a key is a breaking change to shared links — treat it as one.
+- `shallow: false` **only** when a Server Component / loader must re-read the param. For loading states during the server re-render, pass React's `startTransition` via `.withOptions({ startTransition, shallow: false })`.
+- Short, stable, **kebab-case** URL keys. Renaming a key is a breaking change to shared links — treat it as one. When the parser-map key is camelCase (for clean destructuring), remap the wire key via the `urlKeys` option in the shared options object (see `files/search-params.ts` `uploadedBy: 'uploaded-by'`, `ee/audit-logs/search-params.ts` `timeRange: 'time-range'`); nuqs also exports a `UrlKeys<typeof parsers>` type helper for standalone mappings.
+- `throttleMs` is deprecated in nuqs — rate-limit URL writes with `limitUrlUpdates: throttle(ms)` / `debounce(ms)` (the debounced-search hook below already does this).
+- A parser **shared across surfaces with different defaults** (e.g. `parseAsTimeRange`) must `parse` unknown tokens to `null` — never to one surface's default — so each consumer's `.withDefault(...)` decides the fallback.
 - For an opaque/literal value use `parseAsStringLiteral([...] as const)`; for a custom wire format use [`createParser`](https://nuqs.dev/docs/parsers).
 - A `createParser` for a value **not** comparable with `===` (arrays, objects, `Date`) **must** define an `eq` — `clearOnDefault` uses it to detect the default, so without it an empty-array/object default never strips from the URL. Built-in `parseAsArrayOf(...)` already ships its own `eq`; only string/number/boolean custom parsers can omit it. Example (array): `eq: (a, b) => a.length === b.length && a.every((v, i) => v === b[i])`.
 
@@ -200,7 +202,11 @@ const [skillId, setSkillId] = useQueryState(skillIdParam.key, {
 const editingSkill = skillId ? (skills.find((s) => s.id === skillId) ?? null) : null
 ```
 
-Open the panel/modal when the id resolves to a loaded entity; closing it calls `setSkillId(null)`. Because this reads `useSearchParams` it needs a **Suspense** boundary on the page (see below). A separate "create new" flow has no id and stays in local `useState`.
+Open the panel/modal only when the id **resolves to a loaded entity** — never gate on the raw param alone, or a dead/stale id (deleted entity, old bookmark) renders a broken detail view and a still-loading list flashes one. A dead id simply falls back to the list; the lingering param is harmless. Because this reads `useSearchParams` it needs a **Suspense** boundary on the page (see below). A separate "create new" flow has no id and stays in local `useState`.
+
+**Close with `replace`, open with `push`.** Opening pushed a history entry; closing must not push another. Close via the setter's per-call options — `setSkillId(null, { history: 'replace' })` — so Back from the list leaves the page instead of reopening the detail (see `mcp.tsx`, `workflow-mcp-servers.tsx`, access-control, custom-blocks, forks). Secondary params scoped to the detail view (e.g. its active tab, `server-tab`) are cleared in the same close handler with their own setter — nuqs batches same-tick writes into one URL update.
+
+**Reusable components** rendered both as a settings/list page and inside a modal (e.g. `BYOKKeyManager`) expose an optional controlled `searchTerm`/`onSearchTermChange` prop pair: the page consumer binds the URL (`useSettingsSearch()`), modal consumers omit the props and keep local state. Never bind URL state from inside a component that can mount in a non-destination context.
 
 ## Read-then-strip deep links
 

--- a/.claude/rules/sim-url-state.md
+++ b/.claude/rules/sim-url-state.md
@@ -3,6 +3,8 @@ paths:
   - "apps/sim/app/**/*.tsx"
   - "apps/sim/app/**/*.ts"
   - "apps/sim/app/**/search-params.ts"
+  - "apps/sim/ee/**/*.tsx"
+  - "apps/sim/ee/**/*.ts"
 ---
 
 # URL / Query-Param State (nuqs)
@@ -51,7 +53,7 @@ Co-locate a `search-params.ts` next to the feature. Export the parser map (and s
 Conventions:
 
 - `.withDefault(...)` on every parser so reads are non-null. A deliberately **nullable** parser (dynamic default, custom-range-only dates, nullable sort) must carry a comment saying why.
-- Filter / search / toggle / pagination options: `{ history: 'replace', clearOnDefault: true }` — clean URLs, no back-stack churn. `shallow` defaults to `true` in nuqs; writing `shallow: true` explicitly is fine but not required.
+- Filter / search / toggle / pagination options: `{ history: 'replace', clearOnDefault: true }` — clean URLs, no back-stack churn. Note all three of `history: 'replace'`, `clearOnDefault: true`, and `shallow: true` are already the nuqs v2 defaults — writing the first two explicitly is documentation (and guards the groups whose options differ, e.g. `history: 'push'`), and `shallow: true` may be omitted entirely.
 - Navigations that belong in browser history (changing folder, opening a deep-linked entity): `{ history: 'push' }`.
 - `shallow: false` **only** when a Server Component / loader must re-read the param. For loading states during the server re-render, pass React's `startTransition` via `.withOptions({ startTransition, shallow: false })`.
 - Short, stable, **kebab-case** URL keys. Renaming a key is a breaking change to shared links — treat it as one. When the parser-map key is camelCase (for clean destructuring), remap the wire key via the `urlKeys` option in the shared options object (see `files/search-params.ts` `uploadedBy: 'uploaded-by'`, `ee/audit-logs/search-params.ts` `timeRange: 'time-range'`); nuqs also exports a `UrlKeys<typeof parsers>` type helper for standalone mappings.
@@ -77,10 +79,11 @@ export const thingsParsers = {
 /** Clean URLs, no back-stack churn for filter changes. */
 export const thingsUrlKeys = {
   history: 'replace',
-  shallow: true,
   clearOnDefault: true,
 } as const
 ```
+
+(The `*UrlKeys` suffix is the repo's naming convention for a feature's shared **options** object — which may itself contain a nuqs `urlKeys` key-remapping entry; the two are different things.)
 
 ### Client — `useQueryStates` (grouped) / `useQueryState` (single)
 
@@ -184,7 +187,7 @@ Sort params live alongside — not inside — the feature's grouped filter parse
 
 A date-only param (a calendar anchor, a date filter) is stored as `yyyy-MM-dd` — never serialize a full `Date`/timestamp when only the day matters.
 
-**Local vs UTC — pick the parser that matches your date math.** nuqs's built-in `parseAsIsoDate` is **UTC-based** (`serialize` via `toISOString()`, `parse` to UTC midnight). If your `Date` is local-time (e.g. produced by local-time helpers and read by `date-fns` `startOfWeek`/`isSameDay`, which are all local), `parseAsIsoDate` will shift the day by ±1 in any non-UTC timezone on reload/deep-link/back-forward. For local-time date math, use a small local-date `createParser` that serializes/parses on local calendar fields (`getFullYear`/`getMonth`/`getDate` ↔ `new Date(y, m-1, d)`) with an `eq` comparing y/m/d. Only use `parseAsIsoDate` when the value is genuinely UTC/midnight-UTC. See `scheduled-tasks/search-params.ts` (`parseAsLocalDate`).
+**Local vs UTC — pick the parser that matches your date math.** nuqs's built-in `parseAsIsoDate` is **UTC-based** (`serialize` via `toISOString().slice(0, 10)`, `parse` to UTC midnight). If your `Date` is local-time (e.g. produced by local-time helpers and read by `date-fns` `startOfWeek`/`isSameDay`, which are all local), `parseAsIsoDate` will shift the day by ±1 in any non-UTC timezone on reload/deep-link/back-forward. For local-time date math, use a small local-date `createParser` that serializes/parses on local calendar fields (`getFullYear`/`getMonth`/`getDate` ↔ `new Date(y, m-1, d)`) with an `eq` comparing y/m/d. Only use `parseAsIsoDate` when the value is genuinely UTC/midnight-UTC. See `scheduled-tasks/search-params.ts` (`parseAsLocalDate`).
 
 When the default is **dynamic** (e.g. "today"), make the param **nullable** (omit `.withDefault`) and derive the fallback in the hook (`const anchor = param ?? today`), so a clean URL means the dynamic default and navigating back to it writes `null` (clears the param). See `scheduled-tasks/hooks/use-calendar.ts`.
 
@@ -202,7 +205,7 @@ const [skillId, setSkillId] = useQueryState(skillIdParam.key, {
 const editingSkill = skillId ? (skills.find((s) => s.id === skillId) ?? null) : null
 ```
 
-Open the panel/modal only when the id **resolves to a loaded entity** — never gate on the raw param alone, or a dead/stale id (deleted entity, old bookmark) renders a broken detail view and a still-loading list flashes one. A dead id simply falls back to the list; the lingering param is harmless. Because this reads `useSearchParams` it needs a **Suspense** boundary on the page (see below). A separate "create new" flow has no id and stays in local `useState`.
+Open the panel/modal only when the id **resolves to a loaded entity** — never gate on the raw param alone, or a dead/stale id (deleted entity, old bookmark) renders a broken detail view and a still-loading list flashes one. A dead id simply falls back to the list; the lingering param is harmless. Because this reads `useSearchParams` it needs a **Suspense** boundary on the page (see "Suspense boundary" above). A separate "create new" flow has no id and stays in local `useState`.
 
 **Close with `replace`, open with `push`.** Opening pushed a history entry; closing must not push another. Close via the setter's per-call options — `setSkillId(null, { history: 'replace' })` — so Back from the list leaves the page instead of reopening the detail (see `mcp.tsx`, `workflow-mcp-servers.tsx`, access-control, custom-blocks, forks). Secondary params scoped to the detail view (e.g. its active tab, `server-tab`) are cleared in the same close handler with their own setter — nuqs batches same-tick writes into one URL update.
 
@@ -223,8 +226,8 @@ The workflow editor (`apps/sim/app/workspace/[workspaceId]/w/**`) is realtime/so
 
 Borderline candidates that *look* shareable but currently stay in Zustand because moving them fights existing machinery:
 
-- **Panel `activeTab`** and **`canvasMode`** — persisted local *preferences* wired into an SSR flash-prevention path (`data-panel-active-tab` + `_hasHydrated`). They are layout prefs, not destinations; moving them would unwind the SSR machinery and risk tab-flash on load.
-- **`focusedBlockId`** ("look at this block") — the only genuinely shareable candidate, but it is entangled with the persisted editor store and panel-open orchestration. Adding it is a *new feature*, not a migration; ship it deliberately (with runtime verification against a live socket), not as part of a sweep.
+- **Panel `activeTab`** — a persisted local *preference* wired into an SSR flash-prevention path (`data-panel-active-tab` + `_hasHydrated`); moving it would unwind that machinery and risk tab-flash on load. **Canvas mode** (`mode` on `useCanvasModeStore`) is likewise a persisted layout preference, not a destination.
+- **The panel editor's `currentBlockId`** (`stores/panel/editor/store.ts` — a would-be "look at this block" deep link) — the only genuinely shareable candidate, but it is persisted and entangled with panel-open orchestration. Adding a URL param for it is a *new feature*, not a migration; ship it deliberately (with runtime verification against a live socket), not as part of a sweep.
 
 Rule of thumb for the editor: if state is socket-coupled, high-frequency, viewport-related, or a persisted resize/preference, it stays in Zustand. When in doubt, leave it and flag it — do not force fragile URL state into the canvas.
 

--- a/apps/sim/app/(landing)/integrations/search-params.ts
+++ b/apps/sim/app/(landing)/integrations/search-params.ts
@@ -6,8 +6,8 @@ import { createSearchParamsCache, parseAsString } from 'nuqs/server'
  * so the filtered view is server-rendered for shareable, crawlable `?category=`/`?q=`
  * URLs — the same SSR pattern the blog index uses.
  *
- * - `q` is the search filter; its URL write is debounced on the setter, never
- *   written per keystroke.
+ * - `q` is the search filter; its URL write is debounced via
+ *   `useDebouncedSearchSetter`, never written per keystroke.
  * - `category` filters by integration type (`''` = all).
  */
 export const integrationsParsers = {

--- a/apps/sim/app/(landing)/models/search-params.ts
+++ b/apps/sim/app/(landing)/models/search-params.ts
@@ -6,8 +6,8 @@ import { createSearchParamsCache, parseAsString } from 'nuqs/server'
  * so the filtered view is server-rendered for shareable, crawlable `?provider=`/`?q=`
  * URLs — the same SSR pattern the blog index uses.
  *
- * - `q` is the search filter; its URL write is debounced on the setter, never
- *   written per keystroke.
+ * - `q` is the search filter; its URL write is debounced via
+ *   `useDebouncedSearchSetter`, never written per keystroke.
  * - `provider` filters by provider id (`''` = all).
  */
 export const modelsParsers = {

--- a/apps/sim/app/workspace/[workspaceId]/integrations/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/search-params.ts
@@ -15,8 +15,8 @@ export const CONNECTED_LABEL = 'Connected'
  *   pseudo-categories and are derived from the data set, so a plain string is
  *   used; the `All` default clears from the URL.
  * - `search` is the integration search term. The input is controlled directly by
- *   the nuqs value; only its URL write is debounced via `limitUrlUpdates`
- *   (`debounce`) on the setter — never written on every keystroke.
+ *   the nuqs value; only its URL write is debounced via
+ *   `useDebouncedSearchSetter` — never written on every keystroke.
  */
 export const integrationsParsers = {
   category: parseAsString.withDefault(ALL_CATEGORY),

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
@@ -137,7 +137,12 @@ export function Document({
   const { workspaceId } = useParams()
   const router = useRouter()
   const [
-    { page: currentPageFromURL, chunk: chunkFromURL, search: searchQuery },
+    {
+      page: currentPageFromURL,
+      chunk: chunkFromURL,
+      search: searchQuery,
+      enabled: enabledFilterParam,
+    },
     setDocumentParams,
   ] = useQueryStates(documentParsers, documentUrlKeys)
   const userPermissions = useUserPermissionsContext()
@@ -160,16 +165,31 @@ export function Document({
   )
   /** Raw URL value drives the input; the chunk search query always sees it trimmed. */
   const debouncedSearchQuery = useDebounce(searchQuery, CHUNK_SEARCH_DEBOUNCE_MS).trim()
-  const [enabledFilter, setEnabledFilter] = useState<string[]>([])
   const {
     activeSort,
     onSort: onSortColumn,
     onClear: onClearSort,
   } = useUrlSort(documentChunkSortParams, documentUrlKeys)
 
-  const enabledFilterParam = useMemo(
-    () => (enabledFilter.length === 1 ? (enabledFilter[0] as 'enabled' | 'disabled') : 'all'),
-    [enabledFilter]
+  /** Multi-select UI view of the scalar `enabled` param (`all` ↔ nothing selected). */
+  const enabledFilter = useMemo<string[]>(
+    () => (enabledFilterParam === 'all' ? [] : [enabledFilterParam]),
+    [enabledFilterParam]
+  )
+
+  /**
+   * Collapses the dropdown's multi-select values to the scalar param (one value
+   * filters; none or both mean `all`) and resets `page` in the same write so a
+   * filter change always lands on the first page.
+   */
+  const setEnabledFilter = useCallback(
+    (values: string[]) => {
+      void setDocumentParams({
+        enabled: values.length === 1 ? (values[0] as 'enabled' | 'disabled') : null,
+        page: null,
+      })
+    },
+    [setDocumentParams]
   )
 
   const {
@@ -638,7 +658,6 @@ export function Document({
             onMultiSelectChange={(values) => {
               setEnabledFilter(values)
               setSelectedChunks(new Set())
-              void goToPage(1)
             }}
             overlayContent={
               <span className='truncate text-[var(--text-primary)]'>{enabledDisplayLabel}</span>
@@ -654,7 +673,6 @@ export function Document({
             onClick={() => {
               setEnabledFilter([])
               setSelectedChunks(new Set())
-              void goToPage(1)
             }}
             className='flex h-[32px] w-full items-center justify-center rounded-md text-[var(--text-secondary)] text-caption transition-colors hover-hover:bg-[var(--surface-active)]'
           >
@@ -663,7 +681,7 @@ export function Document({
         )}
       </div>
     ),
-    [enabledFilter, enabledDisplayLabel, goToPage]
+    [enabledFilter, enabledDisplayLabel, setEnabledFilter]
   )
 
   const filterTags: FilterTag[] = useMemo(
@@ -671,12 +689,11 @@ export function Document({
       enabledFilter.map((value) => ({
         label: `Status: ${value === 'enabled' ? 'Enabled' : 'Disabled'}`,
         onRemove: () => {
-          setEnabledFilter((prev) => prev.filter((v) => v !== value))
+          setEnabledFilter(enabledFilter.filter((v) => v !== value))
           setSelectedChunks(new Set())
-          void goToPage(1)
         },
       })),
-    [enabledFilter, goToPage]
+    [enabledFilter, setEnabledFilter]
   )
 
   const handleChunkClick = useCallback(

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
@@ -639,8 +639,7 @@ export function Document({
 
   const enabledDisplayLabel = useMemo(() => {
     if (enabledFilter.length === 0) return 'All'
-    if (enabledFilter.length === 1) return enabledFilter[0] === 'enabled' ? 'Enabled' : 'Disabled'
-    return `${enabledFilter.length} selected`
+    return enabledFilter[0] === 'enabled' ? 'Enabled' : 'Disabled'
   }, [enabledFilter])
 
   const filterContent = useMemo(

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/search-params.ts
@@ -1,5 +1,8 @@
-import { parseAsInteger, parseAsString } from 'nuqs/server'
+import { parseAsInteger, parseAsString, parseAsStringLiteral } from 'nuqs/server'
 import { createSortParams } from '@/lib/url-state'
+
+/** Chunk `enabled` filter buckets, matching the status filter dropdown. */
+const ENABLED_FILTERS = ['all', 'enabled', 'disabled'] as const
 
 /** Sortable chunk columns, matching the `Resource.Options` sort menu ids. */
 export const CHUNK_SORT_COLUMNS = ['index', 'tokens', 'status'] as const
@@ -24,11 +27,14 @@ export const documentChunkSortParams = createSortParams(CHUNK_SORT_COLUMNS)
  * - `search` is the chunk content search. The input is controlled directly by
  *   the instant nuqs value; only its URL write is debounced via
  *   `useDebouncedSearchSetter` — never written on every keystroke.
+ * - `enabled` filters chunks by enabled status (`all` clears from the URL),
+ *   mirroring the same filter on the knowledge base document list.
  */
 export const documentParsers = {
   page: parseAsInteger.withDefault(1),
   chunk: parseAsString,
   search: parseAsString.withDefault(''),
+  enabled: parseAsStringLiteral(ENABLED_FILTERS).withDefault('all'),
 } as const
 
 /**

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/search-params.ts
@@ -27,8 +27,8 @@ export const knowledgeSortParams = createSortParams(KNOWLEDGE_SORT_COLUMNS, {
  *
  * - `search` is the knowledge base name/description filter. The input is
  *   controlled directly by the instant nuqs value; only its URL write is
- *   debounced via `limitUrlUpdates` (`debounce`) on the setter — never written
- *   on every keystroke.
+ *   debounced via `useDebouncedSearchSetter` — never written on every
+ *   keystroke.
  * - `connector` filters by connector presence; `content` filters by document
  *   presence; `owner` filters by creator id. All are multi-select arrays.
  *

--- a/apps/sim/app/workspace/[workspaceId]/logs/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/logs/search-params.ts
@@ -105,8 +105,10 @@ export const parseAsTriggers = createParser<TriggerType[]>({
  */
 export const logFilterParsers = {
   timeRange: parseAsTimeRange.withDefault(DEFAULT_TIME_RANGE),
-  // Deliberately nullable: only populated when timeRange is "Custom range";
-  // every preset range derives its window from the label instead.
+  /**
+   * Deliberately nullable: only populated when timeRange is "Custom range";
+   * every preset range derives its window from the label instead.
+   */
   startDate: parseAsString,
   endDate: parseAsString,
   level: parseAsLogLevel.withDefault('all'),

--- a/apps/sim/app/workspace/[workspaceId]/logs/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/logs/search-params.ts
@@ -41,12 +41,13 @@ const TOKEN_TO_TIME_RANGE: Record<string, TimeRange> = Object.fromEntries(
 ) as Record<string, TimeRange>
 
 /**
- * Parser for the `timeRange` param. Serializes labels to kebab tokens and
- * tolerantly maps unknown tokens back to the default ("All time").
+ * Parser for the `timeRange` param. Serializes labels to kebab tokens. Unknown
+ * tokens parse to `null` so each consuming surface's `.withDefault(...)` decides
+ * the fallback (logs: "All time"; audit-logs: "Past 30 days").
  */
 export const parseAsTimeRange = createParser<TimeRange>({
   parse(value) {
-    return TOKEN_TO_TIME_RANGE[value] ?? DEFAULT_TIME_RANGE
+    return TOKEN_TO_TIME_RANGE[value] ?? null
   },
   serialize(value) {
     return TIME_RANGE_TO_TOKEN[value] ?? 'all-time'

--- a/apps/sim/app/workspace/[workspaceId]/logs/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/logs/search-params.ts
@@ -104,6 +104,8 @@ export const parseAsTriggers = createParser<TriggerType[]>({
  */
 export const logFilterParsers = {
   timeRange: parseAsTimeRange.withDefault(DEFAULT_TIME_RANGE),
+  // Deliberately nullable: only populated when timeRange is "Custom range";
+  // every preset range derives its window from the label instead.
   startDate: parseAsString,
   endDate: parseAsString,
   level: parseAsLogLevel.withDefault('all'),

--- a/apps/sim/app/workspace/[workspaceId]/logs/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/logs/search-params.ts
@@ -77,6 +77,21 @@ export const parseAsLogLevel = createParser<LogLevel>({
   },
 })
 
+/**
+ * Parser for free-form date/datetime strings (`startDate`/`endDate`). Rejects
+ * unparseable values at the URL boundary — an invalid date string reaching
+ * `new Date(...).toISOString()` throws, so a malformed deep link must parse to
+ * `null` (treated as a missing bound) instead of crashing the consumer.
+ */
+export const parseAsDateString = createParser<string>({
+  parse(value) {
+    return Number.isNaN(Date.parse(value)) ? null : value
+  },
+  serialize(value) {
+    return value
+  },
+})
+
 const CORE_TRIGGER_SET = new Set<string>(CORE_TRIGGER_TYPES)
 
 /**
@@ -109,8 +124,8 @@ export const logFilterParsers = {
    * Deliberately nullable: only populated when timeRange is "Custom range";
    * every preset range derives its window from the label instead.
    */
-  startDate: parseAsString,
-  endDate: parseAsString,
+  startDate: parseAsDateString,
+  endDate: parseAsDateString,
   level: parseAsLogLevel.withDefault('all'),
   workflowIds: parseAsArrayOf(parseAsString).withDefault([]),
   folderIds: parseAsArrayOf(parseAsString).withDefault([]),

--- a/apps/sim/app/workspace/[workspaceId]/settings/[section]/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/[section]/search-params.ts
@@ -50,6 +50,22 @@ export const forkViewUrlKeys = {
 } as const
 
 /**
+ * `server-tab` is the active tab (Details / Workflows) inside the deep-linked
+ * workflow MCP server detail view, so a shared `mcpServerId` link can land on
+ * either tab.
+ */
+export const serverTabParam = {
+  key: 'server-tab',
+  parser: parseAsStringLiteral(['details', 'workflows'] as const).withDefault('details'),
+} as const
+
+/** Tab view-state: clean URLs, no back-stack churn. */
+export const serverTabUrlKeys = {
+  history: 'replace',
+  clearOnDefault: true,
+} as const
+
+/**
  * `group-id` deep-links the Access Control settings tab to a specific
  * permission group's detail sub-view (mirrors `mcpServerId` on the MCP tab).
  */

--- a/apps/sim/app/workspace/[workspaceId]/settings/[section]/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/[section]/search-params.ts
@@ -50,6 +50,37 @@ export const forkViewUrlKeys = {
 } as const
 
 /**
+ * `group-id` deep-links the Access Control settings tab to a specific
+ * permission group's detail sub-view (mirrors `mcpServerId` on the MCP tab).
+ */
+export const groupIdParam = {
+  key: 'group-id',
+  parser: parseAsString,
+} as const
+
+/** Opening a group's detail is a destination → push to history; clear on close. */
+export const groupIdUrlKeys = {
+  history: 'push',
+  clearOnDefault: true,
+} as const
+
+/**
+ * `custom-block-id` deep-links the Custom Blocks settings tab to a specific
+ * block's detail sub-view. The "create new" flow stays in local state — only
+ * existing entities are deep-linkable.
+ */
+export const customBlockIdParam = {
+  key: 'custom-block-id',
+  parser: parseAsString,
+} as const
+
+/** Opening a block's detail is a destination → push to history; clear on close. */
+export const customBlockIdUrlKeys = {
+  history: 'push',
+  clearOnDefault: true,
+} as const
+
+/**
  * `fork-direction` is the sync direction (push/pull) on the parent fork's detail
  * page — shareable view state, so a copied link opens the same side of the sync.
  */

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/byok/byok-key-manager.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/byok/byok-key-manager.tsx
@@ -66,6 +66,13 @@ interface BYOKKeyManagerBaseProps {
   description?: string
   /** Show the provider search box (hidden when there are only a couple). */
   showSearch?: boolean
+  /**
+   * Controlled search value + setter. The BYOK settings page passes the shared
+   * `?search=` binding (`useSettingsSearch`) so the search is deep-linkable;
+   * modal/embedded consumers omit both and keep local state.
+   */
+  searchTerm?: string
+  onSearchTermChange?: (value: string) => void
 }
 
 /** One key per provider; saving replaces the stored key. */
@@ -138,7 +145,9 @@ export function BYOKKeyManager(props: BYOKKeyManagerProps) {
     showSearch = true,
   } = props
 
-  const [searchTerm, setSearchTerm] = useState('')
+  const [localSearchTerm, setLocalSearchTerm] = useState('')
+  const searchTerm = props.searchTerm ?? localSearchTerm
+  const setSearchTerm = props.onSearchTermChange ?? setLocalSearchTerm
   const [editing, setEditing] = useState<EditingState | null>(null)
   const [apiKeyInput, setApiKeyInput] = useState('')
   const [nameInput, setNameInput] = useState('')

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/byok/byok.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/byok/byok.tsx
@@ -48,6 +48,7 @@ import {
   type BYOKProviderSection,
 } from '@/app/workspace/[workspaceId]/settings/components/byok/byok-key-manager'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
+import { useSettingsSearch } from '@/app/workspace/[workspaceId]/settings/components/use-settings-search'
 import { useBYOKKeys, useDeleteBYOKKey, useUpsertBYOKKey } from '@/hooks/queries/byok-keys'
 import type { BYOKProviderId } from '@/tools/types'
 
@@ -354,6 +355,7 @@ export function BYOK() {
   const workspaceId = (params?.workspaceId as string) || ''
   const workspacePermissions = useUserPermissionsContext()
   const canManage = canMutateWorkspaceSettingsSection('byok', workspacePermissions)
+  const [searchTerm, setSearchTerm] = useSettingsSearch()
 
   const { data, isLoading } = useBYOKKeys(workspaceId)
   const upsertKey = useUpsertBYOKKey()
@@ -381,6 +383,8 @@ export function BYOK() {
         isSaving={upsertKey.isPending}
         isDeleting={deleteKey.isPending}
         readOnly={!canManage}
+        searchTerm={searchTerm}
+        onSearchTermChange={setSearchTerm}
         onSaveKey={async ({ providerId, apiKey, keyId, name }) => {
           await upsertKey.mutateAsync({
             workspaceId,

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/inbox/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/inbox/search-params.ts
@@ -18,7 +18,7 @@ export type InboxStatusFilter = (typeof INBOX_STATUS_FILTERS)[number]
  * - `status` is the active status filter (feeds the tasks query key).
  * - `search` is the subject/sender/body name filter. The input is controlled
  *   directly by the nuqs value; only its URL write is debounced via
- *   `limitUrlUpdates` (`debounce`) on the setter — never written per keystroke.
+ *   `useDebouncedSearchSetter` — never written per keystroke.
  */
 export const inboxTaskParsers = {
   status: parseAsStringLiteral(INBOX_STATUS_FILTERS).withDefault('all'),

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/search-params.ts
@@ -3,8 +3,9 @@ import { parseAsString } from 'nuqs/server'
 /**
  * Shared URL query-param definition for the settings list search boxes
  * (teammates, api-keys, copilot, custom-tools, mcp, secrets,
- * workflow-mcp-servers). Settings sections never co-render, so they all share
- * the `search` key without collisions.
+ * workflow-mcp-servers, and the ee sections: audit-logs, access-control,
+ * custom-blocks, data-drains, forks). Settings sections never co-render, so
+ * they all share the `search` key without collisions.
  *
  * Consume via `useSettingsSearch` (`settings/components/use-settings-search`),
  * which owns the debounced-write wiring — the input is controlled directly by

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/search-params.ts
@@ -2,7 +2,7 @@ import { parseAsString } from 'nuqs/server'
 
 /**
  * Shared URL query-param definition for the settings list search boxes
- * (teammates, api-keys, copilot, custom-tools, mcp, secrets,
+ * (teammates, api-keys, byok, copilot, custom-tools, mcp, secrets,
  * workflow-mcp-servers, and the ee sections: audit-logs, access-control,
  * custom-blocks, data-drains, forks). Settings sections never co-render, so
  * they all share the `search` key without collisions.

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/use-settings-search.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/use-settings-search.ts
@@ -9,7 +9,8 @@ import { useDebouncedSearchSetter } from '@/hooks/use-debounced-search-setter'
 
 /**
  * The shared `?search=` binding for settings list search boxes (teammates,
- * api-keys, copilot, custom-tools, mcp, secrets, workflow-mcp-servers).
+ * api-keys, copilot, custom-tools, mcp, secrets, workflow-mcp-servers, and the
+ * ee sections: audit-logs, access-control, custom-blocks, data-drains, forks).
  * Composes `useDebouncedSearchSetter`, so it carries the canonical semantics:
  * the value updates instantly (drives the controlled input and the in-memory
  * filter), non-empty URL writes are debounced, and clearing (or a

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/use-settings-search.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/use-settings-search.ts
@@ -9,8 +9,9 @@ import { useDebouncedSearchSetter } from '@/hooks/use-debounced-search-setter'
 
 /**
  * The shared `?search=` binding for settings list search boxes (teammates,
- * api-keys, copilot, custom-tools, mcp, secrets, workflow-mcp-servers, and the
- * ee sections: audit-logs, access-control, custom-blocks, data-drains, forks).
+ * api-keys, byok, copilot, custom-tools, mcp, secrets, workflow-mcp-servers,
+ * and the ee sections: audit-logs, access-control, custom-blocks, data-drains,
+ * forks).
  * Composes `useDebouncedSearchSetter`, so it carries the canonical semantics:
  * the value updates instantly (drives the controlled input and the in-memory
  * filter), non-empty URL writes are debounced, and clearing (or a

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/workflow-mcp-servers/workflow-mcp-servers.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/workflow-mcp-servers/workflow-mcp-servers.tsx
@@ -1024,7 +1024,14 @@ export function WorkflowMcpServers() {
                       <RowActionsMenu
                         label='Server actions'
                         actions={[
-                          { label: 'Details', onSelect: () => setSelectedServerId(server.id) },
+                          {
+                            label: 'Details',
+                            onSelect: () => {
+                              // A lingering ?server-tab= (dead deep link) must not re-target the next open — reset it in the same batched push.
+                              void setServerTab(null)
+                              void setSelectedServerId(server.id)
+                            },
+                          },
                           ...(canAdmin
                             ? [
                                 {

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/workflow-mcp-servers/workflow-mcp-servers.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/workflow-mcp-servers/workflow-mcp-servers.tsx
@@ -32,6 +32,8 @@ import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/provide
 import {
   mcpServerIdParam,
   mcpServerIdUrlKeys,
+  serverTabParam,
+  serverTabUrlKeys,
 } from '@/app/workspace/[workspaceId]/settings/[section]/search-params'
 import { CreateApiKeyModal } from '@/app/workspace/[workspaceId]/settings/components/api-keys/components'
 import { RowActionsMenu } from '@/app/workspace/[workspaceId]/settings/components/row-actions-menu'
@@ -108,7 +110,10 @@ function ServerDetailView({ canManage, workspaceId, serverId, onBack }: ServerDe
   const [editServerName, setEditServerName] = useState('')
   const [editServerDescription, setEditServerDescription] = useState('')
   const [editServerIsPublic, setEditServerIsPublic] = useState(false)
-  const [activeServerTab, setActiveServerTab] = useState<'workflows' | 'details'>('details')
+  const [activeServerTab, setActiveServerTab] = useQueryState(serverTabParam.key, {
+    ...serverTabParam.parser,
+    ...serverTabUrlKeys,
+  })
 
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null)
 
@@ -401,7 +406,7 @@ function ServerDetailView({ canManage, workspaceId, serverId, onBack }: ServerDe
               { value: 'workflows', label: 'Workflows' },
             ]}
             value={activeServerTab}
-            onChange={(value) => setActiveServerTab(value as 'workflows' | 'details')}
+            onChange={(value) => void setActiveServerTab(value as 'workflows' | 'details')}
           />
 
           <div className='min-h-[300px] pt-4'>
@@ -892,6 +897,11 @@ export function WorkflowMcpServers() {
   })
   const [serverToDelete, setServerToDelete] = useState<WorkflowMcpServer | null>(null)
   const [deletingServers, setDeletingServers] = useState<Set<string>>(() => new Set())
+  /** Cleared alongside the server id on close so the tab never lingers on the list URL. */
+  const [, setServerTab] = useQueryState(serverTabParam.key, {
+    ...serverTabParam.parser,
+    ...serverTabUrlKeys,
+  })
 
   const filteredServers = useMemo(() => {
     if (!searchTerm.trim()) return servers
@@ -948,7 +958,10 @@ export function WorkflowMcpServers() {
         canManage={canAdmin}
         workspaceId={workspaceId}
         serverId={selectedServerId}
-        onBack={() => setSelectedServerId(null, { history: 'replace' })}
+        onBack={() => {
+          void setServerTab(null, { history: 'replace' })
+          void setSelectedServerId(null, { history: 'replace' })
+        }}
       />
     )
   }

--- a/apps/sim/app/workspace/[workspaceId]/skills/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/skills/search-params.ts
@@ -23,8 +23,7 @@ export const skillIdUrlKeys = {
 /**
  * `search` filters the skills list by name/description. The input is controlled
  * directly by the instant nuqs value; only its URL write is debounced via
- * `limitUrlUpdates` (`debounce`) on the setter — never written on every
- * keystroke.
+ * `useDebouncedSearchSetter` — never written on every keystroke.
  */
 export const skillSearchParam = {
   key: 'search',

--- a/apps/sim/ee/access-control/components/access-control.tsx
+++ b/apps/sim/ee/access-control/components/access-control.tsx
@@ -16,11 +16,17 @@ import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
 import { ArrowRight, Plus } from 'lucide-react'
 import { useParams } from 'next/navigation'
+import { useQueryState } from 'nuqs'
 import { isEnterprise } from '@/lib/billing/plan-helpers'
 import { getEnv, isTruthy } from '@/lib/core/config/env'
+import {
+  groupIdParam,
+  groupIdUrlKeys,
+} from '@/app/workspace/[workspaceId]/settings/[section]/search-params'
 import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
 import { SettingsSection } from '@/app/workspace/[workspaceId]/settings/components/settings-section/settings-section'
+import { useSettingsSearch } from '@/app/workspace/[workspaceId]/settings/components/use-settings-search'
 import { GroupDetail } from '@/ee/access-control/components/group-detail'
 import { WorkspaceSelect } from '@/ee/access-control/components/workspace-select'
 import {
@@ -74,8 +80,11 @@ export function AccessControl({ isOrganizationAdmin, organizationId }: AccessCon
 
   const createPermissionGroup = useCreatePermissionGroup()
 
-  const [searchTerm, setSearchTerm] = useState('')
-  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null)
+  const [searchTerm, setSearchTerm] = useSettingsSearch()
+  const [selectedGroupId, setSelectedGroupId] = useQueryState(groupIdParam.key, {
+    ...groupIdParam.parser,
+    ...groupIdUrlKeys,
+  })
   const [showCreateModal, setShowCreateModal] = useState(false)
   const [newGroupName, setNewGroupName] = useState('')
   const [newGroupDescription, setNewGroupDescription] = useState('')
@@ -160,8 +169,8 @@ export function AccessControl({ isOrganizationAdmin, organizationId }: AccessCon
         workspaceOptions={workspaceOptions}
         organizationWorkspaces={organizationWorkspaces}
         workspacesLoading={workspacesLoading}
-        onBack={() => setSelectedGroupId(null)}
-        onDeleted={() => setSelectedGroupId(null)}
+        onBack={() => void setSelectedGroupId(null, { history: 'replace' })}
+        onDeleted={() => void setSelectedGroupId(null, { history: 'replace' })}
       />
     )
   }
@@ -198,7 +207,7 @@ export function AccessControl({ isOrganizationAdmin, organizationId }: AccessCon
                 <button
                   key={group.id}
                   type='button'
-                  onClick={() => setSelectedGroupId(group.id)}
+                  onClick={() => void setSelectedGroupId(group.id)}
                   className='flex items-center gap-2.5 rounded-lg p-2 text-left transition-colors hover-hover:bg-[var(--surface-active)]'
                 >
                   <div className='flex min-w-0 flex-1 flex-col'>

--- a/apps/sim/ee/audit-logs/components/audit-logs.tsx
+++ b/apps/sim/ee/audit-logs/components/audit-logs.tsx
@@ -251,10 +251,6 @@ export function AuditLogs({ organizationId }: AuditLogsProps) {
       ? DEFAULT_AUDIT_TIME_RANGE
       : urlFilters.timeRange
   const [datePickerOpen, setDatePickerOpen] = useState(false)
-  /** Cancel target for the date picker — never 'Custom range' itself, so a deep link straight to an empty custom range still cancels back to a preset. */
-  const previousTimeRangeRef = useRef<TimeRange>(
-    timeRange === 'Custom range' ? DEFAULT_AUDIT_TIME_RANGE : timeRange
-  )
   const dateRangeAppliedRef = useRef(false)
   const [searchTerm, setSearchTerm] = useSettingsSearch()
   const debouncedSearch = useDebounce(searchTerm, SEARCH_DEBOUNCE_MS).trim()
@@ -307,7 +303,6 @@ export function AuditLogs({ organizationId }: AuditLogsProps) {
 
   const handleTimeRangeChange = (value: string) => {
     if (value === 'Custom range') {
-      previousTimeRangeRef.current = timeRange
       setDatePickerOpen(true)
     } else {
       void setUrlFilters({ timeRange: value as TimeRange, startDate: null, endDate: null })
@@ -320,10 +315,11 @@ export function AuditLogs({ organizationId }: AuditLogsProps) {
     setDatePickerOpen(false)
   }
 
+  /**
+   * Cancel is a pure close: the URL only ever holds 'Custom range' after Apply
+   * wrote both bounds atomically, so there is never a pending state to revert.
+   */
   const handleDatePickerCancel = () => {
-    if (timeRange === 'Custom range' && !customStartDate) {
-      void setUrlFilters({ timeRange: previousTimeRangeRef.current })
-    }
     setDatePickerOpen(false)
   }
 

--- a/apps/sim/ee/audit-logs/components/audit-logs.tsx
+++ b/apps/sim/ee/audit-logs/components/audit-logs.tsx
@@ -238,7 +238,10 @@ export function AuditLogs({ organizationId }: AuditLogsProps) {
   const customStartDate = urlFilters.startDate ?? ''
   const customEndDate = urlFilters.endDate ?? ''
   const [datePickerOpen, setDatePickerOpen] = useState(false)
-  const previousTimeRangeRef = useRef<TimeRange>(timeRange)
+  /** Cancel target for the date picker — never 'Custom range' itself, so a deep link straight to an empty custom range still cancels back to a preset. */
+  const previousTimeRangeRef = useRef<TimeRange>(
+    timeRange === 'Custom range' ? 'Past 30 days' : timeRange
+  )
   const dateRangeAppliedRef = useRef(false)
   const [searchTerm, setSearchTerm] = useSettingsSearch()
   const debouncedSearch = useDebounce(searchTerm, SEARCH_DEBOUNCE_MS).trim()

--- a/apps/sim/ee/audit-logs/components/audit-logs.tsx
+++ b/apps/sim/ee/audit-logs/components/audit-logs.tsx
@@ -20,7 +20,9 @@ import {
 import { createLogger } from '@sim/logger'
 import { formatDateTime } from '@sim/utils/formatting'
 import { isRecordLike } from '@sim/utils/object'
+import { useQueryStates } from 'nuqs'
 import { getEndDateFromTimeRange, getStartDateFromTimeRange } from '@/lib/logs/filters'
+import { SEARCH_DEBOUNCE_MS } from '@/lib/url-state'
 import type { EnterpriseAuditLogEntry } from '@/app/api/v1/audit-logs/format'
 import { formatDateShort } from '@/app/workspace/[workspaceId]/logs/utils'
 import {
@@ -29,8 +31,11 @@ import {
 } from '@/app/workspace/[workspaceId]/settings/components/activity-log'
 import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
+import { useSettingsSearch } from '@/app/workspace/[workspaceId]/settings/components/use-settings-search'
 import { RESOURCE_TYPE_OPTIONS } from '@/ee/audit-logs/constants'
 import { type AuditLogFilters, useAuditLogs } from '@/ee/audit-logs/hooks/audit-logs'
+import { auditLogFilterParsers, auditLogFilterUrlKeys } from '@/ee/audit-logs/search-params'
+import { useDebounce } from '@/hooks/use-debounce'
 import type { TimeRange } from '@/stores/logs/filters/types'
 
 const logger = createLogger('AuditLogs')
@@ -228,30 +233,18 @@ interface AuditLogsProps {
 }
 
 export function AuditLogs({ organizationId }: AuditLogsProps) {
-  const [selectedTypes, setSelectedTypes] = useState<string[]>([])
-  const [timeRange, setTimeRange] = useState<TimeRange>('Past 30 days')
-  const [customStartDate, setCustomStartDate] = useState('')
-  const [customEndDate, setCustomEndDate] = useState('')
+  const [urlFilters, setUrlFilters] = useQueryStates(auditLogFilterParsers, auditLogFilterUrlKeys)
+  const { types: selectedTypes, timeRange } = urlFilters
+  const customStartDate = urlFilters.startDate ?? ''
+  const customEndDate = urlFilters.endDate ?? ''
   const [datePickerOpen, setDatePickerOpen] = useState(false)
-  const previousTimeRangeRef = useRef<TimeRange>('Past 30 days')
+  const previousTimeRangeRef = useRef<TimeRange>(timeRange)
   const dateRangeAppliedRef = useRef(false)
-  const [searchTerm, setSearchTerm] = useState('')
-  const [debouncedSearch, setDebouncedSearch] = useState('')
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [searchTerm, setSearchTerm] = useSettingsSearch()
+  const debouncedSearch = useDebounce(searchTerm, SEARCH_DEBOUNCE_MS).trim()
   const [isVisuallyRefreshing, setIsVisuallyRefreshing] = useState(false)
   const refreshTimersRef = useRef(new Set<number>())
   const [isExporting, setIsExporting] = useState(false)
-
-  useEffect(() => {
-    const trimmed = searchTerm.trim()
-    if (trimmed === debouncedSearch) return
-    debounceRef.current = setTimeout(() => {
-      setDebouncedSearch(trimmed)
-    }, 300)
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current)
-    }
-  }, [searchTerm, debouncedSearch])
 
   useEffect(() => {
     const timers = refreshTimersRef.current
@@ -301,23 +294,19 @@ export function AuditLogs({ organizationId }: AuditLogsProps) {
       previousTimeRangeRef.current = timeRange
       setDatePickerOpen(true)
     } else {
-      setCustomStartDate('')
-      setCustomEndDate('')
-      setTimeRange(value as TimeRange)
+      void setUrlFilters({ timeRange: value as TimeRange, startDate: null, endDate: null })
     }
   }
 
   const handleDateRangeApply = (start: string, end: string) => {
     dateRangeAppliedRef.current = true
-    setCustomStartDate(start)
-    setCustomEndDate(end)
-    setTimeRange('Custom range')
+    void setUrlFilters({ timeRange: 'Custom range', startDate: start, endDate: end })
     setDatePickerOpen(false)
   }
 
   const handleDatePickerCancel = () => {
     if (timeRange === 'Custom range' && !customStartDate) {
-      setTimeRange(previousTimeRangeRef.current)
+      void setUrlFilters({ timeRange: previousTimeRangeRef.current })
     }
     setDatePickerOpen(false)
   }
@@ -399,7 +388,7 @@ export function AuditLogs({ organizationId }: AuditLogsProps) {
           options={RESOURCE_TYPE_OPTIONS}
           multiSelect
           multiSelectValues={selectedTypes}
-          onMultiSelectChange={setSelectedTypes}
+          onMultiSelectChange={(values) => void setUrlFilters({ types: values })}
           placeholder='All types'
           displayLabel={typeDisplayLabel}
           searchable

--- a/apps/sim/ee/audit-logs/components/audit-logs.tsx
+++ b/apps/sim/ee/audit-logs/components/audit-logs.tsx
@@ -34,7 +34,11 @@ import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components
 import { useSettingsSearch } from '@/app/workspace/[workspaceId]/settings/components/use-settings-search'
 import { RESOURCE_TYPE_OPTIONS } from '@/ee/audit-logs/constants'
 import { type AuditLogFilters, useAuditLogs } from '@/ee/audit-logs/hooks/audit-logs'
-import { auditLogFilterParsers, auditLogFilterUrlKeys } from '@/ee/audit-logs/search-params'
+import {
+  auditLogFilterParsers,
+  auditLogFilterUrlKeys,
+  DEFAULT_AUDIT_TIME_RANGE,
+} from '@/ee/audit-logs/search-params'
 import { useDebounce } from '@/hooks/use-debounce'
 import type { TimeRange } from '@/stores/logs/filters/types'
 
@@ -234,13 +238,22 @@ interface AuditLogsProps {
 
 export function AuditLogs({ organizationId }: AuditLogsProps) {
   const [urlFilters, setUrlFilters] = useQueryStates(auditLogFilterParsers, auditLogFilterUrlKeys)
-  const { types: selectedTypes, timeRange } = urlFilters
+  const { types: selectedTypes } = urlFilters
   const customStartDate = urlFilters.startDate ?? ''
   const customEndDate = urlFilters.endDate ?? ''
+  /**
+   * 'Custom range' is only honored with both bounds present — a partial deep
+   * link (`?time-range=custom` with a missing date) falls back to the default
+   * preset window instead of silently querying unbounded.
+   */
+  const timeRange: TimeRange =
+    urlFilters.timeRange === 'Custom range' && (!customStartDate || !customEndDate)
+      ? DEFAULT_AUDIT_TIME_RANGE
+      : urlFilters.timeRange
   const [datePickerOpen, setDatePickerOpen] = useState(false)
   /** Cancel target for the date picker — never 'Custom range' itself, so a deep link straight to an empty custom range still cancels back to a preset. */
   const previousTimeRangeRef = useRef<TimeRange>(
-    timeRange === 'Custom range' ? 'Past 30 days' : timeRange
+    timeRange === 'Custom range' ? DEFAULT_AUDIT_TIME_RANGE : timeRange
   )
   const dateRangeAppliedRef = useRef(false)
   const [searchTerm, setSearchTerm] = useSettingsSearch()

--- a/apps/sim/ee/audit-logs/search-params.ts
+++ b/apps/sim/ee/audit-logs/search-params.ts
@@ -1,5 +1,8 @@
 import { parseAsArrayOf, parseAsString } from 'nuqs/server'
-import { parseAsTimeRange } from '@/app/workspace/[workspaceId]/logs/search-params'
+import {
+  parseAsDateString,
+  parseAsTimeRange,
+} from '@/app/workspace/[workspaceId]/logs/search-params'
 import type { TimeRange } from '@/stores/logs/filters/types'
 
 export const DEFAULT_AUDIT_TIME_RANGE: TimeRange = 'Past 30 days'
@@ -18,8 +21,8 @@ export const DEFAULT_AUDIT_TIME_RANGE: TimeRange = 'Past 30 days'
 export const auditLogFilterParsers = {
   types: parseAsArrayOf(parseAsString).withDefault([]),
   timeRange: parseAsTimeRange.withDefault(DEFAULT_AUDIT_TIME_RANGE),
-  startDate: parseAsString,
-  endDate: parseAsString,
+  startDate: parseAsDateString,
+  endDate: parseAsDateString,
 } as const
 
 /** Filter view-state: clean URLs, no back-stack churn, kebab-case URL keys. */

--- a/apps/sim/ee/audit-logs/search-params.ts
+++ b/apps/sim/ee/audit-logs/search-params.ts
@@ -2,7 +2,7 @@ import { parseAsArrayOf, parseAsString } from 'nuqs/server'
 import { parseAsTimeRange } from '@/app/workspace/[workspaceId]/logs/search-params'
 import type { TimeRange } from '@/stores/logs/filters/types'
 
-const DEFAULT_AUDIT_TIME_RANGE: TimeRange = 'Past 30 days'
+export const DEFAULT_AUDIT_TIME_RANGE: TimeRange = 'Past 30 days'
 
 /**
  * Co-located, typed URL query-param definitions for the enterprise audit-logs

--- a/apps/sim/ee/audit-logs/search-params.ts
+++ b/apps/sim/ee/audit-logs/search-params.ts
@@ -1,0 +1,35 @@
+import { parseAsArrayOf, parseAsString } from 'nuqs/server'
+import { parseAsTimeRange } from '@/app/workspace/[workspaceId]/logs/search-params'
+import type { TimeRange } from '@/stores/logs/filters/types'
+
+const DEFAULT_AUDIT_TIME_RANGE: TimeRange = 'Past 30 days'
+
+/**
+ * Co-located, typed URL query-param definitions for the enterprise audit-logs
+ * settings section. `timeRange` reuses the logs feature's kebab-token parser so
+ * both surfaces share one wire format for time windows.
+ *
+ * `startDate`/`endDate` are deliberately nullable (no `.withDefault`) — they are
+ * only populated when `timeRange` is "Custom range"; for every preset range the
+ * window is derived from the range label, so a default would be meaningless.
+ * The search box binds to the shared settings `?search=` param via
+ * `useSettingsSearch`, not this map.
+ */
+export const auditLogFilterParsers = {
+  types: parseAsArrayOf(parseAsString).withDefault([]),
+  timeRange: parseAsTimeRange.withDefault(DEFAULT_AUDIT_TIME_RANGE),
+  startDate: parseAsString,
+  endDate: parseAsString,
+} as const
+
+/** Filter view-state: clean URLs, no back-stack churn, kebab-case URL keys. */
+export const auditLogFilterUrlKeys = {
+  history: 'replace',
+  shallow: true,
+  clearOnDefault: true,
+  urlKeys: {
+    timeRange: 'time-range',
+    startDate: 'start-date',
+    endDate: 'end-date',
+  },
+} as const

--- a/apps/sim/ee/custom-blocks/components/custom-blocks.tsx
+++ b/apps/sim/ee/custom-blocks/components/custom-blocks.tsx
@@ -4,12 +4,18 @@ import { useMemo, useState } from 'react'
 import { ChipTag } from '@sim/emcn'
 import { ArrowRight, Plus } from 'lucide-react'
 import { useParams } from 'next/navigation'
+import { useQueryState } from 'nuqs'
 import { canMutateWorkspaceSettingsSection } from '@/components/settings/navigation'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
+import {
+  customBlockIdParam,
+  customBlockIdUrlKeys,
+} from '@/app/workspace/[workspaceId]/settings/[section]/search-params'
 import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
 import { SettingsResourceRow } from '@/app/workspace/[workspaceId]/settings/components/settings-resource-row/settings-resource-row'
 import { SettingsSection } from '@/app/workspace/[workspaceId]/settings/components/settings-section/settings-section'
+import { useSettingsSearch } from '@/app/workspace/[workspaceId]/settings/components/use-settings-search'
 import { getCustomBlockIcon } from '@/blocks/custom/custom-block-icon'
 import { CustomBlockDetail } from '@/ee/custom-blocks/components/custom-block-detail'
 import { useOrgBrandConfig } from '@/ee/whitelabeling/components/branding-provider'
@@ -40,8 +46,13 @@ export function CustomBlocks() {
   )
   const fallbackIconUrl = useOrgBrandConfig().logoUrl ?? null
 
-  const [searchTerm, setSearchTerm] = useState('')
-  const [selected, setSelected] = useState<string | 'new' | null>(null)
+  const [searchTerm, setSearchTerm] = useSettingsSearch()
+  const [selectedBlockId, setSelectedBlockId] = useQueryState(customBlockIdParam.key, {
+    ...customBlockIdParam.parser,
+    ...customBlockIdUrlKeys,
+  })
+  /** The create flow has no entity id and is not deep-linkable — stays local. */
+  const [isCreating, setIsCreating] = useState(false)
 
   const filtered = useMemo(() => {
     if (!searchTerm.trim()) return blocks
@@ -59,13 +70,16 @@ export function CustomBlocks() {
     )
   }
 
-  if (selected !== null && workspaceId) {
+  if ((isCreating || (selectedBlockId && canAdmin)) && workspaceId) {
     return (
       <CustomBlockDetail
-        key={selected}
-        blockId={selected === 'new' ? null : selected}
+        key={isCreating ? 'new' : selectedBlockId}
+        blockId={isCreating ? null : selectedBlockId}
         workspaceId={workspaceId}
-        onBack={() => setSelected(null)}
+        onBack={() => {
+          setIsCreating(false)
+          void setSelectedBlockId(null, { history: 'replace' })
+        }}
       />
     )
   }
@@ -84,7 +98,7 @@ export function CustomBlocks() {
                 text: 'Create block',
                 icon: Plus,
                 variant: 'primary',
-                onSelect: () => setSelected('new'),
+                onSelect: () => setIsCreating(true),
               },
             ]
           : []
@@ -109,7 +123,7 @@ export function CustomBlocks() {
                 <button
                   key={cb.id}
                   type='button'
-                  onClick={() => canAdmin && setSelected(cb.id)}
+                  onClick={() => canAdmin && void setSelectedBlockId(cb.id)}
                   className='w-full rounded-lg p-2 text-left transition-colors hover-hover:bg-[var(--surface-active)]'
                   disabled={!canAdmin}
                 >

--- a/apps/sim/ee/custom-blocks/components/custom-blocks.tsx
+++ b/apps/sim/ee/custom-blocks/components/custom-blocks.tsx
@@ -29,7 +29,7 @@ export function CustomBlocks() {
   const canAdmin = canMutateWorkspaceSettingsSection('custom-blocks', workspacePermissions)
 
   const { data: canManage = false, isLoading } = useCanPublishCustomBlock(workspaceId)
-  const { data: blocks = [] } = useCustomBlocks(workspaceId)
+  const { data: blocks = [], isPending: blocksPending } = useCustomBlocks(workspaceId)
   const { data: workspaces = [] } = useWorkspacesQuery()
 
   /** Publishing requires admin on a source workspace; viewing remains workspace-scoped. */
@@ -63,7 +63,12 @@ export function CustomBlocks() {
   /** Open the detail only once the deep-linked id resolves to a loaded block. */
   const selectedBlock = selectedBlockId ? blocks.find((b) => b.id === selectedBlockId) : undefined
 
-  if (isLoading) return null
+  /**
+   * Hold the first paint while a deep-linked id could still resolve, so a
+   * valid link never flashes the list before jumping to the detail (a dead id
+   * falls back to the list once the blocks load).
+   */
+  if (isLoading || (selectedBlockId && canAdmin && blocksPending)) return null
 
   if (!canManage) {
     return (

--- a/apps/sim/ee/custom-blocks/components/custom-blocks.tsx
+++ b/apps/sim/ee/custom-blocks/components/custom-blocks.tsx
@@ -27,9 +27,10 @@ export function CustomBlocks() {
   const workspaceId = typeof params?.workspaceId === 'string' ? params.workspaceId : undefined
   const workspacePermissions = useUserPermissionsContext()
   const canAdmin = canMutateWorkspaceSettingsSection('custom-blocks', workspacePermissions)
+  const permissionsLoading = workspacePermissions.isLoading
 
   const { data: canManage = false, isLoading } = useCanPublishCustomBlock(workspaceId)
-  const { data: blocks = [], isPending: blocksPending } = useCustomBlocks(workspaceId)
+  const { data: blocks = [] } = useCustomBlocks(workspaceId)
   const { data: workspaces = [] } = useWorkspacesQuery()
 
   /** Publishing requires admin on a source workspace; viewing remains workspace-scoped. */
@@ -64,11 +65,12 @@ export function CustomBlocks() {
   const selectedBlock = selectedBlockId ? blocks.find((b) => b.id === selectedBlockId) : undefined
 
   /**
-   * Hold the first paint while a deep-linked id could still resolve, so a
-   * valid link never flashes the list before jumping to the detail (a dead id
-   * falls back to the list once the blocks load).
+   * Hold the first paint while a deep-linked id could still resolve — the
+   * blocks query (`isLoading`, shared with `useCanPublishCustomBlock`) and the
+   * permissions context both gate the detail, so a valid link never flashes
+   * the list before jumping to it. A dead id still falls back to the list.
    */
-  if (isLoading || (selectedBlockId && canAdmin && blocksPending)) return null
+  if (isLoading || (selectedBlockId !== null && permissionsLoading)) return null
 
   if (!canManage) {
     return (

--- a/apps/sim/ee/custom-blocks/components/custom-blocks.tsx
+++ b/apps/sim/ee/custom-blocks/components/custom-blocks.tsx
@@ -60,6 +60,9 @@ export function CustomBlocks() {
     return blocks.filter((b) => b.name.toLowerCase().includes(q))
   }, [blocks, searchTerm])
 
+  /** Open the detail only once the deep-linked id resolves to a loaded block. */
+  const selectedBlock = selectedBlockId ? blocks.find((b) => b.id === selectedBlockId) : undefined
+
   if (isLoading) return null
 
   if (!canManage) {
@@ -70,11 +73,11 @@ export function CustomBlocks() {
     )
   }
 
-  if ((isCreating || (selectedBlockId && canAdmin)) && workspaceId) {
+  if ((isCreating || (selectedBlock && canAdmin)) && workspaceId) {
     return (
       <CustomBlockDetail
-        key={isCreating ? 'new' : selectedBlockId}
-        blockId={isCreating ? null : selectedBlockId}
+        key={isCreating ? 'new' : selectedBlock?.id}
+        blockId={isCreating ? null : (selectedBlock?.id ?? null)}
         workspaceId={workspaceId}
         onBack={() => {
           setIsCreating(false)

--- a/apps/sim/ee/data-drains/components/data-drains-settings.tsx
+++ b/apps/sim/ee/data-drains/components/data-drains-settings.tsx
@@ -29,6 +29,7 @@ import { CADENCE_TYPES, DESTINATION_TYPES, SOURCE_TYPES } from '@/lib/data-drain
 import { RowActionsMenu } from '@/app/workspace/[workspaceId]/settings/components/row-actions-menu'
 import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
+import { useSettingsSearch } from '@/app/workspace/[workspaceId]/settings/components/use-settings-search'
 import { DESTINATION_FORM_REGISTRY } from '@/ee/data-drains/destinations/registry'
 import {
   useCreateDataDrain,
@@ -86,7 +87,7 @@ export function DataDrainsSettings({ organizationId }: DataDrainsSettingsProps) 
 
   const [createOpen, setCreateOpen] = useState(false)
   const [expandedDrainId, setExpandedDrainId] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState('')
+  const [searchTerm, setSearchTerm] = useSettingsSearch()
 
   const query = searchTerm.trim().toLowerCase()
   const filteredDrains = !query

--- a/apps/sim/ee/workspace-forking/components/forks.tsx
+++ b/apps/sim/ee/workspace-forking/components/forks.tsx
@@ -29,6 +29,7 @@ import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/compo
 import type { SettingsAction } from '@/app/workspace/[workspaceId]/settings/components/settings-header/settings-header'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
 import { SettingsSection } from '@/app/workspace/[workspaceId]/settings/components/settings-section/settings-section'
+import { useSettingsSearch } from '@/app/workspace/[workspaceId]/settings/components/use-settings-search'
 import { useSettingsUnsavedGuard } from '@/app/workspace/[workspaceId]/settings/hooks/use-settings-unsaved-guard'
 import { ForkActivityPanel } from '@/ee/workspace-forking/components/fork-activity-panel/fork-activity-panel'
 import { ForkExcludedWorkflows } from '@/ee/workspace-forking/components/fork-excluded-workflows/fork-excluded-workflows'
@@ -288,7 +289,7 @@ export function Forks() {
   const rollback = useRollbackFork()
   const unlink = useUnlinkFork()
 
-  const [searchTerm, setSearchTerm] = useState('')
+  const [searchTerm, setSearchTerm] = useSettingsSearch()
   const [isForkModalOpen, setIsForkModalOpen] = useState(false)
   const [confirmRollbackOpen, setConfirmRollbackOpen] = useState(false)
   const [confirmUnlink, setConfirmUnlink] = useState<{ id: string; name: string } | null>(null)
@@ -403,7 +404,7 @@ export function Forks() {
           workspaceId={workspaceId}
           otherWorkspaceId={parent.id}
           otherWorkspaceName={parent.name}
-          onBack={() => setSelectedForkId(null)}
+          onBack={() => setSelectedForkId(null, { history: 'replace' })}
           actions={parentHeaderActions}
         />
       ) : forkView === 'activity' ? (

--- a/apps/sim/ee/workspace-forking/components/forks.tsx
+++ b/apps/sim/ee/workspace-forking/components/forks.tsx
@@ -411,7 +411,7 @@ export function Forks() {
         <ForkActivityDetailView
           workspaceId={workspaceId}
           workspaceNames={lineagePartnerNames(parent, forks)}
-          onBack={() => setForkView(null)}
+          onBack={() => void setForkView(null, { history: 'replace' })}
           actions={
             undoableRun
               ? [


### PR DESCRIPTION
## Summary
- full platform audit (landing, workspace, settings, ee) found the app surface clean except the ee settings sections and three stragglers — this PR migrates all of them so view-state is consistently deep-linkable via nuqs
- ee sections: audit-logs filters get a co-located `search-params.ts` (`?types=`, `?time-range=`, `?start-date=`, `?end-date=`, reusing the logs kebab-token time-range parser); access-control deep-links `?group-id=`; custom-blocks deep-links `?custom-block-id=` (create flow stays local); audit-logs/access-control/custom-blocks/data-drains/forks search binds the shared settings `?search=` via `useSettingsSearch()` — deletes audit-logs' hand-rolled debounce effect
- sweep stragglers: knowledge document chunk `?enabled=` filter (page reset in the same write), workflow-mcp-servers `?server-tab=` deep-link (cleared with the server id on close), byok provider search via a controlled prop pair (modal consumers keep local state)
- correctness: detail views gate on the resolved entity (dead/loading ids fall back to the list); every deep-link opens with push and closes with replace; `parseAsTimeRange` parses unknown tokens to null so each surface's default applies
- rule updates (`.claude/rules/sim-url-state.md`): shallow default, urlKeys kebab remapping, throttleMs deprecation, startTransition with shallow:false, shared-parser null-fallback, resolve-before-open, close-with-replace, reusable-component controlled search

## Type of Change
- [x] Improvement

## Testing
Typecheck, biome, lint:check, and 617 tests across the touched areas pass. Ran an adversarial review pass plus the full cleanup battery (effects/state/memo/callback/react-query/emcn/url-state/comments) — all findings fixed in-branch.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)