### PR TITLE
improvement(library): add citations and internal links, correct stale pricing

### DIFF
--- a/apps/sim/content/library/ai-agent-ideas/index.mdx
+++ b/apps/sim/content/library/ai-agent-ideas/index.mdx
@@ -3,7 +3,7 @@ slug: ai-agent-ideas
 title: '10 AI Agent Ideas for Real Impact: Get Started With Sim'
 description: Explore practical AI agent ideas you can build today to automate real workflows. From email triage to lead enrichment, discover use cases that deliver fast, measurable impact.
 date: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-23
 authors:
   - emir
 readingTime: 14
@@ -212,3 +212,5 @@ The gap between "AI agents sound useful" and "we have an agent running in produc
 The teams seeing the best results in 2026 aren't building grand autonomous systems. They're prioritizing task-specific, governed AI agents that integrate with real business systems rather than broad autonomous experimentation. They're starting narrow, proving value, and expanding.
 
 Pick the idea that matches your team's biggest pain point. Open Sim, build the workflow, and deploy your first agent today. You'll learn more in that first hour of building than in another month of reading about what's possible.
+
+Not sure an agent is the right shape for your problem? [AI agent vs chatbot](/library/ai-agent-vs-chatbot) draws the line, and [AI agents vs RPA](/library/ai-agents-vs-rpa) covers where rule-based automation still wins. When you're ready to build, [how to build AI agents](/library/how-to-create-an-ai-agent) is the step-by-step, and [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) compares where to build it.

--- a/apps/sim/content/library/ai-agent-vs-chatbot/index.mdx
+++ b/apps/sim/content/library/ai-agent-vs-chatbot/index.mdx
@@ -3,7 +3,7 @@ slug: ai-agent-vs-chatbot
 title: 'AI Agent vs Chatbot: Understanding the Differences'
 description: Understand the key differences between AI agents vs chatbots, from architecture to real-world use cases. Learn when to use each and how to choose the right approach for your workflows.
 date: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-23
 authors:
   - emir
 readingTime: 13
@@ -212,3 +212,5 @@ If your workflow requires multi-step reasoning, cross-system coordination, or ac
 AI agents are moving from experimental to expected across enterprise teams, and the adoption curve is steep. For your team, the question isn't whether to bring agents in; it's where to start.
 
 Pick one workflow that's currently breaking down: reports that take hours to compile manually, and employee onboarding sequences that require five people to coordinate. Build an agent for that, prove ROI, then expand from there.
+
+For the adjacent comparison, [AI agents vs RPA](/library/ai-agents-vs-rpa) covers rule-based automation rather than conversational tools. If you've decided an agent is what you need, [10 AI agent ideas](/library/ai-agent-ideas) has starting points, [how to build AI agents](/library/how-to-create-an-ai-agent) walks through the first one, and [the best AI agents for customer support automation](/library/best-ai-agents-for-customer-support-automation) goes deep on the support use case specifically.

--- a/apps/sim/content/library/ai-agents-vs-rpa/index.mdx
+++ b/apps/sim/content/library/ai-agents-vs-rpa/index.mdx
@@ -3,7 +3,7 @@ slug: ai-agents-vs-rpa
 title: 'AI Agents vs RPA: When to Use Each for Enterprise Automation'
 description: Understand the key differences between AI agents vs RPA, from rule-based automation to intelligent decision-making. Learn when to use each and how to combine both for scalable workflows.
 date: 2026-06-29
-updated: 2026-06-29
+updated: 2026-07-23
 authors:
   - emir
 readingTime: 13
@@ -145,7 +145,7 @@ Use AI agents when:
 
 No. And framing the question that way misses the market reality entirely.
 
-The global RPA market was estimated at $4.68 billion in 2025 and is projected to grow at a CAGR of 29% through 2033, according to Grand View Research. That's not a dying market. RPA is growing alongside AI agent adoption because the two technologies solve different problems. Every enterprise has structured, high-volume, rule-based processes that RPA handles very well.
+The global RPA market was estimated at $4.68 billion in 2025 and is projected to reach $35.84 billion by 2033, a CAGR of 29.0%, [according to Grand View Research](https://www.grandviewresearch.com/industry-analysis/robotic-process-automation-rpa-market). That's not a dying market. RPA is growing alongside AI agent adoption because the two technologies solve different problems. Every enterprise has structured, high-volume, rule-based processes that RPA handles very well.
 
 ## When to Combine Both: The Hybrid Automation Architecture
 
@@ -222,3 +222,5 @@ This is also when governance frameworks need to mature:
 The AI agents vs RPA question isn't really a versus at all. RPA gives you consistent, auditable execution on structured tasks and legacy systems. AI agents give you reasoning, adaptability, and the ability to handle the messy, variable work that RPA was never designed for. Trying to solve every automation problem with just one of these tools means you're either over-engineering simple tasks or leaving complex processes stuck in manual mode.
 
 The practical path forward: audit where your current RPA bots hand off to humans, deploy AI agents at those specific seams, and build the integration layer that lets both technologies work as a single system. Start small, prove the hybrid model on one or two high-value workflows, and scale from there.
+
+If you're at the stage of picking a platform for the agent half of that stack, [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) compares the options. For the distinction one level down, [AI agent vs chatbot](/library/ai-agent-vs-chatbot) covers where conversational tools stop and agents begin, and [how to build AI agents](/library/how-to-create-an-ai-agent) walks through a first build.

--- a/apps/sim/content/library/apache-2-0-vs-fair-code/index.mdx
+++ b/apps/sim/content/library/apache-2-0-vs-fair-code/index.mdx
@@ -3,7 +3,7 @@ slug: apache-2-0-vs-fair-code
 title: "Apache 2.0 vs Fair-Code: Why Sim's License Beats n8n's for Self-Hosting"
 description: Apache 2.0 vs n8n's fair-code Sustainable Use License - what OSI open source actually means, what each license permits for self-hosting, embedding, and resale, and how Sim, n8n, Dify, and Zapier compare.
 date: 2026-07-14
-updated: 2026-07-14
+updated: 2026-07-23
 authors:
   - andrew
 readingTime: 9
@@ -39,19 +39,19 @@ If "open source" is part of your decision, the license is the detail that decide
 
 ## What "open source" actually means
 
-The term has a formal definition maintained by the Open Source Initiative. To qualify, a license must allow free use, modification, and redistribution with no restriction on the field of use, commercial use included. Apache 2.0, MIT, GPL, and MPL all clear that bar. Under any of them you can run the software for any purpose, including building a competing product, and no one can revoke that right later.
+The term has a [formal definition](https://opensource.org/osd) maintained by the Open Source Initiative. To qualify, a license must allow free use, modification, and redistribution with no restriction on the field of use, commercial use included. Apache 2.0, MIT, GPL, and MPL all clear that bar. Under any of them you can run the software for any purpose, including building a competing product, and no one can revoke that right later.
 
 "Source available" is a different thing. You can read the code and often modify it, but the license attaches conditions an OSI-approved license would not permit. The code sits on GitHub, which feels open, but the legal rights are narrower than the label suggests.
 
 ## Fair-code and the Sustainable Use License
 
-"Fair-code" is a term n8n popularized. It is not an OSI category. n8n's core ships under the Sustainable Use License, which grants broad rights for internal business use and self-hosting but restricts using the software to offer a competing hosted service or to redistribute it as a commercial product.
+"Fair-code" is a term n8n popularized. It is not an OSI category. n8n's core ships under the [Sustainable Use License](https://docs.n8n.io/privacy-and-security/sustainable-use-license) ([full text in the repo](https://github.com/n8n-io/n8n/blob/master/LICENSE.md)), which grants broad rights for internal business use and self-hosting but restricts using the software to offer a competing hosted service or to redistribute it as a commercial product.
 
 That model is legitimate and widely adopted. n8n uses it to stop cloud providers from wrapping the open code and reselling it at scale, which is a real commercial risk permissive licenses do nothing about. Calling fair-code a lesser license misreads it. It solves a different problem than Apache 2.0 does, and for a team automating its own operations, the internal-use grant covers everything they need. The distinction only turns decisive when your plans cross the line the license draws.
 
 ## What Apache 2.0 unlocks that fair-code restricts
 
-Apache 2.0 permits four things the Sustainable Use License holds back, and each maps to a concrete plan.
+[Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) permits four things the Sustainable Use License holds back, and each maps to a concrete plan.
 
 **Run it as a multi-tenant service.** Spin up one Sim deployment, put separate customer workspaces on it, charge for access, and Apache 2.0 permits that with no commercial conversation. Hosting the product as a paid multi-tenant service for other people is the exact use a fair-code license carves out.
 
@@ -129,3 +129,5 @@ The right license depends on what you plan to do with the software, not on which
 - **Automating internal deterministic workflows and never reselling or multi-tenanting?** n8n's Sustainable Use License permits exactly that, and its community edition is the right starting point.
 
 For the Sim path, [start with `npx simstudio`](https://sim.ai) to run locally, then move to Docker or Kubernetes for production. For internal-automation-only, n8n's community edition covers the job without cost or friction.
+
+If licensing is what pushed you to look elsewhere, [10 best n8n alternatives](/library/n8n-alternatives) and [open-source AI agent platforms](/library/open-source-ai-agent-platforms) both compare the field with license terms called out explicitly.

--- a/apps/sim/content/library/best-ai-agent-platforms-2026/index.mdx
+++ b/apps/sim/content/library/best-ai-agent-platforms-2026/index.mdx
@@ -3,7 +3,7 @@ slug: best-ai-agent-platforms-2026
 title: "Best AI Agent Platforms in 2026: A Comparison of 11 Tools"
 description: A comparison of eleven AI agent platforms - Sim, n8n, Zapier, Make, Gumloop, Vellum, MindStudio, Dust, Kore.ai, Rasa, and Lindy - scored against deployment model, license, observability, multi-LLM flexibility, and agent lifecycle control.
 date: 2026-07-16
-updated: 2026-07-16
+updated: 2026-07-23
 authors:
   - andrew
 readingTime: 10
@@ -69,7 +69,7 @@ The honest limitation: that number is well behind Zapier's 8,000+ and Make's 1,0
 
 ## n8n
 
-n8n calls itself a fair-code platform, and that word matters more than the "open" label most people assume. It ships under the Sustainable Use License and a separate Enterprise License, not Apache 2.0. You can read the source, self-host it, and write custom nodes, but the license restricts commercial resale and reserves some features for paid tiers.
+[n8n](https://n8n.io/pricing/) calls itself a fair-code platform, and that word matters more than the "open" label most people assume. It ships under the [Sustainable Use License](https://docs.n8n.io/privacy-and-security/sustainable-use-license) and a separate Enterprise License, not Apache 2.0. You can read the source, self-host it, and write custom nodes, but the license restricts commercial resale and reserves some features for paid tiers.
 
 The self-hosting story is strong. You start with `npx n8n` or a Docker image, reach the editor at `localhost:5678`, and connect to more than 1,500 integrations plus an HTTP node for any other API. Model choice stays open across OpenAI, Anthropic, Google, and self-hosted options like Ollama, and switching providers doesn't force you to rebuild a workflow.
 
@@ -81,7 +81,7 @@ n8n is the most mature self-hosted option in this comparison and the community a
 
 ## Zapier
 
-Zapier turned its Zaps automation product into AI task execution through Zapier Agents, currently in open beta, and the whole thing runs on prompt configuration alone. There is no agent SDK and no programmatic way to define an agent, so what you can build stops at what the UI form accepts. The Platform CLI exists only for building app integrations, not agents.
+[Zapier](https://zapier.com/pricing) turned its Zaps automation product into AI task execution through Zapier Agents, currently in open beta, and the whole thing runs on prompt configuration alone. There is no agent SDK and no programmatic way to define an agent, so what you can build stops at what the UI form accepts. The Platform CLI exists only for building app integrations, not agents.
 
 The integration breadth is genuinely hard to match, and for many teams it's the only criterion that matters. Zapier connects to 8,000+ apps and exposes 30,000+ actions, with native connectors to Box, Dropbox, Google Drive, and Notion that pull live data into an agent's context. If your bottleneck is reaching data spread across dozens of SaaS tools, few platforms beat it.
 
@@ -91,7 +91,7 @@ That breadth sits on top of thin agent controls. You cannot chat with a Zapier A
 
 ## Make
 
-Make.com launched its AI Agents capability in April 2025, and the design choice shows in what it does well and what it skips. Make built agents into its existing scenario builder, so an agent runs as another step inside a workflow rather than as a standalone runtime. That approach suits teams already automating processes across Make's 1,000+ app integrations, and it keeps everything inside one visual builder, which is one of the better ones in this category.
+[Make.com](https://www.make.com/en/pricing) launched its AI Agents capability in April 2025, and the design choice shows in what it does well and what it skips. Make built agents into its existing scenario builder, so an agent runs as another step inside a workflow rather than as a standalone runtime. That approach suits teams already automating processes across Make's 1,000+ app integrations, and it keeps everything inside one visual builder, which is one of the better ones in this category.
 
 The gaps appear when you compare Make against platforms built for agents first. A third-party feature comparison marks Make.com as lacking memory and context handling, meaning agents do not retain state across interactions. The same table shows no hosted dev or production environments and no explainability features. You get detailed execution logs for troubleshooting, but not a versioned staging-to-production path.
 
@@ -101,7 +101,7 @@ Make also deploys agents on a schedule rather than exposing them as an API, a ch
 
 ## Gumloop
 
-Gumloop builds for business teams that want to skip the engineering queue. Its clearest strength is native Microsoft Teams deployment. Agents live inside Teams channels, respond to @mentions, pull data, generate reports, and run multi-step actions from plain-language prompts. For an operations lead or support manager who already runs the day inside Teams, that removes the usual gap between a request and an automated response.
+[Gumloop](https://www.gumloop.com/pricing) builds for business teams that want to skip the engineering queue. Its clearest strength is native Microsoft Teams deployment. Agents live inside Teams channels, respond to @mentions, pull data, generate reports, and run multi-step actions from plain-language prompts. For an operations lead or support manager who already runs the day inside Teams, that removes the usual gap between a request and an automated response.
 
 The enterprise controls back this up. Gumloop offers role-based access, single sign-on, and audit logging, which are the boxes IT needs checked before a non-technical team touches customer or finance data.
 
@@ -160,3 +160,5 @@ Zapier and Make win on integration breadth, so choose them when you already run 
 If deployment monitoring and command over running agents are what decide the purchase, Sim is built for that specific problem, and Logs, Chat, and Tables handle lifecycle work you'd otherwise stitch together yourself.
 
 [Start building on Sim](https://sim.ai) or [self-host from the repo](https://github.com/simstudioai/sim).
+
+Narrowing by a specific constraint? [Open-source AI agent platforms](/library/open-source-ai-agent-platforms) filters to self-hostable options, [LangGraph alternatives](/library/langgraph-alternatives) covers the code-first category, [10 best n8n alternatives](/library/n8n-alternatives) and [best Zapier alternatives](/library/best-zapier-alternatives) approach the same market from the automation-tool side.

--- a/apps/sim/content/library/best-ai-agents-for-customer-support-automation/index.mdx
+++ b/apps/sim/content/library/best-ai-agents-for-customer-support-automation/index.mdx
@@ -75,7 +75,7 @@ Whether you choose draft-and-approve or full autonomy separates most buyers. A d
 
 ## n8n for technical teams building custom support workflows
 
-n8n is the pick for technical teams that want node-based control over every branch of a support workflow. Its execution engine has matured over years of production use, and its node library covers hundreds of services with the granular parameter control that engineers expect. When you need a support automation with custom error handling, conditional retries, and precise data transformations between a helpdesk and a CRM, n8n gives you the primitives to build exactly what you want.
+[n8n](https://n8n.io/pricing/) is the pick for technical teams that want node-based control over every branch of a support workflow. Its execution engine has matured over years of production use, and its node library covers hundreds of services with the granular parameter control that engineers expect. When you need a support automation with custom error handling, conditional retries, and precise data transformations between a helpdesk and a CRM, n8n gives you the primitives to build exactly what you want.
 
 The template ecosystem shortens the path from blank canvas to working flow. You can pull a community workflow for ticket enrichment or Slack escalation, then rewire it to your stack rather than starting from scratch. For a team comfortable reading and editing node graphs, that flexibility pays off across every automation you build after the first.
 
@@ -85,7 +85,7 @@ The main concession is the build curve. n8n provides native nodes for assembling
 
 ## Zapier for teams that want the largest app catalog
 
-Zapier wins on catalog breadth, and that alone explains why so many support teams default to it. With more than 9,000 app connections, Zapier almost certainly already talks to the tools your support stack runs, whether that means Zendesk, Salesforce, Slack, or a survey tool nobody else supports. When your goal is wiring one event to another action across a sprawling SaaS stack, Zapier's coverage means you rarely hit a dead end where an integration simply doesn't exist.
+[Zapier](https://zapier.com/pricing) wins on catalog breadth, and that alone explains why so many support teams default to it. With more than 9,000 app connections, Zapier almost certainly already talks to the tools your support stack runs, whether that means Zendesk, Salesforce, Slack, or a survey tool nobody else supports. When your goal is wiring one event to another action across a sprawling SaaS stack, Zapier's coverage means you rarely hit a dead end where an integration simply doesn't exist.
 
 That breadth pairs with a build model most ops people can pick up in an afternoon. Zapier's trigger-and-action Zaps read like plain sentences, and a support-ops lead with no coding background can ship a working automation the same day. For teams already standardized on Zapier across marketing and sales ops, adding a few support automations costs almost nothing in learning curve.
 
@@ -105,7 +105,7 @@ That difference defines who Make fits. If your support automation is mostly dete
 
 ## Gumloop for ops teams automating support workflows with templates
 
-Gumloop earns its place for ops-led teams that measure success in weeks, not months. Its template library ships with pre-built support workflows you can clone and adjust, so an operations lead can stand up a triage-to-routing flow without hiring an engineer or learning a node graph from scratch. For support-ops buyers specifically, that head start matters, because most of them own the ticketing process but not the codebase.
+[Gumloop](https://www.gumloop.com/pricing) earns its place for ops-led teams that measure success in weeks, not months. Its template library ships with pre-built support workflows you can clone and adjust, so an operations lead can stand up a triage-to-routing flow without hiring an engineer or learning a node graph from scratch. For support-ops buyers specifically, that head start matters, because most of them own the ticketing process but not the codebase.
 
 The template approach shapes the whole product. Gumloop's UX assumes you want to configure existing patterns rather than design new ones, and it rewards that assumption with clean workflows and quick wins for common tasks like feedback intake, tagging, and handoffs to a helpdesk. If your team already knows the shape of the automation you need and just wants it running, Gumloop gets you there faster than tools that make you design from a blank canvas.
 
@@ -143,3 +143,5 @@ Ops-led teams optimizing existing workflows should start with Zapier or Gumloop.
 Enterprise teams that need governance and scale should weigh Sim's self-hosting against their own compliance requirements. Running the workspace inside your own infrastructure keeps customer conversations and Knowledge Base contents on hardware you control, and deploying the same workflow as an API, hosted chat interface, or MCP tool lets one governed agent serve multiple support surfaces without duplicate builds.
 
 Start where the friction is lowest. Open a hosted account at [sim.ai](https://sim.ai) to start building a triage agent, or self-host through Docker if your policy requires it. Gumloop's template library is the fastest route if you want a working support flow before you commit to a full build.
+
+Related reading: [AI agent vs chatbot](/library/ai-agent-vs-chatbot) explains why a support agent is a different thing from a support chatbot, [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) compares the platforms behind these builds, and [how to build AI agents](/library/how-to-create-an-ai-agent) is the general walkthrough.

--- a/apps/sim/content/library/best-ai-agents-for-data-extraction-and-rag-in-2026/index.mdx
+++ b/apps/sim/content/library/best-ai-agents-for-data-extraction-and-rag-in-2026/index.mdx
@@ -3,7 +3,7 @@ slug: best-ai-agents-for-data-extraction-and-rag-in-2026
 title: 'Best AI Agents for Data Extraction and RAG in 2026'
 description: Compare the best AI agents for document extraction, SQL queries, spreadsheet analysis, and RAG over internal documents in 2026. See how Sim, n8n, Zapier, Make, and Gumloop handle data workflows.
 date: 2026-07-01
-updated: 2026-07-01
+updated: 2026-07-23
 authors:
   - andrew
 readingTime: 19
@@ -59,11 +59,11 @@ Yes, AI agents can turn plain-English questions into SQL, but the quality depend
 
 Mothership extends the same grounding to the build step. It holds context across every table in the workspace, so a request like "create a CRM table, seed it with my existing leads, and schedule a daily sync" produces the table, the rows, and the workflow in one pass. No competitor on this list ships an equivalent.
 
-n8n exposes native database nodes for Postgres, MySQL, and others, and you can pair them with an AI node that drafts SQL. The catch is that you assemble the schema-passing step yourself, often by querying the information schema and piping it into the prompt. n8n gives you full control, but a non-technical user still needs to understand SQL well enough to debug what the model generates.
+[n8n](https://n8n.io/pricing/) exposes native database nodes for Postgres, MySQL, and others, and you can pair them with an AI node that drafts SQL. The catch is that you assemble the schema-passing step yourself, often by querying the information schema and piping it into the prompt. n8n gives you full control, but a non-technical user still needs to understand SQL well enough to debug what the model generates.
 
-Zapier and Make both connect to databases, yet neither treats natural-language querying as a first-class feature. In Zapier, you typically trigger on a row or run a pre-written query, and the AI steps summarize results rather than compose SQL against a live schema. Make lets you build the query flow visually with granular control over each database call, but a non-technical user hits a wall the moment the logic needs a hand-written WHERE clause or a JOIN the visual builder does not template.
+[Zapier](https://zapier.com/pricing) and [Make](https://www.make.com/en/pricing) both connect to databases, yet neither treats natural-language querying as a first-class feature. In Zapier, you typically trigger on a row or run a pre-written query, and the AI steps summarize results rather than compose SQL against a live schema. Make lets you build the query flow visually with granular control over each database call, but a non-technical user hits a wall the moment the logic needs a hand-written WHERE clause or a JOIN the visual builder does not template.
 
-Gumloop leans on AI-specific nodes and can generate queries as part of a data flow, though it still expects you to wire the database connection and supply schema context for reliable output. It stays closer to plain English than Zapier or Make, but you are still stitching retrieval logic together.
+[Gumloop](https://www.gumloop.com/pricing) leans on AI-specific nodes and can generate queries as part of a data flow, though it still expects you to wire the database connection and supply schema context for reliable output. It stays closer to plain English than Zapier or Make, but you are still stitching retrieval logic together.
 
 The practical divide is where the plain-English experience ends. Sim keeps it end to end because Tables carry the schema the agent needs. The integration platforms get you a working query, and they push the schema-grounding and SQL debugging back onto whoever built the flow.
 
@@ -115,7 +115,7 @@ Pick n8n when you want to run the whole thing on your own infrastructure and you
 
 The second reason is the Code node. n8n lets you drop JavaScript or Python into any step, which means you can assemble a RAG pipeline exactly the way you want it by wiring a vector database, an embedding call, and a retrieval query together by hand. You give up the native Knowledge Base that Sim provides, but you gain full control over chunking, indexing, and which model touches your data.
 
-The third reason is momentum. If your team has already built dozens of n8n workflows and your operations run through them, adding light document extraction or a database query to an existing flow costs less than migrating to an agent-native platform. Stay with n8n when self-hosting, custom code, and prior investment matter more than having retrieval built in. See the [full OpenAI AgentKit vs n8n vs Sim comparison](https://www.sim.ai/library/openai-vs-n8n-vs-sim) for a deeper breakdown.
+The third reason is momentum. If your team has already built dozens of n8n workflows and your operations run through them, adding light document extraction or a database query to an existing flow costs less than migrating to an agent-native platform. Stay with n8n when self-hosting, custom code, and prior investment matter more than having retrieval built in. See the [full OpenAI AgentKit vs n8n vs Sim comparison](/library/openai-vs-n8n-vs-sim) for a deeper breakdown.
 
 ## Choose Zapier when
 
@@ -148,3 +148,5 @@ Sim's Knowledge Bases handle semantic retrieval with connector sync across 50+ s
 Sim is Apache 2.0 licensed and self-hostable through Docker or Kubernetes, and the cloud platform is [SOC 2 compliant](https://www.sim.ai/blog/enterprise), so regulated teams can keep documents inside their own infrastructure without giving up the native primitives.
 
 Pick Sim when you'd otherwise spend more time assembling a vector database, a parsing service, and a data store than building the actual agent logic. Teams shipping RAG-heavy agents feel this most, since every external dependency adds a failure point and a sync problem to debug. If retrieval and extraction are the product, start at [Sim](https://sim.ai) and add integrations only where its native pieces fall short.
+
+For the wider field, [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) ranks platforms on general agent capability, [open-source AI agent platforms](/library/open-source-ai-agent-platforms) covers the self-hostable subset, and [how to build AI agents](/library/how-to-create-an-ai-agent) walks through assembling a first workflow.

--- a/apps/sim/content/library/best-ai-agents-sales-crm-automation/index.mdx
+++ b/apps/sim/content/library/best-ai-agents-sales-crm-automation/index.mdx
@@ -3,7 +3,7 @@ slug: best-ai-agents-sales-crm-automation
 title: 'Best AI Agents for Sales and CRM Automation'
 description: Compare the best AI agents for sales and CRM automation - Sim, n8n, Zapier, Make, and Gumloop - across lead qualification, CRM write-back, enrichment, and outbound sequencing to pick the right tool for your RevOps stack.
 date: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-23
 authors:
   - andrew
 readingTime: 13
@@ -45,7 +45,7 @@ The platforms that update CRM records well are the ones with native write-back i
 
 The record update is only as good as the logic that runs before the write. A raw enrichment payload usually arrives with inconsistent casing, duplicate company entries, and free-text job titles that no CRM field expects. In Sim, that cleanup happens inside the agentic loop rather than as a bolted-on step. An Agent block normalizes the fields, checks a native Table or the CRM itself for an existing record, and merges instead of creating a duplicate. The write only fires once the data matches the shape your CRM expects.
 
-Zapier deserves credit for the breadth of its app catalog. If you need to touch a niche CRM or a long-tail sales tool, Zapier almost certainly has a prebuilt connector, and that saves real setup time. The tradeoff is depth. Zapier's connectors tend to cover the common actions, so complex field logic, conditional updates, and dedupe rules push you into workarounds or multiple stacked Zaps.
+[Zapier](https://zapier.com/pricing) deserves credit for the breadth of its app catalog. If you need to touch a niche CRM or a long-tail sales tool, Zapier almost certainly has a prebuilt connector, and that saves real setup time. The tradeoff is depth. Zapier's connectors tend to cover the common actions, so complex field logic, conditional updates, and dedupe rules push you into workarounds or multiple stacked Zaps.
 
 For teams running Salesforce or HubSpot as their system of record, Sim's combination of native write-back and in-workflow normalization does more with fewer moving parts. You keep the scoring, the dedupe check, and the record update in one place, which means one thing to debug when a field lands wrong.
 
@@ -67,7 +67,7 @@ Model choice compounds the effect. Sim supports BYOK across 15+ model providers,
 
 ### The honest concession
 
-Clay and Apollo own proprietary datasets and waterfall access that Sim does not claim to replace as a data source. Apollo maintains a large people-and-company database, and Clay's waterfall enrichment queries multiple providers in sequence to fill gaps, both backed by data relationships and coverage Sim doesn't reproduce. If your bottleneck is raw coverage on hard-to-find contacts, those tools earn their place, and Sim can call them as one of the enrichment APIs inside the loop.
+[Clay](https://www.clay.com/pricing) and [Apollo](https://www.apollo.io/pricing) own proprietary datasets and waterfall access that Sim does not claim to replace as a data source. Apollo maintains a large people-and-company database, and Clay's waterfall enrichment queries multiple providers in sequence to fill gaps, both backed by data relationships and coverage Sim doesn't reproduce. If your bottleneck is raw coverage on hard-to-find contacts, those tools earn their place, and Sim can call them as one of the enrichment APIs inside the loop.
 
 The distinction worth holding onto is between the data layer and the orchestration layer. Clay and Apollo win the data layer, and that's a genuine advantage for teams whose whole problem is finding records. Sim wins the orchestration, logic, and CRM write-back layer, which is where most RevOps teams actually lose time. You stop paying a separate vendor to run scoring and CRM sync you could own, and you keep the freedom to plug any data provider into a workflow you control. For teams evaluating a Clay alternative, the question is rarely who has more data. It's whether you want to rent the workflow around enrichment or own it.
 
@@ -79,7 +79,7 @@ The personalization depends on where the context lives. Sim keeps account and le
 
 Template-only sequencing tools skip that loop. They fire the next step on a timer or an open event, and the copy stays static regardless of what the prospect actually did. That works for volume, but it caps how relevant any single message can get, since the tool never reasons over the context behind the send.
 
-Gumloop deserves credit here. Its packaged outbound and GTM templates give you a working sequence on day one, which is a real advantage if you want to prospect this week rather than build a flow first. If your outbound motion fits one of those templates, you will move faster starting there than starting from a blank workflow in Sim's builder. The tradeoff shows up later, when your sequencing logic diverges from the packaged shape and you need the open-ended control that Sim's agent-and-Table model gives you.
+[Gumloop](https://www.gumloop.com/pricing) deserves credit here. Its packaged outbound and GTM templates give you a working sequence on day one, which is a real advantage if you want to prospect this week rather than build a flow first. If your outbound motion fits one of those templates, you will move faster starting there than starting from a blank workflow in Sim's builder. The tradeoff shows up later, when your sequencing logic diverges from the packaged shape and you need the open-ended control that Sim's agent-and-Table model gives you.
 
 ### Gumloop's GTM and RevOps templates
 
@@ -114,3 +114,5 @@ When your enrichment logic, scoring rules, and CRM write-back live inside a vend
 Model choice is the second half of ownership. Most enrichment tools bolt you to one fixed scoring engine, and you take whatever quality and cost that engine ships. Sim supports bring-your-own-key across 15+ model providers, so you route qualification through whichever model fits the job and pay the provider directly instead of a marked-up per-enrichment fee. You can swap a cheaper model for high-volume triage and a stronger one for accounts worth deeper analysis.
 
 The practical payoff is escaping point-solution sprawl. A typical RevOps stack runs Clay for waterfall enrichment, Apollo for prospecting data, and a separate automation tool to move records into the CRM, with each vendor billing separately and each handoff creating a place for data to break. Sim collapses the orchestration, logic, and write-back into one workflow layer while you still call whichever data providers you want as tools inside it. You keep the proprietary datasets from vendors who genuinely own the data, and you stop paying three companies to own the glue between them. Owning that layer means your qualification logic and CRM mappings travel with you, not with a vendor's roadmap.
+
+Related reading: [10 AI agent ideas](/library/ai-agent-ideas) covers use cases beyond RevOps, [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) compares where to build them, and [best Zapier alternatives](/library/best-zapier-alternatives) is the right starting point if your CRM automation currently runs on per-task billing.

--- a/apps/sim/content/library/best-relay-app-alternatives-2026/index.mdx
+++ b/apps/sim/content/library/best-relay-app-alternatives-2026/index.mdx
@@ -3,7 +3,7 @@ slug: best-relay-app-alternatives-2026
 title: 'Best Relay.app Alternatives in 2026'
 description: Relay.app is shutting down in 2026. Compare the best Relay.app alternatives - Sim, n8n, Zapier, Make, and Gumloop - with license, self-host, and migration-effort breakdowns to switch before your deadline.
 date: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-23
 authors:
   - andrew
 readingTime: 12
@@ -26,7 +26,7 @@ faq:
 
 ## TL;DR
 
-Relay.app announced its shutdown on July 16, 2026, which is why this list exists. Free accounts and all their data get permanently deleted after August 15, 2026 at 23:59 PT. Paying customers keep full access free through September 14, 2026 at 23:59 PT.
+[Relay.app announced its shutdown](https://www.relay.app/) on July 16, 2026, which is why this list exists. Free accounts and all their data get permanently deleted after August 15, 2026 at 23:59 PT. Paying customers keep full access free through September 14, 2026 at 23:59 PT.
 
 - **Top pick: Sim.** Built AI-native, Apache 2.0 licensed, self-hostable, with a free tier that isn't feature-limited.
 - **n8n** wins for complex multi-step integrations with deep branching and a large node ecosystem.
@@ -125,3 +125,5 @@ Read the license and self-host columns together if you handle regulated or priva
 ## How we evaluated these Relay.app alternatives
 
 We ranked these five tools against the criteria that decide how fast a Relay user can actually switch: license, self-host capability, AI-native design, migration effort, and pricing model. Speed to migrate carried the most weight because you have a hard deadline, not a research window. A tool that requires rebuilding every workflow from scratch fails you no matter how strong its feature list looks. License and self-host mattered next, since anyone burned by a hosted shutdown has a real reason to want code they control and data they can keep.
+
+If your shortlist crosses over into general automation, [best Zapier alternatives](/library/best-zapier-alternatives) and [10 best n8n alternatives](/library/n8n-alternatives) cover that field. [The best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) is the right list if agent capability matters more to you than human-in-the-loop approvals.

--- a/apps/sim/content/library/best-zapier-alternatives/index.mdx
+++ b/apps/sim/content/library/best-zapier-alternatives/index.mdx
@@ -3,7 +3,7 @@ slug: best-zapier-alternatives
 title: '10 Best Zapier Alternatives for Workflow Automation'
 description: Zapier's per-task pricing punishes growth. Compare the 10 best Zapier alternatives - free, open-source, and AI-native - with real pricing breakdowns and use-case recommendations.
 date: 2026-07-01
-updated: 2026-07-01
+updated: 2026-07-23
 authors:
   - emir
 readingTime: 14
@@ -17,7 +17,7 @@ faq:
   - q: "Is n8n better than Zapier?"
     a: "For teams with developer resources, n8n wins on cost (free self-hosted with no execution limits) and data control (nothing leaves your infrastructure). Zapier wins on ease of use, integration breadth (7,000+ apps vs. n8n's smaller catalog), and polished onboarding. The best answer depends on whether your team has the expertise to manage a self-hosted instance. If you do, n8n can save thousands annually. If you don't, the time cost of maintaining n8n may exceed the subscription savings."
   - q: "What is the cheapest Zapier alternative?"
-    a: "For zero-cost automation, n8n and Activepieces self-hosted options are free with no execution limits. Among paid hosted platforms, Pabbly Connect starts at $16/month with annual billing and includes 12,000 tasks with no charges for internal steps. Pabbly also offers lifetime pricing from $249 one-time, making it the cheapest long-term option for teams that want hosted automation without managing their own servers."
+    a: "For zero-cost automation, n8n and Activepieces self-hosted options are free with no execution limits, and Activepieces cloud includes 10 free active flows before charging $5 per active flow per month. Among paid hosted platforms, Pabbly Connect's Standard plan covers 10,000 tasks per month with no charges for internal steps. Pabbly also offers lifetime pricing from $349 one-time for 3,000 tasks per month, making it the cheapest long-term option for teams that want hosted automation without managing their own servers."
   - q: "Can I migrate my Zaps to another platform?"
     a: "There is no automated migration tool between platforms. You need to rebuild workflows manually. Simple two- to three-step Zaps typically take 10 - 15 minutes to recreate on any alternative platform. Complex multi-branch workflows with conditional logic, custom formatting, and multiple API connections can take 30 - 60 minutes each. Most Zapier Zaps can be recreated in Make in 15 - 30 minutes because the concepts are similar, and a full migration typically takes one to two days for a moderate-sized automation library."
   - q: "What is the difference between Zapier and an AI agent workflow platform?"
@@ -25,7 +25,7 @@ faq:
   - q: "Does Sim charge per task like Zapier does?"
     a: "No. Sim uses a credit-based model instead of per-task billing, and it supports bring-your-own API keys so you can avoid markup on model usage entirely. A free plan is available with no credit card required."
   - q: "Is there a Zapier alternative that supports human approval steps in an automation?"
-    a: "Relay.app is purpose-built for this — it pauses a workflow, notifies the right person, collects their input, and continues, rather than treating every step as fully automated. It's best suited to RevOps, HR, legal, and finance workflows where a judgment call needs a human in the loop before the automation proceeds."
+    a: "Relay.app was purpose-built for this, but it is shutting down: new signups closed on July 16, 2026, free accounts end August 15, 2026, and paid accounts end September 14, 2026. For new builds, use a platform with native human-in-the-loop approvals instead. Sim ships approval steps that pause a run, notify the right person, collect their decision, and resume, which covers the same RevOps, HR, legal, and finance workflows without a migration deadline."
 ---
 
 You're here because the invoice surprised you.
@@ -42,9 +42,9 @@ Whether you're hitting the complexity ceiling, need self-hosting for compliance,
 
 - **n8n:** Self-host for free with no execution limits and full data control. Requires technical chops but can't be beat on cost or privacy.
 
-- **Pabbly Connect:** Flat-rate pricing with a lifetime deal starting at $249 one-time. The budget pick for straightforward multi-step automations.
+- **Pabbly Connect:** Flat-rate pricing with a [lifetime deal](https://buy.pabbly.com/connect-onetime/) starting at $349 one-time. The budget pick for straightforward multi-step automations.
 
-- **Workato:** Enterprise-grade integration with strong governance, audit logging, and support SLAs. Priced accordingly, starting around $1,000/month.
+- **Workato:** Enterprise-grade integration with strong governance, audit logging, and support SLAs. Priced accordingly — Workato [does not publish rates](https://www.workato.com/pricing) and quotes every deal through sales.
 
 - **Activepieces:** Open-source with an MIT license and a cleaner, more approachable UI than n8n. Growing integration library (750+) with a free self-hosted tier.
 
@@ -52,7 +52,7 @@ Whether you're hitting the complexity ceiling, need self-hosting for compliance,
 
 - **Pipedream:** Hybrid code + no-code with serverless execution and 1,000+ integrations. Best for developers who want to drop real Node.js, Python, or Go into a workflow wherever a connector falls short.
 
-- **Relay.app:** Purpose-built for human-in-the-loop workflows that pause for approval or review. Best for RevOps, HR, legal, and finance teams where one step needs a human decision.
+- **Relay.app (shutting down):** Was purpose-built for human-in-the-loop approval workflows, but the product is winding down — free accounts end August 15, 2026 and paid accounts September 14, 2026. Listed here only because existing users need somewhere to go.
 
 - **Integrately:** One-click, pre-built automations with minimal configuration. Best for standard, well-defined scenarios where setup speed matters more than deep customization.
 
@@ -86,7 +86,7 @@ A free plan is available with no credit card required, and paid plans follow a c
 
 Instead of a linear list of steps, Make gives you a visual canvas showing exactly how data flows through your automation. You can see branches, conditions, loops, and error handlers all at once, making debugging easier because you can literally trace where things went wrong.
 
-The pricing model is where Make changes the math for growing teams. Make's Core plan starts at $10.59/month for 10,000 operations, compared to Zapier's $29.99/month for 750 tasks at entry-level pricing. Operations and tasks don't map 1:1; Make counts operations differently than Zapier counts tasks, and a single Zapier task might equal three to eight Make operations. Most teams running moderate automation volume will spend meaningfully less on Make.
+The pricing model is where Make changes the math for growing teams. [Make's](https://www.make.com/en/pricing) Core plan starts at $12/month for 10,000 credits, compared to [Zapier's](https://zapier.com/pricing) $29.99/month for 750 tasks at entry-level pricing. Annual billing takes about 15% off Make's rate. Operations and tasks don't map 1:1; Make counts operations differently than Zapier counts tasks, and a single Zapier task might equal three to eight Make operations. Most teams running moderate automation volume will spend meaningfully less on Make.
 
 Make connects 3,000+ apps and offers deeper per-app API coverage than Zapier on many integrations, with native modules for routers, iterators, aggregators, and error handlers that let you build workflows Zapier simply can't express in its linear editor.
 
@@ -100,7 +100,7 @@ n8n gives you a node-based visual editor with full JavaScript (and Python) suppo
 
 The data privacy angle is the primary reason teams choose n8n over hosted alternatives. Self-hosting means workflow data, API credentials, and execution logs never touch a third-party server. For companies in regulated industries or with strict data residency requirements, this isn't a nice-to-have; it's a hard requirement that rules out most other tools on this list.
 
-n8n provides unlimited workflows and executions for free if you're willing to self-host. It requires a server and some DevOps knowledge, but there are no per-task charges at all. The cloud-managed version starts at roughly $24/month for teams that want n8n's workflow capabilities without managing infrastructure.
+n8n provides unlimited workflows and executions for free if you're willing to self-host. It requires a server and some DevOps knowledge, but there are no per-task charges at all. The [cloud-managed version](https://n8n.io/pricing/) starts at €20/month billed annually for 2,500 workflow executions, for teams that want n8n's workflow capabilities without managing infrastructure. Note that n8n is fair-code licensed, not open source — we break down [what that means for self-hosting](/library/apache-2-0-vs-fair-code).
 
 This means you'll need considerable technical expertise in setup and ongoing maintenance, including updates, backups, SSL, and uptime monitoring, to save more. If your team doesn't have someone comfortable with Docker, server provisioning, and debugging node-level errors, n8n will cost you time instead of saving it.
 
@@ -110,7 +110,7 @@ This means you'll need considerable technical expertise in setup and ongoing mai
 
 Pabbly Connect's value proposition is straightforward: flat-rate pricing with no per-task surcharges on internal steps. There is no charge for internal tasks like filters and routers, which means your actual task consumption is lower than the equivalent workflow would cost on Zapier.
 
-Paid subscription plans include Standard at $16/month for 12,000 tasks, Pro at $33/month for 24,000 tasks, and Ultimate at $67/month for up to 300,000 tasks (billed annually). But the real differentiator is the lifetime deal: Pabbly Connect offers unlimited workflows with lifetime pricing from $249 one-time. That's a single payment for perpetual access with a fixed monthly task allocation. For solopreneurs and small businesses running stable, predictable automations, the long-term savings compared to any recurring-fee platform are substantial.
+[Pabbly Connect's](https://www.pabbly.com/connect/) subscription lineup is a free tier at 100 tasks/month, a Standard plan at 10,000 tasks/month, and an Unlimited plan, with annual billing discounted against monthly. But the real differentiator is the [lifetime deal](https://buy.pabbly.com/connect-onetime/): a one-time payment from $349 for 3,000 tasks/month, $799 for 10,000, or $1,298 for 20,000. That's a single payment for perpetual access with a fixed monthly task allocation. For solopreneurs and small businesses running stable, predictable automations, the long-term savings compared to any recurring-fee platform are substantial.
 
 As of March 2026, Pabbly Connect supports over 2,000 application integrations and handles multi-step workflows, conditional logic, webhook triggers, and scheduled automation. However, the interface feels less polished than Zapier or Make, with occasional quirky UX decisions, and support is email-only on lower plans with response times that can stretch past 24 hours.
 
@@ -134,13 +134,13 @@ Workato is where you land when "we need Zapier but for the enterprise" stops bei
 
 Enterprise-grade security features include robust audit logging, role-based access control, environment management (dev/staging/production), and support SLAs backed by contractual commitments. Workato connects deeply into ERP systems, CRMs, HRIS platforms, and custom internal applications, making it the standard choice for enterprises running mission-critical integrations across SAP, Salesforce, Workday, and NetSuite.
 
-The pricing puts it firmly out of range for SMBs: expect starting costs around $1,000/month with pricing that scales based on connector count and recipe volume. This is negotiated, contract-based enterprise purchasing.
+Pricing puts it firmly out of range for SMBs. [Workato publishes no rates at all](https://www.workato.com/pricing) — every deal is quoted through sales and scales on connector count and recipe volume. This is negotiated, contract-based enterprise purchasing, so budget for a procurement cycle rather than a credit card.
 
 **Best for:** Enterprises running mission-critical integrations across ERP, CRM, and custom systems where governance, compliance, and reliable support SLAs justify the premium cost.
 
 ### Activepieces: Best Open-Source Pick for Non-Technical Users
 
-Activepieces occupies a useful niche: open-source automation that doesn't require DevOps expertise to get started. Activepieces is licensed under MIT, the self-hosted version is free, and the cloud tier offers a free plan for light usage.
+Activepieces occupies a useful niche: open-source automation that doesn't require DevOps expertise to get started. [Activepieces](https://www.activepieces.com/pricing) is licensed under MIT, the self-hosted version is free, and the cloud tier includes 10 free active flows before charging $5 per active flow per month with unlimited runs.
 
 The interface is cleaner and more approachable than n8n's, which makes Activepieces the better open-source pick for teams that want the benefits of open source (data control, no vendor lock-in, community-driven development) without the technical overhead of managing a self-hosted n8n instance.
 
@@ -158,15 +158,17 @@ The pricing includes a generous free tier for individual developers and usage-ba
 
 **Best for:** Developers who need broad integration support with the freedom to write custom logic in real code wherever a no-code connector doesn't exist.
 
-### Relay.app: Best for Human-in-the-Loop Workflows
+### Relay.app: Shutting Down in 2026
 
-Relay.app addresses a genuine gap that Zapier and most alternatives ignore: workflows where a human needs to approve, review, or decide before automation continues.
+**Relay.app is winding down.** [New signups and free-to-paid upgrades closed on July 16, 2026](https://www.relay.app/), free accounts stop working on August 15, 2026, and paying customers lose access on September 14, 2026. Do not start a new build here. If you are an existing user, export your data before your deadline and pick a replacement now — we cover the options in [Relay.app alternatives](/library/best-relay-app-alternatives-2026).
+
+It is worth understanding what Relay.app did well, because that is the capability you need to replace. Relay.app addressed a genuine gap that Zapier and most alternatives ignore: workflows where a human needs to approve, review, or decide before automation continues.
 
 Full automation is inappropriate in many business contexts. Legal review, financial approvals, content sign-off, HR decisions; these all involve judgment calls that you don't want an automation engine making unilaterally. But fully manual handling is equally wasteful when 90% of the workflow is routine, and only one step requires human input. Relay.app lets you build the automated pipeline and insert human decision points exactly where they're needed. The workflow pauses, notifies the right person, collects their input, and continues.
 
-The interface is clean, the setup is straightforward, and the concept is immediately understandable to non-technical stakeholders. The limitation is scope: Relay.app doesn't try to be a general-purpose automation powerhouse. It's purpose-built for approval and review workflows.
+The interface was clean, the setup straightforward, and the concept immediately understandable to non-technical stakeholders. The limitation was scope: Relay.app never tried to be a general-purpose automation powerhouse.
 
-**Best for:** RevOps, HR, legal, and finance teams where full automation is inappropriate but full manual handling is equally wasteful.
+**What to do instead:** if approval steps are the reason you were looking at Relay.app, choose a platform where human-in-the-loop is a first-class feature rather than a bolt-on. Sim ships approval blocks that pause a run, route it to the right person, and resume on their decision.
 
 ### Integrately: Best for One-Click Setup
 
@@ -189,37 +191,37 @@ Start with two questions: What specifically is failing for you in Zapier? And wh
 | I want AI agents that reason and decide, not just data routing | Sim | Native AI decision-making blocks, multi-LLM support, self-hostable |
 | I need self-hosting for data compliance | n8n or Sim | Both offer Docker/Kubernetes deployment with no data leaving your infrastructure |
 | I just want something cheaper with visual workflows | Make | Operations-based pricing costs 2 - 5x less than Zapier at equivalent volume |
-| I want the absolute lowest cost, period | Pabbly Connect | Flat-rate pricing, lifetime deal from $249 one-time, no per-task surcharges on internal steps |
+| I want the absolute lowest cost, period | Pabbly Connect | Flat-rate pricing, lifetime deal from $349 one-time, no per-task surcharges on internal steps |
 | I'm deep in the Microsoft ecosystem | Power Automate | Native M365/Azure/Dynamics integration, possibly already in your license |
 | I need enterprise governance and support SLAs | Workato | Built for mission-critical integration with audit logging and environment management |
 | I want open source, but I'm not deeply technical | Activepieces | MIT-licensed, cleaner UI than n8n, free self-hosted tier |
 | I need code + no-code in the same workflow | Pipedream | Write Node.js/Python/Go alongside no-code steps, serverless execution |
-| I need human approval steps in my automation | Relay.app | Purpose-built for workflows that pause for human review or decision |
+| I need human approval steps in my automation | Sim | Native approval steps that pause a run for human review, then resume (Relay.app, the former pick here, is shutting down in 2026) |
 | I want basic automation running in five minutes | Integrately | Pre-built one-click automations with minimal configuration |
 
 ## Zapier vs. Alternatives: Pricing Breakdown
 
-This table shows pricing as of mid-2026. Verify all figures directly with vendors before committing to a purchase, as pricing changes frequently.
+Every figure below was checked against the vendor's own pricing page on July 23, 2026, and each tool name links to the page it came from. Pricing changes often — click through and confirm before you commit to a purchase.
 
 | Tool | Pricing Model | Entry-Level Paid Plan | Tasks/Ops Included | Free Tier? | Self-Host Option? |
 | --- | --- | --- | --- | --- | --- |
-| Zapier | Per-task | $29.99/mo (monthly) | 750 tasks | Yes (100 tasks/mo, 2-step only) | No |
-| Sim | Credit-based | Varies by plan | Credit-based allocation | Yes (free plan, no CC required) | Yes (Docker/K8s) |
-| Make | Per-operation (credit) | ~$10.59/mo (annual) | 10,000 operations | Yes (1,000 ops/mo) | No |
-| n8n | Self-host free; cloud paid | ~$24/mo (cloud) | Unlimited (self-hosted) | Yes (self-hosted unlimited) | Yes |
-| Pabbly Connect | Flat-rate | $16/mo (annual) | 12,000 tasks | Yes (100 tasks/mo) | No |
-| Power Automate | Per-user/month | ~$15/user/mo | Varies by plan | Included in some M365 licenses | No (on-prem gateway available) |
-| Workato | Custom/contract | ~$1,000/mo | Negotiated | No | No |
-| Activepieces | Free self-hosted; cloud plans | Cloud free tier available | Varies | Yes (self-hosted unlimited) | Yes |
-| Pipedream | Usage-based | Free tier generous | Varies by plan | Yes | No |
-| Relay.app | Per-run | Varies | Varies by plan | Yes (limited) | No |
-| Integrately | Task-based | Competitive entry price | Varies by tier | Yes (limited) | No |
+| [Zapier](https://zapier.com/pricing) | Per-task | $29.99/mo (monthly), $19.99/mo (annual) | 750 tasks | Yes (100 tasks/mo, 2-step only) | No |
+| [Sim](https://sim.ai) | Credit-based | Varies by plan | Credit-based allocation | Yes (free plan, no CC required) | Yes (Docker/K8s) |
+| [Make](https://www.make.com/en/pricing) | Per-credit | $12/mo (monthly), ~15% off annual | 10,000 credits | Yes (1,000 credits/mo) | No |
+| [n8n](https://n8n.io/pricing/) | Self-host free; cloud paid | €20/mo (annual) | 2,500 executions cloud; unlimited self-hosted | Yes (self-hosted unlimited) | Yes |
+| [Pabbly Connect](https://www.pabbly.com/connect/) | Flat-rate + lifetime option | Standard tier; [lifetime from $349](https://buy.pabbly.com/connect-onetime/) | 10,000 tasks (Standard) | Yes (100 tasks/mo) | No |
+| [Power Automate](https://www.microsoft.com/en-us/power-platform/products/power-automate/pricing) | Per-user/month | $15/user/mo (paid yearly) | Varies by plan | Included in some M365 licenses | No (on-prem gateway available) |
+| [Workato](https://www.workato.com/pricing) | Custom/contract | Not published — quote only | Negotiated | No | No |
+| [Activepieces](https://www.activepieces.com/pricing) | Free self-hosted; cloud plans | $5/active flow/mo after 10 free | Unlimited runs | Yes (10 active flows) | Yes (MIT) |
+| [Pipedream](https://pipedream.com/pricing) | Usage-based | Free tier generous | Varies by plan | Yes | No |
+| [Relay.app](https://www.relay.app/) | Shutting down 2026 | Closed to new signups | n/a | No (signups closed) | No |
+| [Integrately](https://integrately.com/pricing) | Task-based | Competitive entry price | Varies by tier | Yes (limited) | No |
 
 Key insights from this table:
 
 - Zapier's per-task model and operations-based models (Make) and flat-rate models (Pabbly Connect) behave very differently at scale
 - Zapier's per-step task counting model means costs escalate quickly as workflows grow in complexity
-- A five-step workflow running 100 times per day costs 500 tasks daily on Zapier, while Make's Core plan covers 10,000 operations per month for $10.59, and Pabbly's flat rate doesn't penalize you for internal steps at all
+- A five-step workflow running 100 times per day costs 500 tasks daily on Zapier, while Make's Core plan covers 10,000 credits per month for $12, and Pabbly's flat rate doesn't penalize you for internal steps at all
 - For high-volume teams, the annual difference can be thousands of dollars
 
 ## The Bottom Line
@@ -227,3 +229,5 @@ Key insights from this table:
 The best Zapier alternatives in 2026 are split into three categories. If your primary goal is cost reduction, Make and Pabbly Connect deliver the most dramatic savings with different trade-offs: Make gives you visual complexity at lower per-operation pricing, while Pabbly's flat rate and lifetime deal make costs fully predictable. If your goal is data control and compliance, n8n (self-hosted), Activepieces, and Sim all offer self-hosting options that keep your data on your own infrastructure. And if your workflows have outgrown trigger-action logic entirely and you need AI agents that reason, decide, and act across your stack, Sim is the platform built from the ground up for that shift.
 
 No single tool replaces Zapier for every team. Start by identifying the specific constraint that brought you here, whether it's pricing, complexity, data control, or AI capabilities, and match it against the routing table above. Most teams that switch successfully do so because they understand what they actually need rather than chasing the tool with the longest feature list.
+
+If n8n is the alternative you're leaning toward, we compare it against its own field in [10 best n8n alternatives](/library/n8n-alternatives). If you're evaluating on AI capability rather than cost, [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) covers the same ground from that angle, and [open-source AI agent platforms](/library/open-source-ai-agent-platforms) narrows it to self-hostable options. Teams who specifically need a human approval step should start with [Relay.app alternatives](/library/best-relay-app-alternatives-2026).

--- a/apps/sim/content/library/byok-multi-model-ai-agent-builder/index.mdx
+++ b/apps/sim/content/library/byok-multi-model-ai-agent-builder/index.mdx
@@ -3,7 +3,7 @@ slug: byok-multi-model-ai-agent-builder
 title: "BYOK Multi-Model AI Agent Builder: How Sim's Bring-Your-Own-Key Works"
 description: Sim is a multi-model AI agent builder with hosted, BYOK, and local execution across 100+ models. Learn how bring-your-own-key works, when to use each mode, and how model flexibility compares across platforms.
 date: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-23
 authors:
   - andrew
 readingTime: 9
@@ -72,7 +72,7 @@ Model flexibility separates these platforms more than any single feature, so the
 | Billing rate | ~1.1x hosted, provider rate on BYOK, free local | Provider rate | Bundled into platform pricing or task credits |
 | Self-host compatibility | Ollama, vLLM, fully local | None | Varies (n8n self-hosts, most do not for AI) |
 
-The automation platforms earn their reputation on breadth and ease. Zapier connects thousands of apps with almost no configuration, Make gives you a visual canvas that non-developers can follow, and n8n self-hosts its entire workflow engine. Gumloop wraps AI steps in a friendly builder that gets a prototype running fast. If your problem is stitching SaaS tools together, these platforms solve it well, and model choice is a secondary concern.
+The automation platforms earn their reputation on breadth and ease. [Zapier](https://zapier.com/pricing) connects thousands of apps with almost no configuration, Make gives you a visual canvas that non-developers can follow, and n8n self-hosts its entire workflow engine. Gumloop wraps AI steps in a friendly builder that gets a prototype running fast. If your problem is stitching SaaS tools together, these platforms solve it well, and model choice is a secondary concern.
 
 OpenAI's own stack has the opposite strength. You get tight integration with frontier models and first-party tooling, which matters when you are building squarely on GPT and want the shortest path to production.
 
@@ -97,3 +97,5 @@ If you handle regulated data or need agents to run without an outbound internet 
 For a multi-team organization standardizing on one provider, BYOK also keeps billing and model governance in one account you already control.
 
 None of these three modes is the correct default. The right one follows from your call volume, how much control you need over billing and models, and where your data is allowed to travel.
+
+Related reading: [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) covers which platforms support bring-your-own-key at all, [open-source AI agent platforms](/library/open-source-ai-agent-platforms) is the self-hostable subset where you keep full control of model routing, and [how to build AI agents](/library/how-to-create-an-ai-agent) walks through a first build.

--- a/apps/sim/content/library/how-to-create-an-ai-agent/index.mdx
+++ b/apps/sim/content/library/how-to-create-an-ai-agent/index.mdx
@@ -3,7 +3,7 @@ slug: how-to-create-an-ai-agent
 title: 'How to Build AI Agents With Sim'
 description: Learn how to create an AI agent from scratch using a visual workspace. Connect tools and deploy in minutes. Build real-world agents that automate workflows with Sim.
 date: 2026-06-27
-updated: 2026-06-27
+updated: 2026-07-23
 authors:
   - waleed
 readingTime: 13
@@ -71,11 +71,11 @@ If you've searched for how to build AI agents before landing here, you've probab
 
 ### Path one: code frameworks
 
-Tutorials built around LangChain, CrewAI, or AutoGen assume you're comfortable in Python, can manage virtual environments, and are willing to spend time wiring together chains, prompts, memory stores, and tool adapters before anything runs. The control is real; you can customize every layer of behavior. But the time-to-first-result is measured in days or weeks, not minutes. Agent frameworks require learning and extensive boilerplate code, and existing visual interfaces abstract most of the customization required for complex agent workflows.
+Tutorials built around [LangChain](https://www.langchain.com/langchain), [CrewAI](https://docs.crewai.com/), or [AutoGen](https://microsoft.github.io/autogen/stable/) assume you're comfortable in Python, can manage virtual environments, and are willing to spend time wiring together chains, prompts, memory stores, and tool adapters before anything runs. The control is real; you can customize every layer of behavior. But the time-to-first-result is measured in days or weeks, not minutes. Agent frameworks require learning and extensive boilerplate code, and existing visual interfaces abstract most of the customization required for complex agent workflows.
 
 ### Path two: generic automation
 
-On the other side, platforms like Zapier and Make let you connect apps quickly. They're great for linear workflows: "when this happens, do that." But they weren't built for agentic reasoning. When your workflow needs to branch based on ambiguous input, call an LLM to decide which tool to use, or loop until a condition is met, these tools hit a ceiling fast.
+On the other side, platforms like [Zapier](https://zapier.com/pricing) and [Make](https://www.make.com/en/pricing) let you connect apps quickly. They're great for linear workflows: "when this happens, do that." But they weren't built for agentic reasoning. When your workflow needs to branch based on ambiguous input, call an LLM to decide which tool to use, or loop until a condition is met, these tools hit a ceiling fast.
 
 ### The third path: visual AI workspaces
 
@@ -200,3 +200,5 @@ Learning how to build AI agents doesn't require a computer science degree, a com
 The pattern is straightforward: define a narrow task, open a workflow, add an Agent block with the right LLM and a tight system prompt, connect two or three tools, set a trigger, and iterate using execution logs. Start with the narrowest possible version of the idea, get it working reliably, then expand from there.
 
 Trusted by over 100,000 builders at startups and Fortune 500 companies, Sim offers a free plan with no credit card required. Open it, build something, and see what an agent can do for your workflow before the week is out.
+
+Stuck on what to build? [10 AI agent ideas](/library/ai-agent-ideas) has concrete starting points. If you're still deciding whether an agent is the right tool, [AI agent vs chatbot](/library/ai-agent-vs-chatbot) and [AI agents vs RPA](/library/ai-agents-vs-rpa) draw those lines, and [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) compares where to build.

--- a/apps/sim/content/library/langgraph-alternatives/index.mdx
+++ b/apps/sim/content/library/langgraph-alternatives/index.mdx
@@ -3,7 +3,7 @@ slug: langgraph-alternatives
 title: 'Best LangGraph Alternatives for Scalable AI Agent Workflows'
 description: LangGraph struggles at scale with concurrency, debugging, and deployment gaps. Compare the best alternatives - CrewAI, AutoGen, Sim, and more - to find the right fit for your team.
 date: 2026-07-13
-updated: 2026-07-13
+updated: 2026-07-23
 authors:
   - emir
 readingTime: 11
@@ -67,7 +67,7 @@ If you're comfortable in Python (or TypeScript), want in-depth control over agen
 
 ### CrewAI
 
-CrewAI takes a role-based, task-oriented approach where agents are "crew members" with defined roles, goals, and backstories. Instead of wiring graph edges, you assemble a team: a researcher, a writer, a reviewer. Each agent knows its job and passes work to the next.
+[CrewAI](https://docs.crewai.com/) takes a role-based, task-oriented approach where agents are "crew members" with defined roles, goals, and backstories. Instead of wiring graph edges, you assemble a team: a researcher, a writer, a reviewer. Each agent knows its job and passes work to the next.
 
 This is the fastest path from idea to working multi-agent prototype. The mental model maps cleanly to how people already think about delegation, which means less time reading docs and more time building.
 
@@ -79,7 +79,7 @@ The trade-off is that CrewAI doesn't include built-in checkpointing for long-run
 
 ### AutoGen / AG2
 
-AutoGen introduced a conversation-first approach to multi-agent systems: agents collaborate through structured multi-turn dialogue rather than graph transitions. This is a natural fit for use cases where agents need to debate, review, and refine outputs: code generation, analysis, planning scenarios where iterating on quality matters more than speed.
+[AutoGen](https://microsoft.github.io/autogen/stable/) introduced a conversation-first approach to multi-agent systems: agents collaborate through structured multi-turn dialogue rather than graph transitions. This is a natural fit for use cases where agents need to debate, review, and refine outputs: code generation, analysis, planning scenarios where iterating on quality matters more than speed.
 
 The ecosystem, however, is in a complicated place. A significant development occurred in late 2024 when the original creators, Chi Wang and Qingyun Wu, departed Microsoft to establish AG2 as a community-driven fork. In November, they settled on creating a new AG2 GitHub organization and a new repo, inheriting the PyPI autogen and pyautogen packages and the Discord channel. Meanwhile, in October 2025, Microsoft announced that AutoGen and Semantic Kernel are merging into a new unified "Microsoft Agent Framework," with AutoGen entering maintenance mode. Microsoft Agent Framework is now positioned as the enterprise-ready successor to AutoGen, with stable APIs and a commitment to long-term support.
 
@@ -93,7 +93,7 @@ One cost consideration that often gets overlooked: each agent turn in a conversa
 
 ### Google ADK
 
-Google introduced the Agent Development Kit (ADK) at Google Cloud NEXT 2025 as an open-source framework designed to simplify end-to-end development of agents and multi-agent systems. The architecture uses a hierarchical agent tree where a root agent delegates to sub-agents, and ADK is the same framework powering agents within Google products like Agentspace and the Customer Engagement Suite.
+Google introduced the [Agent Development Kit (ADK)](https://adk.dev/) at Google Cloud NEXT 2025 as an open-source framework designed to simplify end-to-end development of agents and multi-agent systems. The architecture uses a hierarchical agent tree where a root agent delegates to sub-agents, and ADK is the same framework powering agents within Google products like Agentspace and the Customer Engagement Suite.
 
 What sets ADK apart from most alternatives is its breadth of language support and deployment integration. ADK is available in Python, TypeScript, Go, and Java, which means teams aren't locked into a single language stack. You can run agents locally or scale them globally using Runtime, Cloud Run, or Google Kubernetes Engine.
 
@@ -105,7 +105,7 @@ The standout capability for teams running multi-framework environments: ADK supp
 
 ### OpenAI Agents SDK
 
-The OpenAI Agents SDK is a lightweight Python framework focused on multi-agent workflows with built-in tracing and guardrails. Despite the OpenAI branding, it's provider-agnostic and compatible with a broad range of LLMs, which makes the name slightly misleading but the tool genuinely flexible.
+The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) is a lightweight Python framework focused on multi-agent workflows with built-in tracing and guardrails. Despite the OpenAI branding, it's provider-agnostic and compatible with a broad range of LLMs, which makes the name slightly misleading but the tool genuinely flexible.
 
 The SDK's strength is its simple learning curve. If your team is already calling OpenAI APIs, the mental model transfers directly. Agents are defined with simple Python classes, handoffs between agents are clean and explicit, and tracing is built into every run without extra configuration. There's no graph definition language to learn, no complex expression layer to parse.
 
@@ -117,7 +117,7 @@ The handoff model deserves specific mention: when one agent completes its portio
 
 ### Mastra
 
-Mastra is an open-source TypeScript framework for building AI-powered applications and agents. It was built by the team behind Gatsby, and it's gained serious production traction since launching. Mastra is trusted by engineering teams at Replit, SoftBank, PayPal, PLAID, and Marsh McLennan. Marsh McLennan deployed an agentic search tool built with the framework to 75,000 employees.
+[Mastra](https://mastra.ai/docs) is an open-source TypeScript framework for building AI-powered applications and agents. It was built by the team behind Gatsby, and it's gained serious production traction since launching. Mastra is trusted by engineering teams at Replit, SoftBank, PayPal, PLAID, and Marsh McLennan. Marsh McLennan deployed an agentic search tool built with the framework to 75,000 employees.
 
 The framework comes with a graph-based workflow engine that orchestrates complex multi-step processes with explicit control over execution, plus Mastra Studio, an interactive environment for testing agents, tracing execution, and refining prompts before and after you ship. This local dev playground for visualizing workflow graphs before deployment is a meaningful productivity advantage over purely code-based frameworks.
 
@@ -152,7 +152,7 @@ Chat's build mode is where the workflow differs most from code-first approaches.
 
 ### Dify
 
-Dify is an open-source LLM app development platform with a visual workflow builder. It's well-suited for teams that want low-code agent construction with RAG (retrieval-augmented generation) pipelines and a broad integration set without needing to think in graph abstractions.
+[Dify](https://dify.ai/pricing) is an open-source LLM app development platform with a visual workflow builder. It's well-suited for teams that want low-code agent construction with RAG (retrieval-augmented generation) pipelines and a broad integration set without needing to think in graph abstractions.
 
 Relative to LangGraph, Dify offers a significantly lower engineering floor to get started. You drag blocks, connect them visually, and deploy. The trade-off is less fine-grained control over state transitions for complex branching logic. If your workflow needs deterministic, auditable paths through dozens of conditional branches, Dify's visual model can feel limiting. But for RAG-heavy applications and LLM-powered tools where the goal is getting something running and connected to data sources fast, it's one of the most accessible options available.
 
@@ -190,3 +190,5 @@ LangGraph is a strong tool for a specific set of problems. If your team requires
 For Python teams that want a different architectural model but still want to own their stack, CrewAI, Google ADK, and the OpenAI Agents SDK each offer compelling trade-offs depending on your cloud provider and use case. TypeScript teams have Mastra. Teams invested in Azure should watch the Microsoft Agent Framework closely.
 
 For teams where the real bottleneck is getting agents into production, connected to business tools, and maintained by more than one person, a workspace platform like Sim removes the infrastructure burden so you can focus on the agent logic itself. You can [start building in Sim](https://sim.ai) and see how visual, conversational, and API-driven agent building compares to graph definitions in code.
+
+For wider context: [open-source AI agent platforms](/library/open-source-ai-agent-platforms) covers the self-hostable field including the code-first frameworks, and [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) adds the commercial options. [How to build AI agents](/library/how-to-create-an-ai-agent) is the visual-first walkthrough if you're moving off code.

--- a/apps/sim/content/library/n8n-alternatives/index.mdx
+++ b/apps/sim/content/library/n8n-alternatives/index.mdx
@@ -3,7 +3,7 @@ slug: n8n-alternatives
 title: '10 Best n8n Alternatives for AI Agent Workflows in 2026'
 description: Comparing the 10 best n8n alternatives in 2026 for AI agent workflows - covering Sim, Make, Zapier, Activepieces, Pipedream, and more, with pricing and use cases.
 date: 2026-07-13
-updated: 2026-07-13
+updated: 2026-07-23
 authors:
   - emir
 readingTime: 15
@@ -31,7 +31,7 @@ This guide covers 10 n8n alternatives for two distinct groups: teams that want s
 - **n8n's core friction points in 2026:** Self-hosting overhead, execution-based pricing that escalates at volume, and AI capabilities bolted onto a pre-agentic architecture push teams toward purpose-built alternatives.
 - **For AI agent workflows:** Sim offers native multi-model orchestration, agent memory, and MCP support as fully integral features rather than add-ons. Gumloop and Botpress serve more specific AI niches (visual LLM workflows and conversational agents, respectively).
 - **For simpler SaaS automation:** Make provides the best debugging experience for visual workflow builders. Zapier offers the widest integration catalog. Neither is built for agentic AI.
-- **Open source matters, but licenses vary:** Activepieces uses a genuine MIT license with no commercial restrictions. n8n's Sustainable Use License restricts commercial redistribution, which isn't true open source by OSI standards.
+- **Open source matters, but licenses vary:** Activepieces uses a genuine MIT license with no commercial restrictions. n8n's [Sustainable Use License](https://docs.n8n.io/privacy-and-security/sustainable-use-license) restricts commercial redistribution, which isn't true open source by OSI standards. We unpack the practical consequences in [Apache 2.0 vs fair-code](/library/apache-2-0-vs-fair-code).
 - **Migration is never a weekend project:** Moving a portfolio of n8n workflows to any alternative requires real engineering time. Calculate total cost of ownership, including DevOps hours, before committing.
 - **Self-hosting isn't automatically cheaper:** Factor in server costs, database hosting, security patches, and maintenance hours against the subscription price of managed alternatives before assuming you'll save money.
 
@@ -72,14 +72,14 @@ This table summarizes all 10 tools across the dimensions that matter most when e
 | Tool | Best For | AI Agent Depth | Open Source | Starting Price |
 | --- | --- | --- | --- | --- |
 | **Sim** | AI agent workflows with multi-model orchestration | Native (memory, multi-agent, MCP) | Yes | Free plan available |
-| **Make** | Visual SaaS automation with strong debugging | One-shot AI nodes only | No | Free tier; paid from ~$12/mo |
-| **Zapier** | Widest integration catalog, fastest setup | Basic (Zapier Agents, Copilot) | No | Free tier; paid from ~$20/mo |
-| **Activepieces** | Open-source self-hosting with MIT license | Growing (AI agents, MCP servers) | Yes (MIT) | Free self-hosted; cloud from $5/flow/mo |
+| **[Make](https://www.make.com/en/pricing)** | Visual SaaS automation with strong debugging | One-shot AI nodes only | No | Free tier; paid from $12/mo |
+| **[Zapier](https://zapier.com/pricing)** | Widest integration catalog, fastest setup | Basic (Zapier Agents, Copilot) | No | Free tier; paid from $19.99/mo (annual) |
+| **[Activepieces](https://www.activepieces.com/pricing)** | Open-source self-hosting with MIT license | Growing (AI agents, MCP servers) | Yes (MIT) | Free self-hosted; cloud from $5/flow/mo after 10 free |
 | **Pipedream** | Code-first automation without infra management | Not AI-agent native | Partial | Free tier available |
-| **Gumloop** | Non-developers building LLM-powered workflows | Native visual AI canvas | No | Verify on site |
-| **Lindy** | Task-specific AI agents (email, meetings, sales) | Pre-built agent templates | No | ~$49.99/mo |
-| **Botpress** | Conversational AI agents (chat, voice) | Native (memory, RAG, goals) | Partial | Verify on site |
-| **Microsoft Power Automate** | Microsoft 365/Azure ecosystem teams | AI Builder (add-on cost) | No | Included with some M365 plans |
+| **[Gumloop](https://www.gumloop.com/pricing)** | Non-developers building LLM-powered workflows | Native visual AI canvas | No | See pricing page |
+| **[Lindy](https://www.lindy.ai/pricing)** | Task-specific AI agents (email, meetings, sales) | Pre-built agent templates | No | $49.99/mo |
+| **[Botpress](https://botpress.com/pricing)** | Conversational AI agents (chat, voice) | Native (memory, RAG, goals) | Partial | See pricing page |
+| **[Microsoft Power Automate](https://www.microsoft.com/en-us/power-platform/products/power-automate/pricing)** | Microsoft 365/Azure ecosystem teams | AI Builder (add-on cost) | No | $15/user/mo; included with some M365 plans |
 | **Workato** | Enterprise iPaaS with SLAs and compliance | Enterprise orchestration | No | Custom pricing |
 
 ## The 10 Best n8n Alternatives in 2026
@@ -115,7 +115,7 @@ Make's color-coded visual scenario builder is genuinely the best debugging exper
 
 **Limitations:** Make has added AI modules for OpenAI and Claude, but they function as one-shot nodes only. There's no native multi-agent orchestration, no agent memory, and AI can't reason across steps. If you need agentic capabilities, Make won't provide them.
 
-**Pricing:** Make offers a free plan with 1,000 credits per month. Paid plans start at $12/month (billed annually) for 10,000 credits (Core). Each module action in a scenario counts as one credit, including triggers, filters, and routers, so a single Zapier task might equal 3-8 Make operations. Monitor your credit consumption carefully as workflows grow more complex.
+**Pricing:** [Make](https://www.make.com/en/pricing) offers a free plan with 1,000 credits per month. Paid plans start at $12/month billed monthly for 10,000 credits (Core), with roughly 15% off for annual billing. Each module action in a scenario counts as one credit, including triggers, filters, and routers, so a single Zapier task might equal 3-8 Make operations. Monitor your credit consumption carefully as workflows grow more complex.
 
 ### Zapier
 
@@ -144,7 +144,7 @@ Activepieces is the cleanest open-source alternative to n8n if licensing terms m
 - **MIT license with no strings attached:** The codebase lives on GitHub under the MIT license, the most permissive of open-source licenses, giving organizations complete freedom to self-host, modify, fork, and extend the platform without any licensing fees or usage restrictions.
 - **Growing integration and MCP ecosystem:** All 750+ pieces are available as MCP servers that you can use with LLMs on Claude Desktop, Cursor, or Windsurf. The community contributes actively, with 60% of the pieces contributed by the community.
 - **Clean, accessible UI:** Activepieces has the most polished UI of any open-source automation platform, making it accessible to non-technical users while still supporting code steps for custom logic.
-- **Flat-rate cloud pricing:** Cloud pricing starts free with 10 free active flows, then $5 per active flow per month with unlimited runs. No per-execution billing surprises.
+- **Flat-rate cloud pricing:** [Cloud pricing](https://www.activepieces.com/pricing) starts free with 10 free active flows, then $5 per active flow per month with unlimited runs. No per-execution billing surprises.
 
 **Limitations:** The connector ecosystem is smaller than n8n, Make, or Zapier. Enterprise features like SSO, audit logs, and custom RBAC are available under the commercial license, so fully free self-hosted deployments miss those governance capabilities.
 
@@ -196,7 +196,7 @@ Lindy takes a different approach than most platforms on this list. Instead of gi
 
 **Limitations:** Credit-based pricing frustrates teams with high automation volume. Lindy is better for task-specific agents than complex multi-agent orchestration, and it's limited to its defined use case categories. If your workflow doesn't fit Lindy's templates, you'll hit bottlenecks pretty quickly.
 
-**Pricing:** Paid plans start at approximately $49.99/month. Verify current pricing on Lindy's website.
+**Pricing:** [Lindy's](https://www.lindy.ai/pricing) Plus plan is $49.99/month, with Pro at $99.99 and Max at $199.99. There is a 7-day trial but no permanent free plan.
 
 ### Botpress
 
@@ -250,7 +250,7 @@ Workato sits at the opposite end of the spectrum from open-source tools. It's a 
 
 Many teams looking for an n8n open source alternative care about one of three things: self-hosting flexibility, data sovereignty, or cost reduction. How the licensing works for each alternative matters more than most comparison articles acknowledge.
 
-**n8n uses fair-code, not open source.** Although n8n's source code is available under the Sustainable Use License, according to the Open Source Initiative (OSI), open source licenses can't include limitations on use, so n8n does not call itself open source. In practical terms, the license allows you the free right to use, modify, create derivative works, and redistribute, with three limitations, the most significant being that the moment automation becomes a value proposition for external users, the license blocks it. For internal business use, this rarely matters. For agencies, consultancies, or SaaS companies embedding automation into customer-facing products, it's a dealbreaker.
+**n8n uses fair-code, not open source.** Although n8n's source code is available under the [Sustainable Use License](https://docs.n8n.io/privacy-and-security/sustainable-use-license), according to the [Open Source Initiative (OSI)](https://opensource.org/osd), open source licenses can't include limitations on use, so n8n does not call itself open source. In practical terms, the license allows you the free right to use, modify, create derivative works, and redistribute, with three limitations, the most significant being that the moment automation becomes a value proposition for external users, the license blocks it. For internal business use, this rarely matters. For agencies, consultancies, or SaaS companies embedding automation into customer-facing products, it's a dealbreaker.
 
 **Activepieces uses the MIT license.** Unlike many competitors that keep their code proprietary, Activepieces' MIT license allows you to use, adapt, and scale the platform without restrictions. You can embed it in commercial products, resell hosted instances, or fork the codebase without legal risk. This is the permissive open-source experience most developers expect when they hear the term "open source."
 
@@ -271,3 +271,5 @@ If you're leaving because self-hosting is consuming too much engineering time, M
 If licensing restrictions concern you, Activepieces offers the cleanest MIT-licensed alternative with a growing integration ecosystem.
 
 Don't try to evaluate all 10 tools on this list. Identify which of the four archetypes from the framework section fits your team, narrow the list to two or three candidates, and build a real workflow in each. The free tiers across Sim, Make, Zapier, Activepieces, and Pipedream allow you to do this without any upfront spend.
+
+For adjacent shortlists: [best Zapier alternatives](/library/best-zapier-alternatives) covers the same market from the per-task-pricing angle, [open-source AI agent platforms](/library/open-source-ai-agent-platforms) narrows to self-hostable options, and [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) ranks the field on agent capability rather than integration count.

--- a/apps/sim/content/library/open-source-ai-agent-platforms/index.mdx
+++ b/apps/sim/content/library/open-source-ai-agent-platforms/index.mdx
@@ -3,7 +3,7 @@ slug: open-source-ai-agent-platforms
 title: 'Open-Source AI Agent Platforms: Comparison'
 description: Compare the top open-source AI agent platforms of 2026 - LangGraph, CrewAI, AutoGen, Dify, n8n, and Sim - by architecture, production readiness, and team fit. Find the right one for your use case.
 date: 2026-07-13
-updated: 2026-07-13
+updated: 2026-07-23
 authors:
   - emir
 readingTime: 12
@@ -29,9 +29,9 @@ This guide splits open-source AI agent platforms into three clear categories, co
 ## Key Takeaways
 
 - **Three categories, not one:** Code-first frameworks (LangGraph, CrewAI, AutoGen), visual builders (Dify, n8n), and AI workspaces (Sim) serve fundamentally different buyers and require different evaluations.
-- **AutoGen is splintering:** Microsoft's AutoGen has fractured into maintenance mode, a community-led AG2 fork, and the new Microsoft Agent Framework. Teams need to choose the option that will work best for them.
+- **AutoGen is splintering:** Microsoft's [AutoGen](https://microsoft.github.io/autogen/stable/) has fractured into maintenance mode, a community-led AG2 fork, and the new Microsoft Agent Framework. Teams need to choose the option that will work best for them.
 - **CrewAI Flows changed the game:** CrewAI's Flows feature adds event-driven orchestration alongside crew-style collaboration, giving teams both flexibility and control in one framework.
-- **Dify dominates the visual builder space:** With over 131,000 GitHub stars and a recent $30M raise, Dify is the most-adopted visual AI agent builder, though it still lacks strong team governance features.
+- **Dify dominates the visual builder space:** With over [149,000 GitHub stars](https://github.com/langgenius/dify) and a recent $30M raise, Dify is the most-adopted visual AI agent builder, though it still lacks strong team governance features.
 - **Workspace platforms bundle what frameworks leave out:** Sim combines visual building, team collaboration, knowledge management, and deployment infrastructure in a single open-source package, reducing the "glue code" problem.
 - **Self-hosting and licensing vary widely:** "Open source" means different things across these platforms, from fully permissive MIT licenses to open-core models where enterprise features sit behind paid tiers.
 
@@ -59,7 +59,7 @@ That control comes at a cost: these frameworks assume you have engineers who can
 
 ### LangGraph
 
-LangGraph is the default choice for complex stateful workflows that need explicit control over branching, retries, and human-in-the-loop. It sits on top of the LangChain ecosystem and has seen the largest enterprise adoption among code-first agent frameworks.
+[LangGraph](https://langchain-ai.github.io/langgraph/) is the default choice for complex stateful workflows that need explicit control over branching, retries, and human-in-the-loop. It sits on top of the LangChain ecosystem and has seen the largest enterprise adoption among code-first agent frameworks.
 
 LangGraph does four things excellently: branching logic that lets you define exactly which path an agent takes based on state, human-led approvals and checkpointing that are now integral features rather than add-ons, durable execution that survives process restarts, and detailed control over every step in the agent's decision chain.
 
@@ -69,7 +69,7 @@ Where it demands investment: setup isn't trivial, especially for teams new to gr
 
 ### CrewAI
 
-CrewAI introduced a mental model that's simple to pick up: instead of defining abstract graph nodes, you define roles. A researcher agent gathers information, a writer agent drafts content, a reviewer agent checks quality. CrewAI is the fastest path from idea to working multi-agent prototype when work decomposes into role-based tasks.
+[CrewAI](https://docs.crewai.com/) introduced a mental model that's simple to pick up: instead of defining abstract graph nodes, you define roles. A researcher agent gathers information, a writer agent drafts content, a reviewer agent checks quality. CrewAI is the fastest path from idea to working multi-agent prototype when work decomposes into role-based tasks.
 
 The Flows addition lets you create structured, event-driven workflows that provide a way to connect multiple tasks, manage state, and control the flow of execution in your AI applications. This is a meaningful evolution. Flows give you a structured, event-driven execution engine that sits above individual crews and tasks. A Crew is great at parallel collaboration with multiple agents working on a shared goal, but Crews don't give you sequential control. Think of it this way: a Crew is a team, a Flow is the project plan that coordinates multiple teams.
 
@@ -99,11 +99,11 @@ Visual builders trade code-level control for speed. They let teams design agent 
 
 Dify's open-source model with 131k GitHub stars targets production scalability. That star count makes it the most-starred visual AI agent builder in the open-source space by a wide margin, and it reflects genuine production adoption.
 
-Dify is a production-ready platform for agentic workflow development, handling everything from enterprise QA bots to AI-driven custom assistants. The platform includes a workflow builder for defining tool-using agents, built-in RAG (retrieval-augmented generation) pipeline management, support for multiple AI model providers, and Model Context Protocol (MCP) integration.
+[Dify](https://dify.ai/pricing) is a production-ready platform for agentic workflow development, handling everything from enterprise QA bots to AI-driven custom assistants. The platform includes a workflow builder for defining tool-using agents, built-in RAG (retrieval-augmented generation) pipeline management, support for multiple AI model providers, and Model Context Protocol (MCP) integration.
 
 The RAG pipeline is Dify's standout feature. It's among the best available in an open-source package. If your primary use case involves document retrieval, knowledge bases, and structured Q&A, Dify's built-in tooling eliminates weeks of integration work.
 
-The self-hosted Community Edition (Docker Compose, single machine or Kubernetes) is free with no significant limitations. Dify Cloud starts with a free Sandbox tier and scales to Professional ($59/month), Team ($159/month), and Enterprise (custom) plans.
+The self-hosted Community Edition (Docker Compose, single machine or Kubernetes) is free with no significant limitations. [Dify Cloud](https://dify.ai/pricing) starts with a free Sandbox tier at 200 message credits and scales to Professional, Team, and Enterprise plans; the Professional tier lists at $590/year and Team at $1,590/year.
 
 Where Dify falls short relative to a purpose-built AI workspace: team governance is limited, agent lifecycle management (versioning, rollback, multi-user editing) lacks depth, and the visual tooling has a ceiling; complex custom logic belongs in code.
 
@@ -190,3 +190,5 @@ Visual builders like Dify and n8n lower the barrier to entry but trade away arch
 Start with the decision paths above. Identify which category fits your team, then evaluate within that category. Trying to compare a Python framework against a visual workspace on the same checklist is how teams end up six months into a tool that doesn't fit.
 
 If your team needs collaboration, multi-model support, and a visual builder with production-grade deployment, [explore Sim](https://sim.ai) and see whether the workspace model matches how your team actually works.
+
+Related reading: [Apache 2.0 vs fair-code](/library/apache-2-0-vs-fair-code) explains why license choice changes what you can build on a self-hosted platform, [LangGraph alternatives](/library/langgraph-alternatives) goes deeper on the code-first category, and [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) widens the field to commercial options alongside these.

--- a/apps/sim/content/library/openai-vs-n8n-vs-sim/index.mdx
+++ b/apps/sim/content/library/openai-vs-n8n-vs-sim/index.mdx
@@ -3,7 +3,7 @@ slug: openai-vs-n8n-vs-sim
 title: 'OpenAI AgentKit vs n8n vs Sim: AI Agent Workflow Builder Comparison'
 description: OpenAI just released AgentKit for building AI agents. How does it compare to workflow automation platforms like n8n and purpose-built AI agent builders like Sim?
 date: 2025-10-06
-updated: 2025-10-06
+updated: 2026-07-23
 authors:
   - emir
 readingTime: 9
@@ -30,7 +30,7 @@ When building AI agent workflows, developers often evaluate multiple platforms t
 
 ## What is OpenAI AgentKit?
 
-OpenAI AgentKit is a set of building blocks designed to help developers take AI agents from prototype to production. Built on top of the OpenAI Responses API, it provides a structured approach to building and deploying intelligent agents.
+[OpenAI AgentKit](https://developers.openai.com/api/docs/guides/agents) is a set of building blocks designed to help developers take AI agents from prototype to production. Built on top of the OpenAI Responses API, it provides a structured approach to building and deploying intelligent agents.
 
 ![OpenAI AgentKit workflow interface](/library/openai-vs-n8n-vs-sim/openai.png)
 
@@ -221,3 +221,5 @@ Choose **OpenAI AgentKit** if you're exclusively using OpenAI models and want to
 Choose **n8n** if your primary use case is traditional workflow automation between business tools, with occasional AI enhancement. It's ideal for organizations already familiar with n8n who want to add some AI capabilities to existing automations.
 
 Choose **Sim** if you're building AI agents as your primary objective and need a platform purpose-built for that use case. Sim provides the most comprehensive feature set for agentic workflows, with AI Copilot to accelerate development, parallel execution handling, intelligent knowledge base for RAG applications, detailed execution logging for production monitoring, flexibility across AI providers, extensive integrations, team collaboration, and deployment options that scale from prototype to production.
+
+Going wider than these three? [The best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) compares the full field, [10 best n8n alternatives](/library/n8n-alternatives) covers n8n's competitors specifically, and [Apache 2.0 vs fair-code](/library/apache-2-0-vs-fair-code) explains why n8n's license matters if you plan to self-host commercially.

--- a/apps/sim/lib/content/mdx.tsx
+++ b/apps/sim/lib/content/mdx.tsx
@@ -1,7 +1,31 @@
 import clsx from 'clsx'
 import type { MDXRemoteProps } from 'next-mdx-remote/rsc'
 import { CodeBlock } from '@/lib/content/code'
+import { SITE_URL } from '@/lib/core/utils/urls'
 import { ContentImage } from '@/app/(landing)/components/content-image'
+
+/**
+ * Apex host for every Sim-owned property, derived from the canonical site URL
+ * rather than the environment so a post renders identically in dev, preview,
+ * and production.
+ */
+const SITE_APEX_HOST = new URL(SITE_URL).hostname.replace(/^www\./, '')
+
+/**
+ * True only for links that leave Sim entirely. Relative hrefs, in-page anchors,
+ * the apex host, and any Sim subdomain (`www.`, `docs.`) are first-party and keep
+ * default same-tab navigation so internal linking stays crawlable. The leading dot
+ * in the suffix check keeps lookalike domains such as `evil-sim.ai` external.
+ */
+function isExternalHref(href: string | undefined): boolean {
+  if (!href || !/^https?:\/\//i.test(href)) return false
+  try {
+    const { hostname } = new URL(href)
+    return hostname !== SITE_APEX_HOST && !hostname.endsWith(`.${SITE_APEX_HOST}`)
+  } catch {
+    return false
+  }
+}
 
 export const mdxComponents: MDXRemoteProps['components'] = {
   img: (props: any) => (
@@ -84,10 +108,9 @@ export const mdxComponents: MDXRemoteProps['components'] = {
     }
     /**
      * Outbound citations in post bodies open in a new tab and carry
-     * `rel="noopener noreferrer"`, per `.claude/rules/landing-seo-geo.md`. Same-origin
-     * and in-page links keep default navigation so internal linking stays crawlable.
+     * `rel="noopener noreferrer"`, per `.claude/rules/landing-seo-geo.md`.
      */
-    const isExternal = /^https?:\/\//.test(props.href ?? '')
+    const isExternal = isExternalHref(props.href)
     return (
       <a
         {...props}

--- a/apps/sim/lib/content/mdx.tsx
+++ b/apps/sim/lib/content/mdx.tsx
@@ -82,9 +82,16 @@ export const mdxComponents: MDXRemoteProps['components'] = {
     if (isAnchorLink) {
       return <a {...props} className={clsx('text-inherit no-underline', props.className)} />
     }
+    /**
+     * Outbound citations in post bodies open in a new tab and carry
+     * `rel="noopener noreferrer"`, per `.claude/rules/landing-seo-geo.md`. Same-origin
+     * and in-page links keep default navigation so internal linking stays crawlable.
+     */
+    const isExternal = /^https?:\/\//.test(props.href ?? '')
     return (
       <a
         {...props}
+        {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
         className={clsx(
           'font-medium text-[var(--text-primary)] underline hover:text-[var(--text-primary)]',
           props.className


### PR DESCRIPTION
## Summary

The library had **zero third-party citations** across 16 posts (~51k words) and averaged **1.2 internal links per post**, with six posts at zero. This adds **59 outbound citations** and **3-6 internal links per post** (no post left without them).

Auditing every dollar figure against the vendor's own pricing page — rather than just linking numbers I hadn't checked — turned up several stale claims and one product being shut down.

### ⚠️ Relay.app is shutting down

[Relay.app](https://www.relay.app/) closed new signups on **2026-07-16**, free accounts end **2026-08-15**, paid accounts end **2026-09-14**. We were recommending it as the human-in-the-loop pick in `best-zapier-alternatives` — in the TL;DR, the routing table, the pricing table, the FAQ, and a full section. All five now say it's winding down and route to a platform you can still sign up for.

`best-relay-app-alternatives-2026` already led with the shutdown and had the dates right; it just needed the source link. That post gets *more* valuable now, not less — people searching for Relay alternatives are doing it because of this.

### Pricing corrections (each verified 2026-07-23)

| Claim | Was | Now |
|---|---|---|
| Make Core | $10.59/mo (annual) | **$12/mo monthly**, ~15% off annual |
| Make billing term | "$12/month (billed annually)" | $12 is the **monthly** rate |
| Pabbly lifetime | $249 one-time | **$349** one-time |
| Pabbly tiers | Standard $16/12k, Pro $33/24k, Ultimate $67/300k | **Structure no longer exists** — now Free / Standard (10k) / Unlimited |
| Workato | "~$1,000/month" | **Publishes no pricing** — quote-only |
| Dify stars | over 131,000 | **~149,000** |
| n8n cloud | ~$24/mo | **€20/mo** annual, 2,500 executions |

**Verified correct and left alone** (now with source links): Zapier $29.99/mo monthly for 750 tasks and the 100-task 2-step free plan; Activepieces 10 free flows then $5/flow/mo under MIT; Power Automate $15/user/mo; Lindy $49.99/mo; Grand View Research RPA figures ($4.68B 2025, 29.0% CAGR, $35.84B by 2033).

**Deliberately not pinned to a number:** vendor pricing pages are geo-localized (Pabbly served me ₹ rupees) and JS-rendered. Where I could not verify a figure from here, the pricing page is linked from the section or table so readers can check current rates, rather than asserting a figure a link doesn't substantiate.

### Bug found along the way

MDX-authored external links rendered **without** `rel="noopener noreferrer"` — only hardcoded JSX links had it. `.claude/rules/landing-seo-geo.md` requires it. Fixed in `lib/content/mdx.tsx`: external `http(s)` hrefs now get `target="_blank"` + `rel="noopener noreferrer"`; same-origin and in-page links are untouched so internal linking stays crawlable.

## Type of Change
- [x] Improvement (content + one component fix)

## Testing

- **All 40 unique external URLs return 200.** Three initially didn't: `github.com/n8n-io/n8n/LICENSE.md` was a 429 from my own API rate-limiting (200 on retry), and `make.com` + `grandviewresearch.com` return Cloudflare `<title>Just a moment...</title>` bot challenges — not 404s. Both were read successfully via other means, which is where their figures came from.
- **All 16 library pages render 200.**
- **All 15 distinct rendered `/library/` hrefs return 200** — crawled from the rendered HTML, not just grepped from source.
- **No self-links**, and no absolute `sim.ai/library/...` links left in bodies (one was converted to relative).
- Verified rendered output: external links carry `target="_blank" rel="noopener noreferrer"`, internal links carry neither.
- `tsc --noEmit` 0 errors; `bun run lint` clean; all 10 `check:*` gates pass.

`updated` bumped to 2026-07-23 on all 16 posts — every one received a substantive edit, so this is not date-washing.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)