### PR TITLE
improvement(ship): pre-flight regenerate artifacts + parallel audit suite

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -35,27 +35,24 @@ When the user runs `/ship`:
 5. **Run migration safety** — only if the diff touches `packages/db/migrations/**` or `packages/db/schema.ts`:
   - Run `/db-migrate` to review the migration for zero-downtime safety (expand/contract phasing, backward-compatibility with the deployed app version).
   - `bun run check:migrations origin/staging` must pass (staging is the PR base). Do not silence a flagged statement with a `-- migration-safe:` annotation unless `/db-migrate` confirmed the old code no longer depends on it; otherwise split the destructive change into a later deploy.
-6. **Run pre-ship checks** from the repo root before staging. This has two phases: first **regenerate** every committed-artifact so generated files never drift into a CI failure (this is what catches things like `agent-stream-docs` going stale after a `models.ts` edit), then run the **full audit suite** CI's `Lint and Test` job enforces. Both phases parallelize — the generators touch disjoint files, and the audits are read-only — so run each phase's commands concurrently and `wait`.
+6. **Run pre-ship checks** from the repo root before staging. This has two phases: first **regenerate** every committed artifact so generated files never drift into a CI failure (this is what catches things like `agent-stream-docs` going stale after a `models.ts` edit), then run the **full audit suite** CI's `Lint and Test` job enforces. Both phases parallelize — but only across commands that write **disjoint** outputs — and a bare `wait` swallows child exit codes, so both phases below explicitly collect each job's status and abort ship if any failed.
 
-  **Phase A — regenerate committed artifacts (parallel), then let step 7 stage whatever changed.** These are the `:generate` / `:sync` counterpart of every `*:check` CI runs; each is idempotent (a no-op when already in sync), so running them all is safe. Keep this list in lockstep with the `*:check` scripts in the root `package.json` — if a new `foo:check` lands in CI, add its `foo:generate` here:
+  **Phase A — regenerate the always-in-repo committed artifacts (parallel), then let step 7 stage whatever changed.** Regenerate only the generators whose inputs live entirely in this repo and that any ordinary code change can drift — `agent-stream-docs:generate` (derives from the provider model registry) and `skills:sync` (derives from `.agents/skills/**`). They write disjoint trees (`apps/docs/…/agent.mdx` vs the `.claude`/`.cursor` command projections), so they parallelize safely, and each is idempotent (a no-op when already in sync):
   ```bash
-  bun run agent-stream-docs:generate &
-  bun run skills:sync &
-  bun run mship-contracts:generate &
-  bun run billing-protocol-contract:generate &
-  bun run mship-tools:generate &
-  bun run trace-spans-contract:generate &
-  bun run trace-attributes-contract:generate &
-  bun run trace-attribute-values-contract:generate &
-  bun run trace-events-contract:generate &
-  bun run metrics-contract:generate &
-  bun run vfs-snapshot-contract:generate &
-  bun run mship:generate &
+  rm -f /tmp/ship-gen-results
+  for g in agent-stream-docs:generate skills:sync; do
+    ( bun run "$g" >"/tmp/ship-gen-${g//:/-}.log" 2>&1; echo "$? $g" >>/tmp/ship-gen-results ) &
+  done
   wait
+  # any non-zero line is a FAILED generator — read /tmp/ship-gen-<name>.log and fix before shipping;
+  # a silently-failed generate leaves a stale artifact that Phase B / CI then rejects
+  grep -vE '^0 ' /tmp/ship-gen-results && echo "❌ generator(s) failed" || echo "✅ artifacts regenerated"
   ```
   Then `git status --short` to see what regenerated — those files must be staged in step 7 alongside your own changes.
 
-  **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes:
+  **Do NOT blanket-run the domain generators here.** `mship:generate` (`generate-mship-contracts.ts`) is an **umbrella** that drives all nine mothership contract generators (`mship-contracts`, `billing-protocol-contract`, `mship-tools`, the four `trace-*`, `metrics-contract`, `vfs-snapshot-contract`) and biome-formats `apps/sim/lib/copilot/generated/` — never run it *and* its constituents (they write the same files and corrupt each other in parallel), and never run it on an ordinary ship: it reads an **external** copilot-contract source that isn't checked out in most worktrees, so it hard-fails with `ENOENT` and would abort ship for an unrelated reason. `generate:pi-model-catalog` (under `apps/sim`) likewise regenerates from the installed Pi package, not repo source. Only when **this PR's diff actually touches** a domain generator's input do you regenerate it deliberately and run its matching `:check` (`bun run mship:check` / the individual `*:check`) — with the external source present.
+
+  **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes. This is exactly the read-only audit set from CI's `Lint and Test` job (all in-repo, runnable in any worktree):
   ```bash
   bun run lint   # autofix formatting first (mutating; not parallel-safe with the audits)
   rm -f /tmp/ship-audit-results
@@ -68,7 +65,7 @@ When the user runs `/ship`:
   # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping
   grep -vE '^0 ' /tmp/ship-audit-results && echo "❌ audit(s) failed" || echo "✅ all audits passed"
   ```
-  If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
+  If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any generator or audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
 7. **Stage and commit** the changes with the generated message — including any files Phase A regenerated in step 6
 8. **Push to origin** using the current branch name — `--force-with-lease` if step 2's sync
    check did any history rewrite (a clean rebase or a cherry-pick rebuild) on a branch that had

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -58,7 +58,9 @@ When the user runs `/ship`:
 
   **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes. This is exactly the read-only audit set from CI's `Lint and Test` job (all in-repo, runnable in any worktree):
   ```bash
-  bun run lint   # autofix formatting first (mutating; not parallel-safe with the audits)
+  # autofix formatting first (mutating; not parallel-safe with the audits). Gate its exit too —
+  # a non-zero lint (unfixable errors) must abort before the audits run, not be ignored.
+  bun run lint || { echo "❌ lint failed — do not ship"; exit 1; }
   rm -f /tmp/ship-audit-results
   for s in check:boundaries check:api-validation:strict check:utils check:zustand-v5 \
            check:react-query check:client-boundary check:bare-icons check:icon-paths \

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -35,10 +35,41 @@ When the user runs `/ship`:
 5. **Run migration safety** — only if the diff touches `packages/db/migrations/**` or `packages/db/schema.ts`:
   - Run `/db-migrate` to review the migration for zero-downtime safety (expand/contract phasing, backward-compatibility with the deployed app version).
   - `bun run check:migrations origin/staging` must pass (staging is the PR base). Do not silence a flagged statement with a `-- migration-safe:` annotation unless `/db-migrate` confirmed the old code no longer depends on it; otherwise split the destructive change into a later deploy.
-6. **Run pre-ship checks** from the repo root before staging:
-  - `bun run lint` to fix formatting issues
-  - `bun run check:api-validation:strict` to catch boundary contract failures before CI
-7. **Stage and commit** the changes with the generated message
+6. **Run pre-ship checks** from the repo root before staging. This has two phases: first **regenerate** every committed-artifact so generated files never drift into a CI failure (this is what catches things like `agent-stream-docs` going stale after a `models.ts` edit), then run the **full audit suite** CI's `Lint and Test` job enforces. Both phases parallelize — the generators touch disjoint files, and the audits are read-only — so run each phase's commands concurrently and `wait`.
+
+  **Phase A — regenerate committed artifacts (parallel), then let step 7 stage whatever changed.** These are the `:generate` / `:sync` counterpart of every `*:check` CI runs; each is idempotent (a no-op when already in sync), so running them all is safe. Keep this list in lockstep with the `*:check` scripts in the root `package.json` — if a new `foo:check` lands in CI, add its `foo:generate` here:
+  ```bash
+  bun run agent-stream-docs:generate &
+  bun run skills:sync &
+  bun run mship-contracts:generate &
+  bun run billing-protocol-contract:generate &
+  bun run mship-tools:generate &
+  bun run trace-spans-contract:generate &
+  bun run trace-attributes-contract:generate &
+  bun run trace-attribute-values-contract:generate &
+  bun run trace-events-contract:generate &
+  bun run metrics-contract:generate &
+  bun run vfs-snapshot-contract:generate &
+  bun run mship:generate &
+  wait
+  ```
+  Then `git status --short` to see what regenerated — those files must be staged in step 7 alongside your own changes.
+
+  **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes:
+  ```bash
+  bun run lint   # autofix formatting first (mutating; not parallel-safe with the audits)
+  rm -f /tmp/ship-audit-results
+  for s in check:boundaries check:api-validation:strict check:utils check:zustand-v5 \
+           check:react-query check:client-boundary check:bare-icons check:icon-paths \
+           check:realtime-prune skills:check agent-stream-docs:check; do
+    ( bun run "$s" >"/tmp/ship-audit-${s//:/-}.log" 2>&1; echo "$? $s" >>/tmp/ship-audit-results ) &
+  done
+  wait
+  # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping
+  grep -vE '^0 ' /tmp/ship-audit-results && echo "❌ audit(s) failed" || echo "✅ all audits passed"
+  ```
+  If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
+7. **Stage and commit** the changes with the generated message — including any files Phase A regenerated in step 6
 8. **Push to origin** using the current branch name — `--force-with-lease` if step 2's sync
    check did any history rewrite (a clean rebase or a cherry-pick rebuild) on a branch that had
    already been pushed once; a plain push would be rejected in exactly the polluted-remote case

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -45,8 +45,12 @@ When the user runs `/ship`:
   done
   wait
   # any non-zero line is a FAILED generator — read /tmp/ship-gen-<name>.log and fix before shipping;
-  # a silently-failed generate leaves a stale artifact that Phase B / CI then rejects
-  grep -vE '^0 ' /tmp/ship-gen-results && echo "❌ generator(s) failed" || echo "✅ artifacts regenerated"
+  # a silently-failed generate leaves a stale artifact that Phase B / CI then rejects.
+  # The `exit 1` makes this block itself exit non-zero on failure, so anything gating on the
+  # command's status (an agent, or a wrapping script) actually stops — do NOT collapse it to
+  # `grep … && echo ❌ || echo ✅`, which always exits 0 and silently lets ship continue.
+  if grep -vE '^0 ' /tmp/ship-gen-results; then echo "❌ generator(s) failed — do not ship"; exit 1; fi
+  echo "✅ artifacts regenerated"
   ```
   Then `git status --short` to see what regenerated — those files must be staged in step 7 alongside your own changes.
 
@@ -62,8 +66,11 @@ When the user runs `/ship`:
     ( bun run "$s" >"/tmp/ship-audit-${s//:/-}.log" 2>&1; echo "$? $s" >>/tmp/ship-audit-results ) &
   done
   wait
-  # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping
-  grep -vE '^0 ' /tmp/ship-audit-results && echo "❌ audit(s) failed" || echo "✅ all audits passed"
+  # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping.
+  # `exit 1` on failure preserves the original sequential checks' semantics (their non-zero exit is
+  # what an agent gates on); never use `grep … && echo ❌ || echo ✅` here — it always exits 0.
+  if grep -vE '^0 ' /tmp/ship-audit-results; then echo "❌ audit(s) failed — do not ship"; exit 1; fi
+  echo "✅ all audits passed"
   ```
   If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any generator or audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
 7. **Stage and commit** the changes with the generated message — including any files Phase A regenerated in step 6

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -57,7 +57,9 @@ When the user runs `/ship`:
 
   **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes. This is exactly the read-only audit set from CI's `Lint and Test` job (all in-repo, runnable in any worktree):
   ```bash
-  bun run lint   # autofix formatting first (mutating; not parallel-safe with the audits)
+  # autofix formatting first (mutating; not parallel-safe with the audits). Gate its exit too —
+  # a non-zero lint (unfixable errors) must abort before the audits run, not be ignored.
+  bun run lint || { echo "❌ lint failed — do not ship"; exit 1; }
   rm -f /tmp/ship-audit-results
   for s in check:boundaries check:api-validation:strict check:utils check:zustand-v5 \
            check:react-query check:client-boundary check:bare-icons check:icon-paths \

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -34,27 +34,24 @@ When the user runs `/ship`:
 5. **Run migration safety** — only if the diff touches `packages/db/migrations/**` or `packages/db/schema.ts`:
   - Run `/db-migrate` to review the migration for zero-downtime safety (expand/contract phasing, backward-compatibility with the deployed app version).
   - `bun run check:migrations origin/staging` must pass (staging is the PR base). Do not silence a flagged statement with a `-- migration-safe:` annotation unless `/db-migrate` confirmed the old code no longer depends on it; otherwise split the destructive change into a later deploy.
-6. **Run pre-ship checks** from the repo root before staging. This has two phases: first **regenerate** every committed-artifact so generated files never drift into a CI failure (this is what catches things like `agent-stream-docs` going stale after a `models.ts` edit), then run the **full audit suite** CI's `Lint and Test` job enforces. Both phases parallelize — the generators touch disjoint files, and the audits are read-only — so run each phase's commands concurrently and `wait`.
+6. **Run pre-ship checks** from the repo root before staging. This has two phases: first **regenerate** every committed artifact so generated files never drift into a CI failure (this is what catches things like `agent-stream-docs` going stale after a `models.ts` edit), then run the **full audit suite** CI's `Lint and Test` job enforces. Both phases parallelize — but only across commands that write **disjoint** outputs — and a bare `wait` swallows child exit codes, so both phases below explicitly collect each job's status and abort ship if any failed.
 
-  **Phase A — regenerate committed artifacts (parallel), then let step 7 stage whatever changed.** These are the `:generate` / `:sync` counterpart of every `*:check` CI runs; each is idempotent (a no-op when already in sync), so running them all is safe. Keep this list in lockstep with the `*:check` scripts in the root `package.json` — if a new `foo:check` lands in CI, add its `foo:generate` here:
+  **Phase A — regenerate the always-in-repo committed artifacts (parallel), then let step 7 stage whatever changed.** Regenerate only the generators whose inputs live entirely in this repo and that any ordinary code change can drift — `agent-stream-docs:generate` (derives from the provider model registry) and `skills:sync` (derives from `.agents/skills/**`). They write disjoint trees (`apps/docs/…/agent.mdx` vs the `.claude`/`.cursor` command projections), so they parallelize safely, and each is idempotent (a no-op when already in sync):
   ```bash
-  bun run agent-stream-docs:generate &
-  bun run skills:sync &
-  bun run mship-contracts:generate &
-  bun run billing-protocol-contract:generate &
-  bun run mship-tools:generate &
-  bun run trace-spans-contract:generate &
-  bun run trace-attributes-contract:generate &
-  bun run trace-attribute-values-contract:generate &
-  bun run trace-events-contract:generate &
-  bun run metrics-contract:generate &
-  bun run vfs-snapshot-contract:generate &
-  bun run mship:generate &
+  rm -f /tmp/ship-gen-results
+  for g in agent-stream-docs:generate skills:sync; do
+    ( bun run "$g" >"/tmp/ship-gen-${g//:/-}.log" 2>&1; echo "$? $g" >>/tmp/ship-gen-results ) &
+  done
   wait
+  # any non-zero line is a FAILED generator — read /tmp/ship-gen-<name>.log and fix before shipping;
+  # a silently-failed generate leaves a stale artifact that Phase B / CI then rejects
+  grep -vE '^0 ' /tmp/ship-gen-results && echo "❌ generator(s) failed" || echo "✅ artifacts regenerated"
   ```
   Then `git status --short` to see what regenerated — those files must be staged in step 7 alongside your own changes.
 
-  **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes:
+  **Do NOT blanket-run the domain generators here.** `mship:generate` (`generate-mship-contracts.ts`) is an **umbrella** that drives all nine mothership contract generators (`mship-contracts`, `billing-protocol-contract`, `mship-tools`, the four `trace-*`, `metrics-contract`, `vfs-snapshot-contract`) and biome-formats `apps/sim/lib/copilot/generated/` — never run it *and* its constituents (they write the same files and corrupt each other in parallel), and never run it on an ordinary ship: it reads an **external** copilot-contract source that isn't checked out in most worktrees, so it hard-fails with `ENOENT` and would abort ship for an unrelated reason. `generate:pi-model-catalog` (under `apps/sim`) likewise regenerates from the installed Pi package, not repo source. Only when **this PR's diff actually touches** a domain generator's input do you regenerate it deliberately and run its matching `:check` (`bun run mship:check` / the individual `*:check`) — with the external source present.
+
+  **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes. This is exactly the read-only audit set from CI's `Lint and Test` job (all in-repo, runnable in any worktree):
   ```bash
   bun run lint   # autofix formatting first (mutating; not parallel-safe with the audits)
   rm -f /tmp/ship-audit-results
@@ -67,7 +64,7 @@ When the user runs `/ship`:
   # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping
   grep -vE '^0 ' /tmp/ship-audit-results && echo "❌ audit(s) failed" || echo "✅ all audits passed"
   ```
-  If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
+  If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any generator or audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
 7. **Stage and commit** the changes with the generated message — including any files Phase A regenerated in step 6
 8. **Push to origin** using the current branch name — `--force-with-lease` if step 2's sync
    check did any history rewrite (a clean rebase or a cherry-pick rebuild) on a branch that had

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -44,8 +44,12 @@ When the user runs `/ship`:
   done
   wait
   # any non-zero line is a FAILED generator — read /tmp/ship-gen-<name>.log and fix before shipping;
-  # a silently-failed generate leaves a stale artifact that Phase B / CI then rejects
-  grep -vE '^0 ' /tmp/ship-gen-results && echo "❌ generator(s) failed" || echo "✅ artifacts regenerated"
+  # a silently-failed generate leaves a stale artifact that Phase B / CI then rejects.
+  # The `exit 1` makes this block itself exit non-zero on failure, so anything gating on the
+  # command's status (an agent, or a wrapping script) actually stops — do NOT collapse it to
+  # `grep … && echo ❌ || echo ✅`, which always exits 0 and silently lets ship continue.
+  if grep -vE '^0 ' /tmp/ship-gen-results; then echo "❌ generator(s) failed — do not ship"; exit 1; fi
+  echo "✅ artifacts regenerated"
   ```
   Then `git status --short` to see what regenerated — those files must be staged in step 7 alongside your own changes.
 
@@ -61,8 +65,11 @@ When the user runs `/ship`:
     ( bun run "$s" >"/tmp/ship-audit-${s//:/-}.log" 2>&1; echo "$? $s" >>/tmp/ship-audit-results ) &
   done
   wait
-  # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping
-  grep -vE '^0 ' /tmp/ship-audit-results && echo "❌ audit(s) failed" || echo "✅ all audits passed"
+  # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping.
+  # `exit 1` on failure preserves the original sequential checks' semantics (their non-zero exit is
+  # what an agent gates on); never use `grep … && echo ❌ || echo ✅` here — it always exits 0.
+  if grep -vE '^0 ' /tmp/ship-audit-results; then echo "❌ audit(s) failed — do not ship"; exit 1; fi
+  echo "✅ all audits passed"
   ```
   If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any generator or audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
 7. **Stage and commit** the changes with the generated message — including any files Phase A regenerated in step 6

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -34,10 +34,41 @@ When the user runs `/ship`:
 5. **Run migration safety** — only if the diff touches `packages/db/migrations/**` or `packages/db/schema.ts`:
   - Run `/db-migrate` to review the migration for zero-downtime safety (expand/contract phasing, backward-compatibility with the deployed app version).
   - `bun run check:migrations origin/staging` must pass (staging is the PR base). Do not silence a flagged statement with a `-- migration-safe:` annotation unless `/db-migrate` confirmed the old code no longer depends on it; otherwise split the destructive change into a later deploy.
-6. **Run pre-ship checks** from the repo root before staging:
-  - `bun run lint` to fix formatting issues
-  - `bun run check:api-validation:strict` to catch boundary contract failures before CI
-7. **Stage and commit** the changes with the generated message
+6. **Run pre-ship checks** from the repo root before staging. This has two phases: first **regenerate** every committed-artifact so generated files never drift into a CI failure (this is what catches things like `agent-stream-docs` going stale after a `models.ts` edit), then run the **full audit suite** CI's `Lint and Test` job enforces. Both phases parallelize — the generators touch disjoint files, and the audits are read-only — so run each phase's commands concurrently and `wait`.
+
+  **Phase A — regenerate committed artifacts (parallel), then let step 7 stage whatever changed.** These are the `:generate` / `:sync` counterpart of every `*:check` CI runs; each is idempotent (a no-op when already in sync), so running them all is safe. Keep this list in lockstep with the `*:check` scripts in the root `package.json` — if a new `foo:check` lands in CI, add its `foo:generate` here:
+  ```bash
+  bun run agent-stream-docs:generate &
+  bun run skills:sync &
+  bun run mship-contracts:generate &
+  bun run billing-protocol-contract:generate &
+  bun run mship-tools:generate &
+  bun run trace-spans-contract:generate &
+  bun run trace-attributes-contract:generate &
+  bun run trace-attribute-values-contract:generate &
+  bun run trace-events-contract:generate &
+  bun run metrics-contract:generate &
+  bun run vfs-snapshot-contract:generate &
+  bun run mship:generate &
+  wait
+  ```
+  Then `git status --short` to see what regenerated — those files must be staged in step 7 alongside your own changes.
+
+  **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes:
+  ```bash
+  bun run lint   # autofix formatting first (mutating; not parallel-safe with the audits)
+  rm -f /tmp/ship-audit-results
+  for s in check:boundaries check:api-validation:strict check:utils check:zustand-v5 \
+           check:react-query check:client-boundary check:bare-icons check:icon-paths \
+           check:realtime-prune skills:check agent-stream-docs:check; do
+    ( bun run "$s" >"/tmp/ship-audit-${s//:/-}.log" 2>&1; echo "$? $s" >>/tmp/ship-audit-results ) &
+  done
+  wait
+  # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping
+  grep -vE '^0 ' /tmp/ship-audit-results && echo "❌ audit(s) failed" || echo "✅ all audits passed"
+  ```
+  If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
+7. **Stage and commit** the changes with the generated message — including any files Phase A regenerated in step 6
 8. **Push to origin** using the current branch name — `--force-with-lease` if step 2's sync
    check did any history rewrite (a clean rebase or a cherry-pick rebuild) on a branch that had
    already been pushed once; a plain push would be rejected in exactly the polluted-remote case

--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -39,8 +39,12 @@ When the user runs `/ship`:
   done
   wait
   # any non-zero line is a FAILED generator — read /tmp/ship-gen-<name>.log and fix before shipping;
-  # a silently-failed generate leaves a stale artifact that Phase B / CI then rejects
-  grep -vE '^0 ' /tmp/ship-gen-results && echo "❌ generator(s) failed" || echo "✅ artifacts regenerated"
+  # a silently-failed generate leaves a stale artifact that Phase B / CI then rejects.
+  # The `exit 1` makes this block itself exit non-zero on failure, so anything gating on the
+  # command's status (an agent, or a wrapping script) actually stops — do NOT collapse it to
+  # `grep … && echo ❌ || echo ✅`, which always exits 0 and silently lets ship continue.
+  if grep -vE '^0 ' /tmp/ship-gen-results; then echo "❌ generator(s) failed — do not ship"; exit 1; fi
+  echo "✅ artifacts regenerated"
   ```
   Then `git status --short` to see what regenerated — those files must be staged in step 7 alongside your own changes.
 
@@ -56,8 +60,11 @@ When the user runs `/ship`:
     ( bun run "$s" >"/tmp/ship-audit-${s//:/-}.log" 2>&1; echo "$? $s" >>/tmp/ship-audit-results ) &
   done
   wait
-  # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping
-  grep -vE '^0 ' /tmp/ship-audit-results && echo "❌ audit(s) failed" || echo "✅ all audits passed"
+  # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping.
+  # `exit 1` on failure preserves the original sequential checks' semantics (their non-zero exit is
+  # what an agent gates on); never use `grep … && echo ❌ || echo ✅` here — it always exits 0.
+  if grep -vE '^0 ' /tmp/ship-audit-results; then echo "❌ audit(s) failed — do not ship"; exit 1; fi
+  echo "✅ all audits passed"
   ```
   If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any generator or audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
 7. **Stage and commit** the changes with the generated message — including any files Phase A regenerated in step 6

--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -52,7 +52,9 @@ When the user runs `/ship`:
 
   **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes. This is exactly the read-only audit set from CI's `Lint and Test` job (all in-repo, runnable in any worktree):
   ```bash
-  bun run lint   # autofix formatting first (mutating; not parallel-safe with the audits)
+  # autofix formatting first (mutating; not parallel-safe with the audits). Gate its exit too —
+  # a non-zero lint (unfixable errors) must abort before the audits run, not be ignored.
+  bun run lint || { echo "❌ lint failed — do not ship"; exit 1; }
   rm -f /tmp/ship-audit-results
   for s in check:boundaries check:api-validation:strict check:utils check:zustand-v5 \
            check:react-query check:client-boundary check:bare-icons check:icon-paths \

--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -29,27 +29,24 @@ When the user runs `/ship`:
 5. **Run migration safety** — only if the diff touches `packages/db/migrations/**` or `packages/db/schema.ts`:
   - Run `/db-migrate` to review the migration for zero-downtime safety (expand/contract phasing, backward-compatibility with the deployed app version).
   - `bun run check:migrations origin/staging` must pass (staging is the PR base). Do not silence a flagged statement with a `-- migration-safe:` annotation unless `/db-migrate` confirmed the old code no longer depends on it; otherwise split the destructive change into a later deploy.
-6. **Run pre-ship checks** from the repo root before staging. This has two phases: first **regenerate** every committed-artifact so generated files never drift into a CI failure (this is what catches things like `agent-stream-docs` going stale after a `models.ts` edit), then run the **full audit suite** CI's `Lint and Test` job enforces. Both phases parallelize — the generators touch disjoint files, and the audits are read-only — so run each phase's commands concurrently and `wait`.
+6. **Run pre-ship checks** from the repo root before staging. This has two phases: first **regenerate** every committed artifact so generated files never drift into a CI failure (this is what catches things like `agent-stream-docs` going stale after a `models.ts` edit), then run the **full audit suite** CI's `Lint and Test` job enforces. Both phases parallelize — but only across commands that write **disjoint** outputs — and a bare `wait` swallows child exit codes, so both phases below explicitly collect each job's status and abort ship if any failed.
 
-  **Phase A — regenerate committed artifacts (parallel), then let step 7 stage whatever changed.** These are the `:generate` / `:sync` counterpart of every `*:check` CI runs; each is idempotent (a no-op when already in sync), so running them all is safe. Keep this list in lockstep with the `*:check` scripts in the root `package.json` — if a new `foo:check` lands in CI, add its `foo:generate` here:
+  **Phase A — regenerate the always-in-repo committed artifacts (parallel), then let step 7 stage whatever changed.** Regenerate only the generators whose inputs live entirely in this repo and that any ordinary code change can drift — `agent-stream-docs:generate` (derives from the provider model registry) and `skills:sync` (derives from `.agents/skills/**`). They write disjoint trees (`apps/docs/…/agent.mdx` vs the `.claude`/`.cursor` command projections), so they parallelize safely, and each is idempotent (a no-op when already in sync):
   ```bash
-  bun run agent-stream-docs:generate &
-  bun run skills:sync &
-  bun run mship-contracts:generate &
-  bun run billing-protocol-contract:generate &
-  bun run mship-tools:generate &
-  bun run trace-spans-contract:generate &
-  bun run trace-attributes-contract:generate &
-  bun run trace-attribute-values-contract:generate &
-  bun run trace-events-contract:generate &
-  bun run metrics-contract:generate &
-  bun run vfs-snapshot-contract:generate &
-  bun run mship:generate &
+  rm -f /tmp/ship-gen-results
+  for g in agent-stream-docs:generate skills:sync; do
+    ( bun run "$g" >"/tmp/ship-gen-${g//:/-}.log" 2>&1; echo "$? $g" >>/tmp/ship-gen-results ) &
+  done
   wait
+  # any non-zero line is a FAILED generator — read /tmp/ship-gen-<name>.log and fix before shipping;
+  # a silently-failed generate leaves a stale artifact that Phase B / CI then rejects
+  grep -vE '^0 ' /tmp/ship-gen-results && echo "❌ generator(s) failed" || echo "✅ artifacts regenerated"
   ```
   Then `git status --short` to see what regenerated — those files must be staged in step 7 alongside your own changes.
 
-  **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes:
+  **Do NOT blanket-run the domain generators here.** `mship:generate` (`generate-mship-contracts.ts`) is an **umbrella** that drives all nine mothership contract generators (`mship-contracts`, `billing-protocol-contract`, `mship-tools`, the four `trace-*`, `metrics-contract`, `vfs-snapshot-contract`) and biome-formats `apps/sim/lib/copilot/generated/` — never run it *and* its constituents (they write the same files and corrupt each other in parallel), and never run it on an ordinary ship: it reads an **external** copilot-contract source that isn't checked out in most worktrees, so it hard-fails with `ENOENT` and would abort ship for an unrelated reason. `generate:pi-model-catalog` (under `apps/sim`) likewise regenerates from the installed Pi package, not repo source. Only when **this PR's diff actually touches** a domain generator's input do you regenerate it deliberately and run its matching `:check` (`bun run mship:check` / the individual `*:check`) — with the external source present.
+
+  **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes. This is exactly the read-only audit set from CI's `Lint and Test` job (all in-repo, runnable in any worktree):
   ```bash
   bun run lint   # autofix formatting first (mutating; not parallel-safe with the audits)
   rm -f /tmp/ship-audit-results
@@ -62,7 +59,7 @@ When the user runs `/ship`:
   # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping
   grep -vE '^0 ' /tmp/ship-audit-results && echo "❌ audit(s) failed" || echo "✅ all audits passed"
   ```
-  If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
+  If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any generator or audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
 7. **Stage and commit** the changes with the generated message — including any files Phase A regenerated in step 6
 8. **Push to origin** using the current branch name — `--force-with-lease` if step 2's sync
    check did any history rewrite (a clean rebase or a cherry-pick rebuild) on a branch that had

--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -29,10 +29,41 @@ When the user runs `/ship`:
 5. **Run migration safety** — only if the diff touches `packages/db/migrations/**` or `packages/db/schema.ts`:
   - Run `/db-migrate` to review the migration for zero-downtime safety (expand/contract phasing, backward-compatibility with the deployed app version).
   - `bun run check:migrations origin/staging` must pass (staging is the PR base). Do not silence a flagged statement with a `-- migration-safe:` annotation unless `/db-migrate` confirmed the old code no longer depends on it; otherwise split the destructive change into a later deploy.
-6. **Run pre-ship checks** from the repo root before staging:
-  - `bun run lint` to fix formatting issues
-  - `bun run check:api-validation:strict` to catch boundary contract failures before CI
-7. **Stage and commit** the changes with the generated message
+6. **Run pre-ship checks** from the repo root before staging. This has two phases: first **regenerate** every committed-artifact so generated files never drift into a CI failure (this is what catches things like `agent-stream-docs` going stale after a `models.ts` edit), then run the **full audit suite** CI's `Lint and Test` job enforces. Both phases parallelize — the generators touch disjoint files, and the audits are read-only — so run each phase's commands concurrently and `wait`.
+
+  **Phase A — regenerate committed artifacts (parallel), then let step 7 stage whatever changed.** These are the `:generate` / `:sync` counterpart of every `*:check` CI runs; each is idempotent (a no-op when already in sync), so running them all is safe. Keep this list in lockstep with the `*:check` scripts in the root `package.json` — if a new `foo:check` lands in CI, add its `foo:generate` here:
+  ```bash
+  bun run agent-stream-docs:generate &
+  bun run skills:sync &
+  bun run mship-contracts:generate &
+  bun run billing-protocol-contract:generate &
+  bun run mship-tools:generate &
+  bun run trace-spans-contract:generate &
+  bun run trace-attributes-contract:generate &
+  bun run trace-attribute-values-contract:generate &
+  bun run trace-events-contract:generate &
+  bun run metrics-contract:generate &
+  bun run vfs-snapshot-contract:generate &
+  bun run mship:generate &
+  wait
+  ```
+  Then `git status --short` to see what regenerated — those files must be staged in step 7 alongside your own changes.
+
+  **Phase B — run lint + every audit CI enforces, in parallel, and abort ship if any fails.** `bun run lint` first (it autofixes formatting and mutates files, so don't parallelize it with the read-only audits), then fan the rest out and collect exit codes:
+  ```bash
+  bun run lint   # autofix formatting first (mutating; not parallel-safe with the audits)
+  rm -f /tmp/ship-audit-results
+  for s in check:boundaries check:api-validation:strict check:utils check:zustand-v5 \
+           check:react-query check:client-boundary check:bare-icons check:icon-paths \
+           check:realtime-prune skills:check agent-stream-docs:check; do
+    ( bun run "$s" >"/tmp/ship-audit-${s//:/-}.log" 2>&1; echo "$? $s" >>/tmp/ship-audit-results ) &
+  done
+  wait
+  # any non-zero line is a failing audit — read its /tmp/ship-audit-<name>.log and fix before shipping
+  grep -vE '^0 ' /tmp/ship-audit-results && echo "❌ audit(s) failed" || echo "✅ all audits passed"
+  ```
+  If Phase A regenerated a file, its matching `:check` in Phase B now passes trivially — that parity is the point. Do not ship with any audit failing; fix the cause (never silence it) and re-run. `check:migrations` and `type-check` are covered by steps 5 and CI respectively and are not repeated here.
+7. **Stage and commit** the changes with the generated message — including any files Phase A regenerated in step 6
 8. **Push to origin** using the current branch name — `--force-with-lease` if step 2's sync
    check did any history rewrite (a clean rebase or a cherry-pick rebuild) on a branch that had
    already been pushed once; a plain push would be rejected in exactly the polluted-remote case


### PR DESCRIPTION
## Summary
- Expand `/ship` step 6 into two phases so generated files never drift into a CI failure (the `agent-stream-docs` drift we just hit on the Opus 5 PR)
- **Phase A** — regenerate every committed artifact in parallel (`agent-stream-docs:generate`, `skills:sync`, and all the contract `*:generate` scripts); idempotent, staged into the commit
- **Phase B** — run `lint` then the full audit suite CI's `Lint and Test` job enforces (`check:boundaries`, `check:api-validation:strict`, `check:utils`, `check:zustand-v5`, `check:react-query`, `check:client-boundary`, `check:bare-icons`, `check:icon-paths`, `check:realtime-prune`, `skills:check`, `agent-stream-docs:check`) in parallel, aborting ship on any failure
- Regenerated the `.claude/commands/ship.md` + `.cursor/commands/ship.md` projections

## Type of Change
- [x] Improvement (tooling / developer workflow)

## Testing
- Dogfooded on this change: `skills:sync` regenerated the ship projections, `skills:check` passes, `bun run lint` clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)