### PR TITLE
feat(files): collaborator cursors over the file list

### DIFF
--- a/apps/realtime/src/handlers/workspace-files.ts
+++ b/apps/realtime/src/handlers/workspace-files.ts
@@ -201,6 +201,29 @@ export function setupWorkspaceFilesHandlers(
     }
   )
 
+  socket.on('files-cursor-update', async ({ cursor, folderId }) => {
+    try {
+      const room = await roomManager.getRoomForSocket(socket.id, ROOM_TYPES.WORKSPACE_FILES)
+      const session = await roomManager.getUserSession(socket.id)
+      if (!room || !session) return
+
+      await roomManager.updateUserActivity(room, socket.id, { cursor })
+
+      // Broadcast to the room; the client scopes rendering to the same folder via
+      // the `folderId` carried on the payload.
+      socket.to(roomName(room)).emit('files-cursor-update', {
+        socketId: socket.id,
+        userId: session.userId,
+        userName: session.userName,
+        avatarUrl: session.avatarUrl,
+        cursor,
+        folderId: folderId ?? null,
+      })
+    } catch (error) {
+      logger.error(`Error handling files cursor update for socket ${socket.id}:`, error)
+    }
+  })
+
   socket.on('leave-workspace-files', async (payload?: { workspaceId?: string }) => {
     try {
       if (!roomManager.isReady()) return

--- a/apps/sim/app/workspace/[workspaceId]/components/presence/remote-cursor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/presence/remote-cursor.tsx
@@ -1,0 +1,33 @@
+interface RemoteCursorProps {
+  name: string
+  color: string
+}
+
+/**
+ * The shared collaborator cursor mark — a filled pointer plus a colored name tag.
+ * Positioning is the caller's responsibility (the canvas applies the ReactFlow
+ * viewport transform; the file browser applies the list scroll offset), so this
+ * component is purely the visual and is identical across every surface.
+ */
+export function RemoteCursor({ name, color }: RemoteCursorProps) {
+  return (
+    <div className='relative flex items-start'>
+      <svg
+        className='-mt-4.5'
+        width={24}
+        height={24}
+        viewBox='0 0 24 24'
+        fill={color}
+        aria-hidden='true'
+      >
+        <path d='M4.037 4.688a.495.495 0 0 1 .651-.651l16 6.5a.5.5 0 0 1-.063.947l-6.124 1.58a2 2 0 0 0-1.438 1.435l-1.579 6.126a.5.5 0 0 1-.947.063z' />
+      </svg>
+      <div
+        className='ml-[-4px] inline-flex max-w-[160px] truncate whitespace-nowrap rounded-xs px-1.5 py-0.5 font-medium text-[var(--surface-1)] text-xs'
+        style={{ backgroundColor: color }}
+      >
+        {name}
+      </div>
+    </div>
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/resource.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/resource.tsx
@@ -164,6 +164,8 @@ function ResourceRoot({ children, onContextMenu }: ResourceProps) {
 export interface ResourceTableHandle {
   /** Scroll the row with the given id into view via the virtualizer (works even when the row is not in the DOM). */
   scrollToRow: (rowId: string) => void
+  /** The scrolling element, for overlays that must map content coordinates to the viewport (e.g. collaborator cursors). */
+  getScrollElement: () => HTMLDivElement | null
 }
 
 interface ResourceTableProps {
@@ -315,6 +317,7 @@ const ResourceTable = memo(function ResourceTable({
         const index = rows.findIndex((row) => row.id === rowId)
         if (index >= 0) rowVirtualizer.scrollToIndex(index, { align: 'auto' })
       },
+      getScrollElement: () => scrollRef.current,
     }),
     [rows, rowVirtualizer]
   )

--- a/apps/sim/app/workspace/[workspaceId]/files/components/files-cursors.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/files-cursors.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { type RefObject, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { getUserColor } from '@/lib/workspaces/colors'
+import type { ResourceTableHandle } from '@/app/workspace/[workspaceId]/components'
+import { RemoteCursor } from '@/app/workspace/[workspaceId]/components/presence/remote-cursor'
+import type { FilesCursor } from '@/app/workspace/[workspaceId]/files/hooks/use-workspace-files-room'
+
+interface FilesCursorsProps {
+  /** Imperative handle of the Resource table, exposing the scroll element. */
+  tableApiRef: RefObject<ResourceTableHandle | null>
+  /** Remote cursors in content-space coordinates (already folder-scoped, self excluded). */
+  cursors: FilesCursor[]
+  /** Emit the local pointer in content-space; `null` when it leaves the list. */
+  emitCursor: (cursor: { x: number; y: number } | null) => void
+}
+
+/**
+ * Collaborator cursors over the file list. Emits the local pointer in the list's
+ * content-space (viewport-relative + scroll offset) and renders each remote cursor
+ * back at `content − scroll`, so cursors stay anchored to content when either user
+ * scrolls. Rendered via a portal in fixed/viewport space (matching the header's
+ * veil) and clipped to the list's visible rect, so it survives any transformed
+ * ancestor and never spills outside the panel. The mark itself is the shared
+ * {@link RemoteCursor}, identical to the canvas.
+ */
+export function FilesCursors({ tableApiRef, cursors, emitCursor }: FilesCursorsProps) {
+  const [mounted, setMounted] = useState(false)
+  // Bumped on scroll/resize so the render re-reads scroll offset and repositions.
+  const [, setViewportTick] = useState(0)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    const el = tableApiRef.current?.getScrollElement()
+    if (!el) return
+
+    const handleMove = (event: MouseEvent) => {
+      const rect = el.getBoundingClientRect()
+      emitCursor({
+        x: event.clientX - rect.left + el.scrollLeft,
+        y: event.clientY - rect.top + el.scrollTop,
+      })
+    }
+    const handleLeave = () => emitCursor(null)
+    const reposition = () => setViewportTick((tick) => tick + 1)
+
+    el.addEventListener('mousemove', handleMove)
+    el.addEventListener('mouseleave', handleLeave)
+    el.addEventListener('scroll', reposition, { passive: true })
+    window.addEventListener('resize', reposition)
+
+    return () => {
+      el.removeEventListener('mousemove', handleMove)
+      el.removeEventListener('mouseleave', handleLeave)
+      el.removeEventListener('scroll', reposition)
+      window.removeEventListener('resize', reposition)
+      emitCursor(null)
+    }
+  }, [tableApiRef, emitCursor])
+
+  const el = tableApiRef.current?.getScrollElement()
+  if (!mounted || !el || cursors.length === 0) return null
+
+  const rect = el.getBoundingClientRect()
+
+  return createPortal(
+    cursors.map((collaborator) => {
+      const viewportX = rect.left + (collaborator.cursor.x - el.scrollLeft)
+      const viewportY = rect.top + (collaborator.cursor.y - el.scrollTop)
+      // Clip to the list's visible bounds so a cursor scrolled out of view (or in
+      // another pane) is not drawn floating over the rest of the app.
+      if (
+        viewportX < rect.left ||
+        viewportX > rect.right ||
+        viewportY < rect.top ||
+        viewportY > rect.bottom
+      ) {
+        return null
+      }
+      return (
+        <div
+          key={collaborator.socketId}
+          className='pointer-events-none fixed top-0 left-0 z-20 select-none'
+          style={{
+            transform: `translate3d(${viewportX}px, ${viewportY}px, 0)`,
+            transition: 'transform 0.1s ease-out',
+          }}
+        >
+          <RemoteCursor
+            name={collaborator.userName?.trim() || 'Collaborator'}
+            color={getUserColor(collaborator.userId)}
+          />
+        </div>
+      )
+    }),
+    document.body
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -51,6 +51,7 @@ import type {
   ResourceAction,
   ResourceColumn,
   ResourceRow,
+  ResourceTableHandle,
   RowDragDropConfig,
   SearchConfig,
   SortConfig,
@@ -73,6 +74,7 @@ import {
   isPreviewable,
   isTextEditable,
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer'
+import { FilesCursors } from '@/app/workspace/[workspaceId]/files/components/files-cursors'
 import { FilesListContextMenu } from '@/app/workspace/[workspaceId]/files/components/files-list-context-menu'
 import { ShareModal } from '@/app/workspace/[workspaceId]/files/components/share-modal'
 import { useWorkspaceFilesRoom } from '@/app/workspace/[workspaceId]/files/hooks/use-workspace-files-room'
@@ -205,10 +207,12 @@ export function Files() {
   const canEdit = userPermissions.canEdit === true
   const { config: permissionConfig } = usePermissionConfig()
 
-  const { otherUsers: filesPresenceUsers } = useWorkspaceFilesRoom(
-    workspaceId,
-    currentFolderId ?? null
-  )
+  const {
+    otherUsers: filesPresenceUsers,
+    cursors: filesCursors,
+    emitCursor: emitFilesCursor,
+  } = useWorkspaceFilesRoom(workspaceId, currentFolderId ?? null)
+  const filesTableApiRef = useRef<ResourceTableHandle>(null)
 
   useEffect(() => {
     if (permissionConfig.hideFilesTab) {
@@ -1975,6 +1979,7 @@ export function Files() {
           filter={filterContent ? { content: filterContent } : undefined}
         />
         <Resource.Table
+          apiRef={filesTableApiRef}
           columns={COLUMNS}
           rows={rows}
           selectable={selectableConfig}
@@ -1990,6 +1995,11 @@ export function Files() {
                 moveOptions={canEdit ? contextMenuMoveOptions : undefined}
                 onDelete={canEdit ? handleBulkDelete : undefined}
                 isLoading={bulkArchiveItems.isPending || moveItems.isPending}
+              />
+              <FilesCursors
+                tableApiRef={filesTableApiRef}
+                cursors={filesCursors}
+                emitCursor={emitFilesCursor}
               />
               {isDraggingOver ? (
                 <div className='pointer-events-none absolute inset-0 z-[var(--z-dropdown)] flex flex-col items-center justify-center gap-2 border border-[var(--brand-secondary)] border-dashed bg-[var(--surface-4)] transition-colors'>

--- a/apps/sim/app/workspace/[workspaceId]/files/hooks/use-workspace-files-room.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/hooks/use-workspace-files-room.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createLogger } from '@sim/logger'
 import { generateShortId } from '@sim/utils/id'
 import { useQueryClient } from '@tanstack/react-query'
@@ -13,6 +13,8 @@ const logger = createLogger('WorkspaceFilesRoom')
 /** Retry cap + base delay for a retryable join failure on an otherwise-live socket. */
 const MAX_JOIN_RETRIES = 3
 const JOIN_RETRY_BASE_MS = 1000
+/** Minimum gap between outbound cursor frames (~30fps), matching the canvas. */
+const CURSOR_THROTTLE_MS = 33
 
 interface PresenceUpdatePayload extends PresenceAvatarUser {
   folderId?: string | null
@@ -25,9 +27,29 @@ interface JoinErrorPayload {
   retryable?: boolean
 }
 
+/** A collaborator's cursor in content-space coordinates of the file list. */
+export interface FilesCursor {
+  socketId: string
+  userId: string
+  userName: string
+  cursor: { x: number; y: number }
+}
+
+interface FilesCursorPayload {
+  socketId: string
+  userId: string
+  userName: string
+  cursor: { x: number; y: number } | null
+  folderId: string | null
+}
+
 interface UseWorkspaceFilesRoomResult {
   /** Collaborators viewing this workspace's files, excluding the current socket. */
   otherUsers: PresenceAvatarUser[]
+  /** Remote cursors in the currently-open folder, excluding the current socket. */
+  cursors: FilesCursor[]
+  /** Emit the local content-space pointer position (throttled). Pass `null` when it leaves the list. */
+  emitCursor: (cursor: { x: number; y: number } | null) => void
 }
 
 /**
@@ -48,10 +70,14 @@ export function useWorkspaceFilesRoom(
   const queryClient = useQueryClient()
 
   const [presenceUsers, setPresenceUsers] = useState<PresenceUpdatePayload[]>([])
+  const [cursorBySocket, setCursorBySocket] = useState<
+    Map<string, FilesCursor & { folderId: string | null }>
+  >(() => new Map())
 
   const tabSessionIdRef = useRef<string>('')
   if (!tabSessionIdRef.current) tabSessionIdRef.current = generateShortId()
   const folderIdRef = useRef(folderId)
+  const lastCursorEmitRef = useRef(0)
 
   useEffect(() => {
     folderIdRef.current = folderId
@@ -98,6 +124,23 @@ export function useWorkspaceFilesRoom(
       if (data.workspaceId === workspaceId)
         invalidateWorkspaceFileBrowsers(queryClient, workspaceId)
     }
+    const handleCursor = (data: FilesCursorPayload) => {
+      setCursorBySocket((prev) => {
+        const next = new Map(prev)
+        if (data.cursor) {
+          next.set(data.socketId, {
+            socketId: data.socketId,
+            userId: data.userId,
+            userName: data.userName,
+            cursor: data.cursor,
+            folderId: data.folderId ?? null,
+          })
+        } else {
+          next.delete(data.socketId)
+        }
+        return next
+      })
+    }
 
     // Join now if the socket is already connected; `connect` covers (re)connects.
     if (socket.connected) join()
@@ -106,6 +149,7 @@ export function useWorkspaceFilesRoom(
     socket.on('join-workspace-files-error', handleJoinError)
     socket.on('workspace-files:presence-update', handlePresence)
     socket.on('workspace-files-changed', handleChanged)
+    socket.on('files-cursor-update', handleCursor)
 
     return () => {
       if (retryTimer) clearTimeout(retryTimer)
@@ -114,7 +158,9 @@ export function useWorkspaceFilesRoom(
       socket.off('join-workspace-files-error', handleJoinError)
       socket.off('workspace-files:presence-update', handlePresence)
       socket.off('workspace-files-changed', handleChanged)
+      socket.off('files-cursor-update', handleCursor)
       setPresenceUsers([])
+      setCursorBySocket(new Map())
 
       // Leave the room, scoped to THIS workspace: the server no-ops if the socket
       // has already switched to another workspace's files room (so a workspace
@@ -124,10 +170,31 @@ export function useWorkspaceFilesRoom(
     }
   }, [socket, workspaceId, queryClient])
 
+  const emitCursor = useCallback(
+    (cursor: { x: number; y: number } | null) => {
+      if (!socket) return
+      if (cursor) {
+        const now = Date.now()
+        if (now - lastCursorEmitRef.current < CURSOR_THROTTLE_MS) return
+        lastCursorEmitRef.current = now
+      }
+      socket.emit('files-cursor-update', { cursor, folderId: folderIdRef.current })
+    },
+    [socket]
+  )
+
   const otherUsers = useMemo(
     () => presenceUsers.filter((user) => user.socketId !== currentSocketId),
     [presenceUsers, currentSocketId]
   )
 
-  return { otherUsers }
+  const cursors = useMemo(
+    () =>
+      Array.from(cursorBySocket.values()).filter(
+        (c) => c.socketId !== currentSocketId && (c.folderId ?? null) === (folderId ?? null)
+      ),
+    [cursorBySocket, currentSocketId, folderId]
+  )
+
+  return { otherUsers, cursors, emitCursor }
 }

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/cursors/cursors.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/cursors/cursors.tsx
@@ -3,6 +3,7 @@
 import { memo, useMemo } from 'react'
 import { useViewport } from 'reactflow'
 import { getUserColor } from '@/lib/workspaces/colors'
+import { RemoteCursor } from '@/app/workspace/[workspaceId]/components/presence/remote-cursor'
 import { usePreventZoom } from '@/app/workspace/[workspaceId]/w/[workflowId]/hooks'
 import { useSocket } from '@/app/workspace/providers/socket-provider'
 import { usePresenceStore } from '@/stores/presence/store'
@@ -65,20 +66,7 @@ const CursorsComponent = () => {
               transition: 'transform 0.12s ease-out',
             }}
           >
-            <div className='relative flex items-start'>
-              {/* Filled mouse pointer cursor */}
-              <svg className='-mt-4.5' width={24} height={24} viewBox='0 0 24 24' fill={color}>
-                <path d='M4.037 4.688a.495.495 0 0 1 .651-.651l16 6.5a.5.5 0 0 1-.063.947l-6.124 1.58a2 2 0 0 0-1.438 1.435l-1.579 6.126a.5.5 0 0 1-.947.063z' />
-              </svg>
-
-              {/* Name tag to the right, background tightly wrapping text */}
-              <div
-                className='ml-[-4px] inline-flex max-w-[160px] truncate whitespace-nowrap rounded-xs px-1.5 py-0.5 font-medium text-[var(--surface-1)] text-xs'
-                style={{ backgroundColor: color }}
-              >
-                {name}
-              </div>
-            </div>
+            <RemoteCursor name={name} color={color} />
           </div>
         )
       })}


### PR DESCRIPTION
## Realtime Rooms — Files cursors (the deferred piece)

Adds live pointer cursors to the Files browser, on the presence room shipped earlier. Design-aligned with the canvas.

### Design-system alignment (per emcn principles)
- **Shared `<RemoteCursor>`** (filled pointer + colored name tag via `getUserColor`) extracted from the workflow cursors, so the mark is **identical on canvas and Files**. The workflow `cursors.tsx` now consumes it — the duplicate SVG/tag is deleted (one source of truth).
- Scroll element accessed via a new **`ResourceTableHandle.getScrollElement()`** on the Resource table's existing imperative handle — no DOM traversal hacks.
- Overlay **portaled to `document.body`** in fixed/viewport space — the same pattern the Resource header's focus-veil uses — so it survives transformed ancestors, and **clipped to the list's visible rect** so a scrolled-out cursor never floats over the app.

### How it works
- Server `files-cursor-update` broadcasts a collaborator's cursor to the room, carrying `folderId`; the client renders only same-folder cursors.
- The hook emits the local pointer in the list's **content space** (`viewport + scrollOffset`, throttled ~30fps) and renders each remote cursor at `content − scroll`, so cursors stay anchored to content when **either** user scrolls.
- **Y** tracks the same row cross-window; **X** is approximate under responsive column widths (acceptable for a vertical list).

### ⚠️ Needs live verification before merge
The scroll-synced coordinate rendering is the one thing tests can't cover — it needs **two-browser verification** (move + scroll in one window, confirm the cursor tracks the right content in the other). I've deliberately flagged this rather than assume the DOM math is right. Everything else (server handler, shared component, hook plumbing, imperative-handle wiring) is verified: 128 realtime tests pass, both apps `tsc` clean, biome + api-validation green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)