### PR TITLE
improvement(access-control): edit group details, filter by status, and colocate chat deploy auth

### DIFF
--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react'
 import {
   Checkbox,
   Chip,
@@ -102,6 +102,59 @@ const STATUS_FILTER_OPTIONS: { value: StatusFilter; label: string }[] = [
 
 function matchesStatusFilter(filter: StatusFilter, enabled: boolean) {
   return filter === 'all' || (filter === 'enabled') === enabled
+}
+
+interface StatusFilterChipProps {
+  value: StatusFilter
+  onChange: (value: StatusFilter) => void
+  /** Set when the chip is the last control in its row, so it sits flush to the edge. */
+  flush?: boolean
+}
+
+/** The All/Enabled/Disabled narrowing control shared by the three list tabs. */
+function StatusFilterChip({ value, onChange, flush }: StatusFilterChipProps) {
+  return (
+    <ChipDropdown
+      value={value}
+      onChange={(next) => onChange(next as StatusFilter)}
+      options={STATUS_FILTER_OPTIONS}
+      matchTriggerWidth={false}
+      flush={flush}
+      className='w-[140px] flex-shrink-0'
+    />
+  )
+}
+
+interface AuthModeFieldProps {
+  label: string
+  value: ShareAuthType[]
+  onChange: (values: string[]) => void
+  options: { value: ShareAuthType; label: string }[]
+  disabled: boolean
+}
+
+/**
+ * The allowed-auth-modes multi-select nested under a platform toggle. Dims and
+ * disables together with the toggle that owns it, so the coupling lives here
+ * rather than being re-derived at each call site.
+ */
+function AuthModeField({ label, value, onChange, options, disabled }: AuthModeFieldProps) {
+  return (
+    <div className={cn('flex flex-col gap-1.5 px-2 pt-1 pb-1', disabled && 'opacity-50')}>
+      <span className='text-[var(--text-muted)] text-caption'>{label}</span>
+      <ChipDropdown
+        multiple
+        showAllOption={false}
+        allLabel='None'
+        value={value}
+        onChange={onChange}
+        options={options}
+        disabled={disabled}
+        matchTriggerWidth={false}
+        className='w-[200px]'
+      />
+    </div>
+  )
 }
 
 interface OrganizationMemberOption {
@@ -816,6 +869,22 @@ export function GroupDetail({
         configKey: 'disablePublicApi' as const,
         hint: 'Disable public API access to deployed workflows.',
       },
+      // Chat and Files get a category of their own so their nested auth-mode
+      // dropdown (see `featureExtras`) reads as part of the toggle it qualifies.
+      {
+        id: 'hide-deploy-chatbot',
+        label: 'Deployment',
+        category: 'Chat',
+        configKey: 'hideDeployChatbot' as const,
+        hint: 'Hide the chat deployment option.',
+      },
+      {
+        id: 'disable-public-file-sharing',
+        label: 'Public Sharing',
+        category: 'Files',
+        configKey: 'disablePublicFileSharing' as const,
+        hint: 'Disable public file-share links.',
+      },
     ],
     []
   )
@@ -855,10 +924,12 @@ export function GroupDetail({
       'Features',
       'Settings Tabs',
       'Logs',
+      'Chat',
+      'Files',
     ]
     const known = order.filter((c) => platformCategories[c]?.length)
     const extras = Object.keys(platformCategories).filter(
-      (c) => c !== 'Files' && !order.includes(c) && platformCategories[c]?.length
+      (c) => !order.includes(c) && platformCategories[c]?.length
     )
     return [...known, ...extras].map((category) => ({
       category,
@@ -866,57 +937,79 @@ export function GroupDetail({
     }))
   }, [platformCategories])
 
-  /**
-   * Chat and Files render as standalone sections (a toggle plus its nested
-   * auth-mode dropdown) rather than as `platformFeatures` rows, so they need the
-   * tab's search + status filter applied by hand — otherwise they'd be the only
-   * Platform controls that ignore both.
-   */
-  const platformSectionVisible = (label: string, enabled: boolean) => {
-    const search = platformSearchTerm.trim().toLowerCase()
-    if (search && !label.toLowerCase().includes(search)) return false
-    return matchesStatusFilter(platformStatusFilter, enabled)
-  }
-
-  const showChatSection = platformSectionVisible('Chat', !editingConfig.hideDeployChatbot)
-  const showFilesSection = platformSectionVisible('Files', !editingConfig.disablePublicFileSharing)
-  const hasPlatformMatches =
-    platformCategorySections.length > 0 || showChatSection || showFilesSection
-
   const hasConfigChanges = useMemo(() => {
     return JSON.stringify(viewingGroup.config) !== JSON.stringify(editingConfig)
   }, [viewingGroup.config, editingConfig])
 
   const trimmedName = editingName.trim()
   const trimmedDescription = editingDescription.trim()
-  const hasDetailChanges =
-    trimmedName !== viewingGroup.name || trimmedDescription !== (viewingGroup.description ?? '')
-  const hasChanges = hasConfigChanges || hasDetailChanges
+  const nameChanged = trimmedName !== viewingGroup.name
+  const descriptionChanged = trimmedDescription !== (viewingGroup.description ?? '')
+  const hasChanges = hasConfigChanges || nameChanged || descriptionChanged
 
   const guard = useSettingsUnsavedGuard({ isDirty: hasChanges })
 
-  const filteredProviders = useMemo(() => {
+  /**
+   * `null` means "everything allowed". Indexing the allow-lists once keeps the
+   * per-row membership checks O(1) — they run for every one of the ~200 block
+   * rows on each render, and again in the section-wide `every(...)` scans.
+   */
+  const allowedIntegrationSet = useMemo(
+    () =>
+      editingConfig.allowedIntegrations === null
+        ? null
+        : new Set(editingConfig.allowedIntegrations),
+    [editingConfig.allowedIntegrations]
+  )
+
+  const allowedProviderSet = useMemo(
+    () =>
+      editingConfig.allowedModelProviders === null
+        ? null
+        : new Set(editingConfig.allowedModelProviders),
+    [editingConfig.allowedModelProviders]
+  )
+
+  const isIntegrationAllowed = useCallback(
+    (blockType: string) => allowedIntegrationSet === null || allowedIntegrationSet.has(blockType),
+    [allowedIntegrationSet]
+  )
+
+  const isProviderAllowed = useCallback(
+    (providerId: string) => allowedProviderSet === null || allowedProviderSet.has(providerId),
+    [allowedProviderSet]
+  )
+
+  const searchedProviders = useMemo(() => {
     const query = providerSearchTerm.trim().toLowerCase()
-    const allowed = editingConfig.allowedModelProviders
-    return allProviderIds.filter((id) => {
-      if (query && !id.toLowerCase().includes(query)) return false
-      return matchesStatusFilter(providerStatusFilter, allowed === null || allowed.includes(id))
-    })
-  }, [
-    allProviderIds,
-    providerSearchTerm,
-    providerStatusFilter,
-    editingConfig.allowedModelProviders,
-  ])
+    if (!query) return allProviderIds
+    return allProviderIds.filter((id) => id.toLowerCase().includes(query))
+  }, [allProviderIds, providerSearchTerm])
+
+  /**
+   * Split from the search pass so the common `all` case returns the searched
+   * list by reference. Only the status pass depends on the allow-list, so a
+   * checkbox toggle no longer invalidates the downstream core/tool splits.
+   */
+  const filteredProviders = useMemo(() => {
+    if (providerStatusFilter === 'all') return searchedProviders
+    return searchedProviders.filter((id) =>
+      matchesStatusFilter(providerStatusFilter, isProviderAllowed(id))
+    )
+  }, [searchedProviders, providerStatusFilter, isProviderAllowed])
+
+  const searchedBlocks = useMemo(() => {
+    const query = integrationSearchTerm.trim().toLowerCase()
+    if (!query) return visibleBlocks
+    return visibleBlocks.filter((b) => b.name.toLowerCase().includes(query))
+  }, [visibleBlocks, integrationSearchTerm])
 
   const filteredBlocks = useMemo(() => {
-    const query = integrationSearchTerm.trim().toLowerCase()
-    const allowed = editingConfig.allowedIntegrations
-    return visibleBlocks.filter((b) => {
-      if (query && !b.name.toLowerCase().includes(query)) return false
-      return matchesStatusFilter(blockStatusFilter, allowed === null || allowed.includes(b.type))
-    })
-  }, [visibleBlocks, integrationSearchTerm, blockStatusFilter, editingConfig.allowedIntegrations])
+    if (blockStatusFilter === 'all') return searchedBlocks
+    return searchedBlocks.filter((b) =>
+      matchesStatusFilter(blockStatusFilter, isIntegrationAllowed(b.type))
+    )
+  }, [searchedBlocks, blockStatusFilter, isIntegrationAllowed])
 
   const filteredCoreBlocks = useMemo(
     () => filteredBlocks.filter((block) => block.category === 'blocks'),
@@ -945,13 +1038,6 @@ export function GroupDetail({
     const existingMemberUserIds = new Set(members.map((m) => m.userId))
     return organizationMembers.filter((m) => !existingMemberUserIds.has(m.userId))
   }, [organizationMembers, members])
-
-  const isIntegrationAllowed = useCallback(
-    (blockType: string) =>
-      editingConfig.allowedIntegrations === null ||
-      editingConfig.allowedIntegrations.includes(blockType),
-    [editingConfig.allowedIntegrations]
-  )
 
   /**
    * Drops denied tools whose integration is no longer allowed, keeping the
@@ -1062,13 +1148,6 @@ export function GroupDetail({
     }
     return counts
   }, [editingConfig.deniedTools, allBlocks])
-
-  const isProviderAllowed = useCallback(
-    (providerId: string) =>
-      editingConfig.allowedModelProviders === null ||
-      editingConfig.allowedModelProviders.includes(providerId),
-    [editingConfig.allowedModelProviders]
-  )
 
   const toggleProvider = useCallback(
     (providerId: string) => {
@@ -1199,19 +1278,43 @@ export function GroupDetail({
     }))
   }, [])
 
+  /**
+   * Nested controls rendered under a platform feature's checkbox, keyed by
+   * feature id. Keeping these out of `platformFeatures` leaves that array pure
+   * data (and its memo dependency-free) while the toggles themselves still flow
+   * through the tab's search, status filter, Select All, and empty state.
+   */
+  const featureExtras: Partial<Record<string, ReactNode>> = {
+    'hide-deploy-chatbot': (
+      <AuthModeField
+        label='Auth modes chat deployments may use'
+        value={chatDeployAuthValue}
+        onChange={setChatDeployAuthTypes}
+        options={CHAT_DEPLOY_AUTH_TYPE_OPTIONS}
+        disabled={editingConfig.hideDeployChatbot}
+      />
+    ),
+    'disable-public-file-sharing': (
+      <AuthModeField
+        label='Auth modes public file-share links may use'
+        value={fileShareAuthValue}
+        onChange={setFileShareAuthTypes}
+        options={FILE_SHARE_AUTH_TYPE_OPTIONS}
+        disabled={editingConfig.disablePublicFileSharing}
+      />
+    ),
+  }
+
   /** Persists the editing buffer — name/description are only sent when they changed. */
   const handleSaveConfig = useCallback(async () => {
     if (!trimmedName) return
-    const nextDescription = trimmedDescription || null
     try {
       const result = await updatePermissionGroup.mutateAsync({
         id: viewingGroup.id,
         organizationId,
         ...(hasConfigChanges && { config: editingConfig }),
-        ...(trimmedName !== viewingGroup.name && { name: trimmedName }),
-        ...(trimmedDescription !== (viewingGroup.description ?? '') && {
-          description: nextDescription,
-        }),
+        ...(nameChanged && { name: trimmedName }),
+        ...(descriptionChanged && { description: trimmedDescription || null }),
       })
       // Reconcile from the server's copy, like the scope/default writes do, so a
       // server-side normalization can't leave the dirty check comparing against a
@@ -1233,10 +1336,10 @@ export function GroupDetail({
     }
   }, [
     viewingGroup.id,
-    viewingGroup.name,
-    viewingGroup.description,
     editingConfig,
     hasConfigChanges,
+    nameChanged,
+    descriptionChanged,
     trimmedName,
     trimmedDescription,
     organizationId,
@@ -1574,13 +1677,7 @@ export function GroupDetail({
                 onChange={(e) => setProviderSearchTerm(e.target.value)}
                 className='min-w-0 flex-1'
               />
-              <ChipDropdown
-                value={providerStatusFilter}
-                onChange={(value) => setProviderStatusFilter(value as StatusFilter)}
-                options={STATUS_FILTER_OPTIONS}
-                matchTriggerWidth={false}
-                className='w-[140px] flex-shrink-0'
-              />
+              <StatusFilterChip value={providerStatusFilter} onChange={setProviderStatusFilter} />
               <Chip
                 onClick={() => setProvidersAllowed(filteredProviders, !filteredProvidersAllAllowed)}
                 disabled={filteredProviders.length === 0}
@@ -1622,14 +1719,7 @@ export function GroupDetail({
                 onChange={(e) => setIntegrationSearchTerm(e.target.value)}
                 className='min-w-0 flex-1'
               />
-              <ChipDropdown
-                value={blockStatusFilter}
-                onChange={(value) => setBlockStatusFilter(value as StatusFilter)}
-                options={STATUS_FILTER_OPTIONS}
-                matchTriggerWidth={false}
-                flush
-                className='w-[140px] flex-shrink-0'
-              />
+              <StatusFilterChip value={blockStatusFilter} onChange={setBlockStatusFilter} flush />
             </div>
             {filteredCoreBlocks.length === 0 && filteredToolBlocks.length === 0 && (
               <SettingsEmptyState variant='inline'>
@@ -1732,13 +1822,7 @@ export function GroupDetail({
                 onChange={(e) => setPlatformSearchTerm(e.target.value)}
                 className='min-w-0 flex-1'
               />
-              <ChipDropdown
-                value={platformStatusFilter}
-                onChange={(value) => setPlatformStatusFilter(value as StatusFilter)}
-                options={STATUS_FILTER_OPTIONS}
-                matchTriggerWidth={false}
-                className='w-[140px] flex-shrink-0'
-              />
+              <StatusFilterChip value={platformStatusFilter} onChange={setPlatformStatusFilter} />
               <Chip
                 onClick={() =>
                   setEditingConfig((prev) => ({
@@ -1753,126 +1837,43 @@ export function GroupDetail({
                 {platformAllVisible ? 'Deselect All' : 'Select All'}
               </Chip>
             </div>
+            {platformCategorySections.length === 0 && (
+              <SettingsEmptyState variant='inline'>
+                No features match your filters.
+              </SettingsEmptyState>
+            )}
             {platformCategorySections.map(({ category, features }) => (
               <SettingsSection key={category} label={category}>
                 <div className='flex flex-col gap-0.5'>
                   {features.map((feature) => (
-                    <div key={feature.id} className='flex items-center gap-1.5'>
-                      <label
-                        htmlFor={feature.id}
-                        className='flex flex-1 cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
-                      >
-                        <Checkbox
-                          id={feature.id}
-                          checked={!editingConfig[feature.configKey]}
-                          onCheckedChange={(checked) =>
-                            setEditingConfig((prev) => ({
-                              ...prev,
-                              [feature.configKey]: checked !== true,
-                            }))
-                          }
-                        />
-                        <span className='font-normal text-sm'>{feature.label}</span>
-                      </label>
-                      <Info side='top' className='flex-shrink-0'>
-                        {feature.hint}
-                      </Info>
+                    <div key={feature.id} className='flex flex-col'>
+                      <div className='flex items-center gap-1.5'>
+                        <label
+                          htmlFor={feature.id}
+                          className='flex flex-1 cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
+                        >
+                          <Checkbox
+                            id={feature.id}
+                            checked={!editingConfig[feature.configKey]}
+                            onCheckedChange={(checked) =>
+                              setEditingConfig((prev) => ({
+                                ...prev,
+                                [feature.configKey]: checked !== true,
+                              }))
+                            }
+                          />
+                          <span className='font-normal text-sm'>{feature.label}</span>
+                        </label>
+                        <Info side='top' className='flex-shrink-0'>
+                          {feature.hint}
+                        </Info>
+                      </div>
+                      {featureExtras[feature.id]}
                     </div>
                   ))}
                 </div>
               </SettingsSection>
             ))}
-            {showChatSection && (
-              <SettingsSection label='Chat'>
-                <div className='flex flex-col gap-1.5'>
-                  <label
-                    htmlFor='hide-deploy-chatbot'
-                    className='flex cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
-                  >
-                    <Checkbox
-                      id='hide-deploy-chatbot'
-                      checked={!editingConfig.hideDeployChatbot}
-                      onCheckedChange={(checked) =>
-                        setEditingConfig((prev) => ({
-                          ...prev,
-                          hideDeployChatbot: checked !== true,
-                        }))
-                      }
-                    />
-                    <span className='font-normal text-sm'>Deployment</span>
-                  </label>
-                  <div
-                    className={cn(
-                      'flex flex-col gap-1.5 px-2 pt-1',
-                      editingConfig.hideDeployChatbot && 'opacity-50'
-                    )}
-                  >
-                    <span className='text-[var(--text-muted)] text-caption'>
-                      Auth modes chat deployments may use
-                    </span>
-                    <ChipDropdown
-                      multiple
-                      showAllOption={false}
-                      allLabel='None'
-                      value={chatDeployAuthValue}
-                      onChange={setChatDeployAuthTypes}
-                      options={CHAT_DEPLOY_AUTH_TYPE_OPTIONS}
-                      disabled={editingConfig.hideDeployChatbot}
-                      matchTriggerWidth={false}
-                      className='w-[200px]'
-                    />
-                  </div>
-                </div>
-              </SettingsSection>
-            )}
-            {showFilesSection && (
-              <SettingsSection label='Files'>
-                <div className='flex flex-col gap-1.5'>
-                  <label
-                    htmlFor='disable-public-file-sharing'
-                    className='flex cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
-                  >
-                    <Checkbox
-                      id='disable-public-file-sharing'
-                      checked={!editingConfig.disablePublicFileSharing}
-                      onCheckedChange={(checked) =>
-                        setEditingConfig((prev) => ({
-                          ...prev,
-                          disablePublicFileSharing: checked !== true,
-                        }))
-                      }
-                    />
-                    <span className='font-normal text-sm'>Public Sharing</span>
-                  </label>
-                  <div
-                    className={cn(
-                      'flex flex-col gap-1.5 px-2 pt-1',
-                      editingConfig.disablePublicFileSharing && 'opacity-50'
-                    )}
-                  >
-                    <span className='text-[var(--text-muted)] text-caption'>
-                      Auth modes public file-share links may use
-                    </span>
-                    <ChipDropdown
-                      multiple
-                      showAllOption={false}
-                      allLabel='None'
-                      value={fileShareAuthValue}
-                      onChange={setFileShareAuthTypes}
-                      options={FILE_SHARE_AUTH_TYPE_OPTIONS}
-                      disabled={editingConfig.disablePublicFileSharing}
-                      matchTriggerWidth={false}
-                      className='w-[200px]'
-                    />
-                  </div>
-                </div>
-              </SettingsSection>
-            )}
-            {!hasPlatformMatches && (
-              <SettingsEmptyState variant='inline'>
-                No features match your filters.
-              </SettingsEmptyState>
-            )}
           </div>
         )}
       </SettingsPanel>

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -135,22 +135,28 @@ interface AuthModeFieldProps {
 
 /**
  * The allowed-auth-modes multi-select nested under a platform toggle. Dims and
- * disables together with the toggle that owns it. The left padding lines the
- * sub-label up with its parent's label text (row gutter + checkbox + gap), so
- * the field reads as subordinate to the toggle rather than as a sibling row.
+ * disables together with the toggle that owns it. The left padding lines both
+ * children up with the parent's label text — row gutter (8) + checkbox (16) +
+ * gap (8) = 32 — so the field reads as subordinate rather than as a sibling row.
+ * The dropdown is `flush` so its own `mx-0.5` doesn't push it 2px past the
+ * caption above it.
  */
 function AuthModeField({ label, value, onChange, options, disabled }: AuthModeFieldProps) {
   const labelId = useId()
+  const triggerId = useId()
   return (
-    <div className={cn('flex flex-col gap-1.5 pt-1 pr-2 pb-2 pl-[30px]', disabled && 'opacity-50')}>
+    <div className={cn('flex flex-col gap-1.5 pt-1 pr-2 pb-2 pl-8', disabled && 'opacity-50')}>
       <span id={labelId} className='text-[var(--text-muted)] text-caption'>
         {label}
       </span>
       <ChipDropdown
         multiple
+        flush
         showAllOption={false}
-        allLabel='None'
-        aria-labelledby={labelId}
+        id={triggerId}
+        // Both ids: `aria-labelledby` replaces the content-derived name, so
+        // naming it with the label alone would drop the selected value.
+        aria-labelledby={`${labelId} ${triggerId}`}
         value={value}
         onChange={onChange}
         options={options}
@@ -906,19 +912,21 @@ export function GroupDetail({
     return map
   }, [allBlocks])
 
-  const filteredPlatformFeatures = useMemo(() => {
+  const searchedPlatformFeatures = useMemo(() => {
     const search = platformSearchTerm.trim().toLowerCase()
-    return PLATFORM_FEATURES.filter((f) => {
-      if (
-        search &&
-        !f.label.toLowerCase().includes(search) &&
-        !f.category.toLowerCase().includes(search)
-      ) {
-        return false
-      }
-      return matchesStatusFilter(platformStatusFilter, !editingConfig[f.configKey])
-    })
-  }, [platformSearchTerm, platformStatusFilter, editingConfig])
+    if (!search) return PLATFORM_FEATURES
+    return PLATFORM_FEATURES.filter(
+      (f) => f.label.toLowerCase().includes(search) || f.category.toLowerCase().includes(search)
+    )
+  }, [platformSearchTerm])
+
+  /** Split from the search pass for the same reason as the provider and block lists. */
+  const filteredPlatformFeatures = useMemo(() => {
+    if (platformStatusFilter === 'all') return searchedPlatformFeatures
+    return searchedPlatformFeatures.filter((f) =>
+      matchesStatusFilter(platformStatusFilter, !editingConfig[f.configKey])
+    )
+  }, [searchedPlatformFeatures, platformStatusFilter, editingConfig])
 
   const platformCategories = useMemo(() => {
     const categories: Record<string, typeof PLATFORM_FEATURES> = {}
@@ -949,8 +957,9 @@ export function GroupDetail({
   const trimmedName = editingName.trim()
   const trimmedDescription = editingDescription.trim()
   const nameChanged = trimmedName !== viewingGroup.name
-  // `name` is trimmed by its contract schema, but a description stored before this
-  // PR (or written straight to the API) can still carry padding. The buffer is
+  // `name` is trimmed by its contract schema, but a description stored before
+  // description trimming was added (or written straight to the API) can still
+  // carry padding. The buffer is
   // seeded trimmed and compared against a trimmed baseline, so such a row opens
   // clean instead of being dirty with no way to clear it.
   const descriptionChanged = trimmedDescription !== (viewingGroup.description ?? '').trim()
@@ -1843,10 +1852,10 @@ export function GroupDetail({
                 <div className='flex flex-col gap-0.5'>
                   {features.map((feature) => (
                     <div key={feature.id} className='flex flex-col'>
-                      <div className='flex items-center gap-1.5'>
+                      <div className='flex items-center gap-1.5 rounded-md pr-2 transition-colors hover-hover:bg-[var(--surface-active)]'>
                         <label
                           htmlFor={feature.id}
-                          className='flex flex-1 cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
+                          className='flex flex-1 cursor-pointer items-center gap-2 py-[5px] pl-2'
                         >
                           <Checkbox
                             id={feature.id}

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -949,7 +949,11 @@ export function GroupDetail({
   const trimmedName = editingName.trim()
   const trimmedDescription = editingDescription.trim()
   const nameChanged = trimmedName !== viewingGroup.name
-  const descriptionChanged = trimmedDescription !== (viewingGroup.description ?? '')
+  // Compare trimmed on both sides: `name` is trimmed by its contract schema but a
+  // description stored before this PR (or written straight to the API) can still
+  // carry padding, and comparing it raw would leave the form dirty on open with
+  // no way to clear it — Discard restores the same padded value.
+  const descriptionChanged = trimmedDescription !== (viewingGroup.description ?? '').trim()
   const hasChanges = hasConfigChanges || nameChanged || descriptionChanged
 
   const guard = useSettingsUnsavedGuard({ isDirty: hasChanges })

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/app/workspace/[workspaceId]/settings/components/member-list'
 import { RowActionsMenu } from '@/app/workspace/[workspaceId]/settings/components/row-actions-menu'
 import { saveDiscardActions } from '@/app/workspace/[workspaceId]/settings/components/save-discard-actions/save-discard-actions'
+import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
 import { SettingsSection } from '@/app/workspace/[workspaceId]/settings/components/settings-section/settings-section'
 import { useSettingsUnsavedGuard } from '@/app/workspace/[workspaceId]/settings/hooks/use-settings-unsaved-guard'
@@ -91,13 +92,12 @@ const ALL_CHAT_DEPLOY_AUTH_TYPES: ShareAuthType[] = CHAT_DEPLOY_AUTH_TYPE_OPTION
   (o) => o.value
 )
 
-/** Narrows an allow/deny list to entries that are currently on or off. */
 type StatusFilter = 'all' | 'enabled' | 'disabled'
 
 const STATUS_FILTER_OPTIONS: { value: StatusFilter; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'enabled', label: 'Enabled' },
-  { value: 'disabled', label: 'Disabled' },
+  { value: 'all', label: 'Show all' },
+  { value: 'enabled', label: 'Show enabled' },
+  { value: 'disabled', label: 'Show disabled' },
 ]
 
 function matchesStatusFilter(filter: StatusFilter, enabled: boolean) {
@@ -535,7 +535,7 @@ function BlockToolRow({
           onClick={() => isBlockAllowed && isExpandable && setExpanded((prev) => !prev)}
           disabled={!isBlockAllowed || !isExpandable}
           className={cn(
-            'flex min-w-0 items-center gap-2 text-left',
+            'flex min-w-0 flex-1 items-center gap-2 text-left',
             isBlockAllowed && isExpandable ? 'cursor-pointer' : 'cursor-default',
             !isBlockAllowed && 'opacity-60'
           )}
@@ -547,9 +547,11 @@ function BlockToolRow({
             </ChipTag>
           )}
         </button>
-        <Info side='top' className='flex-shrink-0'>
-          {block.description}
-        </Info>
+        {block.description && (
+          <Info side='top' className='flex-shrink-0'>
+            {block.description}
+          </Info>
+        )}
         {isBlockAllowed && isExpandable && (
           <ChevronDown
             className={cn(
@@ -863,6 +865,23 @@ export function GroupDetail({
       features: platformCategories[category] ?? [],
     }))
   }, [platformCategories])
+
+  /**
+   * Chat and Files render as standalone sections (a toggle plus its nested
+   * auth-mode dropdown) rather than as `platformFeatures` rows, so they need the
+   * tab's search + status filter applied by hand — otherwise they'd be the only
+   * Platform controls that ignore both.
+   */
+  const platformSectionVisible = (label: string, enabled: boolean) => {
+    const search = platformSearchTerm.trim().toLowerCase()
+    if (search && !label.toLowerCase().includes(search)) return false
+    return matchesStatusFilter(platformStatusFilter, enabled)
+  }
+
+  const showChatSection = platformSectionVisible('Chat', !editingConfig.hideDeployChatbot)
+  const showFilesSection = platformSectionVisible('Files', !editingConfig.disablePublicFileSharing)
+  const hasPlatformMatches =
+    platformCategorySections.length > 0 || showChatSection || showFilesSection
 
   const hasConfigChanges = useMemo(() => {
     return JSON.stringify(viewingGroup.config) !== JSON.stringify(editingConfig)
@@ -1185,7 +1204,7 @@ export function GroupDetail({
     if (!trimmedName) return
     const nextDescription = trimmedDescription || null
     try {
-      await updatePermissionGroup.mutateAsync({
+      const result = await updatePermissionGroup.mutateAsync({
         id: viewingGroup.id,
         organizationId,
         ...(hasConfigChanges && { config: editingConfig }),
@@ -1194,14 +1213,18 @@ export function GroupDetail({
           description: nextDescription,
         }),
       })
+      // Reconcile from the server's copy, like the scope/default writes do, so a
+      // server-side normalization can't leave the dirty check comparing against a
+      // baseline that was never persisted. The editing buffers are deliberately
+      // left alone: edits made while the save was in flight stay, and correctly
+      // re-mark the form dirty.
+      const saved = result.permissionGroup
       setViewingGroup((prev) => ({
         ...prev,
-        config: editingConfig,
-        name: trimmedName,
-        description: nextDescription,
+        config: saved.config,
+        name: saved.name,
+        description: saved.description,
       }))
-      setEditingName(trimmedName)
-      setEditingDescription(trimmedDescription)
     } catch (error) {
       logger.error('Failed to save permission group', error)
       toast.error("Couldn't save changes", {
@@ -1406,8 +1429,12 @@ export function GroupDetail({
                     placeholder='e.g., Marketing Team'
                     maxLength={100}
                     error={!trimmedName}
-                    className='max-w-[320px]'
                   />
+                  {!trimmedName && (
+                    <p className='mt-1.5 text-[var(--text-error)] text-caption'>
+                      Name is required.
+                    </p>
+                  )}
                 </SettingRow>
                 <SettingRow label='Description'>
                   <ChipInput
@@ -1552,29 +1579,36 @@ export function GroupDetail({
                 onChange={(value) => setProviderStatusFilter(value as StatusFilter)}
                 options={STATUS_FILTER_OPTIONS}
                 matchTriggerWidth={false}
-                className='flex-shrink-0'
+                className='w-[140px] flex-shrink-0'
               />
               <Chip
                 onClick={() => setProvidersAllowed(filteredProviders, !filteredProvidersAllAllowed)}
+                disabled={filteredProviders.length === 0}
               >
                 {filteredProvidersAllAllowed ? 'Deselect All' : 'Select All'}
               </Chip>
             </div>
-            <div className='flex flex-col gap-0.5'>
-              {filteredProviders.map((providerId) => (
-                <ProviderRow
-                  key={providerId}
-                  providerId={providerId}
-                  isProviderAllowed={isProviderAllowed(providerId)}
-                  onToggleProvider={() => toggleProvider(providerId)}
-                  deniedCount={deniedCountByProvider[providerId] ?? 0}
-                  workspaceId={workspaceId}
-                  isAllowed={isModelAllowed}
-                  onToggle={toggleModel}
-                  onSetDenied={setModelsDenied}
-                />
-              ))}
-            </div>
+            {filteredProviders.length === 0 ? (
+              <SettingsEmptyState variant='inline'>
+                No providers match your filters.
+              </SettingsEmptyState>
+            ) : (
+              <div className='flex flex-col gap-0.5'>
+                {filteredProviders.map((providerId) => (
+                  <ProviderRow
+                    key={providerId}
+                    providerId={providerId}
+                    isProviderAllowed={isProviderAllowed(providerId)}
+                    onToggleProvider={() => toggleProvider(providerId)}
+                    deniedCount={deniedCountByProvider[providerId] ?? 0}
+                    workspaceId={workspaceId}
+                    isAllowed={isModelAllowed}
+                    onToggle={toggleModel}
+                    onSetDenied={setModelsDenied}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         )}
 
@@ -1593,9 +1627,15 @@ export function GroupDetail({
                 onChange={(value) => setBlockStatusFilter(value as StatusFilter)}
                 options={STATUS_FILTER_OPTIONS}
                 matchTriggerWidth={false}
-                className='flex-shrink-0'
+                flush
+                className='w-[140px] flex-shrink-0'
               />
             </div>
+            {filteredCoreBlocks.length === 0 && filteredToolBlocks.length === 0 && (
+              <SettingsEmptyState variant='inline'>
+                No blocks match your filters.
+              </SettingsEmptyState>
+            )}
             {filteredCoreBlocks.length > 0 && (
               <SettingsSection
                 label='Core Blocks'
@@ -1613,10 +1653,13 @@ export function GroupDetail({
                     const BlockIcon = block.icon
                     const checkboxId = `block-${block.type}`
                     return (
-                      <div key={block.type} className='flex items-center gap-1.5'>
+                      <div
+                        key={block.type}
+                        className='flex items-center gap-1.5 rounded-md pr-2 transition-colors hover-hover:bg-[var(--surface-active)]'
+                      >
                         <label
                           htmlFor={checkboxId}
-                          className='flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
+                          className='flex min-w-0 flex-1 cursor-pointer items-center gap-2 py-[5px] pl-2'
                         >
                           <Checkbox
                             id={checkboxId}
@@ -1631,9 +1674,11 @@ export function GroupDetail({
                           </div>
                           <span className='truncate font-medium text-sm'>{block.name}</span>
                         </label>
-                        <Info side='top' className='flex-shrink-0'>
-                          {block.description}
-                        </Info>
+                        {block.description && (
+                          <Info side='top' className='flex-shrink-0'>
+                            {block.description}
+                          </Info>
+                        )}
                       </div>
                     )
                   })}
@@ -1692,7 +1737,7 @@ export function GroupDetail({
                 onChange={(value) => setPlatformStatusFilter(value as StatusFilter)}
                 options={STATUS_FILTER_OPTIONS}
                 matchTriggerWidth={false}
-                className='flex-shrink-0'
+                className='w-[140px] flex-shrink-0'
               />
               <Chip
                 onClick={() =>
@@ -1703,6 +1748,7 @@ export function GroupDetail({
                     ),
                   }))
                 }
+                disabled={filteredPlatformFeatures.length === 0}
               >
                 {platformAllVisible ? 'Deselect All' : 'Select All'}
               </Chip>
@@ -1728,94 +1774,105 @@ export function GroupDetail({
                         />
                         <span className='font-normal text-sm'>{feature.label}</span>
                       </label>
-                      <Info side='top'>{feature.hint}</Info>
+                      <Info side='top' className='flex-shrink-0'>
+                        {feature.hint}
+                      </Info>
                     </div>
                   ))}
                 </div>
               </SettingsSection>
             ))}
-            <SettingsSection label='Chat'>
-              <div className='flex flex-col gap-1.5'>
-                <label
-                  htmlFor='hide-deploy-chatbot'
-                  className='flex cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
-                >
-                  <Checkbox
-                    id='hide-deploy-chatbot'
-                    checked={!editingConfig.hideDeployChatbot}
-                    onCheckedChange={(checked) =>
-                      setEditingConfig((prev) => ({
-                        ...prev,
-                        hideDeployChatbot: checked !== true,
-                      }))
-                    }
-                  />
-                  <span className='font-normal text-sm'>Chat Deployment</span>
-                </label>
-                <div
-                  className={cn(
-                    'flex flex-col gap-1.5 px-2 pt-1',
-                    editingConfig.hideDeployChatbot && 'opacity-50'
-                  )}
-                >
-                  <span className='text-[var(--text-secondary)] text-xs'>
-                    Auth modes chat deployments may use
-                  </span>
-                  <ChipDropdown
-                    multiple
-                    showAllOption={false}
-                    allLabel='None'
-                    value={chatDeployAuthValue}
-                    onChange={setChatDeployAuthTypes}
-                    options={CHAT_DEPLOY_AUTH_TYPE_OPTIONS}
-                    disabled={editingConfig.hideDeployChatbot}
-                    matchTriggerWidth={false}
-                    className='w-[200px]'
-                  />
+            {showChatSection && (
+              <SettingsSection label='Chat'>
+                <div className='flex flex-col gap-1.5'>
+                  <label
+                    htmlFor='hide-deploy-chatbot'
+                    className='flex cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
+                  >
+                    <Checkbox
+                      id='hide-deploy-chatbot'
+                      checked={!editingConfig.hideDeployChatbot}
+                      onCheckedChange={(checked) =>
+                        setEditingConfig((prev) => ({
+                          ...prev,
+                          hideDeployChatbot: checked !== true,
+                        }))
+                      }
+                    />
+                    <span className='font-normal text-sm'>Deployment</span>
+                  </label>
+                  <div
+                    className={cn(
+                      'flex flex-col gap-1.5 px-2 pt-1',
+                      editingConfig.hideDeployChatbot && 'opacity-50'
+                    )}
+                  >
+                    <span className='text-[var(--text-muted)] text-caption'>
+                      Auth modes chat deployments may use
+                    </span>
+                    <ChipDropdown
+                      multiple
+                      showAllOption={false}
+                      allLabel='None'
+                      value={chatDeployAuthValue}
+                      onChange={setChatDeployAuthTypes}
+                      options={CHAT_DEPLOY_AUTH_TYPE_OPTIONS}
+                      disabled={editingConfig.hideDeployChatbot}
+                      matchTriggerWidth={false}
+                      className='w-[200px]'
+                    />
+                  </div>
                 </div>
-              </div>
-            </SettingsSection>
-            <SettingsSection label='Files'>
-              <div className='flex flex-col gap-1.5'>
-                <label
-                  htmlFor='disable-public-file-sharing'
-                  className='flex cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
-                >
-                  <Checkbox
-                    id='disable-public-file-sharing'
-                    checked={!editingConfig.disablePublicFileSharing}
-                    onCheckedChange={(checked) =>
-                      setEditingConfig((prev) => ({
-                        ...prev,
-                        disablePublicFileSharing: checked !== true,
-                      }))
-                    }
-                  />
-                  <span className='font-normal text-sm'>Public Sharing</span>
-                </label>
-                <div
-                  className={cn(
-                    'flex flex-col gap-1.5 px-2 pt-1',
-                    editingConfig.disablePublicFileSharing && 'opacity-50'
-                  )}
-                >
-                  <span className='text-[var(--text-secondary)] text-xs'>
-                    Auth modes public file-share links may use
-                  </span>
-                  <ChipDropdown
-                    multiple
-                    showAllOption={false}
-                    allLabel='None'
-                    value={fileShareAuthValue}
-                    onChange={setFileShareAuthTypes}
-                    options={FILE_SHARE_AUTH_TYPE_OPTIONS}
-                    disabled={editingConfig.disablePublicFileSharing}
-                    matchTriggerWidth={false}
-                    className='w-[200px]'
-                  />
+              </SettingsSection>
+            )}
+            {showFilesSection && (
+              <SettingsSection label='Files'>
+                <div className='flex flex-col gap-1.5'>
+                  <label
+                    htmlFor='disable-public-file-sharing'
+                    className='flex cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
+                  >
+                    <Checkbox
+                      id='disable-public-file-sharing'
+                      checked={!editingConfig.disablePublicFileSharing}
+                      onCheckedChange={(checked) =>
+                        setEditingConfig((prev) => ({
+                          ...prev,
+                          disablePublicFileSharing: checked !== true,
+                        }))
+                      }
+                    />
+                    <span className='font-normal text-sm'>Public Sharing</span>
+                  </label>
+                  <div
+                    className={cn(
+                      'flex flex-col gap-1.5 px-2 pt-1',
+                      editingConfig.disablePublicFileSharing && 'opacity-50'
+                    )}
+                  >
+                    <span className='text-[var(--text-muted)] text-caption'>
+                      Auth modes public file-share links may use
+                    </span>
+                    <ChipDropdown
+                      multiple
+                      showAllOption={false}
+                      allLabel='None'
+                      value={fileShareAuthValue}
+                      onChange={setFileShareAuthTypes}
+                      options={FILE_SHARE_AUTH_TYPE_OPTIONS}
+                      disabled={editingConfig.disablePublicFileSharing}
+                      matchTriggerWidth={false}
+                      className='w-[200px]'
+                    />
+                  </div>
                 </div>
-              </div>
-            </SettingsSection>
+              </SettingsSection>
+            )}
+            {!hasPlatformMatches && (
+              <SettingsEmptyState variant='inline'>
+                No features match your filters.
+              </SettingsEmptyState>
+            )}
           </div>
         )}
       </SettingsPanel>

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useId, useMemo, useRef, useState } from 'react'
 import {
   Checkbox,
   Chip,
@@ -135,17 +135,22 @@ interface AuthModeFieldProps {
 
 /**
  * The allowed-auth-modes multi-select nested under a platform toggle. Dims and
- * disables together with the toggle that owns it, so the coupling lives here
- * rather than being re-derived at each call site.
+ * disables together with the toggle that owns it. The left padding lines the
+ * sub-label up with its parent's label text (row gutter + checkbox + gap), so
+ * the field reads as subordinate to the toggle rather than as a sibling row.
  */
 function AuthModeField({ label, value, onChange, options, disabled }: AuthModeFieldProps) {
+  const labelId = useId()
   return (
-    <div className={cn('flex flex-col gap-1.5 px-2 pt-1 pb-1', disabled && 'opacity-50')}>
-      <span className='text-[var(--text-muted)] text-caption'>{label}</span>
+    <div className={cn('flex flex-col gap-1.5 pt-1 pr-2 pb-2 pl-[30px]', disabled && 'opacity-50')}>
+      <span id={labelId} className='text-[var(--text-muted)] text-caption'>
+        {label}
+      </span>
       <ChipDropdown
         multiple
         showAllOption={false}
         allLabel='None'
+        aria-labelledby={labelId}
         value={value}
         onChange={onChange}
         options={options}
@@ -156,6 +161,151 @@ function AuthModeField({ label, value, onChange, options, disabled }: AuthModeFi
     </div>
   )
 }
+
+/** Render order for the platform-feature category sections; unlisted ones follow. */
+const PLATFORM_CATEGORY_ORDER = [
+  'Sidebar',
+  'Deploy Tabs',
+  'Chat',
+  'Collaboration',
+  'Workflow Panel',
+  'Tools',
+  'Features',
+  'Settings Tabs',
+  'Logs',
+  'Files',
+]
+
+const PLATFORM_FEATURES = [
+  {
+    id: 'hide-knowledge-base',
+    label: 'Knowledge Base',
+    category: 'Sidebar',
+    configKey: 'hideKnowledgeBaseTab' as const,
+    hint: 'Hide the Knowledge Base module from the sidebar.',
+  },
+  {
+    id: 'hide-tables',
+    label: 'Tables',
+    category: 'Sidebar',
+    configKey: 'hideTablesTab' as const,
+    hint: 'Hide the Tables module from the sidebar.',
+  },
+  {
+    id: 'hide-copilot',
+    label: 'Chat',
+    category: 'Workflow Panel',
+    configKey: 'hideCopilot' as const,
+    hint: 'Hide the Chat panel so users cannot build or edit with natural language.',
+  },
+  {
+    id: 'hide-integrations',
+    label: 'Integrations',
+    category: 'Settings Tabs',
+    configKey: 'hideIntegrationsTab' as const,
+    hint: 'Hide the Integrations settings tab (OAuth connections).',
+  },
+  {
+    id: 'hide-secrets',
+    label: 'Secrets',
+    category: 'Settings Tabs',
+    configKey: 'hideSecretsTab' as const,
+    hint: 'Hide the Secrets (environment variables) settings tab.',
+  },
+  {
+    id: 'hide-api-keys',
+    label: 'API Keys',
+    category: 'Settings Tabs',
+    configKey: 'hideApiKeysTab' as const,
+    hint: 'Hide the API Keys settings tab.',
+  },
+  {
+    id: 'hide-files',
+    label: 'Files',
+    category: 'Settings Tabs',
+    configKey: 'hideFilesTab' as const,
+    hint: 'Hide the Files settings tab.',
+  },
+  {
+    id: 'hide-deploy-api',
+    label: 'API',
+    category: 'Deploy Tabs',
+    configKey: 'hideDeployApi' as const,
+    hint: 'Hide the API deployment option.',
+  },
+  {
+    id: 'hide-deploy-mcp',
+    label: 'MCP',
+    category: 'Deploy Tabs',
+    configKey: 'hideDeployMcp' as const,
+    hint: 'Hide the MCP server deployment option.',
+  },
+  {
+    id: 'disable-mcp',
+    label: 'MCP Tools',
+    category: 'Tools',
+    configKey: 'disableMcpTools' as const,
+    hint: 'Block agents from calling MCP tools.',
+  },
+  {
+    id: 'disable-custom-tools',
+    label: 'Custom Tools',
+    category: 'Tools',
+    configKey: 'disableCustomTools' as const,
+    hint: 'Block agents from calling user-defined custom tools.',
+  },
+  {
+    id: 'disable-skills',
+    label: 'Skills',
+    category: 'Tools',
+    configKey: 'disableSkills' as const,
+    hint: 'Block agents from loading skills.',
+  },
+  {
+    id: 'hide-trace-spans',
+    label: 'Trace Spans',
+    category: 'Logs',
+    configKey: 'hideTraceSpans' as const,
+    hint: 'Hide per-block trace spans in logs.',
+  },
+  {
+    id: 'disable-invitations',
+    label: 'Invitations',
+    category: 'Collaboration',
+    configKey: 'disableInvitations' as const,
+    hint: 'Prevent users from inviting others to workspaces.',
+  },
+  {
+    id: 'hide-inbox',
+    label: 'Sim Mailer',
+    category: 'Features',
+    configKey: 'hideInboxTab' as const,
+    hint: 'Hide the Sim Mailer inbox.',
+  },
+  {
+    id: 'disable-public-api',
+    label: 'Public API',
+    category: 'Features',
+    configKey: 'disablePublicApi' as const,
+    hint: 'Disable public API access to deployed workflows.',
+  },
+  // Chat and Files get a category of their own so their nested auth-mode
+  // dropdown (see `featureExtras`) reads as part of the toggle it qualifies.
+  {
+    id: 'hide-deploy-chatbot',
+    label: 'Deployment',
+    category: 'Chat',
+    configKey: 'hideDeployChatbot' as const,
+    hint: 'Hide the chat deployment option.',
+  },
+  {
+    id: 'disable-public-file-sharing',
+    label: 'Public Sharing',
+    category: 'Files',
+    configKey: 'disablePublicFileSharing' as const,
+    hint: 'Disable public file-share links.',
+  },
+]
 
 interface OrganizationMemberOption {
   userId: string
@@ -755,143 +905,9 @@ export function GroupDetail({
     return map
   }, [allBlocks])
 
-  const platformFeatures = useMemo(
-    () => [
-      {
-        id: 'hide-knowledge-base',
-        label: 'Knowledge Base',
-        category: 'Sidebar',
-        configKey: 'hideKnowledgeBaseTab' as const,
-        hint: 'Hide the Knowledge Base module from the sidebar.',
-      },
-      {
-        id: 'hide-tables',
-        label: 'Tables',
-        category: 'Sidebar',
-        configKey: 'hideTablesTab' as const,
-        hint: 'Hide the Tables module from the sidebar.',
-      },
-      {
-        id: 'hide-copilot',
-        label: 'Chat',
-        category: 'Workflow Panel',
-        configKey: 'hideCopilot' as const,
-        hint: 'Hide the Chat panel so users cannot build or edit with natural language.',
-      },
-      {
-        id: 'hide-integrations',
-        label: 'Integrations',
-        category: 'Settings Tabs',
-        configKey: 'hideIntegrationsTab' as const,
-        hint: 'Hide the Integrations settings tab (OAuth connections).',
-      },
-      {
-        id: 'hide-secrets',
-        label: 'Secrets',
-        category: 'Settings Tabs',
-        configKey: 'hideSecretsTab' as const,
-        hint: 'Hide the Secrets (environment variables) settings tab.',
-      },
-      {
-        id: 'hide-api-keys',
-        label: 'API Keys',
-        category: 'Settings Tabs',
-        configKey: 'hideApiKeysTab' as const,
-        hint: 'Hide the API Keys settings tab.',
-      },
-      {
-        id: 'hide-files',
-        label: 'Files',
-        category: 'Settings Tabs',
-        configKey: 'hideFilesTab' as const,
-        hint: 'Hide the Files settings tab.',
-      },
-      {
-        id: 'hide-deploy-api',
-        label: 'API',
-        category: 'Deploy Tabs',
-        configKey: 'hideDeployApi' as const,
-        hint: 'Hide the API deployment option.',
-      },
-      {
-        id: 'hide-deploy-mcp',
-        label: 'MCP',
-        category: 'Deploy Tabs',
-        configKey: 'hideDeployMcp' as const,
-        hint: 'Hide the MCP server deployment option.',
-      },
-      {
-        id: 'disable-mcp',
-        label: 'MCP Tools',
-        category: 'Tools',
-        configKey: 'disableMcpTools' as const,
-        hint: 'Block agents from calling MCP tools.',
-      },
-      {
-        id: 'disable-custom-tools',
-        label: 'Custom Tools',
-        category: 'Tools',
-        configKey: 'disableCustomTools' as const,
-        hint: 'Block agents from calling user-defined custom tools.',
-      },
-      {
-        id: 'disable-skills',
-        label: 'Skills',
-        category: 'Tools',
-        configKey: 'disableSkills' as const,
-        hint: 'Block agents from loading skills.',
-      },
-      {
-        id: 'hide-trace-spans',
-        label: 'Trace Spans',
-        category: 'Logs',
-        configKey: 'hideTraceSpans' as const,
-        hint: 'Hide per-block trace spans in logs.',
-      },
-      {
-        id: 'disable-invitations',
-        label: 'Invitations',
-        category: 'Collaboration',
-        configKey: 'disableInvitations' as const,
-        hint: 'Prevent users from inviting others to workspaces.',
-      },
-      {
-        id: 'hide-inbox',
-        label: 'Sim Mailer',
-        category: 'Features',
-        configKey: 'hideInboxTab' as const,
-        hint: 'Hide the Sim Mailer inbox.',
-      },
-      {
-        id: 'disable-public-api',
-        label: 'Public API',
-        category: 'Features',
-        configKey: 'disablePublicApi' as const,
-        hint: 'Disable public API access to deployed workflows.',
-      },
-      // Chat and Files get a category of their own so their nested auth-mode
-      // dropdown (see `featureExtras`) reads as part of the toggle it qualifies.
-      {
-        id: 'hide-deploy-chatbot',
-        label: 'Deployment',
-        category: 'Chat',
-        configKey: 'hideDeployChatbot' as const,
-        hint: 'Hide the chat deployment option.',
-      },
-      {
-        id: 'disable-public-file-sharing',
-        label: 'Public Sharing',
-        category: 'Files',
-        configKey: 'disablePublicFileSharing' as const,
-        hint: 'Disable public file-share links.',
-      },
-    ],
-    []
-  )
-
   const filteredPlatformFeatures = useMemo(() => {
     const search = platformSearchTerm.trim().toLowerCase()
-    return platformFeatures.filter((f) => {
+    return PLATFORM_FEATURES.filter((f) => {
       if (
         search &&
         !f.label.toLowerCase().includes(search) &&
@@ -901,10 +917,10 @@ export function GroupDetail({
       }
       return matchesStatusFilter(platformStatusFilter, !editingConfig[f.configKey])
     })
-  }, [platformFeatures, platformSearchTerm, platformStatusFilter, editingConfig])
+  }, [platformSearchTerm, platformStatusFilter, editingConfig])
 
   const platformCategories = useMemo(() => {
-    const categories: Record<string, typeof platformFeatures> = {}
+    const categories: Record<string, typeof PLATFORM_FEATURES> = {}
     for (const feature of filteredPlatformFeatures) {
       if (!categories[feature.category]) {
         categories[feature.category] = []
@@ -915,21 +931,9 @@ export function GroupDetail({
   }, [filteredPlatformFeatures])
 
   const platformCategorySections = useMemo(() => {
-    const order = [
-      'Sidebar',
-      'Deploy Tabs',
-      'Collaboration',
-      'Workflow Panel',
-      'Tools',
-      'Features',
-      'Settings Tabs',
-      'Logs',
-      'Chat',
-      'Files',
-    ]
-    const known = order.filter((c) => platformCategories[c]?.length)
+    const known = PLATFORM_CATEGORY_ORDER.filter((c) => platformCategories[c]?.length)
     const extras = Object.keys(platformCategories).filter(
-      (c) => !order.includes(c) && platformCategories[c]?.length
+      (c) => !PLATFORM_CATEGORY_ORDER.includes(c) && platformCategories[c]?.length
     )
     return [...known, ...extras].map((category) => ({
       category,
@@ -988,8 +992,8 @@ export function GroupDetail({
 
   /**
    * Split from the search pass so the common `all` case returns the searched
-   * list by reference. Only the status pass depends on the allow-list, so a
-   * checkbox toggle no longer invalidates the downstream core/tool splits.
+   * list by reference — only the status pass depends on the allow-list, so a
+   * checkbox toggle no longer invalidates downstream consumers.
    */
   const filteredProviders = useMemo(() => {
     if (providerStatusFilter === 'all') return searchedProviders
@@ -1269,7 +1273,7 @@ export function GroupDetail({
   const setChatDeployAuthTypes = useCallback((values: string[]) => {
     // At least one mode must stay allowed while chat deploy is enabled — an empty
     // allow-list would silently block every chat deployment. To turn chat deploy
-    // off entirely, use the Hide Chat toggle instead.
+    // off entirely, uncheck Chat → Deployment instead.
     if (values.length === 0) return
     setEditingConfig((prev) => ({
       ...prev,
@@ -1280,9 +1284,7 @@ export function GroupDetail({
 
   /**
    * Nested controls rendered under a platform feature's checkbox, keyed by
-   * feature id. Keeping these out of `platformFeatures` leaves that array pure
-   * data (and its memo dependency-free) while the toggles themselves still flow
-   * through the tab's search, status filter, Select All, and empty state.
+   * feature id. Kept out of `PLATFORM_FEATURES` so that array stays pure data.
    */
   const featureExtras: Partial<Record<string, ReactNode>> = {
     'hide-deploy-chatbot': (
@@ -1306,7 +1308,7 @@ export function GroupDetail({
   }
 
   /** Persists the editing buffer — name/description are only sent when they changed. */
-  const handleSaveConfig = useCallback(async () => {
+  const handleSaveConfig = async () => {
     if (!trimmedName) return
     try {
       const result = await updatePermissionGroup.mutateAsync({
@@ -1318,9 +1320,8 @@ export function GroupDetail({
       })
       // Reconcile from the server's copy, like the scope/default writes do, so a
       // server-side normalization can't leave the dirty check comparing against a
-      // baseline that was never persisted. The editing buffers are deliberately
-      // left alone: edits made while the save was in flight stay, and correctly
-      // re-mark the form dirty.
+      // baseline that was never persisted. Editing buffers are left alone so
+      // in-flight edits survive and correctly re-mark the form dirty.
       const saved = result.permissionGroup
       setViewingGroup((prev) => ({
         ...prev,
@@ -1334,23 +1335,13 @@ export function GroupDetail({
         description: getErrorMessage(error, 'Please try again in a moment.'),
       })
     }
-  }, [
-    viewingGroup.id,
-    editingConfig,
-    hasConfigChanges,
-    nameChanged,
-    descriptionChanged,
-    trimmedName,
-    trimmedDescription,
-    organizationId,
-    updatePermissionGroup,
-  ])
+  }
 
-  const handleDiscardConfig = useCallback(() => {
+  const handleDiscardConfig = () => {
     setEditingConfig({ ...viewingGroup.config })
     setEditingName(viewingGroup.name)
     setEditingDescription(viewingGroup.description ?? '')
-  }, [viewingGroup.config, viewingGroup.name, viewingGroup.description])
+  }
 
   const handleBack = useCallback(() => {
     guard.guardBack(onBack)
@@ -1534,9 +1525,7 @@ export function GroupDetail({
                     error={!trimmedName}
                   />
                   {!trimmedName && (
-                    <p className='mt-1.5 text-[var(--text-error)] text-caption'>
-                      Name is required.
-                    </p>
+                    <p className='text-[var(--text-error)] text-caption'>Name is required.</p>
                   )}
                 </SettingRow>
                 <SettingRow label='Description'>
@@ -1679,6 +1668,7 @@ export function GroupDetail({
               />
               <StatusFilterChip value={providerStatusFilter} onChange={setProviderStatusFilter} />
               <Chip
+                flush
                 onClick={() => setProvidersAllowed(filteredProviders, !filteredProvidersAllAllowed)}
                 disabled={filteredProviders.length === 0}
               >
@@ -1832,6 +1822,7 @@ export function GroupDetail({
                     ),
                   }))
                 }
+                flush
                 disabled={filteredPlatformFeatures.length === 0}
               >
                 {platformAllVisible ? 'Deselect All' : 'Select All'}

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -819,14 +819,14 @@ export function GroupDetail({
   const [viewingGroup, setViewingGroup] = useState<PermissionGroup>(group)
   const [editingConfig, setEditingConfig] = useState<PermissionGroupConfig>({ ...group.config })
   const [editingName, setEditingName] = useState(group.name)
-  const [editingDescription, setEditingDescription] = useState(group.description ?? '')
+  const [editingDescription, setEditingDescription] = useState((group.description ?? '').trim())
   const prevGroupIdRef = useRef(group.id)
   if (prevGroupIdRef.current !== group.id) {
     prevGroupIdRef.current = group.id
     setViewingGroup(group)
     setEditingConfig({ ...group.config })
     setEditingName(group.name)
-    setEditingDescription(group.description ?? '')
+    setEditingDescription((group.description ?? '').trim())
   }
 
   /**
@@ -949,10 +949,10 @@ export function GroupDetail({
   const trimmedName = editingName.trim()
   const trimmedDescription = editingDescription.trim()
   const nameChanged = trimmedName !== viewingGroup.name
-  // Compare trimmed on both sides: `name` is trimmed by its contract schema but a
-  // description stored before this PR (or written straight to the API) can still
-  // carry padding, and comparing it raw would leave the form dirty on open with
-  // no way to clear it — Discard restores the same padded value.
+  // `name` is trimmed by its contract schema, but a description stored before this
+  // PR (or written straight to the API) can still carry padding. The buffer is
+  // seeded trimmed and compared against a trimmed baseline, so such a row opens
+  // clean instead of being dirty with no way to clear it.
   const descriptionChanged = trimmedDescription !== (viewingGroup.description ?? '').trim()
   const hasChanges = hasConfigChanges || nameChanged || descriptionChanged
 
@@ -1345,7 +1345,7 @@ export function GroupDetail({
   const handleDiscardConfig = () => {
     setEditingConfig({ ...viewingGroup.config })
     setEditingName(viewingGroup.name)
-    setEditingDescription(viewingGroup.description ?? '')
+    setEditingDescription((viewingGroup.description ?? '').trim())
   }
 
   const handleBack = useCallback(() => {

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -53,6 +53,7 @@ import {
   useRemovePermissionGroupMember,
   useUpdatePermissionGroup,
 } from '@/ee/access-control/hooks/permission-groups'
+import { SettingRow } from '@/ee/components/setting-row'
 import { useBlacklistedProviders } from '@/hooks/queries/allowed-providers'
 import { useOrganizationRoster } from '@/hooks/queries/organization'
 import { useProviderModels } from '@/hooks/queries/providers'
@@ -89,6 +90,19 @@ const CHAT_DEPLOY_AUTH_TYPE_OPTIONS: { value: ShareAuthType; label: string }[] =
 const ALL_CHAT_DEPLOY_AUTH_TYPES: ShareAuthType[] = CHAT_DEPLOY_AUTH_TYPE_OPTIONS.map(
   (o) => o.value
 )
+
+/** Narrows an allow/deny list to entries that are currently on or off. */
+type StatusFilter = 'all' | 'enabled' | 'disabled'
+
+const STATUS_FILTER_OPTIONS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'enabled', label: 'Enabled' },
+  { value: 'disabled', label: 'Disabled' },
+]
+
+function matchesStatusFilter(filter: StatusFilter, enabled: boolean) {
+  return filter === 'all' || (filter === 'enabled') === enabled
+}
 
 interface OrganizationMemberOption {
   userId: string
@@ -521,7 +535,7 @@ function BlockToolRow({
           onClick={() => isBlockAllowed && isExpandable && setExpanded((prev) => !prev)}
           disabled={!isBlockAllowed || !isExpandable}
           className={cn(
-            'flex flex-1 items-center gap-2 text-left',
+            'flex min-w-0 items-center gap-2 text-left',
             isBlockAllowed && isExpandable ? 'cursor-pointer' : 'cursor-default',
             !isBlockAllowed && 'opacity-60'
           )}
@@ -532,15 +546,18 @@ function BlockToolRow({
               {deniedCount} blocked
             </ChipTag>
           )}
-          {isBlockAllowed && isExpandable && (
-            <ChevronDown
-              className={cn(
-                'ml-auto size-[14px] flex-shrink-0 text-[var(--text-icon)] transition-transform',
-                expanded && 'rotate-180'
-              )}
-            />
-          )}
         </button>
+        <Info side='top' className='flex-shrink-0'>
+          {block.description}
+        </Info>
+        {isBlockAllowed && isExpandable && (
+          <ChevronDown
+            className={cn(
+              'ml-auto size-[14px] flex-shrink-0 text-[var(--text-icon)] transition-transform',
+              expanded && 'rotate-180'
+            )}
+          />
+        )}
       </div>
       {expanded && isBlockAllowed && isExpandable && (
         <div className='border-[var(--border)] border-t px-2 pt-2 pb-3'>
@@ -595,11 +612,15 @@ export function GroupDetail({
    */
   const [viewingGroup, setViewingGroup] = useState<PermissionGroup>(group)
   const [editingConfig, setEditingConfig] = useState<PermissionGroupConfig>({ ...group.config })
+  const [editingName, setEditingName] = useState(group.name)
+  const [editingDescription, setEditingDescription] = useState(group.description ?? '')
   const prevGroupIdRef = useRef(group.id)
   if (prevGroupIdRef.current !== group.id) {
     prevGroupIdRef.current = group.id
     setViewingGroup(group)
     setEditingConfig({ ...group.config })
+    setEditingName(group.name)
+    setEditingDescription(group.description ?? '')
   }
 
   /**
@@ -613,6 +634,9 @@ export function GroupDetail({
   const [providerSearchTerm, setProviderSearchTerm] = useState('')
   const [integrationSearchTerm, setIntegrationSearchTerm] = useState('')
   const [platformSearchTerm, setPlatformSearchTerm] = useState('')
+  const [providerStatusFilter, setProviderStatusFilter] = useState<StatusFilter>('all')
+  const [blockStatusFilter, setBlockStatusFilter] = useState<StatusFilter>('all')
+  const [platformStatusFilter, setPlatformStatusFilter] = useState<StatusFilter>('all')
 
   const [showAddMembersModal, setShowAddMembersModal] = useState(false)
   const [addMembersError, setAddMembersError] = useState<string | null>(null)
@@ -742,13 +766,6 @@ export function GroupDetail({
         hint: 'Hide the MCP server deployment option.',
       },
       {
-        id: 'hide-deploy-chatbot',
-        label: 'Chat',
-        category: 'Deploy Tabs',
-        configKey: 'hideDeployChatbot' as const,
-        hint: 'Hide the chatbot deployment option.',
-      },
-      {
         id: 'disable-mcp',
         label: 'MCP Tools',
         category: 'Tools',
@@ -802,12 +819,18 @@ export function GroupDetail({
   )
 
   const filteredPlatformFeatures = useMemo(() => {
-    if (!platformSearchTerm.trim()) return platformFeatures
-    const search = platformSearchTerm.toLowerCase()
-    return platformFeatures.filter(
-      (f) => f.label.toLowerCase().includes(search) || f.category.toLowerCase().includes(search)
-    )
-  }, [platformFeatures, platformSearchTerm])
+    const search = platformSearchTerm.trim().toLowerCase()
+    return platformFeatures.filter((f) => {
+      if (
+        search &&
+        !f.label.toLowerCase().includes(search) &&
+        !f.category.toLowerCase().includes(search)
+      ) {
+        return false
+      }
+      return matchesStatusFilter(platformStatusFilter, !editingConfig[f.configKey])
+    })
+  }, [platformFeatures, platformSearchTerm, platformStatusFilter, editingConfig])
 
   const platformCategories = useMemo(() => {
     const categories: Record<string, typeof platformFeatures> = {}
@@ -844,19 +867,37 @@ export function GroupDetail({
   const hasConfigChanges = useMemo(() => {
     return JSON.stringify(viewingGroup.config) !== JSON.stringify(editingConfig)
   }, [viewingGroup.config, editingConfig])
-  const guard = useSettingsUnsavedGuard({ isDirty: hasConfigChanges })
+
+  const trimmedName = editingName.trim()
+  const trimmedDescription = editingDescription.trim()
+  const hasDetailChanges =
+    trimmedName !== viewingGroup.name || trimmedDescription !== (viewingGroup.description ?? '')
+  const hasChanges = hasConfigChanges || hasDetailChanges
+
+  const guard = useSettingsUnsavedGuard({ isDirty: hasChanges })
 
   const filteredProviders = useMemo(() => {
-    if (!providerSearchTerm.trim()) return allProviderIds
-    const query = providerSearchTerm.toLowerCase()
-    return allProviderIds.filter((id) => id.toLowerCase().includes(query))
-  }, [allProviderIds, providerSearchTerm])
+    const query = providerSearchTerm.trim().toLowerCase()
+    const allowed = editingConfig.allowedModelProviders
+    return allProviderIds.filter((id) => {
+      if (query && !id.toLowerCase().includes(query)) return false
+      return matchesStatusFilter(providerStatusFilter, allowed === null || allowed.includes(id))
+    })
+  }, [
+    allProviderIds,
+    providerSearchTerm,
+    providerStatusFilter,
+    editingConfig.allowedModelProviders,
+  ])
 
   const filteredBlocks = useMemo(() => {
-    if (!integrationSearchTerm.trim()) return visibleBlocks
-    const query = integrationSearchTerm.toLowerCase()
-    return visibleBlocks.filter((b) => b.name.toLowerCase().includes(query))
-  }, [visibleBlocks, integrationSearchTerm])
+    const query = integrationSearchTerm.trim().toLowerCase()
+    const allowed = editingConfig.allowedIntegrations
+    return visibleBlocks.filter((b) => {
+      if (query && !b.name.toLowerCase().includes(query)) return false
+      return matchesStatusFilter(blockStatusFilter, allowed === null || allowed.includes(b.type))
+    })
+  }, [visibleBlocks, integrationSearchTerm, blockStatusFilter, editingConfig.allowedIntegrations])
 
   const filteredCoreBlocks = useMemo(
     () => filteredBlocks.filter((block) => block.category === 'blocks'),
@@ -1139,26 +1180,51 @@ export function GroupDetail({
     }))
   }, [])
 
-  /** Persists the editing buffer. */
+  /** Persists the editing buffer — name/description are only sent when they changed. */
   const handleSaveConfig = useCallback(async () => {
+    if (!trimmedName) return
+    const nextDescription = trimmedDescription || null
     try {
       await updatePermissionGroup.mutateAsync({
         id: viewingGroup.id,
         organizationId,
-        config: editingConfig,
+        ...(hasConfigChanges && { config: editingConfig }),
+        ...(trimmedName !== viewingGroup.name && { name: trimmedName }),
+        ...(trimmedDescription !== (viewingGroup.description ?? '') && {
+          description: nextDescription,
+        }),
       })
-      setViewingGroup((prev) => ({ ...prev, config: editingConfig }))
+      setViewingGroup((prev) => ({
+        ...prev,
+        config: editingConfig,
+        name: trimmedName,
+        description: nextDescription,
+      }))
+      setEditingName(trimmedName)
+      setEditingDescription(trimmedDescription)
     } catch (error) {
-      logger.error('Failed to update config', error)
+      logger.error('Failed to save permission group', error)
       toast.error("Couldn't save changes", {
         description: getErrorMessage(error, 'Please try again in a moment.'),
       })
     }
-  }, [viewingGroup.id, editingConfig, organizationId, updatePermissionGroup])
+  }, [
+    viewingGroup.id,
+    viewingGroup.name,
+    viewingGroup.description,
+    editingConfig,
+    hasConfigChanges,
+    trimmedName,
+    trimmedDescription,
+    organizationId,
+    updatePermissionGroup,
+  ])
 
   const handleDiscardConfig = useCallback(() => {
     setEditingConfig({ ...viewingGroup.config })
-  }, [viewingGroup.config])
+    setEditingName(viewingGroup.name)
+    setEditingDescription(viewingGroup.description ?? '')
+  }, [viewingGroup.config, viewingGroup.name, viewingGroup.description])
 
   const handleBack = useCallback(() => {
     guard.guardBack(onBack)
@@ -1307,10 +1373,11 @@ export function GroupDetail({
         description={viewingGroup.description ?? undefined}
         actions={[
           ...saveDiscardActions({
-            dirty: hasConfigChanges,
+            dirty: hasChanges,
             saving: updatePermissionGroup.isPending,
             onSave: handleSaveConfig,
             onDiscard: handleDiscardConfig,
+            saveDisabled: !trimmedName,
           }),
           {
             text: deletePermissionGroup.isPending ? 'Deleting...' : 'Delete',
@@ -1330,6 +1397,29 @@ export function GroupDetail({
 
         {configTab === 'general' && (
           <>
+            <SettingsSection label='Details'>
+              <div className='flex flex-col gap-4'>
+                <SettingRow label='Name'>
+                  <ChipInput
+                    value={editingName}
+                    onChange={(e) => setEditingName(e.target.value)}
+                    placeholder='e.g., Marketing Team'
+                    maxLength={100}
+                    error={!trimmedName}
+                    className='max-w-[320px]'
+                  />
+                </SettingRow>
+                <SettingRow label='Description'>
+                  <ChipInput
+                    value={editingDescription}
+                    onChange={(e) => setEditingDescription(e.target.value)}
+                    placeholder='e.g., Limited access for marketing users'
+                    maxLength={500}
+                  />
+                </SettingRow>
+              </div>
+            </SettingsSection>
+
             <SettingsSection label='Default group'>
               <div className='flex items-center justify-between gap-3'>
                 <span className='text-[var(--text-muted)] text-small'>
@@ -1457,6 +1547,13 @@ export function GroupDetail({
                 onChange={(e) => setProviderSearchTerm(e.target.value)}
                 className='min-w-0 flex-1'
               />
+              <ChipDropdown
+                value={providerStatusFilter}
+                onChange={(value) => setProviderStatusFilter(value as StatusFilter)}
+                options={STATUS_FILTER_OPTIONS}
+                matchTriggerWidth={false}
+                className='flex-shrink-0'
+              />
               <Chip
                 onClick={() => setProvidersAllowed(filteredProviders, !filteredProvidersAllAllowed)}
               >
@@ -1491,6 +1588,13 @@ export function GroupDetail({
                 onChange={(e) => setIntegrationSearchTerm(e.target.value)}
                 className='min-w-0 flex-1'
               />
+              <ChipDropdown
+                value={blockStatusFilter}
+                onChange={(value) => setBlockStatusFilter(value as StatusFilter)}
+                options={STATUS_FILTER_OPTIONS}
+                matchTriggerWidth={false}
+                className='flex-shrink-0'
+              />
             </div>
             {filteredCoreBlocks.length > 0 && (
               <SettingsSection
@@ -1509,24 +1613,28 @@ export function GroupDetail({
                     const BlockIcon = block.icon
                     const checkboxId = `block-${block.type}`
                     return (
-                      <label
-                        key={block.type}
-                        htmlFor={checkboxId}
-                        className='flex cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
-                      >
-                        <Checkbox
-                          id={checkboxId}
-                          checked={isIntegrationAllowed(block.type)}
-                          onCheckedChange={() => toggleIntegration(block.type)}
-                        />
-                        <div
-                          className='relative flex size-[16px] flex-shrink-0 items-center justify-center overflow-hidden rounded-sm'
-                          style={{ background: block.bgColor }}
+                      <div key={block.type} className='flex items-center gap-1.5'>
+                        <label
+                          htmlFor={checkboxId}
+                          className='flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
                         >
-                          {BlockIcon && <BlockIcon className='!size-[9px] text-white' />}
-                        </div>
-                        <span className='truncate font-medium text-sm'>{block.name}</span>
-                      </label>
+                          <Checkbox
+                            id={checkboxId}
+                            checked={isIntegrationAllowed(block.type)}
+                            onCheckedChange={() => toggleIntegration(block.type)}
+                          />
+                          <div
+                            className='relative flex size-[16px] flex-shrink-0 items-center justify-center overflow-hidden rounded-sm'
+                            style={{ background: block.bgColor }}
+                          >
+                            {BlockIcon && <BlockIcon className='!size-[9px] text-white' />}
+                          </div>
+                          <span className='truncate font-medium text-sm'>{block.name}</span>
+                        </label>
+                        <Info side='top' className='flex-shrink-0'>
+                          {block.description}
+                        </Info>
+                      </div>
                     )
                   })}
                 </div>
@@ -1579,6 +1687,13 @@ export function GroupDetail({
                 onChange={(e) => setPlatformSearchTerm(e.target.value)}
                 className='min-w-0 flex-1'
               />
+              <ChipDropdown
+                value={platformStatusFilter}
+                onChange={(value) => setPlatformStatusFilter(value as StatusFilter)}
+                options={STATUS_FILTER_OPTIONS}
+                matchTriggerWidth={false}
+                className='flex-shrink-0'
+              />
               <Chip
                 onClick={() =>
                   setEditingConfig((prev) => ({
@@ -1620,26 +1735,44 @@ export function GroupDetail({
               </SettingsSection>
             ))}
             <SettingsSection label='Chat'>
-              <div
-                className={cn(
-                  'flex flex-col gap-1.5 px-2 pt-1',
-                  editingConfig.hideDeployChatbot && 'opacity-50'
-                )}
-              >
-                <span className='text-[var(--text-secondary)] text-xs'>
-                  Auth modes chat deployments may use
-                </span>
-                <ChipDropdown
-                  multiple
-                  showAllOption={false}
-                  allLabel='None'
-                  value={chatDeployAuthValue}
-                  onChange={setChatDeployAuthTypes}
-                  options={CHAT_DEPLOY_AUTH_TYPE_OPTIONS}
-                  disabled={editingConfig.hideDeployChatbot}
-                  matchTriggerWidth={false}
-                  className='w-[200px]'
-                />
+              <div className='flex flex-col gap-1.5'>
+                <label
+                  htmlFor='hide-deploy-chatbot'
+                  className='flex cursor-pointer items-center gap-2 rounded-md px-2 py-[5px] transition-colors hover-hover:bg-[var(--surface-active)]'
+                >
+                  <Checkbox
+                    id='hide-deploy-chatbot'
+                    checked={!editingConfig.hideDeployChatbot}
+                    onCheckedChange={(checked) =>
+                      setEditingConfig((prev) => ({
+                        ...prev,
+                        hideDeployChatbot: checked !== true,
+                      }))
+                    }
+                  />
+                  <span className='font-normal text-sm'>Chat Deployment</span>
+                </label>
+                <div
+                  className={cn(
+                    'flex flex-col gap-1.5 px-2 pt-1',
+                    editingConfig.hideDeployChatbot && 'opacity-50'
+                  )}
+                >
+                  <span className='text-[var(--text-secondary)] text-xs'>
+                    Auth modes chat deployments may use
+                  </span>
+                  <ChipDropdown
+                    multiple
+                    showAllOption={false}
+                    allLabel='None'
+                    value={chatDeployAuthValue}
+                    onChange={setChatDeployAuthTypes}
+                    options={CHAT_DEPLOY_AUTH_TYPE_OPTIONS}
+                    disabled={editingConfig.hideDeployChatbot}
+                    matchTriggerWidth={false}
+                    className='w-[200px]'
+                  />
+                </div>
               </div>
             </SettingsSection>
             <SettingsSection label='Files'>

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -749,19 +749,20 @@ function BlockToolRow({
               {deniedCount} blocked
             </ChipTag>
           )}
+          {isBlockAllowed && isExpandable && (
+            <ChevronDown
+              className={cn(
+                'ml-auto size-[14px] flex-shrink-0 text-[var(--text-icon)] transition-transform',
+                expanded && 'rotate-180'
+              )}
+            />
+          )}
         </button>
+        {/* Outside the button: an Info trigger is itself a button and cannot nest. */}
         {block.description && (
           <Info side='top' className='flex-shrink-0'>
             {block.description}
           </Info>
-        )}
-        {isBlockAllowed && isExpandable && (
-          <ChevronDown
-            className={cn(
-              'ml-auto size-[14px] flex-shrink-0 text-[var(--text-icon)] transition-transform',
-              expanded && 'rotate-180'
-            )}
-          />
         )}
       </div>
       {expanded && isBlockAllowed && isExpandable && (

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -766,7 +766,7 @@ function BlockToolRow({
         </button>
         {/* Outside the button: an Info trigger is itself a button and cannot nest. */}
         {block.description && (
-          <Info side='top' className='flex-shrink-0'>
+          <Info side='top' className={cn('flex-shrink-0', !isBlockAllowed && 'opacity-60')}>
             {block.description}
           </Info>
         )}
@@ -824,14 +824,14 @@ export function GroupDetail({
    */
   const [viewingGroup, setViewingGroup] = useState<PermissionGroup>(group)
   const [editingConfig, setEditingConfig] = useState<PermissionGroupConfig>({ ...group.config })
-  const [editingName, setEditingName] = useState(group.name)
+  const [editingName, setEditingName] = useState(group.name.trim())
   const [editingDescription, setEditingDescription] = useState((group.description ?? '').trim())
   const prevGroupIdRef = useRef(group.id)
   if (prevGroupIdRef.current !== group.id) {
     prevGroupIdRef.current = group.id
     setViewingGroup(group)
     setEditingConfig({ ...group.config })
-    setEditingName(group.name)
+    setEditingName(group.name.trim())
     setEditingDescription((group.description ?? '').trim())
   }
 
@@ -954,14 +954,14 @@ export function GroupDetail({
     return JSON.stringify(viewingGroup.config) !== JSON.stringify(editingConfig)
   }, [viewingGroup.config, editingConfig])
 
+  // Both buffers are seeded trimmed and compared against a trimmed baseline. The
+  // contract trims name and description on write, but a row stored before those
+  // schemas gained `.trim()` (or written straight to the API) can still carry
+  // padding — compared raw it would open dirty with no way to clear it, since
+  // Discard restores the same padded value.
   const trimmedName = editingName.trim()
   const trimmedDescription = editingDescription.trim()
-  const nameChanged = trimmedName !== viewingGroup.name
-  // `name` is trimmed by its contract schema, but a description stored before
-  // description trimming was added (or written straight to the API) can still
-  // carry padding. The buffer is
-  // seeded trimmed and compared against a trimmed baseline, so such a row opens
-  // clean instead of being dirty with no way to clear it.
+  const nameChanged = trimmedName !== viewingGroup.name.trim()
   const descriptionChanged = trimmedDescription !== (viewingGroup.description ?? '').trim()
   const hasChanges = hasConfigChanges || nameChanged || descriptionChanged
 
@@ -1353,7 +1353,7 @@ export function GroupDetail({
 
   const handleDiscardConfig = () => {
     setEditingConfig({ ...viewingGroup.config })
-    setEditingName(viewingGroup.name)
+    setEditingName(viewingGroup.name.trim())
     setEditingDescription((viewingGroup.description ?? '').trim())
   }
 

--- a/apps/sim/lib/api/contracts/permission-groups.test.ts
+++ b/apps/sim/lib/api/contracts/permission-groups.test.ts
@@ -4,8 +4,13 @@
 import { describe, expect, it } from 'vitest'
 import {
   createPermissionGroupBodySchema,
+  permissionGroupFullConfigSchema,
   updatePermissionGroupBodySchema,
 } from '@/lib/api/contracts/permission-groups'
+import {
+  DEFAULT_PERMISSION_GROUP_CONFIG,
+  parsePermissionGroupConfig,
+} from '@/lib/permission-groups/types'
 
 describe('createPermissionGroupBodySchema', () => {
   it('accepts a name-only body (scope is resolved and validated server-side)', () => {
@@ -78,5 +83,37 @@ describe('updatePermissionGroupBodySchema', () => {
       workspaceIds: ['ws-1'],
     })
     expect(result.success).toBe(false)
+  })
+})
+
+/**
+ * The access-control group detail view decides whether its config buffer is
+ * dirty by comparing `JSON.stringify(savedConfig)` against
+ * `JSON.stringify(editingConfig)`, and reconciles the saved baseline from the
+ * update response. That only works while every config that reaches the client —
+ * from the list route and from the update route alike — carries the same key
+ * order, which holds because both pass through `parsePermissionGroupConfig` and
+ * then `permissionGroupFullConfigSchema`. If the two ever drift, the detail view
+ * would report unsaved changes forever after a successful save.
+ */
+describe('permissionGroupFullConfigSchema key order', () => {
+  it('matches parsePermissionGroupConfig so a saved config compares equal', () => {
+    const stored = parsePermissionGroupConfig({
+      allowedIntegrations: ['slack'],
+      hideCopilot: true,
+    })
+    const overWire = permissionGroupFullConfigSchema.parse(JSON.parse(JSON.stringify(stored)))
+    expect(JSON.stringify(overWire)).toBe(JSON.stringify(stored))
+  })
+
+  it('keeps an edited client buffer comparable to the server echo', () => {
+    const fromList = permissionGroupFullConfigSchema.parse(
+      JSON.parse(JSON.stringify(parsePermissionGroupConfig(DEFAULT_PERMISSION_GROUP_CONFIG)))
+    )
+    const edited = { ...fromList, hideDeployChatbot: true, deniedTools: ['slack_canvas'] }
+    const serverEcho = permissionGroupFullConfigSchema.parse(
+      JSON.parse(JSON.stringify(parsePermissionGroupConfig(edited)))
+    )
+    expect(JSON.stringify(serverEcho)).toBe(JSON.stringify(edited))
   })
 })

--- a/apps/sim/lib/api/contracts/permission-groups.test.ts
+++ b/apps/sim/lib/api/contracts/permission-groups.test.ts
@@ -117,3 +117,23 @@ describe('permissionGroupFullConfigSchema key order', () => {
     expect(JSON.stringify(serverEcho)).toBe(JSON.stringify(edited))
   })
 })
+
+describe('permission group description trimming', () => {
+  it('trims a padded description on create', () => {
+    const result = createPermissionGroupBodySchema.safeParse({
+      name: 'Engineering',
+      description: '  padded  ',
+    })
+    expect(result.success && result.data.description).toBe('padded')
+  })
+
+  it('trims a padded description on update', () => {
+    const result = updatePermissionGroupBodySchema.safeParse({ description: '  padded  ' })
+    expect(result.success && result.data.description).toBe('padded')
+  })
+
+  it('still accepts a null description on update', () => {
+    const result = updatePermissionGroupBodySchema.safeParse({ description: null })
+    expect(result.success && result.data.description).toBeNull()
+  })
+})

--- a/apps/sim/lib/api/contracts/permission-groups.test.ts
+++ b/apps/sim/lib/api/contracts/permission-groups.test.ts
@@ -102,17 +102,17 @@ describe('permissionGroupFullConfigSchema key order', () => {
       allowedIntegrations: ['slack'],
       hideCopilot: true,
     })
-    const overWire = permissionGroupFullConfigSchema.parse(JSON.parse(JSON.stringify(stored)))
+    const overWire = permissionGroupFullConfigSchema.parse(structuredClone(stored))
     expect(JSON.stringify(overWire)).toBe(JSON.stringify(stored))
   })
 
   it('keeps an edited client buffer comparable to the server echo', () => {
     const fromList = permissionGroupFullConfigSchema.parse(
-      JSON.parse(JSON.stringify(parsePermissionGroupConfig(DEFAULT_PERMISSION_GROUP_CONFIG)))
+      structuredClone(parsePermissionGroupConfig(DEFAULT_PERMISSION_GROUP_CONFIG))
     )
     const edited = { ...fromList, hideDeployChatbot: true, deniedTools: ['slack_canvas'] }
     const serverEcho = permissionGroupFullConfigSchema.parse(
-      JSON.parse(JSON.stringify(parsePermissionGroupConfig(edited)))
+      structuredClone(parsePermissionGroupConfig(edited))
     )
     expect(JSON.stringify(serverEcho)).toBe(JSON.stringify(edited))
   })

--- a/apps/sim/lib/api/contracts/permission-groups.ts
+++ b/apps/sim/lib/api/contracts/permission-groups.ts
@@ -148,7 +148,7 @@ function refineWorkspaceScope(
 export const createPermissionGroupBodySchema = z
   .object({
     name: z.string().trim().min(1).max(100),
-    description: z.string().max(500).optional(),
+    description: z.string().trim().max(500).optional(),
     config: permissionGroupConfigSchema.optional(),
     isDefault: z.boolean().optional(),
     workspaceIds: workspaceIdsSchema.optional(),
@@ -158,7 +158,7 @@ export const createPermissionGroupBodySchema = z
 export const updatePermissionGroupBodySchema = z
   .object({
     name: z.string().trim().min(1).max(100).optional(),
-    description: z.string().max(500).nullable().optional(),
+    description: z.string().trim().max(500).nullable().optional(),
     config: permissionGroupConfigSchema.optional(),
     isDefault: z.boolean().optional(),
     workspaceIds: workspaceIdsSchema.optional(),

--- a/packages/emcn/src/components/chip-dropdown/chip-dropdown.tsx
+++ b/packages/emcn/src/components/chip-dropdown/chip-dropdown.tsx
@@ -76,8 +76,15 @@ interface ChipDropdownBaseProps extends VariantProps<typeof chipVariants> {
    * the component (a field label above it) rather than in the selected value.
    */
   'aria-label'?: string
-  /** Id of the element naming the trigger. Pair with a visible field label. */
+  /**
+   * Ids of the elements naming the trigger. Because `aria-labelledby` REPLACES
+   * the name derived from the trigger's contents, include the trigger's own id
+   * alongside the external label's — `\`${labelId} ${triggerId}\`` — or the
+   * selected value is dropped from the accessible name.
+   */
   'aria-labelledby'?: string
+  /** Id for the trigger button. Needed to reference it from `aria-labelledby`. */
+  id?: string
 }
 
 /**
@@ -177,6 +184,7 @@ const ChipDropdown = forwardRef<HTMLButtonElement, ChipDropdownProps>(
       flush,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
+      id,
     } = props
 
     const isMultiple = props.multiple === true
@@ -294,6 +302,7 @@ const ChipDropdown = forwardRef<HTMLButtonElement, ChipDropdownProps>(
         <DropdownMenuTrigger asChild disabled={disabled}>
           <button
             ref={ref}
+            id={id}
             type='button'
             disabled={disabled}
             aria-label={ariaLabel}

--- a/packages/emcn/src/components/chip-dropdown/chip-dropdown.tsx
+++ b/packages/emcn/src/components/chip-dropdown/chip-dropdown.tsx
@@ -71,6 +71,13 @@ interface ChipDropdownBaseProps extends VariantProps<typeof chipVariants> {
   leftIcon?: ChipIcon
   /** Forwarded class for the trigger button. */
   className?: string
+  /**
+   * Accessible name for the trigger. Use when the visible label sits outside
+   * the component (a field label above it) rather than in the selected value.
+   */
+  'aria-label'?: string
+  /** Id of the element naming the trigger. Pair with a visible field label. */
+  'aria-labelledby'?: string
 }
 
 /**
@@ -168,6 +175,8 @@ const ChipDropdown = forwardRef<HTMLButtonElement, ChipDropdownProps>(
       active,
       fullWidth,
       flush,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
     } = props
 
     const isMultiple = props.multiple === true
@@ -287,6 +296,8 @@ const ChipDropdown = forwardRef<HTMLButtonElement, ChipDropdownProps>(
             ref={ref}
             type='button'
             disabled={disabled}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledBy}
             className={cn(
               chipVariants({ variant, active, fullWidth, flush }),
               hasTriggerBorder && TRIGGER_BORDER_CLASS,


### PR DESCRIPTION
## Summary
- Name and description are now editable from a group's own page — a Details section on the General tab, wired into the existing dirty buffer so Save/Discard and the unsaved-changes guard cover them for free
- Added a Show all / Show enabled / Show disabled filter to the Blocks, Model Providers, and Platform tabs, with an empty state when nothing matches
- Every block row carries an info tooltip with the block's description
- The chat deploy toggle now sits with its allowed-auth-modes dropdown under a Chat section, mirroring Files. Both are ordinary entries in the platform feature registry, so search, filtering, Select All, hints and the empty state apply to them like any other toggle
- `ChipDropdown` gained `aria-label` / `aria-labelledby` / `id` props forwarded to its trigger, so a control labelled by an external field label gets a real accessible name

## Behavior change worth knowing
Public file sharing was previously a bespoke checkbox outside the platform registry, so **Deselect All never touched it**. It is a registry entry now, so Deselect All on the Platform tab also disables it. It fails closed and is visibly listed, but it is a real change in what that button does.

## Type of Change
- [x] Improvement

## Testing
- `tsc --noEmit` clean in `apps/sim` and `packages/emcn`; `lint:check` and all 11 `check:*` gates pass
- 747 tests across `ee/`, `lib/api/contracts/`, `components/settings/`, plus 14 in `packages/emcn`
- Added contract tests locking the config key-order invariant the dirty check relies on (without it a successful save could leave the form permanently dirty) and the description trimming
- Not exercised in a browser — the tooltip column, filter rows and new Chat section have not been visually checked

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
