### PR TITLE
fix(slack): stop requesting the unapproved scopes, gate them behind an opt-in flag

### DIFF
--- a/apps/sim/blocks/blocks/slack.ts
+++ b/apps/sim/blocks/blocks/slack.ts
@@ -7,25 +7,6 @@ import { normalizeFileInput } from '@/blocks/utils'
 import type { SlackResponse } from '@/tools/slack/types'
 import { getTrigger } from '@/triggers'
 
-/**
- * Scopes added for the native Sim Slack app trigger (`slack_oauth`): the shared
- * app's `app_mention`, assistant-thread, and DM events don't deliver without
- * them. Advertised by `slack_v2` and the trigger only — the legacy block has no
- * feature that needs them, and listing them there would flag every existing
- * Slack credential as missing scopes and prompt a reconnect.
- *
- * This only controls what each picker *advertises* and treats as missing. The
- * authorization request itself is provider-wide
- * (`getCanonicalScopesForProvider('slack')`), so any reconnect grants the full
- * set regardless of which block started it.
- */
-const SLACK_V2_ONLY_SCOPES = new Set(['app_mentions:read', 'assistant:write', 'im:history'])
-
-/** Slack scopes the legacy v1 block advertises — the set from before the trigger expansion. */
-const SLACK_V1_ADVERTISED_SCOPES = getScopesForService('slack').filter(
-  (scope) => !SLACK_V2_ONLY_SCOPES.has(scope)
-)
-
 export const SlackBlock: BlockConfig<SlackResponse> = {
   type: 'slack',
   name: 'Slack',
@@ -126,7 +107,7 @@ export const SlackBlock: BlockConfig<SlackResponse> = {
       canonicalParamId: 'oauthCredential',
       mode: 'basic',
       serviceId: 'slack',
-      requiredScopes: SLACK_V1_ADVERTISED_SCOPES,
+      requiredScopes: getScopesForService('slack'),
       placeholder: 'Select Slack workspace',
       dependsOn: ['authMethod'],
       condition: {
@@ -2661,9 +2642,6 @@ function adaptSubBlockForV2(sb: SubBlockConfig): SubBlockConfig {
       ...rest,
       credentialKind: 'any',
       placeholder: 'Select Slack account or bot',
-      // Full set, unlike v1: v2 hosts the native Sim app trigger, whose events
-      // need the mention/assistant/DM scopes.
-      requiredScopes: getScopesForService('slack'),
       credentialLabels: {
         oauthGroup: 'Sim app',
         oauthConnect: 'Connect the Sim app',

--- a/apps/sim/lib/core/config/env-flags.ts
+++ b/apps/sim/lib/core/config/env-flags.ts
@@ -145,6 +145,28 @@ export const isAppConfigEnabled =
   isHosted && Boolean(env.APPCONFIG_APPLICATION && env.APPCONFIG_ENVIRONMENT)
 
 /**
+ * Whether the deployment's Slack app is approved for `app_mentions:read`,
+ * `assistant:write`, and `im:history` — the scopes backing the native Sim app
+ * trigger's mention, assistant-thread, and DM events.
+ *
+ * Off by default because Slack rejects the ENTIRE authorization when it requests
+ * a scope the app is not approved for, breaking every Slack connect. Sim Cloud's
+ * app is directory-listed and pinned to its review-approved set, so this stays
+ * off there until review lands; a self-hosted deployment pointing at its own
+ * (unlisted) Slack app can opt in.
+ *
+ * Server code reads `SLACK_EXTENDED_SCOPES`. Server-only vars never reach browser
+ * bundles, so client evaluation reads the `NEXT_PUBLIC_SLACK_EXTENDED_SCOPES`
+ * twin (see {@link isBillingEnabled}) — deployments must set both together. The
+ * server value decides the grant; the client value only decides what the credential
+ * pickers advertise and treat as missing.
+ */
+export const isSlackExtendedScopesEnabled =
+  typeof window === 'undefined'
+    ? isTruthy(env.SLACK_EXTENDED_SCOPES)
+    : isTruthy(getEnv('NEXT_PUBLIC_SLACK_EXTENDED_SCOPES'))
+
+/**
  * Is Trigger.dev enabled for async job processing
  */
 export const isTriggerDevEnabled = isTruthy(env.TRIGGER_DEV_ENABLED)

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -421,6 +421,7 @@ export const env = createEnv({
     SLACK_CLIENT_ID:                       z.string().optional(),                  // Slack OAuth client ID
     SLACK_CLIENT_SECRET:                   z.string().optional(),                  // Slack OAuth client secret
     SLACK_SIGNING_SECRET:                  z.string().optional(),                  // Official Sim Slack app signing secret (verifies inbound events for the native OAuth trigger)
+    SLACK_EXTENDED_SCOPES:                 z.boolean().optional(),                 // Request app_mentions:read, assistant:write, im:history — only where the Slack app is approved for them
     REDDIT_CLIENT_ID:                      z.string().optional(),                  // Reddit OAuth client ID
     REDDIT_CLIENT_SECRET:                  z.string().optional(),                  // Reddit OAuth client secret
     WEBFLOW_CLIENT_ID:                     z.string().optional(),                  // Webflow OAuth client ID
@@ -571,6 +572,7 @@ export const env = createEnv({
     // Feature Flags
     NEXT_PUBLIC_SSO_ENABLED:               z.boolean().optional(),                   // Enable SSO login UI components
     NEXT_PUBLIC_ACCESS_CONTROL_ENABLED:    z.boolean().optional(),                   // Enable access control (permission groups) on self-hosted
+    NEXT_PUBLIC_SLACK_EXTENDED_SCOPES:     z.boolean().optional(),                   // Client twin of SLACK_EXTENDED_SCOPES — set both together
     NEXT_PUBLIC_CUSTOM_BLOCKS_ENABLED:     z.boolean().optional(),                   // Enable custom blocks (deploy-as-block) settings on self-hosted
     NEXT_PUBLIC_WHITELABELING_ENABLED:     z.boolean().optional(),                   // Enable whitelabeling on self-hosted (bypasses hosted requirements)
     NEXT_PUBLIC_AUDIT_LOGS_ENABLED:        z.boolean().optional(),                   // Enable audit logs on self-hosted (bypasses hosted requirements)
@@ -612,6 +614,7 @@ export const env = createEnv({
     NEXT_PUBLIC_BRAND_BACKGROUND_COLOR: process.env.NEXT_PUBLIC_BRAND_BACKGROUND_COLOR,
     NEXT_PUBLIC_SSO_ENABLED: process.env.NEXT_PUBLIC_SSO_ENABLED,
     NEXT_PUBLIC_ACCESS_CONTROL_ENABLED: process.env.NEXT_PUBLIC_ACCESS_CONTROL_ENABLED,
+    NEXT_PUBLIC_SLACK_EXTENDED_SCOPES: process.env.NEXT_PUBLIC_SLACK_EXTENDED_SCOPES,
     NEXT_PUBLIC_CUSTOM_BLOCKS_ENABLED: process.env.NEXT_PUBLIC_CUSTOM_BLOCKS_ENABLED,
     NEXT_PUBLIC_WHITELABELING_ENABLED: process.env.NEXT_PUBLIC_WHITELABELING_ENABLED,
     NEXT_PUBLIC_AUDIT_LOGS_ENABLED: process.env.NEXT_PUBLIC_AUDIT_LOGS_ENABLED,

--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -782,9 +782,12 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
           'groups:write',
           'chat:write',
           'chat:write.public',
-          'assistant:write',
-          'app_mentions:read',
-          'im:history',
+          // TODO: Re-add once Slack app review approves these. Requesting a scope
+          // the app is not yet approved for makes Slack reject the entire
+          // authorization with "unapproved permissions requested", breaking connect.
+          // 'assistant:write',
+          // 'app_mentions:read',
+          // 'im:history',
           'im:write',
           'im:read',
           'users:read',

--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -57,6 +57,7 @@ import {
   ZoomIcon,
 } from '@/components/icons'
 import { env } from '@/lib/core/config/env'
+import { isSlackExtendedScopesEnabled } from '@/lib/core/config/env-flags'
 import {
   DEFAULT_MAX_ERROR_BODY_BYTES,
   readResponseTextWithLimit,
@@ -65,6 +66,16 @@ import { parseInstagramLongLivedToken } from '@/lib/oauth/instagram'
 import type { OAuthProviderConfig } from './types'
 
 const logger = createLogger('OAuth')
+
+/**
+ * Slack scopes requested only where the app is approved for them, gated by
+ * {@link isSlackExtendedScopesEnabled}. Slack rejects the entire authorization
+ * with "unapproved permissions requested" when any requested scope is not on the
+ * app's approved list, so these stay out of the default grant.
+ */
+const SLACK_APPROVAL_GATED_SCOPES = isSlackExtendedScopesEnabled
+  ? (['assistant:write', 'app_mentions:read', 'im:history'] as const)
+  : ([] as const)
 
 export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
   'claude-platform': {
@@ -782,12 +793,7 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
           'groups:write',
           'chat:write',
           'chat:write.public',
-          // TODO: Re-add once Slack app review approves these. Requesting a scope
-          // the app is not yet approved for makes Slack reject the entire
-          // authorization with "unapproved permissions requested", breaking connect.
-          // 'assistant:write',
-          // 'app_mentions:read',
-          // 'im:history',
+          ...SLACK_APPROVAL_GATED_SCOPES,
           'im:write',
           'im:read',
           'users:read',

--- a/packages/testing/src/mocks/env-flags.mock.ts
+++ b/packages/testing/src/mocks/env-flags.mock.ts
@@ -21,6 +21,7 @@ export interface EnvFlagsMockState {
   isEmailPasswordEnabled: boolean
   isSignupMxValidationEnabled: boolean
   isAppConfigEnabled: boolean
+  isSlackExtendedScopesEnabled: boolean
   isTriggerDevEnabled: boolean
   isSsoEnabled: boolean
   isAccessControlEnabled: boolean
@@ -61,6 +62,7 @@ const defaultEnvFlagsState: EnvFlagsMockState = {
   isEmailPasswordEnabled: true,
   isSignupMxValidationEnabled: false,
   isAppConfigEnabled: false,
+  isSlackExtendedScopesEnabled: false,
   isTriggerDevEnabled: false,
   isSsoEnabled: false,
   isAccessControlEnabled: false,


### PR DESCRIPTION
## Summary
- Connecting the Sim Slack app fails with `Unapproved permissions requested: assistant:write, app_mentions:read, im:history`. Slack rejects the **entire** authorization when it requests a scope the app isn't approved for, so every native Slack connect is broken on prod.
- #5898 re-added those three scopes on the premise that Slack app review had approved them. It hasn't. This reverts that change — an exact revert, `git diff 84e7aad633^` against both files is empty. Same regression #5631 fixed in July.
- Also drops the `SLACK_V2_ONLY_SCOPES` / `SLACK_V1_ADVERTISED_SCOPES` advertising split #5898 added. With the three scopes out of the base list that filter removes nothing, and having `slack_v2` advertise them would flag every Slack credential as missing scopes with no reconnect that clears it.
- Adds `SLACK_EXTENDED_SCOPES` (+ `NEXT_PUBLIC_SLACK_EXTENDED_SCOPES` client twin) so the three scopes can be turned back on without another code change. Defaults to **false** — `isTruthy(undefined)` is false, so unset means the 17 approved scopes. Flip it the day Slack approves, or on a self-hosted deployment pointing at its own (unlisted) Slack app that already carries them.

Gated via `env-flags.ts` rather than AppConfig because `OAUTH_PROVIDERS` is imported by client components for `requiredScopes` — an async server-only lookup can't reach it. Server var decides the grant; the client twin only decides what the credential pickers advertise. Set both together.

Cost until the flag goes on is the same as pre-#5898: `app_mention`, assistant-thread, and DM events don't deliver on the native Sim app trigger. Custom bot is unaffected and still covers those.

## Type of Change
- [x] Bug fix (regression)

## Testing
Tested manually. Verified the flag toggles the grant correctly — off yields 17 scopes with none of the gated three, on yields 20 with exactly `assistant:write`, `app_mentions:read`, `im:history`. `bun run type-check` clean (19/19), `bun run lint` clean, and the full audit suite passes (`check:boundaries`, `check:api-validation:strict`, `check:utils`, `check:zustand-v5`, `check:react-query`, `check:client-boundary`, `check:bare-icons`, `check:icon-paths`, `check:realtime-prune`, `skills:check`, `agent-stream-docs:check`). 3,361 tests green across `lib/oauth`, `lib/core`, `lib/auth`, `lib/credentials`, `blocks/`, `triggers/`, `tools/slack`, `lib/webhooks`, `lib/copilot`, `lib/permissions`, `lib/integrations` — broad sweep because the new flag needed a field in the repo-wide shared `env-flags` test mock.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)