### PR TITLE
fix(tables): fix the filter on built in timestamp columns

### DIFF
--- a/apps/sim/app/api/table/utils.ts
+++ b/apps/sim/app/api/table/utils.ts
@@ -156,7 +156,10 @@ async function checkTableAccess(tableId: string, userId: string): Promise<TableA
     return { hasAccess: true, table }
   }
 
-  return { hasAccess: false, reason: 'User does not have access to this table' }
+  return {
+    hasAccess: false,
+    reason: 'User does not have access to this table',
+  }
 }
 
 /**
@@ -175,7 +178,10 @@ async function checkTableWriteAccess(tableId: string, userId: string): Promise<T
     return { hasAccess: true, table }
   }
 
-  return { hasAccess: false, reason: 'User does not have write access to this table' }
+  return {
+    hasAccess: false,
+    reason: 'User does not have write access to this table',
+  }
 }
 
 /**
@@ -280,4 +286,11 @@ export function normalizeColumn(col: ColumnDefinition): ColumnDefinition {
     unique: col.unique ?? false,
     ...(col.workflowGroupId ? { workflowGroupId: col.workflowGroupId } : {}),
   }
+}
+
+export function isBuiltInDateField(field: string): boolean {
+  if (field === 'created_at' || field === 'updated_at') {
+    return true
+  }
+  return false
 }

--- a/apps/sim/app/api/table/utils.ts
+++ b/apps/sim/app/api/table/utils.ts
@@ -289,7 +289,7 @@ export function normalizeColumn(col: ColumnDefinition): ColumnDefinition {
 }
 
 export function isBuiltInDateField(field: string): boolean {
-  if (field === 'created_at' || field === 'updated_at') {
+  if (['created_at', 'updated_at', 'createdAt', 'updatedAt'].includes(field)) {
     return true
   }
   return false

--- a/apps/sim/lib/table/__tests__/sql.test.ts
+++ b/apps/sim/lib/table/__tests__/sql.test.ts
@@ -227,7 +227,9 @@ describe('SQL Builder', () => {
     it('handles nested $or and $and', () => {
       const out = render(
         buildFilterClause(
-          { $or: [{ $and: [{ status: 'active' }, { verified: true }] }, { role: 'admin' }] },
+          {
+            $or: [{ $and: [{ status: 'active' }, { verified: true }] }, { role: 'admin' }],
+          },
           TABLE,
           NO_COLUMNS
         )
@@ -297,7 +299,9 @@ describe('SQL Builder', () => {
     it('propagates date cast through nested $and', () => {
       const out = render(
         buildFilterClause(
-          { $and: [{ birthDate: { $gte: '2024-01-01' } }, { birthDate: { $lt: '2025-01-01' } }] },
+          {
+            $and: [{ birthDate: { $gte: '2024-01-01' } }, { birthDate: { $lt: '2025-01-01' } }],
+          },
           TABLE,
           dateCols
         )
@@ -309,7 +313,9 @@ describe('SQL Builder', () => {
     it('propagates date cast through nested $or', () => {
       const out = render(
         buildFilterClause(
-          { $or: [{ birthDate: { $lt: '2000-01-01' } }, { birthDate: { $gt: '2024-01-01' } }] },
+          {
+            $or: [{ birthDate: { $lt: '2000-01-01' } }, { birthDate: { $gt: '2024-01-01' } }],
+          },
           TABLE,
           dateCols
         )
@@ -397,6 +403,26 @@ describe('SQL Builder', () => {
       expect(render(buildSortClause({ updatedAt: 'asc' }, TABLE, NO_COLUMNS))).toBe(
         `${TABLE}.updatedAt ASC`
       )
+    })
+
+    it('uses direct timestamp column for created_at comparisons', () => {
+      const out = render(
+        buildFilterClause({ created_at: { $gt: '2026-07-20' } }, TABLE, NO_COLUMNS)
+      )
+
+      expect(out).toContain(`${TABLE}.created_at`)
+      expect(out).not.toContain(`data->>'created_at'`)
+      expect(out).toContain('::timestamptz')
+    })
+
+    it('uses direct column equality for created_at', () => {
+      const out = render(
+        buildFilterClause({ created_at: { $eq: '2026-07-20' } }, TABLE, NO_COLUMNS)
+      )
+
+      expect(out).toContain(`${TABLE}.created_at`)
+      expect(out).toContain('=')
+      expect(out).not.toContain(`${TABLE}.data @>`)
     })
 
     it('combines multiple sort fields with commas', () => {

--- a/apps/sim/lib/table/sql.ts
+++ b/apps/sim/lib/table/sql.ts
@@ -17,7 +17,7 @@ import type {
   JsonValue,
   Sort,
 } from '@/lib/table/types'
-import { isBuiltInDateField } from '../../app/api/table/utils'
+import { isBuiltInDateField } from '@/app/api/table/utils.ts'
 
 /**
  * Error thrown when caller-supplied filter or sort input is malformed.

--- a/apps/sim/lib/table/sql.ts
+++ b/apps/sim/lib/table/sql.ts
@@ -17,6 +17,7 @@ import type {
   JsonValue,
   Sort,
 } from '@/lib/table/types'
+import { isBuiltInDateField } from '../../app/api/table/utils'
 
 /**
  * Error thrown when caller-supplied filter or sort input is malformed.
@@ -380,7 +381,9 @@ function buildFieldCondition(
 
         case '$ncontains':
           conditions.push(
-            buildLikeClause(tableName, field, value as string, 'contains', { negate: true })
+            buildLikeClause(tableName, field, value as string, 'contains', {
+              negate: true,
+            })
           )
           break
 
@@ -458,8 +461,15 @@ function buildLogicalClause(
 
 /** Builds JSONB containment clause: `data @> '{"field": value}'::jsonb` (uses GIN index) */
 function buildContainmentClause(tableName: string, field: string, value: JsonValue): SQL {
+  if (isBuiltInDateField(field)) {
+    return sql`${sql.raw(`${tableName}.${field}`)} = ${value}::timestamptz`
+  }
+
   const jsonObj = JSON.stringify({ [field]: value })
   return sql`${sql.raw(`${tableName}.data`)} @> ${jsonObj}::jsonb`
+
+  // const jsonObj = JSON.stringify({ [field]: value })
+  // return sql`${sql.raw(`${tableName}.data`)} @> ${jsonObj}::jsonb`
 }
 
 /**
@@ -485,10 +495,17 @@ function buildComparisonClause(
   value: number | string,
   columnType: ColumnType | undefined
 ): SQL {
+  if (isBuiltInDateField(field)) {
+    columnType = 'date'
+  }
+
   const escapedField = field.replace(/'/g, "''")
   const cast = jsonbCastForType(columnType) ?? 'numeric'
   validateComparisonValue(field, columnType, cast, value)
-  const cell = sql.raw(`(${tableName}.data->>'${escapedField}')::${cast}`)
+
+  const cell = isBuiltInDateField(field)
+    ? sql.raw(`${tableName}.${field}`)
+    : sql.raw(`(${tableName}.data->>'${escapedField}')::${cast}`)
   return cast === 'timestamptz'
     ? sql`${cell} ${sql.raw(operator)} ${value}::timestamptz`
     : sql`${cell} ${sql.raw(operator)} ${value}`


### PR DESCRIPTION
## Summary
Fixes filtering on the built-in timestamp columns (created_at and updated_at) in the Table block.

Previously, filters on these built-in columns incorrectly treated them as JSON fields, causing type validation errors or returning zero rows. This change queries the built-in PostgreSQL timestamp columns directly instead of the JSON data column.

Fixes #5920

## Type of Change
- [X] Bug fix

## Testing
Verified the fix by applying comparison filters ($gt, $gte, $lt, $lte, $eq) on the built-in created_at and updated_at columns and confirming that the expected rows are returned.

Also added/updated unit tests covering built-in timestamp column filtering.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my changes
- [X] Tests added/updated and passing
- [X] No new warnings introduced
- [X] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

Before the fix, applying filters on the built-in timestamp columns (created_at, updated_at) resulted in validation errors:
<img width="1919" height="945" alt="image" src="https://github.com/user-attachments/assets/e9a28ab5-05ca-4a17-9eef-21eefe8101e7" />

Additionally, even when providing a Unix timestamp, the query returned zero rows because the filters were applied against the JSON data column instead of the built-in timestamp columns.