### PR TITLE
fix(tables): truncate long sort option labels

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SortDropdown } from '@/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options'
+
+const LONG_COLUMN_LABEL = 'highest_current_champion_role_across_the_entire_company'
+
+function ColumnIcon() {
+  return <svg data-testid='column-icon' aria-hidden='true' />
+}
+
+class ResizeObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.unstubAllGlobals()
+})
+
+describe('SortDropdown', () => {
+  it('renders long option labels in the truncatable span between both icons', () => {
+    act(() => {
+      root.render(
+        <SortDropdown
+          open
+          onOpenChange={vi.fn()}
+          config={{
+            options: [
+              {
+                id: 'long-column',
+                label: LONG_COLUMN_LABEL,
+                icon: ColumnIcon,
+              },
+            ],
+            active: { column: 'long-column', direction: 'asc' },
+            onSort: vi.fn(),
+          }}
+        />
+      )
+    })
+
+    const item = document.body.querySelector<HTMLElement>('[role="menuitem"]')
+    expect(item).not.toBeNull()
+    expect(item).toHaveAccessibleName(LONG_COLUMN_LABEL)
+
+    const label = item?.querySelector('span')
+    expect(label).not.toBeNull()
+    expect(label).toHaveTextContent(LONG_COLUMN_LABEL)
+    expect(label).toHaveClass('min-w-0', 'block', 'truncate')
+    expect(item?.querySelector('[data-testid="column-icon"]')).not.toBeNull()
+    expect(item?.querySelectorAll('svg')).toHaveLength(2)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.tsx
@@ -287,7 +287,7 @@ export const SortDropdown = memo(function SortDropdown({
               }}
             >
               {Icon && <Icon />}
-              {option.label}
+              <FloatingOverflowText label={option.label} className='block truncate' />
               {DirectionIcon && (
                 <DirectionIcon className='ml-auto size-[12px] text-[var(--text-tertiary)]' />
               )}


### PR DESCRIPTION
## Summary

Fixes table sort dropdown labels being abruptly clipped when a column name exceeds the shared menu's 220px width.

The shared `DropdownMenuItem` already truncates direct child spans, but `SortDropdown` rendered dynamic labels as bare text nodes. The label now uses `FloatingOverflowText`, which restores the intended ellipsis behavior and exposes the full value on hover while preserving its accessible text.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing

- Added a jsdom regression test covering a long option label, its truncatable span contract, full accessible name, and leading/trailing icons.
- `bun run test -- 'app/workspace/[workspaceId]/components/resource/components/resource-options/resource-options.test.tsx'`
- Biome check on both changed files
- `bun run type-check` in `apps/sim`
- `git diff --check`

The full local app format task also inspected pre-existing untracked `apps/sim/e2e/.runs` artifacts and reported formatting differences there; those artifacts are unrelated and excluded from this PR. A live browser surface was unavailable in this session, so no new before/after screenshot was captured.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the Contributor License Agreement (CLA)
