### PR TITLE
improvement(shopify): pin Admin API to supported 2025-10 via shared constant

### DIFF
--- a/apps/sim/app/api/auth/oauth2/shopify/store/route.ts
+++ b/apps/sim/app/api/auth/oauth2/shopify/store/route.ts
@@ -13,6 +13,7 @@ import { isSameOrigin } from '@/lib/core/utils/validation'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { processCredentialDraft } from '@/lib/credentials/draft-processor'
 import { safeAccountInsert } from '@/app/api/auth/oauth/utils'
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 
 const logger = createLogger('ShopifyStore')
 
@@ -46,12 +47,15 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       return NextResponse.redirect(`${baseUrl}/workspace?error=shopify_invalid_domain`)
     }
 
-    const shopResponse = await fetch(`https://${shopDomain}/admin/api/2024-10/shop.json`, {
-      headers: {
-        'X-Shopify-Access-Token': accessToken,
-        'Content-Type': 'application/json',
-      },
-    })
+    const shopResponse = await fetch(
+      `https://${shopDomain}/admin/api/${SHOPIFY_API_VERSION}/shop.json`,
+      {
+        headers: {
+          'X-Shopify-Access-Token': accessToken,
+          'Content-Type': 'application/json',
+        },
+      }
+    )
 
     if (!shopResponse.ok) {
       const errorText = await shopResponse.text()

--- a/apps/sim/lib/credentials/token-service-accounts/validators/shopify.test.ts
+++ b/apps/sim/lib/credentials/token-service-accounts/validators/shopify.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TokenServiceAccountValidationError } from '@/lib/credentials/token-service-accounts/errors'
 import { validateShopifyServiceAccount } from '@/lib/credentials/token-service-accounts/validators/shopify'
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 
 const mockFetch = vi.fn()
 
@@ -48,7 +49,7 @@ describe('validateShopifyServiceAccount', () => {
       normalizedDomain: 'acme-store.myshopify.com',
     })
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://acme-store.myshopify.com/admin/api/2024-10/graphql.json',
+      `https://acme-store.myshopify.com/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
       {
         method: 'POST',
         headers: {

--- a/apps/sim/lib/credentials/token-service-accounts/validators/shopify.ts
+++ b/apps/sim/lib/credentials/token-service-accounts/validators/shopify.ts
@@ -9,14 +9,7 @@ import type {
   TokenServiceAccountFields,
   TokenServiceAccountValidationResult,
 } from '@/lib/credentials/token-service-accounts/server'
-
-/**
- * Pinned to match the Admin API version hardcoded in every Sim Shopify tool
- * (`apps/sim/tools/shopify/*`) — bump both together. Note 2024-10 is retired;
- * Shopify silently serves the oldest supported version for retired versions,
- * so validation and tool runtime still hit the same effective API.
- */
-const SHOPIFY_API_VERSION = '2024-10'
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 
 /**
  * SSRF guard: the Admin API must target the permanent `*.myshopify.com`

--- a/apps/sim/tools/shopify/adjust_inventory.ts
+++ b/apps/sim/tools/shopify/adjust_inventory.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type {
   ShopifyAdjustInventoryParams,
   ShopifyInventoryAdjustmentResponse,
@@ -48,7 +49,7 @@ export const shopifyAdjustInventoryTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/cancel_order.ts
+++ b/apps/sim/tools/shopify/cancel_order.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyCancelOrderParams, ShopifyCancelOrderResponse } from '@/tools/shopify/types'
 import { CANCEL_ORDER_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -64,7 +65,7 @@ export const shopifyCancelOrderTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/constants.ts
+++ b/apps/sim/tools/shopify/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * The Shopify Admin API version every Sim Shopify tool targets, plus the
+ * credential validator in
+ * `@/lib/credentials/token-service-accounts/validators/shopify`. Keep this the
+ * single source of truth — bump it here and every caller moves in lockstep.
+ *
+ * Shopify supports each stable version for at least 12 months and forward-falls
+ * to the oldest supported version for retired ones, so a request never breaks
+ * the day a version retires — but the served version drifts silently, so pin an
+ * explicitly supported version and bump on the quarterly cadence.
+ *
+ * @see https://shopify.dev/docs/api/usage/versioning
+ */
+export const SHOPIFY_API_VERSION = '2025-10'

--- a/apps/sim/tools/shopify/create_customer.ts
+++ b/apps/sim/tools/shopify/create_customer.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyCreateCustomerParams, ShopifyCustomerResponse } from '@/tools/shopify/types'
 import { CUSTOMER_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -69,7 +70,7 @@ export const shopifyCreateCustomerTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/create_fulfillment.ts
+++ b/apps/sim/tools/shopify/create_fulfillment.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type {
   ShopifyCreateFulfillmentParams,
   ShopifyFulfillmentResponse,
@@ -61,7 +62,7 @@ export const shopifyCreateFulfillmentTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/create_product.ts
+++ b/apps/sim/tools/shopify/create_product.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyCreateProductParams, ShopifyProductResponse } from '@/tools/shopify/types'
 import { PRODUCT_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -63,7 +64,7 @@ export const shopifyCreateProductTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/delete_customer.ts
+++ b/apps/sim/tools/shopify/delete_customer.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyDeleteCustomerParams, ShopifyDeleteResponse } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
 
@@ -32,7 +33,7 @@ export const shopifyDeleteCustomerTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/delete_product.ts
+++ b/apps/sim/tools/shopify/delete_product.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyDeleteProductParams, ShopifyDeleteResponse } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
 
@@ -32,7 +33,7 @@ export const shopifyDeleteProductTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/get_collection.ts
+++ b/apps/sim/tools/shopify/get_collection.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyCollectionResponse, ShopifyGetCollectionParams } from '@/tools/shopify/types'
 import { COLLECTION_WITH_PRODUCTS_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -40,7 +41,7 @@ export const shopifyGetCollectionTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/get_customer.ts
+++ b/apps/sim/tools/shopify/get_customer.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyCustomerResponse, ShopifyGetCustomerParams } from '@/tools/shopify/types'
 import { CUSTOMER_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -31,7 +32,7 @@ export const shopifyGetCustomerTool: ToolConfig<ShopifyGetCustomerParams, Shopif
 
     request: {
       url: (params) =>
-        `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+        `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
       method: 'POST',
       headers: (params) => {
         if (!params.accessToken) {

--- a/apps/sim/tools/shopify/get_inventory_level.ts
+++ b/apps/sim/tools/shopify/get_inventory_level.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type {
   ShopifyGetInventoryLevelParams,
   ShopifyInventoryResponse,
@@ -42,7 +43,7 @@ export const shopifyGetInventoryLevelTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/get_order.ts
+++ b/apps/sim/tools/shopify/get_order.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyGetOrderParams, ShopifyOrderResponse } from '@/tools/shopify/types'
 import { ORDER_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -30,7 +31,7 @@ export const shopifyGetOrderTool: ToolConfig<ShopifyGetOrderParams, ShopifyOrder
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/get_product.ts
+++ b/apps/sim/tools/shopify/get_product.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyGetProductParams, ShopifyProductResponse } from '@/tools/shopify/types'
 import { PRODUCT_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -30,7 +31,7 @@ export const shopifyGetProductTool: ToolConfig<ShopifyGetProductParams, ShopifyP
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/list_collections.ts
+++ b/apps/sim/tools/shopify/list_collections.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type {
   ShopifyCollectionsResponse,
   ShopifyListCollectionsParams,
@@ -44,7 +45,7 @@ export const shopifyListCollectionsTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/list_customers.ts
+++ b/apps/sim/tools/shopify/list_customers.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyCustomersResponse, ShopifyListCustomersParams } from '@/tools/shopify/types'
 import { CUSTOMER_OUTPUT_PROPERTIES, PAGE_INFO_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -40,7 +41,7 @@ export const shopifyListCustomersTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/list_inventory_items.ts
+++ b/apps/sim/tools/shopify/list_inventory_items.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import {
   INVENTORY_ITEM_OUTPUT_PROPERTIES,
   PAGE_INFO_OUTPUT_PROPERTIES,
@@ -44,7 +45,7 @@ export const shopifyListInventoryItemsTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/list_locations.ts
+++ b/apps/sim/tools/shopify/list_locations.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyListLocationsParams, ShopifyLocationsResponse } from '@/tools/shopify/types'
 import { LOCATION_OUTPUT_PROPERTIES, PAGE_INFO_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -40,7 +41,7 @@ export const shopifyListLocationsTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/list_orders.ts
+++ b/apps/sim/tools/shopify/list_orders.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyListOrdersParams, ShopifyOrdersResponse } from '@/tools/shopify/types'
 import { ORDER_OUTPUT_PROPERTIES, PAGE_INFO_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -43,7 +44,7 @@ export const shopifyListOrdersTool: ToolConfig<ShopifyListOrdersParams, ShopifyO
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/list_products.ts
+++ b/apps/sim/tools/shopify/list_products.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyListProductsParams, ShopifyProductsResponse } from '@/tools/shopify/types'
 import { PAGE_INFO_OUTPUT_PROPERTIES, PRODUCT_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -40,7 +41,7 @@ export const shopifyListProductsTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/types.ts
+++ b/apps/sim/tools/shopify/types.ts
@@ -847,12 +847,6 @@ export interface ShopifyAdjustInventoryParams extends ShopifyBaseParams {
   delta: number
 }
 
-interface ShopifySetInventoryParams extends ShopifyBaseParams {
-  inventoryItemId: string
-  locationId: string
-  quantity: number
-}
-
 // Fulfillment Tool Params
 export interface ShopifyCreateFulfillmentParams extends ShopifyBaseParams {
   fulfillmentOrderId: string

--- a/apps/sim/tools/shopify/update_customer.ts
+++ b/apps/sim/tools/shopify/update_customer.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyCustomerResponse, ShopifyUpdateCustomerParams } from '@/tools/shopify/types'
 import { CUSTOMER_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -69,7 +70,7 @@ export const shopifyUpdateCustomerTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/update_order.ts
+++ b/apps/sim/tools/shopify/update_order.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyOrderResponse, ShopifyUpdateOrderParams } from '@/tools/shopify/types'
 import { ORDER_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -48,7 +49,7 @@ export const shopifyUpdateOrderTool: ToolConfig<ShopifyUpdateOrderParams, Shopif
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/shopify/update_product.ts
+++ b/apps/sim/tools/shopify/update_product.ts
@@ -1,3 +1,4 @@
+import { SHOPIFY_API_VERSION } from '@/tools/shopify/constants'
 import type { ShopifyProductResponse, ShopifyUpdateProductParams } from '@/tools/shopify/types'
 import { PRODUCT_OUTPUT_PROPERTIES } from '@/tools/shopify/types'
 import type { ToolConfig } from '@/tools/types'
@@ -69,7 +70,7 @@ export const shopifyUpdateProductTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/2024-10/graphql.json`,
+      `https://${params.domain || params.shopDomain || params.idToken}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`,
     method: 'POST',
     headers: (params) => {
       if (!params.accessToken) {


### PR DESCRIPTION
## Summary
- Every Shopify tool and the credential validator hardcoded the **retired** `2024-10` Admin API version. Retired versions still function (Shopify forward-falls to the oldest supported version) but the served version drifts silently each quarter and emits deprecation signals.
- Added `apps/sim/tools/shopify/constants.ts` exporting `SHOPIFY_API_VERSION` as the single source of truth, pinned to the supported **`2025-10`** (supported through Oct 2026).
- Wired all 21 Shopify tools, the token-service-account validator, and the OAuth store route to the shared constant — no more per-file inline version. Next bump is a one-line change.
- Derived the validator test's expected URL from the constant so it can't drift again.

## Compatibility
Our operations already use modern `2024-10`+ shapes — `ProductCreateInput` / `ProductUpdateInput` (new product model; `variants` is output-only, **not** the removed inline `ProductInput.variants`), `orderCancel` new signature, `CustomerInput`, `InventoryAdjustQuantitiesInput`, `fulfillmentCreate`. Because `2024-10` is retired, Shopify already forward-serves us ~`2025-07` in production today, so this is a small, explicit step from what's effectively already live.

## Type of Change
- [x] Improvement

## Testing
- Typecheck clean; validator tests pass (11); Biome + `check:api-validation` pass.
- Not yet smoke-tested against a live store — recommend one `list_products` read post-merge to close the loop.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)