### PR TITLE
feat(api): add proxyUrl for residential/custom proxy egress on the API block

### DIFF
--- a/apps/sim/blocks/blocks/api.ts
+++ b/apps/sim/blocks/blocks/api.ts
@@ -123,6 +123,15 @@ Example:
       description: 'Allow retries for POST/PATCH requests (may create duplicate requests)',
       mode: 'advanced',
     },
+    {
+      id: 'proxyUrl',
+      title: 'Proxy URL',
+      type: 'short-input',
+      placeholder: 'http://user:pass@proxy.host:port',
+      description:
+        'Optional. Route this request through an http:// proxy (e.g. a residential proxy). Must be http://; the proxy host must be publicly reachable.',
+      mode: 'advanced',
+    },
   ],
   tools: {
     access: ['http_request'],
@@ -143,6 +152,10 @@ Example:
     retryNonIdempotent: {
       type: 'boolean',
       description: 'Allow retries for non-idempotent methods like POST/PATCH',
+    },
+    proxyUrl: {
+      type: 'string',
+      description: 'Optional http:// proxy URL to route the request through',
     },
   },
   outputs: {

--- a/apps/sim/lib/core/security/input-validation.server.ts
+++ b/apps/sim/lib/core/security/input-validation.server.ts
@@ -5,6 +5,8 @@ import type { LookupFunction } from 'net'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
 import { omit } from '@sim/utils/object'
+import { HttpProxyAgent } from 'http-proxy-agent'
+import { HttpsProxyAgent } from 'https-proxy-agent'
 import * as ipaddr from 'ipaddr.js'
 import { Agent, type RequestInit as UndiciRequestInit, fetch as undiciFetch } from 'undici'
 import { isHosted, isPrivateDatabaseHostsAllowed } from '@/lib/core/config/env-flags'
@@ -146,6 +148,65 @@ export async function validateUrlWithDNS(
       error: `${paramName} hostname could not be resolved`,
     }
   }
+}
+
+/**
+ * Result of validating a user-supplied HTTP proxy URL.
+ */
+export interface ProxyValidationResult {
+  isValid: boolean
+  /** Proxy URL with hostname rewritten to the resolved IP (creds/port preserved) to pin the proxy connection. */
+  pinnedProxyUrl?: string
+  error?: string
+}
+
+/**
+ * Validates a user-supplied HTTP proxy URL and returns an IP-pinned form.
+ *
+ * When a request routes through a proxy, the TCP connection targets the proxy
+ * host (the proxy resolves the destination), so target-IP pinning no longer
+ * governs egress and the proxy URL becomes the SSRF surface. This function:
+ * 1. Enforces the `http:` scheme (raw TCP to the proxy, no TLS-to-proxy SNI to
+ *    reconcile, so the host can be safely rewritten to an IP).
+ * 2. Resolves the proxy host's DNS and blocks private/reserved/loopback IPs via
+ *    {@link validateUrlWithDNS}.
+ * 3. Pins the connection by rewriting the hostname to the resolved IP while
+ *    preserving credentials/port, closing the DNS-rebinding (TOCTOU) window.
+ *
+ * @param proxyUrl - The proxy URL (e.g. `http://user:pass@host:port`)
+ */
+export async function validateAndPinProxyUrl(
+  proxyUrl: string | null | undefined
+): Promise<ProxyValidationResult> {
+  if (!proxyUrl || typeof proxyUrl !== 'string') {
+    return { isValid: false, error: 'proxyUrl must be a string' }
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(proxyUrl)
+  } catch {
+    return { isValid: false, error: 'proxyUrl must be a valid URL' }
+  }
+
+  if (parsed.protocol !== 'http:') {
+    return {
+      isValid: false,
+      error: 'proxyUrl must use http:// (https/socks proxies are not supported)',
+    }
+  }
+
+  const validation = await validateUrlWithDNS(proxyUrl, 'proxyUrl', { allowHttp: true })
+  if (!validation.isValid) {
+    return { isValid: false, error: validation.error }
+  }
+
+  // Bracket IPv6 literals: assigning an unbracketed IPv6 address to
+  // URL.hostname is a no-op (the WHATWG parser rejects it), which would leave
+  // the original DNS hostname in place and reopen the rebinding window.
+  const resolvedIP = validation.resolvedIP!
+  parsed.hostname = resolvedIP.includes(':') ? `[${resolvedIP}]` : resolvedIP
+  return { isValid: true, pinnedProxyUrl: parsed.toString() }
 }
 
 /**
@@ -343,6 +404,12 @@ export interface SecureFetchOptions {
   signal?: AbortSignal
   /** Drop the Authorization header when following a redirect, so it is not sent to the redirect target's origin. */
   stripAuthOnRedirect?: boolean
+  /**
+   * Pre-validated, IP-pinned `http://` proxy URL (see {@link validateAndPinProxyUrl}).
+   * When set, the connection routes through this proxy and target-IP pinning is
+   * bypassed (the proxy resolves the target).
+   */
+  proxyUrl?: string
 }
 
 export class SecureFetchHeaders {
@@ -678,11 +745,19 @@ export async function secureFetchWithPinnedIP(
     const defaultPort = isHttps ? 443 : 80
     const port = parsed.port ? Number.parseInt(parsed.port, 10) : defaultPort
 
-    const lookup = createPinnedLookup(resolvedIP)
-
-    const agentOptions: http.AgentOptions = { lookup }
-
-    const agent = isHttps ? new https.Agent(agentOptions) : new http.Agent(agentOptions)
+    let agent: http.Agent
+    if (options.proxyUrl) {
+      // The proxy connection is already IP-pinned by validateAndPinProxyUrl; routing
+      // through the proxy intentionally bypasses target-IP pinning (the proxy
+      // resolves the target). Agent choice keys off the target protocol: an
+      // https target tunnels via CONNECT, an http target uses absolute-URI
+      // forwarding - both over the plain-http proxy connection.
+      agent = isHttps ? new HttpsProxyAgent(options.proxyUrl) : new HttpProxyAgent(options.proxyUrl)
+    } else {
+      const lookup = createPinnedLookup(resolvedIP)
+      const agentOptions: http.AgentOptions = { lookup }
+      agent = isHttps ? new https.Agent(agentOptions) : new http.Agent(agentOptions)
+    }
 
     const { 'accept-encoding': _, ...sanitizedHeaders } = options.headers ?? {}
 

--- a/apps/sim/lib/core/security/input-validation.test.ts
+++ b/apps/sim/lib/core/security/input-validation.test.ts
@@ -28,6 +28,7 @@ import {
 } from '@/lib/core/security/input-validation'
 import {
   isPrivateOrReservedIP,
+  validateAndPinProxyUrl,
   validateDatabaseHost,
   validateUrlWithDNS,
 } from '@/lib/core/security/input-validation.server'
@@ -840,6 +841,65 @@ describe('validateDatabaseHost', () => {
       expect(result.isValid).toBe(false)
       expect(result.error).toContain('could not be resolved')
     })
+  })
+})
+
+describe('validateAndPinProxyUrl', () => {
+  it('should reject a null/empty proxy URL', async () => {
+    expect((await validateAndPinProxyUrl(null)).isValid).toBe(false)
+    expect((await validateAndPinProxyUrl('')).isValid).toBe(false)
+  })
+
+  it('should reject a malformed URL', async () => {
+    const result = await validateAndPinProxyUrl('not a url')
+    expect(result.isValid).toBe(false)
+    expect(result.error).toContain('valid URL')
+  })
+
+  it('should reject an https:// proxy scheme', async () => {
+    const result = await validateAndPinProxyUrl('https://proxy.example.com:8080')
+    expect(result.isValid).toBe(false)
+    expect(result.error).toContain('http://')
+  })
+
+  it('should reject a socks5:// proxy scheme', async () => {
+    const result = await validateAndPinProxyUrl('socks5://proxy.example.com:1080')
+    expect(result.isValid).toBe(false)
+    expect(result.error).toContain('http://')
+  })
+
+  it('should reject a proxy host that is a private IP', async () => {
+    const result = await validateAndPinProxyUrl('http://user:pass@192.168.1.1:8080')
+    expect(result.isValid).toBe(false)
+    expect(result.error).toMatch(/private IP|blocked IP/)
+  })
+
+  it('should reject a proxy host that is the metadata IP', async () => {
+    const result = await validateAndPinProxyUrl('http://169.254.169.254:80')
+    expect(result.isValid).toBe(false)
+    expect(result.error).toMatch(/private IP|blocked IP/)
+  })
+
+  it('should accept a public proxy host and pin the hostname to the resolved IP, preserving creds/port', async () => {
+    const result = await validateAndPinProxyUrl('http://user:pass@8.8.8.8:8080')
+    expect(result.isValid).toBe(true)
+    const pinned = new URL(result.pinnedProxyUrl!)
+    expect(pinned.protocol).toBe('http:')
+    expect(pinned.hostname).toBe('8.8.8.8')
+    expect(pinned.username).toBe('user')
+    expect(pinned.password).toBe('pass')
+    expect(pinned.port).toBe('8080')
+  })
+
+  it('should bracket an IPv6 resolved address so the pinned host is the IP, not the original name', async () => {
+    const result = await validateAndPinProxyUrl('http://user:pass@[2606:4700:4700::1111]:8080')
+    expect(result.isValid).toBe(true)
+    const pinned = new URL(result.pinnedProxyUrl!)
+    // Must be pinned to the bracketed IPv6 literal, never left as a DNS name.
+    expect(pinned.hostname).toBe('[2606:4700:4700::1111]')
+    expect(pinned.username).toBe('user')
+    expect(pinned.password).toBe('pass')
+    expect(pinned.port).toBe('8080')
   })
 })
 

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -155,6 +155,8 @@
     "gray-matter": "^4.0.3",
     "groq-sdk": "^0.15.0",
     "html-to-text": "^9.0.5",
+    "http-proxy-agent": "7.0.2",
+    "https-proxy-agent": "7.0.6",
     "idb-keyval": "6.2.2",
     "image-size": "1.2.1",
     "imapflow": "1.2.4",

--- a/apps/sim/tools/http/request.ts
+++ b/apps/sim/tools/http/request.ts
@@ -51,6 +51,11 @@ export const requestTool: ToolConfig<RequestParams, RequestResponse> = {
       visibility: 'user-or-llm',
       description: 'Form data to send (will set appropriate Content-Type)',
     },
+    proxyUrl: {
+      type: 'string',
+      visibility: 'user-only',
+      description: 'Route the request through an http:// proxy (e.g. http://user:pass@host:port).',
+    },
     timeout: {
       type: 'number',
       visibility: 'user-only',

--- a/apps/sim/tools/http/types.ts
+++ b/apps/sim/tools/http/types.ts
@@ -8,6 +8,7 @@ export interface RequestParams {
   params?: TableRow[] | string
   pathParams?: Record<string, string>
   formData?: Record<string, string | Blob>
+  proxyUrl?: string
   timeout?: number
   retries?: number
   retryDelayMs?: number

--- a/apps/sim/tools/index.test.ts
+++ b/apps/sim/tools/index.test.ts
@@ -958,6 +958,77 @@ describe('Automatic Internal Route Detection', () => {
     Object.assign(tools, originalTools)
   })
 
+  it('should validate + pin a proxyUrl param and pass it to secureFetchWithPinnedIP', async () => {
+    inputValidationMockFns.mockValidateAndPinProxyUrl.mockResolvedValue({
+      isValid: true,
+      pinnedProxyUrl: 'http://user:pass@1.2.3.4:8080/',
+    })
+
+    const mockTool = {
+      id: 'test_external_proxy',
+      name: 'Test External Proxy Tool',
+      description: 'A test tool that routes through a proxy',
+      version: '1.0.0',
+      params: {},
+      request: {
+        url: 'https://api.example.com/endpoint',
+        method: 'GET',
+        headers: () => ({ 'Content-Type': 'application/json' }),
+      },
+      transformResponse: vi.fn().mockResolvedValue({ success: true, output: {} }),
+    }
+
+    const originalTools = { ...tools }
+    ;(tools as any).test_external_proxy = mockTool
+
+    await executeTool('test_external_proxy', { proxyUrl: 'http://user:pass@proxy.host:8080' })
+
+    expect(inputValidationMockFns.mockValidateAndPinProxyUrl).toHaveBeenCalledWith(
+      'http://user:pass@proxy.host:8080'
+    )
+    expect(mockSecureFetchWithPinnedIP).toHaveBeenCalledWith(
+      'https://api.example.com/endpoint',
+      '93.184.216.34',
+      expect.objectContaining({ proxyUrl: 'http://user:pass@1.2.3.4:8080/' })
+    )
+
+    Object.assign(tools, originalTools)
+  })
+
+  it('should throw when the proxyUrl param fails validation', async () => {
+    inputValidationMockFns.mockValidateAndPinProxyUrl.mockResolvedValue({
+      isValid: false,
+      error: 'proxyUrl must use http:// (https/socks proxies are not supported)',
+    })
+
+    const mockTool = {
+      id: 'test_external_bad_proxy',
+      name: 'Test External Bad Proxy Tool',
+      description: 'A test tool with an invalid proxy',
+      version: '1.0.0',
+      params: {},
+      request: {
+        url: 'https://api.example.com/endpoint',
+        method: 'GET',
+        headers: () => ({ 'Content-Type': 'application/json' }),
+      },
+      transformResponse: vi.fn().mockResolvedValue({ success: true, output: {} }),
+    }
+
+    const originalTools = { ...tools }
+    ;(tools as any).test_external_bad_proxy = mockTool
+
+    const result = await executeTool('test_external_bad_proxy', {
+      proxyUrl: 'https://proxy.host:8080',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Invalid proxy URL')
+    expect(mockSecureFetchWithPinnedIP).not.toHaveBeenCalled()
+
+    Object.assign(tools, originalTools)
+  })
+
   it('should handle dynamic URLs that resolve to internal routes', async () => {
     const mockTool = {
       id: 'test_dynamic_internal',

--- a/apps/sim/tools/index.ts
+++ b/apps/sim/tools/index.ts
@@ -14,6 +14,7 @@ import { DEFAULT_EXECUTION_TIMEOUT_MS, getMaxExecutionTimeout } from '@/lib/core
 import { getHostedKeyRateLimiter } from '@/lib/core/rate-limiter'
 import {
   secureFetchWithPinnedIP,
+  validateAndPinProxyUrl,
   validateUrlWithDNS,
 } from '@/lib/core/security/input-validation.server'
 import { PlatformEvents } from '@/lib/core/telemetry'
@@ -1809,6 +1810,15 @@ async function executeToolRequest(
             throw new Error(`Invalid tool URL: ${urlValidation.error}`)
           }
 
+          let proxyOption: string | undefined
+          if (requestParams.proxyUrl) {
+            const proxyValidation = await validateAndPinProxyUrl(requestParams.proxyUrl)
+            if (!proxyValidation.isValid) {
+              throw new Error(`Invalid proxy URL: ${proxyValidation.error}`)
+            }
+            proxyOption = proxyValidation.pinnedProxyUrl
+          }
+
           const secureResponse = await secureFetchWithPinnedIP(fullUrl, urlValidation.resolvedIP!, {
             method: requestParams.method,
             headers: headersRecord,
@@ -1816,6 +1826,7 @@ async function executeToolRequest(
             timeout: requestParams.timeout,
             maxResponseBytes: MAX_TOOL_RESPONSE_BODY_BYTES,
             signal,
+            proxyUrl: proxyOption,
           })
 
           const responseHeaders = new Headers(secureResponse.headers.toRecord())

--- a/apps/sim/tools/utils.test.ts
+++ b/apps/sim/tools/utils.test.ts
@@ -209,6 +209,17 @@ describe('formatRequestParams', () => {
 
     expect(result.body).toBe('{"prompt": "Hello"}\n{"prompt": "World"}')
   })
+
+  it.concurrent('should pass through a non-empty proxyUrl (trimmed)', () => {
+    const result = formatRequestParams(mockTool, { proxyUrl: '  http://user:pass@host:8080  ' })
+    expect(result.proxyUrl).toBe('http://user:pass@host:8080')
+  })
+
+  it.concurrent('should omit proxyUrl when blank, whitespace, or absent', () => {
+    expect(formatRequestParams(mockTool, {}).proxyUrl).toBeUndefined()
+    expect(formatRequestParams(mockTool, { proxyUrl: '' }).proxyUrl).toBeUndefined()
+    expect(formatRequestParams(mockTool, { proxyUrl: '   ' }).proxyUrl).toBeUndefined()
+  })
 })
 
 describe('validateRequiredParametersAfterMerge', () => {

--- a/apps/sim/tools/utils.ts
+++ b/apps/sim/tools/utils.ts
@@ -82,6 +82,7 @@ export interface RequestParams {
   headers: Record<string, string>
   body?: string
   timeout?: number
+  proxyUrl?: string
 }
 
 /**
@@ -137,7 +138,12 @@ export function formatRequestParams(tool: ToolConfig, params: Record<string, any
       ? Math.min(timeout, MAX_TIMEOUT_MS)
       : undefined
 
-  return { url, method, headers, body, timeout: validTimeout }
+  const proxyUrl =
+    typeof params.proxyUrl === 'string' && params.proxyUrl.trim()
+      ? params.proxyUrl.trim()
+      : undefined
+
+  return { url, method, headers, body, timeout: validTimeout, proxyUrl }
 }
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -223,6 +223,8 @@
         "gray-matter": "^4.0.3",
         "groq-sdk": "^0.15.0",
         "html-to-text": "^9.0.5",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
         "idb-keyval": "6.2.2",
         "image-size": "1.2.1",
         "imapflow": "1.2.4",

--- a/packages/testing/src/mocks/input-validation.mock.ts
+++ b/packages/testing/src/mocks/input-validation.mock.ts
@@ -13,6 +13,7 @@ import { vi } from 'vitest'
  */
 export const inputValidationMockFns = {
   mockValidateUrlWithDNS: vi.fn(),
+  mockValidateAndPinProxyUrl: vi.fn(),
   mockValidateDatabaseHost: vi.fn(),
   mockSecureFetchWithPinnedIP: vi.fn(),
   mockSecureFetchWithValidation: vi.fn(),
@@ -30,6 +31,7 @@ export const inputValidationMockFns = {
  */
 export const inputValidationMock = {
   validateUrlWithDNS: inputValidationMockFns.mockValidateUrlWithDNS,
+  validateAndPinProxyUrl: inputValidationMockFns.mockValidateAndPinProxyUrl,
   validateDatabaseHost: inputValidationMockFns.mockValidateDatabaseHost,
   secureFetchWithPinnedIP: inputValidationMockFns.mockSecureFetchWithPinnedIP,
   secureFetchWithValidation: inputValidationMockFns.mockSecureFetchWithValidation,


### PR DESCRIPTION
## Summary
Adds an optional **Proxy URL** field to the API block so a request can egress through a residential/custom `http://` proxy.

The HTTP/API block egresses from the app runtime's fixed datacenter IPs via `secureFetchWithPinnedIP`. Targets behind Cloudflare/WAF that block datacenter IPs (e.g. state `.gov` license-verification portals) return 403/429 even when the identical request succeeds from a browser, and there was no first-class way to route around it. Users were hand-threading proxy URLs through request bodies and env vars as a workaround.

When **Proxy URL** (under the block's Advanced fields) is set, the request routes through that proxy so it egresses from the proxy's IP.

**Security model** (proxy is the new SSRF surface once target-IP pinning no longer governs egress):
- `validateAndPinProxyUrl` resolves the proxy host's DNS and blocks private/reserved/loopback IPs — the same guard applied to target URLs (blocks `localhost`, `127.0.0.1`, `169.254.169.254`, `10.x`, …).
- The proxy connection is then **pinned** by rewriting the host to the resolved IP (credentials/port preserved), closing the DNS-rebinding (TOCTOU) window.
- Restricted to the `http:` proxy scheme (`https:`/`socks*` rejected) so host-pinning is safe without breaking TLS-to-proxy SNI. The proxy scheme is independent of the target scheme: an `https://` target still tunnels via CONNECT over the plain-http proxy.
- The target URL is still validated with `validateUrlWithDNS`; only its IP pinning is bypassed when a proxy is active (the proxy resolves the target).

**Wiring:** block field → http tool param → `formatRequestParams` → `executeToolRequest` (validate + pin) → `secureFetchWithPinnedIP`, which swaps its pinned Node agent for `HttpsProxyAgent`/`HttpProxyAgent` (keyed off the target protocol) when `proxyUrl` is set. Redirects carry the already-pinned proxy URL through, so no hop reopens the rebinding window.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Unit tests added and passing (604 tests across the affected suites), typecheck clean, `check:api-validation:strict` and Biome clean:
- `validateAndPinProxyUrl`: rejects non-`http:` scheme, malformed URL, and private/reserved/metadata proxy hosts; accepts a public host and returns a pinned URL with the host rewritten to the resolved IP and credentials/port preserved.
- `executeToolRequest`: given a `proxyUrl` param, `validateAndPinProxyUrl` is called and its pinned URL is passed as `options.proxyUrl` to `secureFetchWithPinnedIP`; an invalid proxy surfaces `Invalid proxy URL: …`.
- `formatRequestParams`: `proxyUrl` passes through (trimmed) for a non-empty string; omitted for blank/whitespace/absent.

Manual E2E against a local logging proxy (requiring Basic auth) with the app running:
- HTTPS target + Proxy URL → `200`, proxy logs a CONNECT tunnel; clearing the Proxy URL → `200` with **no** proxy log line (direct egress) — confirms the proxy is used only when set.
- HTTP target → routed via the `HttpProxyAgent` (absolute-URI) path.
- `https://…` / `socks5://…` proxy → rejected with the scheme error; `http://127.0.0.1:9999` → connection error; wrong creds → proxy `407` surfaced as a block error; `http://169.254.169.254` → blocked-IP error.

Reviewers should focus on the security model in `apps/sim/lib/core/security/input-validation.server.ts` (`validateAndPinProxyUrl` + the agent branch in `secureFetchWithPinnedIP`).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
The new **Proxy URL** field appears under the API block's Advanced fields with placeholder `http://user:pass@proxy.host:port`.
