### PR TITLE
improvement(realtime): post-review fixes for collab dirty-state + relay lifecycle

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -112,7 +112,13 @@ async function main() {
     logger.info(`Health check available at: http://localhost:${PORT}/health`)
   })
 
+  let shuttingDown = false
   const shutdown = async () => {
+    // SIGINT and SIGTERM both bind this; a double signal (or SIGTERM then SIGINT during the drain)
+    // must not run the whole teardown twice — that means a second forced-exit timer and a second
+    // Redis quit (which throws "The client is closed").
+    if (shuttingDown) return
+    shuttingDown = true
     logger.info('Shutting down Socket.IO server...')
 
     accessRevalidation.stop()
@@ -143,6 +149,15 @@ async function main() {
       await getFileDocStore().shutdown()
     } catch (error) {
       logger.error('Error during FileDocStore shutdown:', error)
+    }
+
+    // Close local client connections so `httpServer.close()` can complete its callback and exit
+    // gracefully — otherwise open websockets keep it hanging until the forced-exit timer below.
+    // Local-only: a rolling deploy must not disconnect clients pinned to other pods.
+    try {
+      io.local.disconnectSockets(true)
+    } catch (error) {
+      logger.error('Error disconnecting sockets on shutdown:', error)
     }
 
     httpServer.close(() => {

--- a/apps/realtime/src/routes/http.ts
+++ b/apps/realtime/src/routes/http.ts
@@ -169,13 +169,12 @@ export function createHttpHandler(roomManager: IRoomManager, logger: Logger) {
       try {
         const body = await readRequestBody(req)
         const { workspaceId } = JSON.parse(body)
-        if (typeof workspaceId === 'string' && workspaceId.length > 0) {
-          roomManager.emitToRoom(
-            { type: ROOM_TYPES.WORKSPACE_FILES, id: workspaceId },
-            'workspace-files-changed',
-            { workspaceId, timestamp: Date.now() }
-          )
-        }
+        if (!isNonEmptyString(workspaceId)) return sendError(res, 'Invalid workspaceId', 400)
+        roomManager.emitToRoom(
+          { type: ROOM_TYPES.WORKSPACE_FILES, id: workspaceId },
+          'workspace-files-changed',
+          { workspaceId, timestamp: Date.now() }
+        )
         sendSuccess(res)
       } catch (error) {
         logger.error('Error handling workspace files changed notification:', error)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -257,9 +257,16 @@ export function useEditableFileContent({
       ),
   })
 
+  // When the client can't autosave it isn't the durability owner: the collaborative editor holds
+  // `canAutosave` permanently false because the relay persists the doc server-side (debounced + on
+  // last-disconnect), so `savedContent` never advances and raw `isDirty` would latch true after any
+  // local OR remote keystroke — surfacing a spurious "Unsaved changes" navigation prompt whose
+  // "Discard" discards nothing real. With nothing the user can save, there is nothing to warn about.
+  const isDirtyForCaller = canAutosave && isDirty
+
   useEffect(() => {
-    onDirtyChangeRef.current?.(isDirty)
-  }, [isDirty])
+    onDirtyChangeRef.current?.(isDirtyForCaller)
+  }, [isDirtyForCaller])
 
   useEffect(() => {
     onSaveStatusChangeRef.current?.(
@@ -307,6 +314,6 @@ export function useEditableFileContent({
     hasContentError: streamingContent === undefined && Boolean(error) && !isInitialized,
     saveStatus,
     saveImmediately,
-    isDirty,
+    isDirty: isDirtyForCaller,
   }
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/hooks/use-workspace-files-room.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/hooks/use-workspace-files-room.ts
@@ -41,9 +41,14 @@ export function useWorkspaceFilesRoom(workspaceId: string): void {
     const join = () => socket.emit('join-workspace-files', { workspaceId })
 
     // A fresh (re)connect gets a fresh retry budget, so a prior full exhaustion doesn't leave the
-    // socket unable to retry a failed re-join until the next success.
+    // socket unable to retry a failed re-join until the next success. Cancel any retry still pending
+    // from before the reconnect so it can't fire a duplicate join after this immediate one.
     const handleConnect = () => {
       retries = 0
+      if (retryTimer) {
+        clearTimeout(retryTimer)
+        retryTimer = null
+      }
       join()
     }
 


### PR DESCRIPTION
## Summary
Post-review polish surfaced by an 8-agent whole-branch audit of `realtime-rooms`. The audit found **zero correctness bugs**; these are the five real, root-cause fixes worth landing (one confirmed UX bug + four lifecycle/consistency items). Solo/Monaco editing and workflow paths are untouched.

- **Collab editor no longer latches a spurious "Unsaved changes" prompt.** In a collaborative session the relay owns durability (persists server-side, debounced + on last-disconnect), so `canAutosave` stays false and `savedContent` never advances — raw `isDirty` latched true after any local *or remote* keystroke, popping a nav-guard modal whose "Discard" discarded nothing. Now dirty is reported only when the client actually owns the save (`canAutosave && isDirty`).
- **Guard `shutdown` against a double SIGINT/SIGTERM** running the whole teardown twice (double forced-exit timer, double Redis quit).
- **Disconnect local sockets before `httpServer.close()`** so shutdown exits gracefully instead of always hitting the 10s forced-exit timer. Local-only, so a rolling deploy never drops clients pinned to other pods.
- **Return 400 (not a silent 200)** on an invalid `workspaceId` in the files-changed fanout, matching every sibling endpoint.
- **Clear a pending join-retry timer on reconnect** so it can't fire a duplicate `join-workspace-files`.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Full gate suite green on top of these changes: realtime + sim typecheck, 74 realtime handler tests, 674 editor/autosave tests, 26 collab/tables/hooks tests, api-validation, monorepo-boundaries, realtime-prune.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)