### PR TITLE
fix(connectors): attribute SharePoint not-found errors to the matched library

### DIFF
--- a/apps/sim/connectors/sharepoint/sharepoint.test.ts
+++ b/apps/sim/connectors/sharepoint/sharepoint.test.ts
@@ -283,6 +283,20 @@ describe('resolveFolderTarget', () => {
     expect(message).not.toContain('Shared Documents" should be omitted')
   })
 
+  it('still offers the prefix hint when the path names the default library itself', async () => {
+    mockGraph({
+      ...defaultDriveRoute,
+      ...sitesDrivesRoute,
+      ...rootChildren(DEFAULT_DRIVE_ID, [folder('d1', 'Archive')]),
+    })
+
+    const error = await resolve('Shared Documents/Reports').catch((e: Error) => e)
+
+    const message = (error as Error).message
+    expect(message).toContain('document library "Documents"')
+    expect(message).toContain('Shared Documents" should be omitted')
+  })
+
   it('surfaces a failure to open the default library rather than reporting not-found', async () => {
     mockGraph({
       [`${GRAPH}/sites/${SITE_ID}/drive?$select=id,name,webUrl`]: { status: 403 },

--- a/apps/sim/connectors/sharepoint/sharepoint.test.ts
+++ b/apps/sim/connectors/sharepoint/sharepoint.test.ts
@@ -264,6 +264,25 @@ describe('resolveFolderTarget', () => {
     )
   })
 
+  it('blames the matched library, not the default one, when its remainder is wrong', async () => {
+    mockGraph({
+      ...defaultDriveRoute,
+      ...sitesDrivesRoute,
+      ...rootChildren(DEFAULT_DRIVE_ID, [folder('d1', 'Archive')]),
+      ...rootChildren(POLICIES_DRIVE_ID, [folder('p1', 'Onboarding')]),
+    })
+
+    const error = await resolve('Policies/HR').catch((e: Error) => e)
+
+    expect(error).toBeInstanceOf(Error)
+    const message = (error as Error).message
+    expect(message).toContain('document library "Policies"')
+    expect(message).toContain('"HR"')
+    expect(message).toContain('"Onboarding"')
+    expect(message).not.toContain('document library "Documents"')
+    expect(message).not.toContain('Shared Documents" should be omitted')
+  })
+
   it('surfaces a failure to open the default library rather than reporting not-found', async () => {
     mockGraph({
       [`${GRAPH}/sites/${SITE_ID}/drive?$select=id,name,webUrl`]: { status: 403 },

--- a/apps/sim/connectors/sharepoint/sharepoint.ts
+++ b/apps/sim/connectors/sharepoint/sharepoint.ts
@@ -545,7 +545,7 @@ export async function resolveFolderTarget(
       trimmed,
       libraryMatch ? segments.slice(1) : segments,
       drives,
-      !libraryMatch,
+      reportDrive.id === defaultDrive.id,
       retryOptions
     )
   )

--- a/apps/sim/connectors/sharepoint/sharepoint.ts
+++ b/apps/sim/connectors/sharepoint/sharepoint.ts
@@ -527,14 +527,25 @@ export async function resolveFolderTarget(
     return { driveId: defaultDrive.id, driveName: defaultDriveName, folderId: walked.id }
   }
 
+  /**
+   * When the first segment named a real library, that library is the one the
+   * user meant — report against it and its remainder, not against the default
+   * library and the full path, which would blame the wrong library and advise
+   * stripping a prefix that was correct.
+   */
+  const reportDrive = libraryMatch
+    ? { id: libraryMatch.id, name: libraryMatch.name || segments[0] }
+    : { id: defaultDrive.id, name: defaultDriveName }
+
   throw new Error(
     await buildFolderNotFoundMessage(
       accessToken,
-      { id: defaultDrive.id, name: defaultDriveName },
+      reportDrive,
       siteName || siteUrl,
       trimmed,
-      segments,
+      libraryMatch ? segments.slice(1) : segments,
       drives,
+      !libraryMatch,
       retryOptions
     )
   )
@@ -572,6 +583,11 @@ function matchesDriveName(drive: Drive, segment: string): boolean {
 /**
  * Builds a diagnostic failure message naming the site, the library searched,
  * the path attempted, and the folders that actually exist at that level.
+ *
+ * `searchedDefaultLibrary` gates the advice about stripping a leading library
+ * name: that hint only applies when the path was interpreted against the site's
+ * default library, and would be actively misleading when the caller supplied a
+ * library name that matched.
  */
 async function buildFolderNotFoundMessage(
   accessToken: string,
@@ -580,6 +596,7 @@ async function buildFolderNotFoundMessage(
   rawFolderPath: string,
   segments: string[],
   drives: Drive[],
+  searchedDefaultLibrary: boolean,
   retryOptions?: RetryOptions
 ): Promise<string> {
   const parts = [
@@ -614,9 +631,11 @@ async function buildFolderNotFoundMessage(
     }
   }
 
-  parts.push(
-    'The folder path is relative to the document library root, so a leading "Documents" or "Shared Documents" should be omitted unless a folder by that name really exists.'
-  )
+  if (searchedDefaultLibrary) {
+    parts.push(
+      'The folder path is relative to the document library root, so a leading "Documents" or "Shared Documents" should be omitted unless a folder by that name really exists.'
+    )
+  }
 
   return parts.join(' ')
 }


### PR DESCRIPTION
## Summary
Follow-up to #6026, fixing a Cursor Bugbot finding that was reported before that PR merged but landed unfixed.

- When the first path segment named a real non-default document library but the remainder did not resolve there, `buildFolderNotFoundMessage` described a search of the *default* library over the *full original* path
- It also advised stripping a leading `Documents` / `Shared Documents` prefix — actively wrong when the user had correctly supplied a library name
- Now reports against the library that was matched, over the remainder actually searched, and only offers the prefix hint when the default library really was the one searched

Concretely: `Policies/HR`, where `Policies` is a real library and `HR` is not in it, previously reported `document library "Documents"` and path `"Policies/HR"` and listed the wrong library's folders. It now names `Policies`, the path `HR`, and lists that library's folders.

Diagnostics only — no change to which folder resolves.

## Type of Change
- [x] Bug fix

## Testing
Added a regression test asserting the message names the matched library, its remainder, and its folder names, and contains neither the default library name nor the prefix hint. 23 connector tests pass; typecheck and lint clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)