### PR TITLE
fix(config): drop three dead next.config entries and correct two stale comments

### DIFF
--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -11,12 +11,22 @@ import {
 /**
  * Dev-only escape hatch: when `SIM_DEV_MINIMAL_REGISTRY=1` (`bun run dev:minimal`),
  * swap the heavy block and tool registries for tiny curated variants via a
- * Turbopack/webpack resolve alias. The shared workspace layout drags the
- * ~247-tool registry (~2,074 modules) into every route via providers/utils →
- * tools/params, and the editor/executor pull all ~268 block configs; aliasing
- * both to minimal variants stops Turbopack from compiling those graphs, cutting
- * dev compile-time RAM (e.g. /logs ~16GB → ~5GB, 4.9min → ~15s). Only the
- * curated core blocks/tools work in this mode. Never enabled in production.
+ * Turbopack/webpack resolve alias.
+ *
+ * The tool registry (4,351 entries across 261 service dirs) pulls ~5,907 modules
+ * and is 68-78% of every workspace route's module graph; aliasing it away takes
+ * `app/workspace/layout.tsx` from 5,916 modules to 1,255. Blocks are NOT a
+ * co-equal cost - `blocks/registry-maps` alone accounts for ~349 modules and
+ * mostly rides in behind the tool registry.
+ *
+ * It is reached through ONE choke point (`tools/utils.ts` → `@/tools/registry`)
+ * fed by four redundant client-reachable edges: providers/utils → tools/params,
+ * lib/workflows/blocks/block-outputs, lib/workflows/sanitization/validation, and
+ * serializer/index. All four must be severed for any of them to matter, which is
+ * why cutting only the providers/utils edge buys a single module.
+ *
+ * Only the curated core blocks/tools work in this mode. Never enabled in
+ * production - the minimal variants genuinely drop ~250 services and ~280 blocks.
  */
 const useMinimalRegistry = isDev && process.env.SIM_DEV_MINIMAL_REGISTRY === '1'
 const minimalRegistryAlias: Record<string, string> = useMinimalRegistry
@@ -150,8 +160,15 @@ const nextConfig: NextConfig = {
      */
     turbopackFileSystemCacheForBuild: process.env.NEXT_TURBOPACK_BUILD_CACHE === '1',
     preloadEntriesOnStart: false,
+    /**
+     * Under Turbopack this is not a no-op: the list feeds
+     * `side_effect_free_packages` and is force-appended to `transpiledPackages`,
+     * which also removes each entry from the server externals set. Entries here
+     * must be real barrel packages that are actually imported - a stale entry
+     * costs transform work and overrides that package's own `sideEffects`
+     * declaration.
+     */
     optimizePackageImports: [
-      'lodash',
       'framer-motion',
       'reactflow',
       '@radix-ui/react-dialog',
@@ -159,7 +176,6 @@ const nextConfig: NextConfig = {
       '@radix-ui/react-popover',
       '@radix-ui/react-select',
       '@radix-ui/react-tabs',
-      '@radix-ui/react-accordion',
       '@radix-ui/react-checkbox',
       '@radix-ui/react-switch',
       '@radix-ui/react-slider',
@@ -186,7 +202,6 @@ const nextConfig: NextConfig = {
     ],
   }),
   transpilePackages: [
-    'prettier',
     '@react-email/components',
     '@react-email/render',
     '@t3-oss/env-nextjs',
@@ -259,7 +274,10 @@ const nextConfig: NextConfig = {
           },
         ],
       },
-      // Block access to sourcemap files (defense in depth). The trailing
+      // Keeps sourcemap files out of search indexes. This does NOT block
+      // access to them - `productionBrowserSourceMaps` is on and the `.map`
+      // files ship publicly in the production image; nothing here restricts
+      // who can fetch one. The trailing
       // `$` this rule previously ended with is not a regex anchor in Next's
       // `source` matcher (path-to-regexp syntax, not raw regex) - it matched
       // a literal `$` character, so this rule never actually fired against


### PR DESCRIPTION
## Summary

Three entries in `apps/sim/next.config.ts` were inert. Removing them is behavior-neutral. Also corrects two comments that claimed more than the code does.

This came out of an audit of build-speed levers. **None of these is a performance fix** — they are hygiene, and I'd rather say so than imply a win that isn't there.

## The `optimizePackageImports` finding

The Next 16.2.11 docs state, verbatim: *"Turbopack automatically analyzes imports and optimizes them. It does not require this configuration."* **That sentence is not backed by the code.** At tag `v16.2.11`:

- `crates/next-core/src/next_client/context.rs:362` and `next_server/context.rs:586` — the list feeds `side_effect_free_packages`
- `next_server/context.rs:167` — the list is force-appended to `transpiled_packages`, and `:191` then removes those entries from the server externals set
- `turbopack-ecmascript/src/chunk/placeable.rs:235` — the glob **short-circuits ahead of each package's own `package.json` `sideEffects` field**. It is an override, not a hint.

Next's own `turbopack-warning.js` also does *not* list the option as Turbopack-unsupported. So a stale entry is not free: it costs transform work and silently overrides a package's `sideEffects` declaration.

## What was removed

| Entry | Why it's dead |
|---|---|
| `lodash` (`optimizePackageImports`) | **Zero import sites repo-wide**, and not a dependency of any package here. Next already applies a `lodash → lodash/{{member}}` `modularizeImports` rule unconditionally. |
| `@radix-ui/react-accordion` (same) | **Zero import sites** — its only occurrence in the repo was this config line. Present in `node_modules` only via transitive hoisting. |
| `prettier` (`transpilePackages`) | Nothing imports it, it's in **no** `package.json`, and the repo formats with Biome. `transpilePackages` matches modules already in the graph, so this transpiled nothing. |

## What was deliberately left alone

- **`zod`, `reactflow`, `framer-motion`, `streamdown`** — real barrels with real import sites (`zod` has 389). Removing them removes genuine `side_effect_free_packages` tree-shaking hints and could *grow* the client bundle. That's a measurable tradeoff, not a cleanup.
- **The 8 remaining `@radix-ui/react-*` entries** — each is a 2-file pre-bundled package, outside the option's documented purpose ("hundreds or thousands of modules"), so they're likely noise plus `sideEffects`-override risk. But they *are* imported, so removal is a bundle-size question. Deferred on purpose.
- **`@react-email/*` and `@t3-oss/*` in `transpilePackages`** — these are where real transform work happens, and all four ship prebuilt JS meeting no documented criterion. Not touched: they were added empirically to fix real bugs, and the `@t3-oss` failure mode is silently-`undefined` client env, which ships unnoticed.
- **The whole `transpilePackages` array must stay non-empty.** `webpack-config.js` gates `shouldIncludeExternalDirs` on `!!config.transpilePackages`, so emptying it would break `dev:webpack` compiling `packages/*/src`. Individual removals are fine.

## Comment corrections

- The `.map` header rule was labelled *"Block access to sourcemap files (defense in depth)"*. It sets `x-robots-tag: noindex` and a TTL — **it blocks nothing**, and the maps ship publicly in the production image (`docker/app.Dockerfile:107`).
- The minimal-registry comment was stale and causally wrong. Measured today: **4,351 tool entries** (not ~247) pulling **~5,907 modules** (not ~2,074); `BLOCK_REGISTRY` is 313. Blocks are **not** a co-equal cost — `blocks/registry-maps` alone is ~349 modules and mostly rides in behind the tool registry. And the registry is reached via **four** redundant client-reachable edges, not just `providers/utils → tools/params`, which is why cutting that one edge buys a single module.

## Type of Change

- [x] Improvement (hygiene / comment accuracy)

## Testing

`tsc --noEmit` clean (exit 0), `biome check` clean. Config-only change with no runtime code touched; the removed entries were inert by the mechanisms cited above. The CI `Build App` check exercises the real build.