### PR TITLE
improvement(landing): lead the hero H1 with the AI workspace keywords

### DIFF
--- a/.claude/rules/landing-seo-geo.md
+++ b/.claude/rules/landing-seo-geo.md
@@ -22,7 +22,7 @@ paths:
 - **Answer-first pattern**: each section's H2 + subtitle should directly answer a user question (e.g. "What is Sim?", "How fast can I deploy?").
 - **Atomic answer blocks**: each feature / template card should be independently extractable by an AI summariser.
 - **Entity consistency**: always write "Sim" by name — never "the platform" or "our tool".
-- **Keyword density**: first 150 visible chars of Hero must name "Sim", "AI workspace", "AI agents".
+- **Keyword density**: first 150 visible chars of Hero must name "AI workspace" and "AI agents". "Sim" is carried by the title tag, the meta description, and the Hero `sr-only` summary — the H1 does not have to spend its opening words on the brand.
 - **sr-only summaries**: Hero and Templates each have a `<p className="sr-only">` (~50 words) as an atomic product/catalog summary for AI citation.
 - **Specific numbers**: prefer concrete figures ("1,000+ integrations", "15+ AI providers") over vague claims.
 

--- a/apps/sim/app/(landing)/CLAUDE.md
+++ b/apps/sim/app/(landing)/CLAUDE.md
@@ -44,7 +44,7 @@ Target: Lighthouse 95+ on mobile, LCP < 2.0s, CLS < 0.05, minimal hydration cost
 
 `page.tsx` owns the metadata (title, description, OG/Twitter, canonical, robots) - keep it the single source of truth and keep it aligned with the constitution's claim hierarchy. Beyond metadata:
 
-- **One `<h1>`, in the hero, containing "Sim" and "AI workspace".** Strict hierarchy below it: H2 per section, H3 for items within a section. Never skip levels, never add a second H1.
+- **One `<h1>`, in the hero, containing "AI workspace".** The brand carries in the title tag, the meta description, and the hero's `sr-only` summary, so the H1 itself is free to lead with the non-brand keywords people actually search ("AI workspace", "AI agents") rather than spending its first two words on "Sim is the". Whichever wording it uses, the hero's `sr-only` paragraph must still open by naming Sim. Strict hierarchy below it: H2 per section, H3 for items within a section. Never skip levels, never add a second H1.
 - **Semantic landmarks**: `<header>`, `<main>`, `<footer>`, `<nav>`; each section is `<section id="…" aria-labelledby="…-heading">`. Decorative/animated elements get `aria-hidden='true'`.
 - **Structured data**: emit JSON-LD (`Organization`, `WebSite`, `WebApplication` with `featureList`, `FAQPage` if an FAQ exists) from a server component rendered before visible content. Keep `featureList` in sync with the features actually shown on the page.
 - **Crawlable links**: all internal navigation uses Next `<Link>` with real `href`s - never `onClick` navigation. External links get `rel='noopener noreferrer'`.

--- a/apps/sim/app/(landing)/components/hero/hero.tsx
+++ b/apps/sim/app/(landing)/components/hero/hero.tsx
@@ -86,8 +86,8 @@ export function Hero() {
         headingId='hero-heading'
         heading={
           <>
-            Sim is the AI workspace for <br />
-            building and managing AI agents.
+            The AI Workspace for Building <br />
+            and Managing AI Agents.
           </>
         }
         description='Open source, with 1,000+ integrations and every major LLM. Build, deploy, and manage agents visually, conversationally, or with code.'


### PR DESCRIPTION
## Summary
- Hero H1: `Sim is the AI workspace for building and managing AI agents.` → `The AI Workspace for Building and Managing AI Agents.`
- Relaxes the landing H1 rule in `app/(landing)/CLAUDE.md` and `.claude/rules/landing-seo-geo.md`, which both required the brand to appear in the heading itself

## Notes
From Emir's SEO doc. The H1 spent its first three words on a brand token already carried by the title tag, the meta description, and the hero's `sr-only` summary — so it now leads with the terms people actually search.

Both rule files asserted the H1 must contain "Sim", so this ships the doc change alongside the code rather than leaving the rules silently contradicting the page. The relaxed rules still require "AI workspace" + "AI agents" in the H1 and still require the hero `sr-only` summary to open by naming Sim, which is what preserves entity consistency for answer engines.

Worth flagging separately: **most of that doc is already live.** The suggested title, meta description, product-demo body, and "AI agents" H2 all shipped previously — verified against the live HTML. This H1 was the only remaining delta worth taking. The suggested hero *subhead* rewrite was not adopted: it opens "Sim is an AI agent and workflow builder", which contradicts `constitution.md` (Sim is the AI workspace; "workflow tool" is in the never column), drops "Open source", and runs 3 sentences against the tone rule.

## Type of Change
- [x] Improvement

## Testing
- `tsc` and lint clean
- Verified the invariants that survive the rule change: H1 still contains "AI workspace" and "AI agents", hero `sr-only` still opens with "Sim", still exactly one `<h1>` in the hero
- No test or structured-data field asserts the old H1 string (checked)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)