### PR TITLE
test(copilot): catch a tool silently dropping its query from the chip

### DIFF
--- a/apps/sim/lib/copilot/tools/tool-display.test.ts
+++ b/apps/sim/lib/copilot/tools/tool-display.test.ts
@@ -84,6 +84,45 @@ describe('getToolDisplayTitle natural-language coverage', () => {
     )
   })
 
+  /**
+   * Tools that take a `query` but whose chip does not show it. This set may
+   * SHRINK, never grow — the assertion below is a subset check, so removing a
+   * tool or teaching one to show its query needs no update here.
+   *
+   * The point is to catch a specific silent regression: a tool that DID show
+   * its query losing that behavior. The neighbouring "has an intentional
+   * display title" test cannot catch it, because a bare fallback label like
+   * "Searching docs" satisfies it just as well as the useful one — a coarse
+   * check contented by a degraded state.
+   */
+  const TITLES_IGNORING_QUERY = new Set([
+    'search_documentation',
+    'search_library_docs',
+    // Has an argument-aware case, but reads toolTitle/title and never falls
+    // back to query.
+    'search_online',
+  ])
+
+  it('no tool silently stops showing its query in the chip', () => {
+    const hiddenToolNames = getHiddenToolNames()
+    const regressions = Object.entries(TOOL_CATALOG)
+      .filter(([name, entry]) => !hiddenToolNames.has(name) && !entry.internal)
+      .filter(([, entry]) => {
+        const properties = (entry.parameters as { properties?: Record<string, unknown> })
+          ?.properties
+        return properties !== undefined && 'query' in properties
+      })
+      .filter(([name]) => {
+        const withoutArgs = getToolDisplayTitle(name)
+        const withQuery = getToolDisplayTitle(name, { query: 'a distinctive query' })
+        return withoutArgs === withQuery
+      })
+      .map(([name]) => name)
+      .filter((name) => !TITLES_IGNORING_QUERY.has(name))
+
+    expect(regressions).toEqual([])
+  })
+
   it('has an intentional display title for every visible catalog tool', () => {
     const hiddenToolNames = getHiddenToolNames()
     const fallbackToolNames = Object.keys(TOOL_CATALOG).filter(


### PR DESCRIPTION
## Summary
`has an intentional display title for every visible catalog tool` only checks that a title exists. A bare fallback label satisfies it exactly as well as a useful one, so a tool that shows its query in the chip can stop doing so with the suite still green.

Adds a subset ratchet: any catalog tool taking a `query` must show it, unless listed in a documented allowlist. The set may shrink but never grow, so removing a tool — or teaching one to show its query — needs no change here.

Three tools currently ignore their query and are baselined with the reason recorded: `search_documentation` and `search_library_docs` have no argument-aware case, and `search_online` has one that reads `toolTitle`/`title` without falling back to `query`. Changing their chips is a UX decision that does not belong in a test-hardening change.

## Type of Change
- [x] Other: test hardening

## Testing
Verified the assertion actually fires — removing an entry from the allowlist fails with the offending tool named:

```
AssertionError: expected [ 'search_online' ] to deeply equal []
```

52 tool-display tests pass, tsc clean, biome clean.

Reviewers should focus on whether the allowlist is the right shape: a subset check keeps the invariant honest about today's state while still catching a regression, but it does mean the three baselined tools are not enforced until someone removes them.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
