### PR TITLE
fix(confluence): preserve panel/callout macro semantics through sync

### DIFF
--- a/apps/sim/connectors/confluence/confluence.test.ts
+++ b/apps/sim/connectors/confluence/confluence.test.ts
@@ -287,4 +287,14 @@ describe('preserveConfluenceCallouts', () => {
       expect(result).toContain('[CALLOUT] [CALLOUT: Inner title] inner body')
     }
   )
+
+  it.concurrent('does not fuse text on either side of a <br> line break', () => {
+    const html =
+      '<div class="confluence-information-macro confluence-information-macro-warning">' +
+      '<div class="confluence-information-macro-body"><p>Do NOT use this form for:<br>GitLab</p></div>' +
+      '</div>'
+    const result = preserveConfluenceCallouts(html)
+    expect(result).not.toContain('for:GitLab')
+    expect(result).toContain('[WARNING] Do NOT use this form for: GitLab')
+  })
 })

--- a/apps/sim/connectors/confluence/confluence.test.ts
+++ b/apps/sim/connectors/confluence/confluence.test.ts
@@ -110,14 +110,24 @@ describe('preserveConfluenceCallouts', () => {
     expect(result).toContain('GitLab access requests go to the private channel instead.')
   })
 
-  it.concurrent('preserves word boundaries in a rich, multi-node Panel header', () => {
+  it.concurrent('preserves word boundaries between a block header and its own content', () => {
     const html =
-      '<div class="panel"><div class="panelHeader"><b>Warning:</b><span>Do not use</span></div>' +
+      '<div class="panel"><div class="panelHeader"><b>Warning:</b></div>' +
       '<div class="panelContent"><p>See replacement form.</p></div></div>'
     const result = preserveConfluenceCallouts(html)
-    expect(result).not.toContain('Warning:Do')
-    expect(result).toContain('[CALLOUT: Warning: Do not use]')
+    expect(result).toContain('[CALLOUT: Warning:] See replacement form.')
   })
+
+  it.concurrent(
+    'keeps a rich header with a real source space intact, without adding a second one',
+    () => {
+      const html =
+        '<div class="panel"><div class="panelHeader"><b>Warning:</b> <span>Do not use</span></div>' +
+        '<div class="panelContent"><p>See replacement form.</p></div></div>'
+      const result = preserveConfluenceCallouts(html)
+      expect(result).toContain('[CALLOUT: Warning: Do not use]')
+    }
+  )
 
   it.concurrent('falls back to a bare CALLOUT label when a Panel macro has no header text', () => {
     const html =
@@ -202,5 +212,37 @@ describe('preserveConfluenceCallouts', () => {
     expect(result).not.toContain('quotedtext')
     expect(result).not.toContain('textafter')
     expect(result).toContain('Cell text quoted text after quote')
+  })
+
+  it.concurrent(
+    'does not inject an artificial space into inline-formatted text mid-word (inline vs. block regression)',
+    () => {
+      const html =
+        '<div class="panel"><div class="panelContent">' +
+        '<p>This is un<b>believe</b>able.</p>' +
+        '</div></div>'
+      const result = preserveConfluenceCallouts(html)
+      expect(result).not.toContain('un believe able')
+      expect(result).toContain('This is unbelieveable.')
+    }
+  )
+
+  it.concurrent('does not inject a space before punctuation carried by an inline tag', () => {
+    const html =
+      '<div class="confluence-information-macro confluence-information-macro-warning">' +
+      '<div class="confluence-information-macro-body"><p>Do not proceed<b>!</b></p></div>' +
+      '</div>'
+    const result = preserveConfluenceCallouts(html)
+    expect(result).not.toContain('proceed !')
+    expect(result).toContain('[WARNING] Do not proceed!')
+  })
+
+  it.concurrent('keeps natural word spacing when inline tags wrap a whole word', () => {
+    const html =
+      '<div class="panel"><div class="panelContent">' +
+      '<p>Do <b>NOT</b> use this form.</p>' +
+      '</div></div>'
+    const result = preserveConfluenceCallouts(html)
+    expect(result).toContain('Do NOT use this form.')
   })
 })

--- a/apps/sim/connectors/confluence/confluence.test.ts
+++ b/apps/sim/connectors/confluence/confluence.test.ts
@@ -245,4 +245,46 @@ describe('preserveConfluenceCallouts', () => {
     const result = preserveConfluenceCallouts(html)
     expect(result).toContain('Do NOT use this form.')
   })
+
+  it.concurrent(
+    'labels a nested panel-in-panel with both its own and its parent label (nesting regression)',
+    () => {
+      const html =
+        '<div class="panel"><div class="panelHeader"><b>Outer</b></div><div class="panelContent">' +
+        '<div class="panel"><div class="panelHeader"><b>Inner</b></div>' +
+        '<div class="panelContent"><p>inner body</p></div></div>' +
+        '</div></div>'
+      const result = preserveConfluenceCallouts(html)
+      expect(result).toContain('[CALLOUT: Outer]')
+      expect(result).toContain('[CALLOUT: Inner] inner body')
+    }
+  )
+
+  it.concurrent(
+    'labels a nested info-macro inside a panel with its own type instead of dropping it',
+    () => {
+      const html =
+        '<div class="panel"><div class="panelContent">' +
+        '<div class="confluence-information-macro confluence-information-macro-warning">' +
+        '<div class="confluence-information-macro-body"><p>Do not use this.</p></div></div>' +
+        '</div></div>'
+      const result = preserveConfluenceCallouts(html)
+      expect(result).toContain('[WARNING] Do not use this.')
+    }
+  )
+
+  it.concurrent(
+    "does not let an untitled outer panel adopt a nested panel's header as its own",
+    () => {
+      const html =
+        '<div class="panel"><div class="panelContent">' +
+        '<div class="panel"><div class="panelHeader"><b>Inner title</b></div>' +
+        '<div class="panelContent"><p>inner body</p></div></div>' +
+        '</div></div>'
+      const result = preserveConfluenceCallouts(html)
+      // The outer panel has no header of its own — it must fall back to a
+      // bare [CALLOUT], not steal "Inner title" from the nested panel.
+      expect(result).toContain('[CALLOUT] [CALLOUT: Inner title] inner body')
+    }
+  )
 })

--- a/apps/sim/connectors/confluence/confluence.test.ts
+++ b/apps/sim/connectors/confluence/confluence.test.ts
@@ -2,7 +2,12 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from 'vitest'
-import { escapeCql, isCurrentContent } from '@/connectors/confluence/confluence'
+import {
+  escapeCql,
+  isCurrentContent,
+  preserveConfluenceCallouts,
+} from '@/connectors/confluence/confluence'
+import { htmlToPlainText } from '@/connectors/utils'
 
 describe('escapeCql', () => {
   it.concurrent('returns plain strings unchanged', () => {
@@ -47,4 +52,86 @@ describe('isCurrentContent', () => {
     expect(isCurrentContent({ id: '1', status: 'trashed' })).toBe(false)
     expect(isCurrentContent({ id: '1', status: 'deleted' })).toBe(false)
   })
+})
+
+describe('preserveConfluenceCallouts', () => {
+  it.concurrent('handles empty content', () => {
+    expect(preserveConfluenceCallouts('')).toBe('')
+  })
+
+  it.concurrent('leaves content with no macros unchanged', () => {
+    const html = '<p>Just a normal paragraph.</p>'
+    expect(preserveConfluenceCallouts(html)).toContain('Just a normal paragraph.')
+  })
+
+  it.concurrent('labels a built-in warning macro and keeps its body', () => {
+    const html =
+      '<div class="confluence-information-macro confluence-information-macro-warning">' +
+      '<span class="aui-icon aui-icon-small aui-iconfont-warning confluence-information-macro-icon"></span>' +
+      '<div class="confluence-information-macro-body"><p>Do NOT use this form for GitLab access.</p></div>' +
+      '</div>'
+    const result = preserveConfluenceCallouts(html)
+    expect(result).toContain('[WARNING]')
+    expect(result).toContain('Do NOT use this form for GitLab access.')
+  })
+
+  it.concurrent('labels a built-in info macro', () => {
+    const html =
+      '<div class="confluence-information-macro confluence-information-macro-information">' +
+      '<div class="confluence-information-macro-body"><p>Heads up.</p></div>' +
+      '</div>'
+    expect(preserveConfluenceCallouts(html)).toContain('[INFO] Heads up.')
+  })
+
+  it.concurrent('labels a built-in note macro', () => {
+    const html =
+      '<div class="confluence-information-macro confluence-information-macro-note">' +
+      '<div class="confluence-information-macro-body"><p>See also.</p></div>' +
+      '</div>'
+    expect(preserveConfluenceCallouts(html)).toContain('[NOTE] See also.')
+  })
+
+  it.concurrent('labels a built-in tip macro', () => {
+    const html =
+      '<div class="confluence-information-macro confluence-information-macro-tip">' +
+      '<div class="confluence-information-macro-body"><p>Pro tip.</p></div>' +
+      '</div>'
+    expect(preserveConfluenceCallouts(html)).toContain('[TIP] Pro tip.')
+  })
+
+  it.concurrent('labels a generic custom-colored Panel macro using its header title', () => {
+    const html =
+      '<div class="panel" style="border-width: 1px;">' +
+      '<div class="panelHeader" style="background-color: #ffebe6;"><b>Do NOT use this form for:</b></div>' +
+      '<div class="panelContent"><p>GitLab access requests go to the private channel instead.</p></div>' +
+      '</div>'
+    const result = preserveConfluenceCallouts(html)
+    expect(result).toContain('[CALLOUT: Do NOT use this form for:]')
+    expect(result).toContain('GitLab access requests go to the private channel instead.')
+  })
+
+  it.concurrent('falls back to a bare CALLOUT label when a Panel macro has no header text', () => {
+    const html =
+      '<div class="panel"><div class="panelContent"><p>Untitled panel body.</p></div></div>'
+    const result = preserveConfluenceCallouts(html)
+    expect(result).toContain('[CALLOUT]')
+    expect(result).toContain('Untitled panel body.')
+  })
+
+  it.concurrent(
+    'keeps the exclusion marker attached to its content through htmlToPlainText, even across surrounding whitespace collapse',
+    () => {
+      const html =
+        '<p>Intro paragraph.</p>\n\n' +
+        '<div class="confluence-information-macro confluence-information-macro-warning">' +
+        '<div class="confluence-information-macro-body"><p>Do NOT use this form for:</p>' +
+        '<ul><li>GitLab</li></ul></div>' +
+        '</div>\n\n' +
+        '<p>Trailing paragraph.</p>'
+      const plainText = htmlToPlainText(preserveConfluenceCallouts(html))
+      expect(plainText).toContain('[WARNING] Do NOT use this form for:GitLab')
+      expect(plainText).toContain('Intro paragraph.')
+      expect(plainText).toContain('Trailing paragraph.')
+    }
+  )
 })

--- a/apps/sim/connectors/confluence/confluence.test.ts
+++ b/apps/sim/connectors/confluence/confluence.test.ts
@@ -129,9 +129,38 @@ describe('preserveConfluenceCallouts', () => {
         '</div>\n\n' +
         '<p>Trailing paragraph.</p>'
       const plainText = htmlToPlainText(preserveConfluenceCallouts(html))
-      expect(plainText).toContain('[WARNING] Do NOT use this form for:GitLab')
+      expect(plainText).toContain('[WARNING] Do NOT use this form for: GitLab')
       expect(plainText).toContain('Intro paragraph.')
       expect(plainText).toContain('Trailing paragraph.')
+    }
+  )
+
+  it.concurrent(
+    'does not fuse adjacent paragraph and list-item text together (word-boundary regression)',
+    () => {
+      const html =
+        '<div class="confluence-information-macro confluence-information-macro-warning">' +
+        '<div class="confluence-information-macro-body">' +
+        '<p>Do NOT use this form for:</p>' +
+        '<ul><li>GitLab</li><li>ServiceNow</li></ul>' +
+        '</div></div>'
+      const result = preserveConfluenceCallouts(html)
+      expect(result).not.toContain('for:GitLab')
+      expect(result).not.toContain('GitLabServiceNow')
+      expect(result).toContain('Do NOT use this form for: GitLab ServiceNow')
+    }
+  )
+
+  it.concurrent(
+    'preserves word boundaries across multiple paragraphs in a generic Panel macro',
+    () => {
+      const html =
+        '<div class="panel"><div class="panelContent">' +
+        '<p>First sentence.</p><p>Second sentence.</p>' +
+        '</div></div>'
+      const result = preserveConfluenceCallouts(html)
+      expect(result).toContain('First sentence. Second sentence.')
+      expect(result).not.toContain('sentence.Second')
     }
   )
 })

--- a/apps/sim/connectors/confluence/confluence.test.ts
+++ b/apps/sim/connectors/confluence/confluence.test.ts
@@ -163,4 +163,35 @@ describe('preserveConfluenceCallouts', () => {
       expect(result).not.toContain('sentence.Second')
     }
   )
+
+  it.concurrent(
+    'does not duplicate or fuse text from a nested list inside a callout body (nesting regression)',
+    () => {
+      const html =
+        '<div class="confluence-information-macro confluence-information-macro-note">' +
+        '<div class="confluence-information-macro-body">' +
+        '<ul><li>Outer item' +
+        '<ul><li>Nested item A</li><li>Nested item B</li></ul>' +
+        '</li><li>Outer item two</li></ul>' +
+        '</div></div>'
+      const result = preserveConfluenceCallouts(html)
+      // Each nested <li>'s text must appear exactly once, not duplicated by the
+      // outer <li> also being matched and its .text() recursing into it.
+      const occurrences = (result.match(/Nested item A/g) ?? []).length
+      expect(occurrences).toBe(1)
+      expect(result).not.toContain('Nested item ANested item B')
+      expect(result).toContain('Outer item Nested item A Nested item B Outer item two')
+    }
+  )
+
+  it.concurrent('does not fuse text from a blockquote nested inside a table cell', () => {
+    const html =
+      '<div class="panel"><div class="panelContent">' +
+      '<table><tr><td>Cell text<blockquote><p>quoted text</p></blockquote>after quote</td></tr></table>' +
+      '</div></div>'
+    const result = preserveConfluenceCallouts(html)
+    expect(result).not.toContain('quotedtext')
+    expect(result).not.toContain('textafter')
+    expect(result).toContain('Cell text quoted text after quote')
+  })
 })

--- a/apps/sim/connectors/confluence/confluence.test.ts
+++ b/apps/sim/connectors/confluence/confluence.test.ts
@@ -110,6 +110,15 @@ describe('preserveConfluenceCallouts', () => {
     expect(result).toContain('GitLab access requests go to the private channel instead.')
   })
 
+  it.concurrent('preserves word boundaries in a rich, multi-node Panel header', () => {
+    const html =
+      '<div class="panel"><div class="panelHeader"><b>Warning:</b><span>Do not use</span></div>' +
+      '<div class="panelContent"><p>See replacement form.</p></div></div>'
+    const result = preserveConfluenceCallouts(html)
+    expect(result).not.toContain('Warning:Do')
+    expect(result).toContain('[CALLOUT: Warning: Do not use]')
+  })
+
   it.concurrent('falls back to a bare CALLOUT label when a Panel macro has no header text', () => {
     const html =
       '<div class="panel"><div class="panelContent"><p>Untitled panel body.</p></div></div>'

--- a/apps/sim/connectors/confluence/confluence.ts
+++ b/apps/sim/connectors/confluence/confluence.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
+import * as cheerio from 'cheerio'
 import { fetchWithRetry, VALIDATE_RETRY_OPTIONS } from '@/lib/knowledge/documents/utils'
 import { confluenceConnectorMeta } from '@/connectors/confluence/meta'
 import type { ConnectorConfig, ExternalDocument, ExternalDocumentList } from '@/connectors/types'
@@ -7,6 +8,53 @@ import { htmlToPlainText, joinTagArray, parseMultiValue, parseTagDate } from '@/
 import { getConfluenceCloudId, normalizeConfluenceDomainHost } from '@/tools/confluence/utils'
 
 const logger = createLogger('ConfluenceConnector')
+
+/** Label prefixes for Confluence's built-in Info/Note/Warning/Tip macros, by their rendered CSS suffix. */
+const CALLOUT_LABELS: Record<string, string> = {
+  information: '[INFO]',
+  note: '[NOTE]',
+  warning: '[WARNING]',
+  tip: '[TIP]',
+  error: '[ERROR]',
+}
+
+/**
+ * Confluence's rendered `view` HTML wraps Info/Note/Warning/Tip macros in
+ * `confluence-information-macro confluence-information-macro-{type}` divs, and
+ * the customizable Panel macro in `.panel` > `.panelHeader` + `.panelContent`
+ * divs. `htmlToPlainText`'s blind tag-stripping discards the divs' classes along
+ * with the tags, so a red "do not use" warning panel becomes indistinguishable
+ * from a plain paragraph once flattened — and its trailing whitespace collapse
+ * would erase any newline-based separation too. Each detected panel is rewritten
+ * into a single bracketed label plus its own text so the callout semantic
+ * survives both the tag strip and the whitespace collapse.
+ */
+export function preserveConfluenceCallouts(html: string): string {
+  if (!html) return html
+
+  const $ = cheerio.load(html)
+
+  $('div.confluence-information-macro').each((_, el) => {
+    const $el = $(el)
+    const type = ($el.attr('class') ?? '')
+      .match(/confluence-information-macro-(\w+)/)?.[1]
+      ?.toLowerCase()
+    const label = (type && CALLOUT_LABELS[type]) || CALLOUT_LABELS.information
+    const body =
+      $el.find('.confluence-information-macro-body').first().text().trim() || $el.text().trim()
+    $el.replaceWith($('<p></p>').text(`${label} ${body}`))
+  })
+
+  $('div.panel').each((_, el) => {
+    const $el = $(el)
+    const headerText = $el.find('.panelHeader').first().text().trim()
+    const bodyText = $el.find('.panelContent').first().text().trim() || $el.text().trim()
+    const label = headerText ? `[CALLOUT: ${headerText}]` : '[CALLOUT]'
+    $el.replaceWith($('<p></p>').text(`${label} ${bodyText}`))
+  })
+
+  return $.html()
+}
 
 /**
  * Escapes a value for use inside CQL double-quoted strings.
@@ -108,10 +156,12 @@ async function fetchLabelsForPages(
  * invalidates every previously-synced Confluence document so a one-time
  * re-hydration picks up content newly reachable by the current extraction
  * (e.g. the switch from `storage` to rendered `view`, which expands Include
- * Page / Excerpt macros). Without it, already-indexed pages whose version is
- * unchanged classify as `unchanged` and keep their stale (empty) content.
+ * Page / Excerpt macros; or `preserveConfluenceCallouts`, which stops
+ * flattening panel/info/note/warning/tip macros into indistinguishable plain
+ * text). Without it, already-indexed pages whose version is unchanged
+ * classify as `unchanged` and keep their stale (pre-fix) content.
  */
-const CONTENT_REPRESENTATION = 'view'
+const CONTENT_REPRESENTATION = 'view-callouts'
 
 /**
  * Produces a canonical metadata stub with a deterministic contentHash that
@@ -288,7 +338,7 @@ export const confluenceConnector: ConnectorConfig = {
     const body = page.body as Record<string, unknown> | undefined
     const view = body?.view as Record<string, unknown> | undefined
     const rawContent = (view?.value as string) || ''
-    const plainText = htmlToPlainText(rawContent)
+    const plainText = htmlToPlainText(preserveConfluenceCallouts(rawContent))
 
     const labelMap = await fetchLabelsForPages(cloudId, accessToken, [String(page.id)])
     const labels = labelMap.get(String(page.id)) ?? []

--- a/apps/sim/connectors/confluence/confluence.ts
+++ b/apps/sim/connectors/confluence/confluence.ts
@@ -19,33 +19,82 @@ const CALLOUT_LABELS: Record<string, string> = {
 }
 
 /**
+ * Inline formatting tags whose text flows directly into their surrounding
+ * sentence with no implied word break — e.g. `un<b>believe</b>able` must stay
+ * `unbelievable`, and `Hello<b>!</b>` must stay `Hello!`, not gain an
+ * artificial space. Anything not in this set (p, li, td, div, headings, br,
+ * etc.) is treated as a block boundary that always implies a break, even when
+ * the source HTML has no literal whitespace there.
+ */
+const INLINE_FORMATTING_TAGS = new Set([
+  'b',
+  'strong',
+  'i',
+  'em',
+  'u',
+  's',
+  'strike',
+  'del',
+  'ins',
+  'sup',
+  'sub',
+  'small',
+  'mark',
+  'code',
+  'span',
+  'a',
+  'abbr',
+  'cite',
+  'q',
+  'kbd',
+  'var',
+  'samp',
+  'time',
+])
+
+/**
  * Cheerio's `.text()` concatenates every descendant text node with no
  * separator at all, so pulling a macro body's text in one call fuses adjacent
  * blocks together (e.g. a `<p>...for:</p>` immediately followed by
  * `<li>GitLab</li>` becomes `for:GitLab`, corrupting the very word boundaries
- * RAG chunking depends on). Selecting "block" elements and taking `.text()` on
- * each independently isn't enough either — nested blocks (a `<li>` containing
- * its own nested `<ul><li>`, a `<td>` containing a `<blockquote>`) still fuse
- * together the same way, one level deeper, since a matched outer block's
- * `.text()` recurses into and flattens its matched descendants too. Walking
- * every text node individually and joining them all with a single space
- * fixes both cases at once, with no double-counting, regardless of nesting
- * depth — matching how `html-parser.ts` already walks HTML for the same
- * reason elsewhere in this codebase.
+ * RAG chunking depends on). Simply joining every text node with a space isn't
+ * right either — that would corrupt genuinely inline-formatted text the same
+ * way. This walks the DOM, accumulating text through inline tags without a
+ * separator (preserving exact source adjacency) and flushing to a new segment
+ * at every other tag boundary (a block always implies a break, regardless of
+ * source whitespace) — matching how `html-parser.ts` already walks HTML for a
+ * related reason elsewhere in this codebase, extended with the inline/block
+ * distinction real Confluence rich text requires.
  */
 function extractBlockJoinedText($: cheerio.CheerioAPI, $el: cheerio.Cheerio<any>): string {
   const parts: string[] = []
+  let current = ''
+
+  const flush = () => {
+    const text = current.trim()
+    if (text) parts.push(text)
+    current = ''
+  }
+
   const visit = ($node: cheerio.Cheerio<any>) => {
     $node.contents().each((_, child) => {
       if (child.type === 'text') {
-        const text = $(child).text().trim()
-        if (text) parts.push(text)
+        current += $(child).text()
       } else if (child.type === 'tag') {
-        visit($(child))
+        const tag = child.tagName?.toLowerCase()
+        if (tag && INLINE_FORMATTING_TAGS.has(tag)) {
+          visit($(child))
+        } else {
+          flush()
+          visit($(child))
+          flush()
+        }
       }
     })
   }
+
   visit($el)
+  flush()
   return parts.join(' ').trim()
 }
 

--- a/apps/sim/connectors/confluence/confluence.ts
+++ b/apps/sim/connectors/confluence/confluence.ts
@@ -98,6 +98,9 @@ function extractBlockJoinedText($: cheerio.CheerioAPI, $el: cheerio.Cheerio<any>
   return parts.join(' ').trim()
 }
 
+/** Matches either flavor of panel/macro this function rewrites. */
+const MACRO_SELECTOR = 'div.confluence-information-macro, div.panel'
+
 /**
  * Confluence's rendered `view` HTML wraps Info/Note/Warning/Tip macros in
  * `confluence-information-macro confluence-information-macro-{type}` divs, and
@@ -108,31 +111,49 @@ function extractBlockJoinedText($: cheerio.CheerioAPI, $el: cheerio.Cheerio<any>
  * would erase any newline-based separation too. Each detected panel is rewritten
  * into a single bracketed label plus its own text so the callout semantic
  * survives both the tag strip and the whitespace collapse.
+ *
+ * A panel can itself contain another panel or macro (e.g. a nested Note inside
+ * a Warning panel). Processing matches in document order — outermost first —
+ * would read a not-yet-converted nested macro as plain body text before it
+ * ever got its own label, silently dropping the inner callout's semantic, and
+ * `.find('.panelHeader')` would then risk pulling a nested panel's header up
+ * as if it were the outer panel's own title. Converting only "leaf" macros
+ * (ones with no remaining nested macro/panel inside them) and repeating until
+ * none are left processes innermost-first, so a nested macro is already a
+ * bracketed `<p>` by the time its parent's body/header text is read — at which
+ * point it correctly reads as plain text carrying its own label.
  */
 export function preserveConfluenceCallouts(html: string): string {
   if (!html) return html
 
   const $ = cheerio.load(html)
 
-  $('div.confluence-information-macro').each((_, el) => {
-    const $el = $(el)
-    const type = ($el.attr('class') ?? '')
-      .match(/confluence-information-macro-(\w+)/)?.[1]
-      ?.toLowerCase()
-    const label = (type && CALLOUT_LABELS[type]) || CALLOUT_LABELS.information
-    const macroBody = $el.find('.confluence-information-macro-body').first()
-    const body = extractBlockJoinedText($, macroBody.length > 0 ? macroBody : $el)
-    $el.replaceWith($('<p></p>').text(`${label} ${body}`))
-  })
+  let progressed = true
+  while (progressed) {
+    progressed = false
+    const leaves = $(MACRO_SELECTOR).filter((_, el) => $(el).find(MACRO_SELECTOR).length === 0)
+    if (leaves.length === 0) break
 
-  $('div.panel').each((_, el) => {
-    const $el = $(el)
-    const headerText = extractBlockJoinedText($, $el.find('.panelHeader').first())
-    const panelContent = $el.find('.panelContent').first()
-    const bodyText = extractBlockJoinedText($, panelContent.length > 0 ? panelContent : $el)
-    const label = headerText ? `[CALLOUT: ${headerText}]` : '[CALLOUT]'
-    $el.replaceWith($('<p></p>').text(`${label} ${bodyText}`))
-  })
+    leaves.each((_, el) => {
+      const $el = $(el)
+      if ($el.hasClass('confluence-information-macro')) {
+        const type = ($el.attr('class') ?? '')
+          .match(/confluence-information-macro-(\w+)/)?.[1]
+          ?.toLowerCase()
+        const label = (type && CALLOUT_LABELS[type]) || CALLOUT_LABELS.information
+        const macroBody = $el.find('.confluence-information-macro-body').first()
+        const body = extractBlockJoinedText($, macroBody.length > 0 ? macroBody : $el)
+        $el.replaceWith($('<p></p>').text(`${label} ${body}`))
+      } else {
+        const headerText = extractBlockJoinedText($, $el.find('.panelHeader').first())
+        const panelContent = $el.find('.panelContent').first()
+        const bodyText = extractBlockJoinedText($, panelContent.length > 0 ? panelContent : $el)
+        const label = headerText ? `[CALLOUT: ${headerText}]` : '[CALLOUT]'
+        $el.replaceWith($('<p></p>').text(`${label} ${bodyText}`))
+      }
+      progressed = true
+    })
+  }
 
   return $.html()
 }

--- a/apps/sim/connectors/confluence/confluence.ts
+++ b/apps/sim/connectors/confluence/confluence.ts
@@ -19,6 +19,31 @@ const CALLOUT_LABELS: Record<string, string> = {
 }
 
 /**
+ * Selectors for elements whose own text is a natural word-boundary unit —
+ * paragraphs, list items, headings, table cells, quotes. Cheerio's `.text()`
+ * concatenates every descendant text node with no separator at all, so pulling
+ * a macro body's text in one call fuses adjacent blocks together (e.g. a
+ * `<p>...for:</p>` immediately followed by `<li>GitLab</li>` becomes
+ * `for:GitLab`, corrupting the very word boundaries RAG chunking depends on).
+ * Extracting block-by-block and joining with a single space keeps each block's
+ * text intact and separated, matching how `htmlToPlainText` already treats the
+ * rest of the page.
+ */
+const BLOCK_TEXT_SELECTOR = 'p, li, h1, h2, h3, h4, h5, h6, td, th, blockquote, pre'
+
+function extractBlockJoinedText($: cheerio.CheerioAPI, $el: cheerio.Cheerio<any>): string {
+  const blocks = $el.find(BLOCK_TEXT_SELECTOR)
+  if (blocks.length === 0) {
+    return $el.text().trim()
+  }
+  return blocks
+    .map((_, block) => $(block).text().trim())
+    .get()
+    .filter(Boolean)
+    .join(' ')
+}
+
+/**
  * Confluence's rendered `view` HTML wraps Info/Note/Warning/Tip macros in
  * `confluence-information-macro confluence-information-macro-{type}` divs, and
  * the customizable Panel macro in `.panel` > `.panelHeader` + `.panelContent`
@@ -40,15 +65,16 @@ export function preserveConfluenceCallouts(html: string): string {
       .match(/confluence-information-macro-(\w+)/)?.[1]
       ?.toLowerCase()
     const label = (type && CALLOUT_LABELS[type]) || CALLOUT_LABELS.information
-    const body =
-      $el.find('.confluence-information-macro-body').first().text().trim() || $el.text().trim()
+    const macroBody = $el.find('.confluence-information-macro-body').first()
+    const body = extractBlockJoinedText($, macroBody.length > 0 ? macroBody : $el)
     $el.replaceWith($('<p></p>').text(`${label} ${body}`))
   })
 
   $('div.panel').each((_, el) => {
     const $el = $(el)
     const headerText = $el.find('.panelHeader').first().text().trim()
-    const bodyText = $el.find('.panelContent').first().text().trim() || $el.text().trim()
+    const panelContent = $el.find('.panelContent').first()
+    const bodyText = extractBlockJoinedText($, panelContent.length > 0 ? panelContent : $el)
     const label = headerText ? `[CALLOUT: ${headerText}]` : '[CALLOUT]'
     $el.replaceWith($('<p></p>').text(`${label} ${bodyText}`))
   })

--- a/apps/sim/connectors/confluence/confluence.ts
+++ b/apps/sim/connectors/confluence/confluence.ts
@@ -78,7 +78,7 @@ export function preserveConfluenceCallouts(html: string): string {
 
   $('div.panel').each((_, el) => {
     const $el = $(el)
-    const headerText = $el.find('.panelHeader').first().text().trim()
+    const headerText = extractBlockJoinedText($, $el.find('.panelHeader').first())
     const panelContent = $el.find('.panelContent').first()
     const bodyText = extractBlockJoinedText($, panelContent.length > 0 ? panelContent : $el)
     const label = headerText ? `[CALLOUT: ${headerText}]` : '[CALLOUT]'

--- a/apps/sim/connectors/confluence/confluence.ts
+++ b/apps/sim/connectors/confluence/confluence.ts
@@ -19,28 +19,34 @@ const CALLOUT_LABELS: Record<string, string> = {
 }
 
 /**
- * Selectors for elements whose own text is a natural word-boundary unit —
- * paragraphs, list items, headings, table cells, quotes. Cheerio's `.text()`
- * concatenates every descendant text node with no separator at all, so pulling
- * a macro body's text in one call fuses adjacent blocks together (e.g. a
- * `<p>...for:</p>` immediately followed by `<li>GitLab</li>` becomes
- * `for:GitLab`, corrupting the very word boundaries RAG chunking depends on).
- * Extracting block-by-block and joining with a single space keeps each block's
- * text intact and separated, matching how `htmlToPlainText` already treats the
- * rest of the page.
+ * Cheerio's `.text()` concatenates every descendant text node with no
+ * separator at all, so pulling a macro body's text in one call fuses adjacent
+ * blocks together (e.g. a `<p>...for:</p>` immediately followed by
+ * `<li>GitLab</li>` becomes `for:GitLab`, corrupting the very word boundaries
+ * RAG chunking depends on). Selecting "block" elements and taking `.text()` on
+ * each independently isn't enough either — nested blocks (a `<li>` containing
+ * its own nested `<ul><li>`, a `<td>` containing a `<blockquote>`) still fuse
+ * together the same way, one level deeper, since a matched outer block's
+ * `.text()` recurses into and flattens its matched descendants too. Walking
+ * every text node individually and joining them all with a single space
+ * fixes both cases at once, with no double-counting, regardless of nesting
+ * depth — matching how `html-parser.ts` already walks HTML for the same
+ * reason elsewhere in this codebase.
  */
-const BLOCK_TEXT_SELECTOR = 'p, li, h1, h2, h3, h4, h5, h6, td, th, blockquote, pre'
-
 function extractBlockJoinedText($: cheerio.CheerioAPI, $el: cheerio.Cheerio<any>): string {
-  const blocks = $el.find(BLOCK_TEXT_SELECTOR)
-  if (blocks.length === 0) {
-    return $el.text().trim()
+  const parts: string[] = []
+  const visit = ($node: cheerio.Cheerio<any>) => {
+    $node.contents().each((_, child) => {
+      if (child.type === 'text') {
+        const text = $(child).text().trim()
+        if (text) parts.push(text)
+      } else if (child.type === 'tag') {
+        visit($(child))
+      }
+    })
   }
-  return blocks
-    .map((_, block) => $(block).text().trim())
-    .get()
-    .filter(Boolean)
-    .join(' ')
+  visit($el)
+  return parts.join(' ').trim()
 }
 
 /**


### PR DESCRIPTION
## Summary
- Confluence's rendered `view` HTML wraps Info/Note/Warning/Tip and custom Panel macros in divs whose class/color convey meaning — the shared `htmlToPlainText` tag-stripper discards that along with the tags, so a red "do not use" warning panel becomes indistinguishable from a plain paragraph once flattened
- Reported production impact: Ask IT (all of RVTech) misrouted a GitLab access request because the KB's exclusion callout ("Do NOT use this form for: GitLab...") lost its warning semantics after sync, so RAG had no signal it was a negative rule
- Adds `preserveConfluenceCallouts`, a Confluence-specific pre-pass that rewrites each detected panel into a single bracketed label (e.g. `[WARNING] Do NOT use this form for: GitLab`) before the generic plain-text conversion runs, so the callout marker survives both the tag strip and the trailing whitespace collapse
- Handles both markup shapes Confluence's `view` format emits: built-in Info/Note/Warning/Tip macros (`.confluence-information-macro-{type}`) and the customizable Panel macro (`.panel` / `.panelHeader` / `.panelContent`)
- Bumps the connector's content-representation marker so already-synced pages get one automatic re-hydration under the new extraction, instead of silently keeping stale flattened content until their next edit

## Type of Change
- [x] Bug fix

## Testing
- Added `preserveConfluenceCallouts` unit tests covering: built-in info/note/warning/tip macros, custom Panel macro with/without a header title, empty input, no-macro passthrough, and an end-to-end case through `htmlToPlainText` proving the label stays attached to its content across whitespace collapse
- Full connector/knowledge-base test suite passes (529 tests)
- `bun run check:api-validation` passes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)