### PR TITLE
improvement(landing): close remaining SEO keyword gaps on home and enterprise

### DIFF
--- a/apps/sim/app/(landing)/components/features/features.tsx
+++ b/apps/sim/app/(landing)/components/features/features.tsx
@@ -67,7 +67,7 @@ export function Features() {
           title='Build agents that solve real problems.'
           description="Wire blocks, models, and integrations into agent logic on Sim's visual builder, from one agent to many working in parallel."
           href='/workflows'
-          linkLabel='Explore the workflow builder'
+          linkLabel='Explore the AI workflow builder'
         >
           <BuildCallout />
         </FeatureCard>

--- a/apps/sim/app/(landing)/enterprise/enterprise.tsx
+++ b/apps/sim/app/(landing)/enterprise/enterprise.tsx
@@ -60,7 +60,7 @@ const ENTERPRISE_CONFIG: SolutionsPageConfig = {
   hero: {
     heading: 'Sim is the AI workspace for enterprise AI agents.',
     description:
-      'Build, deploy, and govern enterprise AI agents with role-based access, approvals, and full audit trails.',
+      'The enterprise AI agent platform. Build, deploy, and govern agents with role-based access, approvals, and full audit trails.',
     summary:
       'Sim is the open-source AI workspace where IT, operations, and technical teams build, deploy, and govern enterprise AI agents across 1,000+ integrations and every major LLM. An enterprise AI agent uses AI models, business data, and connected tools to complete multi-step work within the permissions, approval policies, and human oversight your organization defines.',
     /**


### PR DESCRIPTION
## Summary
Closes the last two target-keyword gaps left after the hero density fixes (#5906, #5910), for a net **+22 characters** across both pages — no new paragraphs, no layout change.

- **Enterprise hero description** — `enterprise ai agent platform` was living only in the `<title>`, with no on-page heading or body copy containing the exact phrase. Reworded the description to lead with it, mirroring the homepage's two-part rhythm. The H1 is untouched.
  - Before: `Build, deploy, and govern enterprise AI agents with role-based access, approvals, and full audit trails.` (104 chars)
  - After: `The enterprise AI agent platform. Build, deploy, and govern agents with role-based access, approvals, and full audit trails.` (124 chars, still one paragraph)
- **Homepage Features link label** — `Explore the workflow builder` → `Explore the AI workflow builder` (+3 chars) so the priority keyword `ai workflow builder` appears as an exact phrase in anchor text.

Note: the first attempt folded both homepage keywords into one phrase ("AI agent **and** workflow builder"), which silently broke the contiguous `ai agent builder` match without forming `ai workflow builder`. Splitting them across two existing strings covers both exactly and reads better.

## Keyword coverage after this change
| Page | Keyword | Status |
|---|---|---|
| Enterprise | enterprise ai agents / enterprise ai agent | covered |
| Enterprise | enterprise ai agent platform | **now covered** (hero) |
| Enterprise | enterprise workflow agents | covered (deploy H2) |
| Home | ai workspace | covered (H1 / title / meta) |
| Home | ai agent builder | covered (product demo) |
| Home | ai workflow builder | **now covered** (Features link) |
| Home | ai agents platform | not covered — awkward phrasing, deliberately skipped |

## Type of Change
- [x] Improvement

## Testing
Typecheck and lint pass. Copy-only; two string changes. Verified exact-phrase coverage across each page's rendered components and metadata.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)