### PR TITLE
feat(ci): warm Next.js builds via Turbopack persistent cache on a sticky disk

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -242,15 +242,17 @@ jobs:
       # compiling against a cache stale since the last lockfile change. The
       # restore-keys prefix match picks the most recently saved cache for this
       # lockfile, falling back across lockfile changes.
-      - name: Restore Next.js build cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      # Turbopack's persistent build cache (NEXT_TURBOPACK_BUILD_CACHE below)
+      # writes ~5 GB into .next/cache — a sticky disk mounts it in ~1s where an
+      # actions/cache round-trip would eat the warm-build win. Same event/fork
+      # namespacing as the other mounts; the GitHub fallback inside cache-mount
+      # still uses actions/cache with a run_id-suffixed key.
+      - name: Mount Next.js build cache
+        uses: ./.github/actions/cache-mount
         with:
+          provider: ${{ vars.CI_PROVIDER }}
+          key: ${{ github.repository }}-nextjs-cache-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}
           path: ./apps/sim/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-${{ github.sha }}-
-            ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-
-            ${{ runner.os }}-nextjs-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -266,4 +268,7 @@ jobs:
           AWS_REGION: 'us-west-2'
           ENCRYPTION_KEY: '7cf672e460e430c1fba707575c2b0e2ad5a99dddf9b7b7e3b5646e630861db1c' # dummy key for CI only
           TURBO_CACHE_DIR: .turbo
+          # Opt into Turbopack's persistent build cache (beta) for this CI
+          # check build only — measured 105s cold vs 22s warm locally.
+          NEXT_TURBOPACK_BUILD_CACHE: '1'
         run: bunx turbo run build --filter=sim

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -236,12 +236,6 @@ jobs:
           key: ${{ github.repository }}-turbo-cache-build-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}
           path: ./.turbo
 
-      # Keyed per commit so EVERY run saves its refreshed cache — a key without
-      # a unique suffix is written once and then frozen (GitHub caches are
-      # immutable per key; a primary-key hit skips the save), which left builds
-      # compiling against a cache stale since the last lockfile change. The
-      # restore-keys prefix match picks the most recently saved cache for this
-      # lockfile, falling back across lockfile changes.
       # Turbopack's persistent build cache (NEXT_TURBOPACK_BUILD_CACHE below)
       # writes ~5 GB into .next/cache — a sticky disk mounts it in ~1s where an
       # actions/cache round-trip would eat the warm-build win. Same event/fork

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -144,6 +144,12 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizeCss: !isDev,
     turbopackFileSystemCacheForDev: false,
+    /**
+     * Turbopack's persistent build cache (beta) — opt-in via env so only the
+     * CI check build uses it; production image builds stay on the default
+     * cold-build path until the feature stabilizes.
+     */
+    turbopackFileSystemCacheForBuild: process.env.NEXT_TURBOPACK_BUILD_CACHE === '1',
     preloadEntriesOnStart: false,
     optimizePackageImports: [
       'lodash',


### PR DESCRIPTION
## Summary
- Enable Next 16's Turbopack persistent build cache (`experimental.turbopackFileSystemCacheForBuild`, beta) behind a `NEXT_TURBOPACK_BUILD_CACHE` env gate — only the CI check build opts in; production image builds keep the default cold path until the feature stabilizes
- Mount `./apps/sim/.next/cache` as a Blacksmith sticky disk via the existing `cache-mount` action (same event/fork namespacing as the other mounts) — the Turbopack cache is ~5 GB, which sticky disks mount in ~1s while an `actions/cache` round-trip would eat the warm-build win; the GitHub-fallback path inside `cache-mount` still works
- Measured locally on this repo: **105s cold compile → 22s warm (4.8×)**. The `Build App` check is the merge gate (~3m40s, compile is ~80% of it), so this is direct merge-wait reduction; expect the effect from the second run onward as the disk warms
- Follow-up to #5859 (which fixed the frozen `actions/cache` keying but revealed the cache carried almost nothing without the Turbopack flag)

## Type of Change
- [x] Improvement

## Testing
Local A/B: cold build 105s (cache written, 4.8 GB), immediate rebuild 22.1s, byte-identical route table. This PR's own `Build App` run is cold (first sticky-disk fill); subsequent runs on the branch/staging show the warm number.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)