### PR TITLE
fix(blocks): stop registry.ts reading BLOCK_REGISTRY at module scope

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/chat-context-kind-registry/chat-context-kind-registry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/chat-context-kind-registry/chat-context-kind-registry.tsx
@@ -14,7 +14,7 @@ import { AgentSkillsIcon, McpIcon } from '@/components/icons'
 import { getDocumentIcon } from '@/components/icons/document-icons'
 import type { ChatContextKind, ChatMessageContext } from '@/app/workspace/[workspaceId]/home/types'
 import { getBareIconStyle } from '@/blocks/icon-color'
-import { registry as blockRegistry } from '@/blocks/registry'
+import { getBlockRegistry } from '@/blocks/registry'
 
 interface RenderIconArgs {
   context: ChatMessageContext
@@ -41,7 +41,7 @@ function renderWorkflowIcon({ className }: RenderIconArgs): ReactNode | null {
 function renderIntegrationTile({ context, className }: RenderIconArgs): ReactNode | null {
   if (context.kind !== 'integration') return null
   if (!context.blockType) return null
-  const block = blockRegistry[context.blockType]
+  const block = getBlockRegistry()[context.blockType]
   if (!block) return null
   const Icon = block.icon
   return <Icon className={className} style={getBareIconStyle(Icon)} />

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-mention-data.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-mention-data.ts
@@ -192,7 +192,8 @@ export function useMentionData(props: UseMentionDataProps): MentionDataReturn {
         // Fetch current blocks from store
         const workflowStoreBlocks = useWorkflowStore.getState().blocks
 
-        const { registry: blockRegistry } = await import('@/blocks/registry')
+        const { getBlockRegistry } = await import('@/blocks/registry')
+        const blockRegistry = getBlockRegistry()
         const mapped = Object.values(workflowStoreBlocks).map((b: any) => {
           const reg = (blockRegistry as any)[b.type]
           return {

--- a/apps/sim/blocks/registry.ts
+++ b/apps/sim/blocks/registry.ts
@@ -24,8 +24,24 @@ export function getBlock(type: string): BlockConfig | undefined {
   return BLOCK_REGISTRY[type] ?? BLOCK_REGISTRY[normalizeType(type)] ?? resolveOverlayBlock(type)
 }
 
-/** Whether any registered block is an unreleased `preview` block. Static — computed once. */
-const HAS_PREVIEW_BLOCKS = Object.values(BLOCK_REGISTRY).some((block) => block.preview)
+/**
+ * Whether any registered block is an unreleased `preview` block. Computed once,
+ * on first use rather than at module scope.
+ *
+ * `blocks/registry-maps` and this module sit in an import cycle (a block config
+ * reaches back here through `providers/utils` → `tools/params` → `blocks/index`),
+ * so whichever module the cycle is entered through evaluates first. Reading
+ * `BLOCK_REGISTRY` at module scope therefore threw
+ * `ReferenceError: Cannot access 'BLOCK_REGISTRY' before initialization` for
+ * anything that imported `blocks/registry-maps` directly — scripts and tests
+ * under Bun. It only worked under Turbopack because that bundler happened to
+ * order the modules favourably, which is not a guarantee to build on.
+ */
+let hasPreviewBlocks: boolean | undefined
+function anyPreviewBlocks(): boolean {
+  hasPreviewBlocks ??= Object.values(BLOCK_REGISTRY).some((block) => block.preview)
+  return hasPreviewBlocks
+}
 
 /**
  * True when the visibility projection cannot change any block, so accessors can
@@ -33,7 +49,7 @@ const HAS_PREVIEW_BLOCKS = Object.values(BLOCK_REGISTRY).some((block) => block.p
  * even with a null state) and no kill-switch entries apply.
  */
 function visibilityInert(vis: BlockVisibilityState | null): boolean {
-  if (HAS_PREVIEW_BLOCKS) return false
+  if (anyPreviewBlocks()) return false
   return vis === null || vis.disabled.size === 0
 }
 
@@ -232,9 +248,16 @@ export function getSuggestedSkillsForBlock(type: string): readonly SuggestedSkil
 
 /**
  * Raw block registry map keyed by block type. Prefer the typed accessors
- * (`getBlock`, `getAllBlocks`, `getCanonicalBlocksByCategory`); this alias is
- * retained for callers that need the underlying record directly.
+ * (`getBlock`, `getAllBlocks`, `getCanonicalBlocksByCategory`); this is retained
+ * for callers that need the underlying record directly.
+ *
+ * A function rather than an eager `const` alias: binding `BLOCK_REGISTRY` at
+ * module scope re-introduces the initialization-order failure that
+ * {@link anyPreviewBlocks} documents, since this module can evaluate before
+ * `blocks/registry-maps` has finished.
  */
-export const registry: Record<string, BlockConfig> = BLOCK_REGISTRY
+export function getBlockRegistry(): Record<string, BlockConfig> {
+  return BLOCK_REGISTRY
+}
 
 export type { BlockCategory }

--- a/apps/sim/lib/copilot/chat/process-contents.ts
+++ b/apps/sim/lib/copilot/chat/process-contents.ts
@@ -545,7 +545,8 @@ async function processBlockMetadata(
       return null
     }
 
-    const { registry: blockRegistry } = await import('@/blocks/registry')
+    const { getBlockRegistry } = await import('@/blocks/registry')
+    const blockRegistry = getBlockRegistry()
     if (!(blockRegistry as any)[blockId]) {
       return null
     }


### PR DESCRIPTION
## Summary

`import('@/blocks/registry-maps')` throws today:

```
ReferenceError: Cannot access 'BLOCK_REGISTRY' before initialization.
    at apps/sim/blocks/registry.ts:28:56
```

`blocks/registry-maps` and `blocks/registry` sit in an import cycle — a block config reaches back through `providers/utils` → `tools/params` → `blocks/index` → `blocks/registry`, which imports `registry-maps`. Whichever module the cycle is entered through evaluates first, so `blocks/registry` can run while `registry-maps` is still initializing.

## Two module-scope reads, not one

```ts
const HAS_PREVIEW_BLOCKS = Object.values(BLOCK_REGISTRY).some(...)   // line 28
export const registry: Record<string, BlockConfig> = BLOCK_REGISTRY  // line 238
```

Only line 28 appears in the stack trace, so fixing it alone would have silently **moved** the failure to line 238. Both are now deferred:

- `anyPreviewBlocks()` memoizes on first use — still "computed once", as the old comment promised, just not at import time
- the raw map is exposed as `getBlockRegistry()` instead of an eager `const` alias

## Scope: only the entry point was broken

Worth being precise, because the original report overstated it. `@/blocks/registry` and `@/tools/registry` both imported **fine** before this change; only `@/blocks/registry-maps` as the entry point threw. After:

| entry point | before | after |
|---|---|---|
| `@/blocks/registry-maps` | **THROWS** | OK |
| `@/blocks/registry` | OK | OK |
| `@/tools/registry` | OK | OK |
| `@/blocks/index`, `@/tools/params`, `@/tools/utils`, `@/providers/utils` | OK | OK |

## Why fix it if the app works

It works under Turbopack only because that bundler happens to order the modules favourably. That's not a property to build on, and it makes `blocks/registry-maps` un-importable from scripts and tests under Bun.

More concretely: the tool-registry module-graph audit found the registry is **68–78% of every workspace route's graph** and proposed a metadata/implementation split. Any such restructuring perturbs module ordering. This is a prerequisite to that work, not something to discover halfway through it.

## `tsc` caught two consumers grep missed

Three consumers updated. Two of them destructure the binding off a **dynamic** import rather than naming it in a static one:

```ts
const { registry: blockRegistry } = await import('@/blocks/registry')
```

My `rg` for the named import found only one callsite; `tsc --noEmit` found the other two (`use-mention-data.ts:195`, `process-contents.ts:548`). Worth noting for anyone doing similar refactors — a grep-only sweep here would have shipped two runtime `undefined` lookups.

## Behaviour preservation

`getBlockRegistry()[type]` is the same raw lookup the alias provided. Deliberately **not** `getBlock()`, which would additionally apply version normalization and custom-block overlay fallback — correct-looking, but a behaviour change smuggled into a cycle fix.

## Type of Change

- [x] Bug fix

## Testing

- `tsc --noEmit` exit 0
- All 7 cycle entry points import cleanly (table above)
- 47 test files / 561 tests passing across `apps/sim/blocks` and `apps/sim/lib/copilot/chat`
- `biome check` clean on all changed files