### PR TITLE
fix(tests): stop pi-lifetime asserting the ceiling on a racing boundary

### DIFF
--- a/apps/sim/lib/execution/remote-sandbox/pi-lifetime.test.ts
+++ b/apps/sim/lib/execution/remote-sandbox/pi-lifetime.test.ts
@@ -127,9 +127,14 @@ describe('resolvePiRunLifetimeMs', () => {
       '@/lib/execution/remote-sandbox/pi-lifetime'
     )
 
-    // The async ceiling is 90 minutes, above what E2B will grant, so the
-    // provider cap still wins.
-    const timeout = createTimeoutAbortController(90 * 60 * 1000)
+    // The deadline must be strictly past the ceiling for the ceiling to win.
+    // Passing exactly `PI_SANDBOX_MAX_LIFETIME_MS` made this a coin flip: the
+    // remaining budget is `deadline - Date.now()`, so it decays below the ceiling
+    // as soon as one millisecond of test time elapses, and `Math.min` then
+    // returns the remaining budget instead (`expected 5399999 to be 5400000`).
+    // An equal deadline also isn't the case the name describes — the run has to
+    // outlive the ceiling, not match it.
+    const timeout = createTimeoutAbortController(PI_SANDBOX_MAX_LIFETIME_MS + 60_000)
 
     expect(resolvePiRunLifetimeMs(timeout.signal)).toBe(PI_SANDBOX_MAX_LIFETIME_MS)
     timeout.cleanup()


### PR DESCRIPTION
## Summary

`pi-lifetime.test.ts > keeps the ceiling when the run outlives it` is flaky. It failed CI tonight as **`AssertionError: expected 5399999 to be 5400000`** — 1 failure out of 16,047 tests.

## Root cause

The test passed a deadline of **exactly** `PI_SANDBOX_MAX_LIFETIME_MS` (90 min), then asserted the resolved lifetime equalled that ceiling:

```ts
const timeout = createTimeoutAbortController(90 * 60 * 1000)
expect(resolvePiRunLifetimeMs(timeout.signal)).toBe(PI_SANDBOX_MAX_LIFETIME_MS)
```

But the resolved lifetime is `Math.min(ceiling, remaining)`, where `remaining` is `getRemainingExecutionMs()` = `deadline - Date.now()`. With the deadline set equal to the ceiling, `remaining` starts at the ceiling and **decays below it the instant any time elapses** — so `Math.min` returns `remaining`, not the ceiling. The assertion held only when zero milliseconds passed between constructing the controller and reading it. A coin flip weighted by runner speed.

## Demonstrated, not guessed

```
ceiling = 5400000
OLD (== ceiling)       after 5ms -> 5399994  FAIL (off by 6ms)
NEW (ceiling + 60s)    after 5ms -> 5400000  PASS
```

The old input drifts by exactly the elapsed time. The new one is exact regardless.

## The fix also repairs the test's intent

The name says the run **outlives** the ceiling — but a deadline *equal* to the ceiling isn't outliving it. Raising the deadline past the ceiling fixes the assertion and the intent together, and it's the case actually worth covering: a run whose deadline exceeds the ceiling should be clamped to the ceiling.

Derived from `PI_SANDBOX_MAX_LIFETIME_MS + 60_000` rather than restating `90 * 60 * 1000`, so the test can't silently drift if the async execution ceiling moves — which is exactly how the original hardcoded value came to sit on the boundary.

Also drops the old comment's claim that *"the provider cap still wins"*. The provider cap is **24 h**, far above the 90 min async ceiling, so the ceiling is what wins — the comment described the opposite of the mechanism.

## Notes

Deliberately **not** reached for `vi.useFakeTimers()`. Freezing the clock would mask the boundary rather than fix it, and the assertion would still be testing an input that contradicts the test's name. The sibling assertions in this file that compare against the ceiling (lines 103-104, 145) are safe — they use signals with no deadline, so `getRemainingExecutionMs` returns `undefined` and the ceiling is returned unconditionally.

## Type of Change

- [x] Bug fix (test correctness / CI flake)

## Testing

Fixed test run 5x, 16/16 passing each time. Mechanism verified directly against the real helpers (output above) rather than inferred from a green run — the old version passed most of the time too, so repetition alone proves nothing here.