### PR TITLE
fix(chat): sweep the text shimmer left-to-right

### DIFF
--- a/apps/sim/components/ui/shimmer-text.module.css
+++ b/apps/sim/components/ui/shimmer-text.module.css
@@ -13,7 +13,7 @@
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
-  animation: shimmer-sweep 2.2s linear infinite reverse;
+  animation: shimmer-sweep 2.2s linear infinite;
 }
 
 :global(.dark) .shimmer {


### PR DESCRIPTION
## Summary
- Drop the `reverse` from the `shimmer-sweep` animation in `shimmer-text.module.css` — the sweep runs right-to-left on staging
- #5650 added `reverse` to flip the old keyframes (implicit `0%` -> `200%`, natively right-to-left) into a left-to-right sweep
- #5671 then rewrote the keyframes to `100%` -> `-100%`, which is already left-to-right, but left `reverse` in place — the two cancel out
- Direction now lives in one place (the keyframes) instead of being split across the shorthand and the `@keyframes` block 10 lines apart
- Affects every `ShimmerText` consumer: subagent labels and tool-call rows in chat, plus the agent-stream thinking chrome

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run lint:check` and `bun run check:api-validation:strict` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
