### PR TITLE
fix: scope copilot drafts by workflow

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -116,6 +116,8 @@ export const Panel = memo(function Panel() {
   const router = useRouter()
   const params = useParams()
   const workspaceId = params.workspaceId as string
+  const workflowId = params.workflowId as string
+  const copilotDraftScopeKey = `${workspaceId}:copilot:${workflowId}`
 
   const posthog = usePostHog()
   const posthogRef = useRef(posthog)
@@ -898,6 +900,7 @@ export const Panel = memo(function Panel() {
                   onCancelQueueEdit={copilotCancelQueueEdit}
                   userId={session?.user?.id}
                   chatId={copilotResolvedChatId}
+                  draftScopeKey={copilotDraftScopeKey}
                   layout='copilot-view'
                 />
               </div>


### PR DESCRIPTION
## Summary
Pass a workflow-specific draft scope key to `MothershipChat` in the workspace copilot panel.

## Why
Copilot drafts need to remain isolated between workflows and from Home chat while preserving persisted text, attachments, and contexts.

## How
Read `workflowId` from the route, build a stable `${workspaceId}:copilot:${workflowId}` key, and provide it through `draftScopeKey`.