### PR TITLE
chore(deps): upgrade next 16.2.11 -> 16.2.12

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -29,7 +29,7 @@
     "fumadocs-openapi": "10.8.1",
     "fumadocs-ui": "16.8.5",
     "lucide-react": "^0.511.0",
-    "next": "16.2.11",
+    "next": "16.2.12",
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -188,7 +188,7 @@
     "mongodb": "6.19.0",
     "mysql2": "3.14.3",
     "neo4j-driver": "6.0.1",
-    "next": "16.2.11",
+    "next": "16.2.12",
     "next-mdx-remote": "^6.0.0",
     "next-runtime-env": "3.3.0",
     "next-themes": "^0.4.6",

--- a/bun.lock
+++ b/bun.lock
@@ -21,10 +21,10 @@
         "turbo": "2.9.14",
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.11",
-        "@next/swc-darwin-x64": "16.2.11",
-        "@next/swc-linux-arm64-gnu": "16.2.11",
-        "@next/swc-linux-x64-gnu": "16.2.11",
+        "@next/swc-darwin-arm64": "16.2.12",
+        "@next/swc-darwin-x64": "16.2.12",
+        "@next/swc-linux-arm64-gnu": "16.2.12",
+        "@next/swc-linux-x64-gnu": "16.2.12",
       },
     },
     "apps/desktop": {
@@ -76,7 +76,7 @@
         "fumadocs-openapi": "10.8.1",
         "fumadocs-ui": "16.8.5",
         "lucide-react": "^0.511.0",
-        "next": "16.2.11",
+        "next": "16.2.12",
         "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -292,7 +292,7 @@
         "mongodb": "6.19.0",
         "mysql2": "3.14.3",
         "neo4j-driver": "6.0.1",
-        "next": "16.2.11",
+        "next": "16.2.12",
         "next-mdx-remote": "^6.0.0",
         "next-runtime-env": "3.3.0",
         "next-themes": "^0.4.6",
@@ -483,7 +483,7 @@
         "framer-motion": "^12.5.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.511.0",
-        "next": "16.2.11",
+        "next": "16.2.12",
         "prismjs": "^1.30.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -689,12 +689,12 @@
     "isolated-vm",
   ],
   "overrides": {
-    "@next/env": "16.2.11",
+    "@next/env": "16.2.12",
     "drizzle-orm": "^0.45.2",
     "e2b": "^2.36.1",
     "mermaid": "11.15.0",
     "minimatch": "^10.2.5",
-    "next": "16.2.11",
+    "next": "16.2.12",
     "postgres": "^3.4.5",
     "react": "19.2.4",
     "react-dom": "19.2.4",
@@ -1361,15 +1361,15 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
-    "@next/env": ["@next/env@16.2.11", "", {}, "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA=="],
+    "@next/env": ["@next/env@16.2.12", "", {}, "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.12", "", { "os": "linux", "cpu": "x64" }, "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
@@ -3633,7 +3633,7 @@
 
     "neo4j-driver-core": ["neo4j-driver-core@6.0.1", "", {}, "sha512-5I2KxICAvcHxnWdJyDqwu8PBAQvWVTlQH2ve3VQmtVdJScPqWhpXN1PiX5IIl+cRF3pFpz9GQF53B5n6s0QQUQ=="],
 
-    "next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
+    "next": ["next@16.2.12", "", { "dependencies": { "@next/env": "16.2.12", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.12", "@next/swc-darwin-x64": "16.2.12", "@next/swc-linux-arm64-gnu": "16.2.12", "@next/swc-linux-arm64-musl": "16.2.12", "@next/swc-linux-x64-gnu": "16.2.12", "@next/swc-linux-x64-musl": "16.2.12", "@next/swc-win32-arm64-msvc": "16.2.12", "@next/swc-win32-x64-msvc": "16.2.12", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw=="],
 
     "next-mdx-remote": ["next-mdx-remote@6.0.0", "", { "dependencies": { "@babel/code-frame": "^7.23.5", "@mdx-js/mdx": "^3.0.1", "@mdx-js/react": "^3.0.1", "unist-util-remove": "^4.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.1", "vfile-matter": "^5.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -7,10 +7,15 @@ minimumReleaseAge = 604800
 # dev builds, so every version is structurally younger than any age gate.
 # The exactly pinned Pi 0.80.10 packages were vetted for the cloud-review SDK
 # migration; they age out of the gate on 2026-07-24 — drop these four entries then.
-# next@16.2.11, @next/env@16.2.11 and the @next/swc-* binaries are the official Vercel
-# security patch for the July 2026 advisories (SSRF, cache confusion, DoS, middleware
-# bypass — GHSA-89xv-2m56-2m9x et al.); published 2026-07-21, they age out of the gate on
-# 2026-07-28 — drop these entries then. The swc binaries ship in lockstep with next and
+# next@16.2.12, @next/env@16.2.12 and the @next/swc-* binaries carry the July 2026 security
+# advisories (SSRF, cache confusion, DoS, middleware bypass — GHSA-89xv-2m56-2m9x et al.,
+# fixed in 16.2.11) plus the TypeScript 7 support backport (vercel/next.js#95831) that
+# 16.2.11 lacks — this repo resolves typescript to 7.x, and on 16.2.11 `next build`'s
+# type-check step can die with a silent SIGSEGV because the legacy TS JS API is gone in TS7.
+# Published 2026-07-25, they age out of the gate on 2026-08-01 — drop these entries then,
+# and re-date this note on any further bump rather than deleting the entries early: removing
+# them while the pinned version is still inside the 7-day window blocks the bump outright.
+# The swc binaries ship in lockstep with next and
 # MUST be excluded alongside it: they are next's platform-gated optionalDependencies, so
 # gating them out leaves them absent from bun.lock entirely, and `bun install
 # --frozen-lockfile` then installs no compiler at all — next falls back to downloading one

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
   "overrides": {
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "next": "16.2.11",
-    "@next/env": "16.2.11",
+    "next": "16.2.12",
+    "@next/env": "16.2.12",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.5",
     "minimatch": "^10.2.5",
@@ -86,10 +86,10 @@
     "e2b": "^2.36.1"
   },
   "optionalDependencies": {
-    "@next/swc-darwin-arm64": "16.2.11",
-    "@next/swc-darwin-x64": "16.2.11",
-    "@next/swc-linux-arm64-gnu": "16.2.11",
-    "@next/swc-linux-x64-gnu": "16.2.11"
+    "@next/swc-darwin-arm64": "16.2.12",
+    "@next/swc-darwin-x64": "16.2.12",
+    "@next/swc-linux-arm64-gnu": "16.2.12",
+    "@next/swc-linux-x64-gnu": "16.2.12"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0-beta.5",

--- a/packages/emcn/package.json
+++ b/packages/emcn/package.json
@@ -84,7 +84,7 @@
     "framer-motion": "^12.5.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.511.0",
-    "next": "16.2.11",
+    "next": "16.2.12",
     "prismjs": "^1.30.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION
## Summary

16.2.12 is the current stable (published 2026-07-25). We were on 16.2.11. The entire changelog is two PRs — one docs backport and one that matters here.

## Why this isn't just a routine bump

[vercel/next.js#95831](https://github.com/vercel/next.js/pull/95831) — *"Fixes to support TypeScript 7"* — resolves [#95801](https://github.com/vercel/next.js/issues/95801): `next build` dying with a **silent SIGSEGV/SIGABRT** during its type-check step when `typescript@7` is installed, because the legacy TypeScript JS API that Next called was removed in TS 7.

That configuration is ours:

- `apps/sim/package.json` declares `typescript: ^7.0.2`; the lockfile resolves **7.0.2**
- `apps/sim/next.config.ts:120` sets `typescript.ignoreBuildErrors` **only** under `DOCKER_BUILD`, so the CI check build runs Next's type-check with TS7 present
- 16.2.11 has neither the fix nor a guard — the cheaper "throw an actionable error instead of SIGSEGV" mitigation ([#95837](https://github.com/vercel/next.js/pull/95837)) was **never merged**

Builds pass today because Next detects `@typescript/native-preview` as the compiler (visible in the Build App log: *"Detected @typescript/native-preview as TypeScript compiler"*) and takes a different path. So we're **accidentally working, not supported** — a change in resolution order could surface a build crash with no useful error. 16.2.12 adds the `experimental.useTypeScriptCli` backend that makes this official.

**No build-performance content in the patch.** This is not a speed change, and I'm not claiming one.

## All eight pins move in lockstep

`next` + `@next/env` + four `@next/swc-*` at the root, plus the copies in `apps/sim`, `apps/docs`, and `packages/emcn`.

The swc binaries must move with `next`. They are platform-gated `optionalDependencies`, so a version skew or gate exclusion leaves them absent from `bun.lock` entirely and `bun install --frozen-lockfile` installs **no compiler at all** — Next then tries to download one at build time, which fails in CI. That is exactly the #5945 failure. Verified all four are recorded at 16.2.12:

```
"@next/swc-darwin-arm64@16.2.12"  "@next/swc-darwin-x64@16.2.12"
"@next/swc-linux-arm64-gnu@16.2.12"  "@next/swc-linux-x64-gnu@16.2.12"
```

## bunfig.toml comment was a live trap

The gate note said to drop the `next`/`@next/*` entries from `minimumReleaseAgeExcludes` on **2026-07-28 — yesterday**. 16.2.12 published 2026-07-25, so it's inside the 7-day window until **2026-08-01**. Anyone following that instruction before this bump would have blocked it and re-triggered the missing-compiler failure. Re-dated the note and added an explicit "re-date on future bumps rather than deleting early."

## Type of Change

- [x] Dependency upgrade (latent build-crash hazard)

## Testing

- `bun install --frozen-lockfile` clean; `next --version` → 16.2.12
- All four swc platform binaries present in `bun.lock` at 16.2.12
- `tsc --noEmit -p apps/sim/tsconfig.json` exit 0
- `biome check` clean
- The CI `Build App` check is the real gate — it exercises `next build` including the TypeScript step this patch fixes

Deliberately **not** paired with any config or perf change so that if a Next patch regresses something, this is a clean single-variable revert.