### PR TITLE
fix(ci): build app on 16vcpu runner to stop cold-cache OOM kills

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -197,11 +197,18 @@ jobs:
   # harmless), but the Turbo cache gets its own key: with a shared key, only
   # the last committer's new entries survive each run, so the test and build
   # Turbo entries would evict each other nondeterministically.
-  # Same next build as the app image, so it needs the same larger runner in
-  # GitHub mode: it peaks ~21.9 GB and SIGKILLs on the free 16 GB ones.
+  # Same next build as the app image, so it needs a large runner. Peak RSS
+  # tracks Turbo/Turbopack cache warmth, and it is the COLD case that sizes the
+  # runner: warm peaks ~12 GB, partial ~28 GB, and a cold full rebuild peaked
+  # 51 GB. The 8vcpu tier only has 30.4 GB, so cold-cache runs OOM-killed the VM
+  # (oom_count 1, memory p100 ~30.5 GB, ~99% of the tier) — the job burned 8-15
+  # min and died, while warm runs finished under 8 min. NODE_OPTIONS'
+  # --max-old-space-size only caps Node's JS heap; the bulk is native Turbopack
+  # worker memory, so the cap cannot prevent this. 16vcpu = 60.8 GB fits the
+  # 51 GB cold peak with headroom. Keep the test job on 8vcpu; its memory is fine.
   build:
     name: Build App
-    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-8vcpu-ubuntu-2404' || 'linux-x64-8-core' }}
+    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-16vcpu-ubuntu-2404' || 'linux-x64-8-core' }}
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Summary
- `Test and Build / Build App` was OOM-killing the whole runner VM on cold-cache runs, not failing to compile
- bumped **only** that job to `blacksmith-16vcpu-ubuntu-2404` (60.8 GB); `Lint and Test` stays on 8vcpu
- refreshed the stale comment above the job (it still claimed a ~21.9 GB peak)

## Evidence
Blacksmith per-VM metrics on failed runs show explicit kernel OOM kills — `oom_count: 1`, memory p100 ~30.5 GB against the 30.4 GB the 8vcpu tier provides (~99%), CPU pinned ~99%.

Duration split over the last 7d is the giveaway — failures run long and then die, successes finish fast:

| Conclusion | Count | Avg | Min | Max |
|---|---|---|---|---|
| success | 16 | 288s | 48s | 484s |
| failure | 19 | 729s | 476s | 878s |
| cancelled | 23 | 625s | 221s | 971s |

Peak RSS tracks Turbo/Turbopack cache warmth: warm ~12 GB, partial ~28 GB (barely fits), cold full rebuild peaked **51 GB** — one such run landed on a 62 GB VM and passed. On the 30.4 GB tier that same build gets OOM-killed. 16vcpu = 60.8 GB fits it with headroom.

`NODE_OPTIONS=--max-old-space-size=8192` can't help here: it caps Node's JS heap, but the memory is native Turbopack build-worker memory, so the VM hits the wall regardless.

## Type of Change
- [x] Bug fix (CI reliability)

## Testing
Tested manually — YAML parses; this PR's own `Build App` run exercises the new tier.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)