### PR TITLE
fix(landing): lead enterprise summary with Sim so product schema names the module

### DIFF
--- a/apps/sim/app/(landing)/enterprise/enterprise.tsx
+++ b/apps/sim/app/(landing)/enterprise/enterprise.tsx
@@ -62,7 +62,7 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
     description:
       'Build, deploy, and govern enterprise AI agents with role-based access, approvals, and full audit trails.',
     summary:
-      'An enterprise AI agent uses AI models, business data, and connected tools to complete multi-step work within the permissions, approval policies, and human oversight your organization defines. Sim is the open-source AI workspace where IT, operations, and technical teams build, deploy, and govern enterprise AI agents across 1,000+ integrations and every major LLM.',
+      'Sim is the open-source AI workspace where IT, operations, and technical teams build, deploy, and govern enterprise AI agents across 1,000+ integrations and every major LLM. An enterprise AI agent uses AI models, business data, and connected tools to complete multi-step work within the permissions, approval policies, and human oversight your organization defines.',
     /**
      * The shared {@link PlatformHeroVisual} backdrop-plus-demo-window
      * composition, filled by the {@link EnterprisePlatformLoop} - a sibling of


### PR DESCRIPTION
## Summary
Follow-up to #5906 — this fix was pushed after that PR was merged, so it missed the merge.

- `SolutionsStructuredData` reuses `hero.summary` as the enterprise `WebApplication.description`. #5906 prepended the "An enterprise AI agent uses…" definition to that summary, so the product schema led with a generic concept definition instead of naming Sim — inconsistent with every other solutions page and a violation of the entity-consistency GEO rule ("always write 'Sim' by name").
- Reorders the two sentences so the summary (and therefore the product schema) leads with "Sim is the open-source AI workspace where…", with the definition kept as the second sentence for AI-citation value.
- Copy-only; no visible change (the summary is `sr-only`).

Caught by Cursor Bugbot on #5906.

## Type of Change
- [x] Bug fix

## Testing
Typecheck and lint pass. Copy-only change to one string.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)