### PR TITLE
improvement(content): surface last-verified and updated dates, codify citation rules

### DIFF
--- a/.claude/rules/landing-seo-geo.md
+++ b/.claude/rules/landing-seo-geo.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - "apps/sim/app/(landing)/**/*.tsx"
+  - "apps/sim/content/**/*.mdx"
 ---
 
 # Landing Page — SEO / GEO
@@ -24,3 +25,22 @@ paths:
 - **Keyword density**: first 150 visible chars of Hero must name "Sim", "AI workspace", "AI agents".
 - **sr-only summaries**: Hero and Templates each have a `<p className="sr-only">` (~50 words) as an atomic product/catalog summary for AI citation.
 - **Specific numbers**: prefer concrete figures ("1,000+ integrations", "15+ AI providers") over vague claims.
+
+## Citations and linking (`/library`, `/blog`, `/comparisons`)
+
+The Princeton GEO study (Aggarwal et al., KDD 2024, [arXiv:2311.09735](https://arxiv.org/abs/2311.09735)) found that adding citations, quotations, and statistics were the three strongest of nine tested tactics, worth 30–40% relative lifts in AI-answer visibility. Sourcing is also what makes a claim checkable by a human reader.
+
+- **Every third-party factual claim carries an outbound source link.** Pricing, rate limits, feature availability, licensing, compliance certifications — link the primary source (the vendor's own pricing page, docs, changelog, or license file), not a secondary blog. External links get `rel="noopener noreferrer"`.
+- **Prefer the primary source over a roundup.** Citing another vendor's comparison post to substantiate a fact about them is second-hand and ages badly.
+- **Internal links: 3–5 per library post**, pointing at genuinely related library entries, using real `href`s (Next `<Link>` in TSX; a plain markdown link in MDX). A post with zero internal links is a dead end for crawlers and readers alike.
+- **Never fabricate a citation.** An unlinked claim is better than a link that does not substantiate it. If a number cannot be sourced, cut the number.
+
+## Freshness
+
+Answer engines weight recency to avoid repeating stale facts, and a reader deciding whether to trust a pricing comparison wants to know when it was last checked. The vendor-published "fresh content earns Nx more citations" figures are directional, not measured — the reason to do this is that both signals must agree and both must be real.
+
+- **Emit `dateModified`** in the page's structured data (JSON-LD or microdata), and emit it exactly once per document.
+- **Show the same date to the reader.** `/comparisons/[provider]` renders "Last verified …" from `getLatestVerifiedDate()`; `/library` and `/blog` posts render "Updated …" next to the publish date. A date that exists only in metadata is invisible to a reader deciding whether to trust the page.
+- **Only surface a modified date when it differs from the publish date** — an "Updated" label on the publish day is noise.
+- **Bump the date only on a substantive edit.** Touching frontmatter without changing the content is date-washing; it degrades the signal for every other page on the domain.
+- **Comparison facts are dated at the fact level.** Every `Fact` in `apps/sim/lib/compare/data` carries `sources: [{ url, label, asOf }]`. Re-checking a fact means updating its `asOf`, which flows through `getLatestVerifiedDate()` to the visible date, the JSON-LD, and the sitemap.

--- a/apps/sim/app/(landing)/comparisons/[provider]/page.tsx
+++ b/apps/sim/app/(landing)/comparisons/[provider]/page.tsx
@@ -177,20 +177,17 @@ export default async function ComparisonProviderPage({
               Sim is the open-source AI workspace where teams build, deploy, and manage AI agents
               visually, conversationally, or with code. Here is how Sim compares to{' '}
               {competitor.name} on platform architecture, AI capabilities, integrations, pricing,
-              security, and support. Every fact below is sourced and dated.
+              security, and support. Every fact below is sourced and dated, last verified{' '}
+              <time dateTime={latestVerified.toISOString().slice(0, 10)}>
+                {latestVerified.toLocaleDateString('en-US', {
+                  month: 'long',
+                  day: 'numeric',
+                  year: 'numeric',
+                  timeZone: 'UTC',
+                })}
+              </time>
+              .
             </p>
-            <time
-              className='text-[var(--text-muted)] text-xs uppercase tracking-[0.1em]'
-              dateTime={latestVerified.toISOString().slice(0, 10)}
-            >
-              Last verified{' '}
-              {latestVerified.toLocaleDateString('en-US', {
-                month: 'short',
-                day: 'numeric',
-                year: 'numeric',
-                timeZone: 'UTC',
-              })}
-            </time>
             <p className='sr-only'>
               Sim is an open-source AI workspace for building, deploying, and managing AI agents.
               This page compares Sim to {competitor.name} across platform architecture, AI

--- a/apps/sim/app/(landing)/comparisons/[provider]/page.tsx
+++ b/apps/sim/app/(landing)/comparisons/[provider]/page.tsx
@@ -179,6 +179,18 @@ export default async function ComparisonProviderPage({
               {competitor.name} on platform architecture, AI capabilities, integrations, pricing,
               security, and support. Every fact below is sourced and dated.
             </p>
+            <time
+              className='text-[var(--text-muted)] text-xs uppercase tracking-[0.1em]'
+              dateTime={latestVerified.toISOString().slice(0, 10)}
+            >
+              Last verified{' '}
+              {latestVerified.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+                timeZone: 'UTC',
+              })}
+            </time>
             <p className='sr-only'>
               Sim is an open-source AI workspace for building, deploying, and managing AI agents.
               This page compares Sim to {competitor.name} across platform architecture, AI

--- a/apps/sim/app/(landing)/components/content-post-page/content-post-page.tsx
+++ b/apps/sim/app/(landing)/components/content-post-page/content-post-page.tsx
@@ -7,6 +7,16 @@ import { BackLink } from '@/app/(landing)/components/back-link'
 import { JsonLd } from '@/app/(landing)/components/json-ld'
 import { ShareButton } from '@/app/(landing)/components/share-button'
 
+/** Renders an ISO date as "Jul 1, 2026". Pinned to UTC so the day matches the frontmatter date in every reader's timezone. */
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
 interface ContentPostPageProps {
   /** Route base path, e.g. `/blog` or `/library`. */
   basePath: string
@@ -32,6 +42,8 @@ export function ContentPostPage({
   shareUrl,
 }: ContentPostPageProps) {
   const Article = post.Content
+  const modifiedIso = post.updated ?? post.date
+  const showUpdated = modifiedIso.slice(0, 10) !== post.date.slice(0, 10)
 
   return (
     <article className='w-full bg-[var(--bg)]' itemScope itemType='https://schema.org/BlogPosting'>
@@ -74,19 +86,31 @@ export function ContentPostPage({
               </p>
             </div>
             <div className='mt-6 flex items-center gap-6'>
-              <time
-                className='text-[var(--text-muted)] text-xs uppercase tracking-[0.1em]'
-                dateTime={post.date}
-                itemProp='datePublished'
-              >
-                {new Date(post.date).toLocaleDateString('en-US', {
-                  month: 'short',
-                  day: 'numeric',
-                  year: 'numeric',
-                  timeZone: 'UTC',
-                })}
-              </time>
-              <meta itemProp='dateModified' content={post.updated ?? post.date} />
+              <div className='flex items-center gap-2'>
+                <time
+                  className='text-[var(--text-muted)] text-xs uppercase tracking-[0.1em]'
+                  dateTime={post.date}
+                  itemProp='datePublished'
+                >
+                  {formatDate(post.date)}
+                </time>
+                {showUpdated ? (
+                  <>
+                    <span aria-hidden='true' className='text-[var(--text-muted)] text-xs'>
+                      ·
+                    </span>
+                    <time
+                      className='text-[var(--text-muted)] text-xs uppercase tracking-[0.1em]'
+                      dateTime={modifiedIso}
+                      itemProp='dateModified'
+                    >
+                      Updated {formatDate(modifiedIso)}
+                    </time>
+                  </>
+                ) : (
+                  <meta itemProp='dateModified' content={modifiedIso} />
+                )}
+              </div>
               <div className='flex items-center gap-3'>
                 {(post.authors || [post.author]).map((a) => (
                   <div key={a?.name} className='flex items-center gap-2'>
@@ -151,12 +175,7 @@ export function ContentPostPage({
                     </div>
                     <div className='flex flex-col gap-2'>
                       <span className='text-[var(--text-muted)] text-xs uppercase tracking-[0.1em]'>
-                        {new Date(p.date).toLocaleDateString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          year: 'numeric',
-                          timeZone: 'UTC',
-                        })}
+                        {formatDate(p.date)}
                       </span>
                       <h3 className='text-[var(--text-primary)] text-lg leading-tight tracking-[-0.01em]'>
                         {p.title}

--- a/apps/sim/app/(landing)/components/content-post-page/content-post-page.tsx
+++ b/apps/sim/app/(landing)/components/content-post-page/content-post-page.tsx
@@ -85,7 +85,7 @@ export function ContentPostPage({
                 {post.description}
               </p>
             </div>
-            <div className='mt-6 flex items-center gap-6'>
+            <div className='mt-6 flex flex-wrap items-center gap-x-6 gap-y-2'>
               <div className='flex items-center gap-2'>
                 <time
                   className='text-[var(--text-muted)] text-xs uppercase tracking-[0.1em]'


### PR DESCRIPTION
## Summary
- `/comparisons/[provider]` now renders a visible **"Last verified <date>"**. The date already existed — `getLatestVerifiedDate()` computes it from every fact source's `asOf` and it feeds JSON-LD `dateModified` and the sitemap — it just was never shown. Visible date and JSON-LD read the same value, so they can't drift.
- `/library` and `/blog` posts render **"Updated <date>"** next to the publish date, but only when the modified day actually differs. When it doesn't, the existing invisible `<meta itemProp='dateModified'>` stays. It's either/or, so microdata emits `dateModified` exactly once.
- Collapsed three duplicated `toLocaleDateString` blocks in `content-post-page.tsx` into one module-scope `formatDate`. Same UTC pinning, byte-identical output.
- `.claude/rules/landing-seo-geo.md`: added **Citations and linking** and **Freshness** sections, and extended the rule's `paths` to `apps/sim/content/**/*.mdx` — it was scoped to `(landing)/**/*.tsx` only, so a rule about MDX post authoring would never have attached.

### Why
Our library has **zero** third-party outbound citations across 16 posts (~51k words) and averages 1.2 internal links per post, with 6 posts at zero. The Princeton GEO study ([arXiv:2311.09735](https://arxiv.org/abs/2311.09735), KDD 2024) found citations, quotations, and statistics were the three strongest of nine tested tactics for AI-answer visibility. This PR ships the freshness half (the code) and codifies the citation half (the rule) — actually backfilling citations into the 16 posts is follow-up work, as is the content-generation prompt change.

## Type of Change
- [x] Improvement

## Testing
Verified against a dev server on the final tree:

| Route | Visible | microdata `dateModified` |
|---|---|---|
| `/comparisons/n8n` | `Last verified Jul 13, 2026` | 0 (JSON-LD only, correct) |
| `/comparisons/zapier` | `Last verified …` | 0 |
| `/library/best-zapier-alternatives` | — (dates equal) | 1 (meta fallback) |
| `/blog/series-a` | published only | 1 |

Both branches exercised by temporarily bumping `updated` on two different posts (reverted):

```
Jul 13, 2026 · Updated Jul 21, 2026
microdata dateModified = 1
JSON-LD  "dateModified":"2026-07-21T00:00:00.000Z"
```

Visible date, microdata, and JSON-LD all agree.

Gates: `tsc --noEmit` 0 errors repo-wide; `biome check` clean; all 10 `check:*` gates pass (`boundaries`, `api-validation:strict`, `realtime-prune`, `zustand-v5`, `react-query`, `client-boundary`, `utils`, `bare-icons`, `icon-paths`, `migrations`).

**Not visually screenshotted** — the browser tooling wasn't available in this session. Markup and tokens are verified from rendered HTML and reuse the exact classes already in those rows, but the pixels haven't been eyeballed. Worth a glance.

**Note:** the library "Updated" label renders on zero pages today — all 24 posts currently have `updated == date`. It activates on the first substantive content refresh. Only `/comparisons/*` shows a date right now.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/simstudioai/codesmith/sim/pr/5904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787440904&installation_model_id=7445&pr_number=5904&repository=simstudioai%2Fsim&return_to=https%3A%2F%2Fgithub.com%2Fsimstudioai%2Fsim%2Fpull%2F5904&signature=35b495b1ef6fb8b68f6e474d45412dc6af0e1b2a0f8aaf42e0a8a23ff0680a55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->