### PR TITLE
fix(ci): save the Next.js build cache every run instead of freezing it at the lockfile key

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -246,8 +246,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ./apps/sim/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-${{ github.sha }}-
             ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-
             ${{ runner.os }}-nextjs-
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -236,12 +236,19 @@ jobs:
           key: ${{ github.repository }}-turbo-cache-build-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}
           path: ./.turbo
 
+      # Keyed per commit so EVERY run saves its refreshed cache — a key without
+      # a unique suffix is written once and then frozen (GitHub caches are
+      # immutable per key; a primary-key hit skips the save), which left builds
+      # compiling against a cache stale since the last lockfile change. The
+      # restore-keys prefix match picks the most recently saved cache for this
+      # lockfile, falling back across lockfile changes.
       - name: Restore Next.js build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ./apps/sim/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-
             ${{ runner.os }}-nextjs-
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- The `Build App` job's Next.js cache key was `os + hashFiles(bun.lock)` with no unique suffix — GitHub caches are immutable per key, so the cache was saved once per lockfile change and then **frozen**: every subsequent run logged `Cache hit occurred on the primary key ... not saving cache` and compiled against an ever-staler cache
- Suffix the key with `github.sha` so every run saves its refreshed `.next/cache`, and restore via prefix match (`os-nextjs-<lockfile>-` → `os-nextjs-`) so each run starts from the most recently saved cache
- This is the standard pattern from the Next.js CI caching docs; expected effect is a meaningfully warmer incremental build on every PR (the build step is ~83% of the 3–4 min job, which gates merges)

## Type of Change
- [x] Bug fix

## Testing
Verified the frozen-cache behavior in the live run log (primary-key hit → save skipped). The fix's effect shows up in this PR's own `Build App` check and the following runs as the cache warms per-commit.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)