### PR TITLE
Pi: Fix Pinecone vector-search output options.
The Pinecone block expose...

### DIFF
--- a/apps/sim/blocks/blocks/pinecone.ts
+++ b/apps/sim/blocks/blocks/pinecone.ts
@@ -541,6 +541,7 @@ export const PineconeBlock: BlockConfig<PineconeResponse> = {
     vector: { type: 'json', description: 'Query vector' },
     includeValues: { type: 'boolean', description: 'Include vector values' },
     includeMetadata: { type: 'boolean', description: 'Include metadata' },
+    options: { type: 'json', description: 'Selected vector search options' },
     id: { type: 'string', description: 'Vector identifier to update' },
     values: { type: 'json', description: 'New dense vector values' },
     sparseValues: { type: 'json', description: 'New sparse vector values' },

--- a/apps/sim/tools/pinecone/search_vector.test.ts
+++ b/apps/sim/tools/pinecone/search_vector.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { searchVectorTool } from '@/tools/pinecone/search_vector'
+
+describe('searchVectorTool', () => {
+  const buildBody = searchVectorTool.request.body!
+  const baseParams = {
+    indexHost: 'https://example.pinecone.io',
+    namespace: 'default',
+    vector: [0.1, 0.2],
+    apiKey: 'test-key',
+  }
+
+  it.each([
+    {
+      name: 'neither option',
+      options: {},
+      expected: { includeValues: false, includeMetadata: false },
+    },
+    {
+      name: 'include values only',
+      options: { includeValues: true },
+      expected: { includeValues: true, includeMetadata: false },
+    },
+    {
+      name: 'include metadata only',
+      options: { includeMetadata: true },
+      expected: { includeValues: false, includeMetadata: true },
+    },
+    {
+      name: 'both options',
+      options: { includeValues: true, includeMetadata: true },
+      expected: { includeValues: true, includeMetadata: true },
+    },
+  ])('maps $name to the Pinecone query flags', ({ options, expected }) => {
+    const body = buildBody({ ...baseParams, ...options })
+
+    expect(body).toMatchObject(expected)
+  })
+})

--- a/apps/sim/tools/pinecone/search_vector.test.ts
+++ b/apps/sim/tools/pinecone/search_vector.test.ts
@@ -13,22 +13,22 @@ describe('searchVectorTool', () => {
   it.each([
     {
       name: 'neither option',
-      options: {},
+      options: [],
       expected: { includeValues: false, includeMetadata: false },
     },
     {
       name: 'include values only',
-      options: { includeValues: true },
+      options: ['includeValues'],
       expected: { includeValues: true, includeMetadata: false },
     },
     {
       name: 'include metadata only',
-      options: { includeMetadata: true },
+      options: ['includeMetadata'],
       expected: { includeValues: false, includeMetadata: true },
     },
     {
       name: 'both options',
-      options: { includeValues: true, includeMetadata: true },
+      options: ['includeValues', 'includeMetadata'],
       expected: { includeValues: true, includeMetadata: true },
     },
   ])('maps $name to the Pinecone query flags', ({ options, expected }) => {

--- a/apps/sim/tools/pinecone/search_vector.test.ts
+++ b/apps/sim/tools/pinecone/search_vector.test.ts
@@ -32,7 +32,7 @@ describe('searchVectorTool', () => {
       expected: { includeValues: true, includeMetadata: true },
     },
   ])('maps $name to the Pinecone query flags', ({ options, expected }) => {
-    const body = buildBody({ ...baseParams, ...options })
+    const body = buildBody({ ...baseParams, options })
 
     expect(body).toMatchObject(expected)
   })

--- a/apps/sim/tools/pinecone/search_vector.ts
+++ b/apps/sim/tools/pinecone/search_vector.ts
@@ -1,6 +1,26 @@
 import type { PineconeResponse, PineconeSearchVectorParams } from '@/tools/pinecone/types'
 import type { ToolConfig } from '@/tools/types'
 
+function parseBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') return value !== 0
+  return typeof value === 'string' && ['true', '1'].includes(value.trim().toLowerCase())
+}
+
+function selectedOptions(value: string[] | string | undefined): Set<string> {
+  if (Array.isArray(value)) return new Set(value)
+  if (typeof value !== 'string' || value.trim().length === 0) return new Set()
+
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return Array.isArray(parsed)
+      ? new Set(parsed.filter((item): item is string => typeof item === 'string'))
+      : new Set()
+  } catch {
+    return new Set()
+  }
+}
+
 export const searchVectorTool: ToolConfig<PineconeSearchVectorParams, PineconeResponse> = {
   id: 'pinecone_search_vector',
   name: 'Pinecone Search Vector',
@@ -51,6 +71,12 @@ export const searchVectorTool: ToolConfig<PineconeSearchVectorParams, PineconeRe
       visibility: 'user-or-llm',
       description: 'Include metadata in response (true/false)',
     },
+    options: {
+      type: 'array',
+      required: false,
+      visibility: 'user-only',
+      description: 'Selected search result options',
+    },
     apiKey: {
       type: 'string',
       required: true,
@@ -76,8 +102,12 @@ export const searchVectorTool: ToolConfig<PineconeSearchVectorParams, PineconeRe
           ? JSON.parse(params.filter)
           : params.filter
         : undefined,
-      includeValues: Boolean(params.includeValues),
-      includeMetadata: Boolean(params.includeMetadata)
+      includeValues: params.options
+        ? selectedOptions(params.options).has('includeValues')
+        : parseBoolean(params.includeValues),
+      includeMetadata: params.options
+        ? selectedOptions(params.options).has('includeMetadata')
+        : parseBoolean(params.includeMetadata),
     }),
   },
 

--- a/apps/sim/tools/pinecone/search_vector.ts
+++ b/apps/sim/tools/pinecone/search_vector.ts
@@ -76,8 +76,8 @@ export const searchVectorTool: ToolConfig<PineconeSearchVectorParams, PineconeRe
           ? JSON.parse(params.filter)
           : params.filter
         : undefined,
-      includeValues: true, //TODO: Make this dynamic
-      includeMetadata: true, //TODO: Make this dynamic
+      includeValues: Boolean(params.includeValues),
+      includeMetadata: Boolean(params.includeMetadata)
     }),
   },
 

--- a/apps/sim/tools/pinecone/types.ts
+++ b/apps/sim/tools/pinecone/types.ts
@@ -179,6 +179,7 @@ export interface PineconeSearchVectorParams extends PineconeBaseParams {
   filter?: Record<string, any> | string
   includeValues?: boolean
   includeMetadata?: boolean
+  options?: string[] | string
 }
 
 export interface PineconeDeleteVectorsParams {


### PR DESCRIPTION
## Task

Fix Pinecone vector-search output options.
The Pinecone block exposes Include Values and Include Metadata checkboxes for the search_vector operation, but apps/sim/tools/pinecone/search_vector.ts always sends both fields as true.
Trace how the options checkbox list is serialized and map its selected IDs to includeValues and includeMetadata in the tool parameters. Use those parameters in the Pinecone query body instead of hardcoded values.
Add focused tests covering neither option, each option individually, and both options. Do not require a live Pinecone account or API key for testing. Run the relevant tests, Biome, and TypeScript checks.

## Summary

Implemented Pinecone vector-search option handling.

Changes:
- `apps/sim/tools/pinecone/search_vector.ts`
  - Uses the serialized checkbox-derived `includeValues` and `includeMetadata` parameters.
  - Defaults both flags to `false` when unchecked.

- `apps/sim/tools/pinecone/search_vector.test.ts`
  - Added focused tests for:
    - Neither option selected
    - Include Values only
    - Include Metadata only
    - Both options selected
  - Tests build the request body directly and require no Pinecone credentials.

Validation could not be run because `bunx` is unavailable in the sandbox (`bunx: command not found`).