### PR TITLE
fix(chat): rotate fork chat split icon 90 degrees

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
@@ -234,7 +234,7 @@ export const MessageActions = memo(function MessageActions({
                 disabled={forkChat.isPending}
                 className={cn(BUTTON_CLASS, forkChat.isPending && 'cursor-not-allowed opacity-50')}
               >
-                <Split className={ICON_CLASS} />
+                <Split className={cn(ICON_CLASS, 'rotate-90')} />
               </button>
             </Tooltip.Trigger>
             <Tooltip.Content side='top'>Branch in new chat</Tooltip.Content>


### PR DESCRIPTION
## Summary
Rotate fork chat Split icon 90 degrees so it faces to the right

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [x] Other: Cosmetic Change

## Testing
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Before
<img width="129" height="40" alt="Screenshot 2026-07-23 at 7 32 07 PM" src="https://github.com/user-attachments/assets/d6bc3652-3bfb-4894-b493-03268292e1fd" />

After
<img width="124" height="46" alt="Screenshot 2026-07-23 at 7 31 18 PM" src="https://github.com/user-attachments/assets/fc763f37-9cfa-497a-88e2-54f9c4eb3275" />
