### PR TITLE
chore(blocks): rename webhook block

### DIFF
--- a/apps/docs/components/workflow-preview/block-display-workflows.ts
+++ b/apps/docs/components/workflow-preview/block-display-workflows.ts
@@ -326,11 +326,11 @@ export const BLOCK_DISPLAY_WORKFLOWS: Record<string, PreviewWorkflow> = {
   },
   webhook_trigger: {
     id: 'webhook_trigger',
-    name: 'Webhook',
+    name: 'Webhook Trigger',
     blocks: [
       {
         id: 'webhook_trigger',
-        name: 'Webhook',
+        name: 'Webhook Trigger',
         type: 'webhook',
         bgColor: '#10B981',
         position: { x: 0, y: 0 },

--- a/apps/docs/content/docs/en/workflows/blocks/webhook.mdx
+++ b/apps/docs/content/docs/en/workflows/blocks/webhook.mdx
@@ -1,6 +1,6 @@
 ---
-title: Outgoing Webhook
-description: The Outgoing Webhook block sends an HTTP POST to an external endpoint, with automatic headers and optional signing.
+title: Webhook
+description: The Webhook block sends an HTTP POST to an external endpoint, with automatic headers and optional signing.
 pageType: reference
 ---
 
@@ -8,7 +8,7 @@ import { Callout } from 'fumadocs-ui/components/callout'
 import { BlockPreview, WorkflowPreview, WEBHOOK_NOTIFY_WORKFLOW, WEBHOOK_TRIGGER_WORKFLOW } from '@/components/workflow-preview'
 import { FAQ } from '@/components/ui/faq'
 
-The Outgoing Webhook block sends HTTP POST requests to external webhook endpoints with automatic webhook headers and optional HMAC signing.
+The Webhook block sends HTTP POST requests to external webhook endpoints with automatic webhook headers and optional HMAC signing.
 
 <BlockPreview type="webhook" />
 
@@ -77,16 +77,16 @@ Format the result, then POST it to a Slack, Discord, or custom endpoint.
 
 <WorkflowPreview workflow={WEBHOOK_TRIGGER_WORKFLOW} />
 
-When the Condition passes, the Outgoing Webhook starts a process in another system.
+When the Condition passes, the Webhook starts a process in another system.
 
 <Callout>
-The Outgoing Webhook block always uses POST. For other HTTP methods or more control, use the [API block](/workflows/blocks/api).
+The Webhook block always uses POST. For other HTTP methods or more control, use the [API block](/workflows/blocks/api).
 </Callout>
 
 <FAQ items={[
-  { question: "Can I use HTTP methods other than POST?", answer: "No. The Outgoing Webhook block always sends POST requests. If you need GET, PUT, DELETE, or PATCH, use the API block instead, which supports all standard HTTP methods." },
+  { question: "Can I use HTTP methods other than POST?", answer: "No. The Webhook block always sends POST requests. If you need GET, PUT, DELETE, or PATCH, use the API block instead, which supports all standard HTTP methods." },
   { question: "How does HMAC payload signing work?", answer: "When you provide a signing secret, the block generates an HMAC-SHA256 signature of the payload and includes it in the X-Webhook-Signature header in the format t=timestamp,v1=signature. The receiver can verify by computing HMAC-SHA256(secret, \"timestamp.body\") and comparing with the v1 value." },
   { question: "What headers are added automatically?", answer: "Every webhook request automatically includes Content-Type (application/json), X-Webhook-Timestamp (Unix timestamp in milliseconds), X-Delivery-ID (unique UUID), and Idempotency-Key (same as X-Delivery-ID for deduplication)." },
   { question: "Can custom headers override the automatic ones?", answer: "Yes. Any custom headers you define in the Additional Headers section will override automatic headers that share the same name." },
-  { question: "How is the Outgoing Webhook block different from the API block?", answer: "The Outgoing Webhook block is purpose-built for webhook delivery: it is POST-only, automatically adds webhook-specific headers (timestamp, delivery ID, idempotency key), and supports optional HMAC signing. The API block is more general-purpose with support for all HTTP methods, query parameters, and configurable retries." },
+  { question: "How is the Webhook block different from the API block?", answer: "The Webhook block is purpose-built for webhook delivery: it is POST-only, automatically adds webhook-specific headers (timestamp, delivery ID, idempotency key), and supports optional HMAC signing. The API block is more general-purpose with support for all HTTP methods, query parameters, and configurable retries." },
 ]} />

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/toolbar/toolbar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/toolbar/toolbar.tsx
@@ -173,14 +173,14 @@ function syncCachesToOverlayVersion(version: number) {
 
 /**
  * Gets triggers data, computing it once per overlay version and caching for
- * subsequent calls. Non-integration triggers (Start, Schedule, Webhook) are
+ * subsequent calls. Non-integration triggers (Start, Schedule, Webhook Trigger) are
  * prioritized first, followed by all other triggers sorted alphabetically.
  */
 function getTriggers(overlayVersion: number): BlockItem[] {
   syncCachesToOverlayVersion(overlayVersion)
   if (cachedTriggers === null) {
     const allTriggers = getTriggersForSidebar()
-    const priorityOrder = ['Start', 'Schedule', 'Webhook']
+    const priorityOrder = ['Start', 'Schedule', 'Webhook Trigger']
 
     const sortedTriggers = allTriggers.sort((a, b) => {
       const aIndex = priorityOrder.indexOf(a.name)

--- a/apps/sim/blocks/blocks/generic_webhook.ts
+++ b/apps/sim/blocks/blocks/generic_webhook.ts
@@ -8,7 +8,7 @@ const WebhookIcon = (props: SVGProps<SVGSVGElement>) => createElement(Webhook, p
 
 export const GenericWebhookBlock: BlockConfig = {
   type: 'generic_webhook',
-  name: 'Webhook',
+  name: 'Webhook Trigger',
   description: 'Receive webhooks from any service by configuring a custom webhook.',
   category: 'triggers',
   icon: WebhookIcon,
@@ -17,7 +17,7 @@ export const GenericWebhookBlock: BlockConfig = {
   triggerAllowed: true,
   bestPractices: `
   - You can test the webhook by sending a request to the webhook URL. E.g. depending on authorization:  curl -X POST http://localhost:3000/api/webhooks/trigger/d8abcf0d-1ee5-4b77-bb07-b1e8142ea4e9 -H "Content-Type: application/json" -H "X-Sim-Secret: 1234" -d '{"message": "Test webhook trigger", "data": {"key": "v"}}'
-  - Continuing example above, the body can be accessed in downstream block using dot notation. E.g. <webhook1.message> and <webhook1.data.key>
+  - Continuing example above, the body can be accessed in downstream block using dot notation. E.g. <webhooktrigger1.message> and <webhooktrigger1.data.key>
   - To deduplicate incoming events, set the Deduplication Field to a dot-notation path of a unique field in the payload (e.g. "event.id"). Duplicate values within 7 days will be skipped.
   - Only use when there's no existing integration for the service with triggerAllowed flag set to true.
   `,

--- a/apps/sim/blocks/blocks/webhook_request.ts
+++ b/apps/sim/blocks/blocks/webhook_request.ts
@@ -4,7 +4,7 @@ import type { RequestResponse } from '@/tools/http/types'
 
 export const WebhookRequestBlock: BlockConfig<RequestResponse> = {
   type: 'webhook_request',
-  name: 'Outgoing Webhook',
+  name: 'Webhook',
   description: 'Send a webhook request',
   longDescription:
     'Send an HTTP POST request to a webhook URL with automatic webhook headers. Optionally sign the payload with HMAC-SHA256 for secure webhook delivery.',

--- a/apps/sim/lib/workflows/triggers/trigger-utils.ts
+++ b/apps/sim/lib/workflows/triggers/trigger-utils.ts
@@ -1,11 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
 import { isInputDefinitionTrigger } from '@/lib/workflows/triggers/input-definition-triggers'
-import {
-  type StartBlockCandidate,
-  StartBlockPath,
-  TRIGGER_TYPES,
-} from '@/lib/workflows/triggers/triggers'
+import { type StartBlockCandidate, StartBlockPath } from '@/lib/workflows/triggers/triggers'
 import { getAllBlocks, getBlock } from '@/blocks'
 import type { BlockConfig } from '@/blocks/types'
 import type { BlockState, WorkflowState } from '@/stores/workflows/workflow/types'
@@ -238,10 +234,6 @@ export function getTriggersForSidebar(): BlockConfig[] {
 export function getTriggerDisplayName(blockType: string): string {
   const block = getBlock(blockType)
   if (!block) return blockType
-
-  if (blockType === TRIGGER_TYPES.GENERIC_WEBHOOK) {
-    return 'Webhook'
-  }
 
   return block.name
 }

--- a/apps/sim/lib/workflows/triggers/triggers.ts
+++ b/apps/sim/lib/workflows/triggers/triggers.ts
@@ -356,9 +356,6 @@ export class TriggerUtils {
     // Use the block's actual name from the registry
     const block = getBlock(triggerType)
     if (block) {
-      if (triggerType === TRIGGER_TYPES.GENERIC_WEBHOOK) {
-        return 'Webhook'
-      }
       return block.name
     }
 

--- a/apps/sim/stores/modals/search/store.ts
+++ b/apps/sim/stores/modals/search/store.ts
@@ -145,7 +145,7 @@ export const useSearchModalStore = create<SearchModalState>()(
 
         const allTriggers = getTriggersForSidebar()
         const filteredTriggers = filterBlocks(allTriggers) as typeof allTriggers
-        const priorityOrder = ['Start', 'Schedule', 'Webhook']
+        const priorityOrder = ['Start', 'Schedule', 'Webhook Trigger']
 
         const sortedTriggers = [...filteredTriggers].sort(
           (a: (typeof filteredTriggers)[number], b: (typeof filteredTriggers)[number]) => {

--- a/apps/sim/triggers/generic/webhook.ts
+++ b/apps/sim/triggers/generic/webhook.ts
@@ -4,7 +4,7 @@ import type { TriggerConfig } from '@/triggers/types'
 
 export const genericWebhookTrigger: TriggerConfig = {
   id: 'generic_webhook',
-  name: 'Generic Webhook',
+  name: 'Webhook Trigger',
   provider: 'generic',
   description: 'Receive webhooks from any service or API',
   version: '1.0.0',


### PR DESCRIPTION
## Summary
Rename webhook block to just be "Webhook"

## Type of Change
- [x] Documentation


## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)