### PR TITLE
fix(rich-markdown-editor): defer non-collab settle/stream mutations off the render phase (flushSync)

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -784,6 +784,7 @@ export function LoadedRichMarkdownEditor({
   const pendingStreamBodyRef = useRef<string | null>(null)
   const streamRafRef = useRef<number | null>(null)
   const lastStreamParseAtRef = useRef(0)
+  const settleRunSeqRef = useRef(0)
   useEffect(() => {
     if (!editor) return
     // Collaboration and agent-streaming are disjoint surfaces: collaboration is enabled
@@ -805,9 +806,16 @@ export function LoadedRichMarkdownEditor({
     // the React node views via flushSync — tiptap#3764), so calling them directly in this effect body
     // throws "flushSync ... cannot flush while rendering" when the effect runs mid-render. Defer to a
     // microtask (after commit, before paint). The streaming rAF tick below already runs off-render.
+    //
+    // Tag each run: a deferred mutation applies only if it is still the latest run (this effect has
+    // several early-return exits, so a run-token beats a per-exit cleanup flag) and the editor is
+    // alive. This drops a superseded run's microtask when React ran the next pass — a newer stream or
+    // settle — before the microtask flushed, so it can't overwrite the newer state.
+    const runSeq = ++settleRunSeqRef.current
     const runOffRender = (mutate: () => void) => {
       queueMicrotask(() => {
-        if (!editor.isDestroyed) mutate()
+        if (runSeq !== settleRunSeqRef.current || editor.isDestroyed) return
+        mutate()
       })
     }
     if (isStreaming) {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -801,13 +801,10 @@ export function LoadedRichMarkdownEditor({
         emitUpdate: false,
       })
     }
-    // Editor view mutations (`setContent`, `setEditable`, `setTextSelection`, `focus`) dispatch
-    // transactions the `@tiptap/react` binding commits with `flushSync` — and `setContent` mounts the
-    // custom node views synchronously through it (tiptap#3764). Called directly in this effect body
-    // they can run while React is mid-render and throw "flushSync ... cannot flush while rendering".
-    // Defer them to a microtask: it runs right after the current commit, before paint. The streaming
-    // rAF tick below already runs off-render, so it keeps writing content directly. Runs the deferred
-    // work only if the editor is still alive when the microtask fires.
+    // Editor view mutations flush synchronously through the @tiptap/react binding (setContent mounts
+    // the React node views via flushSync — tiptap#3764), so calling them directly in this effect body
+    // throws "flushSync ... cannot flush while rendering" when the effect runs mid-render. Defer to a
+    // microtask (after commit, before paint). The streaming rAF tick below already runs off-render.
     const runOffRender = (mutate: () => void) => {
       queueMicrotask(() => {
         if (!editor.isDestroyed) mutate()
@@ -870,14 +867,11 @@ export function LoadedRichMarkdownEditor({
       settledRef.current = lockSettled(content)
       const settledVerdict = settledRef.current.verdict
       const shouldFocus = isInitialSettle && autoFocus
-      // Deferred as ONE microtask so the order is preserved: set the body, THEN collapse the selection,
-      // THEN re-apply editability. `setContent` maps any pre-existing selection onto the new doc rather
-      // than clearing it — a select-all survives as "select everything," permanently painting every
-      // divider/image with the `rich-leaf-in-selection` decoration (keymap.ts) until the user clicks
-      // elsewhere. The collapse must run on every settle regardless of whether `setContent` ran just
-      // above: the last streaming tick already syncs `lastSyncedBodyRef` to the final body before
-      // settle, so `body` usually already equals it here. `setTextSelection` (not `.focus()`) so this
-      // never steals DOM focus from whatever the user is doing outside the editor.
+      // One ordered microtask: set body → collapse selection → re-apply editability. The collapse is
+      // load-bearing and runs on every settle even when the body is unchanged — setContent maps a
+      // pre-existing selection onto the new doc, so a prior select-all survives as "select everything",
+      // permanently painting every divider/image with the rich-leaf-in-selection decoration (keymap.ts)
+      // until the user clicks away. setTextSelection (not .focus()) never steals DOM focus.
       runOffRender(() => {
         syncEditorBody(splitFrontmatter(content).body)
         editor.commands.setTextSelection(editor.state.doc.content.size)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -785,6 +785,7 @@ export function LoadedRichMarkdownEditor({
   const streamRafRef = useRef<number | null>(null)
   const lastStreamParseAtRef = useRef(0)
   const settleRunSeqRef = useRef(0)
+  const pendingCollapseRef = useRef(false)
   useEffect(() => {
     if (!editor) return
     // Collaboration and agent-streaming are disjoint surfaces: collaboration is enabled
@@ -875,6 +876,10 @@ export function LoadedRichMarkdownEditor({
       settledRef.current = lockSettled(content)
       const settledVerdict = settledRef.current.verdict
       const shouldFocus = isInitialSettle && autoFocus
+      // A settle owes a selection collapse. Track it as a ref, not just inline in this microtask: if a
+      // newer run bumps the token before this microtask fires, this settle's task is dropped — but the
+      // debt survives, and the run that supersedes it (settle OR the steady-sync path below) clears it.
+      pendingCollapseRef.current = true
       // One ordered microtask: set body → collapse selection → re-apply editability. The collapse is
       // load-bearing and runs on every settle even when the body is unchanged — setContent maps a
       // pre-existing selection onto the new doc, so a prior select-all survives as "select everything",
@@ -882,6 +887,7 @@ export function LoadedRichMarkdownEditor({
       // until the user clicks away. setTextSelection (not .focus()) never steals DOM focus.
       runOffRender(() => {
         syncEditorBody(splitFrontmatter(content).body)
+        pendingCollapseRef.current = false
         editor.commands.setTextSelection(editor.state.doc.content.size)
         editor.setEditable(canEdit && settledVerdict && collabReady)
         if (shouldFocus) editor.commands.focus('end')
@@ -891,6 +897,12 @@ export function LoadedRichMarkdownEditor({
     const settled = settledRef.current
     runOffRender(() => {
       syncEditorBody(splitFrontmatter(content).body)
+      // Honor a collapse a superseded settle owed but never applied (its microtask was dropped when this
+      // run bumped the token), so a post-stream select-all can't keep the leaf-in-selection decoration.
+      if (pendingCollapseRef.current) {
+        pendingCollapseRef.current = false
+        editor.commands.setTextSelection(editor.state.doc.content.size)
+      }
       if (settled) editor.setEditable(canEdit && settled.verdict && collabReady)
     })
   }, [

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -801,9 +801,25 @@ export function LoadedRichMarkdownEditor({
         emitUpdate: false,
       })
     }
+    // Editor view mutations (`setContent`, `setEditable`, `setTextSelection`, `focus`) dispatch
+    // transactions the `@tiptap/react` binding commits with `flushSync` — and `setContent` mounts the
+    // custom node views synchronously through it (tiptap#3764). Called directly in this effect body
+    // they can run while React is mid-render and throw "flushSync ... cannot flush while rendering".
+    // Defer them to a microtask: it runs right after the current commit, before paint. The streaming
+    // rAF tick below already runs off-render, so it keeps writing content directly. Runs the deferred
+    // work only if the editor is still alive when the microtask fires.
+    const runOffRender = (mutate: () => void) => {
+      queueMicrotask(() => {
+        if (!editor.isDestroyed) mutate()
+      })
+    }
     if (isStreaming) {
       wasStreamingRef.current = true
-      if (editor.isEditable) editor.setEditable(false)
+      if (editor.isEditable) {
+        runOffRender(() => {
+          if (editor.isEditable) editor.setEditable(false)
+        })
+      }
       const body = splitFrontmatter(content).body
       if (body === lastSyncedBodyRef.current) return
       pendingStreamBodyRef.current = body
@@ -852,22 +868,29 @@ export function LoadedRichMarkdownEditor({
     if (isInitialSettle || wasStreamingRef.current) {
       wasStreamingRef.current = false
       settledRef.current = lockSettled(content)
-      syncEditorBody(splitFrontmatter(content).body)
-      // `setContent` maps any pre-existing selection onto the new doc rather than clearing it — a
-      // select-all survives as "select everything," permanently painting every divider/image with the
-      // `rich-leaf-in-selection` decoration (keymap.ts) until the user clicks elsewhere. This must run
-      // on every settle regardless of whether `setContent` ran just above: the last streaming tick
-      // already syncs `lastSyncedBodyRef` to the final body before settle, so `body` usually already
-      // equals it here — collapsing only inside that `if` would skip the common streamed-content case
-      // entirely. `setTextSelection` (not `.focus()`) so this never steals DOM focus from whatever the
-      // user is doing outside the editor.
-      editor.commands.setTextSelection(editor.state.doc.content.size)
-      editor.setEditable(canEdit && settledRef.current.verdict && collabReady)
-      if (isInitialSettle && autoFocus) editor.commands.focus('end')
+      const settledVerdict = settledRef.current.verdict
+      const shouldFocus = isInitialSettle && autoFocus
+      // Deferred as ONE microtask so the order is preserved: set the body, THEN collapse the selection,
+      // THEN re-apply editability. `setContent` maps any pre-existing selection onto the new doc rather
+      // than clearing it — a select-all survives as "select everything," permanently painting every
+      // divider/image with the `rich-leaf-in-selection` decoration (keymap.ts) until the user clicks
+      // elsewhere. The collapse must run on every settle regardless of whether `setContent` ran just
+      // above: the last streaming tick already syncs `lastSyncedBodyRef` to the final body before
+      // settle, so `body` usually already equals it here. `setTextSelection` (not `.focus()`) so this
+      // never steals DOM focus from whatever the user is doing outside the editor.
+      runOffRender(() => {
+        syncEditorBody(splitFrontmatter(content).body)
+        editor.commands.setTextSelection(editor.state.doc.content.size)
+        editor.setEditable(canEdit && settledVerdict && collabReady)
+        if (shouldFocus) editor.commands.focus('end')
+      })
       return
     }
-    syncEditorBody(splitFrontmatter(content).body)
-    if (settledRef.current) editor.setEditable(canEdit && settledRef.current.verdict && collabReady)
+    const settled = settledRef.current
+    runOffRender(() => {
+      syncEditorBody(splitFrontmatter(content).body)
+      if (settled) editor.setEditable(canEdit && settled.verdict && collabReady)
+    })
   }, [
     editor,
     content,


### PR DESCRIPTION
## Summary
Follow-up to #6070. Fixes the **second** `flushSync` source on the rich-markdown editor — the **non-collaborative** streaming/settle path (#6070 fixed the collab editability effect).

The non-collab settle/stream effect called `editor.setContent` / `setEditable` / `setTextSelection` / `focus` directly in the effect body. `setContent` mounts the custom node views synchronously through `@tiptap/react`'s `flushSync` (tiptap#3764), so when the effect runs while React is mid-render it throws *"flushSync was called from inside a lifecycle method."* Surfaces on the **agent-streaming-into-a-non-collab-editor** path.

## Fix
- Small `runOffRender` helper defers the effect-body view mutations to a `queueMicrotask` (runs right after the current commit, before paint; no-ops if the editor was torn down).
- The **settle block is deferred as one microtask** so `setContent → collapse selection → setEditable → focus` keep their exact order.
- The **streaming rAF tick is untouched** — it already runs off-render (inside `requestAnimationFrame`), so it keeps writing content directly with no added latency.
- `queueMicrotask` is TipTap's own [documented remedy](https://tiptap.dev/docs/guides/performance) for this warning (and what they use internally — [PR #3188](https://github.com/ueberdosis/tiptap/pull/3188)).

## Type of Change
- [x] Bug fix

## Testing
- 497 rich-markdown-editor tests pass (incl. `stream-settle-selection`); tsc + lint + api-validation + boundary + prune green.
- **Needs a live check:** stream an agent into a non-collab markdown file and confirm it renders smoothly (this path is client rendering timing that can't be verified headlessly).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
