### PR TITLE
fix(content): stop wide markdown tables breaking the mobile layout

### DIFF
--- a/apps/sim/lib/content/mdx.tsx
+++ b/apps/sim/lib/content/mdx.tsx
@@ -1,3 +1,4 @@
+import type { ComponentPropsWithoutRef } from 'react'
 import clsx from 'clsx'
 import type { MDXRemoteProps } from 'next-mdx-remote/rsc'
 import { CodeBlock } from '@/lib/content/code'
@@ -132,7 +133,7 @@ export const mdxComponents: MDXRemoteProps['components'] = {
    * scroll area — narrow enough that tables which already fit (two or three
    * columns on a tablet, anything on desktop) never gain a scrollbar.
    */
-  table: ({ className, ...props }: any) => (
+  table: ({ className, ...props }: ComponentPropsWithoutRef<'table'>) => (
     <div className='my-6 w-full overflow-x-auto'>
       <table {...props} className={clsx('my-0 min-w-[520px]', className)} />
     </div>

--- a/apps/sim/lib/content/mdx.tsx
+++ b/apps/sim/lib/content/mdx.tsx
@@ -122,6 +122,21 @@ export const mdxComponents: MDXRemoteProps['components'] = {
       />
     )
   },
+  /**
+   * GFM comparison tables run up to nine columns of prose, which no phone can
+   * fit. Without a scroll container the table sets the page's content width and
+   * the whole article scrolls sideways, clipping body copy at both edges. The
+   * wrapper confines that scrolling to the table's own axis.
+   *
+   * `min-w` keeps columns from collapsing to one word per line inside the
+   * scroll area — narrow enough that tables which already fit (two or three
+   * columns on a tablet, anything on desktop) never gain a scrollbar.
+   */
+  table: ({ className, ...props }: any) => (
+    <div className='my-6 w-full overflow-x-auto'>
+      <table {...props} className={clsx('my-0 min-w-[520px]', className)} />
+    </div>
+  ),
   figure: (props: any) => (
     <figure {...props} className={clsx('my-8 overflow-hidden rounded-lg', props.className)} />
   ),

--- a/apps/sim/tailwind.config.ts
+++ b/apps/sim/tailwind.config.ts
@@ -13,6 +13,13 @@ export default {
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
+    /**
+     * `lib/content/mdx.tsx` styles rendered blog/library markdown, so it emits
+     * classes like any component does. Without this glob Tailwind only
+     * generates the ones that happen to appear in a scanned file too, and a
+     * class unique to this directory silently resolves to nothing.
+     */
+    './lib/**/*.{js,ts,jsx,tsx,mdx}',
     '../../packages/emcn/src/**/*.{js,ts,jsx,tsx}',
     '../../packages/workflow-renderer/src/**/*.{js,ts,jsx,tsx}',
     '!./app/node_modules/**',


### PR DESCRIPTION
## Summary
Reported on mobile for [/library/ai-agents-in-procurement](https://www.sim.ai/library/ai-agents-in-procurement).

- Library and blog posts render GFM tables straight into the prose container with no width bound. Comparison tables run up to **nine columns**, so on a phone the table set the article's content width — body copy was clipped at both edges and the table's right-hand columns were unreachable, with no scroll to get to them
- **19 of 20 library posts contain a table**, so this affected nearly the whole section
- Wraps tables in an `overflow-x-auto` container so scrolling is confined to the table's own axis, plus a `min-w` so columns don't crush to one word per line inside it
- Blog and library both compile through the same `mdxComponents` map via `createContentRegistry`, so one fix covers both surfaces

## The Tailwind part
`min-w-[520px]` initially did nothing. `apps/sim/tailwind.config.ts` scanned only `app`, `components`, and `pages` — not `lib` — so `lib/content/mdx.tsx` was invisible to Tailwind and any class unique to it was never generated.

That was **not** a stale-cache artifact; I isolated it in a clean worktree with `.next` removed:

| | computed `min-width` |
|---|---|
| `mdx.tsx` fix only | `0px` |
| `mdx.tsx` fix + `lib/**` glob | `520px` |

It also means existing styles in that file were already silently dead — `list-outside`, `text-[19px]`, `text-[0.9em]`, `my-0` were all missing from the generated CSS, which is why the file leans on inline `style` for font sizes. Adding the glob grows the CSS by 538 bytes minified (+0.26%), all additions, nothing removed.

## Verification
Driven in a real browser (Chromium, iPhone viewport + tablet + desktop) against pages with 3, 4, and 9 column tables:

| viewport | page scrolls sideways | table wrapped | table scrolls |
|---|---|---|---|
| iPhone 390px | no (was: clipped) | yes | yes |
| Tablet 768px | no | yes | only the 9-col |
| Desktop 1440px | no | yes | only the 9-col |

No page scrolls horizontally at any viewport, and narrow tables gain no scrollbar on tablet/desktop, so there's no regression for tables that already fit. Blog verified by temporarily un-drafting `blog/copilot` locally (it's `draft: true`, so it 404s otherwise) — same wrapper, same result.

## Note
The scroll edge has no visual affordance (fade or shadow) hinting the table scrolls. Worth a follow-up, but out of scope here.

## Type of Change
- [x] Bug fix

## Testing
Tested manually in a browser across three viewports and four posts, as tabled above.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)