### PR TITLE
fix(mcp): stream pinned transport under Bun (providers + self-hosted-private MCP)

### DIFF
--- a/apps/sim/lib/core/security/input-validation.server.ts
+++ b/apps/sim/lib/core/security/input-validation.server.ts
@@ -14,7 +14,7 @@ import {
   Agent,
   type Dispatcher,
   type RequestInit as UndiciRequestInit,
-  fetch as undiciFetch,
+  interceptors as undiciInterceptors,
   request as undiciRequest,
 } from 'undici'
 import { isHosted, isPrivateDatabaseHostsAllowed } from '@/lib/core/config/env-flags'
@@ -781,7 +781,7 @@ function nodeReadableToWebStream(nodeStream: Readable): ReadableStream<Uint8Arra
 async function undiciRequestAsResponse(
   input: RequestInfo | URL,
   init: RequestInit,
-  dispatcher: Agent
+  dispatcher: Dispatcher
 ): Promise<Response> {
   let url: string
   let effectiveInit = init as UndiciRequestInit
@@ -977,16 +977,21 @@ export function createPinnedFetchWithDispatcher(
     ...(options?.maxResponseSize !== undefined ? { maxResponseSize: options.maxResponseSize } : {}),
   })
 
-  const pinned = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    // double-cast-allowed: DOM RequestInfo/URL and undici fetch input types differ but are structurally compatible at runtime (Node's global fetch IS undici)
-    const undiciInput = input as unknown as Parameters<typeof undiciFetch>[0]
-    // double-cast-allowed: DOM RequestInit and undici RequestInit are structurally compatible at runtime but the TS types differ
-    const undiciInit: UndiciRequestInit = { ...(init as unknown as UndiciRequestInit), dispatcher }
-    const response = await undiciFetch(undiciInput, undiciInit)
-    // double-cast-allowed: undici Response and DOM Response are structurally compatible at runtime
-    return response as unknown as Response
-  }
+  // Requests go through `undici.request` (not `undici.fetch`) because fetch's streaming
+  // `response.body` never delivers under the Bun runtime the server runs on — the same bug
+  // {@link createSsrfGuardedFetchWithDispatcher} works around. Unlike the guarded builder, the
+  // pinned fetch is handed straight to provider/A2A SDKs with no `followRedirectsGuarded`
+  // wrapper, so redirects are followed here via undici's redirect interceptor. Every hop still
+  // dispatches through the pinned `Agent` (its `connect.lookup` forces `resolvedIP`), so a
+  // redirect can't escape to another address — matching the old fetch path's guarantee.
+  const redirecting = dispatcher.compose(
+    undiciInterceptors.redirect({ maxRedirections: DEFAULT_MAX_REDIRECTS })
+  )
+  const pinned = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
+    undiciRequestAsResponse(input, init ?? {}, redirecting)
 
+  // Return the base `Agent` (not the composed dispatcher) so callers `destroy()` the socket
+  // owner on close; the interceptor is stateless and re-dispatches through it.
   return { fetch: pinned, dispatcher }
 }
 

--- a/apps/sim/lib/core/security/input-validation.server.ts
+++ b/apps/sim/lib/core/security/input-validation.server.ts
@@ -909,6 +909,9 @@ async function liftFetchArgs(
         headers: input.headers,
         body: bodyAllowed ? await input.clone().arrayBuffer() : undefined,
         signal: input.signal,
+        // Carry the Request's redirect mode so the pinned fetch honors `manual`/`error`
+        // instead of defaulting a `Request({ redirect: 'manual' })` to `follow`.
+        redirect: input.redirect,
         ...init,
       },
     }

--- a/apps/sim/lib/core/security/input-validation.server.ts
+++ b/apps/sim/lib/core/security/input-validation.server.ts
@@ -567,12 +567,16 @@ function assertGuardedRedirectTarget(url: URL): void {
 export async function followRedirectsGuarded(
   rawFetch: (url: string, init: UndiciRequestInit) => Promise<Response>,
   input: string,
-  init: UndiciRequestInit
+  init: UndiciRequestInit,
+  options?: { validateInitialTarget?: boolean }
 ): Promise<Response> {
   let currentUrl = new URL(input)
   // The initial URL gets the same IP-literal check as redirect hops, so the exported
-  // guard is self-contained even when a caller skips its own up-front validation.
-  assertGuardedRedirectTarget(currentUrl)
+  // guard is self-contained even when a caller skips its own up-front validation. The
+  // pinned-private MCP carve-out opts out (`validateInitialTarget: false`): its caller has
+  // already validated the URL and legitimately targets a private IP (a self-hosted server
+  // configured with an IP-literal URL). Redirect HOPS below are always validated regardless.
+  if (options?.validateInitialTarget !== false) assertGuardedRedirectTarget(currentUrl)
   let method = (init.method ?? 'GET').toUpperCase()
   let body = init.body
   let headers = init.headers
@@ -1026,7 +1030,11 @@ export function createPinnedFetchWithDispatcher(
       }
       return response
     }
-    return followRedirectsGuarded(rawFetch, target, undiciInit)
+    // The pinned fetch's caller has already validated the target (and the private carve-out
+    // legitimately pins to a private IP), so skip re-validating the initial URL — otherwise a
+    // self-hosted MCP configured with a private IP-literal URL would be blocked by its own
+    // transport. Redirect hops are still validated inside the follower.
+    return followRedirectsGuarded(rawFetch, target, undiciInit, { validateInitialTarget: false })
   }
 
   return { fetch: pinned, dispatcher }

--- a/apps/sim/lib/core/security/input-validation.server.ts
+++ b/apps/sim/lib/core/security/input-validation.server.ts
@@ -543,7 +543,7 @@ const MAX_GUARDED_REDIRECTS = 5
  * a 3xx to `http://169.254.169.254/` would otherwise connect directly. Hostname
  * targets are covered by {@link createSsrfGuardedLookup} at connect time.
  */
-function assertGuardedRedirectTarget(url: URL): void {
+function assertGuardedRedirectTarget(url: URL, allowedPinnedIp?: string): void {
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     throw new Error(`Blocked by SSRF policy: redirect to unsupported protocol ${url.protocol}`)
   }
@@ -552,6 +552,16 @@ function assertGuardedRedirectTarget(url: URL): void {
       ? url.hostname.slice(1, -1)
       : url.hostname
   if (ipaddr.isValid(host) && isPrivateOrReservedIP(host)) {
+    // The pinned-private carve-out permits exactly its own validated IP as a target (a
+    // self-hosted MCP on a private IP, or a same-host redirect that stays on it) — but nothing
+    // else private (a redirect to e.g. the cloud metadata IP is still blocked).
+    if (
+      allowedPinnedIp &&
+      ipaddr.isValid(allowedPinnedIp) &&
+      ipaddr.process(host).toString() === ipaddr.process(allowedPinnedIp).toString()
+    ) {
+      return
+    }
     throw new Error('Blocked by SSRF policy: redirect to a private or reserved address')
   }
 }
@@ -568,15 +578,14 @@ export async function followRedirectsGuarded(
   rawFetch: (url: string, init: UndiciRequestInit) => Promise<Response>,
   input: string,
   init: UndiciRequestInit,
-  options?: { validateInitialTarget?: boolean }
+  options?: { allowRedirectToIp?: string }
 ): Promise<Response> {
   let currentUrl = new URL(input)
-  // The initial URL gets the same IP-literal check as redirect hops, so the exported
-  // guard is self-contained even when a caller skips its own up-front validation. The
-  // pinned-private MCP carve-out opts out (`validateInitialTarget: false`): its caller has
-  // already validated the URL and legitimately targets a private IP (a self-hosted server
-  // configured with an IP-literal URL). Redirect HOPS below are always validated regardless.
-  if (options?.validateInitialTarget !== false) assertGuardedRedirectTarget(currentUrl)
+  // The initial URL gets the same IP-literal check as redirect hops, so the exported guard is
+  // self-contained even when a caller skips its own up-front validation. `allowRedirectToIp`
+  // (the pinned-private MCP carve-out's validated IP) permits that one private target — both the
+  // initial URL and any hop that stays on it — while everything else private stays blocked.
+  assertGuardedRedirectTarget(currentUrl, options?.allowRedirectToIp)
   let method = (init.method ?? 'GET').toUpperCase()
   let body = init.body
   let headers = init.headers
@@ -604,7 +613,7 @@ export async function followRedirectsGuarded(
       throw new Error(`Blocked by SSRF policy: more than ${MAX_GUARDED_REDIRECTS} redirects`)
     }
     const nextUrl = new URL(location, currentUrl)
-    assertGuardedRedirectTarget(nextUrl)
+    assertGuardedRedirectTarget(nextUrl, options?.allowRedirectToIp)
     // Per the fetch spec: 303 (and 301/302 on POST) switch to a bodyless GET, dropping
     // the entity headers that described the removed body (a retained Content-Length /
     // Content-Type on a bodyless GET is malformed and undici rejects it).
@@ -1033,11 +1042,11 @@ export function createPinnedFetchWithDispatcher(
       }
       return response
     }
-    // The pinned fetch's caller has already validated the target (and the private carve-out
-    // legitimately pins to a private IP), so skip re-validating the initial URL — otherwise a
-    // self-hosted MCP configured with a private IP-literal URL would be blocked by its own
-    // transport. Redirect hops are still validated inside the follower.
-    return followRedirectsGuarded(rawFetch, target, undiciInit, { validateInitialTarget: false })
+    // Permit this pinned IP as a redirect/initial target even when it's private (the
+    // self-hosted MCP carve-out on a private/loopback IP, and same-host redirects that stay on
+    // it) — otherwise the guarded policy would block a self-hosted server reaching itself. Any
+    // OTHER private target (e.g. a redirect to the cloud metadata IP) is still blocked.
+    return followRedirectsGuarded(rawFetch, target, undiciInit, { allowRedirectToIp: resolvedIP })
   }
 
   return { fetch: pinned, dispatcher }

--- a/apps/sim/lib/core/security/input-validation.server.ts
+++ b/apps/sim/lib/core/security/input-validation.server.ts
@@ -14,7 +14,6 @@ import {
   Agent,
   type Dispatcher,
   type RequestInit as UndiciRequestInit,
-  interceptors as undiciInterceptors,
   request as undiciRequest,
 } from 'undici'
 import { isHosted, isPrivateDatabaseHostsAllowed } from '@/lib/core/config/env-flags'
@@ -587,7 +586,13 @@ export async function followRedirectsGuarded(
     })
     const status = response.status
     const location = response.headers.get('location')
-    if (![301, 302, 303, 307, 308].includes(status) || !location) return response
+    if (![301, 302, 303, 307, 308].includes(status) || !location) {
+      // `response.url` is already the final hop's URL (set per-request by the raw fetch); flag
+      // `redirected` too when at least one hop was followed, matching fetch semantics.
+      if (hop > 0)
+        Object.defineProperty(response, 'redirected', { value: true, configurable: true })
+      return response
+    }
     // Cancel the redirect body up front so the throw paths below (hop cap, blocked
     // target) can't leave a socket checked out on the long-lived Agent.
     await response.body?.cancel().catch(() => {})
@@ -881,6 +886,33 @@ async function undiciRequestAsResponse(
 }
 
 /**
+ * Normalizes a `fetch(input, init)` call into a URL string + init. A `Request` input carries
+ * its own method/headers/body/signal; lift them into the init (explicit init fields win, per
+ * fetch semantics) so a manual redirect follower can't silently downgrade a POST Request to a
+ * bare GET or lose its headers.
+ */
+async function liftFetchArgs(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<{ target: string; effectiveInit: RequestInit }> {
+  const target = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+  if (typeof Request !== 'undefined' && input instanceof Request) {
+    const bodyAllowed = input.method !== 'GET' && input.method !== 'HEAD'
+    return {
+      target,
+      effectiveInit: {
+        method: input.method,
+        headers: input.headers,
+        body: bodyAllowed ? await input.clone().arrayBuffer() : undefined,
+        signal: input.signal,
+        ...init,
+      },
+    }
+  }
+  return { target, effectiveInit: init ?? {} }
+}
+
+/**
  * SSRF-guarded `fetch` + its `Agent` for outbound requests to user-controlled
  * hosts: DNS resolves normally, and every socket connect validates the chosen
  * addresses via {@link createSsrfGuardedLookup}; redirects are followed manually
@@ -903,21 +935,7 @@ export function createSsrfGuardedFetchWithDispatcher(options?: { maxResponseSize
     undiciRequestAsResponse(url, init as unknown as RequestInit, dispatcher)
 
   const guarded = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const target = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-    // A Request input carries its own method/headers/body/signal; lift them into the
-    // init (explicit init fields win, per fetch semantics) so the manual redirect
-    // follower doesn't silently downgrade a guarded POST Request to a bare GET.
-    let effectiveInit: RequestInit = init ?? {}
-    if (typeof Request !== 'undefined' && input instanceof Request) {
-      const bodyAllowed = input.method !== 'GET' && input.method !== 'HEAD'
-      effectiveInit = {
-        method: input.method,
-        headers: input.headers,
-        body: bodyAllowed ? await input.clone().arrayBuffer() : undefined,
-        signal: input.signal,
-        ...init,
-      }
-    }
+    const { target, effectiveInit } = await liftFetchArgs(input, init)
     // double-cast-allowed: DOM RequestInit and undici RequestInit are structurally compatible at runtime but the TS types differ
     return followRedirectsGuarded(rawFetch, target, effectiveInit as unknown as UndiciRequestInit)
   }
@@ -977,21 +995,40 @@ export function createPinnedFetchWithDispatcher(
     ...(options?.maxResponseSize !== undefined ? { maxResponseSize: options.maxResponseSize } : {}),
   })
 
+  const rawFetch = (url: string, init: UndiciRequestInit): Promise<Response> =>
+    // double-cast-allowed: DOM RequestInit and undici RequestInit differ in TS but match at runtime
+    undiciRequestAsResponse(url, init as unknown as RequestInit, dispatcher)
+
   // Requests go through `undici.request` (not `undici.fetch`) because fetch's streaming
   // `response.body` never delivers under the Bun runtime the server runs on — the same bug
-  // {@link createSsrfGuardedFetchWithDispatcher} works around. Unlike the guarded builder, the
-  // pinned fetch is handed straight to provider/A2A SDKs with no `followRedirectsGuarded`
-  // wrapper, so redirects are followed here via undici's redirect interceptor. Every hop still
-  // dispatches through the pinned `Agent` (its `connect.lookup` forces `resolvedIP`), so a
-  // redirect can't escape to another address — matching the old fetch path's guarantee.
-  const redirecting = dispatcher.compose(
-    undiciInterceptors.redirect({ maxRedirections: DEFAULT_MAX_REDIRECTS })
-  )
-  const pinned = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
-    undiciRequestAsResponse(input, init ?? {}, redirecting)
+  // {@link createSsrfGuardedFetchWithDispatcher} works around. Redirects are handled here (not
+  // by a caller's wrapper — the pinned fetch is passed straight to provider/A2A SDKs), honoring
+  // the request's `redirect` mode: `manual`/`error` must NOT transparently follow (e.g.
+  // `detectMcpAuthType` inspects the 3xx to classify auth). The default `follow` uses
+  // {@link followRedirectsGuarded}, which drops headers on cross-origin hops (so a redirect
+  // can't disclose a provider `api-key` to another origin) and stamps the final `response.url`.
+  // Every hop still dispatches through the pinned `Agent` (its `connect.lookup` forces
+  // `resolvedIP`), so a redirect can't escape to another address.
+  const pinned = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const { target, effectiveInit } = await liftFetchArgs(input, init)
+    const mode = effectiveInit.redirect ?? 'follow'
+    // double-cast-allowed: DOM RequestInit and undici RequestInit are structurally compatible at runtime but the TS types differ
+    const undiciInit = effectiveInit as unknown as UndiciRequestInit
+    if (mode === 'manual') {
+      return rawFetch(target, undiciInit)
+    }
+    if (mode === 'error') {
+      const response = await rawFetch(target, undiciInit)
+      const location = response.headers.get('location')
+      if (response.status >= 300 && response.status < 400 && location) {
+        await response.body?.cancel().catch(() => {})
+        throw new TypeError('Pinned fetch received an unexpected redirect (redirect: "error")')
+      }
+      return response
+    }
+    return followRedirectsGuarded(rawFetch, target, undiciInit)
+  }
 
-  // Return the base `Agent` (not the composed dispatcher) so callers `destroy()` the socket
-  // owner on close; the interceptor is stateless and re-dispatches through it.
   return { fetch: pinned, dispatcher }
 }
 

--- a/apps/sim/lib/core/security/pinned-fetch.server.test.ts
+++ b/apps/sim/lib/core/security/pinned-fetch.server.test.ts
@@ -124,6 +124,18 @@ describe('createPinnedFetch', () => {
     expect(response.headers.get('location')).toBe('https://login.example.com/')
   })
 
+  it('honors redirect mode carried on a Request input (not just init)', async () => {
+    mockUndiciRequest.mockResolvedValueOnce(
+      undiciReply(302, { location: 'https://login.example.com/' }, byteStream(''))
+    )
+    const pinned = createPinnedFetch('203.0.113.10')
+
+    const response = await pinned(new Request('https://mcp.example.com/', { redirect: 'manual' }))
+
+    expect(mockUndiciRequest).toHaveBeenCalledTimes(1)
+    expect(response.status).toBe(302)
+  })
+
   it('follows redirects by default and DROPS headers on a cross-origin hop (no api-key leak)', async () => {
     mockUndiciRequest
       .mockResolvedValueOnce(

--- a/apps/sim/lib/core/security/pinned-fetch.server.test.ts
+++ b/apps/sim/lib/core/security/pinned-fetch.server.test.ts
@@ -4,23 +4,11 @@
 import { Readable } from 'node:stream'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const {
-  mockAgent,
-  mockUndiciRequest,
-  mockRedirectInterceptor,
-  capturedAgentOptions,
-  capturedRedirectOptions,
-} = vi.hoisted(() => {
+const { mockAgent, mockUndiciRequest, capturedAgentOptions } = vi.hoisted(() => {
   const capturedAgentOptions: unknown[] = []
-  const capturedRedirectOptions: unknown[] = []
   class MockAgent {
     constructor(options: unknown) {
       capturedAgentOptions.push(options)
-    }
-    // The pinned builder follows redirects by composing this Agent with the redirect
-    // interceptor; the composed dispatcher is what reaches undici.request.
-    compose(interceptor: unknown) {
-      return { __composed: true, base: this, interceptor }
     }
     close() {
       return Promise.resolve()
@@ -29,24 +17,14 @@ const {
       return Promise.resolve()
     }
   }
-  const mockRedirectInterceptor = vi.fn((options: unknown) => {
-    capturedRedirectOptions.push(options)
-    return { __redirectInterceptor: true }
-  })
   return {
     mockAgent: MockAgent,
     mockUndiciRequest: vi.fn(),
-    mockRedirectInterceptor,
     capturedAgentOptions,
-    capturedRedirectOptions,
   }
 })
 
-vi.mock('undici', () => ({
-  Agent: mockAgent,
-  request: mockUndiciRequest,
-  interceptors: { redirect: mockRedirectInterceptor },
-}))
+vi.mock('undici', () => ({ Agent: mockAgent, request: mockUndiciRequest }))
 
 declare module '@/lib/core/security/input-validation.server?pinned-fetch-test' {
   // biome-ignore lint/suspicious/noExportsInTest: ambient re-declaration for the query-suffixed specifier
@@ -73,7 +51,6 @@ describe('createPinnedFetch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     capturedAgentOptions.length = 0
-    capturedRedirectOptions.length = 0
     mockUndiciRequest.mockResolvedValue(undiciReply(200, {}, byteStream('ok')))
   })
 
@@ -113,13 +90,7 @@ describe('createPinnedFetch', () => {
     expect(resolved).toEqual({ address: '2606:4700:4700::1111', family: 6 })
   })
 
-  it('follows redirects through the pinned Agent (interceptor composed with the app max)', () => {
-    createPinnedFetch('203.0.113.10')
-    expect(mockRedirectInterceptor).toHaveBeenCalledTimes(1)
-    expect(capturedRedirectOptions[0]).toEqual({ maxRedirections: 5 })
-  })
-
-  it('dispatches through the composed (redirect-following) dispatcher, preserving init', async () => {
+  it('dispatches through the pinned Agent, preserving init', async () => {
     const pinned = createPinnedFetch('203.0.113.10')
     const controller = new AbortController()
 
@@ -133,22 +104,54 @@ describe('createPinnedFetch', () => {
     expect(mockUndiciRequest).toHaveBeenCalledTimes(1)
     const [url, options] = mockUndiciRequest.mock.calls[0]
     expect(url).toBe('https://myresource.openai.azure.com/openai/v1/responses')
-    expect((options.dispatcher as { __composed?: boolean }).__composed).toBe(true)
-    expect((options.dispatcher as { base: unknown }).base).toBeInstanceOf(mockAgent)
+    expect(options.dispatcher).toBeInstanceOf(mockAgent)
     expect(options.method).toBe('POST')
     expect(options.headers).toEqual({ 'api-key': 'secret' })
     expect(options.body).toBe('{}')
     expect(options.signal).toBe(controller.signal)
   })
 
-  it('handles an undefined init by still dispatching through the pinned dispatcher', async () => {
+  it('honors redirect: "manual" — returns the 3xx without following (auth-type probe)', async () => {
+    mockUndiciRequest.mockResolvedValueOnce(
+      undiciReply(302, { location: 'https://login.example.com/' }, byteStream(''))
+    )
     const pinned = createPinnedFetch('203.0.113.10')
-    await pinned('https://example.com')
-    const options = mockUndiciRequest.mock.calls[0][1] as { dispatcher: { __composed?: boolean } }
-    expect(options.dispatcher.__composed).toBe(true)
+
+    const response = await pinned('https://mcp.example.com/', { redirect: 'manual' })
+
+    expect(mockUndiciRequest).toHaveBeenCalledTimes(1)
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('https://login.example.com/')
   })
 
-  it('reuses one composed dispatcher across all calls of a single instance', async () => {
+  it('follows redirects by default and DROPS headers on a cross-origin hop (no api-key leak)', async () => {
+    mockUndiciRequest
+      .mockResolvedValueOnce(
+        undiciReply(307, { location: 'https://other-origin.example/final' }, byteStream(''))
+      )
+      .mockResolvedValueOnce(undiciReply(200, {}, byteStream('done')))
+    const pinned = createPinnedFetch('203.0.113.10')
+
+    const response = await pinned('https://azure.example.com/v1/responses', {
+      method: 'GET',
+      headers: { 'api-key': 'secret' },
+    })
+
+    expect(mockUndiciRequest).toHaveBeenCalledTimes(2)
+    // Second (cross-origin) hop must not carry the provider credential — no headers forwarded.
+    const secondHopHeaders = (mockUndiciRequest.mock.calls[1][1].headers ?? {}) as Record<
+      string,
+      string
+    >
+    expect(secondHopHeaders['api-key']).toBeUndefined()
+    expect(Object.keys(secondHopHeaders)).toHaveLength(0)
+    expect(response.status).toBe(200)
+    expect(response.url).toBe('https://other-origin.example/final')
+    expect(response.redirected).toBe(true)
+    expect(await response.text()).toBe('done')
+  })
+
+  it('reuses one dispatcher across all calls of a single instance', async () => {
     const pinned = createPinnedFetch('203.0.113.10')
     await pinned('https://example.com/a')
     await pinned('https://example.com/b')

--- a/apps/sim/lib/core/security/pinned-fetch.server.test.ts
+++ b/apps/sim/lib/core/security/pinned-fetch.server.test.ts
@@ -1,39 +1,55 @@
 /**
  * @vitest-environment node
  */
+import { Readable } from 'node:stream'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockAgent, mockUndiciFetch, capturedAgentOptions, agentCloses } = vi.hoisted(() => {
+const {
+  mockAgent,
+  mockUndiciRequest,
+  mockRedirectInterceptor,
+  capturedAgentOptions,
+  capturedRedirectOptions,
+} = vi.hoisted(() => {
   const capturedAgentOptions: unknown[] = []
-  const agentCloses: unknown[] = []
+  const capturedRedirectOptions: unknown[] = []
   class MockAgent {
     constructor(options: unknown) {
       capturedAgentOptions.push(options)
     }
+    // The pinned builder follows redirects by composing this Agent with the redirect
+    // interceptor; the composed dispatcher is what reaches undici.request.
+    compose(interceptor: unknown) {
+      return { __composed: true, base: this, interceptor }
+    }
     close() {
-      agentCloses.push(this)
+      return Promise.resolve()
+    }
+    destroy() {
       return Promise.resolve()
     }
   }
+  const mockRedirectInterceptor = vi.fn((options: unknown) => {
+    capturedRedirectOptions.push(options)
+    return { __redirectInterceptor: true }
+  })
   return {
     mockAgent: MockAgent,
-    mockUndiciFetch: vi.fn(),
+    mockUndiciRequest: vi.fn(),
+    mockRedirectInterceptor,
     capturedAgentOptions,
-    agentCloses,
+    capturedRedirectOptions,
   }
 })
 
-vi.mock('undici', () => ({ Agent: mockAgent, fetch: mockUndiciFetch }))
-/**
- * Query-suffixed import gives this file a private instance of the module under
- * test. Under `isolate: false` the worker's module graph is shared across test
- * files, so the plain specifier may already be cached with the real `undici`
- * binding (mocks never reach an already-evaluated module) — and evaluating it
- * here under this file's mocks would poison it for later files. The suffixed id
- * is unique to this file, so it always evaluates fresh with the mocks above.
- */
+vi.mock('undici', () => ({
+  Agent: mockAgent,
+  request: mockUndiciRequest,
+  interceptors: { redirect: mockRedirectInterceptor },
+}))
+
 declare module '@/lib/core/security/input-validation.server?pinned-fetch-test' {
-  // biome-ignore lint/suspicious/noExportsInTest: ambient type re-declaration for the query-suffixed specifier, not a runtime export
+  // biome-ignore lint/suspicious/noExportsInTest: ambient re-declaration for the query-suffixed specifier
   export * from '@/lib/core/security/input-validation.server'
 }
 
@@ -42,12 +58,23 @@ import { createPinnedFetch } from '@/lib/core/security/input-validation.server?p
 type LookupCallback = (err: Error | null, address: string, family: number) => void
 type PinnedLookup = (hostname: string, options: { all?: boolean }, callback: LookupCallback) => void
 
+function byteStream(text: string): Readable {
+  const stream = new Readable({ read() {} })
+  stream.push(Buffer.from(text))
+  stream.push(null)
+  return stream
+}
+
+function undiciReply(statusCode: number, headers: Record<string, string>, body: Readable) {
+  return { statusCode, headers, body, trailers: {}, opaque: null, context: {} }
+}
+
 describe('createPinnedFetch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     capturedAgentOptions.length = 0
-    agentCloses.length = 0
-    mockUndiciFetch.mockResolvedValue(new Response('ok'))
+    capturedRedirectOptions.length = 0
+    mockUndiciRequest.mockResolvedValue(undiciReply(200, {}, byteStream('ok')))
   })
 
   it('builds an undici Agent whose pinned lookup always resolves to the validated IP', async () => {
@@ -86,7 +113,13 @@ describe('createPinnedFetch', () => {
     expect(resolved).toEqual({ address: '2606:4700:4700::1111', family: 6 })
   })
 
-  it('forwards the pinned dispatcher on every call while preserving init options', async () => {
+  it('follows redirects through the pinned Agent (interceptor composed with the app max)', () => {
+    createPinnedFetch('203.0.113.10')
+    expect(mockRedirectInterceptor).toHaveBeenCalledTimes(1)
+    expect(capturedRedirectOptions[0]).toEqual({ maxRedirections: 5 })
+  })
+
+  it('dispatches through the composed (redirect-following) dispatcher, preserving init', async () => {
     const pinned = createPinnedFetch('203.0.113.10')
     const controller = new AbortController()
 
@@ -97,32 +130,32 @@ describe('createPinnedFetch', () => {
       signal: controller.signal,
     })
 
-    expect(mockUndiciFetch).toHaveBeenCalledTimes(1)
-    const [url, init] = mockUndiciFetch.mock.calls[0]
+    expect(mockUndiciRequest).toHaveBeenCalledTimes(1)
+    const [url, options] = mockUndiciRequest.mock.calls[0]
     expect(url).toBe('https://myresource.openai.azure.com/openai/v1/responses')
-    const typedInit = init as RequestInit & { dispatcher?: unknown }
-    expect(typedInit.dispatcher).toBeInstanceOf(mockAgent)
-    expect(typedInit.method).toBe('POST')
-    expect(typedInit.headers).toEqual({ 'api-key': 'secret' })
-    expect(typedInit.body).toBe('{}')
-    expect(typedInit.signal).toBe(controller.signal)
+    expect((options.dispatcher as { __composed?: boolean }).__composed).toBe(true)
+    expect((options.dispatcher as { base: unknown }).base).toBeInstanceOf(mockAgent)
+    expect(options.method).toBe('POST')
+    expect(options.headers).toEqual({ 'api-key': 'secret' })
+    expect(options.body).toBe('{}')
+    expect(options.signal).toBe(controller.signal)
   })
 
-  it('handles an undefined init by still attaching the dispatcher', async () => {
+  it('handles an undefined init by still dispatching through the pinned dispatcher', async () => {
     const pinned = createPinnedFetch('203.0.113.10')
     await pinned('https://example.com')
-    const init = mockUndiciFetch.mock.calls[0][1] as { dispatcher?: unknown }
-    expect(init.dispatcher).toBeInstanceOf(mockAgent)
+    const options = mockUndiciRequest.mock.calls[0][1] as { dispatcher: { __composed?: boolean } }
+    expect(options.dispatcher.__composed).toBe(true)
   })
 
-  it('reuses one captured dispatcher across all calls of a single instance', async () => {
+  it('reuses one composed dispatcher across all calls of a single instance', async () => {
     const pinned = createPinnedFetch('203.0.113.10')
     await pinned('https://example.com/a')
     await pinned('https://example.com/b')
 
     expect(capturedAgentOptions).toHaveLength(1)
-    const d1 = (mockUndiciFetch.mock.calls[0][1] as { dispatcher: unknown }).dispatcher
-    const d2 = (mockUndiciFetch.mock.calls[1][1] as { dispatcher: unknown }).dispatcher
+    const d1 = (mockUndiciRequest.mock.calls[0][1] as { dispatcher: unknown }).dispatcher
+    const d2 = (mockUndiciRequest.mock.calls[1][1] as { dispatcher: unknown }).dispatcher
     expect(d1).toBe(d2)
   })
 
@@ -133,13 +166,13 @@ describe('createPinnedFetch', () => {
     await b('https://example.com/b')
 
     expect(capturedAgentOptions).toHaveLength(2)
-    const d1 = (mockUndiciFetch.mock.calls[0][1] as { dispatcher: unknown }).dispatcher
-    const d2 = (mockUndiciFetch.mock.calls[1][1] as { dispatcher: unknown }).dispatcher
+    const d1 = (mockUndiciRequest.mock.calls[0][1] as { dispatcher: unknown }).dispatcher
+    const d2 = (mockUndiciRequest.mock.calls[1][1] as { dispatcher: unknown }).dispatcher
     expect(d1).not.toBe(d2)
   })
 
-  it('returns the response produced by undici fetch', async () => {
-    mockUndiciFetch.mockResolvedValueOnce(new Response('pong', { status: 201 }))
+  it('returns a streaming Response built from the undici.request body', async () => {
+    mockUndiciRequest.mockResolvedValueOnce(undiciReply(201, {}, byteStream('pong')))
     const pinned = createPinnedFetch('203.0.113.10')
     const response = await pinned('https://example.com')
     expect(response.status).toBe(201)

--- a/apps/sim/lib/core/security/pinned-fetch.server.test.ts
+++ b/apps/sim/lib/core/security/pinned-fetch.server.test.ts
@@ -176,6 +176,34 @@ describe('createPinnedFetch', () => {
     expect(await response.text()).toBe('mcp')
   })
 
+  it('follows a redirect that stays on the pinned private IP (self-hosted MCP alias)', async () => {
+    mockUndiciRequest
+      .mockResolvedValueOnce(
+        undiciReply(301, { location: 'http://10.0.0.5:3000/mcp/' }, byteStream(''))
+      )
+      .mockResolvedValueOnce(undiciReply(200, {}, byteStream('mcp')))
+    const pinned = createPinnedFetch('10.0.0.5')
+
+    const response = await pinned('http://10.0.0.5:3000/mcp', { method: 'GET' })
+
+    expect(mockUndiciRequest).toHaveBeenCalledTimes(2)
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('mcp')
+  })
+
+  it('STILL blocks a redirect to a different private IP (no metadata-IP escape)', async () => {
+    mockUndiciRequest.mockResolvedValueOnce(
+      undiciReply(302, { location: 'http://169.254.169.254/latest/meta-data/' }, byteStream(''))
+    )
+    const pinned = createPinnedFetch('10.0.0.5')
+
+    await expect(pinned('http://10.0.0.5:3000/mcp', { method: 'GET' })).rejects.toThrow(
+      /private or reserved/
+    )
+    // The initial request happened; the redirect to the metadata IP was refused.
+    expect(mockUndiciRequest).toHaveBeenCalledTimes(1)
+  })
+
   it('reuses one dispatcher across all calls of a single instance', async () => {
     const pinned = createPinnedFetch('203.0.113.10')
     await pinned('https://example.com/a')

--- a/apps/sim/lib/core/security/pinned-fetch.server.test.ts
+++ b/apps/sim/lib/core/security/pinned-fetch.server.test.ts
@@ -151,6 +151,19 @@ describe('createPinnedFetch', () => {
     expect(await response.text()).toBe('done')
   })
 
+  it('does NOT block a private IP-literal URL (self-hosted-private MCP carve-out)', async () => {
+    mockUndiciRequest.mockResolvedValueOnce(undiciReply(200, {}, byteStream('mcp')))
+    const pinned = createPinnedFetch('10.0.0.5')
+
+    // A self-hosted MCP configured with a private IP-literal URL must still connect — the old
+    // undici.fetch path never ran the SSRF initial-target check that would otherwise block it.
+    const response = await pinned('http://10.0.0.5:3000/mcp', { method: 'POST', body: '{}' })
+
+    expect(mockUndiciRequest).toHaveBeenCalledTimes(1)
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('mcp')
+  })
+
   it('reuses one dispatcher across all calls of a single instance', async () => {
     const pinned = createPinnedFetch('203.0.113.10')
     await pinned('https://example.com/a')


### PR DESCRIPTION
Follow-up to #5897 (now merged). #5897 fixed the Bun undici-streaming hang on the **guarded** path (public MCP servers like GitHub). This extends the same fix to the **pinned** path (`createPinnedFetchWithDispatcher`) — the remaining streaming consumers that were still on `undici.fetch`:
- **LLM provider streaming** — Azure OpenAI, vLLM, Azure Anthropic (they pass `createPinnedFetch` to the SDK as `fetch` and read streamed completion bodies)
- **A2A** client
- **Self-hosted / private-IP MCP** over SSE (`createPinnedPrivateMcpFetch`)

## How
- Pinned builder now routes through the same `undiciRequestAsResponse` helper (`undici.request` + Node→Web bridge), inheriting #5897's hardening for free: Content-Encoding decode, URLSearchParams bodies, chunk-copy, decoder-crash guard, abort, `maxResponseSize`.
- Unlike the guarded path, the pinned fetch is handed **straight to provider/A2A SDKs** with no `followRedirectsGuarded`, and those SDKs rely on `fetch`'s auto-redirect. So redirects use **undici's redirect interceptor** composed onto the pinned `Agent` — every hop still dispatches through the pinned `connect.lookup` (forces `resolvedIP`), so a redirect can't escape to another address (matches the old `undici.fetch` guarantee).
- `secureFetchWithPinnedIP` (tools path, raw Node `http`/`https` with its own redirect loop) is **untouched**.

## Type of Change
- [x] Bug fix

## Testing
- Rewrote `pinned-fetch.server.test.ts` for the new path (pinning/allowH2/IPv6 assertions kept; behavior asserts `undici.request` through the composed redirect dispatcher, init preservation, streaming Response). 93 security/MCP unit tests + 436 provider/a2a/mcp tests green; typecheck + lint clean.
- e2e on **both Node and Bun**: pinned streaming SSE, 302→SSE followed via the interceptor, auth header + body forwarded across the redirect. Decode/abort/cap covered by the shared helper's own suite.
- Pending: staging validation of an actual Azure/vLLM stream + a self-hosted MCP server in the Bun container.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)