### PR TITLE
fix(ci): skip lifecycle scripts on CI installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,14 @@ jobs:
         with:
           bun-version: 1.3.13
 
+      # Required: bun install runs isolated-vm's install script, and upstream
+      # only publishes prebuilds for Node 22/24. On the runner default (Node 20)
+      # it falls back to a node-gyp build that crashes on Node 20.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
       - name: Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
@@ -582,6 +590,14 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.13
+
+      # Required: bun install runs isolated-vm's install script, and upstream
+      # only publishes prebuilds for Node 22/24. On the runner default (Node 20)
+      # it falls back to a node-gyp build that crashes on Node 20.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,8 @@ jobs:
         with:
           bun-version: 1.3.13
 
-      # Required: bun install runs isolated-vm's install script, and upstream
-      # only publishes prebuilds for Node 22/24. On the runner default (Node 20)
-      # it falls back to a node-gyp build that crashes on Node 20.
+      # Repo scripts target engines.node >= 22.19.0; without this the job runs on
+      # the runner default (Node 20).
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -206,7 +205,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Deploy to Trigger.dev
         working-directory: ./apps/sim
@@ -591,16 +590,15 @@ jobs:
         with:
           bun-version: 1.3.13
 
-      # Required: bun install runs isolated-vm's install script, and upstream
-      # only publishes prebuilds for Node 22/24. On the runner default (Node 20)
-      # it falls back to a node-gyp build that crashes on Node 20.
+      # Repo scripts target engines.node >= 22.19.0; without this the job runs on
+      # the runner default (Node 20).
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Create release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,13 +186,6 @@ jobs:
         with:
           bun-version: 1.3.13
 
-      # Repo scripts target engines.node >= 22.19.0; without this the job runs on
-      # the runner default (Node 20).
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: 22
-
       - name: Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
@@ -589,13 +582,6 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.13
-
-      # Repo scripts target engines.node >= 22.19.0; without this the job runs on
-      # the runner default (Node 20).
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: 22
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Process docs embeddings
         working-directory: ./apps/sim

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -36,9 +36,8 @@ jobs:
         with:
           bun-version: 1.3.13
 
-      # Required: bun install runs isolated-vm's install script, and upstream
-      # only publishes prebuilds for Node 22/24. On the runner default (Node 20)
-      # it falls back to a node-gyp build that crashes on Node 20.
+      # Repo scripts target engines.node >= 22.19.0; without this the job runs on
+      # the runner default (Node 20).
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -56,7 +55,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       # The expression maps the explicit environment input to exactly one repo
       # secret, so the job never holds another environment's database URL. An

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -36,13 +36,6 @@ jobs:
         with:
           bun-version: 1.3.13
 
-      # Repo scripts target engines.node >= 22.19.0; without this the job runs on
-      # the runner default (Node 20).
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: 22
-
       - name: Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -36,6 +36,14 @@ jobs:
         with:
           bun-version: 1.3.13
 
+      # Required: bun install runs isolated-vm's install script, and upstream
+      # only publishes prebuilds for Node 22/24. On the runner default (Node 20)
+      # it falls back to a node-gyp build that crashes on Node 20.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
       - name: Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '18'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Cache Bun dependencies

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/cli
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build package
         working-directory: packages/cli

--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Run tests
         working-directory: packages/ts-sdk

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -60,7 +60,7 @@ jobs:
           path: ./.turbo
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       # Surfaces known CVEs in the dependency tree. Non-blocking until the
       # existing advisory backlog is triaged, then flip to a required gate by
@@ -278,7 +278,7 @@ jobs:
           fi
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build application
         env:


### PR DESCRIPTION
## Summary
Fixes the `Create GitHub Release` failure on `main`, a regression from #5935, and removes the class of failure rather than just this instance.

#5935 removed the blanket `.npmrc` `ignore-scripts=true`, so `isolated-vm`'s install script now actually runs. Upstream publishes prebuilds for **Node 22 (ABI 127)** and **Node 24 (ABI 137)** only. Jobs that set up Bun but never `setup-node` inherit the runner default — **Node 20** — where `prebuild-install` finds nothing:

```
prebuild-install warn install No prebuilt binaries found (target=20.20.0 runtime=node arch=x64 libc= platform=linux)
```

and falls back to `node-gyp`, which crashes:

```
gyp ERR! stack TypeError: webidl.util.markAsUncloneable is not a function
error: install script from "isolated-vm" exited with 1
```

That failure is [undici #5024](https://github.com/nodejs/undici/issues/5024) — a regression in **undici 8.0.3** that broke Node 20, still open. `node-gyp` bundles undici and Bun fetches `node-gyp@latest` via `bunx`, so this arrives unpinned at install time. Before #5935 the script never ran, so the skew was invisible.

## The fix: `--ignore-scripts` on all 8 CI installs

No CI job needs a compiled native module. `isolated-vm` landed in December 2025 and `.npmrc` blocked lifecycle scripts until #5935, so **CI ran green for ~7 months with it never built**. That is corroborated structurally: `next.config.ts` lists it in `serverExternalPackages` and `trigger.config.ts` externals it (never bundled), every test mocks it, and the only real `require('isolated-vm')` is in `isolated-vm-worker.cjs`, which no CI job spawns. All three Dockerfiles already install with `--ignore-scripts` and rebuild it by hand.

Building it in CI buys nothing and couples every job to prebuild availability for the pinned Node. With only two ABIs published upstream, the next `setup-node` bump would resurface the same opaque `node-gyp` failure. Local dev keeps the automatic build that #5935 was for.

Skipping lifecycle scripts on CI installs is also standard supply-chain hardening — it is one layer of the usual lockfile + cooldown + script-blocking stack, and Bun blocks scripts by default for the same reason.

## What is deliberately *not* here

An earlier revision of this PR also added `setup-node` to `create-release`, `migrate`, and `deploy-trigger-dev`. That was redundant and has been removed: once scripts are skipped, nothing in those jobs invokes node. They run `bun run scripts/create-single-release.ts`, `bun run db:push` + `bun run scripts/migrate.ts`, and `bunx trigger.dev deploy` — and all three were green without `setup-node` for months. `setup-bun` + `setup-node` is redundant unless a job needs node-specific tooling.

`setup-node` remains only where it is load-bearing: `publish-cli` and `publish-ts-sdk` need it for `npm publish` and its `registry-url` auth; `test-build` and `docs-embeddings` already had it.

The one extra change is `publish-cli.yml` Node **18 → 22**. That job's `setup-node` is required, and 18 has been EOL since April 2025; this matches `publish-ts-sdk.yml`, which already publishes on 22. Separable from the bug fix if you would rather it land on its own.

## Audit
Every job in the repo that runs `bun install`:

| workflow | job | `setup-node` | `--ignore-scripts` |
|---|---|---|---|
| `ci.yml` | `create-release` — **the failing job** | none | added |
| `ci.yml` | `deploy-trigger-dev` | none | added |
| `migrations.yml` | `migrate` | none | added |
| `publish-cli.yml` | `publish-npm` | 18 → **22** (needed for `npm publish`) | added |
| `docs-embeddings.yml` | `process-docs-embeddings` | 22 (unchanged) | added |
| `publish-ts-sdk.yml` | `publish-npm` | 22 (unchanged) | added |
| `test-build.yml` | `test-build` | 22 (unchanged) | added |
| `test-build.yml` | `build` | 22 (unchanged) | added |

## Testing
- Verified upstream prebuild coverage against the `v6.0.2` release assets: `node-v127` and `node-v137` only — no ABI 115 (Node 20) or 108 (Node 18) build on any platform
- Confirmed `prebuild-install` resolves ABI from the real `node` on PATH, not Bun's claimed version
- Audited all 8 install jobs; each passes `--ignore-scripts`, and every remaining `setup-node` is ordered **before** its install step
- `Test and Build / Build App` and `Lint and Test` both **pass** on this branch, exercising the `--ignore-scripts` install path end to end
- All workflow YAML parses cleanly

Note: `create-release` only runs on release commits on `main` and `deploy-trigger-dev` only on pushes to `dev`, so neither is exercised by this PR's own CI. `test-build` and `build` do exercise the `--ignore-scripts` install path here.

## Follow-up (not in this PR)
`.devcontainer/Dockerfile` is `oven/bun:1.3.13-alpine` and `post-create.sh` runs a plain `bun install`. The official `oven/bun` images ship no Node binary, and `prebuild-install` is a node-shebang script with `node-gyp` as its fallback — so #5935 likely broke devcontainer onboarding too. Unverified (no local Docker daemon). The real fix there is adding Node to the image: `isolated-vm` spawns a Node child process at runtime, so the sandbox has never worked in that container regardless.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
