### PR TITLE
fix(deps): build isolated-vm on install via root trustedDependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,4 +37,3 @@ package.json @simstudioai/deps
 bun.lock @simstudioai/deps
 **/bun.lock @simstudioai/deps
 bunfig.toml @simstudioai/deps
-.npmrc @simstudioai/deps

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-ignore-scripts=true

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -257,13 +257,6 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.1.0"
   },
-  "trustedDependencies": [
-    "canvas",
-    "better-sqlite3",
-    "ffmpeg-static",
-    "isolated-vm",
-    "sharp"
-  ],
   "overrides": {
     "next": "16.2.11",
     "@next/env": "16.2.11",

--- a/bun.lock
+++ b/bun.lock
@@ -589,9 +589,8 @@
     },
   },
   "trustedDependencies": [
-    "ffmpeg-static",
-    "isolated-vm",
     "sharp",
+    "isolated-vm",
   ],
   "overrides": {
     "@next/env": "16.2.11",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     ]
   },
   "trustedDependencies": [
+    "isolated-vm",
     "sharp"
   ],
   "dependencies": {


### PR DESCRIPTION
## Summary
- `isolated-vm` now builds on `bun install` — no more manual `npm rebuild` for every contributor
- Root cause was `.npmrc` with `ignore-scripts=true`, a blanket switch that overrode Bun's `trustedDependencies` allowlist and blocked every lifecycle script, including this repo's own root scripts
- That line landed in the May 2025 Bun migration (#371), seven months before `isolated-vm` was introduced (#2385). Two later commits added `isolated-vm` to `trustedDependencies` — root in #2387, then `apps/sim` in #2613 — and both were silently inert
- Deleted `.npmrc`; lifecycle policy now lives solely in root `trustedDependencies`, and added `isolated-vm` to it
- Removed the `trustedDependencies` block from `apps/sim/package.json` — Bun only reads the root list, so it never had any effect and was what misled the two earlier fixes
- Dropped the now-dangling `.npmrc` entry from CODEOWNERS

## Why this doesn't widen the supply-chain surface
Naming any package in `trustedDependencies` **replaces** Bun's curated default-trust list rather than adding to it (verified: with `trustedDependencies: ["nothing-real"]`, `isolated-vm` does not build even though it is on Bun's default list). So the allowlist is deny-by-default and the only packages permitted to run install scripts are `isolated-vm` and `sharp`.

Everything currently blocked stays blocked — `esbuild`, `core-js`, `protobufjs`, `ssh2`, `cpu-features`, `bufferutil`, `free-email-domains`, `ffmpeg-static`. `bunfig.toml`'s `minimumReleaseAge` supply-chain gate is untouched.

`isolated-vm`'s install script is `prebuild-install || node-gyp rebuild`. We already execute that exact binary as the sandbox for all untrusted user code, so running its installer adds no trust we don't already extend.

## Side effect worth knowing
The `.npmrc` switch also blocked the repo's **own** root scripts, so husky's `prepare` never ran and `core.hooksPath` was unset — the `pre-commit` lint-staged hook has not been active for anyone who installed since May 2025. It installs correctly now (the hook ran on this PR's commit).

## Testing
Verified in an isolated worktree, baseline vs. after on a clean `node_modules`:

| | before | after |
|---|---|---|
| `isolated-vm/out/isolated_vm.node` | absent | built |
| `ffmpeg-static` binary | absent | absent (unchanged) |
| `core.hooksPath` | unset | `.husky/_` |

- Binary loads under the real runtime: `node -e "require('isolated-vm')"` → `evalSync('40+2')` = `42`
- ABI targeting is correct — `prebuild-install` runs under the `node` on PATH, not Bun, so it fetched `node-v127` matching local Node 22 rather than Bun's claimed 24.3.0. That is the same Node that spawns the worker in `lib/execution/isolated-vm.ts`
- Upstream publishes prebuilds for node ABI v127/v137 across linux x64/arm64 (incl. musl), darwin-arm64 and win32-x64, covering the Blacksmith ubuntu-2404 x64/arm64 runners. Intel macOS has no prebuild and compiles from source — the same as the manual `npm rebuild` it replaces
- `bun install --frozen-lockfile` (the CI path) exits 0
- `bun run lint:check` clean across all 19 tasks
- Docker unaffected: all three Dockerfiles pass `--ignore-scripts` explicitly and rebuild `isolated-vm` against the Node ABI by hand, so `.npmrc` was never load-bearing there

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
