### PR TITLE
fix(knowledge): change "Create Tag" to "Apply Tag" when applying a tag to a document

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components/document-tags-modal/document-tags-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components/document-tags-modal/document-tags-modal.tsx
@@ -730,7 +730,7 @@ export function DocumentTagsModal({
                         ))
                     }
                   >
-                    {isSavingTag ? 'Creating...' : 'Create Tag'}
+                    {isSavingTag ? 'Applying...' : 'Apply Tag'}
                   </Button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- The "apply an existing tag to a document" button in the knowledge base said "Create Tag" (and "Creating..." while pending), same wording as the separate "create a new tag definition" button — confusing since they're different actions
- Changed the apply-to-document button to say "Apply Tag" / "Applying..."
- Left the KB-level tag-definition creation button (`base-tags-modal.tsx`) as "Create Tag" since that one genuinely creates a new tag schema

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Ran `bun run lint`, boundary/API-validation/react-query/zustand/client-boundary/icon/realtime-prune/skills/agent-stream-docs audits — all passing.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)