### PR TITLE
fix: persist Copilot drafts per workflow

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -116,6 +116,8 @@ export const Panel = memo(function Panel() {
   const router = useRouter()
   const params = useParams()
   const workspaceId = params.workspaceId as string
+  const workflowId = params.workflowId as string
+  const copilotDraftScopeKey = `${workspaceId}:copilot:${workflowId}`
 
   const posthog = usePostHog()
   const posthogRef = useRef(posthog)
@@ -898,6 +900,7 @@ export const Panel = memo(function Panel() {
                   onCancelQueueEdit={copilotCancelQueueEdit}
                   userId={session?.user?.id}
                   chatId={copilotResolvedChatId}
+                  draftScopeKey={copilotDraftScopeKey}
                   layout='copilot-view'
                 />
               </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -116,8 +116,6 @@ export const Panel = memo(function Panel() {
   const router = useRouter()
   const params = useParams()
   const workspaceId = params.workspaceId as string
-  const workflowId = params.workflowId as string
-  const copilotDraftScopeKey = `${workspaceId}:copilot:${workflowId}`
 
   const posthog = usePostHog()
   const posthogRef = useRef(posthog)
@@ -153,6 +151,9 @@ export const Panel = memo(function Panel() {
   const { data: workflows = {} } = useWorkflowMap(workspaceId)
   const { data: folders = {} } = useFolderMap(workspaceId)
   const activeWorkflowId = useWorkflowRegistry((state) => state.activeWorkflowId)
+  const copilotDraftScopeKey = activeWorkflowId
+    ? `${workspaceId}:copilot:${activeWorkflowId}`
+    : undefined
   const { handleAutoLayout: autoLayoutWithFitView } = useAutoLayout(activeWorkflowId || null)
 
   // Check for locked blocks (disables auto-layout)
@@ -885,6 +886,7 @@ export const Panel = memo(function Panel() {
                 </div>
 
                 <MothershipChat
+                  key={copilotDraftScopeKey}
                   className='min-h-0 flex-1'
                   messages={copilotMessages}
                   isSending={copilotIsSending}


### PR DESCRIPTION
## Summary
Persist unsent workflow Copilot drafts across navigation, including text, attachments, and contexts.

## Why
Workflow panel drafts were not restored after navigating away, and must remain isolated per workflow and from the main workspace chat.

## How
Build a stable draft scope key from the route workspace and workflow IDs and pass it to `MothershipChat`, reusing the existing draft restore and post-submission cleanup behavior.