### PR TITLE
content(library): add observability, procurement, and MCP security guides

### DIFF
--- a/apps/sim/content/library/ai-agent-observability/index.mdx
+++ b/apps/sim/content/library/ai-agent-observability/index.mdx
@@ -1,0 +1,134 @@
+---
+slug: ai-agent-observability
+title: 'AI Agent Observability: Why It Is Essential'
+description: AI agent observability gives step-by-step visibility into how agents reason, call tools, and decide, so you can trace failures, control costs, and ship with confidence.
+date: 2026-07-19
+updated: 2026-07-19
+authors:
+  - andrew
+readingTime: 9
+tags: [AI Agent Observability, Observability, AI Agents, Monitoring, Sim]
+ogImage: /library/ai-agent-observability/cover.jpg
+ogAlt: AI agent observability turning an agent from a black box into an inspectable glass box.
+canonical: https://www.sim.ai/library/ai-agent-observability
+draft: false
+faq:
+  - q: "What is AI agent observability?"
+    a: "AI agent observability is the practice of capturing and analyzing an agent's internal behavior to understand and improve how it works. It rests on four pillars: traces (the full task path), logs (step-level events), metrics (latency, cost, and error rates), and evaluations (output quality scoring)."
+  - q: "How is AI agent observability different from traditional monitoring?"
+    a: "Traditional monitoring answers 'is the system up?' by tracking uptime, response times, and status codes. Agent observability answers 'is the agent making good decisions?' by inspecting reasoning and tool choices. It exists because agents are non-deterministic, so the same prompt can produce different behavior each run."
+  - q: "What is the difference between traces and spans?"
+    a: "A trace is the complete path of a single task from start to finish. Spans are the individual steps within that trace, such as one LLM call or one tool invocation. Together they form a span tree that shows how the whole task unfolded."
+  - q: "When does AI agent observability become critical?"
+    a: "In prototyping, it is optional, since print statements and instant reruns are enough. It becomes essential in production, where you need full execution context to reproduce reported failures. It becomes even more important in multi-agent systems, where failures happen between agents and across turns."
+  - q: "What metrics should I track for AI agents?"
+    a: "Track latency per task and step, cost per run and per model, request and tool-call error rates, and success rates by task type. Add agent-specific signals like tool-selection accuracy and hallucination detection, since these predict reliability in ways generic metrics cannot."
+  - q: "Do I need a separate observability tool?"
+    a: "Dedicated observability tools exist and work well, especially for large, multi-framework deployments. But if you build in a workspace with native logging, you can cover core needs like execution logs, trace spans, and per-model cost tracking without setting up a separate stack. Match the choice to your scale and existing tooling."
+  - q: "Does observability help control agent costs?"
+    a: "Yes. By attributing token usage, latency, and cost to individual steps, observability shows exactly which prompts, tools, or loops drive spend. That lets you catch expensive patterns during testing, before they compound across production traffic."
+---
+
+Your agent aced every question in the demo. In production, it confidently returns a wrong answer, calls the wrong tool, or loops on itself, and the dashboard stays green the whole time. You know something broke, but you have no way to see where or why.
+
+AI agent observability helps you fix this issue. It exposes how an agent reasons, which tools it calls, what it retrieves, and where it goes off track, so debugging becomes an evidence-based process instead of guesswork.
+
+This guide covers what observability is, why traditional monitoring falls short for agents, what to instrument at each stage, the signals worth tracking, and how to start.
+
+## Key Takeaways
+
+- **Observability makes agents inspectable:** It captures reasoning steps, tool calls, retrievals, and outputs so you can understand and improve agent behavior.
+- **Observability rests on four key pillars:** Traces, logs, metrics, and evaluations together turn a black box into a glass box.
+- **Traditional monitoring doesn't give you the visibility you need:** APM confirms the system is up, not whether the agent made good decisions on non-deterministic runs.
+- **Flying blind is expensive:** Untraced failures erode trust, hide cost leaks, and create compliance gaps as agents act autonomously.
+- **Instrumentation scales with lifecycle:** Print statements suffice in prototyping; full execution context is non-negotiable in production.
+- **Open standards reduce lock-in:** [OpenTelemetry's GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) standardize what to capture across frameworks and vendors.
+
+## What Is AI Agent Observability?
+
+AI agent observability is the practice of capturing and analyzing an agent's internal behavior – its reasoning steps, tool calls, retrievals, and outputs – to understand and improve how it works. It answers not just whether the agent ran, but what it decided and why.
+
+Four building blocks make this possible. Traces record the full path of a task from start to finish. Logs capture detailed events at each step. Metrics measure latency, token usage, cost, and error or success rates. Evaluations judge whether outputs are accurate, relevant, and safe.
+
+Together, they turn the agent from a black box into a glass box you can inspect, debug, and improve as you observe how it works.
+
+| Pillar | What It Captures | Example Data Point | Why It Matters |
+| --- | --- | --- | --- |
+| Traces | The full path of a single task | Span tree from user request through tool calls | Reproduces exactly how a task unfolded |
+| Logs | Detailed events at each step | Prompt version sent to the model | Pinpoints the moment behavior changed |
+| Metrics | Quantitative performance signals | Tokens and cost per run | Surfaces expensive or slow patterns |
+| Evaluations | Output quality scoring | Faithfulness or relevance score | Confirms whether the answer was any good |
+
+## Why Traditional Monitoring Falls Short for Agents
+
+Traditional application performance monitoring was built for deterministic software. It tracks uptime, response times, CPU, memory, and HTTP status codes, all reliable proxies for health when the same input always produces the same output.
+
+Agents break that assumption. The same prompt can trigger different tool sequences, retrieve different documents, and produce different answers on each run, so a green dashboard tells you nothing about decision quality. As [Fiddler's analysis of OpenTelemetry](https://www.fiddler.ai/blog/opentelemetry-ai-observability-guide) puts it, telemetry captures what happened, but it does not assess whether what happened was good.
+
+Monitoring agent output requires a shift in mindset. You're not just asking "Is the system healthy?" You also need to know whether the agent reasoned soundly and chose the right tools. Establishing this requires data that legacy tools cannot collect: prompts, reasoning chains, tool invocations, context retrieval, and multi-agent handoffs.
+
+## Why Observability Is Essential: The Risks of Flying Blind
+
+Running agents without visibility exposes you to significant risk in four important areas.
+
+The business impact comes first. Incorrect responses erode revenue and customer trust, and you cannot fix a root cause you cannot trace. In [LangChain's State of AI Agents report](https://www.langchain.com/stateofaiagents), quality remains the biggest barrier to production. This year, one-third of respondents cited quality as their primary blocker.
+
+Operationally, hallucinations, hallucinated tool calls, decision loops, and drift degrade performance, and each failure compounds across multi-step systems. On compliance, missing audit trails and weak explainability create regulatory exposure, especially in regulated industries where agents act autonomously on sensitive data. On cost, spend that looked affordable in a pilot leaks unchecked at scale without visibility into token usage and tool-invocation patterns.
+
+These risks scale with adoption. [PwC's AI agent survey](https://www.pwc.com/us/en/tech-effect/ai-analytics/ai-agent-survey.html) found that 79 percent say AI agents are already being adopted in their companies – the more organizations that adopt AI, the greater your potential liability.
+
+## What to Instrument and When
+
+Instrumentation needs to scale with the stage of the agent's lifecycle. Match your effort to where you are instead of over-building early or under-building late.
+
+### Prototyping
+
+Print statements and local logs are usually enough when you run one execution at a time and can rerun instantly. Focus on watching tool calls and outputs while you iterate quickly. This is where edge cases such as ambiguous queries, retrieval failures, and tool timeouts first surface.
+
+### Pre-Production
+
+Move to structured traces that capture tool calls, prompt versions, and model outputs so you can compare behavior across test runs. Start building evaluation datasets from real runs, so your tests reflect real-world behavior rather than idealized inputs.
+
+### Production
+
+You need full execution context, including conversation history, retrieval results, and reasoning, to reproduce reported failures. Track per-step token usage, latency, and cost to catch expensive patterns before they hit the budget, then feed production traces back into regression tests and evaluations to drive continuous improvement.
+
+| Stage | Primary Goal | What to Capture | Tooling Approach |
+| --- | --- | --- | --- |
+| Prototyping | Iterate fast on behavior | Tool calls, outputs, edge cases | Print statements and local logs |
+| Pre-Production | Compare runs reliably | Structured traces, prompt versions, eval sets | Structured tracing and eval datasets |
+| Production | Reproduce and improve | Full execution context, per-step cost and latency | Continuous tracing plus regression evals |
+
+## Core Metrics and Signals to Track
+
+Focus on tracking metrics that indicate how reliably agents perform. Start with the fundamentals: latency per task and per step, cost per run and per model, request and tool-call error rates, and success rates broken out by task type.
+
+Then, add the agent-specific signals traditional tools miss:
+
+- **Tool selection accuracy:** Did the agent choose the right tool for the step?
+- **Reasoning-path quality:** Was the decision chain sound, or did it wander?
+- **Context window utilization:** How much of the window is doing useful work?
+- **Hallucination detection:** Did the output contradict retrieved sources?
+
+Evaluations score the qualitative side. LLM-as-a-judge and code-based evals grade correctness, relevance, and tool-usage accuracy. In multi-agent systems, session-level and thread-level visibility matters more than isolated single traces, because failures happen between agents and across turns.
+
+Retrieval-heavy agents add their own failure surface, which we cover in [the best AI agents for data extraction and RAG](/library/best-ai-agents-for-data-extraction-and-rag-in-2026). If your agents call external tools over the Model Context Protocol, [what an MCP server is](/library/what-is-an-mcp-server) explains the tool boundary you'll be tracing across.
+
+## How to Get Started With AI Agent Observability
+
+Here are some practical first steps you can take immediately:
+
+- **Emit telemetry from day one.** Instrument agents to produce traces, logs, and metrics before you need them, not after an incident.
+- **Adopt open standards.** Use [OpenTelemetry's GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/), which standardize how GenAI operations are recorded. This avoids vendor lock-in.
+- **Trace at the decision layer.** Capture reasoning and tool choices, not just request-response boundaries.
+- **Close the loop.** Build test datasets from real production traces and run continuous evaluations.
+
+Plan for common challenges too: trace volume at scale, alert fatigue, fragmented visibility across systems, and privacy or PII handling in telemetry.
+
+Building in a workspace with native logging removes much of the complexity of this process. When you manage observability from the environment where you build and deploy agents, you get execution logs, trace spans, and per-model cost tracking without assembling a separate stack. Sim's Logs module works this way, giving full workflow logs, trace spans, and cost breakdowns per model and token type inside the visual workflow builder itself. If you are still assembling that workflow, [how to build AI agents with Sim](/library/how-to-create-an-ai-agent) walks through the first one.
+
+## The Bottom Line
+
+If your agents touch production, treat observability as a launch requirement, not a later add-on, because you cannot debug, cost-control, or trust what you cannot see. The fastest way to start is to instrument at the decision layer today and route those traces somewhere you can query them.
+
+[Create your next agent in a workspace with built-in observability](https://sim.ai), so execution logs, trace spans, and per-model cost tracking come standard from your very first run.

--- a/apps/sim/content/library/ai-agents-in-procurement/index.mdx
+++ b/apps/sim/content/library/ai-agents-in-procurement/index.mdx
@@ -1,0 +1,123 @@
+---
+slug: ai-agents-in-procurement
+title: 'AI Agents in Procurement: A Comprehensive Guide'
+description: AI agents in procurement automate intake, sourcing, contracts, and supplier risk. Learn what they do, where they add value, and how to build your own.
+date: 2026-07-21
+updated: 2026-07-21
+authors:
+  - andrew
+readingTime: 8
+tags: [AI Agents, Procurement, Automation, Sim]
+ogImage: /library/ai-agents-in-procurement/cover.jpg
+ogAlt: AI agents in procurement automating intake, sourcing, contracts, and supplier risk.
+canonical: https://www.sim.ai/library/ai-agents-in-procurement
+draft: false
+faq:
+  - q: "What are AI agents in procurement?"
+    a: "AI agents in procurement are software programs that use an LLM to interpret a goal, plan steps, and act across your systems with limited supervision. They handle tasks like intake and routing, sourcing research, contract renewals, PO creation, and supplier risk monitoring, escalating key decisions to a human."
+  - q: "How are AI agents different from RPA or traditional procurement software?"
+    a: "Traditional software and RPA bots follow fixed, predefined rules and break when inputs change. AI agents reason over context, interpret messy or unstructured data, and adapt across multiple steps. Rules-based tools suit stable, high-volume work, while agents handle judgment-heavy tasks."
+  - q: "What procurement tasks can AI agents automate first?"
+    a: "Good starting points include intake and orchestration, sourcing research, contract renewals, purchase order creation, and supplier risk monitoring. Start narrow with one low-risk, repeatable task, assess the value added by the agent, then expand to adjacent workflows."
+  - q: "Will AI agents replace procurement jobs?"
+    a: "Agents clear repetitive, transactional work rather than replacing the function wholesale. Procurement professionals shift toward orchestration, oversight, supplier relationships, and category strategy. They take on more high-level, strategic work as more routine tasks are automated."
+  - q: "Do I need to code to build a procurement agent?"
+    a: "No. In an AI workspace like Sim, you can build agents visually with drag-and-drop blocks or conversationally by describing what you want. Coding is optional for teams that want deeper customization."
+  - q: "How do I keep procurement agents secure and compliant?"
+    a: "Set clear guardrails and thresholds, and require human approval on decisions that touch spend. Use role-based access control, audit trails, and self-hosting or bring-your-own-keys for data control. Choose a platform with SOC2 and HIPAA compliance to meet enterprise standards."
+---
+
+Procurement leaders are being asked to move faster and spend less while keeping a close watch on supplier risk, usually with the same headcount and a queue full of manual intake, purchase orders, and email threads. AI agents in procurement offer a practical way out: software that reads a request, plans the steps, and acts across your systems with light supervision.
+
+This guide covers what these agents are, where they add the most value, and how to get one running. Two decisions are particularly important, so we'll focus there: which procurement tasks to automate first, and whether to buy a pre-built agent or build your own.
+
+## Key Takeaways
+
+- **AI agents are autonomous coworkers:** AI agents use an LLM to interpret a goal, plan steps, and act across your procurement systems with limited human oversight.
+- **Adoption is accelerating:** 90 percent of procurement leaders have considered or are already using AI agents to optimize operations, per an [Icertis and ProcureCon survey](https://www.icertis.com/company/news/90-of-procurement-leaders-to-adopt-ai-agents-in-2025-according-to-icertis-sponsored-study/).
+- **Best first tasks include** intake and orchestration, sourcing research, contract renewals, PO creation, and supplier risk monitoring.
+- **Buy vs build:** Buy for a narrow, standardized need; build when workflows are unique, systems are many, and data control matters.
+- **Start narrow:** Implement one low-risk agent with clear guardrails and well-defined human approvals, then monitor and expand.
+
+## What Are AI Agents in Procurement?
+
+AI agents in procurement use a large language model (LLM) to interpret a goal, break it into steps, and act across your systems with limited human supervision. Agentic AI is the broader layer above that: multiple agents coordinating toward complex, multi-stage goals, like running a full sourcing event end to end.
+
+Agents work in a simple loop. They perceive by monitoring spend, supplier data, and inbound requests. They reason by weighing tradeoffs against policy and thresholds. Then they act, executing or recommending a decision within set guardrails.
+
+Under the hood, agents combine several building blocks:
+
+- LLMs for language understanding
+- Orchestration logic to sequence tasks
+- Memory for context, tools, and API integrations to reach your systems
+- Retrieval-augmented generation to ground answers in your real data
+- Human-in-the-loop controls for approvals
+
+### AI Agents vs Traditional Procurement Software
+
+Legacy procurement tools automate specific tasks using static, predefined rules and lean heavily on human oversight. RPA (robotic process automation) bots automate workflows with clearly defined rules, inputs, outputs, and process triggers. AI agents adapt, interpret messy inputs, and make context-based decisions across multiple steps. We cover this distinction in depth in [AI agents vs RPA](/library/ai-agents-vs-rpa).
+
+| Approach | Adaptability | Human Oversight Needed | Best For |
+| --- | --- | --- | --- |
+| Traditional procurement software | Low, fixed rules | High, manual steps and review | Structured forms, catalogs, approvals |
+| RPA bots | Low, breaks on change | Medium, exception handling | Repetitive, high-volume data entry |
+| AI agents | High, reasons over context | Low to medium, approvals on key calls | Judgment-heavy, multi-step work |
+
+Rules-based tools remain a solid fit for stable, high-volume steps. Agents provide the most value on judgment-heavy, multi-step work where inputs vary.
+
+## Where AI Agents Deliver Value in Procurement
+
+The fastest wins come where there's abundant unstructured data and repeatable knowledge work a human can review. Four areas stand out.
+
+**Intake and orchestration.** Agents translate a business request into structured intake, check policy and spend thresholds, then route the buyer to the right channel or an existing contract. This matches what practitioners already prioritize: a recent [Ironclad survey](https://ironcladapp.com/resources/webinars/virtual-panel-state-of-ai-procurement) found the top AI use cases were tracking supplier contractual commitments (77%) and workflow automation and procurement orchestration (67%).
+
+**Strategic sourcing.** Agents run always-on market research, shortlist suppliers, analyze bids, and prepare recommendations. Humans use these resources to decide who to award a contract to.
+
+**Contract lifecycle and renewals.** Agents surface key terms, flag anomalies, monitor compliance, and prompt renewals before deadlines slip.
+
+**Purchase orders, supplier management, and risk.** Agents automate PO creation, watch supplier performance and external risk signals, and escalate issues to a person. Throughout, humans manage strategy, relationships, and final approvals while agents clear the repetitive load.
+
+## Should You Buy a Pre-Built Agent or Build Your Own?
+
+Buying makes sense when you have a narrow, standardized need and a mature vendor already serves it. Building may have the edge if your workflows are unique, you run multiple existing systems, or you have strict data control requirements.
+
+| Criteria | Pre-Built Suite | Build in a Workspace |
+| --- | --- | --- |
+| Fit to your process | Vendor's template | Shaped to your workflows |
+| Integration with existing tools | Limited to the suite | Broad, connects your stack |
+| Speed to first agent | Fast if it fits | Fast with templates |
+| Customization | Constrained | Full control |
+| Vendor lock-in | High | Low, open options |
+| Data control and governance | Vendor-defined | You define it |
+
+Sim is the open-source AI workspace where procurement and IT teams build agents visually, conversationally, or with code. It connects 1,000+ integrations including Salesforce, Slack, Gmail, databases, and ERP systems, without adopting a rigid suite.
+
+For regulated procurement, it also fits governance needs: real-time collaboration, role-based access control, self-hosting, bring-your-own-keys, and SOC2 and HIPAA compliance. If you're weighing platforms more broadly, [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) compares the field.
+
+## How to Get Started With Procurement Agents
+
+Start with one narrow, low-risk agent rather than a full transformation. A strong first candidate is supplier email triage, an agent that scans inbound messages, flags delays, price increases, or contract issues, and logs each one to your system.
+
+Break the process down into smaller tasks:
+
+- **Pick a repeatable task:** Choose something high-volume with clear inputs.
+- **Confirm data and systems:** Identify the sources and tools the agent needs.
+- **Define goals and thresholds:** Set what "good" looks like and when to escalate.
+- **Add guardrails and approvals:** Keep a human on decisions that touch spend.
+- **Measure, then expand:** Track time saved, cycle time, and spend under management before rolling out more.
+
+Data readiness and guardrails are the two most common failure points, so address both before scaling. Sim's pre-built templates for email triage, data enrichment, and feedback analysis give teams a fast starting point they can customize and deploy quickly. For a step-by-step first build, see [how to build AI agents with Sim](/library/how-to-create-an-ai-agent).
+
+## Challenges and Best Practices
+
+Adoption is rarely painless. The most significant hurdles are messy or siloed data, integration complexity across ERP and spend tools, change management, and trust in autonomous decisions. Data is often the biggest blocker: [GEP-supported research](https://www.gep.com/blogs/strategy/clean-data-agentic-ai-orchestration-key-to-procurement-transformation) found that more than half of organizations (53%) do not have their key procurement data integrated into a single system or architecture. Icertis [reported similar friction](https://www.icertis.com/company/news/90-of-procurement-leaders-to-adopt-ai-agents-in-2025-according-to-icertis-sponsored-study/), with integration issues (88%) and data quality issues (75%) detracting from procurement confidence in AI.
+
+A few best practices keep programs on track. Clean and consolidate your data first, set clear standards and guardrails, keep humans in the loop on strategic decisions, and introduce agents gradually. This incremental path is the norm, since a lot of companies are already using agentic AI in some cross-functional capacity, most of them starting small.
+
+Agents should clear repetitive work while procurement professionals shift toward orchestration, oversight, and category strategy. Avoid seeing AI agents as a direct replacement for human procurement individuals, but hold them to the same security expectations. If they can act on spend or take other actions a human worker could, access control, audit trails, and data residency are non-negotiable.
+
+## The Bottom Line
+
+Start gradually and ship one narrow agent this quarter – the teams pulling ahead are the ones learning from a live use case rather than taking an over-theoretical approach. Pick a repeatable task like supplier email triage, wire in your real systems and approvals, and measure the time it saves.
+
+You can [build that first agent in Sim](https://sim.ai) from a template today, then expand once the results are on the table.

--- a/apps/sim/content/library/ai-agents-in-procurement/index.mdx
+++ b/apps/sim/content/library/ai-agents-in-procurement/index.mdx
@@ -24,7 +24,7 @@ faq:
   - q: "Do I need to code to build a procurement agent?"
     a: "No. In an AI workspace like Sim, you can build agents visually with drag-and-drop blocks or conversationally by describing what you want. Coding is optional for teams that want deeper customization."
   - q: "How do I keep procurement agents secure and compliant?"
-    a: "Set clear guardrails and thresholds, and require human approval on decisions that touch spend. Use role-based access control, audit trails, and self-hosting or bring-your-own-keys for data control. Choose a platform with SOC2 and HIPAA compliance to meet enterprise standards."
+    a: "Set clear guardrails and thresholds, and require human approval on decisions that touch spend. Use role-based access control, audit trails, and self-hosting or bring-your-own-keys for data control. Choose a platform with SOC2 compliance, and self-hosting for data-residency needs, to meet enterprise standards."
 ---
 
 Procurement leaders are being asked to move faster and spend less while keeping a close watch on supplier risk, usually with the same headcount and a queue full of manual intake, purchase orders, and email threads. AI agents in procurement offer a practical way out: software that reads a request, plans the steps, and acts across your systems with light supervision.
@@ -92,7 +92,7 @@ Buying makes sense when you have a narrow, standardized need and a mature vendor
 
 Sim is the open-source AI workspace where procurement and IT teams build agents visually, conversationally, or with code. It connects 1,000+ integrations including Salesforce, Slack, Gmail, databases, and ERP systems, without adopting a rigid suite.
 
-For regulated procurement, it also fits governance needs: real-time collaboration, role-based access control, self-hosting, bring-your-own-keys, and SOC2 and HIPAA compliance. If you're weighing platforms more broadly, [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) compares the field.
+For regulated procurement, it also fits governance needs: real-time collaboration, role-based access control, self-hosting for data residency, bring-your-own-keys, and SOC2 compliance. If you're weighing platforms more broadly, [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) compares the field.
 
 ## How to Get Started With Procurement Agents
 

--- a/apps/sim/content/library/mcp-security/index.mdx
+++ b/apps/sim/content/library/mcp-security/index.mdx
@@ -47,7 +47,7 @@ MCP connectivity is broken down into three roles. The host runs the LLM, the cli
 
 The type of threats you should anticipate depends on deployment type. Local servers run on infrastructure you control and often execute OS-level commands, so a flaw can mean code execution on your box. Remote MCP servers can live on localhost, a private URL, or a public URL and are run by others, yet they still touch your data, so you're trusting a third party with sensitive access.
 
-Adoption is currently outpacing the maturity of MCP servers as a business tool, so the potential for security issues is significant. [Anthropic introduced MCP](https://www.anthropic.com/news/model-context-protocol) in late 2024, and within roughly a year, more than 18,000 servers were listed on [MCP Market](https://mcpmarket.com/). Many ship faster than they're secured. Platforms like Sim use MCP for custom integrations, which makes MCP security a significant product concern.
+Adoption is currently outpacing the maturity of MCP servers as a business tool, so the potential for security issues is significant. [Anthropic introduced MCP](https://www.anthropic.com/news/model-context-protocol) in late 2024, and the ecosystem grew fast — public directories like [MCP Market](https://mcpmarket.com/) now index thousands of community-built servers. Many ship faster than they're secured. Platforms like Sim use MCP for custom integrations, which makes MCP security a significant product concern.
 
 ## The Fundamental MCP Security Risks You Need to Know
 

--- a/apps/sim/content/library/mcp-security/index.mdx
+++ b/apps/sim/content/library/mcp-security/index.mdx
@@ -1,0 +1,118 @@
+---
+slug: mcp-security
+title: 'MCP Security: A Practical Guide to Secure MCP Server Development'
+description: MCP security covers the risks, auth flaws, and prompt-injection threats in Model Context Protocol servers; here's how to build and deploy MCP servers securely.
+date: 2026-07-22
+updated: 2026-07-22
+authors:
+  - andrew
+readingTime: 9
+tags: [MCP Security, MCP, Model Context Protocol, Security, Sim]
+ogImage: /library/mcp-security/cover.jpg
+ogAlt: Securing Model Context Protocol servers against tool poisoning, auth flaws, and supply-chain risk.
+canonical: https://www.sim.ai/library/mcp-security
+draft: false
+faq:
+  - q: "What is MCP security?"
+    a: "MCP security is the practice of keeping MCP servers, clients, and connections from exposing data or executing unintended actions. The main risk categories are prompt and tool injection, authentication flaws like over-scoped tokens and confused-deputy issues, and supply-chain risk from untrusted third-party servers."
+  - q: "Is MCP secure by default?"
+    a: "No. The protocol standardizes how agents connect to tools, but security depends entirely on your implementation. Authorization is optional for MCP implementations, so your servers, token handling, and tool definitions determine whether a deployment is actually safe."
+  - q: "What are the biggest MCP security risks?"
+    a: "The three to prioritize are prompt and tool injection (especially tool poisoning, where malicious instructions hide in tool metadata), over-scoped tokens and confused-deputy problems in OAuth, and untrusted third-party servers that ship hidden behavior. Tool poisoning is the most prevalent and impactful client-side vulnerability."
+  - q: "How do you prevent prompt injection in MCP servers?"
+    a: "Validate and sanitize the inputs and outputs the model can act on, review and version tool definitions to catch silent changes, and require human approval for destructive actions like deletes, writes, and payments. Treating tool metadata as a security boundary is important, since the model reads descriptions as instructions."
+  - q: "Are local or remote MCP servers safer?"
+    a: "There's no definitive answer here; each has different trade-offs. Local servers give you control but execute code on infrastructure you host, so a flaw can mean local code execution. Remote servers can live on localhost, a private URL, or a public URL and reduce local execution risk, but they share your data with a third party you must vet and trust."
+  - q: "How does Sim help secure MCP deployments?"
+    a: "Sim provides self-hosted deployment for full data control, bring-your-own-keys, workspace and group access permissions, and approval flows. It also captures full run logs with trace spans for every execution, so MCP activity stays observable and governed as usage grows across a team."
+---
+
+You wired an agent to your internal tools in an afternoon, and it worked. That speed is exactly why MCP security deserves your attention before you ship. The same connection that lets an agent read your database, call your APIs, and run commands is a live attack surface for credential leakage, prompt injection, and unvetted third-party code.
+
+This guide is for builders who want to ship securely while enjoying the benefits offered by MCP connectivity. We'll take you through defining the risk, building a hardened server, and governing it in production. If you're new to the protocol itself, start with [what an MCP server is](/library/what-is-an-mcp-server).
+
+## Key Takeaways
+
+- **MCP security is implementation-dependent:** The protocol standardizes connections, but your servers, tokens, and tool definitions determine whether you're safe.
+- **Tool poisoning is the sharpest risk:** Malicious instructions hidden in tool metadata can turn an approved server destructive; these evade reviews that only scan user input.
+- **Auth details decide everything:** Over-scoped tokens and token passthrough create confused-deputy problems, so scope narrowly and validate the token audience.
+- **Third-party servers are executable code:** Treat unknown MCP servers like any untrusted dependency, vet, sign, and pin them for ultimate security.
+- **Security continues after deployment:** Sandboxing, secrets management, egress limits, full run logs, and RBAC keep MCP usage controlled as it scales.
+
+## What MCP Security Actually Means
+
+Strong MCP security practices prevent MCP servers, clients, and connections from exposing data or executing unintended actions. A good security strategy should span authentication, tool design, input validation, deployment, and ongoing monitoring.
+
+MCP connectivity is broken down into three roles. The host runs the LLM, the client speaks the protocol, and the server accesses the actual tools and data while holding the credentials. That server is where most risk concentrates, because it sits closest to your systems.
+
+The type of threats you should anticipate depends on deployment type. Local servers run on infrastructure you control and often execute OS-level commands, so a flaw can mean code execution on your box. Remote MCP servers can live on localhost, a private URL, or a public URL and are run by others, yet they still touch your data, so you're trusting a third party with sensitive access.
+
+Adoption is currently outpacing the maturity of MCP servers as a business tool, so the potential for security issues is significant. [Anthropic introduced MCP](https://www.anthropic.com/news/model-context-protocol) in late 2024, and within roughly a year, more than 18,000 servers were listed on [MCP Market](https://mcpmarket.com/). Many ship faster than they're secured. Platforms like Sim use MCP for custom integrations, which makes MCP security a significant product concern.
+
+## The Fundamental MCP Security Risks You Need to Know
+
+These are the threats you design against. The table maps each risk to how it happens and how to shut it down.
+
+| Risk | How It Happens | Real Impact | Primary Mitigation |
+| --- | --- | --- | --- |
+| Prompt / Tool Injection | Malicious instructions hidden in tool metadata or external content | Data exfiltration, destructive actions | Review tool definitions, validate inputs/outputs, human approval |
+| Confused Deputy / OAuth token misuse | Server forwards or accepts tokens meant for another resource | Privilege escalation across APIs | Validate token audience; use resource indicators |
+| Token Passthrough & Over-scoped Credentials | Broad tokens passed to the server or downstream | One breach exposes everything | Least-privilege scopes, per-tool credentials |
+| Supply Chain Risk | Untrusted third-party server ships hidden behavior | Backdoors, RCE | Signing, provenance, dependency scanning |
+| Local Server Misconfiguration | Unauthenticated server executing OS commands | Local code execution | Auth on every server, sandboxing |
+| Session Hijacking | Stolen or predictable session identifiers | Impersonation | Secure session binding, TLS |
+| SSRF | Server fetches attacker-controlled URLs | Internal network access | Egress limits, URL allowlists |
+
+## Three Top MCP Security Concerns To Be Aware Of
+
+### Prompt and tool injection
+
+Tool poisoning, where malicious instructions are embedded in tool metadata, is the most prevalent and impactful client-side vulnerability. An amended tool definition can quietly instruct an agent to delete resources or redirect data while looking like ordinary configuration.
+
+Two documented cases, [MCPoison (CVE-2025-54136)](https://nvd.nist.gov/vuln/detail/CVE-2025-54136) and [CurXecute (CVE-2025-54135)](https://nvd.nist.gov/vuln/detail/CVE-2025-54135), proved the same structural point in Cursor's MCP handling: a trusted configuration could be swapped for a malicious one and reach code execution. Researchers separately demonstrated a [WhatsApp MCP integration flaw](https://www.docker.com/blog/mcp-horror-stories-whatsapp-data-exfiltration-issue/) where a malicious server poisoned tool descriptions, silently redirecting a user's message history to an attacker-controlled number.
+
+### Authentication
+
+If an MCP server accepts tokens with incorrect audiences and forwards them unmodified to downstream services, the downstream API incorrectly trusts the token. Over-scoped tokens compound this: hand a server broad credentials and one compromised path exposes everything. OAuth implementation details are where these bugs live.
+
+### Supply chain risk
+
+MCP servers are executable code, so an unvetted third-party server can carry hidden behavior. Signing, provenance checks, and dependency scanning are your defenses.
+
+## How to Build a Secure MCP Server
+
+### Design With Least Privilege
+
+Scope every token and permission to the minimum each tool needs, and avoid passing broad credentials to the server. Separate credentials per tool and data source so one compromised path doesn't open the rest. Decide local versus remote deployment based on data sensitivity and trust boundaries before you write any auth code.
+
+### Harden Authentication and Authorization
+
+Implement [OAuth](https://oauth.net/2.1/) correctly. An MCP client acts as an OAuth 2.1 client making requests on behalf of a resource owner, and the authorization server issues access tokens for use at the MCP server.
+
+Enforce per-client consent and validate redirect URIs to close confused-deputy gaps. Critically, the MCP server must not pass through the token it received from the client, and clients must use the resource parameter defined in [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) to specify the target resource.
+
+Never let the server act as an ambient super-user; enforce the requesting user's permissions on every call. Use the [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) and [RFC 9700](https://www.rfc-editor.org/rfc/rfc9700), the OAuth 2.0 security best practice published in January 2025, as a guide for best practice.
+
+### Treat Tool Definitions as Security-Critical Code
+
+Review and version tool definitions, and detect and block silent changes to tool behavior. Validate and sanitize the inputs and outputs the model can act on to shrink injection blast radius. Add guardrails or human approval for destructive actions like deletes, writes, and payments.
+
+### Secure the Supply Chain
+
+Run only trusted, signed servers, and vet third-party servers before connecting. Add SAST and software composition analysis to your build pipeline to catch vulnerable dependencies. Pin versions and monitor for behavioral changes in third-party servers.
+
+## Deploying and Governing MCP Servers in Production
+
+Shipping securely is half the job. MCP servers need ongoing governance and monitoring like any production system.
+
+Start with deployment controls. If you're self-hosting, isolate and sandbox servers so a compromise can't spread. You should also manage secrets outside the codebase, and limit network egress to reduce SSRF and lateral movement.
+
+Observability comes next. Log every tool call and MCP interaction, trace execution end to end, and alert on anomalous requests such as mass deletes, unusual data access, or injection patterns. You can't investigate what you don't record.
+
+Access governance keeps things controlled as teams scale. Implement RBAC, approval workflows, separate staging and production, and audit trails to keep track of activity surrounding your MCP servers.
+
+This is where a specialized platform helps. Sim is an AI workspace where teams build MCP-connected agents with enterprise controls, so security lives in the platform instead of being bolted on. You get self-hosted deployment for full data control, bring-your-own-keys, workspace and group access permissions, and full run logs with trace spans for every execution. Custom integrations connect through Sim's MCP support so your controls apply consistently. For the wider self-hosting landscape, see [open-source AI agent platforms](/library/open-source-ai-agent-platforms).
+
+## What To Do Next
+
+Treat your MCP server as untrusted until you've narrowed its tokens, versioned its tool definitions, and put every tool call under logs and approval gates. Pick your highest-risk server today and audit its security using the processes detailed above. If you're comparing where to run MCP-connected agents, [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) covers the field. If you're standardizing MCP across a team, [start building on Sim](https://sim.ai) so self-hosting, access control, and observability come built in.


### PR DESCRIPTION
## Summary

Three new AEO library guides, each dated into a **recent empty day in the posting calendar** so publication is spread out rather than dumped on one day:

| Post | Date (backfilled gap) | Focus keyword |
|---|---|---|
| `ai-agent-observability` | 2026-07-19 (Sun, empty) | ai agent observability |
| `ai-agents-in-procurement` | 2026-07-21 (Tue, empty) | ai agents in procurement |
| `mcp-security` | 2026-07-22 (Wed, empty) | mcp security |

Note the three provided slugs were `/blog/...`, but the content is textbook AEO/GEO (focus keyword, meta description, key takeaways, FAQ) and you asked for the **library** — so they live at `/library/<slug>`, matching the section's purpose. `canonical` and internal links use `/library/`.

## Citations — every claim traced to a verified primary source

Per `.claude/rules/landing-seo-geo.md`, every third-party factual claim carries an outbound citation, and I verified each source actually substantiates the claim before linking it (not just that the URL resolves):

- **Observability:** [OpenTelemetry GenAI semconv](https://opentelemetry.io/docs/specs/semconv/gen-ai/), [Fiddler's OTel analysis](https://www.fiddler.ai/blog/opentelemetry-ai-observability-guide), [LangChain State of AI Agents](https://www.langchain.com/stateofaiagents) (quality ≈ one-third), [PwC survey](https://www.pwc.com/us/en/tech-effect/ai-analytics/ai-agent-survey.html) (79%)
- **Procurement:** [Icertis/ProcureCon](https://www.icertis.com/company/news/90-of-procurement-leaders-to-adopt-ai-agents-in-2025-according-to-icertis-sponsored-study/) (90%, and the 88%/75% friction figures), [Ironclad](https://ironcladapp.com/resources/webinars/virtual-panel-state-of-ai-procurement) (77%/67%), [GEP/Foundry](https://www.gep.com/blogs/strategy/clean-data-agentic-ai-orchestration-key-to-procurement-transformation) (53%)
- **MCP security:** [MCPoison CVE-2025-54136](https://nvd.nist.gov/vuln/detail/CVE-2025-54136) + [CurXecute CVE-2025-54135](https://nvd.nist.gov/vuln/detail/CVE-2025-54135) (both confirmed as Cursor MCP config-poisoning on NVD), [WhatsApp exfil case](https://www.docker.com/blog/mcp-horror-stories-whatsapp-data-exfiltration-issue/), [Anthropic MCP announcement](https://www.anthropic.com/news/model-context-protocol), [MCP Market](https://mcpmarket.com/), [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707), [RFC 9700](https://www.rfc-editor.org/rfc/rfc9700), [OAuth 2.1](https://oauth.net/2.1/), [MCP auth spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)

**One correction to the source copy:** it stated the WhatsApp MCP flaw was found "In November 2025." I could not verify that date (the disclosure was earlier in 2025), so I dropped the specific month rather than assert it — the case itself is cited to Docker's writeup. Per the rule: an unlinked/undated claim beats a wrong one.

Internal links: **3 per post** to related library posts (e.g. procurement → [AI agents vs RPA](/library/ai-agents-vs-rpa), MCP security → [what an MCP server is](/library/what-is-an-mcp-server)). No self-links; all internal targets exist.

## Covers

Cover art comes from your autogeneration pipeline. Each post references the standard `ogImage: /library/<slug>/cover.jpg` path; I did **not** commit placeholder art. Until autogen runs, the hero image at those three paths will 404 — flagging so it's not a surprise.

## Testing

Verified against a running dev server:
- All 3 pages render 200; all 3 appear in the `/library` index with correct dates.
- All 17 unique external URLs resolve (mcpmarket.com returned 429 from my own repeated hits — a live site, not a 404).
- Rendered link treatment: **every** external citation carries `target="_blank" rel="noopener noreferrer"` (5/5, 4/4, 9/9); internal links carry neither. (This relies on the MDX-anchor fix from #5913, now on staging.)
- Tables and heading hierarchy render correctly; FAQ schema present; no "Updated" label (date == updated on new posts).
- `bun run lint` clean; `check:boundaries`, `check:api-validation:strict`, `check:client-boundary` all pass.

**Heads-up unrelated to this PR:** `bunx tsc` reports 5 errors in `providers/anthropic/core.ts` (Anthropic SDK `OutputConfig`/`output_config` typings). These are pre-existing on staging — this PR adds only MDX, which `tsc` doesn't compile — but worth a look since they'll trip a full typecheck.

## Type of Change
- [x] Content

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)