### PR TITLE
chore(ci): run companion-pr-check on Blacksmith

### DIFF
--- a/.github/workflows/companion-pr-check.yml
+++ b/.github/workflows/companion-pr-check.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   companion:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7


### PR DESCRIPTION
## Summary
- `companion-pr-check.yml` was the last workflow still pinned to plain `ubuntu-latest`
- switched it to the same Blacksmith-with-fallback expression every other workflow uses (`blacksmith-2vcpu-ubuntu-2404`, falling back to `ubuntu-latest` when `vars.CI_PROVIDER` is set to anything else)
- 2vcpu matches the other light jobs (helm lint, ci lint) — this job is a single github-script step

## Type of Change
- [x] Chore (CI/infra)

## Testing
Tested manually — YAML parses; runner selection is the identical expression already proven on `ci.yml`, `helm.yml`, and the publish workflows.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)