### PR TITLE
feat(collab-doc): multi-replica shared Yjs backend + server-side markdown persistence

### DIFF
--- a/apps/realtime/src/handlers/file-doc-app.ts
+++ b/apps/realtime/src/handlers/file-doc-app.ts
@@ -72,3 +72,26 @@ export async function fetchFileDocMerge(
   }
   return new Uint8Array(Buffer.from(body.update, 'base64'))
 }
+
+/**
+ * Ask the app to project a live collaborative document back to durable markdown and write it to the
+ * file (Yjs → markdown, through the exact editor engine). This is the server-authoritative durable
+ * path — called debounced while the doc is edited and when the last collaborator leaves — that
+ * replaces the editor's client autosave, so a server/copilot edit can't be clobbered by a stale
+ * keystroke. THROWS on a transport failure so the caller can log/retry on the next debounce.
+ */
+export async function fetchFileDocPersist(
+  workspaceId: string,
+  fileId: string,
+  userId: string,
+  docState: Uint8Array
+): Promise<void> {
+  const response = await postToApp(
+    '/api/internal/file-doc/persist',
+    { workspaceId, fileId, userId, docState: Buffer.from(docState).toString('base64') },
+    FILE_DOC_TIMEOUTS.persistRequestMs
+  )
+  if (!response.ok) {
+    throw new Error(`Persist failed for file ${fileId}: ${response.status}`)
+  }
+}

--- a/apps/realtime/src/handlers/file-doc-store.test.ts
+++ b/apps/realtime/src/handlers/file-doc-store.test.ts
@@ -13,6 +13,8 @@ interface Backing {
   streams: Map<string, { id: string; message: Record<string, string> }[]>
   kv: Map<string, string>
   seq: number
+  /** Number of upcoming xAdd calls to fail with a transient error (to exercise publish retry). */
+  failXAdd: number
 }
 
 const state = vi.hoisted(() => ({ backing: null as Backing | null }))
@@ -30,6 +32,10 @@ function makeClient(): any {
     on: () => client,
     duplicate: () => makeClient(),
     xAdd: async (key: string, _star: string, fields: Record<string, string>) => {
+      if (b().failXAdd > 0) {
+        b().failXAdd--
+        throw new Error('transient xAdd failure')
+      }
       const id = `${++b().seq}-0`
       const arr = b().streams.get(key) ?? []
       arr.push({ id, message: { ...fields } })
@@ -64,6 +70,16 @@ function makeClient(): any {
     del: async (key: string) => {
       b().kv.delete(key)
       return 1
+    },
+    // Compare-and-delete Lua (RELEASE_LOCK_SCRIPT): del only if the stored value matches the token.
+    eval: async (_script: string, opts: { keys: string[]; arguments: string[] }) => {
+      const [key] = opts.keys
+      const [token] = opts.arguments
+      if (b().kv.get(key) === token) {
+        b().kv.delete(key)
+        return 1
+      }
+      return 0
     },
     expire: async () => 1,
   }
@@ -101,7 +117,7 @@ async function newStore(): Promise<FileDocStore> {
 
 describe('FileDocStore', () => {
   beforeEach(() => {
-    state.backing = { streams: new Map(), kv: new Map(), seq: 0 }
+    state.backing = { streams: new Map(), kv: new Map(), seq: 0, failXAdd: 0 }
     stores = []
   })
 
@@ -112,20 +128,22 @@ describe('FileDocStore', () => {
   it('elects exactly one seeder across tasks (no split-brain seed)', async () => {
     const a = await newStore()
     const b = await newStore()
-    const [aWon, bWon] = await Promise.all([a.shouldSeed(NAME), b.shouldSeed(NAME)])
-    expect([aWon, bWon].filter(Boolean)).toHaveLength(1)
+    // shouldSeed returns a lock token (truthy) for the winner, null for the loser.
+    const [aTok, bTok] = await Promise.all([a.shouldSeed(NAME), b.shouldSeed(NAME)])
+    expect([aTok, bTok].filter(Boolean)).toHaveLength(1)
   })
 
   it('does not re-seed once the stream already has content (stale lock)', async () => {
     const a = await newStore()
-    expect(await a.shouldSeed(NAME)).toBe(true)
+    const token = await a.shouldSeed(NAME)
+    expect(token).toBeTruthy()
     // A seeds and releases its lock.
     a.publish(NAME, updateFor('hello'))
     await vi.waitFor(async () => expect(await a.getStreamState(NAME)).not.toBeNull())
-    await a.releaseSeedLock(NAME)
+    await a.releaseSeedLock(NAME, token as string)
     // A different task must NOT seed again — the lock is free but the stream is non-empty.
     const b = await newStore()
-    expect(await b.shouldSeed(NAME)).toBe(false)
+    expect(await b.shouldSeed(NAME)).toBeNull()
   })
 
   it('getStreamState reconstructs the shared document from the stream', async () => {
@@ -204,22 +222,50 @@ describe('FileDocStore', () => {
     doc.destroy()
   })
 
+  it('retries a transient append failure so the edit is not lost from the shared log', async () => {
+    const a = await newStore()
+    state.backing!.failXAdd = 2 // first two xAdd attempts throw; the third must succeed
+    a.publish(NAME, updateFor('resilient'))
+    await vi.waitFor(
+      async () => {
+        const doc = new Y.Doc()
+        Y.applyUpdate(doc, (await a.getStreamState(NAME))!)
+        expect(doc.getText('body').toString()).toBe('resilient')
+        doc.destroy()
+      },
+      { timeout: 2000 }
+    )
+  })
+
+  it('streamHasContent fences a seed apply against an already-seeded stream', async () => {
+    const a = await newStore()
+    expect(await a.streamHasContent(NAME)).toBe(false)
+    a.publish(NAME, updateFor('seeded'))
+    await vi.waitFor(async () => expect(await a.streamHasContent(NAME)).toBe(true))
+  })
+
   it('serializes merges across tasks via the merge lock', async () => {
     const a = await newStore()
     const b = await newStore()
-    expect(await a.acquireMergeSlot(NAME, 5_000)).toBe(true)
+    const aTok = await a.acquireMergeSlot(NAME, 5_000)
+    expect(aTok).toBeTruthy()
     // A holds it → B is refused until A releases.
-    expect(await b.acquireMergeSlot(NAME, 5_000)).toBe(false)
-    await a.releaseMergeSlot(NAME)
-    expect(await b.acquireMergeSlot(NAME, 5_000)).toBe(true)
-    await b.releaseMergeSlot(NAME)
+    expect(await b.acquireMergeSlot(NAME, 5_000)).toBeNull()
+    // A stale-holder release with the WRONG token must NOT free A's lock (compare-and-delete).
+    await b.releaseMergeSlot(NAME, 'wrong-token')
+    expect(await b.acquireMergeSlot(NAME, 5_000)).toBeNull()
+    // A releases with its real token → B can now acquire.
+    await a.releaseMergeSlot(NAME, aTok as string)
+    const bTok = await b.acquireMergeSlot(NAME, 5_000)
+    expect(bTok).toBeTruthy()
+    await b.releaseMergeSlot(NAME, bTok as string)
   })
 
   it('is disabled without a REDIS_URL and behaves single-replica', async () => {
     const store = new FileDocStore(undefined)
     expect(store.enabled).toBe(false)
-    // Seeds locally (returns true), never touches a stream.
-    expect(await store.shouldSeed(NAME)).toBe(true)
+    // Seeds locally (returns a sentinel token), never touches a stream.
+    expect(await store.shouldSeed(NAME)).toBeTruthy()
     expect(await store.getStreamState(NAME)).toBeNull()
     const doc = new Y.Doc()
     await store.attachRoom(NAME, doc) // no-op, no throw

--- a/apps/realtime/src/handlers/file-doc-store.test.ts
+++ b/apps/realtime/src/handlers/file-doc-store.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
+
+/**
+ * One shared in-memory Redis backing per test, so several {@link FileDocStore} instances (modelling
+ * several ECS tasks) all talk to the "same Redis". A minimal fake of just the stream/lock ops the
+ * store uses.
+ */
+interface Backing {
+  streams: Map<string, { id: string; message: Record<string, string> }[]>
+  kv: Map<string, string>
+  seq: number
+}
+
+const state = vi.hoisted(() => ({ backing: null as Backing | null }))
+
+const seqOf = (id: string) => Number(id.split('-')[0])
+
+function makeClient(): any {
+  const b = () => {
+    if (!state.backing) throw new Error('backing not initialized')
+    return state.backing
+  }
+  const client: any = {
+    connect: async () => {},
+    quit: async () => {},
+    on: () => client,
+    duplicate: () => makeClient(),
+    xAdd: async (key: string, _star: string, fields: Record<string, string>) => {
+      const id = `${++b().seq}-0`
+      const arr = b().streams.get(key) ?? []
+      arr.push({ id, message: { ...fields } })
+      b().streams.set(key, arr)
+      return id
+    },
+    xRange: async (key: string) => (b().streams.get(key) ?? []).map((e) => ({ ...e })),
+    xLen: async (key: string) => (b().streams.get(key) ?? []).length,
+    xTrim: async (key: string, _strategy: string, minid: string) => {
+      const arr = b().streams.get(key) ?? []
+      b().streams.set(
+        key,
+        arr.filter((e) => seqOf(e.id) >= seqOf(minid))
+      )
+    },
+    xRead: async (streams: { key: string; id: string }[]) => {
+      const res: { name: string; messages: { id: string; message: Record<string, string> }[] }[] =
+        []
+      for (const { key, id } of streams) {
+        const after = (b().streams.get(key) ?? []).filter((e) => seqOf(e.id) > seqOf(id))
+        if (after.length) res.push({ name: key, messages: after.map((e) => ({ ...e })) })
+      }
+      if (res.length) return res
+      await new Promise((r) => setTimeout(r, 5))
+      return null
+    },
+    set: async (key: string, val: string, opts?: { NX?: boolean }) => {
+      if (opts?.NX && b().kv.has(key)) return null
+      b().kv.set(key, val)
+      return 'OK'
+    },
+    del: async (key: string) => {
+      b().kv.delete(key)
+      return 1
+    },
+    expire: async () => 1,
+  }
+  return client
+}
+
+vi.mock('redis', () => ({ createClient: () => makeClient() }))
+
+import { FileDocStore } from '@/handlers/file-doc-store'
+
+const REDIS_URL = 'redis://fake'
+const NAME = 'workspace-file-doc:file-1'
+
+function docWithText(text: string): Y.Doc {
+  const doc = new Y.Doc()
+  doc.getText('body').insert(0, text)
+  return doc
+}
+
+/** The delta a doc emits when `text` is inserted — what the relay would `publish`. */
+function updateFor(text: string): Uint8Array {
+  const doc = docWithText(text)
+  const update = Y.encodeStateAsUpdate(doc)
+  doc.destroy()
+  return update
+}
+
+let stores: FileDocStore[] = []
+async function newStore(): Promise<FileDocStore> {
+  const store = new FileDocStore(REDIS_URL)
+  await store.init()
+  stores.push(store)
+  return store
+}
+
+describe('FileDocStore', () => {
+  beforeEach(() => {
+    state.backing = { streams: new Map(), kv: new Map(), seq: 0 }
+    stores = []
+  })
+
+  afterEach(async () => {
+    await Promise.all(stores.map((s) => s.shutdown()))
+  })
+
+  it('elects exactly one seeder across tasks (no split-brain seed)', async () => {
+    const a = await newStore()
+    const b = await newStore()
+    const [aWon, bWon] = await Promise.all([a.shouldSeed(NAME), b.shouldSeed(NAME)])
+    expect([aWon, bWon].filter(Boolean)).toHaveLength(1)
+  })
+
+  it('does not re-seed once the stream already has content (stale lock)', async () => {
+    const a = await newStore()
+    expect(await a.shouldSeed(NAME)).toBe(true)
+    // A seeds and releases its lock.
+    a.publish(NAME, updateFor('hello'))
+    await vi.waitFor(async () => expect(await a.getStreamState(NAME)).not.toBeNull())
+    await a.releaseSeedLock(NAME)
+    // A different task must NOT seed again — the lock is free but the stream is non-empty.
+    const b = await newStore()
+    expect(await b.shouldSeed(NAME)).toBe(false)
+  })
+
+  it('getStreamState reconstructs the shared document from the stream', async () => {
+    const a = await newStore()
+    a.publish(NAME, updateFor('shared content'))
+    let state: Uint8Array | null = null
+    await vi.waitFor(async () => {
+      state = await a.getStreamState(NAME)
+      expect(state).not.toBeNull()
+    })
+    const doc = new Y.Doc()
+    Y.applyUpdate(doc, state!)
+    expect(doc.getText('body').toString()).toBe('shared content')
+    doc.destroy()
+  })
+
+  it('attachRoom catches a fresh task up to the current shared state', async () => {
+    const a = await newStore()
+    a.publish(NAME, updateFor('already here'))
+    await vi.waitFor(async () => expect(await a.getStreamState(NAME)).not.toBeNull())
+
+    // A second task opens the same file: its doc must load the existing content, not start empty.
+    const b = await newStore()
+    const doc = new Y.Doc()
+    await b.attachRoom(NAME, doc)
+    expect(doc.getText('body').toString()).toBe('already here')
+    doc.destroy()
+  })
+
+  it('converges a peer task via the tailer after attach', async () => {
+    const a = await newStore()
+    const b = await newStore()
+    const bDoc = new Y.Doc()
+    await b.attachRoom(NAME, bDoc)
+
+    // A publishes an edit; B's multiplexed reader must apply it to B's attached doc.
+    a.publish(NAME, updateFor('from task A'))
+    await vi.waitFor(() => expect(bDoc.getText('body').toString()).toBe('from task A'), {
+      timeout: 2000,
+    })
+    bDoc.destroy()
+  })
+
+  it('compaction never trims peer entries the compacting task has not yet integrated', async () => {
+    const streamKey = `filedoc:stream:${NAME}`
+    const noop = Buffer.from(Y.encodeStateAsUpdate(new Y.Doc())).toString('base64')
+
+    // Two peer edits published by ANOTHER task that this task's tailer has not read yet.
+    const peerDoc = new Y.Doc()
+    const peerUpdates: Uint8Array[] = []
+    peerDoc.on('update', (u: Uint8Array) => peerUpdates.push(u))
+    peerDoc.getText('body').insert(0, 'PEER1')
+    peerDoc.getText('body').insert(5, 'PEER2')
+
+    // Backing: 400 already-integrated (no-op) entries this task's doc reflects, then the 2 un-integrated
+    // peer entries. Enough entries to cross COMPACT_THRESHOLD.
+    const entries = Array.from({ length: 400 }, (_, i) => ({
+      id: `${i + 1}-0`,
+      message: { u: noop },
+    }))
+    entries.push({ id: '401-0', message: { u: Buffer.from(peerUpdates[0]).toString('base64') } })
+    entries.push({ id: '402-0', message: { u: Buffer.from(peerUpdates[1]).toString('base64') } })
+    state.backing!.streams.set(streamKey, entries)
+    state.backing!.seq = 402
+
+    const a = await newStore()
+    // This task has integrated only up to entry 400 (all no-ops) — its local doc is empty and lags the
+    // two peer entries. Inject that lagging room directly.
+    ;(a as any).rooms.set(NAME, { doc: new Y.Doc(), lastId: '400-0', publishes: 0 })
+    await (a as any).maybeCompact(NAME)
+
+    // A fresh catch-up must still reconstruct the peer content — compaction must not have trimmed 401/402.
+    const doc = new Y.Doc()
+    Y.applyUpdate(doc, (await a.getStreamState(NAME))!)
+    expect(doc.getText('body').toString()).toBe('PEER1PEER2')
+    doc.destroy()
+  })
+
+  it('serializes merges across tasks via the merge lock', async () => {
+    const a = await newStore()
+    const b = await newStore()
+    expect(await a.acquireMergeSlot(NAME, 5_000)).toBe(true)
+    // A holds it → B is refused until A releases.
+    expect(await b.acquireMergeSlot(NAME, 5_000)).toBe(false)
+    await a.releaseMergeSlot(NAME)
+    expect(await b.acquireMergeSlot(NAME, 5_000)).toBe(true)
+    await b.releaseMergeSlot(NAME)
+  })
+
+  it('is disabled without a REDIS_URL and behaves single-replica', async () => {
+    const store = new FileDocStore(undefined)
+    expect(store.enabled).toBe(false)
+    // Seeds locally (returns true), never touches a stream.
+    expect(await store.shouldSeed(NAME)).toBe(true)
+    expect(await store.getStreamState(NAME)).toBeNull()
+    const doc = new Y.Doc()
+    await store.attachRoom(NAME, doc) // no-op, no throw
+    expect(doc.getText('body').toString()).toBe('')
+    doc.destroy()
+  })
+})

--- a/apps/realtime/src/handlers/file-doc-store.test.ts
+++ b/apps/realtime/src/handlers/file-doc-store.test.ts
@@ -220,6 +220,11 @@ describe('FileDocStore', () => {
     Y.applyUpdate(doc, (await a.getStreamState(NAME))!)
     expect(doc.getText('body').toString()).toBe('PEER1PEER2')
     doc.destroy()
+
+    // The appended snapshot entry must carry the snapshot marker, so a fresh catch-up task treats it as
+    // edited content (not a bare seed) and persists on last-disconnect.
+    const stream = state.backing!.streams.get(streamKey)!
+    expect(stream[stream.length - 1].message.s).toBe('1')
   })
 
   it('retries a transient append failure so the edit is not lost from the shared log', async () => {

--- a/apps/realtime/src/handlers/file-doc-store.ts
+++ b/apps/realtime/src/handlers/file-doc-store.ts
@@ -1,0 +1,419 @@
+/**
+ * Shared, multi-replica Yjs backend for the collaborative file-document relay, over Redis Streams.
+ *
+ * The relay keeps an in-memory {@link Y.Doc} per open file (for the sync handshake, awareness, and
+ * copilot merges), but on a horizontally-scaled deployment (multiple ECS tasks, autoscaling) that
+ * per-process doc is NOT authoritative on its own: two tasks each seeding the same file from markdown
+ * would mint independent Yjs client ids and union into duplicated content (split-brain), and a task
+ * only ever sees the edits of ITS OWN clients. This module makes every task converge on ONE CRDT per
+ * file by treating a Redis Stream as the shared, ordered, replayable log of Yjs updates — the union of
+ * a stream's entries IS the document. It is the "shared Yjs backend (y-redis / Hocuspocus)" the relay's
+ * single-replica model always deferred, built natively for our Socket.IO transport on the Redis the
+ * Socket.IO adapter already runs.
+ *
+ * How it fits the relay's message flow (see `file-doc.ts`):
+ * - Doc-sync messages no longer ride the Socket.IO Redis ADAPTER cross-pod. Instead each applied
+ *   update is {@link publish}ed to the stream; every task's multiplexed reader
+ *   applies it to its local doc (origin {@link REDIS_ORIGIN}) and fans it out to ITS OWN clients. So a
+ *   client receives each update exactly once, from its own task's local broadcast — no adapter
+ *   amplification, and every task's doc stays converged. (Awareness/presence stay on the adapter: they
+ *   are ephemeral and need no convergence or replay.)
+ * - {@link attachRoom} does a synchronous catch-up read from the head of the stream when a task first
+ *   opens a file, so a late-joining task (the normal case under autoscaling) loads the current shared
+ *   state before its first client syncs. Catch-up + tail are seamless: the tailer resumes from the
+ *   exact id catch-up stopped at.
+ * - {@link shouldSeed} coordinates the one-time seed with a Redis lock AND an empty-stream check, so
+ *   exactly one task ever writes the seed cluster-wide (the fix for split-brain).
+ *
+ * When `REDIS_URL` is unset (single-pod dev) the store is DISABLED and every method degrades to the
+ * relay's original single-replica behavior: seed locally, no stream, no tailer.
+ *
+ * @module
+ */
+import { createLogger } from '@sim/logger'
+import { FILE_DOC_TIMEOUTS } from '@sim/realtime-protocol/file-doc'
+import { getErrorMessage } from '@sim/utils/errors'
+import { sleep } from '@sim/utils/helpers'
+import { createClient, type RedisClientType } from 'redis'
+import * as Y from 'yjs'
+
+const logger = createLogger('FileDocStore')
+
+/**
+ * The transaction origin the store stamps on updates it applies from the stream. The relay's
+ * `doc.on('update')` handler uses it to distinguish an update that ARRIVED from a peer (fan out to
+ * local clients, but do NOT re-publish — it is already in the stream) from a local edit (fan out AND
+ * publish). It must be a non-string sentinel so it is never mistaken for a socket id.
+ */
+export const REDIS_ORIGIN = Symbol('file-doc-redis')
+
+const STREAM_PREFIX = 'filedoc:stream:'
+const SEED_LOCK_PREFIX = 'filedoc:seedlock:'
+const COMPACT_LOCK_PREFIX = 'filedoc:compactlock:'
+const PERSIST_LOCK_PREFIX = 'filedoc:persistlock:'
+const MERGE_LOCK_PREFIX = 'filedoc:mergelock:'
+
+/** The single field each stream entry carries — a base64 Yjs update. */
+const UPDATE_FIELD = 'u'
+
+/** How long a blocking multiplexed read waits before re-snapshotting the live room set. Also bounds
+ * how long a room attached mid-block waits for its first cross-task update (updates are not lost — the
+ * next read resumes from its last id — only briefly delayed). */
+const READ_BLOCK_MS = 1_000
+/** Idle poll cadence when NO room is open on this task, so a freshly-attached room is picked up fast
+ * without busy-spinning an empty task. */
+const IDLE_POLL_MS = 250
+/** Max entries drained per stream per read. */
+const READ_COUNT = 200
+/** Compact a stream once it exceeds this many entries (snapshot + trim). */
+const COMPACT_THRESHOLD = 400
+/** Check whether compaction is due only every Nth local publish, to avoid an XLEN per keystroke. */
+const COMPACT_CHECK_EVERY = 64
+/** The seed lock is held across the app seed fetch (hard-bounded at `seedRequestMs`) plus the apply +
+ * publish. The generous cushion over `seedRequestMs` means only a multi-second event-loop stall — not
+ * ordinary latency — could expire it mid-seed, so the single-seeder invariant does not hinge on a tight
+ * 2s margin coupled to an unrelated timeout. */
+const SEED_LOCK_TTL_MS = FILE_DOC_TIMEOUTS.seedRequestMs + 12_000
+/** How long a stream survives with no heartbeat — long enough that an occupied-but-idle doc never
+ * loses its shared state (the heartbeat refreshes it while any task holds the room). */
+const STREAM_TTL_SEC = 600
+/** Refresh every occupied stream's TTL on this cadence, so a live doc's stream never expires. */
+const HEARTBEAT_MS = 60_000
+
+const streamKey = (name: string) => `${STREAM_PREFIX}${name}`
+
+/**
+ * Decode one stream entry's base64 Yjs update and apply it to `doc`. A malformed entry is logged and
+ * SKIPPED — never thrown — so one bad frame can neither wedge the tailer nor abort a headless
+ * stream-fold. Shared by the tailer/catch-up (applies with {@link REDIS_ORIGIN}) and the merge-base
+ * reconstruction (no origin — a throwaway doc), so the two can never diverge on how an entry is read.
+ */
+function applyEntryToDoc(
+  doc: Y.Doc,
+  id: string,
+  message: Record<string, string>,
+  origin?: unknown
+): void {
+  const encoded = message[UPDATE_FIELD]
+  if (!encoded) return
+  try {
+    Y.applyUpdate(doc, new Uint8Array(Buffer.from(encoded, 'base64')), origin)
+  } catch (error) {
+    logger.warn('FileDocStore dropping malformed stream entry', {
+      id,
+      error: getErrorMessage(error),
+    })
+  }
+}
+
+/** One locally-open room the store tracks: its doc and the last stream id applied to it. */
+interface StoreRoom {
+  doc: Y.Doc
+  /** The id of the last stream entry applied to `doc`; the tailer resumes strictly after it. */
+  lastId: string
+  /** Local publish count, to pace compaction checks. */
+  publishes: number
+}
+
+/**
+ * The Redis-Streams shared Yjs backend. A single instance per process. `enabled` is false when there
+ * is no `REDIS_URL`, in which case every method is a no-op and the relay runs single-replica.
+ */
+export class FileDocStore {
+  readonly enabled: boolean
+  /** Command connection: XADD / locks / XLEN / XTRIM / EXPIRE. */
+  private write: RedisClientType | null = null
+  /** Dedicated connection for blocking XREAD (a blocking command monopolizes its connection). */
+  private read: RedisClientType | null = null
+  private readonly rooms = new Map<string, StoreRoom>()
+  private running = false
+  private heartbeat: ReturnType<typeof setInterval> | null = null
+
+  constructor(private readonly redisUrl: string | undefined) {
+    this.enabled = Boolean(redisUrl)
+  }
+
+  /** Connect the two Redis clients and start the multiplexed reader + TTL heartbeat. Idempotent. */
+  async init(): Promise<void> {
+    if (!this.enabled || this.running || !this.redisUrl) return
+    const options = {
+      url: this.redisUrl,
+      socket: {
+        reconnectStrategy: (retries: number) => {
+          if (retries > 10) return new Error('FileDocStore Redis reconnection failed')
+          return Math.min(retries * 100, 3000)
+        },
+      },
+    }
+    this.write = createClient(options)
+    this.read = this.write.duplicate()
+    this.write.on('error', (err) => logger.error('FileDocStore write client error:', err))
+    this.read.on('error', (err) => logger.error('FileDocStore read client error:', err))
+    await Promise.all([this.write.connect(), this.read.connect()])
+    this.running = true
+    void this.runReader()
+    this.heartbeat = setInterval(() => void this.refreshTtls(), HEARTBEAT_MS)
+    logger.info('FileDocStore ready — shared Yjs backend over Redis Streams enabled')
+  }
+
+  /** Stop the reader/heartbeat and close both clients. */
+  async shutdown(): Promise<void> {
+    this.running = false
+    if (this.heartbeat) clearInterval(this.heartbeat)
+    this.heartbeat = null
+    await Promise.all([this.write?.quit().catch(() => {}), this.read?.quit().catch(() => {})])
+    this.write = null
+    this.read = null
+  }
+
+  /**
+   * Register a locally-opened room and load the shared state into its doc: read the whole stream from
+   * the head, apply every entry (origin {@link REDIS_ORIGIN}), and remember the last id so the tailer
+   * resumes exactly after it. A brand-new file has an empty stream and loads nothing (it is seeded
+   * shortly after, via {@link shouldSeed}). No-op when disabled.
+   */
+  async attachRoom(name: string, doc: Y.Doc): Promise<void> {
+    if (!this.enabled || !this.write) return
+    // Register BEFORE the async read so a concurrent publish/tailer for this room can't be missed —
+    // the tailer resumes from `lastId`, which the catch-up advances.
+    const room: StoreRoom = { doc, lastId: '0', publishes: 0 }
+    this.rooms.set(name, room)
+    try {
+      const entries = await this.write.xRange(streamKey(name), '-', '+')
+      for (const entry of entries) {
+        // The room can be detached + its doc destroyed while catch-up is in flight (a fast open→close);
+        // stop touching it the moment that happens.
+        if (this.rooms.get(name) !== room) return
+        this.applyEntry(room, entry.id, entry.message)
+      }
+      await this.write.expire(streamKey(name), STREAM_TTL_SEC)
+    } catch (error) {
+      logger.warn(`FileDocStore catch-up failed for ${name}`, { error: getErrorMessage(error) })
+    }
+  }
+
+  /** Deregister a room the relay is destroying, so the tailer stops touching its (about-to-be-destroyed) doc. */
+  detachRoom(name: string): void {
+    this.rooms.delete(name)
+  }
+
+  /**
+   * Append a locally-applied update to the shared stream so every task converges. Called from the
+   * relay's `doc.on('update')` for local edits only (never for {@link REDIS_ORIGIN} updates — those
+   * already came from the stream). No-op when disabled.
+   */
+  publish(name: string, update: Uint8Array): void {
+    if (!this.enabled || !this.write) return
+    const room = this.rooms.get(name)
+    void this.write
+      .xAdd(streamKey(name), '*', { [UPDATE_FIELD]: Buffer.from(update).toString('base64') })
+      .then(() => this.write?.expire(streamKey(name), STREAM_TTL_SEC))
+      .then(() => {
+        if (room && ++room.publishes % COMPACT_CHECK_EVERY === 0) return this.maybeCompact(name)
+      })
+      .catch((error) =>
+        logger.warn(`FileDocStore publish failed for ${name}`, { error: getErrorMessage(error) })
+      )
+  }
+
+  /**
+   * Decide whether THIS task should build and write the file's one-time seed. Returns true only when
+   * the shared stream is genuinely empty AND this task wins the seed lock — so exactly one task across
+   * the cluster ever seeds a file, even if several open it at once (the fix for split-brain seeding).
+   * When disabled, always true (single-replica: seed locally).
+   */
+  async shouldSeed(name: string): Promise<boolean> {
+    if (!this.enabled || !this.write) return true
+    try {
+      const won = await this.write.set(`${SEED_LOCK_PREFIX}${name}`, '1', {
+        NX: true,
+        PX: SEED_LOCK_TTL_MS,
+      })
+      if (won !== 'OK') return false
+      // The lock could be free yet the stream already seeded (a prior holder seeded then its lock
+      // expired). Re-check under the lock so we never write a SECOND seed on top of an existing one.
+      if ((await this.write.xLen(streamKey(name))) > 0) {
+        await this.releaseSeedLock(name)
+        return false
+      }
+      return true
+    } catch (error) {
+      logger.warn(`FileDocStore shouldSeed failed for ${name}`, { error: getErrorMessage(error) })
+      return false
+    }
+  }
+
+  /**
+   * Build the file's current shared state from the stream, headless (no registered room), for a merge
+   * that must reach the live doc regardless of which task holds it. Returns the encoded Yjs state, or
+   * `null` when the stream is empty — i.e. no doc is (or was recently) live, so there is nothing to
+   * merge into and the caller should fall back to a direct file write. Disabled → always null.
+   */
+  async getStreamState(name: string): Promise<Uint8Array | null> {
+    if (!this.enabled || !this.write) return null
+    const entries = await this.write.xRange(streamKey(name), '-', '+')
+    if (entries.length === 0) return null
+    const doc = new Y.Doc()
+    try {
+      for (const entry of entries) applyEntryToDoc(doc, entry.id, entry.message)
+      return Y.encodeStateAsUpdate(doc)
+    } finally {
+      doc.destroy()
+    }
+  }
+
+  /** Release the seed lock (best-effort) once the seed has been published or a seed attempt failed. */
+  async releaseSeedLock(name: string): Promise<void> {
+    if (!this.enabled || !this.write) return
+    await this.write.del(`${SEED_LOCK_PREFIX}${name}`).catch(() => {})
+  }
+
+  /**
+   * Try to claim the right to persist this file for the current debounce window, so concurrent tasks
+   * editing the same file don't each write a redundant blob version. Returns true (proceed) when
+   * disabled, or when this task wins a short lock. The final last-collaborator flush does NOT gate on
+   * this — it must always write.
+   */
+  async acquirePersistSlot(name: string, ttlMs: number): Promise<boolean> {
+    if (!this.enabled || !this.write) return true
+    try {
+      const won = await this.write.set(`${PERSIST_LOCK_PREFIX}${name}`, '1', {
+        NX: true,
+        PX: ttlMs,
+      })
+      return won === 'OK'
+    } catch {
+      return true
+    }
+  }
+
+  /**
+   * Try to claim the cross-task right to merge new content into this file. The relay already serializes
+   * merges per task; this extends that across tasks so two copilot edits to the same file landing on
+   * different tasks don't each diff the SAME shared base and publish conflicting full-document rewrites.
+   * The loser waits and retries so it diffs against the winner's RESULT (correct sequential merge).
+   * Returns true (proceed) when disabled or once the lock is won. Release with {@link releaseMergeSlot}.
+   */
+  async acquireMergeSlot(name: string, ttlMs: number): Promise<boolean> {
+    if (!this.enabled || !this.write) return true
+    try {
+      return (
+        (await this.write.set(`${MERGE_LOCK_PREFIX}${name}`, '1', { NX: true, PX: ttlMs })) === 'OK'
+      )
+    } catch {
+      return true
+    }
+  }
+
+  async releaseMergeSlot(name: string): Promise<void> {
+    if (!this.enabled || !this.write) return
+    await this.write.del(`${MERGE_LOCK_PREFIX}${name}`).catch(() => {})
+  }
+
+  private applyEntry(room: StoreRoom, id: string, message: Record<string, string>): void {
+    room.lastId = id
+    applyEntryToDoc(room.doc, id, message, REDIS_ORIGIN)
+  }
+
+  /**
+   * The single multiplexed tail loop: block-read every locally-open room's stream from its last id and
+   * apply new entries. One blocking connection for the whole process regardless of open-file count.
+   */
+  private async runReader(): Promise<void> {
+    while (this.running && this.read) {
+      const snapshot = [...this.rooms.entries()]
+      if (snapshot.length === 0) {
+        await sleep(IDLE_POLL_MS)
+        continue
+      }
+      try {
+        const res = await this.read.xRead(
+          snapshot.map(([name, room]) => ({ key: streamKey(name), id: room.lastId })),
+          { BLOCK: READ_BLOCK_MS, COUNT: READ_COUNT }
+        )
+        if (!res) continue
+        for (const stream of res) {
+          const name = stream.name.slice(STREAM_PREFIX.length)
+          const room = this.rooms.get(name)
+          if (!room) continue // detached mid-read; its doc is being destroyed
+          for (const entry of stream.messages) this.applyEntry(room, entry.id, entry.message)
+        }
+      } catch (error) {
+        if (!this.running) break
+        logger.warn('FileDocStore reader error; retrying', { error: getErrorMessage(error) })
+        await sleep(500)
+      }
+    }
+  }
+
+  /**
+   * Snapshot-then-trim compaction: append a full-state snapshot and drop the older deltas it subsumes,
+   * so the stream stays bounded while a fresh task can still catch up from the head. Lock-guarded so
+   * only one task compacts a given stream at a time (concurrent snapshot+trim would race). Trims only up
+   * to what the snapshot provably contains — never un-integrated peer entries (see below).
+   */
+  private async maybeCompact(name: string): Promise<void> {
+    if (!this.write) return
+    const room = this.rooms.get(name)
+    if (!room) return
+    try {
+      if ((await this.write.xLen(streamKey(name))) < COMPACT_THRESHOLD) return
+      const won = await this.write.set(`${COMPACT_LOCK_PREFIX}${name}`, '1', {
+        NX: true,
+        PX: 10_000,
+      })
+      if (won !== 'OK') return
+      try {
+        // Capture the snapshot AND the id it covers in one synchronous step (no await between): the
+        // snapshot is `room.doc`, which holds exactly what this task's tailer has integrated — every
+        // entry up to `room.lastId`. Entries a peer task published AFTER that (id > lastId) are NOT in
+        // the snapshot and this task's blocking reader may not have seen them yet, so we must NOT trim
+        // them — only entries the snapshot provably subsumes (id <= lastId). Trimming to the freshly
+        // appended snapshot id instead would silently drop those un-integrated peer entries.
+        const upTo = room.lastId
+        const snapshot = Buffer.from(Y.encodeStateAsUpdate(room.doc)).toString('base64')
+        await this.write.xAdd(streamKey(name), '*', { [UPDATE_FIELD]: snapshot })
+        // MINID keeps entries with id >= upTo: the snapshot, any un-integrated peer entries, and
+        // `upTo` itself (redundant with the snapshot, harmless); it drops only the folded older deltas.
+        await this.write.xTrim(streamKey(name), 'MINID', upTo)
+      } finally {
+        await this.write.del(`${COMPACT_LOCK_PREFIX}${name}`).catch(() => {})
+      }
+    } catch (error) {
+      logger.warn(`FileDocStore compaction failed for ${name}`, { error: getErrorMessage(error) })
+    }
+  }
+
+  private async refreshTtls(): Promise<void> {
+    if (!this.write) return
+    for (const name of this.rooms.keys()) {
+      await this.write.expire(streamKey(name), STREAM_TTL_SEC).catch(() => {})
+    }
+  }
+}
+
+let store: FileDocStore | null = null
+
+/**
+ * Initialize the process-wide store from the realtime server bootstrap (alongside the socket adapter).
+ * Authoritative: if a disabled placeholder was lazily created by an early {@link getFileDocStore} call,
+ * this REPLACES it with the real, connected store — so the bootstrap can never silently no-op. A second
+ * call once already initialized is a no-op.
+ */
+export async function initFileDocStore(redisUrl: string | undefined): Promise<FileDocStore> {
+  if (store?.enabled) return store
+  store = new FileDocStore(redisUrl)
+  await store.init()
+  return store
+}
+
+/** The process-wide store. Returns a disabled instance if init was never called (e.g. in unit tests). */
+export function getFileDocStore(): FileDocStore {
+  if (!store) store = new FileDocStore(undefined)
+  return store
+}
+
+/** Test-only: reset the singleton so a test can install its own instance. */
+export function __setFileDocStoreForTest(next: FileDocStore | null): void {
+  store = next
+}

--- a/apps/realtime/src/handlers/file-doc-store.ts
+++ b/apps/realtime/src/handlers/file-doc-store.ts
@@ -56,14 +56,26 @@ const RELEASE_LOCK_SCRIPT =
  */
 export const REDIS_ORIGIN = Symbol('file-doc-redis')
 
+/**
+ * Origin for a COMPACTED SNAPSHOT applied from the stream. A snapshot folds the seed + all prior edits
+ * into one entry, so a fresh task catching up from it would otherwise never see a separate post-seed
+ * edit frame and would treat the doc as unedited. The relay's edit-tracker uses this origin to mark the
+ * doc edited (a snapshot only exists after the stream crossed the compaction threshold, i.e. real edits
+ * happened). Behaves like {@link REDIS_ORIGIN} otherwise (already in the stream — never re-published).
+ */
+export const REDIS_SNAPSHOT_ORIGIN = Symbol('file-doc-redis-snapshot')
+
 const STREAM_PREFIX = 'filedoc:stream:'
 const SEED_LOCK_PREFIX = 'filedoc:seedlock:'
 const COMPACT_LOCK_PREFIX = 'filedoc:compactlock:'
 const PERSIST_LOCK_PREFIX = 'filedoc:persistlock:'
 const MERGE_LOCK_PREFIX = 'filedoc:mergelock:'
 
-/** The single field each stream entry carries — a base64 Yjs update. */
+/** The field each stream entry carries — a base64 Yjs update. */
 const UPDATE_FIELD = 'u'
+/** Marks a stream entry as a compaction SNAPSHOT (folds seed + edits), so the tailer applies it with
+ * {@link REDIS_SNAPSHOT_ORIGIN}. Present only on snapshot entries. */
+const SNAPSHOT_FIELD = 's'
 
 /** Sentinel token a DISABLED store returns from a lock acquire, so single-replica callers proceed
  * without special-casing; {@link FileDocStore.releaseLock} treats it as a no-op. Not a real UUID, so it
@@ -228,12 +240,12 @@ export class FileDocStore {
   private async appendUpdate(name: string, update: Uint8Array): Promise<void> {
     if (!this.write) return
     const encoded = Buffer.from(update).toString('base64')
-    for (let attempt = 0; ; attempt++) {
+    for (let attempt = 0; attempt <= PUBLISH_MAX_RETRIES; attempt++) {
       try {
         await this.write.xAdd(streamKey(name), '*', { [UPDATE_FIELD]: encoded })
         break
       } catch (error) {
-        if (attempt >= PUBLISH_MAX_RETRIES) {
+        if (attempt === PUBLISH_MAX_RETRIES) {
           logger.error(`FileDocStore append failed for ${name}`, { error: getErrorMessage(error) })
           throw error
         }
@@ -352,12 +364,14 @@ export class FileDocStore {
   }
 
   /**
-   * Try to claim the right to persist this file for the current debounce window, so concurrent tasks
-   * editing the same file don't each write a redundant blob version. Returns true (proceed) when
-   * disabled, or when this task wins a short lock. The final last-collaborator flush does NOT gate on
-   * this — it must always write.
+   * A best-effort TTL dedup WINDOW (NOT a lock): claim the right to run a debounced persist for the next
+   * `ttlMs`, so concurrent tasks editing the same file don't each write a redundant blob version. It is
+   * never released — it simply expires after `ttlMs`, gating the debounced persist to ~once per window
+   * cluster-wide. Fails OPEN (returns true on a Redis error): a redundant persist is a harmless
+   * idempotent write, so it must never block a real one. The final last-collaborator flush does NOT gate
+   * on this — it must always write.
    */
-  async acquirePersistSlot(name: string, ttlMs: number): Promise<boolean> {
+  async tryClaimPersistWindow(name: string, ttlMs: number): Promise<boolean> {
     if (!this.enabled || !this.write) return true
     try {
       const won = await this.write.set(`${PERSIST_LOCK_PREFIX}${name}`, '1', {
@@ -388,7 +402,10 @@ export class FileDocStore {
 
   private applyEntry(room: StoreRoom, id: string, message: Record<string, string>): void {
     room.lastId = id
-    applyEntryToDoc(room.doc, id, message, REDIS_ORIGIN)
+    // A compaction snapshot folds seed + edits into one frame; stamp it so the relay's edit-tracker
+    // treats a fresh catch-up from it as edited (a snapshot only exists once real edits accumulated).
+    const origin = message[SNAPSHOT_FIELD] ? REDIS_SNAPSHOT_ORIGIN : REDIS_ORIGIN
+    applyEntryToDoc(room.doc, id, message, origin)
   }
 
   /**
@@ -397,21 +414,24 @@ export class FileDocStore {
    */
   private async runReader(): Promise<void> {
     while (this.running && this.read) {
-      const snapshot = [...this.rooms.entries()]
-      if (snapshot.length === 0) {
+      const snapshot = new Map(this.rooms)
+      if (snapshot.size === 0) {
         await sleep(IDLE_POLL_MS)
         continue
       }
       try {
         const res = await this.read.xRead(
-          snapshot.map(([name, room]) => ({ key: streamKey(name), id: room.lastId })),
+          [...snapshot].map(([name, room]) => ({ key: streamKey(name), id: room.lastId })),
           { BLOCK: READ_BLOCK_MS, COUNT: READ_COUNT }
         )
         if (!res) continue
         for (const stream of res) {
           const name = stream.name.slice(STREAM_PREFIX.length)
           const room = this.rooms.get(name)
-          if (!room) continue // detached mid-read; its doc is being destroyed
+          // Skip if detached mid-read, OR replaced by a close→reopen (a DIFFERENT StoreRoom): applying
+          // entries read against the OLD room's lastId to the new one could regress its lastId (harmless
+          // but wasteful re-delivery). The new room caught itself up via xRange already.
+          if (!room || room !== snapshot.get(name)) continue
           for (const entry of stream.messages) this.applyEntry(room, entry.id, entry.message)
         }
       } catch (error) {
@@ -446,7 +466,11 @@ export class FileDocStore {
         // appended snapshot id instead would silently drop those un-integrated peer entries.
         const upTo = room.lastId
         const snapshot = Buffer.from(Y.encodeStateAsUpdate(room.doc)).toString('base64')
-        await this.write.xAdd(streamKey(name), '*', { [UPDATE_FIELD]: snapshot })
+        // Mark it a snapshot so a fresh catch-up task treats it as edited content, not a bare seed.
+        await this.write.xAdd(streamKey(name), '*', {
+          [UPDATE_FIELD]: snapshot,
+          [SNAPSHOT_FIELD]: '1',
+        })
         // MINID keeps entries with id >= upTo: the snapshot, any un-integrated peer entries, and
         // `upTo` itself (redundant with the snapshot, harmless); it drops only the folded older deltas.
         await this.write.xTrim(streamKey(name), 'MINID', upTo)
@@ -485,9 +509,4 @@ export async function initFileDocStore(redisUrl: string | undefined): Promise<Fi
 export function getFileDocStore(): FileDocStore {
   if (!store) store = new FileDocStore(undefined)
   return store
-}
-
-/** Test-only: reset the singleton so a test can install its own instance. */
-export function __setFileDocStoreForTest(next: FileDocStore | null): void {
-  store = next
 }

--- a/apps/realtime/src/handlers/file-doc-store.ts
+++ b/apps/realtime/src/handlers/file-doc-store.ts
@@ -268,15 +268,20 @@ export class FileDocStore {
 
   /**
    * Whether the file's stream already holds content — fences a seed apply against a peer that seeded
-   * while this task held a (possibly stale) lock, so we never write a second seed (split-brain). False
-   * when disabled or on error (the caller then proceeds under its lock, as before).
+   * while this task held a (possibly stale) lock, so we never write a second seed (split-brain). Both
+   * callers treat `true` as "do not seed", so this fails CLOSED: a Redis `xLen` error returns `true`
+   * (cannot confirm the stream is empty → do not risk a double-seed). `false` only when genuinely empty,
+   * or when disabled (single-replica, where seeding locally is always correct).
    */
   async streamHasContent(name: string): Promise<boolean> {
     if (!this.enabled || !this.write) return false
     try {
       return (await this.write.xLen(streamKey(name))) > 0
-    } catch {
-      return false
+    } catch (error) {
+      logger.warn(`FileDocStore streamHasContent failed for ${name}`, {
+        error: getErrorMessage(error),
+      })
+      return true
     }
   }
 

--- a/apps/realtime/src/handlers/file-doc-store.ts
+++ b/apps/realtime/src/handlers/file-doc-store.ts
@@ -34,10 +34,19 @@ import { createLogger } from '@sim/logger'
 import { FILE_DOC_TIMEOUTS } from '@sim/realtime-protocol/file-doc'
 import { getErrorMessage } from '@sim/utils/errors'
 import { sleep } from '@sim/utils/helpers'
+import { generateId } from '@sim/utils/id'
+import { backoffWithJitter } from '@sim/utils/retry'
 import { createClient, type RedisClientType } from 'redis'
 import * as Y from 'yjs'
 
 const logger = createLogger('FileDocStore')
+
+/**
+ * Compare-and-delete: release a lock ONLY if this task still holds it (its token still the value), so a
+ * lock that expired and was re-acquired by another task is never stolen by the original holder's release.
+ */
+const RELEASE_LOCK_SCRIPT =
+  "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end"
 
 /**
  * The transaction origin the store stamps on updates it applies from the stream. The relay's
@@ -56,6 +65,11 @@ const MERGE_LOCK_PREFIX = 'filedoc:mergelock:'
 /** The single field each stream entry carries — a base64 Yjs update. */
 const UPDATE_FIELD = 'u'
 
+/** Sentinel token a DISABLED store returns from a lock acquire, so single-replica callers proceed
+ * without special-casing; {@link FileDocStore.releaseLock} treats it as a no-op. Not a real UUID, so it
+ * can never collide with a {@link generateId} token. */
+const DISABLED_LOCK_TOKEN = '__disabled__'
+
 /** How long a blocking multiplexed read waits before re-snapshotting the live room set. Also bounds
  * how long a room attached mid-block waits for its first cross-task update (updates are not lost — the
  * next read resumes from its last id — only briefly delayed). */
@@ -69,11 +83,19 @@ const READ_COUNT = 200
 const COMPACT_THRESHOLD = 400
 /** Check whether compaction is due only every Nth local publish, to avoid an XLEN per keystroke. */
 const COMPACT_CHECK_EVERY = 64
-/** The seed lock is held across the app seed fetch (hard-bounded at `seedRequestMs`) plus the apply +
- * publish. The generous cushion over `seedRequestMs` means only a multi-second event-loop stall — not
- * ordinary latency — could expire it mid-seed, so the single-seeder invariant does not hinge on a tight
- * 2s margin coupled to an unrelated timeout. */
-const SEED_LOCK_TTL_MS = FILE_DOC_TIMEOUTS.seedRequestMs + 12_000
+/** Compaction critical section (snapshot + xAdd + xTrim) is fast; a generous TTL covers a slow Redis
+ * round-trip without risking expiry mid-compact. Released via compare-and-delete regardless. */
+const COMPACT_LOCK_TTL_MS = 10_000
+/** Retry a failed stream append this many times before giving up, so a transient Redis blip doesn't
+ * silently drop an edit from the shared log (which no peer would then ever see). */
+const PUBLISH_MAX_RETRIES = 3
+/** The seed lock spans the app seed fetch (hard-bounded at `seedRequestMs = 8s`) + the apply + the
+ * AWAITED seed publish. The margin comfortably exceeds the fetch bound so the lock does not expire
+ * mid-seed, while staying at the client readiness deadline (12s) so a dead seeder's lock frees when
+ * clients would recover anyway. Double-seed is prevented regardless of the margin: the seeder publishes
+ * the seed to the stream BEFORE releasing the lock, so any later seeder's {@link streamHasContent} fence
+ * sees it. */
+const SEED_LOCK_TTL_MS = FILE_DOC_TIMEOUTS.seedRequestMs + 4_000
 /** How long a stream survives with no heartbeat — long enough that an occupied-but-idle doc never
  * loses its shared state (the heartbeat refreshes it while any task holds the room). */
 const STREAM_TTL_SEC = 600
@@ -198,49 +220,106 @@ export class FileDocStore {
   }
 
   /**
-   * Append a locally-applied update to the shared stream so every task converges. Called from the
-   * relay's `doc.on('update')` for local edits only (never for {@link REDIS_ORIGIN} updates — those
-   * already came from the stream). No-op when disabled.
+   * Append a locally-applied update to the shared stream so every task converges, AWAITING the write
+   * and retrying a transient failure ({@link PUBLISH_MAX_RETRIES}) so a Redis blip can't silently drop
+   * an edit from the shared log. Only the `xAdd` is retried; the TTL refresh + compaction check are
+   * post-write best-effort and never re-trigger the append. Throws if the append ultimately fails.
    */
-  publish(name: string, update: Uint8Array): void {
-    if (!this.enabled || !this.write) return
+  private async appendUpdate(name: string, update: Uint8Array): Promise<void> {
+    if (!this.write) return
+    const encoded = Buffer.from(update).toString('base64')
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await this.write.xAdd(streamKey(name), '*', { [UPDATE_FIELD]: encoded })
+        break
+      } catch (error) {
+        if (attempt >= PUBLISH_MAX_RETRIES) {
+          logger.error(`FileDocStore append failed for ${name}`, { error: getErrorMessage(error) })
+          throw error
+        }
+        // Snappy backoff — a stream append is a fast op; a transient blip clears in tens of ms.
+        // `backoffWithJitter` is 1-indexed, so pass the 1-based attempt number.
+        await sleep(backoffWithJitter(attempt + 1, null, { baseMs: 50, maxMs: 500 }))
+      }
+    }
+    await this.write.expire(streamKey(name), STREAM_TTL_SEC).catch(() => {})
     const room = this.rooms.get(name)
-    void this.write
-      .xAdd(streamKey(name), '*', { [UPDATE_FIELD]: Buffer.from(update).toString('base64') })
-      .then(() => this.write?.expire(streamKey(name), STREAM_TTL_SEC))
-      .then(() => {
-        if (room && ++room.publishes % COMPACT_CHECK_EVERY === 0) return this.maybeCompact(name)
-      })
-      .catch((error) =>
-        logger.warn(`FileDocStore publish failed for ${name}`, { error: getErrorMessage(error) })
-      )
+    if (room && ++room.publishes % COMPACT_CHECK_EVERY === 0) void this.maybeCompact(name)
   }
 
   /**
-   * Decide whether THIS task should build and write the file's one-time seed. Returns true only when
-   * the shared stream is genuinely empty AND this task wins the seed lock — so exactly one task across
-   * the cluster ever seeds a file, even if several open it at once (the fix for split-brain seeding).
-   * When disabled, always true (single-replica: seed locally).
+   * Fire-and-forget append for the hot keystroke path (`doc.on('update')`): converges peers without
+   * blocking the relay. Retries internally; never throws. No-op when disabled.
    */
-  async shouldSeed(name: string): Promise<boolean> {
-    if (!this.enabled || !this.write) return true
+  publish(name: string, update: Uint8Array): void {
+    if (!this.enabled || !this.write) return
+    void this.appendUpdate(name, update).catch(() => {}) // already logged inside appendUpdate
+  }
+
+  /**
+   * Awaitable append for callers that must know the update is durably in the stream before proceeding
+   * — the copilot merge, so the cross-task merge lock is not released before the diff is committed
+   * (else the next task would diff a stale base). Throws on ultimate failure. No-op when disabled.
+   */
+  async publishAndWait(name: string, update: Uint8Array): Promise<void> {
+    if (!this.enabled || !this.write) return
+    await this.appendUpdate(name, update)
+  }
+
+  /**
+   * Whether the file's stream already holds content — fences a seed apply against a peer that seeded
+   * while this task held a (possibly stale) lock, so we never write a second seed (split-brain). False
+   * when disabled or on error (the caller then proceeds under its lock, as before).
+   */
+  async streamHasContent(name: string): Promise<boolean> {
+    if (!this.enabled || !this.write) return false
     try {
-      const won = await this.write.set(`${SEED_LOCK_PREFIX}${name}`, '1', {
-        NX: true,
-        PX: SEED_LOCK_TTL_MS,
-      })
-      if (won !== 'OK') return false
-      // The lock could be free yet the stream already seeded (a prior holder seeded then its lock
-      // expired). Re-check under the lock so we never write a SECOND seed on top of an existing one.
-      if ((await this.write.xLen(streamKey(name))) > 0) {
-        await this.releaseSeedLock(name)
-        return false
-      }
-      return true
-    } catch (error) {
-      logger.warn(`FileDocStore shouldSeed failed for ${name}`, { error: getErrorMessage(error) })
+      return (await this.write.xLen(streamKey(name))) > 0
+    } catch {
       return false
     }
+  }
+
+  /**
+   * Acquire a distributed lock with a unique ownership TOKEN (`SET key <token> NX PX`). Returns the
+   * token to release with, or `null` if not won. Fails CLOSED (null) on a Redis error — a lock we can't
+   * prove we hold must not be treated as held. The special sentinel {@link DISABLED_LOCK_TOKEN} lets a
+   * disabled store return a truthy token so callers proceed single-replica without special-casing.
+   */
+  private async acquireLock(key: string, ttlMs: number): Promise<string | null> {
+    if (!this.enabled || !this.write) return DISABLED_LOCK_TOKEN
+    const token = generateId()
+    try {
+      return (await this.write.set(key, token, { NX: true, PX: ttlMs })) === 'OK' ? token : null
+    } catch (error) {
+      logger.warn(`FileDocStore lock ${key} failed`, { error: getErrorMessage(error) })
+      return null
+    }
+  }
+
+  /** Release a lock via compare-and-delete, so it is only dropped if we still hold our token. */
+  private async releaseLock(key: string, token: string): Promise<void> {
+    if (!this.write || token === DISABLED_LOCK_TOKEN) return
+    await this.write.eval(RELEASE_LOCK_SCRIPT, { keys: [key], arguments: [token] }).catch(() => {})
+  }
+
+  /**
+   * Decide whether THIS task should build and write the file's one-time seed. Returns a lock TOKEN only
+   * when the shared stream is genuinely empty AND this task wins the seed lock — so exactly one task
+   * across the cluster ever seeds a file, even if several open it at once (the fix for split-brain
+   * seeding). `null` otherwise. Release the token with {@link releaseSeedLock}. Disabled → always a
+   * token (single-replica: seed locally).
+   */
+  async shouldSeed(name: string): Promise<string | null> {
+    const token = await this.acquireLock(`${SEED_LOCK_PREFIX}${name}`, SEED_LOCK_TTL_MS)
+    if (!token || token === DISABLED_LOCK_TOKEN) return token
+    // The lock could be free yet the stream already seeded (a prior holder seeded then its lock
+    // expired). Re-check under the lock so we never write a SECOND seed on top of an existing one.
+    if (await this.streamHasContent(name)) {
+      await this.releaseSeedLock(name, token)
+      return null
+    }
+    return token
   }
 
   /**
@@ -262,10 +341,9 @@ export class FileDocStore {
     }
   }
 
-  /** Release the seed lock (best-effort) once the seed has been published or a seed attempt failed. */
-  async releaseSeedLock(name: string): Promise<void> {
-    if (!this.enabled || !this.write) return
-    await this.write.del(`${SEED_LOCK_PREFIX}${name}`).catch(() => {})
+  /** Release the seed lock (compare-and-delete) once the seed has been published or a seed attempt failed. */
+  async releaseSeedLock(name: string, token: string): Promise<void> {
+    await this.releaseLock(`${SEED_LOCK_PREFIX}${name}`, token)
   }
 
   /**
@@ -292,22 +370,15 @@ export class FileDocStore {
    * merges per task; this extends that across tasks so two copilot edits to the same file landing on
    * different tasks don't each diff the SAME shared base and publish conflicting full-document rewrites.
    * The loser waits and retries so it diffs against the winner's RESULT (correct sequential merge).
-   * Returns true (proceed) when disabled or once the lock is won. Release with {@link releaseMergeSlot}.
+   * Returns a lock TOKEN (proceed) when disabled or once won; `null` otherwise (fails CLOSED on error, so
+   * a merge never races when exclusivity can't be proven). Release with {@link releaseMergeSlot}.
    */
-  async acquireMergeSlot(name: string, ttlMs: number): Promise<boolean> {
-    if (!this.enabled || !this.write) return true
-    try {
-      return (
-        (await this.write.set(`${MERGE_LOCK_PREFIX}${name}`, '1', { NX: true, PX: ttlMs })) === 'OK'
-      )
-    } catch {
-      return true
-    }
+  async acquireMergeSlot(name: string, ttlMs: number): Promise<string | null> {
+    return this.acquireLock(`${MERGE_LOCK_PREFIX}${name}`, ttlMs)
   }
 
-  async releaseMergeSlot(name: string): Promise<void> {
-    if (!this.enabled || !this.write) return
-    await this.write.del(`${MERGE_LOCK_PREFIX}${name}`).catch(() => {})
+  async releaseMergeSlot(name: string, token: string): Promise<void> {
+    await this.releaseLock(`${MERGE_LOCK_PREFIX}${name}`, token)
   }
 
   private applyEntry(room: StoreRoom, id: string, message: Record<string, string>): void {
@@ -358,11 +429,9 @@ export class FileDocStore {
     if (!room) return
     try {
       if ((await this.write.xLen(streamKey(name))) < COMPACT_THRESHOLD) return
-      const won = await this.write.set(`${COMPACT_LOCK_PREFIX}${name}`, '1', {
-        NX: true,
-        PX: 10_000,
-      })
-      if (won !== 'OK') return
+      const key = `${COMPACT_LOCK_PREFIX}${name}`
+      const token = await this.acquireLock(key, COMPACT_LOCK_TTL_MS)
+      if (!token) return
       try {
         // Capture the snapshot AND the id it covers in one synchronous step (no await between): the
         // snapshot is `room.doc`, which holds exactly what this task's tailer has integrated — every
@@ -377,7 +446,7 @@ export class FileDocStore {
         // `upTo` itself (redundant with the snapshot, harmless); it drops only the folded older deltas.
         await this.write.xTrim(streamKey(name), 'MINID', upTo)
       } finally {
-        await this.write.del(`${COMPACT_LOCK_PREFIX}${name}`).catch(() => {})
+        await this.releaseLock(key, token)
       }
     } catch (error) {
       logger.warn(`FileDocStore compaction failed for ${name}`, { error: getErrorMessage(error) })

--- a/apps/realtime/src/handlers/file-doc.test.ts
+++ b/apps/realtime/src/handlers/file-doc.test.ts
@@ -260,6 +260,42 @@ describe('setupWorkspaceFileDocHandlers', () => {
     )
   })
 
+  it('does NOT persist a seeded-but-unedited doc on last disconnect (no clobber of a concurrent write)', async () => {
+    mockFetchFileDocSeed.mockResolvedValue(encodedSeedUpdate('# From server'))
+    const { io } = createIo()
+    const { handlers } = setup('socket-1', io)
+    await handlers[FILE_DOC_EVENTS.JOIN]({ fileId: 'file-1', clientId: 1 })
+    await flushMicrotasks() // let the seed apply
+
+    // Last collaborator leaves without ever editing — projecting this seed back over the file could
+    // clobber a concurrent copilot write, so the final flush must NOT persist.
+    cleanupFileDocForSocket('socket-1', io, true)
+    await flushMicrotasks()
+    expect(mockFetchFileDocPersist).not.toHaveBeenCalled()
+  })
+
+  it('persists on last disconnect once a genuine user edit has landed', async () => {
+    mockFetchFileDocSeed.mockResolvedValue(encodedSeedUpdate('# From server'))
+    const { io } = createIo()
+    const { handlers } = setup('socket-1', io)
+    await handlers[FILE_DOC_EVENTS.JOIN]({ fileId: 'file-1', clientId: 1 })
+    await flushMicrotasks()
+
+    // A real user edit (socket-origin sync update) marks the doc dirty.
+    const edit = new Y.Doc()
+    edit.getText(FILE_DOC_FIELD).insert(0, 'user typed this')
+    handlers[FILE_DOC_EVENTS.MESSAGE](
+      frame(FILE_DOC_MESSAGE_TYPE.SYNC, (e) =>
+        syncProtocol.writeUpdate(e, Y.encodeStateAsUpdate(edit))
+      )
+    )
+    await flushMicrotasks()
+
+    cleanupFileDocForSocket('socket-1', io, true)
+    await flushMicrotasks()
+    expect(mockFetchFileDocPersist).toHaveBeenCalled()
+  })
+
   it('joins the room, sends sync step 1, and seeds the document from the server', async () => {
     mockFetchFileDocSeed.mockResolvedValue(encodedSeedUpdate('# From server'))
     const { io } = createIo()

--- a/apps/realtime/src/handlers/file-doc.test.ts
+++ b/apps/realtime/src/handlers/file-doc.test.ts
@@ -14,11 +14,13 @@ import * as syncProtocol from 'y-protocols/sync'
 import * as Y from 'yjs'
 import type { IRoomManager } from '@/rooms'
 
-const { mockAuthorizeRoom, mockFetchFileDocSeed, mockFetchFileDocMerge } = vi.hoisted(() => ({
-  mockAuthorizeRoom: vi.fn(),
-  mockFetchFileDocSeed: vi.fn(),
-  mockFetchFileDocMerge: vi.fn(),
-}))
+const { mockAuthorizeRoom, mockFetchFileDocSeed, mockFetchFileDocMerge, mockFetchFileDocPersist } =
+  vi.hoisted(() => ({
+    mockAuthorizeRoom: vi.fn(),
+    mockFetchFileDocSeed: vi.fn(),
+    mockFetchFileDocMerge: vi.fn(),
+    mockFetchFileDocPersist: vi.fn(),
+  }))
 
 vi.mock('@sim/platform-authz/rooms', () => ({
   authorizeRoom: mockAuthorizeRoom,
@@ -27,6 +29,7 @@ vi.mock('@sim/platform-authz/rooms', () => ({
 vi.mock('@/handlers/file-doc-app', () => ({
   fetchFileDocSeed: mockFetchFileDocSeed,
   fetchFileDocMerge: mockFetchFileDocMerge,
+  fetchFileDocPersist: mockFetchFileDocPersist,
 }))
 
 import {
@@ -63,7 +66,10 @@ function createIo() {
       left.push({ socketId, room })
     },
   }))
-  return { io: { to, in: inFn } as unknown as IRoomManager['io'], sent, left }
+  // Doc-sync frames fan out via `io.local.to(...)` (cross-task delivery rides the Redis stream, not the
+  // adapter). With the store disabled in tests, `local` is the whole room — mirror `to` so those emits
+  // are recorded identically. Awareness/presence still use `io.to(...)`.
+  return { io: { to, in: inFn, local: { to } } as unknown as IRoomManager['io'], sent, left }
 }
 
 /** Every socket id a test created, so `afterEach` can drop their rooms without a

--- a/apps/realtime/src/handlers/file-doc.test.ts
+++ b/apps/realtime/src/handlers/file-doc.test.ts
@@ -35,6 +35,7 @@ vi.mock('@/handlers/file-doc-app', () => ({
 import {
   applyMarkdownToLiveFileDoc,
   cleanupFileDocForSocket,
+  flushAllFileDocRooms,
   setupWorkspaceFileDocHandlers,
 } from '@/handlers/file-doc'
 
@@ -293,6 +294,32 @@ describe('setupWorkspaceFileDocHandlers', () => {
 
     cleanupFileDocForSocket('socket-1', io, true)
     await flushMicrotasks()
+    expect(mockFetchFileDocPersist).toHaveBeenCalled()
+  })
+
+  it('flushAllFileDocRooms persists open EDITED rooms (graceful shutdown), skips unedited', async () => {
+    mockFetchFileDocSeed.mockResolvedValue(encodedSeedUpdate('# From server'))
+    const { io } = createIo()
+    const { handlers } = setup('socket-1', io)
+    await handlers[FILE_DOC_EVENTS.JOIN]({ fileId: 'file-1', clientId: 1 })
+    await flushMicrotasks()
+
+    // Seed-only room: a graceful-shutdown flush must NOT persist it.
+    mockFetchFileDocPersist.mockClear()
+    await flushAllFileDocRooms()
+    expect(mockFetchFileDocPersist).not.toHaveBeenCalled()
+
+    // After a real user edit, the same flush persists (edits would otherwise be lost on deploy).
+    const edit = new Y.Doc()
+    edit.getText(FILE_DOC_FIELD).insert(0, 'typed')
+    handlers[FILE_DOC_EVENTS.MESSAGE](
+      frame(FILE_DOC_MESSAGE_TYPE.SYNC, (e) =>
+        syncProtocol.writeUpdate(e, Y.encodeStateAsUpdate(edit))
+      )
+    )
+    await flushMicrotasks()
+    mockFetchFileDocPersist.mockClear()
+    await flushAllFileDocRooms()
     expect(mockFetchFileDocPersist).toHaveBeenCalled()
   })
 

--- a/apps/realtime/src/handlers/file-doc.test.ts
+++ b/apps/realtime/src/handlers/file-doc.test.ts
@@ -121,8 +121,8 @@ const FILE_DOC_FIELD = 'default'
 
 /** Let a fire-and-forget `void ensureServerSeed(...)` chain settle (mock resolves synchronously). */
 async function flushMicrotasks(): Promise<void> {
-  await Promise.resolve()
-  await Promise.resolve()
+  // Enough to drain the fire-and-forget seed chain (shouldSeed → fetch → fence → publish → apply).
+  for (let i = 0; i < 8; i++) await Promise.resolve()
 }
 
 /**

--- a/apps/realtime/src/handlers/file-doc.ts
+++ b/apps/realtime/src/handlers/file-doc.ts
@@ -45,7 +45,7 @@ import * as syncProtocol from 'y-protocols/sync'
 import * as Y from 'yjs'
 import { resolveAvatarUrl } from '@/handlers/avatar'
 import { fetchFileDocMerge, fetchFileDocPersist, fetchFileDocSeed } from '@/handlers/file-doc-app'
-import { getFileDocStore, REDIS_ORIGIN } from '@/handlers/file-doc-store'
+import { getFileDocStore, REDIS_ORIGIN, REDIS_SNAPSHOT_ORIGIN } from '@/handlers/file-doc-store'
 import { resolveRoomJoinAuth } from '@/handlers/room-join-auth'
 import type { AuthenticatedSocket } from '@/middleware/auth'
 import type { IRoomManager } from '@/rooms'
@@ -61,6 +61,10 @@ const SEED_ORIGIN = Symbol('file-doc-seed')
 
 /** Debounce window for the server-side project-to-markdown persist while a doc is actively edited. */
 const PERSIST_DEBOUNCE_MS = 5_000
+/** Max-wait cap on the persist debounce: a CONTINUOUS edit burst keeps resetting the 5s debounce and
+ * would otherwise never persist until an idle pause, so force a flush at least this often — bounding how
+ * many edits are unpersisted (in the stream only) if the task dies mid-burst. */
+const PERSIST_MAX_WAIT_MS = 20_000
 
 /** Cross-task merge lock. The TTL must exceed the whole critical section it guards — stream fold +
  * `fetchFileDocMerge` (bounded at `mergeRequestMs`) + the awaited publish — so the lock never expires
@@ -118,6 +122,9 @@ interface FileDocRoom {
   seededObserved: boolean
   /** The pending debounced persist timer, if any. */
   persistTimer: ReturnType<typeof setTimeout> | null
+  /** Absolute time (ms) by which a debounced persist must fire even under continuous editing (the
+   * max-wait cap); null when no persist is pending. */
+  persistDeadline: number | null
 }
 
 /** Live documents keyed by Socket.IO room name. Module-global: one Y.Doc per file. */
@@ -184,24 +191,29 @@ function broadcastLocal(
 
 /**
  * Schedule a debounced server-side persist of the live doc back to durable markdown. Coalesces rapid
- * edits; a no-op until the room knows its workspace (set at join). The final flush on last-disconnect
- * is separate ({@link flushPersist} with `final`).
+ * edits; a no-op until the room knows its workspace (set at join). A {@link PERSIST_MAX_WAIT_MS}
+ * max-wait caps the debounce so a continuous burst still persists periodically. The final flush on
+ * last-disconnect is separate ({@link flushPersist} with `final`).
  */
 function schedulePersist(name: string, room: FileDocRoom): void {
   if (!room.workspaceId || !room.lastEditorUserId) return
+  const now = Date.now()
+  if (room.persistDeadline === null) room.persistDeadline = now + PERSIST_MAX_WAIT_MS
   if (room.persistTimer) clearTimeout(room.persistTimer)
+  const delay = Math.max(0, Math.min(PERSIST_DEBOUNCE_MS, room.persistDeadline - now))
   room.persistTimer = setTimeout(() => {
     room.persistTimer = null
+    room.persistDeadline = null
     void flushPersist(name, room, false)
-  }, PERSIST_DEBOUNCE_MS)
+  }, delay)
 }
 
 /**
  * Project the live doc to markdown and write it durably via the app. `final` (last collaborator
- * leaving) always writes; a debounced mid-edit flush first claims a cross-task slot (held for the whole
- * write, so a concurrent task can't issue an overlapping blob write) so tasks don't each write a
- * redundant version. Best-effort: never throws (a failure is retried on the next debounce; the stream
- * holds the state meanwhile).
+ * leaving) always writes; a debounced mid-edit flush first claims a best-effort cross-task dedup WINDOW
+ * (a TTL key that just expires, so at most ~one persist per window cluster-wide) so concurrent tasks
+ * editing the same file don't each write a redundant blob version. Best-effort: never throws (a failure
+ * is retried on the next debounce; the stream holds the state meanwhile).
  *
  * Persists the AUTHORITATIVE shared state (the stream), not this task's local doc: a copilot merge — or
  * a peer's edit — published by another task may not be integrated into `room.doc` yet (and the stream
@@ -218,7 +230,7 @@ async function flushPersist(name: string, room: FileDocRoom, final: boolean): Pr
   // this yields. Only meaningful once seeded; used only when the authoritative stream state is absent.
   const localState = isDocSeeded(room.doc) ? Y.encodeStateAsUpdate(room.doc) : null
   try {
-    if (!final && !(await store.acquirePersistSlot(name, FILE_DOC_TIMEOUTS.persistRequestMs)))
+    if (!final && !(await store.tryClaimPersistWindow(name, FILE_DOC_TIMEOUTS.persistRequestMs)))
       return
     let docState = localState
     if (store.enabled) {
@@ -294,6 +306,7 @@ function awarenessUpdateClientIds(update: Uint8Array): number[] {
 function destroyRoomIfIdle(name: string) {
   const room = fileDocRooms.get(name)
   if (!room || room.owners.size > 0) return
+  room.persistDeadline = null
   if (room.persistTimer) {
     clearTimeout(room.persistTimer)
     room.persistTimer = null
@@ -305,6 +318,21 @@ function destroyRoomIfIdle(name: string) {
   room.awareness.destroy()
   room.doc.destroy()
   fileDocRooms.delete(name)
+}
+
+/**
+ * Flush every open, edited room's converged doc to durable markdown, AWAITING the writes. Called on
+ * graceful shutdown (rolling deploy / scale-in) so edits since the last debounce aren't left only in the
+ * ephemeral stream — the per-socket disconnect flush is fire-and-forget and would race `process.exit`.
+ * Best-effort and bounded by each persist's own timeout; never throws. Rooms are NOT torn down here (the
+ * process is exiting); only their durable state is secured.
+ */
+export async function flushAllFileDocRooms(): Promise<void> {
+  const flushes: Promise<void>[] = []
+  for (const [name, room] of fileDocRooms) {
+    if (room.edited) flushes.push(flushPersist(name, room, true))
+  }
+  await Promise.all(flushes)
 }
 
 /**
@@ -498,6 +526,7 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
     edited: false,
     seededObserved: false,
     persistTimer: null,
+    persistDeadline: null,
   }
   // Register synchronously BEFORE the async catch-up so a concurrent join sees this room, not a second.
   fileDocRooms.set(name, room)
@@ -509,18 +538,27 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
     // Fan out to THIS task's clients only (excluding the origin socket if local). Cross-task delivery
     // rides the shared stream — every task's tailer applies + runs its own local fan-out.
     broadcastLocal(io, name, encoding.toUint8Array(encoder), originSocketId(origin))
-    // Share every locally-originated update to the stream so peers converge. Skip REDIS_ORIGIN (already
-    // in the stream) and SEED_ORIGIN — the seed is published EXPLICITLY and AWAITED under the seed lock
-    // (so it lands before the lock releases), which a fire-and-forget publish here couldn't guarantee.
-    if (origin !== REDIS_ORIGIN && origin !== SEED_ORIGIN) getFileDocStore().publish(name, update)
+    // Share every locally-originated update to the stream so peers converge. Skip updates that already
+    // came FROM the stream (REDIS_ORIGIN / REDIS_SNAPSHOT_ORIGIN) and SEED_ORIGIN — the seed is published
+    // EXPLICITLY and AWAITED under the seed lock (so it lands before the lock releases), which a
+    // fire-and-forget publish here couldn't guarantee.
+    if (origin !== REDIS_ORIGIN && origin !== REDIS_SNAPSHOT_ORIGIN && origin !== SEED_ORIGIN)
+      getFileDocStore().publish(name, update)
     // Edit tracking for persistence. Mark the doc dirty on any update applied AFTER it was seeded — a
     // local user edit (socket origin) OR a peer's edit relayed via the tailer (REDIS_ORIGIN) — so
-    // whichever task is last to leave persists real edits, even one that only tailed them. The seed
-    // transition itself is never counted (nor a purely-local copilot merge, already durable via
-    // copilot's direct file write), so a seeded-but-unedited doc is never projected back over the file.
+    // whichever task is last to leave persists real edits, even one that only tailed them. A compaction
+    // snapshot on catch-up (REDIS_SNAPSHOT_ORIGIN) also counts: it folds real edits into one frame, so a
+    // fresh task catching up purely from it must not treat the doc as unedited. The seed transition
+    // itself is never counted (nor a purely-local copilot merge, already durable via copilot's direct
+    // file write), so a seeded-but-unedited doc is never projected back over the file.
     const seededBefore = room.seededObserved
     if (isDocSeeded(room.doc)) room.seededObserved = true
-    if (originSocketId(origin) || (seededBefore && origin === REDIS_ORIGIN)) room.edited = true
+    if (
+      originSocketId(origin) ||
+      origin === REDIS_SNAPSHOT_ORIGIN ||
+      (seededBefore && origin === REDIS_ORIGIN)
+    )
+      room.edited = true
     // Debounce a persist for LOCAL user edits only (peers debounce their own).
     if (originSocketId(origin)) schedulePersist(name, room)
   })

--- a/apps/realtime/src/handlers/file-doc.ts
+++ b/apps/realtime/src/handlers/file-doc.ts
@@ -216,7 +216,19 @@ async function flushPersist(name: string, room: FileDocRoom, final: boolean): Pr
   try {
     if (!final && !(await store.acquirePersistSlot(name, FILE_DOC_TIMEOUTS.persistRequestMs)))
       return
-    const docState = (store.enabled ? await store.getStreamState(name) : null) ?? localState
+    let docState = localState
+    if (store.enabled) {
+      try {
+        docState = (await store.getStreamState(name)) ?? localState
+      } catch (streamError) {
+        // A transient Redis read must NOT drop the write when we already hold a valid local snapshot —
+        // else the last-disconnect flush loses the session's edits as the room is torn down.
+        if (!localState) throw streamError
+        logger.warn(`Stream state unavailable for file ${room.fileId}; persisting local snapshot`, {
+          error: getErrorMessage(streamError),
+        })
+      }
+    }
     if (!docState) return // nothing seeded/authoritative to persist yet
     await fetchFileDocPersist(room.workspaceId, room.fileId, room.lastEditorUserId, docState)
   } catch (error) {
@@ -332,23 +344,32 @@ async function ensureServerSeed(
     // Fence against a peer that seeded while we held a stale lock (a rare long stall): if the stream
     // already has content it is seeded, so never write a SECOND seed on top — that would split-brain.
     if (await store.streamHasContent(name)) return
-    // SEED_ORIGIN → `doc.on('update')` fans the seed to THIS task's clients but does NOT publish it
-    // (nor persist it — the seed is the file's current content). We publish it EXPLICITLY and AWAIT the
-    // stream write below, so the seed is durably in the stream BEFORE the lock releases — then any later
-    // seeder's `streamHasContent` fence is guaranteed to see it. Closes the fence's publish-after-release
-    // gap that a fire-and-forget publish left open.
-    if (update) Y.applyUpdate(room.doc, update, SEED_ORIGIN)
-    else
-      room.doc.transact(
-        () => room.doc.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.flag, true),
-        SEED_ORIGIN
-      )
-    await store.publishAndWait(name, Y.encodeStateAsUpdate(room.doc))
+    // Build the seed (file content + seed flag, or just the flag for an empty/missing file), then
+    // PUBLISH it to the shared stream AWAITED *before* seeding the local doc. The doc is marked seeded
+    // only once the seed is durably shared — so if the publish fails we leave the doc unseeded and the
+    // stream empty for a clean retry, rather than serving an unpublished local seed that a peer would
+    // re-seed on top of (split-brain). SEED_ORIGIN keeps `doc.on('update')` from re-publishing it.
+    const seedUpdate = update ?? emptySeedUpdate()
+    await store.publishAndWait(name, seedUpdate)
+    if (fileDocRooms.get(name) !== room || isDocSeeded(room.doc)) return
+    Y.applyUpdate(room.doc, seedUpdate, SEED_ORIGIN)
   } catch (error) {
     logger.warn(`Server seed failed for file ${room.fileId} (workspace ${workspaceId})`, error)
     room.serverSeedStarted = false
   } finally {
     await store.releaseSeedLock(name, token)
+  }
+}
+
+/** The seed update for an empty/missing file: just the `initialContentLoaded` flag, so an empty doc
+ * still reaches readiness (and its emptiness is durably shared like any seed). */
+function emptySeedUpdate(): Uint8Array {
+  const doc = new Y.Doc()
+  doc.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.flag, true)
+  try {
+    return Y.encodeStateAsUpdate(doc)
+  } finally {
+    doc.destroy()
   }
 }
 

--- a/apps/realtime/src/handlers/file-doc.ts
+++ b/apps/realtime/src/handlers/file-doc.ts
@@ -105,6 +105,13 @@ interface FileDocRoom {
   workspaceId: string | null
   /** The last collaborator to edit here, for persist attribution (blob metadata) only. */
   lastEditorUserId: string | null
+  /**
+   * True once a genuine USER edit has been applied here. Persistence is gated on it so a doc that was
+   * only seeded (or only received a copilot merge) is NEVER projected back over the file: copilot writes
+   * the file durably itself, and a seed captured from possibly-stale markdown must not clobber a
+   * concurrent external write.
+   */
+  edited: boolean
   /** The pending debounced persist timer, if any. */
   persistTimer: ReturnType<typeof setTimeout> | null
 }
@@ -200,7 +207,8 @@ function schedulePersist(name: string, room: FileDocRoom): void {
  * caller destroys `room.doc` never encodes a destroyed doc, and the disabled path stays authoritative.
  */
 async function flushPersist(name: string, room: FileDocRoom, final: boolean): Promise<void> {
-  if (!room.workspaceId || !room.lastEditorUserId) return
+  // Never project a doc no user actually edited back over the file (see {@link FileDocRoom.edited}).
+  if (!room.edited || !room.workspaceId || !room.lastEditorUserId) return
   const store = getFileDocStore()
   // Synchronous fallback capture — before any await, since the caller may destroy `room.doc` the moment
   // this yields. Only meaningful once seeded; used only when the authoritative stream state is absent.
@@ -456,6 +464,7 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
     serverSeedStarted: false,
     workspaceId: null,
     lastEditorUserId: null,
+    edited: false,
     persistTimer: null,
   }
   // Register synchronously BEFORE the async catch-up so a concurrent join sees this room, not a second.
@@ -472,9 +481,13 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
     // in the stream) and SEED_ORIGIN — the seed is published EXPLICITLY and AWAITED under the seed lock
     // (so it lands before the lock releases), which a fire-and-forget publish here couldn't guarantee.
     if (origin !== REDIS_ORIGIN && origin !== SEED_ORIGIN) getFileDocStore().publish(name, update)
-    // Persist real edits (user edits + copilot merges) back to markdown, debounced. Skip the seed (it
-    // is the file's current content) and stream-relayed updates (their originating task persists them).
-    if (origin !== REDIS_ORIGIN && origin !== SEED_ORIGIN) schedulePersist(name, room)
+    // Persist ONLY genuine USER edits (socket origin), debounced. A seed or a bare copilot merge must
+    // NOT project back over the file — copilot writes the file durably itself, so persisting a
+    // seeded-but-unedited doc (built from possibly-stale markdown) could clobber that concurrent write.
+    if (originSocketId(origin)) {
+      room.edited = true
+      schedulePersist(name, room)
+    }
   })
 
   awareness.on('update', ({ added, updated, removed }: AwarenessChange, origin: unknown) => {

--- a/apps/realtime/src/handlers/file-doc.ts
+++ b/apps/realtime/src/handlers/file-doc.ts
@@ -106,12 +106,16 @@ interface FileDocRoom {
   /** The last collaborator to edit here, for persist attribution (blob metadata) only. */
   lastEditorUserId: string | null
   /**
-   * True once a genuine USER edit has been applied here. Persistence is gated on it so a doc that was
-   * only seeded (or only received a copilot merge) is NEVER projected back over the file: copilot writes
-   * the file durably itself, and a seed captured from possibly-stale markdown must not clobber a
-   * concurrent external write.
+   * True once a genuine edit (a user edit — local OR a peer's, relayed via the tailer) has been applied
+   * here AFTER seeding. Persistence is gated on it so a doc that was only seeded is NEVER projected back
+   * over the file: the seed is captured from possibly-stale markdown and must not clobber a concurrent
+   * external write, whereas real edits are not otherwise durable and must be persisted by whichever task
+   * is last to leave — even one that only tailed the edits.
    */
   edited: boolean
+  /** Whether this room has observed its doc become seeded — so a post-seed update counts as an edit but
+   * the seed transition itself does not. See the `doc.on('update')` edit-tracking below. */
+  seededObserved: boolean
   /** The pending debounced persist timer, if any. */
   persistTimer: ReturnType<typeof setTimeout> | null
 }
@@ -343,7 +347,13 @@ async function ensureServerSeed(
     if (fileDocRooms.get(name) !== room || isDocSeeded(room.doc)) return
     // Fence against a peer that seeded while we held a stale lock (a rare long stall): if the stream
     // already has content it is seeded, so never write a SECOND seed on top — that would split-brain.
-    if (await store.streamHasContent(name)) return
+    if (await store.streamHasContent(name)) {
+      // Clear the guard so a later join can retry. Safe in both cases: a genuine peer-seed arrives via
+      // the tailer (and shouldSeed/this fence then no-op), and a fail-closed Redis `xLen` error must not
+      // strand the room unseeded forever.
+      room.serverSeedStarted = false
+      return
+    }
     // Build the seed (file content + seed flag, or just the flag for an empty/missing file), then
     // PUBLISH it to the shared stream AWAITED *before* seeding the local doc. The doc is marked seeded
     // only once the seed is durably shared — so if the publish fails we leave the doc unseeded and the
@@ -486,6 +496,7 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
     workspaceId: null,
     lastEditorUserId: null,
     edited: false,
+    seededObserved: false,
     persistTimer: null,
   }
   // Register synchronously BEFORE the async catch-up so a concurrent join sees this room, not a second.
@@ -502,13 +513,16 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
     // in the stream) and SEED_ORIGIN — the seed is published EXPLICITLY and AWAITED under the seed lock
     // (so it lands before the lock releases), which a fire-and-forget publish here couldn't guarantee.
     if (origin !== REDIS_ORIGIN && origin !== SEED_ORIGIN) getFileDocStore().publish(name, update)
-    // Persist ONLY genuine USER edits (socket origin), debounced. A seed or a bare copilot merge must
-    // NOT project back over the file — copilot writes the file durably itself, so persisting a
-    // seeded-but-unedited doc (built from possibly-stale markdown) could clobber that concurrent write.
-    if (originSocketId(origin)) {
-      room.edited = true
-      schedulePersist(name, room)
-    }
+    // Edit tracking for persistence. Mark the doc dirty on any update applied AFTER it was seeded — a
+    // local user edit (socket origin) OR a peer's edit relayed via the tailer (REDIS_ORIGIN) — so
+    // whichever task is last to leave persists real edits, even one that only tailed them. The seed
+    // transition itself is never counted (nor a purely-local copilot merge, already durable via
+    // copilot's direct file write), so a seeded-but-unedited doc is never projected back over the file.
+    const seededBefore = room.seededObserved
+    if (isDocSeeded(room.doc)) room.seededObserved = true
+    if (originSocketId(origin) || (seededBefore && origin === REDIS_ORIGIN)) room.edited = true
+    // Debounce a persist for LOCAL user edits only (peers debounce their own).
+    if (originSocketId(origin)) schedulePersist(name, room)
   })
 
   awareness.on('update', ({ added, updated, removed }: AwarenessChange, origin: unknown) => {

--- a/apps/realtime/src/handlers/file-doc.ts
+++ b/apps/realtime/src/handlers/file-doc.ts
@@ -62,10 +62,17 @@ const SEED_ORIGIN = Symbol('file-doc-seed')
 /** Debounce window for the server-side project-to-markdown persist while a doc is actively edited. */
 const PERSIST_DEBOUNCE_MS = 5_000
 
-/** Cross-task merge-lock wait: while a peer task is merging the same file, retry at this cadence for up
- * to ~`mergeRequestMs` so we diff against the peer's RESULT rather than racing it; then proceed. */
+/** Cross-task merge lock. The TTL must exceed the whole critical section it guards — stream fold +
+ * `fetchFileDocMerge` (bounded at `mergeRequestMs`) + the awaited publish — so the lock never expires
+ * mid-merge and lets a second task race the same base; hence `mergeRequestMs` plus generous headroom.
+ * The waiter retries at {@link MERGE_LOCK_RETRY_MS} for LONGER than the TTL, so a live holder always
+ * releases (or a dead holder's lock expires) within the window. Release is compare-and-delete on an
+ * ownership token, so even a pathological over-TTL hold never deletes another task's re-acquired lock. */
+const MERGE_LOCK_TTL_MS = FILE_DOC_TIMEOUTS.mergeRequestMs + 5_000
 const MERGE_LOCK_RETRY_MS = 200
-const MERGE_LOCK_RETRIES = Math.ceil(FILE_DOC_TIMEOUTS.mergeRequestMs / MERGE_LOCK_RETRY_MS)
+const MERGE_LOCK_RETRIES = Math.ceil(
+  (MERGE_LOCK_TTL_MS + FILE_DOC_TIMEOUTS.mergeRequestMs) / MERGE_LOCK_RETRY_MS
+)
 
 /** A socket's presence ownership within a room. */
 interface FileDocOwner {
@@ -186,21 +193,23 @@ function schedulePersist(name: string, room: FileDocRoom): void {
  * holds the state meanwhile).
  *
  * Persists the AUTHORITATIVE shared state (the stream), not this task's local doc: a copilot merge — or
- * a peer's edit — published by another task may not be integrated into `room.doc` yet, and a
- * last-disconnect flush of that lagging local doc would clobber the durable file (the exact
- * copilot-write regression a naive local-doc flush reintroduces). Reading from the stream also means
- * the enabled path never touches `room.doc`, so `void flushPersist(name, room, true)` is safe to fire
- * immediately before the caller destroys it. When disabled the local doc IS authoritative, and is
- * encoded synchronously (before the first await) so the same fire-then-destroy ordering holds.
+ * a peer's edit — published by another task may not be integrated into `room.doc` yet (and the stream
+ * holds content even when THIS task's doc was never locally seeded), so a last-disconnect flush can't
+ * clobber the durable file with a lagging projection. The local doc is captured SYNCHRONOUSLY as a
+ * fallback before any await, so a `void flushPersist(name, room, true)` fired immediately before the
+ * caller destroys `room.doc` never encodes a destroyed doc, and the disabled path stays authoritative.
  */
 async function flushPersist(name: string, room: FileDocRoom, final: boolean): Promise<void> {
-  if (!isDocSeeded(room.doc) || !room.workspaceId || !room.lastEditorUserId) return
+  if (!room.workspaceId || !room.lastEditorUserId) return
   const store = getFileDocStore()
+  // Synchronous fallback capture — before any await, since the caller may destroy `room.doc` the moment
+  // this yields. Only meaningful once seeded; used only when the authoritative stream state is absent.
+  const localState = isDocSeeded(room.doc) ? Y.encodeStateAsUpdate(room.doc) : null
   try {
     if (!final && !(await store.acquirePersistSlot(name, FILE_DOC_TIMEOUTS.persistRequestMs)))
       return
-    const shared = store.enabled ? await store.getStreamState(name) : null
-    const docState = shared ?? Y.encodeStateAsUpdate(room.doc)
+    const docState = (store.enabled ? await store.getStreamState(name) : null) ?? localState
+    if (!docState) return // nothing seeded/authoritative to persist yet
     await fetchFileDocPersist(room.workspaceId, room.fileId, room.lastEditorUserId, docState)
   } catch (error) {
     logger.warn(`Persist failed for file ${room.fileId}`, { error: getErrorMessage(error) })
@@ -300,8 +309,9 @@ async function ensureServerSeed(
   room.serverSeedStarted = true
   const store = getFileDocStore()
   // Exactly one task across the cluster builds the seed; the others receive it via the stream (the fix
-  // for split-brain seeding). `shouldSeed` is true here on a single-pod deployment.
-  if (!(await store.shouldSeed(name))) {
+  // for split-brain seeding). Returns a lock token here (single-pod: a sentinel token).
+  const token = await store.shouldSeed(name)
+  if (!token) {
     // A peer is seeding (or already did). Release our guard so a later join can retry if the seed never
     // arrives (e.g. the seeder died); the stream / this doc being seeded makes a retry safe.
     room.serverSeedStarted = false
@@ -311,19 +321,26 @@ async function ensureServerSeed(
   try {
     const update = await fetchFileDocSeed(workspaceId, room.fileId)
     if (fileDocRooms.get(name) !== room || isDocSeeded(room.doc)) return
-    // SEED_ORIGIN → `doc.on('update')` shares the seed to the stream (peers need it) but skips the
-    // persist (the seed is the file's current content, so a persist would only churn a blob version).
+    // Fence against a peer that seeded while we held a stale lock (a rare long stall): if the stream
+    // already has content it is seeded, so never write a SECOND seed on top — that would split-brain.
+    if (await store.streamHasContent(name)) return
+    // SEED_ORIGIN → `doc.on('update')` fans the seed to THIS task's clients but does NOT publish it
+    // (nor persist it — the seed is the file's current content). We publish it EXPLICITLY and AWAIT the
+    // stream write below, so the seed is durably in the stream BEFORE the lock releases — then any later
+    // seeder's `streamHasContent` fence is guaranteed to see it. Closes the fence's publish-after-release
+    // gap that a fire-and-forget publish left open.
     if (update) Y.applyUpdate(room.doc, update, SEED_ORIGIN)
     else
       room.doc.transact(
         () => room.doc.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.flag, true),
         SEED_ORIGIN
       )
+    await store.publishAndWait(name, Y.encodeStateAsUpdate(room.doc))
   } catch (error) {
     logger.warn(`Server seed failed for file ${room.fileId} (workspace ${workspaceId})`, error)
     room.serverSeedStarted = false
   } finally {
-    await store.releaseSeedLock(name)
+    await store.releaseSeedLock(name, token)
   }
 }
 
@@ -376,27 +393,32 @@ async function mergeMarkdownIntoRoom(
   if (store.enabled) {
     // Serialize merges to this file ACROSS tasks — the per-file chain above only covers this process.
     // Two copilot edits to the same file landing on different tasks must not diff the SAME shared base
-    // and publish conflicting full-document rewrites; wait briefly for a peer's merge to finish so we
-    // diff against its RESULT. If the holder is stuck past the wait (likely dead; its lock TTL will
-    // lapse), proceed anyway rather than drop the edit.
-    const lockTtl = FILE_DOC_TIMEOUTS.mergeRequestMs + 2_000
-    let acquired = await store.acquireMergeSlot(name, lockTtl)
-    for (let i = 0; !acquired && i < MERGE_LOCK_RETRIES; i++) {
+    // and publish conflicting full-document rewrites. Retry LONGER than the lock TTL, so a live holder
+    // always releases (or its lock expires) first and we acquire — never merging against a shared base
+    // while a peer holds the lock. If somehow still unavailable, skip the live merge (copilot's durable
+    // file write stands) rather than race.
+    let token = await store.acquireMergeSlot(name, MERGE_LOCK_TTL_MS)
+    for (let i = 0; !token && i < MERGE_LOCK_RETRIES; i++) {
       await sleep(MERGE_LOCK_RETRY_MS)
-      acquired = await store.acquireMergeSlot(name, lockTtl)
+      token = await store.acquireMergeSlot(name, MERGE_LOCK_TTL_MS)
+    }
+    if (!token) {
+      logger.warn(`Merge lock unavailable for file ${fileId}; skipping live merge`)
+      return 'no-live-room'
     }
     try {
       // Compute the diff against the committed SHARED state and PUBLISH it — every task with the doc
       // live (including this one, via its own tailer) applies it and fans it out to its clients, so the
       // merge reaches the live doc no matter which task the apply-edit call landed on. An empty stream
-      // means no doc is (or was recently) live → nothing to merge into.
+      // means no doc is (or was recently) live → nothing to merge into. AWAIT the publish so the diff is
+      // durably in the stream before we release the lock (else the next task would diff a stale base).
       const base = await store.getStreamState(name)
       if (!base) return 'no-live-room'
       const diff = await fetchFileDocMerge(fileId, base, markdown)
-      store.publish(name, diff)
+      await store.publishAndWait(name, diff)
       return 'applied'
     } finally {
-      if (acquired) await store.releaseMergeSlot(name)
+      await store.releaseMergeSlot(name, token)
     }
   }
 
@@ -446,9 +468,10 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
     // Fan out to THIS task's clients only (excluding the origin socket if local). Cross-task delivery
     // rides the shared stream — every task's tailer applies + runs its own local fan-out.
     broadcastLocal(io, name, encoding.toUint8Array(encoder), originSocketId(origin))
-    // Share every locally-originated update to the stream so peers converge; an update that ARRIVED
-    // from the stream (REDIS_ORIGIN) is already there — never re-publish it.
-    if (origin !== REDIS_ORIGIN) getFileDocStore().publish(name, update)
+    // Share every locally-originated update to the stream so peers converge. Skip REDIS_ORIGIN (already
+    // in the stream) and SEED_ORIGIN — the seed is published EXPLICITLY and AWAITED under the seed lock
+    // (so it lands before the lock releases), which a fire-and-forget publish here couldn't guarantee.
+    if (origin !== REDIS_ORIGIN && origin !== SEED_ORIGIN) getFileDocStore().publish(name, update)
     // Persist real edits (user edits + copilot merges) back to markdown, debounced. Skip the seed (it
     // is the file's current content) and stream-relayed updates (their originating task persists them).
     if (origin !== REDIS_ORIGIN && origin !== SEED_ORIGIN) schedulePersist(name, room)

--- a/apps/realtime/src/handlers/file-doc.ts
+++ b/apps/realtime/src/handlers/file-doc.ts
@@ -6,15 +6,20 @@
  * and the room abstraction, rather than a separate ws server. Clients speak the
  * `y-protocols` sync + awareness protocols; the server applies and relays them.
  *
- * No durable Yjs state is kept yet: the document lives only while at least one
- * collaborator is connected, and is re-seeded from the file's stored markdown on
- * the next cold open (the markdown, saved by a client through the content API, is
- * the durable source of truth). Durable Yjs snapshots are a separate follow-up.
+ * Multi-replica safe. The in-memory {@link Y.Doc} is NOT authoritative on its own — every task
+ * converges on one CRDT per file through the shared Redis-Streams backend in {@link file-doc-store}:
+ * each applied update is published to the file's stream and every task's tailer applies it to its own
+ * doc and fans it out to its own clients, so two tasks can never split-brain. Consequently doc-sync
+ * messages are broadcast LOCALLY ({@link io.local}) and cross-task delivery rides the stream — NOT the
+ * Socket.IO adapter (that would double-deliver). Awareness/presence stay on the adapter: they are
+ * ephemeral and need neither convergence nor replay. When `REDIS_URL` is unset the store is disabled
+ * and this falls back to the original single-replica behavior (local doc, local seed, local fan-out).
  *
- * Single-writer assumption: the authoritative {@link Y.Doc} is held in this
- * process's memory, so correctness assumes one realtime replica per file (Helm
- * pins `realtime.replicaCount: 1`). Horizontal scaling would need a shared Yjs
- * backend (y-redis / Hocuspocus) — out of scope here.
+ * Durability: the live doc is projected back to the file's markdown server-side — debounced while it is
+ * edited and flushed when the last collaborator leaves — via the app's `/persist` endpoint (the app
+ * owns the conversion engine). This replaces the editor's client autosave, closing the copilot
+ * clobber-window, and the Redis stream is the crash buffer between flushes. The markdown file remains
+ * the long-term source of truth; the Redis stream is ephemeral (TTL'd, heartbeat-refreshed while live).
  *
  * @module
  */
@@ -23,12 +28,15 @@ import {
   FILE_DOC_EVENTS,
   FILE_DOC_MESSAGE_TYPE,
   FILE_DOC_SEED,
+  FILE_DOC_TIMEOUTS,
   type FileDocPresenceUser,
   type JoinFileDocPayload,
   type LeaveFileDocPayload,
   toFileDocBytes,
 } from '@sim/realtime-protocol/file-doc'
 import { ROOM_TYPES, type RoomRef, roomName } from '@sim/realtime-protocol/rooms'
+import { getErrorMessage } from '@sim/utils/errors'
+import { sleep } from '@sim/utils/helpers'
 import * as decoding from 'lib0/decoding'
 import * as encoding from 'lib0/encoding'
 import type { Server } from 'socket.io'
@@ -36,12 +44,28 @@ import * as awarenessProtocol from 'y-protocols/awareness'
 import * as syncProtocol from 'y-protocols/sync'
 import * as Y from 'yjs'
 import { resolveAvatarUrl } from '@/handlers/avatar'
-import { fetchFileDocMerge, fetchFileDocSeed } from '@/handlers/file-doc-app'
+import { fetchFileDocMerge, fetchFileDocPersist, fetchFileDocSeed } from '@/handlers/file-doc-app'
+import { getFileDocStore, REDIS_ORIGIN } from '@/handlers/file-doc-store'
 import { resolveRoomJoinAuth } from '@/handlers/room-join-auth'
 import type { AuthenticatedSocket } from '@/middleware/auth'
 import type { IRoomManager } from '@/rooms'
 
 const logger = createLogger('FileDocHandlers')
+
+/**
+ * The transaction origin the server stamps on a SEED apply, so `doc.on('update')` can broadcast + share
+ * it (peers still need the seed) but skip the debounced persist — the seed IS the file's current
+ * content, so writing it straight back would only churn a redundant blob version.
+ */
+const SEED_ORIGIN = Symbol('file-doc-seed')
+
+/** Debounce window for the server-side project-to-markdown persist while a doc is actively edited. */
+const PERSIST_DEBOUNCE_MS = 5_000
+
+/** Cross-task merge-lock wait: while a peer task is merging the same file, retry at this cadence for up
+ * to ~`mergeRequestMs` so we diff against the peer's RESULT rather than racing it; then proceed. */
+const MERGE_LOCK_RETRY_MS = 200
+const MERGE_LOCK_RETRIES = Math.ceil(FILE_DOC_TIMEOUTS.mergeRequestMs / MERGE_LOCK_RETRY_MS)
 
 /** A socket's presence ownership within a room. */
 interface FileDocOwner {
@@ -70,6 +94,12 @@ interface FileDocRoom {
   /** True once the server-side seed fetch has started, so concurrent joins don't each fetch.
    * Reset on a fetch FAILURE so a later join can retry (a genuinely empty file stays empty). */
   serverSeedStarted: boolean
+  /** The workspace this file belongs to, captured at join — needed to persist back to markdown. */
+  workspaceId: string | null
+  /** The last collaborator to edit here, for persist attribution (blob metadata) only. */
+  lastEditorUserId: string | null
+  /** The pending debounced persist timer, if any. */
+  persistTimer: ReturnType<typeof setTimeout> | null
 }
 
 /** Live documents keyed by Socket.IO room name. Module-global: one Y.Doc per file. */
@@ -108,9 +138,73 @@ function originSocketId(origin: unknown): string | null {
   return typeof origin === 'string' ? origin : null
 }
 
+/**
+ * Broadcast an AWARENESS frame to the room ACROSS tasks via the Socket.IO Redis adapter. Awareness
+ * (cursors/selection) is ephemeral and needs no convergence or replay, so the adapter's cross-task
+ * fan-out is exactly right for it.
+ */
 function broadcast(io: Server, name: string, payload: Uint8Array, exceptSocketId: string | null) {
   const channel = exceptSocketId ? io.to(name).except(exceptSocketId) : io.to(name)
   channel.emit(FILE_DOC_EVENTS.MESSAGE, payload)
+}
+
+/**
+ * Broadcast a DOC-SYNC frame to this task's LOCAL clients only. Cross-task delivery rides the shared
+ * Redis stream (each task's tailer applies the update and runs its OWN local fan-out), so using the
+ * adapter here would double-deliver and amplify. With no adapter (single-pod dev) `io.local` is the
+ * whole room, so behavior is unchanged.
+ */
+function broadcastLocal(
+  io: Server,
+  name: string,
+  payload: Uint8Array,
+  exceptSocketId: string | null
+) {
+  const channel = exceptSocketId ? io.local.to(name).except(exceptSocketId) : io.local.to(name)
+  channel.emit(FILE_DOC_EVENTS.MESSAGE, payload)
+}
+
+/**
+ * Schedule a debounced server-side persist of the live doc back to durable markdown. Coalesces rapid
+ * edits; a no-op until the room knows its workspace (set at join). The final flush on last-disconnect
+ * is separate ({@link flushPersist} with `final`).
+ */
+function schedulePersist(name: string, room: FileDocRoom): void {
+  if (!room.workspaceId || !room.lastEditorUserId) return
+  if (room.persistTimer) clearTimeout(room.persistTimer)
+  room.persistTimer = setTimeout(() => {
+    room.persistTimer = null
+    void flushPersist(name, room, false)
+  }, PERSIST_DEBOUNCE_MS)
+}
+
+/**
+ * Project the live doc to markdown and write it durably via the app. `final` (last collaborator
+ * leaving) always writes; a debounced mid-edit flush first claims a cross-task slot (held for the whole
+ * write, so a concurrent task can't issue an overlapping blob write) so tasks don't each write a
+ * redundant version. Best-effort: never throws (a failure is retried on the next debounce; the stream
+ * holds the state meanwhile).
+ *
+ * Persists the AUTHORITATIVE shared state (the stream), not this task's local doc: a copilot merge — or
+ * a peer's edit — published by another task may not be integrated into `room.doc` yet, and a
+ * last-disconnect flush of that lagging local doc would clobber the durable file (the exact
+ * copilot-write regression a naive local-doc flush reintroduces). Reading from the stream also means
+ * the enabled path never touches `room.doc`, so `void flushPersist(name, room, true)` is safe to fire
+ * immediately before the caller destroys it. When disabled the local doc IS authoritative, and is
+ * encoded synchronously (before the first await) so the same fire-then-destroy ordering holds.
+ */
+async function flushPersist(name: string, room: FileDocRoom, final: boolean): Promise<void> {
+  if (!isDocSeeded(room.doc) || !room.workspaceId || !room.lastEditorUserId) return
+  const store = getFileDocStore()
+  try {
+    if (!final && !(await store.acquirePersistSlot(name, FILE_DOC_TIMEOUTS.persistRequestMs)))
+      return
+    const shared = store.enabled ? await store.getStreamState(name) : null
+    const docState = shared ?? Y.encodeStateAsUpdate(room.doc)
+    await fetchFileDocPersist(room.workspaceId, room.fileId, room.lastEditorUserId, docState)
+  } catch (error) {
+    logger.warn(`Persist failed for file ${room.fileId}`, { error: getErrorMessage(error) })
+  }
 }
 
 /**
@@ -159,12 +253,22 @@ function awarenessUpdateClientIds(update: Uint8Array): number[] {
 }
 
 /**
- * Drop a room's document + awareness once it has no owners, so an idle file holds no memory.
- * A later joiner re-creates and re-seeds it from the file's current markdown.
+ * Drop a room's document + awareness once it has no owners on THIS task, so an idle file holds no
+ * memory. Before dropping, flush the converged doc back to durable markdown (the last collaborator on
+ * this task leaving) and detach from the shared stream. A later joiner re-creates it — catching up
+ * from the stream if the doc is still live on another task, or re-seeding from markdown otherwise.
  */
 function destroyRoomIfIdle(name: string) {
   const room = fileDocRooms.get(name)
   if (!room || room.owners.size > 0) return
+  if (room.persistTimer) {
+    clearTimeout(room.persistTimer)
+    room.persistTimer = null
+  }
+  // Final durable flush BEFORE teardown — `flushPersist` encodes the doc synchronously (before the
+  // destroy below) and awaits the write in the background. Best-effort; never throws.
+  void flushPersist(name, room, true)
+  getFileDocStore().detachRoom(name)
   room.awareness.destroy()
   room.doc.destroy()
   fileDocRooms.delete(name)
@@ -194,14 +298,32 @@ async function ensureServerSeed(
 ): Promise<void> {
   if (room.serverSeedStarted || isDocSeeded(room.doc)) return
   room.serverSeedStarted = true
+  const store = getFileDocStore()
+  // Exactly one task across the cluster builds the seed; the others receive it via the stream (the fix
+  // for split-brain seeding). `shouldSeed` is true here on a single-pod deployment.
+  if (!(await store.shouldSeed(name))) {
+    // A peer is seeding (or already did). Release our guard so a later join can retry if the seed never
+    // arrives (e.g. the seeder died); the stream / this doc being seeded makes a retry safe.
+    room.serverSeedStarted = false
+    return
+  }
+  // We hold the seed lock — release it on EVERY exit from here (one `finally`, impossible to leak).
   try {
     const update = await fetchFileDocSeed(workspaceId, room.fileId)
     if (fileDocRooms.get(name) !== room || isDocSeeded(room.doc)) return
-    if (update) Y.applyUpdate(room.doc, update)
-    else room.doc.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.flag, true)
+    // SEED_ORIGIN → `doc.on('update')` shares the seed to the stream (peers need it) but skips the
+    // persist (the seed is the file's current content, so a persist would only churn a blob version).
+    if (update) Y.applyUpdate(room.doc, update, SEED_ORIGIN)
+    else
+      room.doc.transact(
+        () => room.doc.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.flag, true),
+        SEED_ORIGIN
+      )
   } catch (error) {
     logger.warn(`Server seed failed for file ${room.fileId} (workspace ${workspaceId})`, error)
     room.serverSeedStarted = false
+  } finally {
+    await store.releaseSeedLock(name)
   }
 }
 
@@ -214,15 +336,18 @@ const fileDocMergeChains = new Map<string, Promise<unknown>>()
  * fires `doc.on('update')` and relays the merge to every connected editor, reconciled with any
  * concurrent user edits — and reports whether it landed.
  *
- * Merges for the same file are SERIALIZED: each waits for any in-flight merge on that doc, so it
- * snapshots the already-updated state and its diff is computed against current content — two
- * overlapping full-document rewrites can never each diff the same stale snapshot and apply out of
- * order. (The relay is single-writer per file — Helm pins one replica — so an in-process chain
- * suffices.)
+ * Merges for the same file are SERIALIZED — within a task by the {@link fileDocMergeChains} promise
+ * chain, and ACROSS tasks by a Redis merge lock (below) — so each diff is computed against the previous
+ * merge's result, never the same stale base concurrently.
  *
- * Returns `'no-live-room'` when the file has no seeded, occupied room: an unseeded/empty doc has no
- * authoritative content to merge against, so the caller (copilot) writes the file directly instead and
- * the seed picks up the new content on the next open.
+ * Multi-task: the diff is computed against, and published to, the file's SHARED stream state — so the
+ * merge reaches the live doc no matter which task holds it (the apply-edit HTTP call can land on any
+ * task). Every task's tailer then applies it and fans it out to its own clients. Because the merge
+ * always lands in the stream while the stream exists, the stream can never go stale relative to a
+ * copilot direct file write.
+ *
+ * Returns `'no-live-room'` when there is no shared state to merge against (no doc is or was recently
+ * live): the caller (copilot) writes the file directly and the next open seeds from that markdown.
  */
 export function applyMarkdownToLiveFileDoc(
   fileId: string,
@@ -246,9 +371,38 @@ async function mergeMarkdownIntoRoom(
   fileId: string,
   markdown: string
 ): Promise<'applied' | 'no-live-room'> {
+  const store = getFileDocStore()
+
+  if (store.enabled) {
+    // Serialize merges to this file ACROSS tasks — the per-file chain above only covers this process.
+    // Two copilot edits to the same file landing on different tasks must not diff the SAME shared base
+    // and publish conflicting full-document rewrites; wait briefly for a peer's merge to finish so we
+    // diff against its RESULT. If the holder is stuck past the wait (likely dead; its lock TTL will
+    // lapse), proceed anyway rather than drop the edit.
+    const lockTtl = FILE_DOC_TIMEOUTS.mergeRequestMs + 2_000
+    let acquired = await store.acquireMergeSlot(name, lockTtl)
+    for (let i = 0; !acquired && i < MERGE_LOCK_RETRIES; i++) {
+      await sleep(MERGE_LOCK_RETRY_MS)
+      acquired = await store.acquireMergeSlot(name, lockTtl)
+    }
+    try {
+      // Compute the diff against the committed SHARED state and PUBLISH it — every task with the doc
+      // live (including this one, via its own tailer) applies it and fans it out to its clients, so the
+      // merge reaches the live doc no matter which task the apply-edit call landed on. An empty stream
+      // means no doc is (or was recently) live → nothing to merge into.
+      const base = await store.getStreamState(name)
+      if (!base) return 'no-live-room'
+      const diff = await fetchFileDocMerge(fileId, base, markdown)
+      store.publish(name, diff)
+      return 'applied'
+    } finally {
+      if (acquired) await store.releaseMergeSlot(name)
+    }
+  }
+
+  // Single-replica fallback: apply straight to the local authoritative doc.
   const room = fileDocRooms.get(name)
   if (!room || room.owners.size === 0 || !isDocSeeded(room.doc)) return 'no-live-room'
-
   const update = await fetchFileDocMerge(fileId, Y.encodeStateAsUpdate(room.doc), markdown)
   // The room may have been dropped while the diff was being built; never touch a destroyed doc.
   if (fileDocRooms.get(name) !== room) return 'no-live-room'
@@ -278,14 +432,26 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
     awareness,
     owners: new Map(),
     serverSeedStarted: false,
+    workspaceId: null,
+    lastEditorUserId: null,
+    persistTimer: null,
   }
+  // Register synchronously BEFORE the async catch-up so a concurrent join sees this room, not a second.
   fileDocRooms.set(name, room)
 
   doc.on('update', (update: Uint8Array, origin: unknown) => {
     const encoder = encoding.createEncoder()
     encoding.writeVarUint(encoder, FILE_DOC_MESSAGE_TYPE.SYNC)
     syncProtocol.writeUpdate(encoder, update)
-    broadcast(io, name, encoding.toUint8Array(encoder), originSocketId(origin))
+    // Fan out to THIS task's clients only (excluding the origin socket if local). Cross-task delivery
+    // rides the shared stream — every task's tailer applies + runs its own local fan-out.
+    broadcastLocal(io, name, encoding.toUint8Array(encoder), originSocketId(origin))
+    // Share every locally-originated update to the stream so peers converge; an update that ARRIVED
+    // from the stream (REDIS_ORIGIN) is already there — never re-publish it.
+    if (origin !== REDIS_ORIGIN) getFileDocStore().publish(name, update)
+    // Persist real edits (user edits + copilot merges) back to markdown, debounced. Skip the seed (it
+    // is the file's current content) and stream-relayed updates (their originating task persists them).
+    if (origin !== REDIS_ORIGIN && origin !== SEED_ORIGIN) schedulePersist(name, room)
   })
 
   awareness.on('update', ({ added, updated, removed }: AwarenessChange, origin: unknown) => {
@@ -299,6 +465,10 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
     )
     broadcast(io, name, encoding.toUint8Array(encoder), originSocketId(origin))
   })
+
+  // Load the shared state into the doc and start tailing the stream (fire-and-forget: content streams
+  // in via `doc.on('update')` as it lands, mirroring the fire-and-forget seed below). Disabled → no-op.
+  void getFileDocStore().attachRoom(name, doc)
 
   return room
 }
@@ -335,6 +505,9 @@ function handleMessage(socket: AuthenticatedSocket, data: unknown) {
 
     switch (messageType) {
       case FILE_DOC_MESSAGE_TYPE.SYNC: {
+        // Attribute a server-side persist of the resulting edit to the actual editor (blob metadata).
+        const editor = room.owners.get(socket.id)?.userId
+        if (editor) room.lastEditorUserId = editor
         const encoder = encoding.createEncoder()
         encoding.writeVarUint(encoder, FILE_DOC_MESSAGE_TYPE.SYNC)
         // `socket.id` is the transaction origin, so the doc's `update` handler
@@ -533,6 +706,11 @@ export function setupWorkspaceFileDocHandlers(
       entry.owners.set(socket.id, { clientId, userId, userName, avatarUrl })
       socketToRoomName.set(socket.id, name)
       socket.join(name)
+
+      // Capture what the server-side persist needs: the workspace to write back to, and the current
+      // user for attribution (refreshed to the actual editor on each edit in `handleMessage`).
+      if (authorized.workspaceId) entry.workspaceId = authorized.workspaceId
+      entry.lastEditorUserId = userId
 
       socket.emit(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId })
       // Server-authenticated roster → everyone in the room, including this joiner.

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -6,6 +6,7 @@ import { createSocketIOServer, shutdownSocketIOAdapter } from '@/config/socket'
 import { assertSchemaCompatibility } from '@/database/preflight'
 import { env } from '@/env'
 import { setupAllHandlers } from '@/handlers'
+import { getFileDocStore, initFileDocStore } from '@/handlers/file-doc-store'
 import { type AuthenticatedSocket, authenticateSocket } from '@/middleware/auth'
 import { type IRoomManager, MemoryRoomManager, RedisRoomManager } from '@/rooms'
 import { createHttpHandler } from '@/routes/http'
@@ -54,6 +55,10 @@ async function main() {
 
   // Initialize room manager (Redis or in-memory based on config)
   const roomManager = await createRoomManager(io)
+
+  // Initialize the shared Yjs backend for collaborative file docs (Redis Streams). Enabled only when
+  // REDIS_URL is set; otherwise the relay runs its original single-replica in-memory doc path.
+  await initFileDocStore(env.REDIS_URL)
 
   // Set up authentication middleware
   io.use(authenticateSocket)
@@ -122,6 +127,12 @@ async function main() {
       await shutdownSocketIOAdapter()
     } catch (error) {
       logger.error('Error during Socket.IO adapter shutdown:', error)
+    }
+
+    try {
+      await getFileDocStore().shutdown()
+    } catch (error) {
+      logger.error('Error during FileDocStore shutdown:', error)
     }
 
     httpServer.close(() => {

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -6,6 +6,7 @@ import { createSocketIOServer, shutdownSocketIOAdapter } from '@/config/socket'
 import { assertSchemaCompatibility } from '@/database/preflight'
 import { env } from '@/env'
 import { setupAllHandlers } from '@/handlers'
+import { flushAllFileDocRooms } from '@/handlers/file-doc'
 import { getFileDocStore, initFileDocStore } from '@/handlers/file-doc-store'
 import { type AuthenticatedSocket, authenticateSocket } from '@/middleware/auth'
 import { type IRoomManager, MemoryRoomManager, RedisRoomManager } from '@/rooms'
@@ -115,6 +116,15 @@ async function main() {
     logger.info('Shutting down Socket.IO server...')
 
     accessRevalidation.stop()
+
+    // Flush open collaborative docs to durable markdown BEFORE tearing down Redis/the store — the
+    // per-socket disconnect flush is fire-and-forget and would race process exit.
+    try {
+      await flushAllFileDocRooms()
+      logger.info('Flushed open collaborative documents')
+    } catch (error) {
+      logger.error('Error flushing collaborative documents on shutdown:', error)
+    }
 
     try {
       await roomManager.shutdown()

--- a/apps/sim/app/api/internal/file-doc/persist/route.ts
+++ b/apps/sim/app/api/internal/file-doc/persist/route.ts
@@ -1,0 +1,43 @@
+import { createLogger } from '@sim/logger'
+import { getErrorMessage } from '@sim/utils/errors'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { persistFileDocContract } from '@/lib/api/contracts/file-doc'
+import { parseRequest } from '@/lib/api/server'
+import { persistFileDoc } from '@/lib/collab-doc/persist'
+import { checkInternalApiKey, createUnauthorizedResponse } from '@/lib/copilot/request/http'
+import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+
+const logger = createLogger('FileDocPersistAPI')
+
+/**
+ * POST /api/internal/file-doc/persist — project a live collaborative document back to durable markdown
+ * (Yjs → markdown, through the exact editor engine) and write it to the file. Internal only: gated on
+ * the shared `x-api-key: INTERNAL_API_SECRET` secret, matching the header the realtime relay sends.
+ * The relay owns the live doc but not the conversion engine or blob/DB access, so it ships the current
+ * doc state here — the server-authoritative durable path that replaces the editor's client autosave.
+ */
+export const POST = withRouteHandler(async (request: NextRequest) => {
+  const auth = checkInternalApiKey(request)
+  if (!auth.success) return createUnauthorizedResponse()
+
+  const parsed = await parseRequest(persistFileDocContract, request, {})
+  if (!parsed.success) return parsed.response
+  const { workspaceId, fileId, userId, docState } = parsed.data.body
+
+  try {
+    const persisted = await persistFileDoc(
+      workspaceId,
+      fileId,
+      userId,
+      new Uint8Array(Buffer.from(docState, 'base64'))
+    )
+    return NextResponse.json({ persisted })
+  } catch (error) {
+    logger.error('Failed to persist file-doc', { workspaceId, fileId, error })
+    return NextResponse.json(
+      { error: getErrorMessage(error, 'Failed to persist document') },
+      { status: 500 }
+    )
+  }
+})

--- a/apps/sim/app/api/internal/file-doc/seed/route.ts
+++ b/apps/sim/app/api/internal/file-doc/seed/route.ts
@@ -14,7 +14,7 @@ const logger = createLogger('FileDocSeedAPI')
  * POST /api/internal/file-doc/seed — build a server-authoritative collaborative-document seed
  * (markdown → Yjs) for the realtime relay to apply on room creation. Internal only: gated on the
  * shared `x-api-key: INTERNAL_API_SECRET` secret, matching the header the realtime relay sends
- * (`apps/realtime/src/handlers/file-doc-seed.ts`) and the realtime server's own inbound validator.
+ * (`apps/realtime/src/handlers/file-doc-app.ts`) and the realtime server's own inbound validator.
  */
 export const POST = withRouteHandler(async (request: NextRequest) => {
   const auth = checkInternalApiKey(request)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -126,8 +126,12 @@ export const RichMarkdownEditor = memo(function RichMarkdownEditor({
    * shared document to markdown server-side, so the client must never also autosave — a stale keystroke
    * saving over a server/copilot edit is exactly the clobber the server path closes. The child reports
    * the right value up via `onCollabReadyChange`.
+   *
+   * Initialize from the `collaborative` prop (NOT unconditionally `true`): a collaborative file must
+   * start with autosave OFF, or a save could fire in the window before the child mounts and reports —
+   * re-clobbering exactly what this closes. The child turns it on for the non-collaborative fallback.
    */
-  const [collabReady, setCollabReady] = useState(true)
+  const [collabReady, setCollabReady] = useState(!collaborative)
 
   const {
     content,

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -121,10 +121,11 @@ export const RichMarkdownEditor = memo(function RichMarkdownEditor({
   const userName = session?.user?.name?.trim() || 'Collaborator'
 
   /**
-   * Autosave gate for the collaborative path: the child reports `false` while its
-   * shared document is still syncing/seeding and `true` once it is safe to persist
-   * the markdown mirror — so an empty or partially-synced doc can never overwrite
-   * the real file. `true` for non-collaborative files (never gated).
+   * Client-autosave gate. For a NON-collaborative file this is `true` (the client owns durability and
+   * autosaves the markdown). For a collaborative file it stays `false`: the realtime relay persists the
+   * shared document to markdown server-side, so the client must never also autosave — a stale keystroke
+   * saving over a server/copilot edit is exactly the clobber the server path closes. The child reports
+   * the right value up via `onCollabReadyChange`.
    */
   const [collabReady, setCollabReady] = useState(true)
 
@@ -652,8 +653,13 @@ export function LoadedRichMarkdownEditor({
    */
   useEffect(() => {
     const setReady = (ready: boolean) => {
+      // Child-local: gates editability (a user must never type into an unsynced/unseeded doc).
       setCollabReady(ready)
-      onCollabReadyChange(ready)
+      // Parent: gates CLIENT autosave. In a collaborative session the relay persists the doc to
+      // markdown server-side (debounced + on last-disconnect), so the client must NOT also autosave —
+      // a stale keystroke saving over a server/copilot edit is the clobber the server path closes.
+      // Only the non-collaborative (solo) path client-autosaves.
+      onCollabReadyChange(collaboration ? false : ready)
     }
     if (!collaboration) {
       setReady(true)

--- a/apps/sim/lib/api/contracts/file-doc.ts
+++ b/apps/sim/lib/api/contracts/file-doc.ts
@@ -75,3 +75,45 @@ export const mergeFileDocContract = defineRouteContract({
     schema: mergeFileDocResponseSchema,
   },
 })
+
+export const persistFileDocBodySchema = z.object({
+  workspaceId: z.string().min(1, 'workspaceId is required'),
+  fileId: z.string().min(1, 'fileId is required'),
+  /** Attribution only (blob metadata) — the last collaborator to touch the live doc. */
+  userId: z.string().min(1, 'userId is required'),
+  /**
+   * Base64-encoded `Y.encodeStateAsUpdate` of the live document as the relay currently holds it — the
+   * bound matches the merge contract (generous base64 headroom over a ≤256 KB collab doc's Yjs state).
+   */
+  docState: z
+    .string()
+    .min(1, 'docState is required')
+    .max(16 * 1024 * 1024, 'docState is too large'),
+})
+export type PersistFileDocBody = z.input<typeof persistFileDocBodySchema>
+
+export const persistFileDocResponseSchema = z.object({
+  /**
+   * `true` when the document was projected to markdown and written durably to the file; `false` when
+   * the file was missing/deleted (nothing to write). A transport/conversion failure is a non-2xx.
+   */
+  persisted: z.boolean(),
+})
+export type PersistFileDocResponse = z.output<typeof persistFileDocResponseSchema>
+
+/**
+ * Internal, `x-api-key`-gated: the realtime relay asks the app to project a live collaborative
+ * document back to durable markdown (Yjs → markdown, through the exact editor engine) and write it to
+ * the file. The relay owns the live doc but not the conversion engine or blob/DB access, so it ships
+ * the current doc state here. Called debounced during editing and when the last collaborator leaves —
+ * the server-authoritative durable path that replaces the editor's client-side autosave.
+ */
+export const persistFileDocContract = defineRouteContract({
+  method: 'POST',
+  path: '/api/internal/file-doc/persist',
+  body: persistFileDocBodySchema,
+  response: {
+    mode: 'json',
+    schema: persistFileDocResponseSchema,
+  },
+})

--- a/apps/sim/lib/collab-doc/converter.test.ts
+++ b/apps/sim/lib/collab-doc/converter.test.ts
@@ -1,10 +1,20 @@
 /**
  * @vitest-environment jsdom
  */
+import { FILE_DOC_SEED } from '@sim/realtime-protocol/file-doc'
 import { describe, expect, it } from 'vitest'
 import * as Y from 'yjs'
+import {
+  applyFrontmatter,
+  postProcessSerializedMarkdown,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
 import { serializeMarkdownBody } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
-import { applyMarkdownToYDoc, markdownToYDoc, yDocToMarkdown } from './converter'
+import {
+  applyMarkdownToYDoc,
+  markdownToYDoc,
+  yDocToFileMarkdown,
+  yDocToMarkdown,
+} from './converter'
 
 /** Representative markdown covering the custom-fidelity constructs (tables, code, lists, marks). */
 const SAMPLES = [
@@ -73,5 +83,26 @@ describe('collab-doc converter', () => {
     const merged = yDocToMarkdown(server)
     expect(merged).toContain('Alpha paragraph. EDITED')
     expect(merged).toContain('expanded by the agent')
+  })
+
+  it('yDocToFileMarkdown matches the client save composition (frontmatter + postProcess body pass)', () => {
+    // A server-side persist must be byte-identical to the editor save — `applyFrontmatter(frontmatter,
+    // postProcessSerializedMarkdown(body))` — or it drifts from a client save / the dirty-check baseline
+    // and churns the blob. This guards against the postProcess pass being dropped from the server path.
+    const frontmatter = '---\ntitle: Doc\n---\n'
+    const doc = markdownToYDoc('- one\n- two\n\n> [!NOTE]\n> hi')
+    doc.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.frontmatterKey, frontmatter)
+    const expected = applyFrontmatter(
+      frontmatter,
+      postProcessSerializedMarkdown(yDocToMarkdown(doc))
+    )
+    expect(yDocToFileMarkdown(doc)).toBe(expected)
+    doc.destroy()
+  })
+
+  it('yDocToFileMarkdown re-attaches empty frontmatter when the config map has none', () => {
+    const doc = markdownToYDoc('plain body\n')
+    expect(yDocToFileMarkdown(doc)).toBe(postProcessSerializedMarkdown(yDocToMarkdown(doc)))
+    doc.destroy()
   })
 })

--- a/apps/sim/lib/collab-doc/converter.ts
+++ b/apps/sim/lib/collab-doc/converter.ts
@@ -1,3 +1,4 @@
+import { FILE_DOC_SEED } from '@sim/realtime-protocol/file-doc'
 import { getSchema } from '@tiptap/core'
 import { Node as ProseMirrorNode, type Schema } from '@tiptap/pm/model'
 import {
@@ -8,6 +9,7 @@ import {
 } from '@tiptap/y-tiptap'
 import type * as Y from 'yjs'
 import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import { applyFrontmatter } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
 import {
   parseMarkdownToDoc,
   serializeDocToMarkdown,
@@ -76,11 +78,22 @@ export function markdownToYDoc(markdown: string): Y.Doc {
   return prosemirrorJSONToYDoc(markdownSchema(), json, COLLAB_DOC_FIELD)
 }
 
-/** Project a collaborative {@link Y.Doc} back to the file's canonical markdown. */
+/** Project a collaborative {@link Y.Doc}'s BODY back to markdown (no frontmatter). */
 export function yDocToMarkdown(ydoc: Y.Doc): string {
   ensureDomForTipTap()
   const json = yDocToProsemirrorJSON(ydoc, COLLAB_DOC_FIELD)
   return serializeDocToMarkdown(json)
+}
+
+/**
+ * Project a collaborative {@link Y.Doc} back to the file's FULL canonical markdown — the body from the
+ * CRDT re-joined with the frontmatter carried in the config map. This is exactly what the editor
+ * writes on save (`applyFrontmatter(resolveSaveFrontmatter(), body)`), so a server-side persist of the
+ * live doc is byte-identical to a client save — no spurious churn on the round-trip.
+ */
+export function yDocToFileMarkdown(ydoc: Y.Doc): string {
+  const frontmatter = ydoc.getMap(FILE_DOC_SEED.configMap).get(FILE_DOC_SEED.frontmatterKey)
+  return applyFrontmatter(typeof frontmatter === 'string' ? frontmatter : '', yDocToMarkdown(ydoc))
 }
 
 /**

--- a/apps/sim/lib/collab-doc/converter.ts
+++ b/apps/sim/lib/collab-doc/converter.ts
@@ -9,7 +9,10 @@ import {
 } from '@tiptap/y-tiptap'
 import type * as Y from 'yjs'
 import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
-import { applyFrontmatter } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
+import {
+  applyFrontmatter,
+  postProcessSerializedMarkdown,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
 import {
   parseMarkdownToDoc,
   serializeDocToMarkdown,
@@ -87,13 +90,18 @@ export function yDocToMarkdown(ydoc: Y.Doc): string {
 
 /**
  * Project a collaborative {@link Y.Doc} back to the file's FULL canonical markdown — the body from the
- * CRDT re-joined with the frontmatter carried in the config map. This is exactly what the editor
- * writes on save (`applyFrontmatter(resolveSaveFrontmatter(), body)`), so a server-side persist of the
- * live doc is byte-identical to a client save — no spurious churn on the round-trip.
+ * CRDT re-joined with the frontmatter carried in the config map. Mirrors the editor's save path EXACTLY
+ * (`applyFrontmatter(resolveSaveFrontmatter(), postProcessSerializedMarkdown(editor.getMarkdown()))`),
+ * INCLUDING the `postProcessSerializedMarkdown` body fidelity pass (empty list markers, callout
+ * un-escaping, trailing whitespace) — so a server-side persist is byte-identical to a client save and
+ * matches the client's dirty-check baseline, with no spurious blob churn on the round-trip.
  */
 export function yDocToFileMarkdown(ydoc: Y.Doc): string {
   const frontmatter = ydoc.getMap(FILE_DOC_SEED.configMap).get(FILE_DOC_SEED.frontmatterKey)
-  return applyFrontmatter(typeof frontmatter === 'string' ? frontmatter : '', yDocToMarkdown(ydoc))
+  return applyFrontmatter(
+    typeof frontmatter === 'string' ? frontmatter : '',
+    postProcessSerializedMarkdown(yDocToMarkdown(ydoc))
+  )
 }
 
 /**

--- a/apps/sim/lib/collab-doc/persist.ts
+++ b/apps/sim/lib/collab-doc/persist.ts
@@ -1,0 +1,42 @@
+import { createLogger } from '@sim/logger'
+import * as Y from 'yjs'
+import { getWorkspaceFile, updateWorkspaceFileContent } from '@/lib/uploads/contexts/workspace'
+import { yDocToFileMarkdown } from './converter'
+
+const logger = createLogger('FileDocPersist')
+
+/**
+ * Project a live collaborative document back to durable markdown and write it to the file. This is the
+ * server-authoritative durable path — the realtime relay owns the live Yjs doc but not the conversion
+ * engine or blob/DB access, so it ships the doc state here and the app persists it. Called debounced
+ * while the doc is being edited and when the last collaborator leaves; it replaces the editor's
+ * client-side autosave, so a copilot (or any server) edit can never be clobbered by a stale keystroke
+ * saving over it.
+ *
+ * Returns `false` when the file is genuinely absent (deleted) — nothing to write. Any other failure
+ * (conversion / blob / DB) THROWS so the caller surfaces a non-2xx and can retry on the next debounce.
+ *
+ * `userId` is attribution only (blob metadata) — the last collaborator to touch the doc; the caller is
+ * already trusted via the internal `x-api-key` gate, so this does not re-authorize.
+ */
+export async function persistFileDoc(
+  workspaceId: string,
+  fileId: string,
+  userId: string,
+  docState: Uint8Array
+): Promise<boolean> {
+  const record = await getWorkspaceFile(workspaceId, fileId, { throwOnError: true })
+  if (!record) return false
+
+  const ydoc = new Y.Doc()
+  try {
+    Y.applyUpdate(ydoc, docState)
+    const markdown = yDocToFileMarkdown(ydoc)
+    await updateWorkspaceFileContent(workspaceId, fileId, userId, Buffer.from(markdown, 'utf-8'))
+  } finally {
+    ydoc.destroy()
+  }
+
+  logger.info(`Persisted live collaborative document to file ${fileId} (workspace ${workspaceId})`)
+  return true
+}

--- a/apps/sim/lib/copilot/tools/server/files/edit-content.ts
+++ b/apps/sim/lib/copilot/tools/server/files/edit-content.ts
@@ -246,8 +246,9 @@ export const editContentServerTool: BaseServerTool<EditContentArgs, EditContentR
       // If a collaborator has this markdown file open, merge the edit into their live document so it
       // streams into the editor as a CRDT merge instead of the file changing under them. Best-effort
       // and gated to markdown, the only format the collaborative editor renders — so code/text/doc
-      // edits don't pay the realtime round-trip. The durable write above is the source of truth, and
-      // the editor's own autosave mirrors the merged doc back to the file.
+      // edits don't pay the realtime round-trip. The durable write above is the source of truth; this
+      // merges the edit into any live collaborative doc so open editors see it stream in (the relay
+      // persists the doc server-side — the collaborative editor's own client autosave is disabled).
       if (isMarkdownFile(fileRecord)) {
         await mergeEditIntoLiveFileDoc(intent.fileId, finalContent)
       }

--- a/apps/sim/lib/realtime/notify.ts
+++ b/apps/sim/lib/realtime/notify.ts
@@ -53,15 +53,14 @@ export async function notifyWorkspaceFilesChanged(workspaceId: string): Promise<
 /**
  * Best-effort: ask the realtime relay to merge a copilot edit into a file's LIVE collaborative
  * document, so open editors see it stream in as a CRDT merge (Stage C) rather than the file changing
- * underneath them. No-op when no editor is connected (the relay reports `applied: false`). The file
- * itself is written durably by the caller regardless — this only drives the live view. Never throws.
+ * underneath them. No-op when no doc is (or was recently) live (the relay reports `applied: false`).
+ * The file itself is written durably by the caller regardless — this only drives the live view.
+ * Never throws.
  *
- * KNOWN GAP (narrow): if an editor IS open but this merge fails (socket pod slow/down), the open
- * editor keeps the pre-edit doc; the user's next keystroke autosaves that stale doc over the durable
- * write, dropping the copilot edit until a reload. This is the interim cost of "durable file write +
- * best-effort live merge + editor autosave reconciles" and is closed by the deferred move to a
- * durable server-authoritative doc (copilot writing THROUGH the document rather than the file). Rare
- * — it needs the socket pod unreachable exactly while the file is open — and non-corrupting.
+ * The former clobber gap — an open editor's autosave dropping this edit — is now closed: a
+ * collaborative editor no longer client-autosaves (the relay persists the shared doc to markdown
+ * server-side), and the relay applies this merge THROUGH the shared Redis stream, so it reaches the
+ * live doc on whichever task holds it and can't go stale relative to this direct write.
  *
  * Awaited (not fire-and-forget) so the fetch dispatches before the route handler returns; bounded to
  * {@link APPLY_EDIT_TIMEOUT_MS}, so it adds latency only when the socket pod is unreachable.

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -138,12 +138,13 @@ const nextConfig: NextConfig = {
   ],
   outputFileTracingIncludes: {
     '/api/tools/stagehand/*': ['./node_modules/ws/**/*'],
-    // The seed and merge endpoints both lazily `require('jsdom')` (via the collab-doc converter), which
-    // is invisible to the standalone file tracer, so force jsdom (and its transitive deps, followed
-    // from its static requires) into the trace — otherwise a Docker/standalone build omits it and the
-    // endpoint 500s with MODULE_NOT_FOUND.
+    // The seed, merge, and persist endpoints all lazily `require('jsdom')` (via the collab-doc
+    // converter), which is invisible to the standalone file tracer, so force jsdom (and its transitive
+    // deps, followed from its static requires) into the trace — otherwise a Docker/standalone build
+    // omits it and the endpoint 500s with MODULE_NOT_FOUND.
     '/api/internal/file-doc/seed': ['./node_modules/jsdom/**/*'],
     '/api/internal/file-doc/merge': ['./node_modules/jsdom/**/*'],
+    '/api/internal/file-doc/persist': ['./node_modules/jsdom/**/*'],
     '/*': [
       './node_modules/sharp/**/*',
       './node_modules/@img/**/*',

--- a/packages/realtime-protocol/src/file-doc.ts
+++ b/packages/realtime-protocol/src/file-doc.ts
@@ -94,12 +94,18 @@ export const FILE_DOC_SEED = {
  *
  * The seed request gets more headroom than the merge because it reads a (possibly cold) blob before
  * converting; the merge is a pure in-memory conversion the caller fully supplies.
+ *
+ * `persistRequestMs` (relay → app `/persist`) stands alone — no client waits on it (the relay flushes
+ * the live doc to durable markdown debounced during editing and on the last collaborator leaving), so
+ * it forms no ordering invariant. It gets seed-level headroom because, like the seed, it crosses a
+ * durable blob write (Yjs → markdown → storage), not just an in-memory conversion.
  */
 export const FILE_DOC_TIMEOUTS = {
   seedRequestMs: 8_000,
   mergeRequestMs: 3_000,
   applyEditMs: 6_000,
   readinessDeadlineMs: 12_000,
+  persistRequestMs: 8_000,
 } as const
 
 /** Client → server join request. `fileId` is the `workspace_files.id`. */

--- a/scripts/check-api-validation-contracts.ts
+++ b/scripts/check-api-validation-contracts.ts
@@ -9,8 +9,8 @@ const QUERY_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/queries')
 const SELECTOR_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/selectors')
 
 const BASELINE = {
-  totalRoutes: 983,
-  zodRoutes: 983,
+  totalRoutes: 984,
+  zodRoutes: 984,
   nonZodRoutes: 0,
 } as const
 


### PR DESCRIPTION
## Summary
- Makes collaborative file-doc editing correct across **multiple ECS tasks** — the per-process `Y.Doc` previously assumed one realtime replica per file (split-brain seeding + stale docs under autoscaling).
- **Shared Yjs backend over Redis Streams** (`apps/realtime/.../file-doc-store.ts`): each file's stream is the ordered, replayable log of updates; a single multiplexed `XREAD` tailer converges every task's in-memory doc. Coordinated single-seeder election (`SET NX` + empty-stream recheck) eliminates split-brain seeds.
- **Channel split**: doc-sync fans out to local clients + the stream (cross-task delivery rides the stream); awareness/presence stay on the Socket.IO Redis adapter. Snapshot + `XTRIM` compaction trims only entries the snapshot provably contains.
- **Server-side persistence**: projects the live doc back to markdown via a new internal `/api/internal/file-doc/persist` endpoint — debounced while editing and flushed on last-disconnect, from the authoritative stream state. Collaborative editors no longer client-autosave, closing the copilot clobber-window.
- **Copilot merges** apply *through* the stream (reach the live doc on whichever task holds it) and serialize cross-task via a Redis merge lock.
- Degrades to the original single-replica behavior when `REDIS_URL` is unset.

## Type of Change
- [x] New feature / infrastructure

## Testing
- 218 realtime tests pass, incl. new store tests (seed election, catch-up, cross-task convergence, compaction-preserves-un-tailed-entries, merge-lock). Typecheck, `check:api-validation`, monorepo-boundary, and realtime-prune gates all green.
- Live 2-browser (ideally 2-task) verification still pending before staging.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)