### PR TITLE
fix(cleanup): bind array params as arrays, not expanded value lists

### DIFF
--- a/apps/sim/lib/execution/payloads/large-value-metadata.ts
+++ b/apps/sim/lib/execution/payloads/large-value-metadata.ts
@@ -396,7 +396,7 @@ async function pruneStaleReferences(
       WHERE ref.ctid IN (
         SELECT ref.ctid
         FROM ${executionLargeValueReferences} AS ref
-        WHERE ref.workspace_id = ANY(${workspaceIds}::text[])
+        WHERE ref.workspace_id = ANY(${sql.param(workspaceIds)}::text[])
           AND (
             (
               ref.source = 'execution_log'
@@ -437,7 +437,7 @@ async function pruneDeletedParentDependencies(
       WHERE dependency.ctid IN (
         SELECT dependency.ctid
         FROM ${executionLargeValueDependencies} AS dependency
-        WHERE dependency.workspace_id = ANY(${workspaceIds}::text[])
+        WHERE dependency.workspace_id = ANY(${sql.param(workspaceIds)}::text[])
           AND (
             EXISTS (
               SELECT 1
@@ -472,7 +472,7 @@ async function pruneDeletedLargeValueTombstones(
       WHERE value.ctid IN (
         SELECT value.ctid
         FROM ${executionLargeValues} AS value
-        WHERE value.workspace_id = ANY(${workspaceIds}::text[])
+        WHERE value.workspace_id = ANY(${sql.param(workspaceIds)}::text[])
           AND value.deleted_at IS NOT NULL
           AND value.deleted_at < ${deletedBefore}
           AND NOT EXISTS (

--- a/apps/sim/lib/execution/payloads/prune-metadata-sql.test.ts
+++ b/apps/sim/lib/execution/payloads/prune-metadata-sql.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment node
+ */
+
+// Renders the real prune statements against the real drizzle dialect and
+// schema. These are raw `sql` templates, so a rendering bug only surfaces at
+// execution time — the global drizzle/schema mocks would hide it entirely.
+import { describe, expect, it, vi } from 'vitest'
+
+vi.unmock('drizzle-orm')
+vi.unmock('@sim/db')
+vi.unmock('@sim/db/schema')
+
+process.env.DATABASE_URL ??= 'postgresql://user:pass@localhost:5432/test'
+
+const { PgDialect } = await import('drizzle-orm/pg-core')
+const { pruneLargeValueMetadata } = await import('@/lib/execution/payloads/large-value-metadata')
+
+/** Captures the raw statements `pruneLargeValueMetadata` issues, without a database. */
+async function renderPruneStatements(workspaceIds: string[]): Promise<string[]> {
+  const dialect = new PgDialect()
+  const rendered: string[] = []
+  const capturingClient = {
+    execute: async (query: Parameters<PgDialect['sqlToQuery']>[0]) => {
+      rendered.push(dialect.sqlToQuery(query).sql)
+      return [{ count: 0 }]
+    },
+  }
+
+  await pruneLargeValueMetadata({
+    workspaceIds,
+    tombstonesDeletedBefore: new Date('2026-01-01T00:00:00Z'),
+    dbClient: capturingClient as unknown as Parameters<
+      typeof pruneLargeValueMetadata
+    >[0]['dbClient'],
+  })
+
+  return rendered
+}
+
+describe('pruneLargeValueMetadata SQL', () => {
+  it('binds workspace ids as one array parameter, not a value list', async () => {
+    const statements = await renderPruneStatements(['ws-1', 'ws-2'])
+
+    expect(statements.length).toBeGreaterThan(0)
+    for (const statement of statements) {
+      // `ANY(($1, $2)::text[])` is what interpolating the raw JS array yields —
+      // Postgres rejects it ("cannot cast type record to text[]"), and with a
+      // single id `ANY(($1)::text[])` fails as 22P02 instead.
+      expect(statement).not.toMatch(/ANY\(\(\$\d+/)
+      expect(statement).toMatch(/ANY\(\$\d+::text\[\]\)/)
+    }
+  })
+
+  it('renders identically for a single workspace id', async () => {
+    const statements = await renderPruneStatements(['ws-only'])
+
+    expect(statements.length).toBeGreaterThan(0)
+    for (const statement of statements) {
+      expect(statement).toMatch(/ANY\(\$\d+::text\[\]\)/)
+    }
+  })
+})

--- a/apps/sim/lib/webhooks/polling/utils.test.ts
+++ b/apps/sim/lib/webhooks/polling/utils.test.ts
@@ -9,18 +9,23 @@ const { sqlCalls } = vi.hoisted(() => ({
   sqlCalls: [] as Array<{ strings: readonly string[]; values: unknown[] }>,
 }))
 
-vi.mock('drizzle-orm', () => ({
-  sql: (strings: readonly string[], ...values: unknown[]) => {
+vi.mock('drizzle-orm', () => {
+  const sql = (strings: readonly string[], ...values: unknown[]) => {
     const node = { strings, values }
     sqlCalls.push(node)
     return node
-  },
-  and: vi.fn(),
-  eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
-  isNull: vi.fn(),
-  ne: vi.fn(),
-  or: vi.fn(),
-}))
+  }
+  // Identity, so a `sql.param(arr)` value still shows up verbatim in `values`.
+  sql.param = (value: unknown) => value
+  return {
+    sql,
+    and: vi.fn(),
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+    isNull: vi.fn(),
+    ne: vi.fn(),
+    or: vi.fn(),
+  }
+})
 vi.mock('@/app/api/auth/oauth/utils', () => ({
   getOAuthToken: vi.fn(),
   refreshAccessTokenIfNeeded: vi.fn(),

--- a/apps/sim/lib/webhooks/polling/utils.ts
+++ b/apps/sim/lib/webhooks/polling/utils.ts
@@ -164,7 +164,8 @@ export async function updateWebhookProviderConfig(
     }
 
     const merged = sql`COALESCE(${webhook.providerConfig}::jsonb, '{}'::jsonb) || ${JSON.stringify(defined)}::jsonb`
-    const nextConfig = removedKeys.length > 0 ? sql`(${merged}) - ${removedKeys}::text[]` : merged
+    const nextConfig =
+      removedKeys.length > 0 ? sql`(${merged}) - ${sql.param(removedKeys)}::text[]` : merged
 
     await db
       .update(webhook)

--- a/packages/testing/src/mocks/database.mock.ts
+++ b/packages/testing/src/mocks/database.mock.ts
@@ -25,6 +25,13 @@ export function createMockSql() {
     }),
   })
 
+  // Binds a value as a single parameter — drizzle's escape hatch for passing an
+  // array to Postgres as an array rather than expanding it into a value list.
+  sqlFn.param = (value: any) => ({
+    value,
+    toSQL: () => ({ sql: '?', params: [value] }),
+  })
+
   return sqlFn
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to #6004, which fixed the status arrays but missed the same pattern elsewhere. Prod is still logging `Failed to prune metadata`: `ref.workspace_id = ANY(($1)::text[])` → `22P02 Array value must start with "{"`
- Drizzle expands an interpolated JS array into a value list, so `ANY(${arr}::text[])` casts a row constructor (or, with one element, a bare scalar) to `text[]` — Postgres rejects both
- Fixed the 3 `workspaceIds` sites in the prune queries with `sql.param(...)`, which binds the whole array as a single parameter (`ANY($1::text[])`) and is correct at every size, including empty
- Swept the codebase for the pattern and found one more real instance: `lib/webhooks/polling/utils.ts` built `- ${removedKeys}::text[]` for the jsonb key-removal operator, so any polling config update that drops a key would fail the same way. Fixed identically
- The `script-migrations` hits use postgres-js's own `sql` tag, which binds arrays natively — not affected. The `mcp/discover` `IN ${workspaceIds}` is guarded against empty upstream — left alone

## Type of Change
- [x] Bug fix

## Testing
- New `prune-metadata-sql.test.ts` renders the real prune statements (unmocking drizzle + schema, capturing via a fake client) and asserts `ANY($1::text[])` — verified it fails on the old form and passes on the fix, for both single and multi id
- Ran the fixed prune query against staging Postgres with 1 workspace id and with an empty array: both execute (the old form errors)
- Added `sql.param` to the shared testing mock and the polling test's local drizzle mock; 126 tests across payloads, webhooks/polling, cleanup pass
- `tsc --noEmit` clean; `bun run lint` and the full audit suite pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)