### PR TITLE
improvement(slack): request the approved mention/assistant/DM scopes, advertised on v2 only

### DIFF
--- a/apps/sim/blocks/blocks/slack.ts
+++ b/apps/sim/blocks/blocks/slack.ts
@@ -7,6 +7,25 @@ import { normalizeFileInput } from '@/blocks/utils'
 import type { SlackResponse } from '@/tools/slack/types'
 import { getTrigger } from '@/triggers'
 
+/**
+ * Scopes added for the native Sim Slack app trigger (`slack_oauth`): the shared
+ * app's `app_mention`, assistant-thread, and DM events don't deliver without
+ * them. Advertised by `slack_v2` and the trigger only — the legacy block has no
+ * feature that needs them, and listing them there would flag every existing
+ * Slack credential as missing scopes and prompt a reconnect.
+ *
+ * This only controls what each picker *advertises* and treats as missing. The
+ * authorization request itself is provider-wide
+ * (`getCanonicalScopesForProvider('slack')`), so any reconnect grants the full
+ * set regardless of which block started it.
+ */
+const SLACK_V2_ONLY_SCOPES = new Set(['app_mentions:read', 'assistant:write', 'im:history'])
+
+/** Slack scopes the legacy v1 block advertises — the set from before the trigger expansion. */
+const SLACK_V1_ADVERTISED_SCOPES = getScopesForService('slack').filter(
+  (scope) => !SLACK_V2_ONLY_SCOPES.has(scope)
+)
+
 export const SlackBlock: BlockConfig<SlackResponse> = {
   type: 'slack',
   name: 'Slack',
@@ -107,7 +126,7 @@ export const SlackBlock: BlockConfig<SlackResponse> = {
       canonicalParamId: 'oauthCredential',
       mode: 'basic',
       serviceId: 'slack',
-      requiredScopes: getScopesForService('slack'),
+      requiredScopes: SLACK_V1_ADVERTISED_SCOPES,
       placeholder: 'Select Slack workspace',
       dependsOn: ['authMethod'],
       condition: {
@@ -2642,6 +2661,9 @@ function adaptSubBlockForV2(sb: SubBlockConfig): SubBlockConfig {
       ...rest,
       credentialKind: 'any',
       placeholder: 'Select Slack account or bot',
+      // Full set, unlike v1: v2 hosts the native Sim app trigger, whose events
+      // need the mention/assistant/DM scopes.
+      requiredScopes: getScopesForService('slack'),
       credentialLabels: {
         oauthGroup: 'Sim app',
         oauthConnect: 'Connect the Sim app',

--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -782,12 +782,9 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
           'groups:write',
           'chat:write',
           'chat:write.public',
-          // TODO: Re-add once Slack app review approves these. Requesting a scope
-          // the app is not yet approved for makes Slack reject the entire
-          // authorization with "unapproved permissions requested", breaking connect.
-          // 'assistant:write',
-          // 'app_mentions:read',
-          // 'im:history',
+          'assistant:write',
+          'app_mentions:read',
+          'im:history',
           'im:write',
           'im:read',
           'users:read',


### PR DESCRIPTION
## What

Slack app review has since approved `app_mentions:read`, `assistant:write`, and `im:history` — they're live in the prod app manifest under `oauth_config.scopes.bot` — but the repo still had them commented out behind a stale *"TODO: Re-add once Slack app review approves these"*.

So Sim was requesting a **narrower grant than the app is entitled to**. Newly connected accounts got tokens missing exactly the scopes that back three `simSubscribed` events on the native Sim app trigger (#5892):

| Event | Scope it needs |
|---|---|
| `app_mention` | `app_mentions:read` |
| `assistant_thread_started` / `_context_changed` | `assistant:write` |
| `message.im` (DMs) | `im:history` |

The requested set now matches the manifest's **20 approved bot scopes exactly** (verified at runtime).

## Why v1 keeps the narrow list

Scopes are **per-credential, not per-block** — one Slack app → one `slack` provider → one shared token, requested server-side via `getCanonicalScopesForProvider('slack')` (`lib/auth/auth.ts:2805`). The grant itself can't be scoped to v2.

What *is* per-block is what each picker advertises and treats as missing. So:

- **`slack_v2` + the `slack_oauth` trigger** advertise the full 20 — they host the native Sim app trigger that needs them.
- **The legacy v1 block** stays pinned to the pre-expansion 17. It has no feature needing the new three, and advertising them there would flag every existing Slack credential as "missing scopes" and prompt a needless reconnect.

A reconnect still grants the full set regardless of which block started it — this only controls the nag and the displayed permission list. Verified that the integrations/connections surface keys `isConnected` off a direct `providerId` match, not scope completeness, so existing Slack connections are not marked incomplete.

## Not included

The Home tab (`app_home_opened`) is still custom-bot-only and correctly gated. It is **absent from the manifest's `event_subscriptions.bot_events`**, so Slack does not deliver it to the shared app. Flipping its `simSubscribed` flag would make deploys pass while the trigger silently never fires. Enabling it is a manifest change first (add `app_home_opened` to `bot_events`; no new scope required), then a one-line catalog flip.

## Checks

- `bunx vitest run lib/webhooks triggers/slack blocks tools/slack` — 886 passed (79 files)
- `bun run type-check` — no new errors (5 pre-existing better-auth errors unchanged)
- `bun run lint:check` — clean
- `check-block-registry.ts` — pass
- Runtime-verified: full=20, v1=17, zero leakage of the three into v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018asmKsWQ5Vi7T7wD9uHofz