### PR TITLE
feat(sidebar): add Slack Community link to help dropdown

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -39,6 +39,7 @@ import { MoreHorizontal, Pin } from 'lucide-react'
 import Link from 'next/link'
 import { useParams, usePathname, useRouter } from 'next/navigation'
 import { usePostHog } from 'posthog-js/react'
+import { SlackIcon } from '@/components/icons'
 import { useSession } from '@/lib/auth/auth-client'
 import { SIM_RESOURCES_DRAG_TYPE } from '@/lib/copilot/resource-types'
 import { isMacPlatform } from '@/lib/core/utils/platform'
@@ -114,6 +115,9 @@ import { useSettingsDirtyStore } from '@/stores/settings/dirty/store'
 import { useSidebarStore } from '@/stores/sidebar/store'
 
 const logger = createLogger('Sidebar')
+
+const SLACK_COMMUNITY_URL =
+  'https://join.slack.com/t/sim-ott9864/shared_invite/zt-451nu802o-ZS8Q5qHLXK1EJ0Mt~wycYA'
 
 export function SidebarTooltip({
   children,
@@ -1170,6 +1174,11 @@ export const Sidebar = memo(function Sidebar({ isCollapsed }: SidebarProps) {
     captureEvent(posthog, 'docs_opened', { source: 'help_menu' })
   }, [posthog])
 
+  const handleOpenSlackCommunity = useCallback(() => {
+    window.open(SLACK_COMMUNITY_URL, '_blank', 'noopener,noreferrer')
+    captureEvent(posthog, 'slack_community_opened', { source: 'help_menu' })
+  }, [posthog])
+
   const handleChatRenameBlur = useCallback(
     () => void chatFlyoutRename.saveRename(),
     [chatFlyoutRename.saveRename]
@@ -1669,6 +1678,10 @@ export const Sidebar = memo(function Sidebar({ isCollapsed }: SidebarProps) {
                       <DropdownMenuItem onSelect={handleOpenDocs}>
                         <BookOpen className='h-[14px] w-[14px]' />
                         Docs
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onSelect={handleOpenSlackCommunity}>
+                        <SlackIcon className='size-[14px]' />
+                        Slack Community
                       </DropdownMenuItem>
                       <DropdownMenuItem onSelect={handleOpenHelpFromMenu}>
                         <HelpCircle className='h-[14px] w-[14px]' />

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -117,7 +117,7 @@ import { useSidebarStore } from '@/stores/sidebar/store'
 const logger = createLogger('Sidebar')
 
 const SLACK_COMMUNITY_URL =
-  'https://join.slack.com/t/sim-ott9864/shared_invite/zt-451nu802o-ZS8Q5qHLXK1EJ0Mt~wycYA'
+  'https://join.slack.com/t/sim-ott9864/shared_invite/zt-43lp8tc5v-0qrrqHGBKUsvQlpoouH~TA'
 
 export function SidebarTooltip({
   children,

--- a/apps/sim/lib/posthog/events.ts
+++ b/apps/sim/lib/posthog/events.ts
@@ -547,6 +547,10 @@ export interface PostHogEventMap {
     block_type?: string
   }
 
+  slack_community_opened: {
+    source: 'help_menu'
+  }
+
   search_result_selected: {
     result_type:
       | 'block'


### PR DESCRIPTION
## Summary
- Add a Slack Community item to the sidebar help dropdown that opens the community invite link in a new tab
- Uses the existing SlackIcon and mirrors the Docs item pattern, with a typed `slack_community_opened` PostHog event

## Type of Change
- [x] New feature

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)