### PR TITLE
fix(collab-doc): stream every external file write into open editors, not just edit_content

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -745,7 +745,21 @@ export function LoadedRichMarkdownEditor({
    */
   useEffect(() => {
     if (!editor || !collaborationEnabled) return
-    if (editor.isEditable !== isEditable) editor.setEditable(isEditable)
+    if (editor.isEditable === isEditable) return
+    // Defer out of the render/commit phase. `isEditable` flips from collab readiness (synced + seeded),
+    // which is driven by a Yjs `config.observe` firing synchronously inside `Y.applyUpdate` — so this
+    // effect can run while React is mid-render. `setEditable` dispatches a TipTap transaction that the
+    // React binding commits with `flushSync`, which throws ("cannot flush while rendering") in that
+    // window. A microtask runs right after the current commit, before paint; re-check liveness/value
+    // since either can change before it fires.
+    let cancelled = false
+    queueMicrotask(() => {
+      if (cancelled || editor.isDestroyed) return
+      if (editor.isEditable !== isEditable) editor.setEditable(isEditable)
+    })
+    return () => {
+      cancelled = true
+    }
   }, [editor, collaborationEnabled, isEditable])
 
   /**

--- a/apps/sim/lib/collab-doc/persist.ts
+++ b/apps/sim/lib/collab-doc/persist.ts
@@ -39,7 +39,12 @@ export async function persistFileDoc(
     ydoc.destroy()
   }
 
-  await updateWorkspaceFileContent(workspaceId, fileId, userId, markdownBuffer)
+  // `syncLiveDoc: false`: this write IS the projection of the live doc back to markdown, so merging it
+  // back into that same doc would be a persist → merge → persist self-loop. The doc already holds this
+  // exact content; peers are already converged through the relay.
+  await updateWorkspaceFileContent(workspaceId, fileId, userId, markdownBuffer, undefined, {
+    syncLiveDoc: false,
+  })
 
   // Cache the Yjs binary (tagged with the exact markdown just written) so a later cold room open loads
   // it directly instead of re-converting markdown → Yjs. Best-effort: the markdown IS the durable file,

--- a/apps/sim/lib/copilot/tools/server/files/create-file.ts
+++ b/apps/sim/lib/copilot/tools/server/files/create-file.ts
@@ -64,6 +64,9 @@ export const createFileServerTool: BaseServerTool<CreateFileArgs, CreateFileResu
       },
       buffer: emptyBuffer,
       inferredMimeType: contentType,
+      // This writes only an empty shell; the real content arrives via a later edit_content write (which
+      // does merge). Merging this empty write would briefly blank an already-open editor on overwrite.
+      syncLiveDoc: false,
     })
 
     logger.info('File created via create_file', {

--- a/apps/sim/lib/copilot/tools/server/files/edit-content.ts
+++ b/apps/sim/lib/copilot/tools/server/files/edit-content.ts
@@ -6,9 +6,7 @@ import {
   type ServerToolContext,
 } from '@/lib/copilot/tools/server/base-tool'
 import { isDocSandboxEnabled } from '@/lib/core/config/env-flags'
-import { mergeEditIntoLiveFileDoc } from '@/lib/realtime/notify'
 import { updateWorkspaceFileContent } from '@/lib/uploads/contexts/workspace/workspace-file-manager'
-import { isMarkdownFile } from '@/lib/uploads/utils/file-utils'
 import { getE2BDocFormat } from './doc-compile'
 import { buildEmbeddedImageRefWarning } from './embedded-image-refs'
 import { consumeLatestFileIntent } from './file-intent-store'
@@ -235,6 +233,9 @@ export const editContentServerTool: BaseServerTool<EditContentArgs, EditContentR
 
       const fileBuffer = Buffer.from(finalContent, 'utf-8')
       assertServerToolNotAborted(context)
+      // `updateWorkspaceFileContent` also streams this edit into any open collaborative editor as a live
+      // CRDT merge (gated to markdown, best-effort) — the shared chokepoint every external write path
+      // goes through — so a copilot edit shows up live instead of the file changing under the reader.
       await updateWorkspaceFileContent(
         workspaceId,
         intent.fileId,
@@ -242,16 +243,6 @@ export const editContentServerTool: BaseServerTool<EditContentArgs, EditContentR
         fileBuffer,
         compiled.sourceMime
       )
-
-      // If a collaborator has this markdown file open, merge the edit into their live document so it
-      // streams into the editor as a CRDT merge instead of the file changing under them. Best-effort
-      // and gated to markdown, the only format the collaborative editor renders — so code/text/doc
-      // edits don't pay the realtime round-trip. The durable write above is the source of truth; this
-      // merges the edit into any live collaborative doc so open editors see it stream in (the relay
-      // persists the doc server-side — the collaborative editor's own client autosave is disabled).
-      if (isMarkdownFile(fileRecord)) {
-        await mergeEditIntoLiveFileDoc(intent.fileId, finalContent)
-      }
 
       const verb =
         operation === 'append' ? 'appended to' : operation === 'update' ? 'updated' : 'patched'

--- a/apps/sim/lib/copilot/vfs/resource-writer.ts
+++ b/apps/sim/lib/copilot/vfs/resource-writer.ts
@@ -164,6 +164,12 @@ export async function writeWorkspaceFileByPath(args: {
   target: WorkspaceFileWriteTarget
   buffer: Buffer
   inferredMimeType: string
+  /**
+   * Forwarded to {@link updateWorkspaceFileContent} on an overwrite. Defaults to `true` (stream a
+   * markdown overwrite into any open collaborative editor). Pass `false` for a write whose content is
+   * only a placeholder — e.g. `create_file`'s empty shell, whose real content lands via a later write.
+   */
+  syncLiveDoc?: boolean
 }): Promise<WorkspaceFileWriteResult> {
   const contentType = args.target.mimeType || args.inferredMimeType
   if (args.target.mode === 'overwrite') {
@@ -177,7 +183,8 @@ export async function writeWorkspaceFileByPath(args: {
       existing.id,
       args.userId,
       args.buffer,
-      contentType || existing.type
+      contentType || existing.type,
+      { syncLiveDoc: args.syncLiveDoc }
     )
 
     return {

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
@@ -22,7 +22,7 @@ import { canonicalWorkspaceFilePath, decodeVfsPathSegments } from '@/lib/copilot
 import { generateRequestId } from '@/lib/core/utils/request'
 import { generateRestoreName } from '@/lib/core/utils/restore-name'
 import type { DbOrTx } from '@/lib/db/types'
-import { notifyWorkspaceFilesChanged } from '@/lib/realtime/notify'
+import { mergeEditIntoLiveFileDoc, notifyWorkspaceFilesChanged } from '@/lib/realtime/notify'
 import { getServePathPrefix } from '@/lib/uploads'
 import {
   deleteFile,
@@ -32,6 +32,7 @@ import {
   uploadFile,
 } from '@/lib/uploads/core/storage-service'
 import { MAX_WORKSPACE_FILE_SIZE } from '@/lib/uploads/shared/types'
+import { isMarkdownFile } from '@/lib/uploads/utils/file-utils'
 import { getWorkspaceWithOwner } from '@/lib/workspaces/permissions/utils'
 import { isUuid, sanitizeFileName } from '@/executor/constants'
 import type { UserFile } from '@/executor/types'
@@ -1024,7 +1025,18 @@ export async function updateWorkspaceFileContent(
   fileId: string,
   userId: string,
   content: Buffer,
-  contentType?: string
+  contentType?: string,
+  options?: {
+    /**
+     * Whether to stream this write into any open collaborative editor as a live CRDT merge. Defaults
+     * to `true`, so EVERY external write path (copilot tools, the file tool, the content route) reaches
+     * an open editor through this one chokepoint — no per-writer wiring to forget. Pass `false` only
+     * for a write that must NOT touch the live doc: the relay's own project-to-markdown persist (which
+     * would otherwise merge the doc back into itself in a loop), and empty-shell creates whose real
+     * content arrives via a subsequent write.
+     */
+    syncLiveDoc?: boolean
+  }
 ): Promise<WorkspaceFileRecord> {
   logger.info(`Updating workspace file content: ${fileId} for workspace ${workspaceId}`)
 
@@ -1141,6 +1153,18 @@ export async function updateWorkspaceFileContent(
     }
     if (finalized.oldKey !== uploadResult.key) {
       await cleanupWorkspaceStorageObject(finalized.oldKey, 'version replacement')
+    }
+
+    // Stream this write into any open collaborative editor as a CRDT merge, so a copilot/tool edit
+    // shows up live instead of the file silently changing underneath the reader. Gated to markdown (the
+    // only format the collaborative editor renders) and best-effort (a no-op when nobody has the file
+    // open; never throws). This is the single chokepoint every external writer shares — the relay's own
+    // persist and empty-shell creates pass `syncLiveDoc: false` to stay out of it.
+    if (
+      options?.syncLiveDoc !== false &&
+      isMarkdownFile({ type: nextContentType, name: finalized.file.originalName })
+    ) {
+      await mergeEditIntoLiveFileDoc(fileId, content.toString('utf-8'))
     }
 
     const pathPrefix = getServePathPrefix()

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-storage-accounting.test.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-storage-accounting.test.ts
@@ -12,6 +12,8 @@ const {
   mockHeadObject,
   mockIncrementStorageUsageForBillingContextInTx,
   mockMaybeNotifyStorageLimitForBillingContext,
+  mockMergeEditIntoLiveFileDoc,
+  mockNotifyWorkspaceFilesChanged,
   mockResolveStorageBillingContext,
   mockUploadFile,
 } = vi.hoisted(() => ({
@@ -22,8 +24,15 @@ const {
   mockHeadObject: vi.fn(),
   mockIncrementStorageUsageForBillingContextInTx: vi.fn(),
   mockMaybeNotifyStorageLimitForBillingContext: vi.fn(),
+  mockMergeEditIntoLiveFileDoc: vi.fn(),
+  mockNotifyWorkspaceFilesChanged: vi.fn(),
   mockResolveStorageBillingContext: vi.fn(),
   mockUploadFile: vi.fn(),
+}))
+
+vi.mock('@/lib/realtime/notify', () => ({
+  mergeEditIntoLiveFileDoc: mockMergeEditIntoLiveFileDoc,
+  notifyWorkspaceFilesChanged: mockNotifyWorkspaceFilesChanged,
 }))
 
 vi.mock('@/lib/billing/storage', () => ({
@@ -105,6 +114,8 @@ describe('workspace file metadata and storage accounting', () => {
     mockDecrementStorageUsageForBillingContextInTx.mockResolvedValue(undefined)
     mockMaybeNotifyStorageLimitForBillingContext.mockResolvedValue(undefined)
     mockDeleteFile.mockResolvedValue(undefined)
+    mockMergeEditIntoLiveFileDoc.mockResolvedValue(undefined)
+    mockNotifyWorkspaceFilesChanged.mockResolvedValue(undefined)
   })
 
   it('cleans up a newly uploaded object when atomic metadata finalization rolls back', async () => {
@@ -327,5 +338,58 @@ describe('workspace file metadata and storage accounting', () => {
 
     expect(mockDeleteFile).toHaveBeenCalledTimes(1)
     expect(mockDeleteFile).toHaveBeenCalledWith({ key: replacementKey, context: 'workspace' })
+  })
+
+  const MD_ROW = { ...FILE_ROW, originalName: 'note.md', contentType: 'text/markdown' }
+
+  it('streams a markdown overwrite into any open collaborative editor (the shared merge chokepoint)', async () => {
+    const updatedFile = { ...MD_ROW, size: 12 }
+    dbChainMockFns.limit.mockResolvedValueOnce([MD_ROW]).mockResolvedValueOnce([MD_ROW])
+    dbChainMockFns.returning.mockResolvedValueOnce([updatedFile])
+    mockUploadFile.mockResolvedValueOnce({ key: MD_ROW.key })
+
+    await updateWorkspaceFileContent(
+      MD_ROW.workspaceId,
+      MD_ROW.id,
+      MD_ROW.userId,
+      Buffer.from('# new content', 'utf-8')
+    )
+
+    expect(mockMergeEditIntoLiveFileDoc).toHaveBeenCalledWith(MD_ROW.id, '# new content')
+  })
+
+  it('does NOT merge when syncLiveDoc is false (the relay persist / empty-shell opt-out)', async () => {
+    const updatedFile = { ...MD_ROW, size: 12 }
+    dbChainMockFns.limit.mockResolvedValueOnce([MD_ROW]).mockResolvedValueOnce([MD_ROW])
+    dbChainMockFns.returning.mockResolvedValueOnce([updatedFile])
+    mockUploadFile.mockResolvedValueOnce({ key: MD_ROW.key })
+
+    await updateWorkspaceFileContent(
+      MD_ROW.workspaceId,
+      MD_ROW.id,
+      MD_ROW.userId,
+      Buffer.from('# new content', 'utf-8'),
+      undefined,
+      { syncLiveDoc: false }
+    )
+
+    expect(mockMergeEditIntoLiveFileDoc).not.toHaveBeenCalled()
+  })
+
+  it('does NOT merge a non-markdown write (the collaborative editor only renders markdown)', async () => {
+    const updatedFile = { ...FILE_ROW, size: 10 }
+    dbChainMockFns.limit.mockResolvedValueOnce([FILE_ROW]).mockResolvedValueOnce([FILE_ROW])
+    dbChainMockFns.returning.mockResolvedValueOnce([updatedFile])
+    mockUploadFile.mockResolvedValueOnce({ key: FILE_ROW.key })
+
+    await updateWorkspaceFileContent(
+      FILE_ROW.workspaceId,
+      FILE_ROW.id,
+      FILE_ROW.userId,
+      Buffer.alloc(10),
+      'application/octet-stream'
+    )
+
+    expect(mockMergeEditIntoLiveFileDoc).not.toHaveBeenCalled()
   })
 })

--- a/scripts/check-api-validation-contracts.ts
+++ b/scripts/check-api-validation-contracts.ts
@@ -9,8 +9,8 @@ const QUERY_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/queries')
 const SELECTOR_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/selectors')
 
 const BASELINE = {
-  totalRoutes: 994,
-  zodRoutes: 994,
+  totalRoutes: 996,
+  zodRoutes: 996,
   nonZodRoutes: 0,
 } as const
 


### PR DESCRIPTION
## Summary
Fixes a real bug found via live testing: a copilot/mothership edit to a markdown file that another user has **open** did not stream into their editor.

Root-caused from the running server logs + local Redis:
- The mothership's "Prepend sentence" ran `read` + `file` + `function_execute` — **zero** `apply-edit` calls.
- Redis confirmed the prepended text never entered the live doc stream.

The live-doc merge bridge (`mergeEditIntoLiveFileDoc`) was wired into the `edit_content` tool **only**. Every other server-side write — the `file` tool (`/api/tools/file/manage`), `function_execute` (`/api/function/execute` via `writeWorkspaceFileByPath`), `create_file` overwrite, and the PUT `/content` route — went straight to `updateWorkspaceFileContent` and skipped the merge. The durable file changed (list refreshed) but the open editor never updated.

## Fix — centralize at the one chokepoint every external writer shares
- `updateWorkspaceFileContent` gains an opt-out `{ syncLiveDoc }` (default on); after the durable write it merges **markdown** writes into any open collaborative doc (best-effort, no-op when nobody has it open). Any current *or future* writer is covered automatically.
- `persist` opts out — it IS the doc→markdown projection, so merging back would be a persist→merge→persist self-loop.
- `create_file` opts its **empty shell** out (real content arrives via a later write) so an open editor never flickers to empty on overwrite.
- `edit_content` drops its now-redundant explicit merge call.
- Binary writers (image/video/audio/ffmpeg/download) are naturally excluded — the merge is gated to markdown.

## Note
Bumps the api-validation route baseline `994 → 996` to match the true route count **already on `realtime-rooms`** (pre-existing ratchet drift from an earlier merge — not routes added by this PR; verified against a clean tree).

## Type of Change
- [x] Bug fix

## Testing
- New unit tests: markdown write merges via the chokepoint; `syncLiveDoc:false` and non-markdown writes do not.
- Full gates green: sim + realtime tsc, lint, api-validation, boundaries, prune, 35 + 74 targeted tests.
- Root cause verified live (server logs + Redis stream). End-to-end 2-browser verify still owed on the branch.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
