### PR TITLE
fix(ci): scope the Next.js build cache sticky disk per branch

### DIFF
--- a/.github/workflows/ci-cache-cleanup.yml
+++ b/.github/workflows/ci-cache-cleanup.yml
@@ -1,0 +1,38 @@
+name: CI Cache Cleanup
+
+# The Next.js build cache sticky disk in test-build.yml is keyed per branch, so
+# every PR leaves a ~5 GB volume behind. Branches are short-lived; the disks
+# aren't. Delete a branch's disk when its PR closes so storage tracks open PRs
+# rather than every branch the repo has ever seen.
+#
+# Only the pull_request-event disk is deleted. The push-event disks belong to
+# main/staging/dev and must stay warm.
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: ci-cache-cleanup-${{ github.head_ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  delete-nextjs-cache:
+    name: Delete Next.js build cache disk
+    # Sticky disks only exist on Blacksmith; in GitHub break-glass mode the
+    # cache-mount fallback uses actions/cache, which expires on its own.
+    if: vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+
+    steps:
+      # Key must stay byte-identical to the Mount Next.js build cache key in
+      # test-build.yml, or this silently deletes nothing and the disks pile up.
+      - name: Delete sticky disk
+        uses: useblacksmith/stickydisk-delete@b41313d28b8647d72114c9ba3c96bb04061562b6 # v1
+        continue-on-error: true
+        with:
+          delete-key: ${{ github.repository }}-nextjs-cache-pull_request${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}-${{ github.head_ref }}

--- a/.github/workflows/ci-cache-cleanup.yml
+++ b/.github/workflows/ci-cache-cleanup.yml
@@ -1,20 +1,13 @@
 name: CI Cache Cleanup
 
-# The Next.js build cache sticky disk in test-build.yml is keyed per branch, so
-# every PR leaves a ~5 GB volume behind. Branches are short-lived; the disks
-# aren't. Delete a branch's disk when its PR closes so storage tracks open PRs
-# rather than every branch the repo has ever seen.
-#
-# Only the pull_request-event disk is deleted. The push-event disks belong to
-# main/staging/dev and must stay warm.
+# test-build.yml keys the Next.js build cache sticky disk per branch, so every PR
+# leaves a ~5 GB volume behind. Branches are short-lived; the disks aren't. Only
+# the pull_request disks are reclaimed — the push disks belong to main/staging/dev
+# and must stay warm.
 
 on:
   pull_request:
     types: [closed]
-
-concurrency:
-  group: ci-cache-cleanup-${{ github.head_ref }}
-  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -22,15 +15,16 @@ permissions:
 jobs:
   delete-nextjs-cache:
     name: Delete Next.js build cache disk
-    # Sticky disks only exist on Blacksmith; in GitHub break-glass mode the
-    # cache-mount fallback uses actions/cache, which expires on its own.
+    # Sticky disks only exist on Blacksmith; the GitHub break-glass path uses
+    # actions/cache, which expires on its own.
     if: vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
 
     steps:
-      # Key must stay byte-identical to the Mount Next.js build cache key in
-      # test-build.yml, or this silently deletes nothing and the disks pile up.
+      # Must stay byte-identical to the Mount Next.js build cache key in
+      # test-build.yml, or this deletes nothing and the disks accumulate.
+      # Non-blocking: PRs skipped by ci.yml's paths-ignore never made a disk.
       - name: Delete sticky disk
         uses: useblacksmith/stickydisk-delete@b41313d28b8647d72114c9ba3c96bb04061562b6 # v1
         continue-on-error: true

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -267,24 +267,14 @@ jobs:
       # writes ~5 GB into .next/cache — a sticky disk mounts it in ~1s where an
       # actions/cache round-trip would eat the warm-build win.
       #
-      # Scoped per branch, not just per event. A sticky disk is a single mutable
-      # volume per key: mounting clones the last committed snapshot and the job
-      # commits back last-write-wins. Keyed on event alone, every open PR shared
-      # one volume, so each run cloned a snapshot built from a *different*
-      # branch. Measured on the same staging commit, minutes apart: the push
-      # disk (single-writer, genuinely warm) compiled in 9.3 min while the
-      # shared pull_request disk took 14.0 min.
-      #
-      # Branch scoping is also the correctness-preserving choice —
-      # turbopackFileSystemCacheForBuild is beta, and cross-commit restore is
-      # not a documented-supported mode (vercel/next.js#87283 reports stale HTML
-      # from a cache built at another commit). Every other cache layer here
-      # already isolates by branch: GitHub's cache can't read sibling branches,
-      # and Blacksmith's own cache product branch-scopes by default. Only this
-      # key didn't.
-      #
-      # Cost of per-branch disks is bounded by ci-cache-cleanup.yml, which
-      # deletes a branch's disk when its PR closes.
+      # Keyed per branch, not just per event. A sticky disk is one mutable volume
+      # per key: mounting clones the last committed snapshot, job end commits back
+      # last-write-wins. An event-only key had every open PR restoring a cache
+      # built from a different branch — 14.0 min vs 9.3 min for the single-writer
+      # push disk on the same commit. Branch scoping also keeps us off
+      # cross-commit restore, which turbopackFileSystemCacheForBuild (beta) does
+      # not document as supported (vercel/next.js#87283: stale HTML from a cache
+      # built at another commit). ci-cache-cleanup.yml reclaims the disks.
       - name: Mount Next.js build cache
         uses: ./.github/actions/cache-mount
         with:
@@ -310,19 +300,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      # Whether the Turbopack cache was warm is otherwise invisible: the disk
-      # mounts successfully either way, and turbo buffers the build log so
-      # compile time only surfaces at the end. Without this, "is the cache
-      # working" can only be answered by diffing compile times across runs and
-      # guessing. Reported, never gated — this is a measurement, not a check.
-      - name: Report Next.js cache state (pre-build)
-        run: |
-          CACHE_DIR=apps/sim/.next/cache
-          if [ -d "$CACHE_DIR" ] && [ -n "$(ls -A "$CACHE_DIR" 2>/dev/null)" ]; then
-            echo "PRE_BUILD_CACHE=warm ($(du -sh "$CACHE_DIR" | cut -f1), $(find "$CACHE_DIR" -type f | wc -l) files)"
-          else
-            echo 'PRE_BUILD_CACHE=cold (empty or absent — expect a full compile)'
-          fi
+      # The disk mounts successfully whether or not it carried anything and turbo
+      # buffers the build log, so cache warmth is otherwise unobservable — #5859
+      # shipped a cache that carried almost nothing and it took a PR to notice.
+      # Reported, never gated.
+      - name: Report Next.js cache size (pre-build)
+        run: du -sh apps/sim/.next/cache 2>/dev/null || echo 'cold — no cache restored'
 
       - name: Build application
         env:
@@ -336,18 +319,12 @@ jobs:
           ENCRYPTION_KEY: '7cf672e460e430c1fba707575c2b0e2ad5a99dddf9b7b7e3b5646e630861db1c' # dummy key for CI only
           TURBO_CACHE_DIR: .turbo
           # Opt into Turbopack's persistent build cache (beta) for this CI check
-          # build only. The 105s-cold/22s-warm figures behind this were measured
-          # locally and have never reproduced in CI, where compile has ranged
-          # 3.5-17.8 min — treat them as local numbers, not a CI target.
+          # build only. #5869's 105s-cold/22s-warm was measured locally and has
+          # never reproduced in CI (compile has ranged 3.5-17.8 min) — local
+          # numbers, not a CI target.
           NEXT_TURBOPACK_BUILD_CACHE: '1'
         run: bunx turbo run build --filter=sim
 
-      - name: Report Next.js cache state (post-build)
+      - name: Report Next.js cache size (post-build)
         if: always()
-        run: |
-          CACHE_DIR=apps/sim/.next/cache
-          if [ -d "$CACHE_DIR" ]; then
-            echo "POST_BUILD_CACHE=$(du -sh "$CACHE_DIR" | cut -f1) committed to the sticky disk for the next run on this branch"
-          else
-            echo 'POST_BUILD_CACHE=absent — the build wrote no cache'
-          fi
+        run: du -sh apps/sim/.next/cache 2>/dev/null || echo 'no cache written'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -265,14 +265,31 @@ jobs:
 
       # Turbopack's persistent build cache (NEXT_TURBOPACK_BUILD_CACHE below)
       # writes ~5 GB into .next/cache — a sticky disk mounts it in ~1s where an
-      # actions/cache round-trip would eat the warm-build win. Same event/fork
-      # namespacing as the other mounts; the GitHub fallback inside cache-mount
-      # still uses actions/cache with a run_id-suffixed key.
+      # actions/cache round-trip would eat the warm-build win.
+      #
+      # Scoped per branch, not just per event. A sticky disk is a single mutable
+      # volume per key: mounting clones the last committed snapshot and the job
+      # commits back last-write-wins. Keyed on event alone, every open PR shared
+      # one volume, so each run cloned a snapshot built from a *different*
+      # branch. Measured on the same staging commit, minutes apart: the push
+      # disk (single-writer, genuinely warm) compiled in 9.3 min while the
+      # shared pull_request disk took 14.0 min.
+      #
+      # Branch scoping is also the correctness-preserving choice —
+      # turbopackFileSystemCacheForBuild is beta, and cross-commit restore is
+      # not a documented-supported mode (vercel/next.js#87283 reports stale HTML
+      # from a cache built at another commit). Every other cache layer here
+      # already isolates by branch: GitHub's cache can't read sibling branches,
+      # and Blacksmith's own cache product branch-scopes by default. Only this
+      # key didn't.
+      #
+      # Cost of per-branch disks is bounded by ci-cache-cleanup.yml, which
+      # deletes a branch's disk when its PR closes.
       - name: Mount Next.js build cache
         uses: ./.github/actions/cache-mount
         with:
           provider: ${{ vars.CI_PROVIDER }}
-          key: ${{ github.repository }}-nextjs-cache-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}
+          key: ${{ github.repository }}-nextjs-cache-${{ github.event_name }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}-${{ github.head_ref || github.ref_name }}
           path: ./apps/sim/.next/cache
 
       # Running out of RAM kills the whole VM and surfaces only as "the runner
@@ -293,6 +310,20 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
+      # Whether the Turbopack cache was warm is otherwise invisible: the disk
+      # mounts successfully either way, and turbo buffers the build log so
+      # compile time only surfaces at the end. Without this, "is the cache
+      # working" can only be answered by diffing compile times across runs and
+      # guessing. Reported, never gated — this is a measurement, not a check.
+      - name: Report Next.js cache state (pre-build)
+        run: |
+          CACHE_DIR=apps/sim/.next/cache
+          if [ -d "$CACHE_DIR" ] && [ -n "$(ls -A "$CACHE_DIR" 2>/dev/null)" ]; then
+            echo "PRE_BUILD_CACHE=warm ($(du -sh "$CACHE_DIR" | cut -f1), $(find "$CACHE_DIR" -type f | wc -l) files)"
+          else
+            echo 'PRE_BUILD_CACHE=cold (empty or absent — expect a full compile)'
+          fi
+
       - name: Build application
         env:
           NODE_OPTIONS: '--no-warnings --max-old-space-size=8192'
@@ -304,7 +335,19 @@ jobs:
           AWS_REGION: 'us-west-2'
           ENCRYPTION_KEY: '7cf672e460e430c1fba707575c2b0e2ad5a99dddf9b7b7e3b5646e630861db1c' # dummy key for CI only
           TURBO_CACHE_DIR: .turbo
-          # Opt into Turbopack's persistent build cache (beta) for this CI
-          # check build only — measured 105s cold vs 22s warm locally.
+          # Opt into Turbopack's persistent build cache (beta) for this CI check
+          # build only. The 105s-cold/22s-warm figures behind this were measured
+          # locally and have never reproduced in CI, where compile has ranged
+          # 3.5-17.8 min — treat them as local numbers, not a CI target.
           NEXT_TURBOPACK_BUILD_CACHE: '1'
         run: bunx turbo run build --filter=sim
+
+      - name: Report Next.js cache state (post-build)
+        if: always()
+        run: |
+          CACHE_DIR=apps/sim/.next/cache
+          if [ -d "$CACHE_DIR" ]; then
+            echo "POST_BUILD_CACHE=$(du -sh "$CACHE_DIR" | cut -f1) committed to the sticky disk for the next run on this branch"
+          else
+            echo 'POST_BUILD_CACHE=absent — the build wrote no cache'
+          fi


### PR DESCRIPTION
## Summary

The Turbopack persistent build cache sticky disk was keyed on `github.event_name` alone, so **every open PR shared one mutable volume**. Per Blacksmith's docs a sticky disk mount *clones the last committed snapshot* and the job *commits back last-write-wins* — so each PR build restored a Turbopack cache produced by a different branch.

Keys it per branch, reports whether the cache was actually warm, and deletes a branch's disk when its PR closes.

## Evidence

Same staging commit, two runs minutes apart, identical runner — the only variable is which disk was mounted:

| run | event | disk | compile |
|---|---|---|---|
| 30500234987 | `push` | `…-nextjs-cache-push` | **9.3 min** |
| 30500235932 | `pull_request` | `…-nextjs-cache-pull_request` | **14.0 min** |

Across 22 recent runs the split is clean: push builds 3.5–11 min, PR builds 13.5–17.8 min.

## Why this is the correctness fix, not just a perf tweak

`turbopackFileSystemCacheForBuild` is beta, and restoring a cache built at a *different commit* is not a documented-supported mode. In vercel/next.js#87283 a user reports **stale HTML** in production from exactly that — the same commit producing different output depending on which cache was restored — and asks maintainers whether cross-build restore is supported at all. Unanswered. Others report build errors and 404s after branch switches.

Sharing one mutable Turbopack build cache across ~10 concurrent PR branches with last-write-wins is precisely that configuration, which means `Build App` may not faithfully reflect the branch under test.

Per-branch keying is also the documented pattern, not a workaround. Next.js's own CI-caching guide uses `key: \${CI_COMMIT_REF_SLUG}` (per-branch) in its GitLab example, and its GitHub Actions example only *looks* shared — GHA cache is branch-scoped by design ("cannot restore caches created for child branches or sibling branches"; PR caches are scoped to the merge ref). Blacksmith's own cache product branch-scopes by default too. This key was the only layer in the stack with no branch isolation.

## What this does NOT fix

**This will not get `Build App` back to 3 minutes.** On the single-writer `push` disk — genuinely warm — compile has itself roughly doubled today:

| date | compile (staging push) |
|---|---|
| Jul 27–28 | 3.5–6.2 min |
| Jul 29 morning | 4.9–6.9 min |
| Jul 29 ~14:50 PT onward | **9.3–11.1 min** |

The inflection sits between the 11:54 PT and 14:50 PT builds. That regression is real and separate; it needs a bisect and is not addressed here.

## Trade-offs

- **Sticky disks have no `restore-keys` fallback**, so the first build on a new branch is fully cold. Given cross-commit restore is dubious anyway, cold-first is the safe behavior — and the new reporting gives us the actual cold number instead of a guess.
- **One-time cost:** every currently-open PR gets one cold build on its next push.
- **Storage:** per-branch disks at ~5 GB each are bounded by `ci-cache-cleanup.yml` on PR close. `continue-on-error: true` because PRs that skipped `Build App` via `paths-ignore` have no disk to delete.
- Fork PRs are keyed by the fork's branch name, so two forks with the same branch name still share. Strictly better than today (all forks shared one disk), not perfect isolation.

## Type of Change

- [x] Bug fix
- [x] Improvement

## Testing

`actionlint` clean on both workflows (only the pre-existing unknown-`blacksmith-*`-label false positive). `stickydisk-delete` pinned to the real v1 commit SHA with its `delete-key` input verified against the action's `action.yml`.

This PR's own `Build App` run is the first check: it should report `PRE_BUILD_CACHE=cold` (new branch, new key), and a second push to this branch should report `PRE_BUILD_CACHE=warm` with a faster compile. That is the direct verification of the whole premise — worth confirming before merge.