### PR TITLE
fix(providers): final regenerated stream must not re-call tools (empty chat answers)

### DIFF
--- a/apps/docs/content/docs/en/workflows/deployment/agent-events.mdx
+++ b/apps/docs/content/docs/en/workflows/deployment/agent-events.mdx
@@ -80,7 +80,7 @@ Per-model support is generated from the model registry on the [Agent block page]
 |--------|----------|------------|
 | Anthropic / Azure Anthropic | Yes (incl. redacted blocks in traces). The newest Claude generations omit full thinking; Sim requests summarized thinking for them on streaming runs | Yes |
 | Gemini / Vertex | Yes when a thinking level is set (thought summaries requested on agent-events runs) | Yes |
-| OpenAI Responses | Reasoning **summaries** when streamed (requires OpenAI organization verification; unverified orgs fall back to no summaries) | Silent tool loop today (answer streams; chips may be absent) |
+| OpenAI Responses | Reasoning **summaries** when streamed (requires OpenAI organization verification; unverified orgs fall back to no summaries) | Silent tool loop; tool chips arrive settled (start + end together) once tools finish, ahead of the streamed answer — no live in-progress chips yet |
 | OpenAI-compat (Groq, DeepSeek, …) | Only if vendor streams `reasoning` / `reasoning_content` | Live loop where wired (e.g. Groq, DeepSeek) |
 | Bedrock | Not invented | Yes when streaming tool loop is used |
 

--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -852,11 +852,17 @@ export async function executeAnthropicProviderRequest(
 
       const accumulatedCost = calculateCost(request.model, tokens.input, tokens.output)
 
+      /**
+       * The regeneration exists purely to stream the settled answer as prose —
+       * streamed tool_use is never executed on this path. `tools` must stay
+       * (history contains tool_use blocks) but tool choice is pinned to none;
+       * with tools present and no choice, `auto` would let the model re-call.
+       */
       const streamingPayload = {
         ...payload,
         messages: currentMessages,
         stream: true,
-        tool_choice: undefined,
+        tool_choice: payload.tools?.length ? ({ type: 'none' } as const) : undefined,
       }
 
       const streamResponse = await anthropic.messages.create(
@@ -890,7 +896,12 @@ export async function executeAnthropicProviderRequest(
           createReadableStreamFromAnthropicStream(
             streamResponse as AsyncIterable<RawMessageStreamEvent>,
             ({ content: streamContent, usage, thinking }) => {
-              output.content = streamContent
+              if (!streamContent && content) {
+                logger.warn(
+                  `${providerLabel} final stream produced no text; keeping tool-loop answer`
+                )
+              }
+              output.content = streamContent || content
               output.tokens = {
                 input: tokens.input + usage.input_tokens,
                 output: tokens.output + usage.output_tokens,
@@ -1286,11 +1297,12 @@ export async function executeAnthropicProviderRequest(
     if (request.stream) {
       logger.info(`Using streaming for final ${providerLabel} response after tool processing`)
 
+      /** Same regeneration guard as the primary path: prose only, no re-calls. */
       const streamingPayload = {
         ...payload,
         messages: currentMessages,
         stream: true,
-        tool_choice: undefined,
+        tool_choice: payload.tools?.length ? ({ type: 'none' } as const) : undefined,
       }
 
       const streamResponse = await anthropic.messages.create(
@@ -1324,7 +1336,12 @@ export async function executeAnthropicProviderRequest(
           createReadableStreamFromAnthropicStream(
             streamResponse as AsyncIterable<RawMessageStreamEvent>,
             ({ content: streamContent, usage, thinking }) => {
-              output.content = streamContent
+              if (!streamContent && content) {
+                logger.warn(
+                  `${providerLabel} final stream produced no text; keeping tool-loop answer`
+                )
+              }
+              output.content = streamContent || content
               output.tokens = {
                 input: tokens.input + usage.input_tokens,
                 output: tokens.output + usage.output_tokens,

--- a/apps/sim/providers/azure-openai/index.ts
+++ b/apps/sim/providers/azure-openai/index.ts
@@ -477,10 +477,14 @@ async function executeChatCompletionsRequest(
 
       const accumulatedCost = calculateCost(request.model, tokens.input, tokens.output)
 
+      /**
+       * The regeneration exists purely to stream the settled answer as prose —
+       * streamed tool_calls are never executed on this path.
+       */
       const streamingParams: ChatCompletionCreateParamsStreaming = {
         ...payload,
         messages: currentMessages,
-        tool_choice: 'auto',
+        tool_choice: 'none',
         stream: true,
         stream_options: { include_usage: true },
       }
@@ -520,8 +524,11 @@ async function executeChatCompletionsRequest(
             : undefined,
         streamFormat: 'agent-events-v1',
         createStream: ({ output, finalizeTiming }) =>
-          createReadableStreamFromAzureOpenAIStream(streamResponse, (content, usage) => {
-            output.content = content
+          createReadableStreamFromAzureOpenAIStream(streamResponse, (streamedContent, usage) => {
+            if (!streamedContent && content) {
+              logger.warn('Azure OpenAI final stream produced no text; keeping tool-loop answer')
+            }
+            output.content = streamedContent || content
             output.tokens = {
               input: tokens.input + usage.prompt_tokens,
               output: tokens.output + usage.completion_tokens,

--- a/apps/sim/providers/bedrock/index.ts
+++ b/apps/sim/providers/bedrock/index.ts
@@ -942,7 +942,16 @@ export const bedrockProvider: ProviderConfig = {
           streamFormat: 'agent-events-v1',
           createStream: ({ output, finalizeTiming }) =>
             createReadableStreamFromBedrockStream(bedrockStream, (streamContent, usage) => {
-              output.content = streamContent
+              /**
+               * Bedrock's ToolChoice has no `none`, and toolConfig is required
+               * when history carries toolUse blocks — the regeneration can
+               * re-call a tool that is never executed on this path. Keep the
+               * tool loop's settled answer when the stream ends without text.
+               */
+              if (!streamContent && content) {
+                logger.warn('Bedrock final stream produced no text; keeping tool-loop answer')
+              }
+              output.content = streamContent || content
               output.tokens = {
                 input: tokens.input + usage.inputTokens,
                 output: tokens.output + usage.outputTokens,

--- a/apps/sim/providers/cerebras/index.ts
+++ b/apps/sim/providers/cerebras/index.ts
@@ -448,10 +448,14 @@ export const cerebrasProvider: ProviderConfig = {
       if (request.stream) {
         logger.info('Using streaming for final Cerebras response after tool processing')
 
+        /**
+         * The regeneration exists purely to stream the settled answer as prose —
+         * streamed tool_calls are never executed on this path.
+         */
         const streamingPayload = {
           ...payload,
           messages: currentMessages,
-          tool_choice: 'auto',
+          tool_choice: 'none',
           stream: true,
         }
 
@@ -495,8 +499,11 @@ export const cerebrasProvider: ProviderConfig = {
           isStreaming: true,
           streamFormat: 'agent-events-v1',
           createStream: ({ output }) =>
-            createReadableStreamFromCerebrasStream(streamResponse, (content, usage) => {
-              output.content = content
+            createReadableStreamFromCerebrasStream(streamResponse, (streamedContent, usage) => {
+              if (!streamedContent && content) {
+                logger.warn('Cerebras final stream produced no text; keeping tool-loop answer')
+              }
+              output.content = streamedContent || content
               output.tokens = {
                 input: tokens.input + usage.prompt_tokens,
                 output: tokens.output + usage.completion_tokens,

--- a/apps/sim/providers/deepseek/index.ts
+++ b/apps/sim/providers/deepseek/index.ts
@@ -544,10 +544,15 @@ export const deepseekProvider: ProviderConfig = {
       if (request.stream) {
         logger.info('Using streaming for final DeepSeek response after tool processing')
 
+        /**
+         * The regeneration exists purely to stream the settled answer as prose —
+         * streamed tool_calls are never executed on this path; with `auto` a
+         * model can re-call and end the stream with no text.
+         */
         const streamingPayload = {
           ...payload,
           messages: currentMessages,
-          tool_choice: 'auto',
+          tool_choice: 'none',
           stream: true,
         }
 
@@ -594,8 +599,11 @@ export const deepseekProvider: ProviderConfig = {
             createReadableStreamFromDeepseekStream(
               // double-cast-allowed: payload is untyped so the SDK cannot resolve the streaming overload; the stream yields OpenAI ChatCompletionChunk objects
               streamResponse as unknown as AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>,
-              (content, usage, thinking) => {
-                output.content = content
+              (streamedContent, usage, thinking) => {
+                if (!streamedContent && content) {
+                  logger.warn('DeepSeek final stream produced no text; keeping tool-loop answer')
+                }
+                output.content = streamedContent || content
                 output.tokens = {
                   input: tokens.input + usage.prompt_tokens,
                   output: tokens.output + usage.completion_tokens,

--- a/apps/sim/providers/gemini/core.ts
+++ b/apps/sim/providers/gemini/core.ts
@@ -1239,7 +1239,20 @@ export async function executeGeminiRequest(
                 request.responseFormat.schema
               ) as Schema
             }
+          } else if (nextConfig.tools) {
+            /**
+             * The regeneration exists purely to stream the settled answer as
+             * prose — streamed function calls are never executed. With AUTO the
+             * model can re-decide to call a tool here, ending the stream with a
+             * dead functionCall and an empty answer.
+             */
+            nextConfig.toolConfig = {
+              functionCallingConfig: { mode: FunctionCallingConfigMode.NONE },
+            }
           }
+
+          /** Settled answer from the check response — kept if the stream ends without text. */
+          const checkAnswer = extractTextContent(checkResponse.candidates?.[0])
 
           // Capture accumulated cost before streaming
           const accumulatedCost = {
@@ -1267,7 +1280,10 @@ export async function executeGeminiRequest(
           const stream = createReadableStreamFromGeminiStream(
             streamGenerator,
             (streamContent: string, usage: GeminiUsage, thinking?: string) => {
-              streamingResult.execution.output.content = streamContent
+              if (!streamContent && checkAnswer) {
+                logger.warn('Gemini final stream produced no text; keeping tool-loop answer')
+              }
+              streamingResult.execution.output.content = streamContent || checkAnswer
               streamingResult.execution.output.tokens = {
                 input: accumulatedTokens.input + usage.promptTokenCount,
                 output: accumulatedTokens.output + usage.candidatesTokenCount,

--- a/apps/sim/providers/groq/index.ts
+++ b/apps/sim/providers/groq/index.ts
@@ -499,10 +499,15 @@ export const groqProvider: ProviderConfig = {
       if (request.stream) {
         logger.info('Using streaming for final Groq response after tool processing')
 
+        /**
+         * The regeneration exists purely to stream the settled answer as prose —
+         * streamed tool_calls are never executed on this path (re-applying the
+         * original forced tool_choice here would even guarantee a dead call).
+         */
         const streamingPayload = {
           ...payload,
           messages: currentMessages,
-          tool_choice: originalToolChoice || 'auto',
+          tool_choice: 'none' as const,
           stream: true,
         }
 
@@ -549,8 +554,11 @@ export const groqProvider: ProviderConfig = {
             createReadableStreamFromGroqStream(
               // double-cast-allowed: payload is untyped so the SDK cannot resolve the streaming overload; groq-sdk stream chunks are wire-compatible with the OpenAI ChatCompletionChunk shape the adapter consumes
               streamResponse as unknown as AsyncIterable<ChatCompletionChunk>,
-              (content, usage, thinking) => {
-                output.content = content
+              (streamedContent, usage, thinking) => {
+                if (!streamedContent && content) {
+                  logger.warn('Groq final stream produced no text; keeping tool-loop answer')
+                }
+                output.content = streamedContent || content
                 output.tokens = {
                   input: tokens.input + usage.prompt_tokens,
                   output: tokens.output + usage.completion_tokens,

--- a/apps/sim/providers/mistral/index.ts
+++ b/apps/sim/providers/mistral/index.ts
@@ -441,10 +441,14 @@ export const mistralProvider: ProviderConfig = {
 
         const accumulatedCost = calculateCost(request.model, tokens.input, tokens.output)
 
+        /**
+         * The regeneration exists purely to stream the settled answer as prose —
+         * streamed tool_calls are never executed on this path.
+         */
         const streamingParams: ChatCompletionCreateParamsStreaming = {
           ...payload,
           messages: currentMessages,
-          tool_choice: 'auto',
+          tool_choice: 'none',
           stream: true,
         }
         const streamResponse = await mistral.chat.completions.create(
@@ -483,8 +487,11 @@ export const mistralProvider: ProviderConfig = {
               : undefined,
           streamFormat: 'agent-events-v1',
           createStream: ({ output }) =>
-            createReadableStreamFromMistralStream(streamResponse, (content, usage) => {
-              output.content = content
+            createReadableStreamFromMistralStream(streamResponse, (streamedContent, usage) => {
+              if (!streamedContent && content) {
+                logger.warn('Mistral final stream produced no text; keeping tool-loop answer')
+              }
+              output.content = streamedContent || content
               output.tokens = {
                 input: tokens.input + usage.prompt_tokens,
                 output: tokens.output + usage.completion_tokens,

--- a/apps/sim/providers/openai/core.reasoning.test.ts
+++ b/apps/sim/providers/openai/core.reasoning.test.ts
@@ -193,12 +193,15 @@ describe('executeResponsesProviderRequest reasoning payload', () => {
       })
     }
 
-    async function drain(stream: ReadableStream<unknown>) {
+    async function collect(stream: ReadableStream<unknown>) {
+      const events: unknown[] = []
       const reader = stream.getReader()
       while (true) {
-        const { done } = await reader.read()
+        const { done, value } = await reader.read()
         if (done) break
+        events.push(value)
       }
+      return events
     }
 
     it('forces tool_choice none and keeps the tool-loop answer when the stream has no text', async () => {
@@ -220,7 +223,15 @@ describe('executeResponsesProviderRequest reasoning payload', () => {
       // The regeneration exists to stream prose; streamed calls are never executed.
       expect(streamBody.tool_choice).toBe('none')
 
-      await drain(result.stream)
+      const events = await collect(result.stream)
+      // Settled chips for the silent loop's executed calls ride ahead of the answer.
+      expect(events[0]).toEqual({ type: 'tool_call_start', id: 'call_1', name: 'exa_search' })
+      expect(events[1]).toEqual({
+        type: 'tool_call_end',
+        id: 'call_1',
+        name: 'exa_search',
+        status: 'success',
+      })
       expect(result.execution.output.content).toBe('Settled answer from loop')
     })
   })

--- a/apps/sim/providers/openai/core.reasoning.test.ts
+++ b/apps/sim/providers/openai/core.reasoning.test.ts
@@ -6,9 +6,10 @@
  * without explicit effort keep a reasoning-free payload, and the
  * unverified-organization 400 falls back to a summary-free retry.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { executeResponsesProviderRequest } from '@/providers/openai/core'
 import type { ProviderRequest } from '@/providers/types'
+import { executeTool } from '@/tools'
 
 vi.mock('@/providers', () => ({ MAX_TOOL_ITERATIONS: 5 }))
 
@@ -161,5 +162,66 @@ describe('executeResponsesProviderRequest reasoning payload', () => {
     await run({ model: 'gpt-4o', agentEvents: true })
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
     expect(body.reasoning).toBeUndefined()
+  })
+
+  describe('final regenerated stream after the tool loop', () => {
+    const TOOL_CALL_RESPONSE = {
+      id: 'resp_tool',
+      status: 'completed',
+      output: [{ type: 'function_call', call_id: 'call_1', name: 'exa_search', arguments: '{}' }],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    }
+
+    const SETTLED_ANSWER_RESPONSE = {
+      id: 'resp_answer',
+      status: 'completed',
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Settled answer from loop' }],
+        },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    }
+
+    /** An SSE stream that ends without any output_text (dead function_call turn). */
+    function emptySseResponse() {
+      return new Response('data: {"type":"response.completed"}\n\ndata: [DONE]\n\n', {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      })
+    }
+
+    async function drain(stream: ReadableStream<unknown>) {
+      const reader = stream.getReader()
+      while (true) {
+        const { done } = await reader.read()
+        if (done) break
+      }
+    }
+
+    it('forces tool_choice none and keeps the tool-loop answer when the stream has no text', async () => {
+      ;(executeTool as Mock).mockResolvedValue({ success: true, output: { results: [] } })
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse(TOOL_CALL_RESPONSE))
+        .mockResolvedValueOnce(jsonResponse(SETTLED_ANSWER_RESPONSE))
+        .mockResolvedValueOnce(emptySseResponse())
+
+      const result = (await run({
+        model: 'gpt-5.5',
+        stream: true,
+        tools: [{ id: 'exa_search', name: 'exa_search', description: 'd', parameters: {} }] as any,
+      })) as { stream: ReadableStream<unknown>; execution: { output: { content: string } } }
+
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      const streamBody = JSON.parse(fetchMock.mock.calls[2][1].body as string)
+      expect(streamBody.stream).toBe(true)
+      // The regeneration exists to stream prose; streamed calls are never executed.
+      expect(streamBody.tool_choice).toBe('none')
+
+      await drain(result.stream)
+      expect(result.execution.output.content).toBe('Settled answer from loop')
+    })
   })
 })

--- a/apps/sim/providers/openai/core.ts
+++ b/apps/sim/providers/openai/core.ts
@@ -701,8 +701,13 @@ export async function executeResponsesProviderRequest(
 
       const accumulatedCost = calculateCost(request.model, tokens.input, tokens.output)
 
-      // For Azure with deferred format in streaming mode, include the format in the streaming call
-      const streamOverrides: Record<string, unknown> = { stream: true, tool_choice: 'auto' }
+      /**
+       * The regeneration exists purely to stream the settled answer as prose —
+       * streamed function calls are never executed. With `tool_choice: 'auto'`
+       * a reasoning model can re-decide to call a tool here, ending the stream
+       * with a dead function_call and an empty answer.
+       */
+      const streamOverrides: Record<string, unknown> = { stream: true, tool_choice: 'none' }
       if (deferredTextFormat) {
         streamOverrides.text = {
           ...((basePayload.text as Record<string, unknown>) ?? {}),
@@ -735,8 +740,18 @@ export async function executeResponsesProviderRequest(
         toolCalls: toolCalls.length > 0 ? { list: toolCalls, count: toolCalls.length } : undefined,
         streamFormat: 'agent-events-v1',
         createStream: ({ output }) =>
-          createReadableStreamFromResponses(streamResponse, (content, usage, thinking) => {
-            output.content = content
+          createReadableStreamFromResponses(streamResponse, (streamedContent, usage, thinking) => {
+            /**
+             * Belt-and-braces for the regeneration ending without text: keep
+             * the tool loop's settled answer instead of clobbering it with an
+             * empty string (clients then render it from the final envelope).
+             */
+            if (!streamedContent && content) {
+              logger.warn(
+                `${config.providerLabel} final stream produced no text; keeping tool-loop answer`
+              )
+            }
+            output.content = streamedContent || content
             output.tokens = {
               input: tokens.input + (usage?.promptTokens || 0),
               output: tokens.output + (usage?.completionTokens || 0),

--- a/apps/sim/providers/openai/core.ts
+++ b/apps/sim/providers/openai/core.ts
@@ -3,6 +3,7 @@ import { getErrorMessage, toError } from '@sim/utils/errors'
 import type OpenAI from 'openai'
 import type { IterationToolCall, StreamingExecution } from '@/executor/types'
 import { MAX_TOOL_ITERATIONS } from '@/providers'
+import type { AgentStreamEvent, ToolCallEndStatus } from '@/providers/stream-events'
 import { createStreamingExecution } from '@/providers/streaming-execution'
 import { adaptOpenAIChatToolSchema } from '@/providers/tool-schema-adapter'
 import { enrichLastModelSegment, parseToolCallArguments } from '@/providers/trace-enrichment'
@@ -385,6 +386,12 @@ export async function executeResponsesProviderRequest(
 
     const toolCalls = []
     const toolResults: Record<string, unknown>[] = []
+    /**
+     * Executed calls in completion order, for settled tool chips on the
+     * regenerated answer stream (the silent loop has no live stream to emit
+     * lifecycle events on while tools actually run).
+     */
+    const toolLifecycle: Array<{ id: string; name: string; status: ToolCallEndStatus }> = []
     let iterationCount = 0
     let modelTime = firstResponseTime
     let toolsTime = 0
@@ -522,6 +529,12 @@ export async function executeResponsesProviderRequest(
           duration: duration,
           result: resultContent,
           success: result.success,
+        })
+
+        toolLifecycle.push({
+          id: toolCall.id,
+          name: toolName,
+          status: result.success ? 'success' : 'error',
         })
 
         currentInput.push({
@@ -739,45 +752,86 @@ export async function executeResponsesProviderRequest(
         },
         toolCalls: toolCalls.length > 0 ? { list: toolCalls, count: toolCalls.length } : undefined,
         streamFormat: 'agent-events-v1',
-        createStream: ({ output }) =>
-          createReadableStreamFromResponses(streamResponse, (streamedContent, usage, thinking) => {
-            /**
-             * Belt-and-braces for the regeneration ending without text: keep
-             * the tool loop's settled answer instead of clobbering it with an
-             * empty string (clients then render it from the final envelope).
-             */
-            if (!streamedContent && content) {
-              logger.warn(
-                `${config.providerLabel} final stream produced no text; keeping tool-loop answer`
+        createStream: ({ output }) => {
+          const answerStream = createReadableStreamFromResponses(
+            streamResponse,
+            (streamedContent, usage, thinking) => {
+              /**
+               * Belt-and-braces for the regeneration ending without text: keep
+               * the tool loop's settled answer instead of clobbering it with an
+               * empty string (clients then render it from the final envelope).
+               */
+              if (!streamedContent && content) {
+                logger.warn(
+                  `${config.providerLabel} final stream produced no text; keeping tool-loop answer`
+                )
+              }
+              output.content = streamedContent || content
+              output.tokens = {
+                input: tokens.input + (usage?.promptTokens || 0),
+                output: tokens.output + (usage?.completionTokens || 0),
+                total: tokens.total + (usage?.totalTokens || 0),
+              }
+
+              const streamCost = calculateCost(
+                request.model,
+                usage?.promptTokens || 0,
+                usage?.completionTokens || 0
               )
-            }
-            output.content = streamedContent || content
-            output.tokens = {
-              input: tokens.input + (usage?.promptTokens || 0),
-              output: tokens.output + (usage?.completionTokens || 0),
-              total: tokens.total + (usage?.totalTokens || 0),
-            }
+              const tc = sumToolCosts(toolResults)
+              output.cost = {
+                input: accumulatedCost.input + streamCost.input,
+                output: accumulatedCost.output + streamCost.output,
+                toolCost: tc || undefined,
+                total: accumulatedCost.total + streamCost.total + tc,
+              }
 
-            const streamCost = calculateCost(
-              request.model,
-              usage?.promptTokens || 0,
-              usage?.completionTokens || 0
-            )
-            const tc = sumToolCosts(toolResults)
-            output.cost = {
-              input: accumulatedCost.input + streamCost.input,
-              output: accumulatedCost.output + streamCost.output,
-              toolCost: tc || undefined,
-              total: accumulatedCost.total + streamCost.total + tc,
-            }
-
-            if (thinking) {
-              const lastModel = [...timeSegments].reverse().find((s) => s.type === 'model')
-              if (lastModel) {
-                lastModel.thinkingContent = thinking
+              if (thinking) {
+                const lastModel = [...timeSegments].reverse().find((s) => s.type === 'model')
+                if (lastModel) {
+                  lastModel.thinkingContent = thinking
+                }
               }
             }
-          }),
+          )
+
+          if (toolLifecycle.length === 0) {
+            return answerStream
+          }
+
+          /**
+           * Settled tool chips ride ahead of the answer: the silent loop's
+           * calls already completed, so opted-in consumers get start+end pairs
+           * (name + status only) before the regenerated text streams. Runs
+           * without a sink never see these events (the byte projection ignores
+           * non-text), so legacy output is unchanged.
+           */
+          const answerReader = answerStream.getReader()
+          return new ReadableStream<AgentStreamEvent>({
+            start(controller) {
+              for (const call of toolLifecycle) {
+                controller.enqueue({ type: 'tool_call_start', id: call.id, name: call.name })
+                controller.enqueue({
+                  type: 'tool_call_end',
+                  id: call.id,
+                  name: call.name,
+                  status: call.status,
+                })
+              }
+            },
+            async pull(controller) {
+              const { done, value } = await answerReader.read()
+              if (done) {
+                controller.close()
+                return
+              }
+              controller.enqueue(value)
+            },
+            cancel(reason) {
+              return answerReader.cancel(reason)
+            },
+          })
+        },
       })
 
       return streamingResult

--- a/apps/sim/providers/openrouter/index.ts
+++ b/apps/sim/providers/openrouter/index.ts
@@ -430,10 +430,14 @@ export const openRouterProvider: ProviderConfig = {
       if (request.stream) {
         const accumulatedCost = calculateCost(requestedModel, tokens.input, tokens.output)
 
+        /**
+         * The regeneration exists purely to stream the settled answer as prose —
+         * streamed tool_calls are never executed on this path.
+         */
         const streamingParams: ChatCompletionCreateParamsStreaming & { provider?: any } = {
           ...payload,
           messages: [...currentMessages],
-          tool_choice: 'auto',
+          tool_choice: 'none',
           stream: true,
           stream_options: { include_usage: true },
         }
@@ -474,8 +478,11 @@ export const openRouterProvider: ProviderConfig = {
             toolCalls.length > 0 ? { list: toolCalls, count: toolCalls.length } : undefined,
           streamFormat: 'agent-events-v1',
           createStream: ({ output }) =>
-            createReadableStreamFromOpenAIStream(streamResponse, (content, usage) => {
-              output.content = content
+            createReadableStreamFromOpenAIStream(streamResponse, (streamedContent, usage) => {
+              if (!streamedContent && content) {
+                logger.warn('OpenRouter final stream produced no text; keeping tool-loop answer')
+              }
+              output.content = streamedContent || content
               output.tokens = {
                 input: tokens.input + usage.prompt_tokens,
                 output: tokens.output + usage.completion_tokens,

--- a/apps/sim/providers/xai/index.ts
+++ b/apps/sim/providers/xai/index.ts
@@ -480,10 +480,14 @@ export const xAIProvider: ProviderConfig = {
             stream: true,
           }
         } else {
+          /**
+           * The regeneration exists purely to stream the settled answer as
+           * prose — streamed tool_calls are never executed on this path.
+           */
           finalStreamingPayload = {
             ...basePayload,
             messages: currentMessages,
-            tool_choice: 'auto',
+            tool_choice: 'none',
             tools: preparedTools?.tools,
             stream: true,
           }
@@ -532,8 +536,11 @@ export const xAIProvider: ProviderConfig = {
             createReadableStreamFromXAIStream(
               // double-cast-allowed: payload is untyped so the SDK cannot resolve the streaming overload; the stream yields OpenAI ChatCompletionChunk objects
               streamResponse as unknown as AsyncIterable<ChatCompletionChunk>,
-              (content, usage) => {
-                output.content = content
+              (streamedContent, usage) => {
+                if (!streamedContent && content) {
+                  logger.warn('xAI final stream produced no text; keeping tool-loop answer')
+                }
+                output.content = streamedContent || content
                 output.tokens = {
                   input: tokens.input + usage.prompt_tokens,
                   output: tokens.output + usage.completion_tokens,


### PR DESCRIPTION
## Summary
- Deployed chat with OpenAI + tools intermittently returned an empty answer (`{"content": ""}`) while thinking streamed fine. Root cause: after the silent tool loop settles, the final **regenerated streaming request** still carried tools with `tool_choice: 'auto'` — a reasoning model can re-decide to call a tool there, but streamed calls are never executed on this path, so the stream ends with a dead `function_call`, no text, and the callback clobbers the tool loop's settled answer with `''`.
- Fix on both providers with this regeneration pattern:
  - **OpenAI Responses** (+ Azure via shared core): final stream now sends `tool_choice: 'none'`, and an empty stream keeps the tool loop's settled answer instead of clobbering it (with a warn log).
  - **Gemini** silent loop: final stream sends `functionCallingConfig: NONE` (unless the responseFormat branch already stripped tools), same settled-answer fallback.
- Latent pre-PR race (`tool_choice: 'auto'` regeneration exists on old staging); reasoning models re-reasoning during the regeneration made it likely enough to hit in practice.
- **Also: settled tool chips for OpenAI.** The silent loop records each executed call and prepends `tool_call_start`/`tool_call_end` pairs (name + status only) to the agent-events stream ahead of the regenerated answer, so opted-in chat/canvas render chips for OpenAI runs. No live in-progress chips (tools run before any stream exists); legacy runs without a sink are untouched. Docs updated.

## Test plan
- [x] New regression test: OpenAI tool-loop run asserts the third (streaming) request body carries `tool_choice: 'none'`, that settled chip events precede the answer, and that an empty stream preserves the settled answer in `execution.output.content`
- [x] `vitest run providers/openai providers/gemini providers/google` passing
- [x] `tsc --noEmit` clean; `agent-stream-docs:check` up to date
- [ ] Manual: deployed chat "use Exa to search news" with a reasoning model streams the answer after tools and shows the Exa chip