### PR TITLE
improvement(landing): keyword-forward SEO copy on the home and enterprise pages

### DIFF
--- a/apps/sim/app/(landing)/components/hero/components/hero-header/hero-header.tsx
+++ b/apps/sim/app/(landing)/components/hero/components/hero-header/hero-header.tsx
@@ -6,6 +6,12 @@ import { LANDING_HERO_CTA_GAP } from '@/app/(landing)/components/landing-layout'
 
 interface LandingHeroHeaderProps {
   description: string
+  /**
+   * Optional second paragraph beneath the description - a self-contained
+   * definition of the page's subject, kept quotable for answer engines (GEO).
+   * Omitted by the homepage, so its hero renders unchanged.
+   */
+  definition?: string
   eyebrow?: ReactNode
   heading: ReactNode
   headingId: string
@@ -17,6 +23,7 @@ interface LandingHeroHeaderProps {
  */
 export function LandingHeroHeader({
   description,
+  definition,
   eyebrow,
   heading,
   headingId,
@@ -36,6 +43,12 @@ export function LandingHeroHeader({
         <p className='w-full min-w-0 max-w-[58ch] text-pretty text-[var(--text-muted)] text-base leading-[1.5]'>
           {description}
         </p>
+
+        {definition ? (
+          <p className='w-full min-w-0 max-w-[58ch] text-pretty text-[var(--text-muted)] text-base leading-[1.5]'>
+            {definition}
+          </p>
+        ) : null}
 
         <div className={cn('max-sm:w-full', LANDING_HERO_CTA_GAP)}>
           <HeroCta />

--- a/apps/sim/app/(landing)/components/hero/hero.tsx
+++ b/apps/sim/app/(landing)/components/hero/hero.tsx
@@ -86,11 +86,12 @@ export function Hero() {
         headingId='hero-heading'
         heading={
           <>
-            Sim is the AI workspace <br />
-            for building AI agents.
+            Sim is the AI workspace for <br />
+            building and managing AI agents.
           </>
         }
-        description='Open source, with 1,000+ integrations and every major LLM. Build, deploy, and manage agents visually, conversationally, or with code.'
+        description='Sim is an AI agent and workflow builder for teams creating agents that automate real work. Design workflows visually, describe what you need in natural language, or use code for complete control.'
+        definition='Connect your agents to 1,000+ integrations and every major LLM, then deploy, monitor, and improve them from one collaborative workspace.'
       />
 
       <div

--- a/apps/sim/app/(landing)/components/hero/hero.tsx
+++ b/apps/sim/app/(landing)/components/hero/hero.tsx
@@ -91,7 +91,7 @@ export function Hero() {
           </>
         }
         description='Sim is an AI agent and workflow builder for teams creating agents that automate real work. Design workflows visually, describe what you need in natural language, or use code for complete control.'
-        definition='Connect your agents to 1,000+ integrations and every major LLM, then deploy, monitor, and improve them from one collaborative workspace.'
+        definition='Connect your agents to 1,000+ integrations and every major LLM, then deploy, monitor, and improve them from one collaborative, open-source workspace.'
       />
 
       <div

--- a/apps/sim/app/(landing)/components/home-structured-data/home-structured-data.tsx
+++ b/apps/sim/app/(landing)/components/home-structured-data/home-structured-data.tsx
@@ -24,6 +24,13 @@ import { JsonLd } from '@/app/(landing)/components/json-ld'
 export const HOME_PAGE_DESCRIPTION =
   'Sim is the open-source AI workspace where teams build, deploy, and manage AI agents across 1,000+ integrations and every major LLM, visually or with code.'
 
+/**
+ * The home page's canonical title - the single string shared by the
+ * `<title>`, OG/Twitter titles (`page.tsx`), and the JSON-LD `WebPage.name`
+ * below, so the title surfaces never drift.
+ */
+export const HOME_PAGE_TITLE = 'The AI Workspace | Build, Deploy & Manage AI Agents | Sim'
+
 const HOME_JSON_LD = {
   '@context': 'https://schema.org',
   '@graph': [
@@ -31,7 +38,7 @@ const HOME_JSON_LD = {
       '@type': 'WebPage',
       '@id': `${SITE_URL}#webpage`,
       url: SITE_URL,
-      name: 'Sim, The AI Workspace | Build, Deploy & Manage AI Agents',
+      name: HOME_PAGE_TITLE,
       isPartOf: { '@id': `${SITE_URL}#website` },
       about: { '@id': `${SITE_URL}#software` },
       datePublished: '2024-01-01T00:00:00+00:00',

--- a/apps/sim/app/(landing)/components/home-structured-data/index.ts
+++ b/apps/sim/app/(landing)/components/home-structured-data/index.ts
@@ -1,1 +1,1 @@
-export { HOME_PAGE_DESCRIPTION, HomeStructuredData } from './home-structured-data'
+export { HOME_PAGE_DESCRIPTION, HOME_PAGE_TITLE, HomeStructuredData } from './home-structured-data'

--- a/apps/sim/app/(landing)/components/mothership/mothership.tsx
+++ b/apps/sim/app/(landing)/components/mothership/mothership.tsx
@@ -83,7 +83,7 @@ export function Mothership() {
         className='max-w-[1200px] text-balance text-[28px] leading-[1.2] max-sm:text-[22px]'
       >
         <span className='block text-[var(--text-primary)]'>
-          Everything your agents need, in one workspace.
+          Everything your AI agents need, in one workspace.
         </span>
         <span className='block text-[var(--text-body)]'>Build, run, and watch every agent.</span>
       </h2>

--- a/apps/sim/app/(landing)/components/product-demo/product-demo.tsx
+++ b/apps/sim/app/(landing)/components/product-demo/product-demo.tsx
@@ -45,8 +45,9 @@ export function ProductDemo() {
             Describe it. Sim builds it.
           </h2>
           <p className='mt-3 text-pretty text-[15px] text-[var(--text-muted)] leading-[1.6]'>
-            Tell Sim what you need in plain English and it wires blocks, models, and integrations
-            into a working agent.
+            Describe what you want to automate in plain English. Sim acts as an AI agent builder,
+            connecting the right blocks, models, tools, and data into a working workflow that you
+            can review, customize, test, and deploy.
           </p>
         </div>
       </div>

--- a/apps/sim/app/(landing)/components/solutions-page/components/solutions-card-row/components/solutions-card-row-header/solutions-card-row-header.tsx
+++ b/apps/sim/app/(landing)/components/solutions-page/components/solutions-card-row/components/solutions-card-row-header/solutions-card-row-header.tsx
@@ -3,8 +3,9 @@ import { SOLUTIONS_SPACING } from '@/app/(landing)/components/solutions-page/con
 import type { SolutionsCardRowConfig } from '@/app/(landing)/components/solutions-page/types'
 
 /**
- * The header block of a card row - an `<h2>` title, a body-color subtitle, and
- * a single pill CTA, stacked with named spacing constants. Extracted from
+ * The header block of a card row - an `<h2>` title, a body-color subtitle, an
+ * optional second subtitle paragraph, and a single pill CTA, stacked with named
+ * spacing constants. Extracted from
  * {@link SolutionsCardRow} so layouts that place row headers inside a shared
  * grid (the enterprise feature grid) render the exact same header chrome.
  */
@@ -27,6 +28,11 @@ export function SolutionsCardRowHeader({ row, headingId }: SolutionsCardRowHeade
       <p className='w-full min-w-0 max-w-[48ch] text-pretty text-[15px] text-[var(--text-muted)] leading-[1.6]'>
         {row.subtitle}
       </p>
+      {row.note ? (
+        <p className='w-full min-w-0 max-w-[48ch] text-pretty text-[15px] text-[var(--text-muted)] leading-[1.6]'>
+          {row.note}
+        </p>
+      ) : null}
       <div className={SOLUTIONS_SPACING.cardRowHeaderCtaGapFeature}>
         <SolutionsPillCta cta={row.cta} />
       </div>

--- a/apps/sim/app/(landing)/components/solutions-page/components/solutions-hero/solutions-hero.tsx
+++ b/apps/sim/app/(landing)/components/solutions-page/components/solutions-hero/solutions-hero.tsx
@@ -67,6 +67,7 @@ export function SolutionsHero({ hero, align = 'left', variant = 'solutions' }: S
           heading={hero.heading}
           headingId='solutions-hero-heading'
           description={hero.description}
+          definition={hero.definition}
         />
 
         <div

--- a/apps/sim/app/(landing)/components/solutions-page/types.ts
+++ b/apps/sim/app/(landing)/components/solutions-page/types.ts
@@ -30,6 +30,13 @@ export interface SolutionsHeroConfig {
   /** Supporting description beneath the heading, in the body color. */
   description: string
   /**
+   * Optional visible definition of the page's subject, rendered as a second
+   * paragraph beneath {@link description}. Self-contained and answer-first so
+   * answer engines can quote it whole ("What is an enterprise AI agent?").
+   * Currently honored by the `home` hero variant.
+   */
+  definition?: string
+  /**
    * ~50-word sr-only atomic summary for AI citation (GEO). Names "Sim" explicitly
    * and states what the module is, who it's for, and what it does.
    */
@@ -89,6 +96,11 @@ export interface SolutionsCardRowConfig {
   title: string
   /** Supporting subtitle beneath the title, in the body color, naming "Sim". */
   subtitle: string
+  /**
+   * Optional second subtitle paragraph - a self-contained follow-on point that
+   * would overload {@link subtitle} if merged into it (e.g. self-hosting).
+   */
+  note?: string
   /** The row's single pill CTA. */
   cta: SolutionsPillCta
   /** The cards in this row - 3 or 4. The grid derives its columns from this length. */

--- a/apps/sim/app/(landing)/enterprise/enterprise.tsx
+++ b/apps/sim/app/(landing)/enterprise/enterprise.tsx
@@ -50,7 +50,7 @@ import {
  * `WebPage.description` via {@link SolutionsPageConfig.seoDescription}.
  */
 export const ENTERPRISE_SEO_DESCRIPTION =
-  'Sim is the AI workspace where teams build, deploy, and govern enterprise AI agents with SOC2, role-based access, audit trails, and 1,000+ integrations.'
+  'Build and govern enterprise AI agents in Sim with SSO, approvals, audit trails, versioning, and 1,000+ integrations.'
 
 const ENTERPRISE_CONFIG: SolutionsPageConfig = {
   module: 'Enterprise',
@@ -58,9 +58,11 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
   seoDescription: ENTERPRISE_SEO_DESCRIPTION,
   offersFreeTier: false,
   hero: {
-    heading: 'Sim is the AI workspace for enterprise AI agents.',
+    heading: 'Sim is the enterprise AI agent platform for governed workflows.',
     description:
-      'IT, operations, and technical teams build, deploy, and govern agents in Sim, with SOC2, role-based access, approvals, and full audit trails.',
+      'Build, deploy, and govern enterprise AI agents in one AI workspace. Connect every major LLM and 1,000+ integrations with role-based access, approval paths, versioning, monitoring, and complete audit trails.',
+    definition:
+      'An enterprise AI agent uses AI models, business data, and connected tools to complete multi-step work within the permissions, approval policies, and human oversight your organization defines.',
     summary:
       'Sim is the open-source AI workspace where IT, operations, and technical teams build, deploy, and govern enterprise AI agents. Connect 1,000+ integrations and every major LLM, with role-based access, approvals, versioning, and full audit trails.',
     /**
@@ -80,14 +82,15 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
   rows: [
     {
       id: 'build',
-      title: 'Build, Deploy, and Manage AI Agents in One Workspace',
+      title: 'Build, Deploy, and Manage Enterprise AI Agents',
       subtitle:
-        'Sim carries agents from first draft to production, with versioning and monitoring built in.',
+        'Sim takes enterprise AI agents from initial design to production in one workspace. Build visually or with code, validate changes, deploy approved versions, and monitor every run without connecting separate development and operations tools.',
       cta: { label: 'Start building', href: SIGNUP_HREF },
       cards: [
         {
           title: 'Build visually or with code',
-          description: "Create agents in Sim's visual builder, through chat, or directly in code.",
+          description:
+            "Create enterprise AI agents in Sim's visual builder, describe the workflow in plain English, or write custom logic directly in code.",
           visual: <BuildMethodsGraphic />,
         },
         {
@@ -100,7 +103,8 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
         },
         {
           title: 'Manage the full lifecycle',
-          description: 'Version, monitor, and edit every agent in Sim as your workflows evolve.',
+          description:
+            'Version, monitor, and update every enterprise AI agent in Sim as your business requirements, integrations, and governance policies evolve.',
           visual: <LifecycleGraphic />,
         },
       ],
@@ -109,7 +113,7 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
       id: 'governance',
       title: 'Governance and Security for Enterprise AI Agents',
       subtitle:
-        'Sim gives security teams role-based access, approval paths, and a complete audit trail for every deployment.',
+        'Control how enterprise AI agents access data, use tools, and take action. Sim provides SSO, permission groups, approval paths, configurable data retention, and append-only audit logs for every security-relevant change.',
       cta: { label: 'See security', href: DEMO_HREF },
       cards: [
         {
@@ -137,7 +141,8 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
       id: 'deploy',
       title: 'Deploy Enterprise Workflow Agents with Confidence',
       subtitle:
-        'Test in staging, watch live runs, and roll back in seconds. Sim versions every deployment.',
+        'Enterprise workflow agents need controlled release processes. Test changes in staging, observe production runs, version every deployment, and restore a stable version if updates cause an issue.',
+      note: 'Deploy Sim on your own infrastructure with Docker or Kubernetes when your organization requires greater control over its environment and data.',
       cta: { label: 'Explore deployment', href: SIGNUP_HREF },
       cards: [
         {

--- a/apps/sim/app/(landing)/files/files.tsx
+++ b/apps/sim/app/(landing)/files/files.tsx
@@ -119,7 +119,7 @@ const FILES_CONFIG: SolutionsPageConfig = {
     },
     {
       id: 'agents',
-      title: 'Agents read, parse, and produce files.',
+      title: 'AI agents read, parse, and produce files.',
       subtitle:
         'Sim agents take files as inputs, pull the data out, and write new files back to the store for your team.',
       cta: { label: 'Build a file-handling agent', href: '/signup' },

--- a/apps/sim/app/(landing)/knowledge/knowledge.tsx
+++ b/apps/sim/app/(landing)/knowledge/knowledge.tsx
@@ -55,7 +55,7 @@ const KNOWLEDGE_CONFIG: SolutionsPageConfig = {
   rows: [
     {
       id: 'memory',
-      title: 'Give agents memory of your data.',
+      title: 'Give AI agents memory of your data.',
       subtitle:
         'Sim turns your docs and sources into searchable memory every agent can read, so answers come from your data instead of guesswork.',
       cta: { label: 'Explore Knowledge Base', href: '/signup' },

--- a/apps/sim/app/(landing)/logs/logs.tsx
+++ b/apps/sim/app/(landing)/logs/logs.tsx
@@ -57,7 +57,7 @@ const LOGS_CONFIG: SolutionsPageConfig = {
   rows: [
     {
       id: 'trace',
-      title: 'See exactly what every agent did.',
+      title: 'See exactly what every AI agent did.',
       subtitle:
         'Sim records every step of every agent run, so teams can follow each decision, tool call, and output on one timeline.',
       cta: { label: 'Explore Logs in Sim', href: '/signup' },

--- a/apps/sim/app/(landing)/page.tsx
+++ b/apps/sim/app/(landing)/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
 import { SITE_URL } from '@/lib/core/utils/urls'
-import { HOME_PAGE_DESCRIPTION } from '@/app/(landing)/components/home-structured-data'
+import {
+  HOME_PAGE_DESCRIPTION,
+  HOME_PAGE_TITLE,
+} from '@/app/(landing)/components/home-structured-data'
 import Landing from '@/app/(landing)/landing'
 
 export const revalidate = 3600
@@ -8,7 +11,7 @@ export const revalidate = 3600
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    absolute: 'The AI Workspace | Build, Deploy & Manage AI Agents | Sim',
+    absolute: HOME_PAGE_TITLE,
   },
   description: HOME_PAGE_DESCRIPTION,
   keywords:
@@ -22,7 +25,7 @@ export const metadata: Metadata = {
     telephone: false,
   },
   openGraph: {
-    title: 'The AI Workspace | Build, Deploy & Manage AI Agents | Sim',
+    title: HOME_PAGE_TITLE,
     description: HOME_PAGE_DESCRIPTION,
     type: 'website',
     url: SITE_URL,
@@ -42,7 +45,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     site: '@simdotai',
     creator: '@simdotai',
-    title: 'The AI Workspace | Build, Deploy & Manage AI Agents | Sim',
+    title: HOME_PAGE_TITLE,
     description: HOME_PAGE_DESCRIPTION,
     images: {
       url: '/logo/426-240/reverse/small.png',

--- a/apps/sim/app/(landing)/page.tsx
+++ b/apps/sim/app/(landing)/page.tsx
@@ -8,7 +8,7 @@ export const revalidate = 3600
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    absolute: 'Sim, The AI Workspace | Build, Deploy & Manage AI Agents',
+    absolute: 'The AI Workspace | Build, Deploy & Manage AI Agents | Sim',
   },
   description: HOME_PAGE_DESCRIPTION,
   keywords:
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
     telephone: false,
   },
   openGraph: {
-    title: 'Sim, The AI Workspace | Build, Deploy & Manage AI Agents',
+    title: 'The AI Workspace | Build, Deploy & Manage AI Agents | Sim',
     description: HOME_PAGE_DESCRIPTION,
     type: 'website',
     url: SITE_URL,
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     site: '@simdotai',
     creator: '@simdotai',
-    title: 'Sim, The AI Workspace | Build, Deploy & Manage AI Agents',
+    title: 'The AI Workspace | Build, Deploy & Manage AI Agents | Sim',
     description: HOME_PAGE_DESCRIPTION,
     images: {
       url: '/logo/426-240/reverse/small.png',

--- a/apps/sim/app/(landing)/scheduled-tasks/scheduled-tasks.tsx
+++ b/apps/sim/app/(landing)/scheduled-tasks/scheduled-tasks.tsx
@@ -56,7 +56,7 @@ const SCHEDULED_TASKS_CONFIG: SolutionsPageConfig = {
   rows: [
     {
       id: 'schedule',
-      title: 'Put any agent on a schedule.',
+      title: 'Put any AI agent on a schedule.',
       subtitle:
         'Sim turns a workflow into a scheduled task with one trigger, from 15-minute intervals to monthly closes, in your timezone.',
       cta: { label: 'Schedule your first agent', href: '/signup' },

--- a/apps/sim/app/(landing)/tables/tables.tsx
+++ b/apps/sim/app/(landing)/tables/tables.tsx
@@ -56,7 +56,7 @@ const TABLES_CONFIG: SolutionsPageConfig = {
   rows: [
     {
       id: 'records',
-      title: 'Give agents structured data to act on.',
+      title: 'Give AI agents structured data to act on.',
       subtitle:
         'Sim stores the leads, tickets, and invoices agents work with as tables in the same workspace as the agents.',
       cta: { label: 'Explore Tables', href: '/signup' },
@@ -85,7 +85,7 @@ const TABLES_CONFIG: SolutionsPageConfig = {
     },
     {
       id: 'memory',
-      title: 'Tables are your agents’ memory.',
+      title: 'Tables are your AI agents’ memory.',
       subtitle:
         'Sim carries state between runs. Every run writes rows, every change is recorded, and agents pick up exactly where they left off.',
       cta: { label: 'See how agents use Tables', href: '/signup' },

--- a/apps/sim/app/(landing)/workflows/workflows.tsx
+++ b/apps/sim/app/(landing)/workflows/workflows.tsx
@@ -58,7 +58,7 @@ const WORKFLOWS_CONFIG: SolutionsPageConfig = {
   rows: [
     {
       id: 'build',
-      title: 'Build agents the way that fits.',
+      title: 'Build AI agents the way that fits.',
       subtitle:
         'Sim lets teams build agents visually, in natural language, or with code, wiring up any model and 1,000+ integrations in one workspace.',
       cta: { label: 'Explore the workflow builder', href: '/signup' },


### PR DESCRIPTION
## Summary
- Rewrote `/enterprise` copy against the SEO brief: keyword-forward H1 (`Sim is the enterprise AI agent platform for governed workflows.`), expanded hero description, new definitional paragraph, and rewritten row H2s/subtitles/card descriptions
- Shortened the enterprise meta description to the suggested one (`Build and govern enterprise AI agents in Sim with SSO, approvals, audit trails, versioning, and 1,000+ integrations.`)
- Homepage: new title order (`The AI Workspace | Build, Deploy & Manage AI Agents | Sim`), expanded H1 + hero description, second hero paragraph, rewritten "Describe it. Sim builds it." subtitle, and `Everything your AI agents need, in one workspace.`
- Added two optional content fields so the copy fits the existing layout contract instead of overloading it: `SolutionsHeroConfig.definition` (second hero paragraph, rendered by the shared `LandingHeroHeader`) and `SolutionsCardRowConfig.note` (second subtitle paragraph, used for the self-hosting line)
- Applied the same entity-explicit theme to the platform pages' row H2s (bare "agents" -> "AI agents") on Workflows, Knowledge, Tables, Files, Logs, and Scheduled Tasks

## Notes
- Both suggested H1s dropped "Sim", which the landing rules require in the single H1 (and "AI workspace" alongside it). Kept "Sim" in both while taking the keyword expansion, and worked "AI workspace" into the enterprise hero description so the first 150 visible characters still carry Sim / AI workspace / AI agents.
- Verified every new claim ships: `ssoProvider` and `permissionGroup` tables, Enterprise-gated configurable data retention, audit logs, and Docker Compose + Helm self-hosting.
- Solutions pages (`/solutions/*`) already lead with keyword-bearing H1s and use deliberately terse H2s, so they were left alone.

## Type of Change
- [x] Improvement

## Testing
Typecheck and lint pass. Copy-only change plus two additive optional props; no visual regression check run.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)