### PR TITLE
fix(ci): harden desktop prerelease tag computation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -710,8 +710,19 @@ jobs:
           # and are always superseded by the next stable. The run-attempt
           # suffix keeps re-runs of the same workflow from colliding on the
           # tag while preserving semver ordering.
-          LATEST="$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName' || true)"
-          LATEST="${LATEST:-v0.0.0}"
+          # Fail loudly if the query itself fails: silently falling back to
+          # v0.0.0 would publish a channel build that sorts below the shipped
+          # stable, and installed shells would never see it as an update.
+          if ! LATEST="$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')"; then
+            echo "::error::Could not query the latest stable release."
+            exit 1
+          fi
+          # An empty release list makes jq print "null", which ${VAR:-default}
+          # does not treat as empty. Anything that is not a bare vX.Y.Z means
+          # "no stable release to build on top of" — start the channel at 0.0.1.
+          if [[ ! "$LATEST" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            LATEST="v0.0.0"
+          fi
           IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST#v}"
           TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))-${CHANNEL}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
           NOTES="Automated ${CHANNEL}-channel desktop build from ${GITHUB_REF_NAME} @ ${GITHUB_SHA::7}."


### PR DESCRIPTION
## Summary
- Flagged by Cursor Bugbot on #6042. With no stable releases, `gh release list --jq '.[0].tagName'` prints the literal string `null` — `${LATEST:-v0.0.0}` doesn't treat that as empty, so the tag became `vnull..1-beta.N` and `gh release create` fails on the invalid ref
- Replaced the `:-` fallback with a `^v?[0-9]+\.[0-9]+\.[0-9]+$` shape check, so `null` / empty / any non-semver tag correctly falls back to `v0.0.0`
- Dropped the `|| true`, which swallowed a failed release query and fell back to `v0.0.0` — that published a `v0.0.1-beta.N` prerelease sorting *below* the shipped stable, so beta-channel shells would silently never see it as an update. Now fails loudly with `::error::`

Not reachable on `simstudioai/sim` today (200 releases, `v0.7.47` stable, and the prune job only deletes prereleases), but it breaks forks and the swallowed-failure path is a green run that quietly takes the update channel down.

## Type of Change
- [x] Bug fix

## Testing
Tested manually — ran the tag logic against each input:

| `LATEST` | resulting tag |
| --- | --- |
| `v0.7.47` | `v0.7.48-beta.42.1` (unchanged) |
| `null` | `v0.0.1-beta.42.1` |
| `""` / `v0.7` / `v1.2.3-rc1` | `v0.0.1-beta.42.1` |
| query fails | exits 1 with `::error::` |

`actionlint` reports nothing new on the edited block (remaining output is pre-existing Blacksmith runner labels and unrelated SC2086).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)