### PR TITLE
improvement(pii): clarify custom regex replacement placeholder

### DIFF
--- a/apps/sim/components/pii/custom-patterns-editor.tsx
+++ b/apps/sim/components/pii/custom-patterns-editor.tsx
@@ -56,7 +56,7 @@ export function CustomPatternsEditor({ patterns, onChange }: CustomPatternsEdito
                 className='flex-1'
               />
               <ChipInput
-                placeholder='EMPLOYEE_ID'
+                placeholder='SUBSTITUTION_TEXT'
                 value={pattern.replacement}
                 onChange={(e) => updateRow(index, { replacement: e.target.value })}
                 className='w-[26%]'


### PR DESCRIPTION
## Summary
- The replacement field in the PII custom regex editor showed `EMPLOYEE_ID` as its placeholder, which read like a specific example rather than a format hint
- Changed it to `SUBSTITUTION_TEXT` so it matches the sibling `Name` / `Pattern (regex)` placeholders

Left `EMPLOYEE_ID` where it's genuinely an example in prose (Data Retention tooltip, docs, TSDoc) — those explain the `EMPLOYEE_ID → <EMPLOYEE_ID>` transform.

## Type of Change
- [x] Improvement

## Testing
Tested manually. `bun run lint` and the full audit suite (boundaries, api-validation:strict, utils, zustand-v5, react-query, client-boundary, bare-icons, icon-paths, realtime-prune, skills:check, agent-stream-docs:check) all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)