### PR TITLE
improvement(agent-streaming): add way to opt in for workflow executions

### DIFF
--- a/apps/docs/content/docs/en/workflows/deployment/agent-events.mdx
+++ b/apps/docs/content/docs/en/workflows/deployment/agent-events.mdx
@@ -12,21 +12,51 @@ Agent blocks can emit more than answer text while they run: **provider-exposed t
 Sim does **not** invent thinking for providers that do not stream it. Bedrock Converse, many OpenAI-compat models, and non-reasoning chat models stay text-only (plus tools when a live tool loop is wired).
 </Callout>
 
-## Protocol opt-in vs. event gates (public chat / simple SSE)
+## Two independent switches
 
-Sending the header is a statement about the **client**: it understands v1 framing, so answer text can stream live and be retracted with `chunk_reset`. That alone does not expose anything — it only changes cadence, and it applies even when both event policies are off.
+Agent events are governed by two things that do not depend on each other.
 
-Thinking and tool frames need the header **plus** their own deployment policy:
+**Policy decides which frames exist.** `includeThinking` turns on `thinking` frames, `includeToolCalls` turns on `tool` frames, and both default to **off**.
 
-1. Thinking frames require chat `includeThinking` (default **off**).
-2. Tool lifecycle frames require chat `includeToolCalls` (default **off**).
-3. Both require the request to opt in with:
+| Surface | Policy source |
+|---------|---------------|
+| Deployed chat (`/api/chat/{identifier}`) | The chat deployment's **Thinking** and **Tool calls** toggles |
+| Workflow API (`/api/workflows/{id}/execute`) | Per-request `includeThinking` / `includeToolCalls` in the body |
+
+**The header declares the protocol version.** Sending it says the client understands v1 framing:
 
 ```http
 X-Sim-Stream-Protocol: agent-events-v1
 ```
 
-Legacy clients that omit the header keep today’s text-only SSE even if either deployment policy is enabled. The hosted chat UI always sends the header for its own deployments, so hosted chats stream token by token regardless of the toggles.
+It does two things. It switches answer text to live token-by-token `chunk` frames that `chunk_reset` can retract, and it is **required** for any `thinking` or `tool` frame — a client that never declared a version has no contract for their shape, so it keeps the text-only stream it already understands.
+
+Omitting the header is always valid and always safe: you get settled final-turn text and no agent-event frames, which is what every pre-existing integration receives. The response echoes the header back when the protocol was negotiated.
+
+The header alone exposes nothing, so a chat with both policies off still streams token by token.
+
+<Callout type="warn">
+On the workflow API, setting `includeThinking` or `includeToolCalls` **without** the header is rejected with `400`. The flags would otherwise be a silent no-op, which is the failure mode this protocol exists to avoid. Deployed chat degrades instead of rejecting, because there the policy comes from the deployment rather than the request.
+</Callout>
+
+### Workflow API
+
+```bash
+curl -N https://sim.ai/api/workflows/{id}/execute \
+  -H "X-API-Key: $SIM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "X-Sim-Stream-Protocol: agent-events-v1" \
+  -d '{
+    "stream": true,
+    "selectedOutputs": ["agent_1.content"],
+    "includeThinking": true,
+    "includeToolCalls": true
+  }'
+```
+
+Both flags default to `false`, so an existing integration receives exactly the frames it does today. The header is required whenever either flag is set; omit it and the request is rejected with `400` rather than silently downgraded.
+
+Two differences from deployed chat are worth knowing. Tool frames carry the name and status only on both surfaces, but the API's terminal `final` envelope keeps tool **arguments and results** — public chat redacts them. And thinking is delivered only as `thinking` frames; it is stripped from `providerTiming.timeSegments` in the envelope on every surface, so enabling the policy is the only way to receive it.
 
 ## Simple SSE frame shapes
 
@@ -47,8 +77,8 @@ Answer text stays on `chunk`. Thinking and tools never reuse `chunk` (so older c
 
 During a live tool loop, the model can’t be classified mid-turn: text it emits may turn out to be the final answer or preamble before a tool call (the stop reason arrives only at turn end).
 
-- **Opted-in clients** (protocol header; no event policy required) receive answer text as `chunk` frames **live**, token by token. If the turn then resolves to tool calls, a `chunk_reset` frame tells the client to discard that block’s streamed text — the final turn re-streams live after tools settle. Append `chunk`, honor `chunk_reset`, and the displayed answer always converges to the block’s final content.
-- **Legacy clients** (no header) never see provisional text: only settled final-turn text is emitted as `chunk`, delivered in one piece when the turn completes. Honoring `chunk_reset` is what buys live cadence, so send the header if you want it.
+- **Clients sending the protocol header** (no event policy required) receive answer text as `chunk` frames **live**, token by token. If the turn then resolves to tool calls, a `chunk_reset` frame tells the client to discard that block’s streamed text — the final turn re-streams live after tools settle. Append `chunk`, honor `chunk_reset`, and the displayed answer always converges to the block’s final content.
+- **Clients without the header** never see provisional text: only settled final-turn text is emitted as `chunk`, delivered in one piece when the turn completes. Honoring `chunk_reset` is what buys live cadence, so send the header if you want it.
 
 Logs, memory, and the block’s `content` output always contain final-turn text only — intermediate preamble is never persisted.
 
@@ -62,7 +92,7 @@ Canvas execution-events `stream:chunk`, `stream:chunk_reset`, `stream:thinking`,
 
 ## Canvas (draft Run)
 
-When you click **Run** in the builder, the execution-events SSE path forwards the same sink. The canvas is always opted in — it does not send (or need) the `X-Sim-Stream-Protocol` header; the dual gate applies only to the public chat / simple SSE surface:
+When you click **Run** in the builder, the execution-events SSE path forwards the same sink. The canvas is always opted in — it does not send (or need) the `X-Sim-Stream-Protocol` header, and the policy switches do not apply to it:
 
 - `stream:thinking` — `{ blockId, text }`
 - `stream:tool` — `{ blockId, phase, id, name, status? }`
@@ -73,7 +103,7 @@ The terminal output panel shows Thinking / Tools chrome above the block output w
 
 ## Chat deployment toggles
 
-In **Deploy → Chat**, enable **Include thinking** for provider-exposed thinking and **Include tool calls** for tool names and lifecycle status. The switches are independent, and both event types still require the protocol header. Neither switch affects answer-text cadence.
+In **Deploy → Chat**, enable **Include thinking** for provider-exposed thinking and **Include tool calls** for tool names and lifecycle status. The switches are independent of each other, and both still require the client to send the protocol header. Neither switch affects answer-text cadence.
 
 Tool arguments and results are never exposed to a public chat — not in lifecycle frames, and not through the terminal `final` envelope, where the block's own tool calls are reduced to the same name-and-lifecycle shape. The authenticated workflow API still returns full tool results. Redeploy or update the chat after changing Agent models or tools.
 
@@ -88,6 +118,68 @@ Per-model support is generated from the model registry on the [Agent block page]
 | OpenAI Responses | Reasoning **summaries** when streamed (requires OpenAI organization verification; unverified orgs fall back to no summaries) | Yes |
 | OpenAI-compat (Groq, DeepSeek, …) | Only if vendor streams `reasoning` / `reasoning_content` | Live loop where wired (e.g. Groq, DeepSeek) |
 | Bedrock | Not invented | Yes when streaming tool loop is used |
+
+## Consuming the stream
+
+A conforming client owes the stream four things:
+
+1. **Discriminate before appending.** Only a frame with **no** `event` field is answer text. Checking `event === undefined` rather than "has a `chunk` field" is what keeps future frame types from leaking into the answer.
+2. **Accumulate per `blockId`.** A workflow can stream more than one block; frames interleave.
+3. **Honor `chunk_reset`** if you sent the protocol header. Clear that block's accumulated text — it belonged to a turn that resolved to tool calls, and the final turn re-streams.
+4. **Stop at the terminal frame.** Exactly one of `final` or `error` arrives, followed by the literal `"[DONE]"` sentinel. `stream_error` is *not* terminal.
+
+### Reference client
+
+```ts
+type Frame = Record<string, unknown>
+
+async function consume(response: Response) {
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  const answers = new Map<string, string>()
+  const thinking = new Map<string, string>()
+  let buffer = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+
+    // SSE frames are newline-delimited; keep the trailing partial line.
+    const lines = buffer.split('\n')
+    buffer = lines.pop() ?? ''
+
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue
+      const payload = line.slice(6)
+
+      const frame = JSON.parse(payload) as Frame | string
+      if (frame === '[DONE]') return { answers, thinking }
+
+      const { blockId, event } = frame as { blockId?: string; event?: string }
+
+      if (event === undefined && typeof frame.chunk === 'string') {
+        answers.set(blockId!, (answers.get(blockId!) ?? '') + frame.chunk)
+      } else if (event === 'chunk_reset') {
+        answers.set(blockId!, '')
+      } else if (event === 'thinking') {
+        thinking.set(blockId!, (thinking.get(blockId!) ?? '') + String(frame.data))
+      } else if (event === 'tool') {
+        // frame.phase is 'start' | 'end'; frame.status is set on 'end'.
+        renderToolChip(frame)
+      } else if (event === 'final') {
+        // Terminal. frame.data.success may be false with frame.data.error.
+      } else if (event === 'error') {
+        throw new Error(String(frame.error))
+      } else if (event === 'stream_error') {
+        // Non-terminal: log and keep reading.
+      }
+    }
+  }
+}
+```
+
+Unknown `event` values should be ignored rather than treated as errors — that is what lets new frame types ship without breaking existing clients.
 
 ## Example (public chat)
 

--- a/apps/docs/content/docs/en/workflows/deployment/api.mdx
+++ b/apps/docs/content/docs/en/workflows/deployment/api.mdx
@@ -237,6 +237,28 @@ while (true) {
   </Tab>
 </Tabs>
 
+#### Streaming agent thinking and tool calls
+
+By default a streaming run carries answer text only. To also receive the Agent block's reasoning and its tool-call lifecycle, set `includeThinking` / `includeToolCalls`:
+
+```bash
+curl -N -X POST https://sim.ai/api/workflows/{workflow-id}/execute \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $SIM_API_KEY" \
+  -H "X-Sim-Stream-Protocol: agent-events-v1" \
+  -d '{
+    "input": "Research this topic",
+    "stream": true,
+    "selectedOutputs": ["agent_1.content"],
+    "includeThinking": true,
+    "includeToolCalls": true
+  }'
+```
+
+The `X-Sim-Stream-Protocol` header is **required** whenever either flag is set — it declares that your client understands agent-event framing. Setting a flag without it returns `400` rather than silently ignoring the flag. The header also switches answer text to live token-by-token delivery that `chunk_reset` can retract.
+
+Both flags default to `false` and the header is optional on its own, so existing integrations keep the exact frames they receive today. Tool frames carry the tool name and status only; arguments and results arrive in the terminal `final` envelope. Not every model exposes thinking. See [Agent stream events](/docs/workflows/deployment/agent-events) for the frame shapes, a reference client, and per-provider support.
+
 #### Oversized outputs
 
 Workflow execution responses are capped by platform request and response limits. When an internal output, log field, streamed field, or async status payload contains a value that is too large to inline, Sim may replace that nested value with a versioned reference:
@@ -378,6 +400,7 @@ For detailed rate limit information and the logs/webhooks API, see [External API
   { question: "Can I deploy the same workflow as both an API and a chat?", answer: "Yes. A workflow can be simultaneously deployed as an API, chat, MCP tool, and more. Each deployment type runs against the same active snapshot." },
   { question: "How do I choose between sync, streaming, and async?", answer: "Use sync for quick workflows that finish in seconds. Use streaming when you want to show progressive output to users as it's generated. Use async for long-running workflows where holding a connection open isn't practical." },
   { question: "How do I select multiple outputs for streaming?", answer: "Open the Select outputs dropdown in the API tab and check each output field you want to stream. You can choose fields from multiple blocks. The selected fields are reflected as an array in the selectedOutputs request body parameter." },
+  { question: "Can I stream an Agent block's thinking and tool calls over the API?", answer: "Yes. Set includeThinking and/or includeToolCalls to true in the request body and send the X-Sim-Stream-Protocol: agent-events-v1 header, which declares that your client understands agent-event framing. Setting a flag without the header returns 400 rather than silently ignoring it. Both flags default to false, so existing integrations are unaffected. Thinking arrives as thinking frames and tool lifecycle as tool frames carrying name and status only — tool arguments and results stay in the final envelope." },
   { question: "How does Promote to live work?", answer: "Promote to live sets an older version as the active deployment without creating a new version. Subsequent API calls immediately run against the promoted snapshot. This is the fastest way to roll back to a previous state." },
   { question: "How long are async job results available?", answer: "Completed and failed job results are retained for 24 hours. After that, the status endpoint returns 404. Retrieve and store results on your end if you need them longer." },
   { question: "What happens if my API key is compromised?", answer: "Revoke the key immediately in Settings → Sim Keys and generate a new one. Revoked keys stop working instantly." },

--- a/apps/sim/app/api/chat/[identifier]/otp/route.ts
+++ b/apps/sim/app/api/chat/[identifier]/otp/route.ts
@@ -212,7 +212,7 @@ export const PUT = withRouteHandler(
         authType: deployment.authType,
         outputConfigs: deployment.outputConfigs,
         includeThinking: deployment.includeThinking ?? false,
-        includeToolCalls: deployment.includeToolCalls ?? deployment.includeThinking ?? false,
+        includeToolCalls: deployment.includeToolCalls ?? false,
       })
       setChatAuthCookie(response, deployment.id, deployment.authType, deployment.password)
 

--- a/apps/sim/app/api/chat/[identifier]/route.test.ts
+++ b/apps/sim/app/api/chat/[identifier]/route.test.ts
@@ -413,7 +413,11 @@ describe('Chat Identifier API Route', () => {
       )
     }, 10000)
 
-    it('preserves the legacy tool policy when includeToolCalls is null', async () => {
+    /**
+     * A row predating the column has no tool policy, so it has not opted in.
+     * Thinking must not drag tool frames along with it.
+     */
+    it('reads a null tool policy as off rather than inheriting thinking', async () => {
       const thinkingChatResult = [
         { ...mockChatResult[0], includeThinking: true, includeToolCalls: null },
       ]
@@ -447,7 +451,7 @@ describe('Chat Identifier API Route', () => {
       const options = vi.mocked(createStreamingResponse).mock.calls[0][0]
       expect(options.streamConfig).toMatchObject({
         includeThinking: true,
-        includeToolCalls: true,
+        includeToolCalls: false,
       })
 
       await options.executeFn({
@@ -458,7 +462,7 @@ describe('Chat Identifier API Route', () => {
       const executeOptions = vi.mocked(executeWorkflow).mock.calls[0][4]
       expect(executeOptions).toMatchObject({
         includeThinking: true,
-        includeToolCalls: true,
+        includeToolCalls: false,
         agentEvents: true,
       })
     }, 10000)
@@ -513,7 +517,11 @@ describe('Chat Identifier API Route', () => {
       })
     }, 10000)
 
-    it('keeps agent events off when the protocol header is missing, even with policy on', async () => {
+    /**
+     * Chat degrades rather than rejecting: the policy comes from the
+     * deployment, so an un-negotiated client made no bad request.
+     */
+    it('keeps agent events off without the protocol header, even with policy on', async () => {
       const thinkingChatResult = [
         { ...mockChatResult[0], includeThinking: true, includeToolCalls: false },
       ]

--- a/apps/sim/app/api/chat/[identifier]/route.ts
+++ b/apps/sim/app/api/chat/[identifier]/route.ts
@@ -40,7 +40,7 @@ function toChatConfigResponse(deployment: ChatConfigSource) {
     authType: deployment.authType,
     outputConfigs: deployment.outputConfigs,
     includeThinking: deployment.includeThinking ?? false,
-    includeToolCalls: deployment.includeToolCalls ?? deployment.includeThinking ?? false,
+    includeToolCalls: deployment.includeToolCalls ?? false,
   }
 }
 
@@ -281,7 +281,7 @@ export const POST = withRouteHandler(
         }
 
         const includeThinking = deployment.includeThinking ?? false
-        const includeToolCalls = deployment.includeToolCalls ?? includeThinking
+        const includeToolCalls = deployment.includeToolCalls ?? false
         const agentEvents = shouldEmitAgentStreamEvents({
           includeThinking,
           includeToolCalls,

--- a/apps/sim/app/api/chat/manage/[id]/route.test.ts
+++ b/apps/sim/app/api/chat/manage/[id]/route.test.ts
@@ -160,7 +160,8 @@ describe('Chat Edit API Route', () => {
       expect(data.title).toBe('Test Chat')
       expect(data.chatUrl).toBe('http://localhost:3000/chat/test-chat')
       expect(data.hasPassword).toBe(true)
-      expect(data.includeToolCalls).toBe(true)
+      // Stored null is not an opt-in.
+      expect(data.includeToolCalls).toBe(false)
     })
   })
 
@@ -227,8 +228,9 @@ describe('Chat Edit API Route', () => {
 
       expect(response.status).toBe(200)
       expect(dbChainMockFns.update).toHaveBeenCalled()
+      // An unrelated field update materializes the stored null as false.
       expect(dbChainMockFns.set).toHaveBeenCalledWith(
-        expect.objectContaining({ includeToolCalls: true })
+        expect.objectContaining({ includeToolCalls: false })
       )
       const data = await response.json()
       expect(data.id).toBe('chat-123')
@@ -236,10 +238,7 @@ describe('Chat Edit API Route', () => {
       expect(data.message).toBe('Chat deployment updated successfully')
     })
 
-    it('turns grandfathered tool calls off when the same update disables thinking', async () => {
-      // Before includeToolCalls existed, includeThinking gated tool frames too.
-      // Resolving the fallback against the stored value would materialize the
-      // stale `true` and silently leave tool frames on.
+    it('leaves tool calls off when a row without a tool policy disables thinking', async () => {
       authMockFns.mockGetSession.mockResolvedValue({ user: { id: 'user-id' } })
 
       mockCheckChatAccess.mockResolvedValue({

--- a/apps/sim/app/api/chat/manage/[id]/route.ts
+++ b/apps/sim/app/api/chat/manage/[id]/route.ts
@@ -62,7 +62,7 @@ export const GET = withRouteHandler(
 
       const result = {
         ...safeData,
-        includeToolCalls: safeData.includeToolCalls ?? safeData.includeThinking ?? false,
+        includeToolCalls: safeData.includeToolCalls ?? false,
         chatUrl,
         hasPassword: !!password,
       }
@@ -257,16 +257,8 @@ export const PATCH = withRouteHandler(
         updateData.includeThinking = includeThinking
       }
 
-      /**
-       * Grandfathering must resolve against the thinking value this request is
-       * setting, not the stored one. Before `includeToolCalls` existed,
-       * `includeThinking` gated tool frames too, so a partial update turning
-       * thinking off has to turn them off as well rather than materializing the
-       * stale `true` and silently leaving tool frames enabled.
-       */
-      const effectiveIncludeThinking = includeThinking ?? existingChatRecord.includeThinking
-      updateData.includeToolCalls =
-        includeToolCalls ?? existingChatRecord.includeToolCalls ?? effectiveIncludeThinking ?? false
+      // Partial updates keep the stored value; a row predating the column reads false.
+      updateData.includeToolCalls = includeToolCalls ?? existingChatRecord.includeToolCalls ?? false
 
       const emailCount = Array.isArray(updateData.allowedEmails)
         ? updateData.allowedEmails.length

--- a/apps/sim/app/api/chat/route.test.ts
+++ b/apps/sim/app/api/chat/route.test.ts
@@ -99,7 +99,13 @@ describe('Chat API Route', () => {
       const response = await GET(req)
 
       expect(response.status).toBe(200)
-      expect(mockCreateSuccessResponse).toHaveBeenCalledWith({ deployments: mockDeployments })
+      // Each row is normalized so a missing tool policy reads as off.
+      expect(mockCreateSuccessResponse).toHaveBeenCalledWith({
+        deployments: mockDeployments.map((deployment) => ({
+          ...deployment,
+          includeToolCalls: false,
+        })),
+      })
       expect(dbChainMockFns.where).toHaveBeenCalled()
     })
 

--- a/apps/sim/app/api/chat/route.ts
+++ b/apps/sim/app/api/chat/route.ts
@@ -35,7 +35,7 @@ export const GET = withRouteHandler(async (_request: NextRequest) => {
     return createSuccessResponse({
       deployments: deployments.map((deployment) => ({
         ...deployment,
-        includeToolCalls: deployment.includeToolCalls ?? deployment.includeThinking,
+        includeToolCalls: deployment.includeToolCalls ?? false,
       })),
     })
   } catch (error) {

--- a/apps/sim/app/api/resume/[workflowId]/[executionId]/[contextId]/route.ts
+++ b/apps/sim/app/api/resume/[workflowId]/[executionId]/[contextId]/route.ts
@@ -254,7 +254,7 @@ export const POST = withRouteHandler(
         ? (persistedSnapshot.metadata.executionMode ?? 'sync')
         : undefined
       const includeThinking = persistedSnapshot.metadata.includeThinking === true
-      const includeToolCalls = persistedSnapshot.metadata.includeToolCalls ?? includeThinking
+      const includeToolCalls = persistedSnapshot.metadata.includeToolCalls === true
 
       if (isApiCaller && executionMode === 'stream') {
         const stream = await createStreamingResponse({

--- a/apps/sim/app/api/workflows/[id]/chat/status/route.test.ts
+++ b/apps/sim/app/api/workflows/[id]/chat/status/route.test.ts
@@ -91,6 +91,7 @@ describe('Workflow Chat Status Route', () => {
     expect(data.deployment.hasPassword).toBe(true)
     expect(data.deployment.outputConfigs).toEqual([{ blockId: 'agent-1', path: 'content' }])
     expect(data.deployment.includeThinking).toBe(true)
-    expect(data.deployment.includeToolCalls).toBe(true)
+    // Independent of thinking: a row without a tool policy reads as off.
+    expect(data.deployment.includeToolCalls).toBe(false)
   })
 })

--- a/apps/sim/app/api/workflows/[id]/chat/status/route.ts
+++ b/apps/sim/app/api/workflows/[id]/chat/status/route.ts
@@ -74,10 +74,7 @@ export const GET = withRouteHandler(
               allowedEmails: deploymentResults[0].allowedEmails,
               outputConfigs: deploymentResults[0].outputConfigs,
               includeThinking: deploymentResults[0].includeThinking ?? false,
-              includeToolCalls:
-                deploymentResults[0].includeToolCalls ??
-                deploymentResults[0].includeThinking ??
-                false,
+              includeToolCalls: deploymentResults[0].includeToolCalls ?? false,
               hasPassword: Boolean(deploymentResults[0].password),
             }
           : null

--- a/apps/sim/app/api/workflows/[id]/execute/route.ts
+++ b/apps/sim/app/api/workflows/[id]/execute/route.ts
@@ -89,10 +89,20 @@ import {
   loadWorkflowFromNormalizedTables,
 } from '@/lib/workflows/persistence/utils'
 import {
+  AGENT_STREAM_PROTOCOL_HEADER_LABEL,
+  AGENT_STREAM_PROTOCOL_V1,
+  clientAcceptsAgentStreamProtocol,
+  hasAgentStreamPolicy,
+  shouldEmitAgentStreamEvents,
+} from '@/lib/workflows/streaming/agent-stream-protocol'
+import {
   forwardAgentStreamToExecutionEvents,
   shouldForwardAnswerTextFromSink,
 } from '@/lib/workflows/streaming/forward-agent-stream-events'
-import { createStreamingResponse } from '@/lib/workflows/streaming/streaming'
+import {
+  agentStreamProtocolResponseHeaders,
+  createStreamingResponse,
+} from '@/lib/workflows/streaming/streaming'
 import { createHttpResponseFromBlock, workflowHasResponseBlock } from '@/lib/workflows/utils'
 import { getWorkspaceBillingSettings } from '@/lib/workspaces/utils'
 import { executeWorkflowJob, type WorkflowExecutionPayload } from '@/background/workflow-execution'
@@ -668,6 +678,8 @@ async function handleExecutePost(
       selectedOutputs,
       triggerType = defaultTriggerType,
       stream: streamParam,
+      includeThinking: requestedIncludeThinking,
+      includeToolCalls: requestedIncludeToolCalls,
       useDraftState,
       input: validatedInput,
       isClientSession = false,
@@ -1436,6 +1448,32 @@ async function handleExecutePost(
         isDeployed: workflow.isDeployed,
         variables: streamVariables,
       }
+      /**
+       * The caller asked for frames whose shape is defined by a protocol
+       * version they never declared. Rejecting beats silently downgrading:
+       * the flags would otherwise be a no-op with no way to notice.
+       */
+      if (
+        hasAgentStreamPolicy({
+          includeThinking: requestedIncludeThinking,
+          includeToolCalls: requestedIncludeToolCalls,
+        }) &&
+        !clientAcceptsAgentStreamProtocol(req.headers)
+      ) {
+        return NextResponse.json(
+          {
+            error: `includeThinking and includeToolCalls require the ${AGENT_STREAM_PROTOCOL_HEADER_LABEL}: ${AGENT_STREAM_PROTOCOL_V1} request header, which declares that the client understands agent-event frames.`,
+          },
+          { status: 400 }
+        )
+      }
+
+      const agentEvents = shouldEmitAgentStreamEvents({
+        includeThinking: requestedIncludeThinking,
+        includeToolCalls: requestedIncludeToolCalls,
+        requestHeaders: req.headers,
+      })
+
       const stream = await createStreamingResponse({
         requestId,
         streamConfig: {
@@ -1445,9 +1483,8 @@ async function handleExecutePost(
           includeFileBase64,
           base64MaxBytes,
           timeoutMs: preprocessResult.executionTimeout?.sync,
-          /** Workflow API has no deployed-chat event policies, so agent-event frames stay off. */
-          includeThinking: false,
-          includeToolCalls: false,
+          includeThinking: requestedIncludeThinking,
+          includeToolCalls: requestedIncludeToolCalls,
         },
         executionId,
         largeValueExecutionIds,
@@ -1482,6 +1519,9 @@ async function handleExecutePost(
               fileKeys,
               stopAfterBlockId,
               runFromBlock: resolvedRunFromBlock,
+              includeThinking: requestedIncludeThinking,
+              includeToolCalls: requestedIncludeToolCalls,
+              agentEvents,
             },
             executionId
           ),
@@ -1490,7 +1530,11 @@ async function handleExecutePost(
       executionIdClaimCommitted = true
       return new NextResponse(stream, {
         status: 200,
-        headers: SSE_HEADERS,
+        headers: {
+          ...SSE_HEADERS,
+          // Echo the negotiated stream protocol (same as the chat and resume routes).
+          ...agentStreamProtocolResponseHeaders({ requestHeaders: req.headers }),
+        },
       })
     }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/api/api.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/api/api.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   Button,
   ButtonGroup,
@@ -12,7 +12,12 @@ import {
   Tooltip,
 } from '@sim/emcn'
 import { Check, Clipboard } from 'lucide-react'
+import {
+  AGENT_STREAM_PROTOCOL_HEADER_LABEL,
+  AGENT_STREAM_PROTOCOL_V1,
+} from '@/lib/workflows/streaming/agent-stream-protocol'
 import { OutputSelect } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/output-select/output-select'
+import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 interface WorkflowDeploymentInfo {
   isDeployed: boolean
@@ -76,6 +81,17 @@ export function ApiDeploy({
 
   const info = deploymentInfo ? { ...deploymentInfo, needsRedeployment } : null
 
+  /**
+   * Thinking and tool frames come off the block's stream sink, independent of
+   * `selectedOutputs`, so the presence of an Agent block is what decides
+   * whether these flags can do anything.
+   */
+  const blocks = useWorkflowStore((state) => state.blocks)
+  const hasAgentBlock = useMemo(
+    () => Object.values(blocks).some((block) => block.type === 'agent'),
+    [blocks]
+  )
+
   const getBaseEndpoint = () => {
     if (!info) return ''
     return info.endpoint.replace(info.apiKey, '$SIM_API_KEY')
@@ -98,6 +114,11 @@ export function ApiDeploy({
     const payload: Record<string, unknown> = { ...getPayloadObject(), stream: true }
     if (selectedStreamingOutputs && selectedStreamingOutputs.length > 0) {
       payload.selectedOutputs = selectedStreamingOutputs
+    }
+    /** Paired with the protocol header, which the API requires alongside them. */
+    if (hasAgentBlock) {
+      payload.includeThinking = true
+      payload.includeToolCalls = true
     }
     return payload
   }
@@ -163,11 +184,19 @@ console.log(data);`
     const endpoint = getBaseEndpoint()
     const payload = getStreamPayloadObject()
     const isPublic = info.isPublicApi
+    /** Required whenever the payload asks for agent-event frames. */
+    const protocol = hasAgentBlock
+      ? {
+          curl: `  -H "${AGENT_STREAM_PROTOCOL_HEADER_LABEL}: ${AGENT_STREAM_PROTOCOL_V1}" \\\n`,
+          python: `        "${AGENT_STREAM_PROTOCOL_HEADER_LABEL}": "${AGENT_STREAM_PROTOCOL_V1}",\n`,
+          js: `    "${AGENT_STREAM_PROTOCOL_HEADER_LABEL}": "${AGENT_STREAM_PROTOCOL_V1}",\n`,
+        }
+      : { curl: '', python: '', js: '' }
 
     switch (language) {
       case 'curl':
         return `curl -X POST \\
-${isPublic ? '' : '  -H "X-API-Key: $SIM_API_KEY" \\\n'}  -H "Content-Type: application/json" \\
+${isPublic ? '' : '  -H "X-API-Key: $SIM_API_KEY" \\\n'}${protocol.curl}  -H "Content-Type: application/json" \\
   -d '${JSON.stringify(payload)}' \\
   ${endpoint}`
 
@@ -178,7 +207,7 @@ import requests
 response = requests.post(
     "${endpoint}",
     headers={
-${isPublic ? '' : '        "X-API-Key": os.environ.get("SIM_API_KEY"),\n'}        "Content-Type": "application/json"
+${isPublic ? '' : '        "X-API-Key": os.environ.get("SIM_API_KEY"),\n'}${protocol.python}        "Content-Type": "application/json"
     },
     json=${JSON.stringify(payload, null, 4).replace(/\n/g, '\n    ')},
     stream=True
@@ -192,7 +221,7 @@ for line in response.iter_lines():
         return `const response = await fetch("${endpoint}", {
   method: "POST",
   headers: {
-${isPublic ? '' : '    "X-API-Key": process.env.SIM_API_KEY,\n'}    "Content-Type": "application/json"
+${isPublic ? '' : '    "X-API-Key": process.env.SIM_API_KEY,\n'}${protocol.js}    "Content-Type": "application/json"
   },
   body: JSON.stringify(${JSON.stringify(payload)})
 });
@@ -210,7 +239,7 @@ while (true) {
         return `const response = await fetch("${endpoint}", {
   method: "POST",
   headers: {
-${isPublic ? '' : '    "X-API-Key": process.env.SIM_API_KEY,\n'}    "Content-Type": "application/json"
+${isPublic ? '' : '    "X-API-Key": process.env.SIM_API_KEY,\n'}${protocol.js}    "Content-Type": "application/json"
   },
   body: JSON.stringify(${JSON.stringify(payload)})
 });

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
@@ -198,7 +198,7 @@ export function ChatDeploy({
             )
           : [],
         includeThinking: existingChat.includeThinking ?? false,
-        includeToolCalls: existingChat.includeToolCalls ?? existingChat.includeThinking ?? false,
+        includeToolCalls: existingChat.includeToolCalls ?? false,
       })
 
       if (existingChat.customizations?.imageUrl) {

--- a/apps/sim/lib/api/contracts/workflows.test.ts
+++ b/apps/sim/lib/api/contracts/workflows.test.ts
@@ -6,6 +6,28 @@ import {
 } from '@/lib/api/contracts/workflows'
 
 describe('workflow contracts', () => {
+  /**
+   * Agent-event frames are additive to an existing wire format, so an
+   * integration that never asked for them must keep the frame set it has.
+   */
+  it('leaves agent-event exposure off when the caller does not ask for it', () => {
+    const parsed = executeWorkflowBodySchema.parse({ stream: true })
+
+    expect(parsed.includeThinking).toBe(false)
+    expect(parsed.includeToolCalls).toBe(false)
+  })
+
+  it('accepts each agent-event policy independently', () => {
+    expect(executeWorkflowBodySchema.parse({ stream: true, includeToolCalls: true })).toMatchObject(
+      { includeThinking: false, includeToolCalls: true }
+    )
+
+    expect(executeWorkflowBodySchema.parse({ stream: true, includeThinking: true })).toMatchObject({
+      includeThinking: true,
+      includeToolCalls: false,
+    })
+  })
+
   it('normalizes null React Flow edge handles in execution overrides', () => {
     const parsed = executeWorkflowBodySchema.parse({
       workflowStateOverride: {

--- a/apps/sim/lib/api/contracts/workflows.ts
+++ b/apps/sim/lib/api/contracts/workflows.ts
@@ -342,6 +342,18 @@ export const executeWorkflowBodySchema = z.object({
   selectedOutputs: z.array(z.string()).optional().default([]),
   triggerType: executeWorkflowTriggerTypeSchema.optional(),
   stream: z.boolean().optional(),
+  /**
+   * Streaming runs only: expose the agent's reasoning as `thinking` frames.
+   * Requires the caller to also send the `agent-events-v1` protocol header.
+   * Off by default so existing integrations keep their current frame set.
+   */
+  includeThinking: z.boolean().optional().default(false),
+  /**
+   * Streaming runs only: expose tool lifecycle as `tool` frames (name and
+   * status only — arguments and results ride the terminal `final` envelope).
+   * Requires the protocol header. Off by default.
+   */
+  includeToolCalls: z.boolean().optional().default(false),
   useDraftState: z.boolean().optional(),
   input: z.any().optional(),
   isClientSession: z.boolean().optional(),

--- a/apps/sim/lib/copilot/tools/handlers/deployment/deploy.ts
+++ b/apps/sim/lib/copilot/tools/handlers/deployment/deploy.ts
@@ -309,8 +309,7 @@ export async function executeDeployChat(
               outputConfigs:
                 (existing[0].outputConfigs as Array<{ blockId: string; path: string }>) || [],
               includeThinking: existing[0].includeThinking ?? false,
-              includeToolCalls:
-                existing[0].includeToolCalls ?? existing[0].includeThinking ?? false,
+              includeToolCalls: existing[0].includeToolCalls ?? false,
               welcomeMessage:
                 (existing[0].customizations as { welcomeMessage?: string } | null)
                   ?.welcomeMessage || 'Hi there! How can I help you today?',
@@ -402,15 +401,10 @@ export async function executeDeployChat(
       typeof params.includeThinking === 'boolean'
         ? params.includeThinking
         : (existingDeployment?.includeThinking ?? false)
-    /**
-     * Grandfathers off the thinking value this call resolves to, not the stored
-     * one: before `includeToolCalls` existed, `includeThinking` gated tool
-     * frames too, so turning thinking off must turn them off with it.
-     */
     const resolvedIncludeToolCalls =
       typeof params.includeToolCalls === 'boolean'
         ? params.includeToolCalls
-        : (existingDeployment?.includeToolCalls ?? resolvedIncludeThinking)
+        : (existingDeployment?.includeToolCalls ?? false)
     const welcomeMessage =
       typeof params.welcomeMessage === 'string'
         ? params.welcomeMessage

--- a/apps/sim/lib/copilot/tools/handlers/deployment/manage.ts
+++ b/apps/sim/lib/copilot/tools/handlers/deployment/manage.ts
@@ -106,7 +106,7 @@ export async function executeCheckDeploymentStatus(
       allowedEmails: chatDeploy[0]?.allowedEmails || null,
       outputConfigs: chatDeploy[0]?.outputConfigs || null,
       includeThinking: chatDeploy[0]?.includeThinking ?? false,
-      includeToolCalls: chatDeploy[0]?.includeToolCalls ?? chatDeploy[0]?.includeThinking ?? false,
+      includeToolCalls: chatDeploy[0]?.includeToolCalls ?? false,
       welcomeMessage: chatCustomizations.welcomeMessage || null,
       primaryColor: chatCustomizations.primaryColor || null,
       hasPassword: Boolean(chatDeploy[0]?.password),

--- a/apps/sim/lib/workflows/streaming/agent-stream-protocol.test.ts
+++ b/apps/sim/lib/workflows/streaming/agent-stream-protocol.test.ts
@@ -6,6 +6,7 @@ import {
   AGENT_STREAM_PROTOCOL_HEADER,
   AGENT_STREAM_PROTOCOL_V1,
   clientAcceptsAgentStreamProtocol,
+  hasAgentStreamPolicy,
   isChatChunkFrame,
   isChatChunkResetFrame,
   isChatToolFrame,
@@ -17,7 +18,7 @@ function headers(init?: Record<string, string>): Headers {
 }
 
 describe('clientAcceptsAgentStreamProtocol', () => {
-  it('depends on the header alone, never on a deployment policy', () => {
+  it('depends on the header alone, never on a policy', () => {
     expect(
       clientAcceptsAgentStreamProtocol(
         headers({ [AGENT_STREAM_PROTOCOL_HEADER]: AGENT_STREAM_PROTOCOL_V1 })
@@ -27,6 +28,19 @@ describe('clientAcceptsAgentStreamProtocol', () => {
       clientAcceptsAgentStreamProtocol(headers({ [AGENT_STREAM_PROTOCOL_HEADER]: ' V1 ' }))
     ).toBe(false)
     expect(clientAcceptsAgentStreamProtocol(headers())).toBe(false)
+  })
+
+  it('tolerates casing and comma lists from proxies', () => {
+    expect(
+      clientAcceptsAgentStreamProtocol(
+        headers({ [AGENT_STREAM_PROTOCOL_HEADER]: ' Agent-Events-V1 ' })
+      )
+    ).toBe(true)
+    expect(
+      clientAcceptsAgentStreamProtocol(
+        headers({ [AGENT_STREAM_PROTOCOL_HEADER]: 'text, agent-events-v1' })
+      )
+    ).toBe(true)
   })
 })
 
@@ -59,74 +73,66 @@ describe('chunk_reset frame guard', () => {
 })
 
 describe('shouldEmitAgentStreamEvents', () => {
-  it('defaults to false when policy is off and header is missing', () => {
+  const negotiated = () => headers({ [AGENT_STREAM_PROTOCOL_HEADER]: AGENT_STREAM_PROTOCOL_V1 })
+
+  it('is off when neither policy is set', () => {
     expect(
       shouldEmitAgentStreamEvents({
         includeThinking: false,
         includeToolCalls: false,
-        requestHeaders: headers(),
+        requestHeaders: negotiated(),
       })
     ).toBe(false)
     expect(
       shouldEmitAgentStreamEvents({
         includeThinking: undefined,
         includeToolCalls: undefined,
-        requestHeaders: headers(),
+        requestHeaders: negotiated(),
       })
     ).toBe(false)
   })
 
-  it('requires the protocol header and at least one event policy', () => {
+  it('is on when either policy is set on a negotiated client', () => {
     expect(
       shouldEmitAgentStreamEvents({
         includeThinking: true,
         includeToolCalls: false,
-        requestHeaders: headers(),
-      })
-    ).toBe(false)
-
-    expect(
-      shouldEmitAgentStreamEvents({
-        includeThinking: false,
-        includeToolCalls: false,
-        requestHeaders: headers({ [AGENT_STREAM_PROTOCOL_HEADER]: AGENT_STREAM_PROTOCOL_V1 }),
-      })
-    ).toBe(false)
-
-    expect(
-      shouldEmitAgentStreamEvents({
-        includeThinking: true,
-        includeToolCalls: false,
-        requestHeaders: headers({ [AGENT_STREAM_PROTOCOL_HEADER]: AGENT_STREAM_PROTOCOL_V1 }),
+        requestHeaders: negotiated(),
       })
     ).toBe(true)
-
     expect(
       shouldEmitAgentStreamEvents({
         includeThinking: false,
         includeToolCalls: true,
-        requestHeaders: headers({ [AGENT_STREAM_PROTOCOL_HEADER]: AGENT_STREAM_PROTOCOL_V1 }),
+        requestHeaders: negotiated(),
       })
     ).toBe(true)
   })
 
-  it('accepts case-insensitive header values and comma lists', () => {
+  /**
+   * Frames have no defined shape for a client that never declared a version,
+   * so policy alone is not enough.
+   */
+  it('is off without the protocol header even when policy is on', () => {
     expect(
       shouldEmitAgentStreamEvents({
         includeThinking: true,
-        includeToolCalls: false,
-        requestHeaders: headers({ [AGENT_STREAM_PROTOCOL_HEADER]: ' Agent-Events-V1 ' }),
-      })
-    ).toBe(true)
-
-    expect(
-      shouldEmitAgentStreamEvents({
-        includeThinking: false,
         includeToolCalls: true,
-        requestHeaders: headers({
-          [AGENT_STREAM_PROTOCOL_HEADER]: 'text, agent-events-v1',
-        }),
+        requestHeaders: headers(),
       })
-    ).toBe(true)
+    ).toBe(false)
+  })
+})
+
+describe('hasAgentStreamPolicy', () => {
+  /**
+   * Surfaces where the caller sets the policy use this to reject an
+   * un-negotiated request instead of silently dropping the flags.
+   */
+  it('reports the policy independently of negotiation', () => {
+    expect(hasAgentStreamPolicy({ includeThinking: true, includeToolCalls: false })).toBe(true)
+    expect(hasAgentStreamPolicy({ includeThinking: false, includeToolCalls: true })).toBe(true)
+    expect(hasAgentStreamPolicy({ includeThinking: false, includeToolCalls: false })).toBe(false)
+    expect(hasAgentStreamPolicy({ includeThinking: undefined, includeToolCalls: null })).toBe(false)
   })
 })

--- a/apps/sim/lib/workflows/streaming/agent-stream-protocol.ts
+++ b/apps/sim/lib/workflows/streaming/agent-stream-protocol.ts
@@ -2,31 +2,36 @@
  * Public agent stream protocol: header negotiation and the wire frame
  * vocabulary for the public chat / simple SSE surface.
  *
- * Two independent things are negotiated here:
+ * Two orthogonal things are decided here:
  *
- * 1. Client capability — {@link AGENT_STREAM_PROTOCOL_HEADER} means the client
+ * 1. Answer-text cadence — {@link AGENT_STREAM_PROTOCOL_HEADER} means the client
  *    understands v1 framing, so answer text may stream live and be retracted
- *    with `chunk_reset`. No deployment policy is involved.
- * 2. Event exposure — thinking frames need `deployment.includeThinking`, tool
- *    frames need `deployment.includeToolCalls`, and both additionally need the
- *    client capability above.
+ *    with `chunk_reset`. Without it the client keeps settled final-turn text.
+ *    This is a capability question: a client that cannot honor `chunk_reset`
+ *    would render duplicated text, so it must not be opted in on its behalf.
+ * 2. Event exposure — thinking frames need `includeThinking`, tool frames need
+ *    `includeToolCalls`, and both additionally need the negotiated protocol
+ *    above. Declaring the version is what lets these frames evolve without
+ *    breaking clients that never opted in.
  *
- * Keeping these separate is what lets a chat with both policies off still
- * stream its answer token by token, exactly as it did before agent events.
+ * The header alone exposes nothing, so a chat with both policies off still
+ * streams token by token. Where the *caller* requests frames — the workflow
+ * API — asking without negotiating is rejected rather than silently downgraded.
  *
  * Canvas draft runs (execution-events) forward the same sink as live-only
- * `stream:thinking` / `stream:tool` events without the deployment policy gates;
- * the executor still disables the sink when block-output PII redaction is on.
- *
- * Legacy clients omitting the header stay on settled final-turn text and never
- * see thinking or tools. The deployed chat UI always sends the header.
+ * `stream:thinking` / `stream:tool` events without the policy gates; the
+ * executor still disables the sink when block-output PII redaction is on.
  *
  * See docs: workflows/deployment/agent-events.
  */
 
 import { isToolCallEndStatus, type ToolCallEndStatus } from '@/providers/stream-events'
 
+/** Lookup key. Lowercase because HTTP/2 lowercases on the wire; `Headers.get` is case-insensitive either way. */
 export const AGENT_STREAM_PROTOCOL_HEADER = 'x-sim-stream-protocol' as const
+
+/** Canonical casing, for docs and generated code samples. */
+export const AGENT_STREAM_PROTOCOL_HEADER_LABEL = 'X-Sim-Stream-Protocol' as const
 
 export const AGENT_STREAM_PROTOCOL_V1 = 'agent-events-v1' as const
 
@@ -197,21 +202,34 @@ export function clientAcceptsAgentStreamProtocol(
   return tokens.includes(AGENT_STREAM_PROTOCOL_V1)
 }
 
+/** True when either agent-event policy is on, before protocol negotiation. */
+export function hasAgentStreamPolicy(options: {
+  includeThinking: boolean | null | undefined
+  includeToolCalls: boolean | null | undefined
+}): boolean {
+  return options.includeThinking === true || options.includeToolCalls === true
+}
+
 /**
  * Returns true when a negotiated client may receive thinking or tool frames —
- * at least one deployment policy is on and the client accepts the protocol.
+ * at least one policy is on and the client declared the protocol version.
  *
  * Drives the run-level `agentEvents` flag, which asks providers for reasoning
  * summaries. Answer-text cadence does *not* depend on this: a negotiated client
  * streams live text even with both policies off. Frame emitters still apply
  * each independent policy before exposing its corresponding frames.
+ *
+ * Surfaces that let the *caller* request frames should reject an un-negotiated
+ * request outright rather than degrade to this returning false — see
+ * {@link hasAgentStreamPolicy}. A silent downgrade is the failure mode this
+ * protocol is meant to avoid.
  */
 export function shouldEmitAgentStreamEvents(options: {
   includeThinking: boolean | null | undefined
   includeToolCalls: boolean | null | undefined
   requestHeaders: Headers | { get(name: string): string | null }
 }): boolean {
-  if (options.includeThinking !== true && options.includeToolCalls !== true) {
+  if (!hasAgentStreamPolicy(options)) {
     return false
   }
 

--- a/apps/sim/lib/workflows/streaming/streaming.test.ts
+++ b/apps/sim/lib/workflows/streaming/streaming.test.ts
@@ -844,7 +844,11 @@ describe('createStreamingResponse agent-events-v1', () => {
       .map((chunk) => chunk.slice(6))
   }
 
-  it('legacy path without protocol header stays text-only', async () => {
+  /**
+   * A client that never declared a protocol version has no contract for frame
+   * shapes, so policy alone must not expose them.
+   */
+  it('stays text-only without the protocol header even with both policies on', async () => {
     const stream = await createStreamingResponse({
       requestId: 'request-1',
       streamConfig: {
@@ -852,7 +856,28 @@ describe('createStreamingResponse agent-events-v1', () => {
         includeToolCalls: true,
         selectedOutputs: ['agent-1_content'],
       },
-      // No requestHeaders → gate closed
+      executeFn: createAgentStreamExecuteFn({
+        thinking: ['a thought'],
+        answer: 'Hello',
+        tools: [{ type: 'tool_call_start', id: 'toolu_1', name: 'get_weather' }],
+      }),
+    })
+
+    const events = await collectSSEEvents(stream)
+    expect(events.some((event) => event.event === 'thinking')).toBe(false)
+    expect(events.some((event) => event.event === 'tool')).toBe(false)
+    expect(events).toContainEqual({ blockId: 'agent-1', chunk: 'Hello' })
+    expect(events.some((event) => event.event === 'final')).toBe(true)
+  })
+
+  it('stays fully text-only when both policies are off', async () => {
+    const stream = await createStreamingResponse({
+      requestId: 'request-1',
+      streamConfig: {
+        includeThinking: false,
+        includeToolCalls: false,
+        selectedOutputs: ['agent-1_content'],
+      },
       executeFn: createAgentStreamExecuteFn({
         thinking: ['secret thought'],
         answer: 'Hello',
@@ -864,7 +889,6 @@ describe('createStreamingResponse agent-events-v1', () => {
     expect(events.some((event) => event.event === 'thinking')).toBe(false)
     expect(events.some((event) => event.event === 'tool')).toBe(false)
     expect(events).toContainEqual({ blockId: 'agent-1', chunk: 'Hello' })
-    expect(events.some((event) => event.event === 'final')).toBe(true)
   })
 
   it('header + includeThinking emits thinking on data and answer on chunk', async () => {

--- a/apps/sim/lib/workflows/streaming/streaming.ts
+++ b/apps/sim/lib/workflows/streaming/streaming.ts
@@ -499,12 +499,17 @@ export async function createStreamingResponse(
   const { requestId, streamConfig, executionId, executeFn } = options
   const timeoutController = createTimeoutAbortController(streamConfig.timeoutMs)
   /**
-   * Client capability, not deployment policy: a negotiated client can render
-   * live answer text and honor `chunk_reset`, so it streams token by token
-   * regardless of whether thinking or tools are exposed.
+   * Answer-text cadence only. A negotiated client renders live text and honors
+   * `chunk_reset`; one that did not negotiate keeps settled final-turn text,
+   * because retracting text it already rendered would corrupt the answer.
    */
   const clientAcceptsProtocol =
     Boolean(options.requestHeaders) && clientAcceptsAgentStreamProtocol(options.requestHeaders!)
+  /**
+   * Frames additionally require the negotiated protocol: a client that never
+   * declared a version has no contract for their shape, so it keeps the text
+   * stream it already understands.
+   */
   const emitThinking = clientAcceptsProtocol && streamConfig.includeThinking === true
   const emitToolCalls = clientAcceptsProtocol && streamConfig.includeToolCalls === true
   const maxThinkingChars = DEFAULT_MAX_THINKING_CHARS

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -1158,18 +1158,20 @@ export const chat = pgTable(
     outputConfigs: json('output_configs').default('[]'), // Array of {blockId, path} objects
 
     /**
-     * When true, public chat SSE may expose provider thinking events if the
-     * client also opts in via `X-Sim-Stream-Protocol: agent-events-v1`.
-     * Default off — never derived from auth type or isSecureMode.
+     * When true, public chat SSE exposes provider thinking events. Independent
+     * of the `X-Sim-Stream-Protocol` header, which governs answer-text cadence
+     * rather than frame exposure. Default off — never derived from auth type or
+     * isSecureMode.
      */
     includeThinking: boolean('include_thinking').notNull().default(false),
     /**
-     * When true, public chat SSE may expose tool lifecycle events if the client
-     * also opts in via `X-Sim-Stream-Protocol: agent-events-v1`.
+     * When true, public chat SSE exposes tool lifecycle events. Independent of
+     * includeThinking and of the protocol header.
      *
-     * Null preserves the pre-expand policy: readers fall back to includeThinking.
+     * Nullable only because the column was added after the table; readers treat
+     * null as false.
      */
-    // contract-pending(after the includeToolCalls expand release is fully deployed): backfill include_tool_calls from include_thinking, then set DEFAULT false and NOT NULL — all new-app chat writes persist an explicit value
+    // contract-pending(any release): normalize nulls to false, then set DEFAULT false and NOT NULL — cosmetic only, since no reader distinguishes null from false
     includeToolCalls: boolean('include_tool_calls'),
 
     archivedAt: timestamp('archived_at'),


### PR DESCRIPTION
## Summary

Add standard way to opt in to thinking and tool call events.


## Type of Change
- [x] New feature  


## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)