### PR TITLE
Pi: You are the senior engineer who opened PR #6020 on simstudioai/sim (...

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -116,6 +116,7 @@ export const Panel = memo(function Panel() {
   const router = useRouter()
   const params = useParams()
   const workspaceId = params.workspaceId as string
+  const workflowId = params.workflowId as string
 
   const posthog = usePostHog()
   const posthogRef = useRef(posthog)
@@ -377,6 +378,9 @@ export const Panel = memo(function Panel() {
       },
     })
   )
+
+  const copilotDraftScopeKey =
+    `${workspaceId}:copilot:${workflowId}:${copilotChatId ?? copilotResolvedChatId ?? 'new'}`
 
   const handleCopilotNewChat = useCallback(() => {
     if (!activeWorkflowId || !workspaceId) return
@@ -898,6 +902,7 @@ export const Panel = memo(function Panel() {
                   onCancelQueueEdit={copilotCancelQueueEdit}
                   userId={session?.user?.id}
                   chatId={copilotResolvedChatId}
+                  draftScopeKey={copilotDraftScopeKey}
                   layout='copilot-view'
                 />
               </div>


### PR DESCRIPTION
## Task

You are the senior engineer who opened PR #6020 on simstudioai/sim (branch ""pi/AHNfUroy"" into staging) for this eng-todo task:
<@U0BLD9VE2P4> do this

CI and/or the automated reviewers (GitHub Actions, Cursor Bugbot, Greptile) are not yet green. Address the following concrete feedback by committing to the SAME existing branch and pull request — do NOT open a new PR:

In `apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx`, include the active/resolved copilot chat ID (falling back to `'new'`) in `copilotDraftScopeKey`, so drafts, attachments, and contexts are isolated per chat rather than shared across the workflow.

IMPORTANT: If the feedback above is empty or only indicates that checks are still pending/running (nothing concrete to change), then make NO code changes and simply exit — a later round will re-check. Otherwise: read the relevant code first, make the SMALLEST correct change that follows existing codebase patterns, and do not add defensive code for unlikely scenarios. Rely on CI to re-run after you push; do not try to run the full test suite locally (the sandbox may lack bun/Biome/TypeScript).

## Summary

Updated `apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx`:

- Added the route workflow ID to the Copilot draft scope.
- Included `copilotChatId`, falling back to `copilotResolvedChatId`, then `'new'`.
- Passed `copilotDraftScopeKey` to `MothershipChat`.

This isolates Copilot drafts, attachments, and contexts by workspace, workflow, and chat. Tests were not run per instructions.