### PR TITLE
fix(ci): unblock @next/swc, lockfile-keyed node_modules, per-image runner sizing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Non-app images sit at 4 vCPU rather than the finer x64 split: the ARM
+        # sizing data is job-level (8 -> 4 for the whole matrix), not per-image,
+        # and this job only runs on push to main — an unprovisioned label would
+        # hang a release in `queued` rather than fail a PR.
         include:
           - dockerfile: ./docker/app.Dockerfile
             image: ghcr.io/simstudioai/simstudio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     name: Build Dev ECR
     needs: [detect-version, migrate-dev]
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-8vcpu-ubuntu-2404' || matrix.gh_runner }}
+    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && matrix.bs_runner || matrix.gh_runner }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -115,18 +115,25 @@ jobs:
         include:
           # Only the app image needs the paid 8-core/32 GB runner: next build
           # exhausts the free 16 GB one (exit 137). The others build in <5 min.
+          # bs_runner mirrors that per-image sizing on Blacksmith — a single
+          # pinned tier put every image on 8 vCPU, where the non-app builds idle
+          # at 12-15% CPU and under 10% memory.
           - dockerfile: ./docker/app.Dockerfile
             ecr_repo_secret: ECR_APP
             gh_runner: linux-x64-8-core
+            bs_runner: blacksmith-8vcpu-ubuntu-2404
           - dockerfile: ./docker/db.Dockerfile
             ecr_repo_secret: ECR_MIGRATIONS
             gh_runner: ubuntu-latest
+            bs_runner: blacksmith-2vcpu-ubuntu-2404
           - dockerfile: ./docker/realtime.Dockerfile
             ecr_repo_secret: ECR_REALTIME
             gh_runner: ubuntu-latest
+            bs_runner: blacksmith-4vcpu-ubuntu-2404
           - dockerfile: ./docker/pii.Dockerfile
             ecr_repo_secret: ECR_PII
             gh_runner: ubuntu-latest
+            bs_runner: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -215,7 +222,7 @@ jobs:
     if: >-
       github.event_name == 'push' &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
-    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-8vcpu-ubuntu-2404' || matrix.gh_runner }}
+    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && matrix.bs_runner || matrix.gh_runner }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -229,18 +236,22 @@ jobs:
             ghcr_image: ghcr.io/simstudioai/simstudio
             ecr_repo_secret: ECR_APP
             gh_runner: linux-x64-8-core
+            bs_runner: blacksmith-8vcpu-ubuntu-2404
           - dockerfile: ./docker/db.Dockerfile
             ghcr_image: ghcr.io/simstudioai/migrations
             ecr_repo_secret: ECR_MIGRATIONS
             gh_runner: ubuntu-latest
+            bs_runner: blacksmith-2vcpu-ubuntu-2404
           - dockerfile: ./docker/realtime.Dockerfile
             ghcr_image: ghcr.io/simstudioai/realtime
             ecr_repo_secret: ECR_REALTIME
             gh_runner: ubuntu-latest
+            bs_runner: blacksmith-4vcpu-ubuntu-2404
           - dockerfile: ./docker/pii.Dockerfile
             ghcr_image: ghcr.io/simstudioai/pii
             ecr_repo_secret: ECR_PII
             gh_runner: ubuntu-latest
+            bs_runner: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -387,7 +398,7 @@ jobs:
   # never moves a documented tag.
   build-ghcr-arm64:
     name: Build ARM64 (GHCR Only)
-    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-8vcpu-ubuntu-2404-arm' || matrix.gh_runner }}
+    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && matrix.bs_runner || matrix.gh_runner }}
     timeout-minutes: 30
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
@@ -400,15 +411,19 @@ jobs:
           - dockerfile: ./docker/app.Dockerfile
             image: ghcr.io/simstudioai/simstudio
             gh_runner: linux-arm64-8-core
+            bs_runner: blacksmith-8vcpu-ubuntu-2404-arm
           - dockerfile: ./docker/db.Dockerfile
             image: ghcr.io/simstudioai/migrations
             gh_runner: ubuntu-24.04-arm
+            bs_runner: blacksmith-4vcpu-ubuntu-2404-arm
           - dockerfile: ./docker/realtime.Dockerfile
             image: ghcr.io/simstudioai/realtime
             gh_runner: ubuntu-24.04-arm
+            bs_runner: blacksmith-4vcpu-ubuntu-2404-arm
           - dockerfile: ./docker/pii.Dockerfile
             image: ghcr.io/simstudioai/pii
             gh_runner: ubuntu-24.04-arm
+            bs_runner: blacksmith-4vcpu-ubuntu-2404-arm
 
     steps:
       - name: Checkout code

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -10,7 +10,8 @@ permissions:
 jobs:
   process-docs-embeddings:
     name: Process Documentation Embeddings
-    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-latest' }}
+    # Network-bound on the embeddings API: ~9% CPU and ~3% peak memory on 8 vCPU.
+    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     timeout-minutes: 30
     if: github.ref == 'refs/heads/main'
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,21 +32,12 @@ jobs:
       # push runs (whose caches feed production image builds) or with trusted
       # internal-PR runs.
       #
-      # node_modules ALSO keys on the lockfile hash, the other two deliberately
-      # do not. A sticky disk is a persistent mutable volume, so every branch
-      # sharing one key shares one node_modules tree, and `bun install
-      # --frozen-lockfile` installs what the lockfile needs without pruning what
-      # it no longer references. Branches cut before a dependency bump therefore
-      # wrote their older copies onto the shared disk and every other branch
-      # inherited them — that is how builds on next 16.2.11 ended up loading a
-      # stale @next/swc 16.2.6 that appears nowhere in bun.lock. Hashing the
-      # lockfile gives each distinct dependency set its own disk, so a tree can
-      # never mix versions from two different lockfiles.
-      #
-      # The bun download cache is content-addressed by package+version and the
-      # Turbo cache is keyed by task hash, so both are safe to share across
-      # lockfiles — and sharing them is what keeps a fresh node_modules disk
-      # cheap to populate.
+      # node_modules also keys on the lockfile hash: a sticky disk is a mutable
+      # volume, and `bun install --frozen-lockfile` adds what the lockfile needs
+      # without pruning what it dropped, so branches on different lockfiles were
+      # contaminating each other (a stale @next/swc 16.2.6 outlived the 16.2.11
+      # bump). The bun and Turbo caches are content/hash-addressed, so they stay
+      # shared — that is what keeps a fresh node_modules disk cheap to fill.
       - name: Mount Bun cache
         uses: ./.github/actions/cache-mount
         with:
@@ -209,21 +200,16 @@ jobs:
   # Next.js production build, in parallel with lint + tests. Sticky disks are
   # cloned from the last committed snapshot per job and committed last-writer-
   # wins, so concurrent mounts are safe. The bun/node_modules disks are shared
-  # with test-build — and because the node_modules key now includes the lockfile
-  # hash, the two jobs only ever share a disk when they really do resolve the
-  # same dependency tree, so the LWW loss really is harmless. The Turbo cache
-  # gets its own key: with a shared key, only
-  # the last committer's new entries survive each run, so the test and build
-  # Turbo entries would evict each other nondeterministically.
-  # Same next build as the app image, so it needs a large runner. Peak RSS
-  # tracks Turbo/Turbopack cache warmth, and it is the COLD case that sizes the
-  # runner: warm peaks ~12 GB, partial ~28 GB, and a cold full rebuild peaked
-  # 51 GB. The 8vcpu tier only has 30.4 GB, so cold-cache runs OOM-killed the VM
-  # (oom_count 1, memory p100 ~30.5 GB, ~99% of the tier) — the job burned 8-15
-  # min and died, while warm runs finished under 8 min. NODE_OPTIONS'
-  # --max-old-space-size only caps Node's JS heap; the bulk is native Turbopack
-  # worker memory, so the cap cannot prevent this. 16vcpu = 60.8 GB fits the
-  # 51 GB cold peak with headroom. Keep the test job on 8vcpu; its memory is fine.
+  # with test-build (the lockfile-hashed key means they only ever share when the
+  # dependency tree really is identical, so LWW loss is harmless), but the Turbo
+  # cache gets its own key: with a shared key, only the last committer's new
+  # entries survive each run, so the test and build Turbo entries would evict
+  # each other nondeterministically.
+  #
+  # Runner is sized for the COLD-cache build, which is what OOM-killed the 8vcpu
+  # tier (23 kills / 1074 runs at 98% of its 30.4 GB): warm peaks ~12 GB, cold
+  # peaked 51 GB. NODE_OPTIONS' --max-old-space-size caps only Node's JS heap,
+  # not the native Turbopack workers that dominate, so it cannot prevent this.
   build:
     name: Build App
     runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-16vcpu-ubuntu-2404' || 'linux-x64-8-core' }}
@@ -275,6 +261,20 @@ jobs:
           provider: ${{ vars.CI_PROVIDER }}
           key: ${{ github.repository }}-nextjs-cache-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}
           path: ./apps/sim/.next/cache
+
+      # A cold build peaks ~51 GB, and running out of RAM kills the whole VM —
+      # which surfaces only as "the runner has received a shutdown signal", with
+      # no mention of memory. Fail up front with the actual numbers instead, so
+      # an undersized runner (any CI_PROVIDER, including the GitHub fallback)
+      # is a one-line diagnosis rather than a 12-minute mystery.
+      - name: Check runner has enough memory
+        run: |
+          TOTAL_GB=$(awk '/MemTotal/ {printf "%d", $2/1048576}' /proc/meminfo)
+          echo "Runner memory: ${TOTAL_GB} GB (cold-cache build peaks ~51 GB)"
+          if [ "$TOTAL_GB" -lt 40 ]; then
+            echo "::error::Runner has ${TOTAL_GB} GB; this build needs ~51 GB on a cold cache and will be OOM-killed. Use a larger runner for the Build App job."
+            exit 1
+          fi
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -262,18 +262,19 @@ jobs:
           key: ${{ github.repository }}-nextjs-cache-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}
           path: ./apps/sim/.next/cache
 
-      # A cold build peaks ~51 GB, and running out of RAM kills the whole VM —
-      # which surfaces only as "the runner has received a shutdown signal", with
-      # no mention of memory. Fail up front with the actual numbers instead, so
-      # an undersized runner (any CI_PROVIDER, including the GitHub fallback)
-      # is a one-line diagnosis rather than a 12-minute mystery.
-      - name: Check runner has enough memory
+      # Running out of RAM kills the whole VM and surfaces only as "the runner
+      # has received a shutdown signal" — no mention of memory, ~12 min in. Warn
+      # with the real numbers so that failure is a one-line diagnosis instead of
+      # a mystery. Warn, never fail: a warm build peaks ~12 GB and a partial one
+      # ~28 GB, so a 32 GB runner still completes plenty of builds, and the
+      # GitHub fallback is the break-glass path — degrading it to a guaranteed
+      # failure would be worse than the risk this flags.
+      - name: Check runner memory headroom
         run: |
           TOTAL_GB=$(awk '/MemTotal/ {printf "%d", $2/1048576}' /proc/meminfo)
-          echo "Runner memory: ${TOTAL_GB} GB (cold-cache build peaks ~51 GB)"
+          echo "Runner memory: ${TOTAL_GB} GB"
           if [ "$TOTAL_GB" -lt 40 ]; then
-            echo "::error::Runner has ${TOTAL_GB} GB; this build needs ~51 GB on a cold cache and will be OOM-killed. Use a larger runner for the Build App job."
-            exit 1
+            echo "::warning::Runner has ${TOTAL_GB} GB. A cold-cache build peaks ~51 GB, so this run may be OOM-killed (reported only as 'the runner has received a shutdown signal'). Warm/partial builds should still fit."
           fi
 
       - name: Install dependencies

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -31,6 +31,22 @@ jobs:
       # namespace on top: untrusted fork runs must never share a cache with
       # push runs (whose caches feed production image builds) or with trusted
       # internal-PR runs.
+      #
+      # node_modules ALSO keys on the lockfile hash, the other two deliberately
+      # do not. A sticky disk is a persistent mutable volume, so every branch
+      # sharing one key shares one node_modules tree, and `bun install
+      # --frozen-lockfile` installs what the lockfile needs without pruning what
+      # it no longer references. Branches cut before a dependency bump therefore
+      # wrote their older copies onto the shared disk and every other branch
+      # inherited them — that is how builds on next 16.2.11 ended up loading a
+      # stale @next/swc 16.2.6 that appears nowhere in bun.lock. Hashing the
+      # lockfile gives each distinct dependency set its own disk, so a tree can
+      # never mix versions from two different lockfiles.
+      #
+      # The bun download cache is content-addressed by package+version and the
+      # Turbo cache is keyed by task hash, so both are safe to share across
+      # lockfiles — and sharing them is what keeps a fresh node_modules disk
+      # cheap to populate.
       - name: Mount Bun cache
         uses: ./.github/actions/cache-mount
         with:
@@ -42,7 +58,7 @@ jobs:
         uses: ./.github/actions/cache-mount
         with:
           provider: ${{ vars.CI_PROVIDER }}
-          key: ${{ github.repository }}-node-modules-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}
+          key: ${{ github.repository }}-node-modules-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}-${{ hashFiles('bun.lock') }}
           path: ./node_modules
 
       - name: Mount Turbo cache
@@ -193,8 +209,10 @@ jobs:
   # Next.js production build, in parallel with lint + tests. Sticky disks are
   # cloned from the last committed snapshot per job and committed last-writer-
   # wins, so concurrent mounts are safe. The bun/node_modules disks are shared
-  # with test-build (identical content from the same lockfile — LWW loss is
-  # harmless), but the Turbo cache gets its own key: with a shared key, only
+  # with test-build — and because the node_modules key now includes the lockfile
+  # hash, the two jobs only ever share a disk when they really do resolve the
+  # same dependency tree, so the LWW loss really is harmless. The Turbo cache
+  # gets its own key: with a shared key, only
   # the last committer's new entries survive each run, so the test and build
   # Turbo entries would evict each other nondeterministically.
   # Same next build as the app image, so it needs a large runner. Peak RSS
@@ -236,7 +254,7 @@ jobs:
         uses: ./.github/actions/cache-mount
         with:
           provider: ${{ vars.CI_PROVIDER }}
-          key: ${{ github.repository }}-node-modules-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}
+          key: ${{ github.repository }}-node-modules-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}-${{ hashFiles('bun.lock') }}
           path: ./node_modules
 
       - name: Mount Turbo cache

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,12 @@
         "turbo": "2.9.14",
         "yaml": "^2.8.1",
       },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.11",
+        "@next/swc-darwin-x64": "16.2.11",
+        "@next/swc-linux-arm64-gnu": "16.2.11",
+        "@next/swc-linux-x64-gnu": "16.2.11",
+      },
     },
     "apps/docs": {
       "name": "docs",
@@ -1229,6 +1235,14 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
     "@next/env": ["@next/env@16.2.11", "", {}, "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA=="],
+
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw=="],
+
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg=="],
+
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g=="],
+
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -7,10 +7,14 @@ minimumReleaseAge = 604800
 # dev builds, so every version is structurally younger than any age gate.
 # The exactly pinned Pi 0.80.10 packages were vetted for the cloud-review SDK
 # migration; they age out of the gate on 2026-07-24 — drop these four entries then.
-# next@16.2.11 and @next/env@16.2.11 are the official Vercel security patch for the
-# July 2026 advisories (SSRF, cache confusion, DoS, middleware bypass — GHSA-89xv-2m56-2m9x
-# et al.); published 2026-07-21, they age out of the gate on 2026-07-28 — drop these two
-# entries then.
+# next@16.2.11, @next/env@16.2.11 and the @next/swc-* binaries are the official Vercel
+# security patch for the July 2026 advisories (SSRF, cache confusion, DoS, middleware
+# bypass — GHSA-89xv-2m56-2m9x et al.); published 2026-07-21, they age out of the gate on
+# 2026-07-28 — drop these entries then. The swc binaries ship in lockstep with next and
+# MUST be excluded alongside it: they are next's platform-gated optionalDependencies, so
+# gating them out leaves them absent from bun.lock entirely, and `bun install
+# --frozen-lockfile` then installs no compiler at all — next falls back to downloading one
+# at build time, which fails in CI.
 # @anthropic-ai/sdk is exactly pinned to 0.114.0, vetted for the agent-events
 # streaming work (adaptive thinking display types + transform-json-schema);
 # published 2026-07-23, it ages out of the gate on 2026-07-30 — drop this entry then.
@@ -22,6 +26,10 @@ minimumReleaseAgeExcludes = [
   "@earendil-works/pi-tui",
   "next",
   "@next/env",
+  "@next/swc-darwin-arm64",
+  "@next/swc-darwin-x64",
+  "@next/swc-linux-arm64-gnu",
+  "@next/swc-linux-x64-gnu",
   "@anthropic-ai/sdk",
 ]
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,12 @@
     "mermaid": "11.15.0",
     "zod": "4.3.6"
   },
+  "optionalDependencies": {
+    "@next/swc-darwin-arm64": "16.2.11",
+    "@next/swc-darwin-x64": "16.2.11",
+    "@next/swc-linux-arm64-gnu": "16.2.11",
+    "@next/swc-linux-x64-gnu": "16.2.11"
+  },
   "devDependencies": {
     "@biomejs/biome": "2.0.0-beta.5",
     "@octokit/rest": "^21.0.0",


### PR DESCRIPTION
## Summary
Three CI fixes, all traced to real telemetry rather than guesswork.

**1. The `@next/swc-*` binaries were blocked by the supply-chain age gate**

Every Build App run logged:

```
⚠ Mismatching @next/swc version, detected: 16.2.6 while Next.js is on 16.2.11
```

`16.2.6` appears nowhere in `bun.lock` or any `package.json`, so CI was compiling production bundles with an SWC binary the lockfile does not reference.

Root cause: #5890 bumped next `16.2.6` → `16.2.11` for the July 2026 security advisories and added `next` + `@next/env` to `minimumReleaseAgeExcludes` so they could install — but not the `@next/swc-*` platform binaries, which ship in lockstep with `next` and were published the same day. They stayed blocked by the 7-day gate, so `bun install` has been silently installing **no compiler at all** since that bump (they are optional deps, so the failure is silent). Reproduced directly: adding `@next/swc-linux-x64-gnu@16.2.11` errored `published within minimum release age of 604800 seconds`; with the exclude added it resolves.

Fix, in two parts (the first alone is not enough — verified by a CI run that still tried to download the compiler):
1. Add the four `@next/swc-*` binaries to `minimumReleaseAgeExcludes`, alongside the `next` entry that should have carried them.
2. Declare them as root `optionalDependencies` so they get **resolved entries in `bun.lock`**. Without an entry, `bun install --frozen-lockfile` cannot install a package at all — next's inline optional-dependency metadata is not sufficient. Each package carries `os`/`cpu` constraints, so only the matching one installs per platform; the lockfile records all four.

**1b. `node_modules` sticky disk was shared across branches**

The disk was keyed only on `github.event_name`, so every branch shared one mutable `node_modules` volume. A sticky disk is a persistent mutable volume, not a content-addressed cache, and `bun install --frozen-lockfile` adds what the lockfile needs without pruning what it dropped — so the pre-bump `16.2.6` binary survived on the shared disk and was served to every `16.2.11` build. That is why the missing-compiler bug above stayed hidden: the stale disk was masking it.

Fix: add the `bun.lock` hash to that key. The bun download cache and Turbo cache are content/hash-addressed and stay shared, which keeps a fresh `node_modules` disk cheap to fill.

Note these two are coupled: fixing the cache key alone gives a clean disk with **no** SWC binary, at which point next tries to download one at build time and dies on registry detection. Both fixes are required together.

**2. Per-image Blacksmith runner sizing (`bs_runner`)**

All three Docker matrices pinned *every* image to 8 vCPU on Blacksmith, even though the existing `gh_runner` column already documents that only the app image needs a big runner. The non-app builds idle at 12–15% CPU and under 10% memory. Added a `bs_runner` field mirroring `gh_runner` so the sizing lives with the image and can't drift back: app 8 vCPU, migrations 2, realtime 4, PII 4 (same for ARM). Also dropped docs-embeddings 8 → 2 vCPU — it's network-bound on the embeddings API at ~9% CPU.

**3. Cold-build memory warning**

Running out of RAM kills the whole VM and surfaces only as `The runner has received a shutdown signal` — no mention of memory, after ~12 minutes of work. That's what made the OOM fixed in #5944 hard to diagnose. The build job now reports `MemTotal` up front and emits a `::warning::` with the real numbers when the runner is under 40 GB. Warning-only on purpose: warm builds peak ~12 GB and partial ~28 GB, so a 32 GB runner still completes many builds, and hard-failing them would degrade the break-glass GitHub path rather than protect it.

This also addresses the P1 left open on #5944: the GitHub fallback (`linux-x64-8-core`, 32 GB) is still below the ~51 GB cold peak. Rather than guess a larger label — `hosted-runners` reports `total_count: 0` for the org, so no GitHub larger runners appear provisioned, and an unresolvable `runs-on` label queues forever — the preflight turns that path into an immediate, explanatory failure on any provider.

## Not included: `.next/cache`
The ~5 GB Turbopack FS cache shares the same event+fork key, but keying it on the lockfile would be redundant: `NEXT_TURBOPACK_BUILD_CACHE` already hashes on config/deps/module content, so a lockfile bump invalidates those slices on its own. The way that cache could be corrupted was a mismatched compiler writing entries into it — which fix 1 removes at the source.

## Type of Change
- [x] Bug fix (CI correctness + reliability + cost)

## Testing
Tested manually — all three workflows parse; preflight verified under `bash -n`; every matrix referencing `bs_runner` defines it on all 12 entries.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)


