### PR TITLE
fix(security): suppress the CodeQL password-hash false positive on sha256Hex

### DIFF
--- a/packages/security/src/hash.ts
+++ b/packages/security/src/hash.ts
@@ -5,13 +5,28 @@ import { createHash } from 'node:crypto'
  * content passes as a Uint8Array/Buffer. Use for indexed lookup of sensitive
  * values (e.g. API key hash columns) and content-integrity receipts where the
  * caller only needs to verify equality without ever reversing the hash.
+ *
+ * NOT for human-chosen passwords — those are low-entropy and need a slow KDF.
+ * User credentials never reach this helper: Better Auth owns them and applies
+ * its own KDF. What does reach it is high-entropy material where a fast digest
+ * is the correct construction:
+ *
+ * - API keys (`sim_`/`sk-sim-` + `generateSecureToken(24)`, 192 random bits).
+ *   A slow KDF here would buy nothing against a keyspace that cannot be
+ *   searched, while forcing every authenticated request through it.
+ * - Already-encrypted values, content digests, and cache/idempotency keys.
+ *
+ * CodeQL's `js/insufficient-password-hash` flags the sink because callers pass
+ * arguments it name-matches as passwords (`apiKey`, `encryptedPassword`). The
+ * suppressions below record that judgement; keep the invariant above true, and
+ * route any genuine password through Better Auth rather than this function.
  */
 export function sha256Hex(input: string | Uint8Array): string {
   const hash = createHash('sha256')
   if (typeof input === 'string') {
-    hash.update(input, 'utf8')
+    hash.update(input, 'utf8') // lgtm[js/insufficient-password-hash]
   } else {
-    hash.update(input)
+    hash.update(input) // lgtm[js/insufficient-password-hash]
   }
   return hash.digest('hex')
 }


### PR DESCRIPTION
## Summary
CodeQL fails **#5963** (the v0.7.46 release PR) with 2 high-severity `js/insufficient-password-hash` alerts on `packages/security/src/hash.ts:12` and `:14`. Both are false positives, but the check is required, so the release is blocked.

**Why they appeared now.** `d362e6816e` (setup wizard) added `sha256Base64Url` to this file. Touching it made every pre-existing taint path that ends here count as "new code changed by this pull request" — CodeQL's own summary hints at this ("Alerts not introduced by this pull request might have been detected because the code changes were too large"). The flagged lines are in `sha256Hex`, which was not modified, and neither were any of its callers.

**Why they're false positives.** Neither taint source is a human-chosen password:

| Caller | What it passes |
|---|---|
| `hashApiKey(plainKey)` | An API key built from `generateSecureToken(24)` = `randomBytes(24)` — 192 bits. A fast digest is the correct construction for an indexed `WHERE key_hash = $1` lookup; a slow KDF would run on every authenticated request and buy nothing against a keyspace that cannot be searched. |
| `passwordSlot(encryptedPassword)` | An **already-encrypted** value, hashed to an 8-char discriminator so deployment auth tokens invalidate when the password changes. Not credential storage. |

User credentials never reach this helper — Better Auth owns them and applies its own KDF. I verified there is no other password-shaped caller.

## Approach
Inline `// lgtm[js/insufficient-password-hash]` on the two flagged lines, matching the convention this repo already uses for the same class of judgement (`uuidV5` in `apps/sim/ee/workspace-forking/lib/remap/block-identity.ts` suppresses `js/weak-cryptographic-algorithm` the same way; there are currently 0 open alerts for that rule, so the mechanism works).

The `sha256Hex` doc comment now states the invariant — high-entropy secrets and content digests only, genuine passwords go to Better Auth — so a future caller has the rule in front of them rather than inheriting a silent suppression.

`sha256Base64Url` is deliberately left unannotated even though it is the same primitive: it was not flagged, and a speculative suppression there would hide a real finding later.

## Type of Change
- [x] Bug fix (unblocks a failing required check)

## Testing
`packages/security` suite passes (35 tests), `bun run lint` clean. No behavior change — comments only.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)