### PR TITLE
improvement(demo): send every booking CTA to the Sim team demo link

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/upgrade/upgrade.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/upgrade/upgrade.tsx
@@ -38,7 +38,7 @@ import {
 import { useFullscreenOriginStore } from '@/stores/fullscreen-origin'
 
 /** Enterprise "Talk to sales" books time with the sales team on Cal.com. */
-const SALES_CAL_URL = 'https://cal.com/team/sim/enterprise' as const
+const SALES_CAL_URL = 'https://cal.com/team/sim/demo' as const
 
 /**
  * Props for {@link Upgrade}.

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -357,7 +357,7 @@ const nextConfig: NextConfig = {
       },
       {
         source: '/team',
-        destination: 'https://cal.com/emirkarabeg/sim-team',
+        destination: 'https://cal.com/team/sim/demo',
         permanent: false,
       }
     )


### PR DESCRIPTION
## Summary
- `/team` redirected to `https://cal.com/emirkarabeg/sim-team` — a personal "15 Mins" Cal.com event, not the team demo link. Now points to `https://cal.com/team/sim/demo`.
- This is the "Schedule a call" link in the **welcome email** (sent to every new signup) and the **plan welcome email** (sent on every paid plan activation), so it was the highest-volume booking path in the product.
- The Upgrade page's "Talk to sales" CTA pointed at a separate `team/sim/enterprise` event; it now uses the same demo link so there is one booking destination everywhere.

## Audit
Swept every booking/meeting CTA in the repo. Sim-owned booking surfaces are:

| Surface | Target | Status |
|---|---|---|
| `/demo` page Cal embed (`NEXT_PUBLIC_CAL_LINK`, hero/nav/pricing/enterprise CTAs all route here) | `team/sim/demo` | already correct |
| `/team` redirect — welcome + plan-welcome emails | was `emirkarabeg/sim-team` | **fixed** |
| Upgrade page "Talk to sales" | was `team/sim/enterprise` | **fixed** |

Every other `cal.com` / `calendly.com` reference in the repo belongs to the customer-facing Cal.com and Calendly **integrations** (`api.cal.com/v2/*` tool endpoints, `app.cal.com` OAuth URLs, CSP allowlist, docs instructions) — not our own booking links. No Calendly/Chili Piper/HubSpot-meetings/mailto-sales CTA exists anywhere, and email footers carry no booking link.

## Type of Change
- [x] Bug fix

## Testing
Verified live: `cal.com/team/sim/demo` → "Demo | Sim"; the old targets were `cal.com/emirkarabeg/sim-team` → "15 Mins | Emir Karabeg" and `cal.com/team/sim/enterprise` → "Enterprise | Sim".

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)