### PR TITLE
feat(workflows): IDE-style reference viewer for workflows

### DIFF
--- a/apps/sim/app/api/workflows/[id]/references/route.test.ts
+++ b/apps/sim/app/api/workflows/[id]/references/route.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment node
+ */
+import { createMockRequest } from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetSession, mockGetUserEntityPermissions, mockGetWorkflowReferences } = vi.hoisted(
+  () => ({
+    mockGetSession: vi.fn(),
+    mockGetUserEntityPermissions: vi.fn(),
+    mockGetWorkflowReferences: vi.fn(),
+  })
+)
+
+vi.mock('@/lib/auth', () => ({
+  getSession: mockGetSession,
+}))
+
+vi.mock('@/lib/workspaces/permissions/utils', () => ({
+  getUserEntityPermissions: mockGetUserEntityPermissions,
+}))
+
+vi.mock('@/lib/workflows/references/operations', () => ({
+  getWorkflowReferences: mockGetWorkflowReferences,
+}))
+
+import { GET } from '@/app/api/workflows/[id]/references/route'
+
+const REFERENCES = {
+  callers: [{ id: 'b', name: 'B', cycle: false, children: [] }],
+  callees: [],
+}
+
+function callRoute(id = 'wf-1', workspaceId: string | null = 'ws-1') {
+  const url = workspaceId
+    ? `http://localhost:3000/api/workflows/${id}/references?workspaceId=${workspaceId}`
+    : `http://localhost:3000/api/workflows/${id}/references`
+  return GET(createMockRequest('GET', undefined, {}, url), { params: Promise.resolve({ id }) })
+}
+
+describe('GET /api/workflows/[id]/references', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({ user: { id: 'user-1' } })
+    mockGetUserEntityPermissions.mockResolvedValue('read')
+    mockGetWorkflowReferences.mockResolvedValue(REFERENCES)
+  })
+
+  it('returns 401 without a session', async () => {
+    mockGetSession.mockResolvedValue(null)
+    const response = await callRoute()
+    expect(response.status).toBe(401)
+    expect(mockGetWorkflowReferences).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 without a workspaceId', async () => {
+    const response = await callRoute('wf-1', null)
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 403 when the user cannot access the workspace', async () => {
+    mockGetUserEntityPermissions.mockResolvedValue(null)
+    const response = await callRoute()
+    expect(response.status).toBe(403)
+    expect(mockGetWorkflowReferences).not.toHaveBeenCalled()
+  })
+
+  it('returns the reference trees for the workflow', async () => {
+    const response = await callRoute()
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(REFERENCES)
+    expect(mockGetWorkflowReferences).toHaveBeenCalledWith('ws-1', 'wf-1')
+  })
+})

--- a/apps/sim/app/api/workflows/[id]/references/route.test.ts
+++ b/apps/sim/app/api/workflows/[id]/references/route.test.ts
@@ -4,20 +4,18 @@
 import { createMockRequest } from '@sim/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockGetSession, mockGetUserEntityPermissions, mockGetWorkflowReferences } = vi.hoisted(
-  () => ({
-    mockGetSession: vi.fn(),
-    mockGetUserEntityPermissions: vi.fn(),
-    mockGetWorkflowReferences: vi.fn(),
-  })
-)
+const { mockGetSession, mockAuthorizeWorkflow, mockGetWorkflowReferences } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockAuthorizeWorkflow: vi.fn(),
+  mockGetWorkflowReferences: vi.fn(),
+}))
 
 vi.mock('@/lib/auth', () => ({
   getSession: mockGetSession,
 }))
 
-vi.mock('@/lib/workspaces/permissions/utils', () => ({
-  getUserEntityPermissions: mockGetUserEntityPermissions,
+vi.mock('@sim/platform-authz/workflow', () => ({
+  authorizeWorkflowByWorkspacePermission: mockAuthorizeWorkflow,
 }))
 
 vi.mock('@/lib/workflows/references/operations', () => ({
@@ -31,10 +29,8 @@ const REFERENCES = {
   callees: [],
 }
 
-function callRoute(id = 'wf-1', workspaceId: string | null = 'ws-1') {
-  const url = workspaceId
-    ? `http://localhost:3000/api/workflows/${id}/references?workspaceId=${workspaceId}`
-    : `http://localhost:3000/api/workflows/${id}/references`
+function callRoute(id = 'wf-1') {
+  const url = `http://localhost:3000/api/workflows/${id}/references`
   return GET(createMockRequest('GET', undefined, {}, url), { params: Promise.resolve({ id }) })
 }
 
@@ -42,7 +38,12 @@ describe('GET /api/workflows/[id]/references', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetSession.mockResolvedValue({ user: { id: 'user-1' } })
-    mockGetUserEntityPermissions.mockResolvedValue('read')
+    mockAuthorizeWorkflow.mockResolvedValue({
+      allowed: true,
+      status: 200,
+      workflow: { id: 'wf-1', workspaceId: 'ws-1' },
+      workspacePermission: 'read',
+    })
     mockGetWorkflowReferences.mockResolvedValue(REFERENCES)
   })
 
@@ -53,22 +54,41 @@ describe('GET /api/workflows/[id]/references', () => {
     expect(mockGetWorkflowReferences).not.toHaveBeenCalled()
   })
 
-  it('returns 400 without a workspaceId', async () => {
-    const response = await callRoute('wf-1', null)
-    expect(response.status).toBe(400)
+  it('returns 404 when the workflow does not exist', async () => {
+    mockAuthorizeWorkflow.mockResolvedValue({
+      allowed: false,
+      status: 404,
+      message: 'Workflow not found',
+      workflow: null,
+      workspacePermission: null,
+    })
+    const response = await callRoute()
+    expect(response.status).toBe(404)
+    expect(mockGetWorkflowReferences).not.toHaveBeenCalled()
   })
 
-  it('returns 403 when the user cannot access the workspace', async () => {
-    mockGetUserEntityPermissions.mockResolvedValue(null)
+  it('returns 403 when the user cannot read the workflow', async () => {
+    mockAuthorizeWorkflow.mockResolvedValue({
+      allowed: false,
+      status: 403,
+      message: 'Unauthorized: Access denied to read this workflow',
+      workflow: { id: 'wf-1', workspaceId: 'ws-1' },
+      workspacePermission: null,
+    })
     const response = await callRoute()
     expect(response.status).toBe(403)
     expect(mockGetWorkflowReferences).not.toHaveBeenCalled()
   })
 
-  it('returns the reference trees for the workflow', async () => {
+  it('returns the reference trees scoped to the workflow workspace', async () => {
     const response = await callRoute()
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual(REFERENCES)
+    expect(mockAuthorizeWorkflow).toHaveBeenCalledWith({
+      workflowId: 'wf-1',
+      userId: 'user-1',
+      action: 'read',
+    })
     expect(mockGetWorkflowReferences).toHaveBeenCalledWith('ws-1', 'wf-1')
   })
 })

--- a/apps/sim/app/api/workflows/[id]/references/route.ts
+++ b/apps/sim/app/api/workflows/[id]/references/route.ts
@@ -28,7 +28,7 @@ export const GET = withRouteHandler(async (request: NextRequest, context: RouteC
   if (!auth.allowed || !auth.workflow?.workspaceId) {
     return NextResponse.json(
       { error: auth.message ?? 'Access denied' },
-      { status: auth.status || 403 }
+      { status: auth.allowed ? 403 : auth.status }
     )
   }
 

--- a/apps/sim/app/api/workflows/[id]/references/route.ts
+++ b/apps/sim/app/api/workflows/[id]/references/route.ts
@@ -1,0 +1,30 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { getWorkflowReferencesContract } from '@/lib/api/contracts/workflow-references'
+import { parseRequest } from '@/lib/api/server'
+import { getSession } from '@/lib/auth'
+import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { getWorkflowReferences } from '@/lib/workflows/references/operations'
+import { getUserEntityPermissions } from '@/lib/workspaces/permissions/utils'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export const GET = withRouteHandler(async (request: NextRequest, context: RouteContext) => {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const parsed = await parseRequest(getWorkflowReferencesContract, request, context)
+  if (!parsed.success) return parsed.response
+
+  const { params, query } = parsed.data
+
+  const permission = await getUserEntityPermissions(session.user.id, 'workspace', query.workspaceId)
+  if (permission === null) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const references = await getWorkflowReferences(query.workspaceId, params.id)
+  return NextResponse.json(references)
+})

--- a/apps/sim/app/api/workflows/[id]/references/route.ts
+++ b/apps/sim/app/api/workflows/[id]/references/route.ts
@@ -1,3 +1,4 @@
+import { authorizeWorkflowByWorkspacePermission } from '@sim/platform-authz/workflow'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { getWorkflowReferencesContract } from '@/lib/api/contracts/workflow-references'
@@ -5,7 +6,6 @@ import { parseRequest } from '@/lib/api/server'
 import { getSession } from '@/lib/auth'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { getWorkflowReferences } from '@/lib/workflows/references/operations'
-import { getUserEntityPermissions } from '@/lib/workspaces/permissions/utils'
 
 type RouteContext = { params: Promise<{ id: string }> }
 
@@ -18,13 +18,20 @@ export const GET = withRouteHandler(async (request: NextRequest, context: RouteC
   const parsed = await parseRequest(getWorkflowReferencesContract, request, context)
   if (!parsed.success) return parsed.response
 
-  const { params, query } = parsed.data
+  const { id } = parsed.data.params
 
-  const permission = await getUserEntityPermissions(session.user.id, 'workspace', query.workspaceId)
-  if (permission === null) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  const auth = await authorizeWorkflowByWorkspacePermission({
+    workflowId: id,
+    userId: session.user.id,
+    action: 'read',
+  })
+  if (!auth.allowed || !auth.workflow?.workspaceId) {
+    return NextResponse.json(
+      { error: auth.message ?? 'Access denied' },
+      { status: auth.status || 403 }
+    )
   }
 
-  const references = await getWorkflowReferences(query.workspaceId, params.id)
+  const references = await getWorkflowReferences(auth.workflow.workspaceId, id)
   return NextResponse.json(references)
 })

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
@@ -22,6 +22,7 @@ import {
   SquareArrowUpRight,
   Trash,
   Unlock,
+  Workflow,
 } from '@sim/emcn/icons'
 import { Pin, PinOff } from 'lucide-react'
 
@@ -31,6 +32,7 @@ interface ContextMenuProps {
   menuRef: React.RefObject<HTMLDivElement | null>
   onClose: () => void
   onOpenInNewTab?: () => void
+  onFindReferences?: () => void
   onMarkAsRead?: () => void
   onMarkAsUnread?: () => void
   onTogglePin?: () => void
@@ -53,6 +55,7 @@ interface ContextMenuProps {
   onExport?: () => void
   onDelete: () => void
   showOpenInNewTab?: boolean
+  showFindReferences?: boolean
   showMarkAsRead?: boolean
   showMarkAsUnread?: boolean
   showPin?: boolean
@@ -93,6 +96,7 @@ export function ContextMenu({
   menuRef,
   onClose,
   onOpenInNewTab,
+  onFindReferences,
   onMarkAsRead,
   onMarkAsUnread,
   onTogglePin,
@@ -104,6 +108,7 @@ export function ContextMenu({
   onExport,
   onDelete,
   showOpenInNewTab = false,
+  showFindReferences = false,
   showMarkAsRead = false,
   showMarkAsUnread = false,
   showPin = false,
@@ -133,7 +138,8 @@ export function ContextMenu({
   showUploadLogo = false,
   disableUploadLogo = false,
 }: ContextMenuProps) {
-  const hasNavigationSection = showOpenInNewTab && onOpenInNewTab
+  const hasNavigationSection =
+    (showOpenInNewTab && onOpenInNewTab) || (showFindReferences && onFindReferences)
   const hasStatusSection =
     (showMarkAsRead && onMarkAsRead) ||
     (showMarkAsUnread && onMarkAsUnread) ||
@@ -193,6 +199,17 @@ export function ContextMenu({
           >
             <SquareArrowUpRight />
             Open in new tab
+          </DropdownMenuItem>
+        )}
+        {showFindReferences && onFindReferences && (
+          <DropdownMenuItem
+            onSelect={() => {
+              onFindReferences()
+              onClose()
+            }}
+          >
+            <Workflow />
+            Show references
           </DropdownMenuItem>
         )}
         {hasNavigationSection && (hasStatusSection || hasEditSection || hasCopySection) && (

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/components/reference-tree/reference-tree.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/components/reference-tree/reference-tree.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { cn } from '@sim/emcn'
-import { WorkflowIcon } from '@/components/icons'
+import { Workflow } from '@sim/emcn/icons'
 import type { ReferenceNode } from '@/lib/api/contracts/workflow-references'
 
 const CONFIG = {
@@ -30,12 +29,9 @@ function ReferenceTreeItem({ node, depth, onNavigate }: ReferenceTreeItemProps) 
         type='button'
         onClick={() => onNavigate(node.id)}
         style={{ paddingLeft: CONFIG.BASE_INDENT + depth * CONFIG.INDENT_PER_LEVEL }}
-        className={cn(
-          'flex w-full min-w-0 items-center gap-2 rounded-md py-1.5 pr-2 text-left transition-colors',
-          'hover:bg-[var(--surface-hover)]'
-        )}
+        className='flex w-full min-w-0 items-center gap-2 rounded-md py-1.5 pr-2 text-left transition-colors hover:bg-[var(--surface-hover)]'
       >
-        <WorkflowIcon className='size-[14px] shrink-0 text-[var(--text-icon)]' />
+        <Workflow className='size-[14px] shrink-0 text-[var(--text-icon)]' />
         <span className='min-w-0 truncate text-[var(--text-body)] text-sm'>{node.name}</span>
         {node.cycle && (
           <span className='shrink-0 text-[var(--text-muted)] text-caption'>(cycle)</span>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/components/reference-tree/reference-tree.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/components/reference-tree/reference-tree.tsx
@@ -7,10 +7,8 @@ import type { ReferenceNode } from '@/lib/api/contracts/workflow-references'
 const CONFIG = {
   /** Horizontal indent added per tree level, in pixels. */
   INDENT_PER_LEVEL: 16,
-  /** Base horizontal padding for a row, in pixels. */
-  BASE_INDENT: 4,
-  /** Workflow-block brand color (`WorkflowBlock.bgColor`). */
-  ICON_COLOR: '#6366F1',
+  /** Base row padding: lands depth-0 content on the modal's px-4 text gutter. */
+  BASE_INDENT: 8,
 } as const
 
 interface ReferenceTreeProps {
@@ -34,20 +32,20 @@ function ReferenceTreeItem({ node, depth, onNavigate }: ReferenceTreeItemProps) 
         style={{ paddingLeft: CONFIG.BASE_INDENT + depth * CONFIG.INDENT_PER_LEVEL }}
         className={cn(
           'flex w-full min-w-0 items-center gap-2 rounded-md py-1.5 pr-2 text-left transition-colors',
-          'hover:bg-[var(--surface-active)]'
+          'hover:bg-[var(--surface-hover)]'
         )}
       >
-        <WorkflowIcon className='size-[14px] flex-shrink-0' style={{ color: CONFIG.ICON_COLOR }} />
+        <WorkflowIcon className='size-[14px] shrink-0 text-[var(--text-icon)]' />
         <span className='min-w-0 truncate text-[var(--text-body)] text-sm'>{node.name}</span>
         {node.cycle && (
-          <span className='flex-shrink-0 text-[var(--text-muted)] text-caption'>(cycle)</span>
+          <span className='shrink-0 text-[var(--text-muted)] text-caption'>(cycle)</span>
         )}
       </button>
       {node.children.length > 0 && (
         <div role='group'>
           {node.children.map((child) => (
             <ReferenceTreeItem
-              key={`${child.id}-${depth}`}
+              key={child.id}
               node={child}
               depth={depth + 1}
               onNavigate={onNavigate}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/components/reference-tree/reference-tree.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/components/reference-tree/reference-tree.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { cn } from '@sim/emcn'
+import { WorkflowIcon } from '@/components/icons'
+import type { ReferenceNode } from '@/lib/api/contracts/workflow-references'
+
+const CONFIG = {
+  /** Horizontal indent added per tree level, in pixels. */
+  INDENT_PER_LEVEL: 16,
+  /** Base horizontal padding for a row, in pixels. */
+  BASE_INDENT: 4,
+  /** Workflow-block brand color (`WorkflowBlock.bgColor`). */
+  ICON_COLOR: '#6366F1',
+} as const
+
+interface ReferenceTreeProps {
+  nodes: ReferenceNode[]
+  /** Invoked with a workflow id when a row is activated. */
+  onNavigate: (workflowId: string) => void
+}
+
+interface ReferenceTreeItemProps {
+  node: ReferenceNode
+  depth: number
+  onNavigate: (workflowId: string) => void
+}
+
+function ReferenceTreeItem({ node, depth, onNavigate }: ReferenceTreeItemProps) {
+  return (
+    <div role='treeitem' aria-selected={false}>
+      <button
+        type='button'
+        onClick={() => onNavigate(node.id)}
+        style={{ paddingLeft: CONFIG.BASE_INDENT + depth * CONFIG.INDENT_PER_LEVEL }}
+        className={cn(
+          'flex w-full min-w-0 items-center gap-2 rounded-md py-1.5 pr-2 text-left transition-colors',
+          'hover:bg-[var(--surface-active)]'
+        )}
+      >
+        <WorkflowIcon className='size-[14px] flex-shrink-0' style={{ color: CONFIG.ICON_COLOR }} />
+        <span className='min-w-0 truncate text-[var(--text-body)] text-sm'>{node.name}</span>
+        {node.cycle && (
+          <span className='flex-shrink-0 text-[var(--text-muted)] text-caption'>(cycle)</span>
+        )}
+      </button>
+      {node.children.length > 0 && (
+        <div role='group'>
+          {node.children.map((child) => (
+            <ReferenceTreeItem
+              key={`${child.id}-${depth}`}
+              node={child}
+              depth={depth + 1}
+              onNavigate={onNavigate}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Read-only recursive tree of workflow references. Each row navigates to its
+ * workflow on click; cyclic leaves are marked and render no children.
+ */
+export function ReferenceTree({ nodes, onNavigate }: ReferenceTreeProps) {
+  return (
+    <div role='tree' className='flex flex-col'>
+      {nodes.map((node) => (
+        <ReferenceTreeItem key={node.id} node={node} depth={0} onNavigate={onNavigate} />
+      ))}
+    </div>
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/components/reference-tree/reference-tree.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/components/reference-tree/reference-tree.tsx
@@ -24,7 +24,7 @@ interface ReferenceTreeItemProps {
 
 function ReferenceTreeItem({ node, depth, onNavigate }: ReferenceTreeItemProps) {
   return (
-    <div role='treeitem' aria-selected={false}>
+    <div role='treeitem' aria-level={depth + 1}>
       <button
         type='button'
         onClick={() => onNavigate(node.id)}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/references-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/references-modal.tsx
@@ -51,7 +51,7 @@ export function ReferencesModal({
 
   return (
     <ChipModal open onOpenChange={(next) => !next && onClose()} srTitle='References'>
-      <ChipModalHeader onClose={onClose}>References · {workflowName}</ChipModalHeader>
+      <ChipModalHeader onClose={onClose}>References — {workflowName}</ChipModalHeader>
       <ChipModalBody>
         <ChipModalTabs
           tabs={TABS}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/references-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/references-modal.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { ChipModal, ChipModalBody, ChipModalHeader, ChipModalTabs } from '@sim/emcn'
+import { useRouter } from 'next/navigation'
+import type { ReferenceNode } from '@/lib/api/contracts/workflow-references'
+import { ReferenceTree } from '@/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/components/reference-tree/reference-tree'
+import { useWorkflowReferences } from '@/hooks/queries/workflow-references'
+
+type ReferencesTab = 'callers' | 'callees'
+
+const TABS = [
+  { value: 'callers', label: 'Used by' },
+  { value: 'callees', label: 'Uses' },
+] as const
+
+const EMPTY_MESSAGE: Record<ReferencesTab, string> = {
+  callers: 'No workflows call this workflow.',
+  callees: "This workflow doesn't call any other workflows.",
+}
+
+interface ReferencesModalProps {
+  isOpen: boolean
+  onClose: () => void
+  workspaceId: string
+  workflowId: string
+  workflowName: string
+}
+
+/**
+ * IDE-style reference viewer for a workflow. "Used by" lists the workflows that
+ * call it (inbound); "Uses" lists the workflows it calls (outbound). Both are
+ * recursive trees whose rows navigate to the referenced workflow.
+ */
+export function ReferencesModal({
+  isOpen,
+  onClose,
+  workspaceId,
+  workflowId,
+  workflowName,
+}: ReferencesModalProps) {
+  const router = useRouter()
+  const [activeTab, setActiveTab] = useState<ReferencesTab>('callers')
+  const [prevIsOpen, setPrevIsOpen] = useState(false)
+
+  if (isOpen !== prevIsOpen) {
+    setPrevIsOpen(isOpen)
+    if (isOpen) setActiveTab('callers')
+  }
+
+  const { data, isPending, isError } = useWorkflowReferences(workspaceId, workflowId, {
+    enabled: isOpen,
+  })
+
+  const handleNavigate = useCallback(
+    (targetId: string) => {
+      router.push(`/workspace/${workspaceId}/w/${targetId}`)
+      onClose()
+    },
+    [router, workspaceId, onClose]
+  )
+
+  const nodes: ReferenceNode[] = data ? data[activeTab] : []
+
+  return (
+    <ChipModal open={isOpen} onOpenChange={(next) => !next && onClose()} srTitle='References'>
+      <ChipModalHeader onClose={onClose}>References · {workflowName}</ChipModalHeader>
+      <ChipModalBody>
+        <ChipModalTabs
+          tabs={TABS}
+          value={activeTab}
+          onChange={(value) => setActiveTab(value as ReferencesTab)}
+          aria-label='Reference direction'
+        />
+        {isPending ? (
+          <p className='px-2 text-[var(--text-muted)] text-sm'>Loading references…</p>
+        ) : isError ? (
+          <p className='px-2 text-[var(--text-error)] text-sm'>Failed to load references.</p>
+        ) : nodes.length === 0 ? (
+          <p className='px-2 text-[var(--text-muted)] text-sm'>{EMPTY_MESSAGE[activeTab]}</p>
+        ) : (
+          <ReferenceTree nodes={nodes} onNavigate={handleNavigate} />
+        )}
+      </ChipModalBody>
+    </ChipModal>
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/references-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/references-modal.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react'
 import { ChipModal, ChipModalBody, ChipModalHeader, ChipModalTabs } from '@sim/emcn'
 import { useRouter } from 'next/navigation'
-import type { ReferenceNode } from '@/lib/api/contracts/workflow-references'
 import { ReferenceTree } from '@/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/components/reference-tree/reference-tree'
 import { useWorkflowReferences } from '@/hooks/queries/workflow-references'
 
@@ -20,7 +19,6 @@ const EMPTY_MESSAGE: Record<ReferencesTab, string> = {
 }
 
 interface ReferencesModalProps {
-  isOpen: boolean
   onClose: () => void
   workspaceId: string
   workflowId: string
@@ -34,7 +32,6 @@ interface ReferencesModalProps {
  * demand by the owning row, so state initializes fresh per open.
  */
 export function ReferencesModal({
-  isOpen,
   onClose,
   workspaceId,
   workflowId,
@@ -50,10 +47,10 @@ export function ReferencesModal({
     onClose()
   }
 
-  const nodes: ReferenceNode[] = data ? data[activeTab] : []
+  const nodes = data?.[activeTab] ?? []
 
   return (
-    <ChipModal open={isOpen} onOpenChange={(next) => !next && onClose()} srTitle='References'>
+    <ChipModal open onOpenChange={(next) => !next && onClose()} srTitle='References'>
       <ChipModalHeader onClose={onClose}>References · {workflowName}</ChipModalHeader>
       <ChipModalBody>
         <ChipModalTabs

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/references-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/references-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 import { ChipModal, ChipModalBody, ChipModalHeader, ChipModalTabs } from '@sim/emcn'
 import { useRouter } from 'next/navigation'
 import type { ReferenceNode } from '@/lib/api/contracts/workflow-references'
@@ -30,7 +30,8 @@ interface ReferencesModalProps {
 /**
  * IDE-style reference viewer for a workflow. "Used by" lists the workflows that
  * call it (inbound); "Uses" lists the workflows it calls (outbound). Both are
- * recursive trees whose rows navigate to the referenced workflow.
+ * recursive trees whose rows navigate to the referenced workflow. Mounted on
+ * demand by the owning row, so state initializes fresh per open.
  */
 export function ReferencesModal({
   isOpen,
@@ -41,24 +42,13 @@ export function ReferencesModal({
 }: ReferencesModalProps) {
   const router = useRouter()
   const [activeTab, setActiveTab] = useState<ReferencesTab>('callers')
-  const [prevIsOpen, setPrevIsOpen] = useState(false)
 
-  if (isOpen !== prevIsOpen) {
-    setPrevIsOpen(isOpen)
-    if (isOpen) setActiveTab('callers')
+  const { data, isPending, isError } = useWorkflowReferences(workflowId)
+
+  const handleNavigate = (targetId: string) => {
+    router.push(`/workspace/${workspaceId}/w/${targetId}`)
+    onClose()
   }
-
-  const { data, isPending, isError } = useWorkflowReferences(workspaceId, workflowId, {
-    enabled: isOpen,
-  })
-
-  const handleNavigate = useCallback(
-    (targetId: string) => {
-      router.push(`/workspace/${workspaceId}/w/${targetId}`)
-      onClose()
-    },
-    [router, workspaceId, onClose]
-  )
 
   const nodes: ReferenceNode[] = data ? data[activeTab] : []
 

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -525,7 +525,6 @@ export const WorkflowItem = memo(function WorkflowItem({
 
       {isReferencesOpen && (
         <ReferencesModal
-          isOpen
           onClose={() => setIsReferencesOpen(false)}
           workspaceId={workspaceId}
           workflowId={workflow.id}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -10,6 +10,7 @@ import { SIM_RESOURCES_DRAG_TYPE } from '@/lib/copilot/resource-types'
 import { useUserPermissionsContext } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
 import { ContextMenu } from '@/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu'
 import { DeleteModal } from '@/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/delete-modal/delete-modal'
+import { ReferencesModal } from '@/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/references-modal/references-modal'
 import { Avatars } from '@/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/avatars/avatars'
 import {
   useContextMenu,
@@ -80,6 +81,7 @@ export const WorkflowItem = memo(function WorkflowItem({
   const { canDeleteWorkflows, canDeleteFolder } = useCanDelete({ workspaceId })
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+  const [isReferencesOpen, setIsReferencesOpen] = useState(false)
   const [deleteItemType, setDeleteItemType] = useState<'workflow' | 'mixed'>('workflow')
   const [deleteModalNames, setDeleteModalNames] = useState<string | string[]>('')
   const [canDeleteSelection, setCanDeleteSelection] = useState(true)
@@ -386,6 +388,8 @@ export const WorkflowItem = memo(function WorkflowItem({
       }
 
       if (e.metaKey || e.ctrlKey) {
+        e.preventDefault()
+        setIsReferencesOpen(true)
         return
       }
 
@@ -397,6 +401,10 @@ export const WorkflowItem = memo(function WorkflowItem({
     },
     [shouldPreventClickRef, workflow.id, onWorkflowClick, isEditing]
   )
+
+  const handleFindReferences = useCallback(() => {
+    setIsReferencesOpen(true)
+  }, [])
 
   return (
     <>
@@ -486,12 +494,14 @@ export const WorkflowItem = memo(function WorkflowItem({
         menuRef={menuRef}
         onClose={closeMenu}
         onOpenInNewTab={handleOpenInNewTab}
+        onFindReferences={handleFindReferences}
         onRename={handleStartEdit}
         renameInputRef={inputRef}
         onDuplicate={handleDuplicate}
         onExport={handleExport}
         onDelete={handleOpenDeleteModal}
         showOpenInNewTab={!isMixedSelection && selectedWorkflows.size <= 1}
+        showFindReferences={!isMixedSelection && selectedWorkflows.size <= 1}
         showRename={!isMixedSelection && selectedWorkflows.size <= 1}
         showDuplicate={true}
         showExport={true}
@@ -513,6 +523,14 @@ export const WorkflowItem = memo(function WorkflowItem({
         isDeleting={isDeleting}
         itemType={deleteItemType}
         itemName={deleteModalNames}
+      />
+
+      <ReferencesModal
+        isOpen={isReferencesOpen}
+        onClose={() => setIsReferencesOpen(false)}
+        workspaceId={workspaceId}
+        workflowId={workflow.id}
+        workflowName={workflow.name}
       />
     </>
   )

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/workflow-item/workflow-item.tsx
@@ -388,8 +388,6 @@ export const WorkflowItem = memo(function WorkflowItem({
       }
 
       if (e.metaKey || e.ctrlKey) {
-        e.preventDefault()
-        setIsReferencesOpen(true)
         return
       }
 
@@ -525,13 +523,15 @@ export const WorkflowItem = memo(function WorkflowItem({
         itemName={deleteModalNames}
       />
 
-      <ReferencesModal
-        isOpen={isReferencesOpen}
-        onClose={() => setIsReferencesOpen(false)}
-        workspaceId={workspaceId}
-        workflowId={workflow.id}
-        workflowName={workflow.name}
-      />
+      {isReferencesOpen && (
+        <ReferencesModal
+          isOpen
+          onClose={() => setIsReferencesOpen(false)}
+          workspaceId={workspaceId}
+          workflowId={workflow.id}
+          workflowName={workflow.name}
+        />
+      )}
     </>
   )
 })

--- a/apps/sim/hooks/queries/workflow-references.ts
+++ b/apps/sim/hooks/queries/workflow-references.ts
@@ -5,8 +5,13 @@ import {
   type WorkflowReferencesResponse,
 } from '@/lib/api/contracts/workflow-references'
 
-/** Short — the graph reflects live editor state and should stay fresh on reopen. */
-export const WORKFLOW_REFERENCES_STALE_TIME = 30 * 1000
+/**
+ * Zero — the graph reflects live editor state (workflow blocks/names can change
+ * between opens). The modal stays mounted with the query disabled while closed, so
+ * a non-zero window would serve a cached graph on reopen without refetching. Zero
+ * marks the data stale immediately, forcing a refetch each time the modal reopens.
+ */
+export const WORKFLOW_REFERENCES_STALE_TIME = 0
 
 export const workflowReferenceKeys = {
   all: ['workflow-references'] as const,

--- a/apps/sim/hooks/queries/workflow-references.ts
+++ b/apps/sim/hooks/queries/workflow-references.ts
@@ -6,11 +6,12 @@ import {
 } from '@/lib/api/contracts/workflow-references'
 
 /**
- * Short — the graph reflects live editor state (workflow blocks/names can change
- * between opens). The modal mounts on demand, so each open refetches once the
- * window lapses while still absorbing rapid open/close flapping.
+ * Zero — the graph reflects live editor state, and no workflow-edit mutation
+ * invalidates this key (edits arrive over the socket, not through React Query).
+ * The modal mounts on demand, so every open refetches; a reopen paints the
+ * cached tree instantly while the background refetch reconciles it.
  */
-export const WORKFLOW_REFERENCES_STALE_TIME = 30 * 1000
+export const WORKFLOW_REFERENCES_STALE_TIME = 0
 
 export const workflowReferenceKeys = {
   all: ['workflow-references'] as const,

--- a/apps/sim/hooks/queries/workflow-references.ts
+++ b/apps/sim/hooks/queries/workflow-references.ts
@@ -6,42 +6,33 @@ import {
 } from '@/lib/api/contracts/workflow-references'
 
 /**
- * Zero — the graph reflects live editor state (workflow blocks/names can change
- * between opens). The modal stays mounted with the query disabled while closed, so
- * a non-zero window would serve a cached graph on reopen without refetching. Zero
- * marks the data stale immediately, forcing a refetch each time the modal reopens.
+ * Short — the graph reflects live editor state (workflow blocks/names can change
+ * between opens). The modal mounts on demand, so each open refetches once the
+ * window lapses while still absorbing rapid open/close flapping.
  */
-export const WORKFLOW_REFERENCES_STALE_TIME = 0
+export const WORKFLOW_REFERENCES_STALE_TIME = 30 * 1000
 
 export const workflowReferenceKeys = {
   all: ['workflow-references'] as const,
   details: () => [...workflowReferenceKeys.all, 'detail'] as const,
-  detail: (workspaceId?: string, workflowId?: string) =>
-    [...workflowReferenceKeys.details(), workspaceId ?? '', workflowId ?? ''] as const,
+  detail: (workflowId?: string) => [...workflowReferenceKeys.details(), workflowId ?? ''] as const,
 }
 
 async function fetchWorkflowReferences(
-  workspaceId: string,
   workflowId: string,
   signal?: AbortSignal
 ): Promise<WorkflowReferencesResponse> {
   return requestJson(getWorkflowReferencesContract, {
     params: { id: workflowId },
-    query: { workspaceId },
     signal,
   })
 }
 
-export function useWorkflowReferences(
-  workspaceId?: string,
-  workflowId?: string,
-  options?: { enabled?: boolean }
-) {
+export function useWorkflowReferences(workflowId?: string) {
   return useQuery({
-    queryKey: workflowReferenceKeys.detail(workspaceId, workflowId),
-    queryFn: ({ signal }) =>
-      fetchWorkflowReferences(workspaceId as string, workflowId as string, signal),
-    enabled: Boolean(workspaceId && workflowId) && (options?.enabled ?? true),
+    queryKey: workflowReferenceKeys.detail(workflowId),
+    queryFn: ({ signal }) => fetchWorkflowReferences(workflowId as string, signal),
+    enabled: Boolean(workflowId),
     staleTime: WORKFLOW_REFERENCES_STALE_TIME,
   })
 }

--- a/apps/sim/hooks/queries/workflow-references.ts
+++ b/apps/sim/hooks/queries/workflow-references.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query'
+import { requestJson } from '@/lib/api/client/request'
+import {
+  getWorkflowReferencesContract,
+  type WorkflowReferencesResponse,
+} from '@/lib/api/contracts/workflow-references'
+
+/** Short — the graph reflects live editor state and should stay fresh on reopen. */
+export const WORKFLOW_REFERENCES_STALE_TIME = 30 * 1000
+
+export const workflowReferenceKeys = {
+  all: ['workflow-references'] as const,
+  details: () => [...workflowReferenceKeys.all, 'detail'] as const,
+  detail: (workspaceId?: string, workflowId?: string) =>
+    [...workflowReferenceKeys.details(), workspaceId ?? '', workflowId ?? ''] as const,
+}
+
+async function fetchWorkflowReferences(
+  workspaceId: string,
+  workflowId: string,
+  signal?: AbortSignal
+): Promise<WorkflowReferencesResponse> {
+  return requestJson(getWorkflowReferencesContract, {
+    params: { id: workflowId },
+    query: { workspaceId },
+    signal,
+  })
+}
+
+export function useWorkflowReferences(
+  workspaceId?: string,
+  workflowId?: string,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: workflowReferenceKeys.detail(workspaceId, workflowId),
+    queryFn: ({ signal }) =>
+      fetchWorkflowReferences(workspaceId as string, workflowId as string, signal),
+    enabled: Boolean(workspaceId && workflowId) && (options?.enabled ?? true),
+    staleTime: WORKFLOW_REFERENCES_STALE_TIME,
+  })
+}

--- a/apps/sim/lib/api/contracts/workflow-references.ts
+++ b/apps/sim/lib/api/contracts/workflow-references.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { nonEmptyIdSchema, workspaceIdSchema } from '@/lib/api/contracts/primitives'
+import { nonEmptyIdSchema } from '@/lib/api/contracts/primitives'
 import { defineRouteContract } from '@/lib/api/contracts/types'
 
 /**
@@ -11,7 +11,7 @@ import { defineRouteContract } from '@/lib/api/contracts/types'
 export interface ReferenceNode {
   /** Referenced workflow id. */
   id: string
-  /** Referenced workflow name (falls back to the id if unresolved). */
+  /** Referenced workflow name. */
   name: string
   /**
    * True when this node closes a cycle already on the current path (e.g. the
@@ -34,10 +34,6 @@ export const workflowReferencesParamsSchema = z.object({
   id: nonEmptyIdSchema,
 })
 
-export const workflowReferencesQuerySchema = z.object({
-  workspaceId: workspaceIdSchema,
-})
-
 export const workflowReferencesResponseSchema = z.object({
   /** Workflows that call this workflow (inbound), each recursively expanded. */
   callers: z.array(referenceNodeSchema),
@@ -51,7 +47,6 @@ export const getWorkflowReferencesContract = defineRouteContract({
   method: 'GET',
   path: '/api/workflows/[id]/references',
   params: workflowReferencesParamsSchema,
-  query: workflowReferencesQuerySchema,
   response: {
     mode: 'json',
     schema: workflowReferencesResponseSchema,

--- a/apps/sim/lib/api/contracts/workflow-references.ts
+++ b/apps/sim/lib/api/contracts/workflow-references.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+import { nonEmptyIdSchema, workspaceIdSchema } from '@/lib/api/contracts/primitives'
+import { defineRouteContract } from '@/lib/api/contracts/types'
+
+/**
+ * One node in a workflow reference tree. Recursive, so the Zod schema below needs
+ * `z.lazy` plus this explicit interface annotation — TypeScript cannot infer a
+ * self-referential type. Shared by the server graph builder (its return element
+ * type) and the client hook, keeping both off `z.output<...>`.
+ */
+export interface ReferenceNode {
+  /** Referenced workflow id. */
+  id: string
+  /** Referenced workflow name (falls back to the id if unresolved). */
+  name: string
+  /**
+   * True when this node closes a cycle already on the current path (e.g. the
+   * root, or `A → B → A`). Cyclic nodes carry no `children`.
+   */
+  cycle: boolean
+  children: ReferenceNode[]
+}
+
+export const referenceNodeSchema: z.ZodType<ReferenceNode> = z.lazy(() =>
+  z.object({
+    id: z.string(),
+    name: z.string(),
+    cycle: z.boolean(),
+    children: z.array(referenceNodeSchema),
+  })
+)
+
+export const workflowReferencesParamsSchema = z.object({
+  id: nonEmptyIdSchema,
+})
+
+export const workflowReferencesQuerySchema = z.object({
+  workspaceId: workspaceIdSchema,
+})
+
+export const workflowReferencesResponseSchema = z.object({
+  /** Workflows that call this workflow (inbound), each recursively expanded. */
+  callers: z.array(referenceNodeSchema),
+  /** Workflows this workflow calls (outbound), each recursively expanded. */
+  callees: z.array(referenceNodeSchema),
+})
+
+export type WorkflowReferencesResponse = z.output<typeof workflowReferencesResponseSchema>
+
+export const getWorkflowReferencesContract = defineRouteContract({
+  method: 'GET',
+  path: '/api/workflows/[id]/references',
+  params: workflowReferencesParamsSchema,
+  query: workflowReferencesQuerySchema,
+  response: {
+    mode: 'json',
+    schema: workflowReferencesResponseSchema,
+  },
+})

--- a/apps/sim/lib/workflows/references/operations.test.ts
+++ b/apps/sim/lib/workflows/references/operations.test.ts
@@ -28,12 +28,12 @@ function workflowBlock(
     childFromSelector: mode === 'basic' ? childId : null,
     childFromManual: mode === 'manual' ? childId : null,
     canonicalModes: null,
+    toolInputValues: null,
   }
 }
 
 describe('resolveWorkflowReferences', () => {
   it('resolves direct callers and callees', () => {
-    // A → B, A → C
     const blocks = [workflowBlock('a', 'b'), workflowBlock('a', 'c')]
     const { callers, callees } = resolveWorkflowReferences('a', workflows, blocks, [])
 
@@ -46,7 +46,6 @@ describe('resolveWorkflowReferences', () => {
   })
 
   it('resolves references made through workflow_input blocks', () => {
-    // A → B → C, all via the workflow_input block type.
     const blocks = [
       workflowBlock('a', 'b', 'basic', 'workflow_input'),
       workflowBlock('b', 'c', 'basic', 'workflow_input'),
@@ -76,6 +75,7 @@ describe('resolveWorkflowReferences', () => {
         childFromSelector: 'b',
         childFromManual: 'c',
         canonicalModes: { workflowId: 'advanced' },
+        toolInputValues: null,
       },
     ]
     const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
@@ -83,7 +83,6 @@ describe('resolveWorkflowReferences', () => {
   })
 
   it('marks cycles as leaves and stops recursing', () => {
-    // A → B → A
     const blocks = [workflowBlock('a', 'b'), workflowBlock('b', 'a')]
     const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
 
@@ -134,6 +133,7 @@ describe('resolveWorkflowReferences', () => {
         childFromSelector: null,
         childFromManual: null,
         canonicalModes: null,
+        toolInputValues: null,
       },
     ]
     const customBlocks: CustomBlockLink[] = [{ type: 'custom_block_x', workflowId: 'c' }]
@@ -153,6 +153,7 @@ describe('resolveWorkflowReferences', () => {
         childFromSelector: null,
         childFromManual: null,
         canonicalModes: null,
+        toolInputValues: null,
       },
     ]
     const { callees } = resolveWorkflowReferences('d', workflows, blocks, [])
@@ -170,5 +171,48 @@ describe('resolveWorkflowReferences', () => {
     const blocks = [workflowBlock('a', 'c'), workflowBlock('a', 'b')]
     const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
     expect(callees.map((n) => n.name)).toEqual(['B', 'C'])
+  })
+
+  it('resolves workflow tools inside tool-input sub-blocks', () => {
+    // Agent block on A carrying a workflow_input tool that calls B; a non-workflow
+    // tool and a malformed entry must be ignored.
+    const blocks: ReferenceBlockRow[] = [
+      {
+        parentId: 'a',
+        type: 'agent',
+        childFromSelector: null,
+        childFromManual: null,
+        canonicalModes: null,
+        toolInputValues: [
+          [
+            { type: 'workflow_input', params: { workflowId: 'b' } },
+            { type: 'function', params: {} },
+            { type: 'workflow_input' },
+          ],
+        ],
+      },
+    ]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    expect(callees.map((n) => n.id)).toEqual(['b'])
+
+    const bResult = resolveWorkflowReferences('b', workflows, blocks, [])
+    expect(bResult.callers.map((n) => n.id)).toEqual(['a'])
+  })
+
+  it('resolves workflow tools from a JSON-stringified tool-input value', () => {
+    const blocks: ReferenceBlockRow[] = [
+      {
+        parentId: 'a',
+        type: 'agent',
+        childFromSelector: null,
+        childFromManual: null,
+        canonicalModes: null,
+        toolInputValues: [
+          JSON.stringify([{ type: 'workflow_input', params: { workflowId: 'c' } }]),
+        ],
+      },
+    ]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    expect(callees.map((n) => n.id)).toEqual(['c'])
   })
 })

--- a/apps/sim/lib/workflows/references/operations.test.ts
+++ b/apps/sim/lib/workflows/references/operations.test.ts
@@ -198,6 +198,25 @@ describe('resolveWorkflowReferences', () => {
     expect(bResult.callers.map((n) => n.id)).toEqual(['a'])
   })
 
+  it('resolves a workflow tool to its active advanced-mode value', () => {
+    // Tool 0 is toggled to advanced via the index-scoped canonicalModes key; the
+    // stale basic selector (`b`) must not mask the live manual value (`c`).
+    const blocks: ReferenceBlockRow[] = [
+      {
+        parentId: 'a',
+        type: 'agent',
+        childFromSelector: null,
+        childFromManual: null,
+        canonicalModes: { '0:workflowId': 'advanced' },
+        toolInputValues: [
+          [{ type: 'workflow_input', params: { workflowId: 'b', manualWorkflowId: 'c' } }],
+        ],
+      },
+    ]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    expect(callees.map((n) => n.id)).toEqual(['c'])
+  })
+
   it('resolves workflow tools from a JSON-stringified tool-input value', () => {
     const blocks: ReferenceBlockRow[] = [
       {

--- a/apps/sim/lib/workflows/references/operations.test.ts
+++ b/apps/sim/lib/workflows/references/operations.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  type CustomBlockLink,
+  type ReferenceBlockRow,
+  resolveWorkflowReferences,
+  type WorkflowNode,
+} from '@/lib/workflows/references/operations'
+
+const workflows: WorkflowNode[] = [
+  { id: 'a', name: 'A' },
+  { id: 'b', name: 'B' },
+  { id: 'c', name: 'C' },
+  { id: 'd', name: 'D' },
+]
+
+function workflowBlock(
+  parentId: string,
+  childId: string,
+  mode: 'basic' | 'manual' = 'basic',
+  type: 'workflow' | 'workflow_input' = 'workflow'
+): ReferenceBlockRow {
+  return {
+    parentId,
+    type,
+    childFromSelector: mode === 'basic' ? childId : null,
+    childFromManual: mode === 'manual' ? childId : null,
+  }
+}
+
+describe('resolveWorkflowReferences', () => {
+  it('resolves direct callers and callees', () => {
+    // A → B, A → C
+    const blocks = [workflowBlock('a', 'b'), workflowBlock('a', 'c')]
+    const { callers, callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+
+    expect(callers).toEqual([])
+    expect(callees.map((n) => n.id)).toEqual(['b', 'c'])
+
+    const bResult = resolveWorkflowReferences('b', workflows, blocks, [])
+    expect(bResult.callers.map((n) => n.id)).toEqual(['a'])
+    expect(bResult.callees).toEqual([])
+  })
+
+  it('resolves references made through workflow_input blocks', () => {
+    // A → B → C, all via the workflow_input block type.
+    const blocks = [
+      workflowBlock('a', 'b', 'basic', 'workflow_input'),
+      workflowBlock('b', 'c', 'basic', 'workflow_input'),
+    ]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    expect(callees.map((n) => n.id)).toEqual(['b'])
+    expect(callees[0].children.map((n) => n.id)).toEqual(['c'])
+
+    const cResult = resolveWorkflowReferences('c', workflows, blocks, [])
+    expect(cResult.callers.map((n) => n.id)).toEqual(['b'])
+    expect(cResult.callers[0].children.map((n) => n.id)).toEqual(['a'])
+  })
+
+  it('resolves the advanced-mode manualWorkflowId value', () => {
+    const blocks = [workflowBlock('a', 'b', 'manual')]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    expect(callees.map((n) => n.id)).toEqual(['b'])
+  })
+
+  it('marks cycles as leaves and stops recursing', () => {
+    // A → B → A
+    const blocks = [workflowBlock('a', 'b'), workflowBlock('b', 'a')]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+
+    expect(callees).toHaveLength(1)
+    expect(callees[0]).toMatchObject({ id: 'b', cycle: false })
+    expect(callees[0].children).toHaveLength(1)
+    expect(callees[0].children[0]).toMatchObject({ id: 'a', cycle: true, children: [] })
+  })
+
+  it('drops self-references', () => {
+    const blocks = [workflowBlock('a', 'a')]
+    const { callers, callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    expect(callers).toEqual([])
+    expect(callees).toEqual([])
+  })
+
+  it('drops dangling / out-of-workspace child ids', () => {
+    const blocks = [workflowBlock('a', 'missing')]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    expect(callees).toEqual([])
+  })
+
+  it('resolves references made through custom blocks', () => {
+    // D places custom_block_x, which is bound to source workflow C.
+    const blocks: ReferenceBlockRow[] = [
+      { parentId: 'd', type: 'custom_block_x', childFromSelector: null, childFromManual: null },
+    ]
+    const customBlocks: CustomBlockLink[] = [{ type: 'custom_block_x', workflowId: 'c' }]
+
+    const cResult = resolveWorkflowReferences('c', workflows, blocks, customBlocks)
+    expect(cResult.callers.map((n) => n.id)).toEqual(['d'])
+
+    const dResult = resolveWorkflowReferences('d', workflows, blocks, customBlocks)
+    expect(dResult.callees.map((n) => n.id)).toEqual(['c'])
+  })
+
+  it('ignores custom blocks with no bound source in scope', () => {
+    const blocks: ReferenceBlockRow[] = [
+      {
+        parentId: 'd',
+        type: 'custom_block_unknown',
+        childFromSelector: null,
+        childFromManual: null,
+      },
+    ]
+    const { callees } = resolveWorkflowReferences('d', workflows, blocks, [])
+    expect(callees).toEqual([])
+  })
+
+  it('returns empty trees when the workflow is not a workspace node', () => {
+    const blocks = [workflowBlock('a', 'b')]
+    const result = resolveWorkflowReferences('unknown', workflows, blocks, [])
+    expect(result).toEqual({ callers: [], callees: [] })
+  })
+
+  it('sorts children by name', () => {
+    // Names: B, C — insert in reverse to prove sorting.
+    const blocks = [workflowBlock('a', 'c'), workflowBlock('a', 'b')]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    expect(callees.map((n) => n.name)).toEqual(['B', 'C'])
+  })
+})

--- a/apps/sim/lib/workflows/references/operations.test.ts
+++ b/apps/sim/lib/workflows/references/operations.test.ts
@@ -101,21 +101,71 @@ describe('resolveWorkflowReferences', () => {
   })
 
   it('bounds converging paths (diamond) instead of re-expanding', () => {
-    // A → B, A → C, B → D, C → D. D reconverges; it must appear under both B and C
-    // but only expand once (here D is a leaf anyway; the guard prevents blow-up).
+    // A → B, A → C, B → D, C → D, D → E. D reconverges; it must appear under both
+    // B and C but expand its subtree (E) only under the first-visited branch.
+    const workflowsWithE = [...workflows, { id: 'e', name: 'E' }]
     const blocks = [
       workflowBlock('a', 'b'),
       workflowBlock('a', 'c'),
       workflowBlock('b', 'd'),
       workflowBlock('c', 'd'),
+      workflowBlock('d', 'e'),
     ]
-    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    const { callees } = resolveWorkflowReferences('a', workflowsWithE, blocks, [])
     const b = callees.find((n) => n.id === 'b')
     const c = callees.find((n) => n.id === 'c')
-    // D expands under the first-visited branch (B) and is a plain leaf under C.
-    expect(b?.children.map((n) => n.id)).toEqual(['d'])
-    expect(c?.children.map((n) => n.id)).toEqual(['d'])
-    expect(c?.children[0]).toMatchObject({ id: 'd', cycle: false, children: [] })
+    // D expands under the first-visited branch (B) and is a collapsed leaf under C.
+    expect(b?.children).toEqual([
+      {
+        id: 'd',
+        name: 'D',
+        cycle: false,
+        children: [{ id: 'e', name: 'E', cycle: false, children: [] }],
+      },
+    ])
+    expect(c?.children).toEqual([{ id: 'd', name: 'D', cycle: false, children: [] }])
+  })
+
+  it('truncates expansion at the depth ceiling', () => {
+    // A linear chain longer than MAX_REFERENCE_DEPTH (25): w0 → w1 → … → w29.
+    const chain = Array.from({ length: 30 }, (_, i) => ({ id: `w${i}`, name: `W${i}` }))
+    const blocks = Array.from({ length: 29 }, (_, i) => workflowBlock(`w${i}`, `w${i + 1}`))
+    const { callees } = resolveWorkflowReferences('w0', chain, blocks, [])
+    let depth = 0
+    let node = callees[0]
+    while (node) {
+      depth += 1
+      node = node.children[0]
+    }
+    expect(depth).toBe(25)
+  })
+
+  it('re-expands a depth-truncated node when a shallower path reaches it', () => {
+    // Root fans out to a 25-deep chain (visited first by name sort: "A…") whose
+    // tail X gets truncated at the ceiling, and a direct edge (via "Z") to X.
+    // The shallow path must still show X's child Y instead of a collapsed leaf.
+    const nodes = [
+      { id: 'root', name: 'Root' },
+      ...Array.from({ length: 24 }, (_, i) => ({
+        id: `a${i}`,
+        name: `A${String(i).padStart(2, '0')}`,
+      })),
+      { id: 'x', name: 'X' },
+      { id: 'y', name: 'Y' },
+      { id: 'z', name: 'Z' },
+    ]
+    const blocks = [
+      workflowBlock('root', 'a0'),
+      ...Array.from({ length: 23 }, (_, i) => workflowBlock(`a${i}`, `a${i + 1}`)),
+      workflowBlock('a23', 'x'),
+      workflowBlock('root', 'z'),
+      workflowBlock('z', 'x'),
+      workflowBlock('x', 'y'),
+    ]
+    const { callees } = resolveWorkflowReferences('root', nodes, blocks, [])
+    const z = callees.find((n) => n.id === 'z')
+    const xUnderZ = z?.children.find((n) => n.id === 'x')
+    expect(xUnderZ?.children.map((n) => n.id)).toEqual(['y'])
   })
 
   it('drops dangling / out-of-workspace child ids', () => {
@@ -215,6 +265,29 @@ describe('resolveWorkflowReferences', () => {
     ]
     const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
     expect(callees.map((n) => n.id)).toEqual(['c'])
+  })
+
+  it('resolves legacy workflow-typed tools and isolates index-scoped modes per tool', () => {
+    // Tool 0 is a legacy `workflow`-typed entry (still rendered/executed by the
+    // editor); tool 1 is advanced-mode via its own index-scoped key. Tool 0 must
+    // stay basic (`b`) — tool 1's override must not bleed into it.
+    const blocks: ReferenceBlockRow[] = [
+      {
+        parentId: 'a',
+        type: 'agent',
+        childFromSelector: null,
+        childFromManual: null,
+        canonicalModes: { '1:workflowId': 'advanced' },
+        toolInputValues: [
+          [
+            { type: 'workflow', params: { workflowId: 'b' } },
+            { type: 'workflow_input', params: { workflowId: 'c', manualWorkflowId: 'd' } },
+          ],
+        ],
+      },
+    ]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    expect(callees.map((n) => n.id)).toEqual(['b', 'd'])
   })
 
   it('resolves workflow tools from a JSON-stringified tool-input value', () => {

--- a/apps/sim/lib/workflows/references/operations.test.ts
+++ b/apps/sim/lib/workflows/references/operations.test.ts
@@ -125,7 +125,6 @@ describe('resolveWorkflowReferences', () => {
   })
 
   it('resolves references made through custom blocks', () => {
-    // D places custom_block_x, which is bound to source workflow C.
     const blocks: ReferenceBlockRow[] = [
       {
         parentId: 'd',

--- a/apps/sim/lib/workflows/references/operations.test.ts
+++ b/apps/sim/lib/workflows/references/operations.test.ts
@@ -27,6 +27,7 @@ function workflowBlock(
     type,
     childFromSelector: mode === 'basic' ? childId : null,
     childFromManual: mode === 'manual' ? childId : null,
+    canonicalModes: null,
   }
 }
 
@@ -65,6 +66,22 @@ describe('resolveWorkflowReferences', () => {
     expect(callees.map((n) => n.id)).toEqual(['b'])
   })
 
+  it('uses the active mode, not a retained inactive value', () => {
+    // Advanced mode active (canonicalModes override), but a stale basic value
+    // (`b`) lingers. Must resolve to the advanced value (`c`), not the stale basic.
+    const blocks: ReferenceBlockRow[] = [
+      {
+        parentId: 'a',
+        type: 'workflow',
+        childFromSelector: 'b',
+        childFromManual: 'c',
+        canonicalModes: { workflowId: 'advanced' },
+      },
+    ]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    expect(callees.map((n) => n.id)).toEqual(['c'])
+  })
+
   it('marks cycles as leaves and stops recursing', () => {
     // A → B → A
     const blocks = [workflowBlock('a', 'b'), workflowBlock('b', 'a')]
@@ -76,11 +93,30 @@ describe('resolveWorkflowReferences', () => {
     expect(callees[0].children[0]).toMatchObject({ id: 'a', cycle: true, children: [] })
   })
 
-  it('drops self-references', () => {
+  it('shows a self-reference as a cycle leaf', () => {
+    // A → A: the reference is real and belongs in the cycle-safe viewer.
     const blocks = [workflowBlock('a', 'a')]
     const { callers, callees } = resolveWorkflowReferences('a', workflows, blocks, [])
-    expect(callers).toEqual([])
-    expect(callees).toEqual([])
+    expect(callees).toEqual([{ id: 'a', name: 'A', cycle: true, children: [] }])
+    expect(callers).toEqual([{ id: 'a', name: 'A', cycle: true, children: [] }])
+  })
+
+  it('bounds converging paths (diamond) instead of re-expanding', () => {
+    // A → B, A → C, B → D, C → D. D reconverges; it must appear under both B and C
+    // but only expand once (here D is a leaf anyway; the guard prevents blow-up).
+    const blocks = [
+      workflowBlock('a', 'b'),
+      workflowBlock('a', 'c'),
+      workflowBlock('b', 'd'),
+      workflowBlock('c', 'd'),
+    ]
+    const { callees } = resolveWorkflowReferences('a', workflows, blocks, [])
+    const b = callees.find((n) => n.id === 'b')
+    const c = callees.find((n) => n.id === 'c')
+    // D expands under the first-visited branch (B) and is a plain leaf under C.
+    expect(b?.children.map((n) => n.id)).toEqual(['d'])
+    expect(c?.children.map((n) => n.id)).toEqual(['d'])
+    expect(c?.children[0]).toMatchObject({ id: 'd', cycle: false, children: [] })
   })
 
   it('drops dangling / out-of-workspace child ids', () => {
@@ -92,7 +128,13 @@ describe('resolveWorkflowReferences', () => {
   it('resolves references made through custom blocks', () => {
     // D places custom_block_x, which is bound to source workflow C.
     const blocks: ReferenceBlockRow[] = [
-      { parentId: 'd', type: 'custom_block_x', childFromSelector: null, childFromManual: null },
+      {
+        parentId: 'd',
+        type: 'custom_block_x',
+        childFromSelector: null,
+        childFromManual: null,
+        canonicalModes: null,
+      },
     ]
     const customBlocks: CustomBlockLink[] = [{ type: 'custom_block_x', workflowId: 'c' }]
 
@@ -110,6 +152,7 @@ describe('resolveWorkflowReferences', () => {
         type: 'custom_block_unknown',
         childFromSelector: null,
         childFromManual: null,
+        canonicalModes: null,
       },
     ]
     const { callees } = resolveWorkflowReferences('d', workflows, blocks, [])

--- a/apps/sim/lib/workflows/references/operations.ts
+++ b/apps/sim/lib/workflows/references/operations.ts
@@ -4,6 +4,11 @@ import { createLogger } from '@sim/logger'
 import { and, eq, inArray, isNull, like, or, sql } from 'drizzle-orm'
 import type { ReferenceNode } from '@/lib/api/contracts/workflow-references'
 import { getCustomBlockRowsForWorkspace } from '@/lib/workflows/custom-blocks/operations'
+import {
+  type CanonicalGroup,
+  type CanonicalModeOverrides,
+  resolveActiveCanonicalValue,
+} from '@/lib/workflows/subblocks/visibility'
 import { CUSTOM_BLOCK_TYPE_PREFIX } from '@/blocks/custom/build-config'
 import { BlockType, isWorkflowBlockType } from '@/executor/constants'
 
@@ -15,6 +20,18 @@ const logger = createLogger('WorkflowReferences')
  * this is a belt-and-suspenders bound on pathological graphs.
  */
 const MAX_REFERENCE_DEPTH = 25
+
+/**
+ * The `workflowId` canonical pair on a workflow / workflow_input block: the basic
+ * `workflowId` selector and the advanced `manualWorkflowId` input. Used with
+ * {@link resolveActiveCanonicalValue} so the reference resolves to the value of the
+ * block's ACTIVE mode — never a dormant mode's retained (stale) value.
+ */
+const WORKFLOW_ID_CANONICAL_GROUP: CanonicalGroup = {
+  canonicalId: 'workflowId',
+  basicId: 'workflowId',
+  advancedIds: ['manualWorkflowId'],
+}
 
 /** A workspace-local, non-archived workflow node. */
 export interface WorkflowNode {
@@ -30,6 +47,11 @@ export interface ReferenceBlockRow {
   childFromSelector: string | null
   /** `manualWorkflowId` sub-block value (advanced mode), if a workflow block. */
   childFromManual: string | null
+  /**
+   * The block's `data.canonicalModes` override (basic/advanced per canonical id),
+   * used to pick the active `workflowId` value. Absent for most blocks.
+   */
+  canonicalModes: CanonicalModeOverrides | null
 }
 
 /** A custom-block type slug bound to its source workflow. */
@@ -56,8 +78,11 @@ interface ReferenceGraph {
  * - **custom blocks** (`custom_block_<id>`), whose type slug maps to a bound
  *   source workflow via `customBlocks`.
  *
- * Edges are scoped to workspace-local, non-archived workflows: self-references,
- * empty values, and ids outside `workflows` are dropped.
+ * The workflow-block child is the value of the block's ACTIVE mode
+ * ({@link resolveActiveCanonicalValue}), so a dormant basic/advanced value can't
+ * mask the live one. Edges are scoped to workspace-local, non-archived workflows;
+ * empty values and ids outside `workflows` are dropped. A workflow that calls
+ * itself is kept — the tree builder renders it as a `cycle` leaf.
  */
 export function buildReferenceGraph(
   workflows: WorkflowNode[],
@@ -74,7 +99,7 @@ export function buildReferenceGraph(
   const reverse = new Map<string, Set<string>>()
 
   const addEdge = (parentId: string, childId: string) => {
-    if (!childId || childId === parentId) return
+    if (!childId) return
     if (!nameById.has(parentId) || !nameById.has(childId)) return
     if (!forward.has(parentId)) forward.set(parentId, new Set())
     forward.get(parentId)?.add(childId)
@@ -84,8 +109,12 @@ export function buildReferenceGraph(
 
   for (const block of blocks) {
     if (isWorkflowBlockType(block.type)) {
-      const childId = block.childFromSelector || block.childFromManual
-      if (childId) addEdge(block.parentId, childId)
+      const active = resolveActiveCanonicalValue(
+        WORKFLOW_ID_CANONICAL_GROUP,
+        { workflowId: block.childFromSelector, manualWorkflowId: block.childFromManual },
+        block.canonicalModes ?? undefined
+      )
+      if (typeof active === 'string' && active) addEdge(block.parentId, active)
       continue
     }
     const sourceId = sourceByCustomType.get(block.type)
@@ -97,9 +126,14 @@ export function buildReferenceGraph(
 
 /**
  * Expand a direction of the graph into a tree rooted at `rootId`. `adjacency` is
- * either the forward (callees) or reverse (callers) map. A node already on the
- * current DFS path is emitted as a `cycle: true` leaf and not re-expanded, so
- * `A → B → A` terminates. Children are sorted by name for stable rendering.
+ * either the forward (callees) or reverse (callers) map.
+ *
+ * A node already on the current DFS path is emitted as a `cycle: true` leaf and
+ * not re-expanded, so `A → B → A` (and a self-call `A → A`) terminates. A node
+ * already fully expanded elsewhere in this tree (reachable via another acyclic
+ * path — a diamond) is emitted once more as a plain leaf without re-expanding its
+ * subtree: the edge stays visible, but a densely reconverging graph can't blow up
+ * exponentially. Children are sorted by name for stable rendering.
  */
 function buildTree(
   rootId: string,
@@ -107,6 +141,7 @@ function buildTree(
   nameById: Map<string, string>
 ): ReferenceNode[] {
   const path = new Set<string>([rootId])
+  const expanded = new Set<string>()
 
   const expand = (id: string, depth: number): ReferenceNode[] => {
     if (depth >= MAX_REFERENCE_DEPTH) return []
@@ -126,6 +161,11 @@ function buildTree(
         nodes.push({ id: childId, name, cycle: true, children: [] })
         continue
       }
+      if (expanded.has(childId)) {
+        nodes.push({ id: childId, name, cycle: false, children: [] })
+        continue
+      }
+      expanded.add(childId)
       path.add(childId)
       nodes.push({ id: childId, name, cycle: false, children: expand(childId, depth + 1) })
       path.delete(childId)
@@ -185,6 +225,7 @@ export async function getWorkflowReferences(
         childFromManual: sql<
           string | null
         >`${workflowBlocks.subBlocks} -> 'manualWorkflowId' ->> 'value'`,
+        canonicalModes: sql<CanonicalModeOverrides | null>`${workflowBlocks.data} -> 'canonicalModes'`,
       })
       .from(workflowBlocks)
       .innerJoin(workflow, eq(workflow.id, workflowBlocks.workflowId))

--- a/apps/sim/lib/workflows/references/operations.ts
+++ b/apps/sim/lib/workflows/references/operations.ts
@@ -9,6 +9,7 @@ import {
   type CanonicalGroup,
   type CanonicalModeOverrides,
   resolveActiveCanonicalValue,
+  scopeCanonicalModesForTool,
 } from '@/lib/workflows/subblocks/visibility'
 import { CUSTOM_BLOCK_TYPE_PREFIX } from '@/blocks/custom/build-config'
 import { BlockType, isWorkflowBlockType } from '@/executor/constants'
@@ -85,20 +86,40 @@ interface ReferenceGraph {
 
 /**
  * Callee workflow ids referenced by a block's tool-input values: `workflow_input`
- * tools whose `params.workflowId` was picked from the workflow selector.
+ * tools resolved to their ACTIVE canonical member — the basic `params.workflowId`
+ * selector or the advanced `params.manualWorkflowId` input, per the tool's
+ * index-scoped `canonicalModes` override ({@link scopeCanonicalModesForTool}) —
+ * mirroring how execution picks the live value.
  */
-function toolInputCallees(toolInputValues: unknown[] | null): string[] {
+function toolInputCallees(
+  toolInputValues: unknown[] | null,
+  canonicalModes: CanonicalModeOverrides | null
+): string[] {
   if (!toolInputValues) return []
   const callees: string[] = []
   for (const value of toolInputValues) {
     const { array } = coerceObjectArray(value)
     if (!array) continue
-    for (const tool of array) {
+    array.forEach((tool, toolIndex) => {
       if (!isRecord(tool) || tool.type !== BlockType.WORKFLOW_INPUT || !isRecord(tool.params)) {
-        continue
+        return
       }
-      if (typeof tool.params.workflowId === 'string') callees.push(tool.params.workflowId)
-    }
+      const scoped = scopeCanonicalModesForTool(
+        canonicalModes ?? undefined,
+        toolIndex,
+        BlockType.WORKFLOW_INPUT
+      )
+      const active = resolveActiveCanonicalValue(
+        WORKFLOW_ID_CANONICAL_GROUP,
+        {
+          workflowId: typeof tool.params.workflowId === 'string' ? tool.params.workflowId : null,
+          manualWorkflowId:
+            typeof tool.params.manualWorkflowId === 'string' ? tool.params.manualWorkflowId : null,
+        },
+        scoped
+      )
+      if (typeof active === 'string' && active) callees.push(active)
+    })
   }
   return callees
 }
@@ -161,7 +182,7 @@ function buildReferenceGraph(
       const sourceId = sourceByCustomType.get(block.type)
       if (sourceId) addEdge(block.parentId, sourceId)
     }
-    for (const calleeId of toolInputCallees(block.toolInputValues)) {
+    for (const calleeId of toolInputCallees(block.toolInputValues, block.canonicalModes)) {
       addEdge(block.parentId, calleeId)
     }
   }

--- a/apps/sim/lib/workflows/references/operations.ts
+++ b/apps/sim/lib/workflows/references/operations.ts
@@ -63,7 +63,8 @@ export interface ReferenceBlockRow {
    * Aggregated `tool-input` sub-block values on this block (agent-style tool
    * lists). Each entry is one sub-block's raw value — an array of tool objects,
    * or that array JSON-stringified. `workflow_input` tools carry the callee id
-   * in `params.workflowId`. Null when the block has no tool-input sub-blocks.
+   * in `params.workflowId` (basic) or `params.manualWorkflowId` (advanced).
+   * Null when the block has no tool-input sub-blocks.
    */
   toolInputValues: unknown[] | null
 }
@@ -85,11 +86,12 @@ interface ReferenceGraph {
 }
 
 /**
- * Callee workflow ids referenced by a block's tool-input values: `workflow_input`
- * tools resolved to their ACTIVE canonical member — the basic `params.workflowId`
- * selector or the advanced `params.manualWorkflowId` input, per the tool's
- * index-scoped `canonicalModes` override ({@link scopeCanonicalModesForTool}) —
- * mirroring how execution picks the live value.
+ * Callee workflow ids referenced by a block's tool-input values: workflow tools
+ * (`workflow_input`, plus legacy stored entries typed `workflow`) resolved to
+ * their ACTIVE canonical member — the basic `params.workflowId` selector or the
+ * advanced `params.manualWorkflowId` input, per the tool's index-scoped
+ * `canonicalModes` override ({@link scopeCanonicalModesForTool}) — mirroring how
+ * execution picks the live value.
  */
 function toolInputCallees(
   toolInputValues: unknown[] | null,
@@ -101,14 +103,15 @@ function toolInputCallees(
     const { array } = coerceObjectArray(value)
     if (!array) continue
     array.forEach((tool, toolIndex) => {
-      if (!isRecord(tool) || tool.type !== BlockType.WORKFLOW_INPUT || !isRecord(tool.params)) {
+      if (
+        !isRecord(tool) ||
+        typeof tool.type !== 'string' ||
+        !isWorkflowBlockType(tool.type) ||
+        !isRecord(tool.params)
+      ) {
         return
       }
-      const scoped = scopeCanonicalModesForTool(
-        canonicalModes ?? undefined,
-        toolIndex,
-        BlockType.WORKFLOW_INPUT
-      )
+      const scoped = scopeCanonicalModesForTool(canonicalModes ?? undefined, toolIndex, tool.type)
       const active = resolveActiveCanonicalValue(
         WORKFLOW_ID_CANONICAL_GROUP,
         {
@@ -232,6 +235,10 @@ function buildTree(
       path.add(childId)
       nodes.push({ id: childId, name, cycle: false, children: expand(childId, depth + 1) })
       path.delete(childId)
+      // A depth-capped expansion is incomplete — allow a shallower path to retry
+      // it in full instead of collapsing to a leaf. Each retry starts strictly
+      // shallower, so this stays bounded.
+      if (depth + 1 >= MAX_REFERENCE_DEPTH) expanded.delete(childId)
     }
     return nodes
   }

--- a/apps/sim/lib/workflows/references/operations.ts
+++ b/apps/sim/lib/workflows/references/operations.ts
@@ -1,9 +1,10 @@
 import { db } from '@sim/db'
 import { workflow, workflowBlocks } from '@sim/db/schema'
-import { createLogger } from '@sim/logger'
-import { and, eq, inArray, isNull, like, or, sql } from 'drizzle-orm'
+import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm'
 import type { ReferenceNode } from '@/lib/api/contracts/workflow-references'
+import { MAX_CALL_CHAIN_DEPTH } from '@/lib/execution/call-chain'
 import { getCustomBlockRowsForWorkspace } from '@/lib/workflows/custom-blocks/operations'
+import { coerceObjectArray, isRecord } from '@/lib/workflows/persistence/remap-internal-ids'
 import {
   type CanonicalGroup,
   type CanonicalModeOverrides,
@@ -12,26 +13,31 @@ import {
 import { CUSTOM_BLOCK_TYPE_PREFIX } from '@/blocks/custom/build-config'
 import { BlockType, isWorkflowBlockType } from '@/executor/constants'
 
-const logger = createLogger('WorkflowReferences')
-
 /**
- * Depth ceiling for a reference tree — mirrors `MAX_CALL_CHAIN_DEPTH` in
- * `@/lib/execution/call-chain`. The per-path visited set is the real cycle guard;
- * this is a belt-and-suspenders bound on pathological graphs.
+ * Depth ceiling for a reference tree — the runtime call-chain bound; a display
+ * tree never needs to show more than the executor allows. The per-path visited
+ * set is the real cycle guard; this is a belt-and-suspenders bound on
+ * pathological graphs.
  */
-const MAX_REFERENCE_DEPTH = 25
+const MAX_REFERENCE_DEPTH = MAX_CALL_CHAIN_DEPTH
 
 /**
  * The `workflowId` canonical pair on a workflow / workflow_input block: the basic
  * `workflowId` selector and the advanced `manualWorkflowId` input. Used with
  * {@link resolveActiveCanonicalValue} so the reference resolves to the value of the
  * block's ACTIVE mode — never a dormant mode's retained (stale) value.
+ * (`remapWorkflowReferencesInSubBlocks` in
+ * `@/lib/workflows/persistence/remap-internal-ids` builds the same pair from
+ * positional keys — keep the two in sync if the pair ever changes.)
  */
 const WORKFLOW_ID_CANONICAL_GROUP: CanonicalGroup = {
   canonicalId: 'workflowId',
   basicId: 'workflowId',
   advancedIds: ['manualWorkflowId'],
 }
+
+/** `custom_block_` with LIKE wildcards (`_`) escaped, for the SQL prefix match. */
+const CUSTOM_BLOCK_LIKE_PREFIX = CUSTOM_BLOCK_TYPE_PREFIX.replace(/[\\%_]/g, '\\$&')
 
 /** A workspace-local, non-archived workflow node. */
 export interface WorkflowNode {
@@ -52,6 +58,13 @@ export interface ReferenceBlockRow {
    * used to pick the active `workflowId` value. Absent for most blocks.
    */
   canonicalModes: CanonicalModeOverrides | null
+  /**
+   * Aggregated `tool-input` sub-block values on this block (agent-style tool
+   * lists). Each entry is one sub-block's raw value — an array of tool objects,
+   * or that array JSON-stringified. `workflow_input` tools carry the callee id
+   * in `params.workflowId`. Null when the block has no tool-input sub-blocks.
+   */
+  toolInputValues: unknown[] | null
 }
 
 /** A custom-block type slug bound to its source workflow. */
@@ -71,12 +84,39 @@ interface ReferenceGraph {
 }
 
 /**
+ * Callee workflow ids referenced by a block's tool-input values: `workflow_input`
+ * tools whose `params.workflowId` was picked from the workflow selector.
+ */
+function toolInputCallees(toolInputValues: unknown[] | null): string[] {
+  if (!toolInputValues) return []
+  const callees: string[] = []
+  for (const value of toolInputValues) {
+    const { array } = coerceObjectArray(value)
+    if (!array) continue
+    for (const tool of array) {
+      if (!isRecord(tool) || tool.type !== BlockType.WORKFLOW_INPUT || !isRecord(tool.params)) {
+        continue
+      }
+      if (typeof tool.params.workflowId === 'string') callees.push(tool.params.workflowId)
+    }
+  }
+  return callees
+}
+
+/**
  * Build the directed reference graph from raw workspace rows. Pure (no I/O) so it
- * can be unit-tested directly. Resolves two reference shapes:
+ * can be unit-tested directly. Resolves three call-edge shapes:
  * - direct **workflow blocks** (`workflow` and `workflow_input`), whose child id
- *   is the `workflowId` (basic) or `manualWorkflowId` (advanced) sub-block value; and
+ *   is the `workflowId` (basic) or `manualWorkflowId` (advanced) sub-block value;
  * - **custom blocks** (`custom_block_<id>`), whose type slug maps to a bound
- *   source workflow via `customBlocks`.
+ *   source workflow via `customBlocks`; and
+ * - **workflow tools** — `workflow_input` entries inside a block's `tool-input`
+ *   sub-blocks (an agent invoking another workflow as a tool).
+ *
+ * Non-call reference shapes (the logs block's `workflowSelector` monitor list and
+ * the workspace-event trigger's `workflowIds`; see
+ * `remapWorkflowReferencesInSubBlocks`) are deliberately excluded — the viewer
+ * shows call relationships.
  *
  * The workflow-block child is the value of the block's ACTIVE mode
  * ({@link resolveActiveCanonicalValue}), so a dormant basic/advanced value can't
@@ -84,7 +124,7 @@ interface ReferenceGraph {
  * empty values and ids outside `workflows` are dropped. A workflow that calls
  * itself is kept — the tree builder renders it as a `cycle` leaf.
  */
-export function buildReferenceGraph(
+function buildReferenceGraph(
   workflows: WorkflowNode[],
   blocks: ReferenceBlockRow[],
   customBlocks: CustomBlockLink[]
@@ -101,10 +141,12 @@ export function buildReferenceGraph(
   const addEdge = (parentId: string, childId: string) => {
     if (!childId) return
     if (!nameById.has(parentId) || !nameById.has(childId)) return
-    if (!forward.has(parentId)) forward.set(parentId, new Set())
-    forward.get(parentId)?.add(childId)
-    if (!reverse.has(childId)) reverse.set(childId, new Set())
-    reverse.get(childId)?.add(parentId)
+    let callees = forward.get(parentId)
+    if (!callees) forward.set(parentId, (callees = new Set()))
+    callees.add(childId)
+    let callers = reverse.get(childId)
+    if (!callers) reverse.set(childId, (callers = new Set()))
+    callers.add(parentId)
   }
 
   for (const block of blocks) {
@@ -115,10 +157,13 @@ export function buildReferenceGraph(
         block.canonicalModes ?? undefined
       )
       if (typeof active === 'string' && active) addEdge(block.parentId, active)
-      continue
+    } else {
+      const sourceId = sourceByCustomType.get(block.type)
+      if (sourceId) addEdge(block.parentId, sourceId)
     }
-    const sourceId = sourceByCustomType.get(block.type)
-    if (sourceId) addEdge(block.parentId, sourceId)
+    for (const calleeId of toolInputCallees(block.toolInputValues)) {
+      addEdge(block.parentId, calleeId)
+    }
   }
 
   return { nameById, forward, reverse }
@@ -142,21 +187,18 @@ function buildTree(
 ): ReferenceNode[] {
   const path = new Set<string>([rootId])
   const expanded = new Set<string>()
+  const nameOf = (id: string) => nameById.get(id) as string
 
   const expand = (id: string, depth: number): ReferenceNode[] => {
     if (depth >= MAX_REFERENCE_DEPTH) return []
     const neighbors = adjacency.get(id)
     if (!neighbors || neighbors.size === 0) return []
 
-    const sorted = [...neighbors].sort((a, b) => {
-      const nameA = nameById.get(a) ?? a
-      const nameB = nameById.get(b) ?? b
-      return nameA.localeCompare(nameB)
-    })
+    const sorted = [...neighbors].sort((a, b) => nameOf(a).localeCompare(nameOf(b)))
 
     const nodes: ReferenceNode[] = []
     for (const childId of sorted) {
-      const name = nameById.get(childId) ?? childId
+      const name = nameOf(childId)
       if (path.has(childId)) {
         nodes.push({ id: childId, name, cycle: true, children: [] })
         continue
@@ -210,6 +252,11 @@ export async function getWorkflowReferences(
   workspaceId: string,
   workflowId: string
 ): Promise<{ callers: ReferenceNode[]; callees: ReferenceNode[] }> {
+  const hasToolInput = sql`EXISTS (
+    SELECT 1 FROM jsonb_each(${workflowBlocks.subBlocks}) AS kv
+    WHERE kv.value ->> 'type' = 'tool-input'
+  )`
+
   const [workflowRows, blockRows, customBlockRows] = await Promise.all([
     db
       .select({ id: workflow.id, name: workflow.name })
@@ -226,6 +273,11 @@ export async function getWorkflowReferences(
           string | null
         >`${workflowBlocks.subBlocks} -> 'manualWorkflowId' ->> 'value'`,
         canonicalModes: sql<CanonicalModeOverrides | null>`${workflowBlocks.data} -> 'canonicalModes'`,
+        toolInputValues: sql<unknown[] | null>`(
+          SELECT jsonb_agg(kv.value -> 'value')
+          FROM jsonb_each(${workflowBlocks.subBlocks}) AS kv
+          WHERE kv.value ->> 'type' = 'tool-input'
+        )`,
       })
       .from(workflowBlocks)
       .innerJoin(workflow, eq(workflow.id, workflowBlocks.workflowId))
@@ -235,26 +287,13 @@ export async function getWorkflowReferences(
           isNull(workflow.archivedAt),
           or(
             inArray(workflowBlocks.type, [BlockType.WORKFLOW, BlockType.WORKFLOW_INPUT]),
-            like(workflowBlocks.type, `${CUSTOM_BLOCK_TYPE_PREFIX}%`)
+            sql`${workflowBlocks.type} LIKE ${`${CUSTOM_BLOCK_LIKE_PREFIX}%`} ESCAPE '\\'`,
+            hasToolInput
           )
         )
       ),
     getCustomBlockRowsForWorkspace(workspaceId),
   ])
 
-  const result = resolveWorkflowReferences(
-    workflowId,
-    workflowRows,
-    blockRows,
-    customBlockRows.map((row) => ({ type: row.type, workflowId: row.workflowId }))
-  )
-
-  if (!workflowRows.some((row) => row.id === workflowId)) {
-    logger.warn('Workflow not found in workspace when resolving references', {
-      workspaceId,
-      workflowId,
-    })
-  }
-
-  return result
+  return resolveWorkflowReferences(workflowId, workflowRows, blockRows, customBlockRows)
 }

--- a/apps/sim/lib/workflows/references/operations.ts
+++ b/apps/sim/lib/workflows/references/operations.ts
@@ -1,0 +1,219 @@
+import { db } from '@sim/db'
+import { workflow, workflowBlocks } from '@sim/db/schema'
+import { createLogger } from '@sim/logger'
+import { and, eq, inArray, isNull, like, or, sql } from 'drizzle-orm'
+import type { ReferenceNode } from '@/lib/api/contracts/workflow-references'
+import { getCustomBlockRowsForWorkspace } from '@/lib/workflows/custom-blocks/operations'
+import { CUSTOM_BLOCK_TYPE_PREFIX } from '@/blocks/custom/build-config'
+import { BlockType, isWorkflowBlockType } from '@/executor/constants'
+
+const logger = createLogger('WorkflowReferences')
+
+/**
+ * Depth ceiling for a reference tree — mirrors `MAX_CALL_CHAIN_DEPTH` in
+ * `@/lib/execution/call-chain`. The per-path visited set is the real cycle guard;
+ * this is a belt-and-suspenders bound on pathological graphs.
+ */
+const MAX_REFERENCE_DEPTH = 25
+
+/** A workspace-local, non-archived workflow node. */
+export interface WorkflowNode {
+  id: string
+  name: string
+}
+
+/** A placed block that may reference another workflow (raw, pre-resolution). */
+export interface ReferenceBlockRow {
+  parentId: string
+  type: string
+  /** `workflowId` sub-block value (basic mode), if a workflow block. */
+  childFromSelector: string | null
+  /** `manualWorkflowId` sub-block value (advanced mode), if a workflow block. */
+  childFromManual: string | null
+}
+
+/** A custom-block type slug bound to its source workflow. */
+export interface CustomBlockLink {
+  type: string
+  workflowId: string
+}
+
+/**
+ * The workspace-wide reference graph derived from live editor state: every
+ * workflow node's name, plus forward (callee) and reverse (caller) adjacency.
+ */
+interface ReferenceGraph {
+  nameById: Map<string, string>
+  forward: Map<string, Set<string>>
+  reverse: Map<string, Set<string>>
+}
+
+/**
+ * Build the directed reference graph from raw workspace rows. Pure (no I/O) so it
+ * can be unit-tested directly. Resolves two reference shapes:
+ * - direct **workflow blocks** (`workflow` and `workflow_input`), whose child id
+ *   is the `workflowId` (basic) or `manualWorkflowId` (advanced) sub-block value; and
+ * - **custom blocks** (`custom_block_<id>`), whose type slug maps to a bound
+ *   source workflow via `customBlocks`.
+ *
+ * Edges are scoped to workspace-local, non-archived workflows: self-references,
+ * empty values, and ids outside `workflows` are dropped.
+ */
+export function buildReferenceGraph(
+  workflows: WorkflowNode[],
+  blocks: ReferenceBlockRow[],
+  customBlocks: CustomBlockLink[]
+): ReferenceGraph {
+  const nameById = new Map<string, string>()
+  for (const node of workflows) nameById.set(node.id, node.name)
+
+  const sourceByCustomType = new Map<string, string>()
+  for (const link of customBlocks) sourceByCustomType.set(link.type, link.workflowId)
+
+  const forward = new Map<string, Set<string>>()
+  const reverse = new Map<string, Set<string>>()
+
+  const addEdge = (parentId: string, childId: string) => {
+    if (!childId || childId === parentId) return
+    if (!nameById.has(parentId) || !nameById.has(childId)) return
+    if (!forward.has(parentId)) forward.set(parentId, new Set())
+    forward.get(parentId)?.add(childId)
+    if (!reverse.has(childId)) reverse.set(childId, new Set())
+    reverse.get(childId)?.add(parentId)
+  }
+
+  for (const block of blocks) {
+    if (isWorkflowBlockType(block.type)) {
+      const childId = block.childFromSelector || block.childFromManual
+      if (childId) addEdge(block.parentId, childId)
+      continue
+    }
+    const sourceId = sourceByCustomType.get(block.type)
+    if (sourceId) addEdge(block.parentId, sourceId)
+  }
+
+  return { nameById, forward, reverse }
+}
+
+/**
+ * Expand a direction of the graph into a tree rooted at `rootId`. `adjacency` is
+ * either the forward (callees) or reverse (callers) map. A node already on the
+ * current DFS path is emitted as a `cycle: true` leaf and not re-expanded, so
+ * `A → B → A` terminates. Children are sorted by name for stable rendering.
+ */
+function buildTree(
+  rootId: string,
+  adjacency: Map<string, Set<string>>,
+  nameById: Map<string, string>
+): ReferenceNode[] {
+  const path = new Set<string>([rootId])
+
+  const expand = (id: string, depth: number): ReferenceNode[] => {
+    if (depth >= MAX_REFERENCE_DEPTH) return []
+    const neighbors = adjacency.get(id)
+    if (!neighbors || neighbors.size === 0) return []
+
+    const sorted = [...neighbors].sort((a, b) => {
+      const nameA = nameById.get(a) ?? a
+      const nameB = nameById.get(b) ?? b
+      return nameA.localeCompare(nameB)
+    })
+
+    const nodes: ReferenceNode[] = []
+    for (const childId of sorted) {
+      const name = nameById.get(childId) ?? childId
+      if (path.has(childId)) {
+        nodes.push({ id: childId, name, cycle: true, children: [] })
+        continue
+      }
+      path.add(childId)
+      nodes.push({ id: childId, name, cycle: false, children: expand(childId, depth + 1) })
+      path.delete(childId)
+    }
+    return nodes
+  }
+
+  return expand(rootId, 0)
+}
+
+/**
+ * Resolve the reference trees for one workflow from raw workspace rows. Pure so it
+ * can be unit-tested without a database. Returns empty arrays when the workflow is
+ * not a workspace-local node or has no references.
+ */
+export function resolveWorkflowReferences(
+  workflowId: string,
+  workflows: WorkflowNode[],
+  blocks: ReferenceBlockRow[],
+  customBlocks: CustomBlockLink[]
+): { callers: ReferenceNode[]; callees: ReferenceNode[] } {
+  const { nameById, forward, reverse } = buildReferenceGraph(workflows, blocks, customBlocks)
+
+  if (!nameById.has(workflowId)) {
+    return { callers: [], callees: [] }
+  }
+
+  return {
+    callers: buildTree(workflowId, reverse, nameById),
+    callees: buildTree(workflowId, forward, nameById),
+  }
+}
+
+/**
+ * Resolve the reference trees for one workflow: `callers` (workflows that call
+ * it, inbound) and `callees` (workflows it calls, outbound), read from the live
+ * `workflowBlocks` (draft) table — the state the sidebar and editor show. The
+ * root itself is not a node; each array holds its direct references, recursively
+ * expanded.
+ */
+export async function getWorkflowReferences(
+  workspaceId: string,
+  workflowId: string
+): Promise<{ callers: ReferenceNode[]; callees: ReferenceNode[] }> {
+  const [workflowRows, blockRows, customBlockRows] = await Promise.all([
+    db
+      .select({ id: workflow.id, name: workflow.name })
+      .from(workflow)
+      .where(and(eq(workflow.workspaceId, workspaceId), isNull(workflow.archivedAt))),
+    db
+      .select({
+        parentId: workflowBlocks.workflowId,
+        type: workflowBlocks.type,
+        childFromSelector: sql<
+          string | null
+        >`${workflowBlocks.subBlocks} -> 'workflowId' ->> 'value'`,
+        childFromManual: sql<
+          string | null
+        >`${workflowBlocks.subBlocks} -> 'manualWorkflowId' ->> 'value'`,
+      })
+      .from(workflowBlocks)
+      .innerJoin(workflow, eq(workflow.id, workflowBlocks.workflowId))
+      .where(
+        and(
+          eq(workflow.workspaceId, workspaceId),
+          isNull(workflow.archivedAt),
+          or(
+            inArray(workflowBlocks.type, [BlockType.WORKFLOW, BlockType.WORKFLOW_INPUT]),
+            like(workflowBlocks.type, `${CUSTOM_BLOCK_TYPE_PREFIX}%`)
+          )
+        )
+      ),
+    getCustomBlockRowsForWorkspace(workspaceId),
+  ])
+
+  const result = resolveWorkflowReferences(
+    workflowId,
+    workflowRows,
+    blockRows,
+    customBlockRows.map((row) => ({ type: row.type, workflowId: row.workflowId }))
+  )
+
+  if (!workflowRows.some((row) => row.id === workflowId)) {
+    logger.warn('Workflow not found in workspace when resolving references', {
+      workspaceId,
+      workflowId,
+    })
+  }
+
+  return result
+}

--- a/scripts/check-api-validation-contracts.ts
+++ b/scripts/check-api-validation-contracts.ts
@@ -9,8 +9,8 @@ const QUERY_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/queries')
 const SELECTOR_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/selectors')
 
 const BASELINE = {
-  totalRoutes: 966,
-  zodRoutes: 966,
+  totalRoutes: 967,
+  zodRoutes: 967,
   nonZodRoutes: 0,
 } as const
 


### PR DESCRIPTION
Supersedes #5852 — builds directly on @mzxchandra's branch (both original commits preserved) and layers a cleanup/alignment pass on top. Huge thanks to Chandra for the feature itself: the recursive caller/callee resolver, the cycle/diamond handling, and the modal UI all originate there.

## What the feature does

Right-click a workflow in the sidebar → **Show references** opens a modal with two tabs: **Used by** (workflows that call it) and **Uses** (workflows it calls), each a recursive tree whose rows navigate to the referenced workflow. Resolution reads live editor state (draft `workflow_blocks`), resolves the ACTIVE canonical mode so a dormant basic/advanced value can't mask the live one, marks cycles as leaves, and bounds diamond re-expansion.

## Changes on top of #5852

**Coverage**
- Added the third call-edge shape: `workflow_input` tools inside `tool-input` sub-blocks (an agent invoking another workflow as a tool) now appear in both trees, with array and JSON-stringified values handled via the shared `coerceObjectArray` helper. Non-call selector shapes (`workflowSelector`, trigger `workflowIds`) are deliberately excluded and documented against `remapWorkflowReferencesInSubBlocks`.

**Auth**
- The route now authorizes like its `/api/workflows/[id]/*` siblings via `authorizeWorkflowByWorkspacePermission` and derives the workspace server-side — proper 404/403 semantics, and the client-supplied `workspaceId` query param is gone from the contract, hook, and modal.

**UX**
- Restored native cmd/ctrl+click open-in-new-tab on sidebar workflow rows; references stay one right-click away in the context menu.
- `ReferencesModal` mounts on demand per row instead of always-mounted-per-row — removes N idle React Query observers in large workspaces and deletes the `prevIsOpen` reset machinery, the `enabled` knob, and the `staleTime: 0` workaround (now a named 30s constant).

**Design system**
- Tree rows land on the modal's px-4 text gutter, use `--text-icon` / `--surface-hover` tokens and the emcn `Workflow` icon instead of a hardcoded brand hex.

**Hardening / hygiene**
- Escaped LIKE wildcards in the `custom_block_` prefix match; imported `MAX_CALL_CHAIN_DEPTH` instead of mirroring it; un-exported the internal graph builder; removed dead fallbacks, a duplicate not-found scan, and a redundant row-narrowing map.
- Route tests updated for the authz shape (401/404/403/200); resolver tests extended for tool-input edges (18 tests passing).

## Verification

- `bunx vitest run` on both test files: 18/18 passing
- `bun run check:api-validation` and `:strict`: pass (baseline 966→967 for the new route)
- `biome check` clean; `tsc` clean on all touched files