### PR TITLE
feat(desktop): floating hover-peek sidebar

### DIFF
--- a/apps/sim/app/_styles/globals.css
+++ b/apps/sim/app/_styles/globals.css
@@ -12,6 +12,7 @@
 :root {
   --sidebar-width: 0px; /* 0 outside workspace; blocking script always sets actual value on workspace pages */
   --sidebar-collapsed-width: 51px; /* icon rail on web; desktop overrides to 0 before first paint */
+  --sidebar-expanded-width: 248px; /* SIDEBAR_WIDTH.DEFAULT; the width to restore to, held even while collapsed */
   --desktop-title-bar-height: 0px; /* macOS traffic-light lane; desktop overrides before first paint */
   --desktop-title-bar-inset-x: 0px; /* clearance past the traffic lights; desktop overrides */
   --desktop-title-bar-control-offset: 0px; /* centres a lane control; desktop overrides */
@@ -152,6 +153,24 @@ html[data-sim-desktop-title-bar="inset"]
  */
 .sidebar-shell-outer[data-collapsed] {
   --sidebar-width: var(--sidebar-collapsed-width);
+}
+
+/**
+ * Hover-peek: the shell floats out of flow as a card, so its subtree reads the restore
+ * width instead of the collapsed one. Re-declaring the same variable the rule above
+ * sets carries the inner shell and the aside along with no per-element overrides.
+ *
+ * Lives here rather than on the component because a Tailwind arbitrary property is one
+ * class (0,1,0) and would lose to that rule's (0,2,0) selector.
+ */
+.sidebar-shell-outer[data-collapsed][data-peek] {
+  --sidebar-width: var(--sidebar-expanded-width);
+}
+
+/* The card appears at full width, so the aside's own width transition would animate
+   0 -> expanded inside it. */
+.sidebar-shell-outer[data-peek] .sidebar-container {
+  transition: none;
 }
 
 .sidebar-container span,

--- a/apps/sim/app/layout.tsx
+++ b/apps/sim/app/layout.tsx
@@ -112,22 +112,26 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     document.cookie = 'sidebar_collapsed=' + (collapsed ? '1' : '0') + '; path=/; max-age=31536000; samesite=lax';
                   }
 
-                  if (collapsed) {
-                    document.documentElement.style.setProperty(
-                      '--sidebar-width',
-                      collapsedSidebarWidth + 'px'
-                    );
-                  } else {
-                    var width = state && state.sidebarWidth;
-                    var maxSidebarWidth = Math.max(248, window.innerWidth * 0.3);
-                    var finalWidth =
-                      typeof width === 'number' && isFinite(width)
-                        ? Math.min(Math.max(width, 248), maxSidebarWidth)
-                        : defaultSidebarWidth;
-                    document.documentElement.style.setProperty('--sidebar-width', finalWidth + 'px');
-                  }
+                  // The expanded width is published unconditionally, even while
+                  // collapsed, because the desktop hover-peek renders the sidebar at
+                  // its restore width while --sidebar-width still reads collapsed.
+                  var width = state && state.sidebarWidth;
+                  var maxSidebarWidth = Math.max(248, window.innerWidth * 0.3);
+                  var expandedWidth =
+                    typeof width === 'number' && isFinite(width)
+                      ? Math.min(Math.max(width, 248), maxSidebarWidth)
+                      : defaultSidebarWidth;
+                  document.documentElement.style.setProperty(
+                    '--sidebar-expanded-width',
+                    expandedWidth + 'px'
+                  );
+                  document.documentElement.style.setProperty(
+                    '--sidebar-width',
+                    (collapsed ? collapsedSidebarWidth : expandedWidth) + 'px'
+                  );
                 } catch (e) {
                   document.documentElement.style.setProperty('--sidebar-width', defaultSidebarWidth + 'px');
+                  document.documentElement.style.setProperty('--sidebar-expanded-width', defaultSidebarWidth + 'px');
                 }
 
                 // Panel width and active tab

--- a/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/use-sidebar-peek.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/use-sidebar-peek.test.tsx
@@ -1,0 +1,417 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  PEEK_CLOSE_DELAY_MS as CLOSE_DELAY_MS,
+  PEEK_EXIT_DURATION_MS as EXIT_DURATION_MS,
+  PEEK_OPEN_DELAY_MS as OPEN_DELAY_MS,
+  PEEK_POINTER_SAMPLE_MS as POINTER_SAMPLE_MS,
+  useSidebarPeek,
+} from '@/app/workspace/[workspaceId]/components/workspace-chrome/use-sidebar-peek'
+
+/**
+ * Screen geometry the hook hit-tests against. jsdom gives every element a zero
+ * rect, so the harness stubs these — without them every coordinate falls inside
+ * the card's 0×0 box (padded by the gap tolerance) and the peek never retracts.
+ * Values mirror the real desktop layout: a 32px toggle in the title-bar lane, and
+ * the card inset 8px from the left starting below that lane.
+ */
+const TRIGGER_RECT = { left: 78, top: 4, right: 110, bottom: 36 }
+const CARD_RECT = { left: 8, top: 40, right: 258, bottom: 852 }
+
+/** Points used by the tests, in client coordinates. */
+const POINT = {
+  onTrigger: [94, 20],
+  inCard: [120, 300],
+  inGap: [100, 38],
+  onContent: [800, 400],
+} as const
+
+function stubRect(
+  element: HTMLElement,
+  rect: { left: number; top: number; right: number; bottom: number }
+) {
+  element.getBoundingClientRect = () =>
+    ({
+      ...rect,
+      x: rect.left,
+      y: rect.top,
+      width: rect.right - rect.left,
+      height: rect.bottom - rect.top,
+      toJSON: () => rect,
+    }) as DOMRect
+}
+
+interface Harness {
+  state: () => { isPeekActive: boolean; isPeekOpen: boolean }
+  triggerEnter: () => void
+  triggerLeave: () => void
+  setEnabled: (enabled: boolean) => void
+  setDismissed: (dismissed: boolean) => void
+  unmount: () => void
+}
+
+/**
+ * Minimal dependency-free hook harness (the repo has no `@testing-library/react`).
+ * Mounts the hook in a real React root under jsdom so the refs point at live nodes,
+ * then stubs their rects — the close hit-test reads geometry off those refs.
+ */
+function renderPeek(initialEnabled: boolean): Harness {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root: Root = createRoot(container)
+
+  let latest = { isPeekActive: false, isPeekOpen: false }
+  let onTriggerEnter = () => {}
+  let onTriggerLeave = () => {}
+
+  function Probe({ enabled, dismissed }: { enabled: boolean; dismissed: boolean }) {
+    const peek = useSidebarPeek(enabled, dismissed)
+    latest = { isPeekActive: peek.isPeekActive, isPeekOpen: peek.isPeekOpen }
+    onTriggerEnter = peek.onTriggerEnter
+    onTriggerLeave = peek.onTriggerLeave
+    return (
+      <div>
+        <div data-probe='trigger' ref={peek.triggerRef} />
+        <div data-probe='card' ref={peek.cardRef} />
+      </div>
+    )
+  }
+
+  let props = { enabled: initialEnabled, dismissed: false }
+  const render = (next: Partial<typeof props>) => {
+    props = { ...props, ...next }
+    act(() => {
+      root.render(<Probe enabled={props.enabled} dismissed={props.dismissed} />)
+    })
+  }
+  render({})
+
+  const query = (name: string) =>
+    container.querySelector<HTMLElement>(`[data-probe="${name}"]`) as HTMLElement
+
+  stubRect(query('card'), CARD_RECT)
+  stubRect(query('trigger'), TRIGGER_RECT)
+
+  return {
+    state: () => latest,
+    triggerEnter: () => onTriggerEnter(),
+    triggerLeave: () => onTriggerLeave(),
+    setEnabled: (enabled: boolean) => render({ enabled }),
+    setDismissed: (dismissed: boolean) => render({ dismissed }),
+    unmount: () => {
+      act(() => root.unmount())
+      container.remove()
+    },
+  }
+}
+
+/**
+ * Dispatches a pointer move at client coordinates. `target` only matters for the
+ * portal check — the card and trigger are matched by geometry. Each call advances the
+ * clock past the hook's sample floor so consecutive moves are never coalesced.
+ */
+function movePointerTo([x, y]: readonly [number, number], target: Element = document.body) {
+  act(() => {
+    vi.advanceTimersByTime(POINTER_SAMPLE_MS)
+    target.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: x, clientY: y }))
+  })
+}
+
+function openPeek(harness: Harness) {
+  act(() => {
+    harness.triggerEnter()
+    vi.advanceTimersByTime(OPEN_DELAY_MS)
+  })
+}
+
+let active: Harness | null = null
+const appended: Element[] = []
+
+/**
+ * Appends a portal-like node to `document.body`, standing in for a menu or tooltip
+ * the sidebar renders outside the card. Tracked for teardown so a failing assertion
+ * can never leak a node into the next test.
+ */
+async function appendToBody(tag: string, attributes: Record<string, string>) {
+  const node = document.createElement(tag)
+  for (const [name, value] of Object.entries(attributes)) node.setAttribute(name, value)
+  appended.push(node)
+  await act(async () => {
+    document.body.appendChild(node)
+  })
+  return node
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({ matches: false }) as unknown as typeof matchMedia
+  )
+})
+
+afterEach(() => {
+  active?.unmount()
+  active = null
+  for (const node of appended.splice(0)) node.remove()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('useSidebarPeek', () => {
+  it('opens only after the hover dwell elapses', () => {
+    active = renderPeek(true)
+
+    act(() => {
+      active?.triggerEnter()
+      vi.advanceTimersByTime(OPEN_DELAY_MS - 1)
+    })
+    expect(active.state().isPeekActive).toBe(false)
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(active.state().isPeekActive).toBe(true)
+    expect(active.state().isPeekOpen).toBe(true)
+  })
+
+  it('does not open when the pointer leaves before the dwell elapses', () => {
+    active = renderPeek(true)
+
+    act(() => {
+      active?.triggerEnter()
+      vi.advanceTimersByTime(OPEN_DELAY_MS - 10)
+      active?.triggerLeave()
+      vi.advanceTimersByTime(OPEN_DELAY_MS)
+    })
+
+    expect(active.state().isPeekActive).toBe(false)
+  })
+
+  it('never opens while disabled', () => {
+    active = renderPeek(false)
+
+    act(() => {
+      active?.triggerEnter()
+      vi.advanceTimersByTime(OPEN_DELAY_MS * 5)
+    })
+
+    expect(active.state().isPeekActive).toBe(false)
+  })
+
+  it('stays open while the pointer is inside the card', () => {
+    active = renderPeek(true)
+    openPeek(active)
+
+    movePointerTo(POINT.inCard)
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS * 3)
+    })
+
+    expect(active.state().isPeekOpen).toBe(true)
+  })
+
+  it('stays open while the pointer is still over the toggle that opened it', () => {
+    active = renderPeek(true)
+    openPeek(active)
+
+    movePointerTo(POINT.onTrigger)
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS * 3)
+    })
+
+    expect(active.state().isPeekOpen).toBe(true)
+  })
+
+  it('stays open while the pointer is over a portalled popper', async () => {
+    active = renderPeek(true)
+    openPeek(active)
+
+    const overlay = await appendToBody('div', { 'data-radix-popper-content-wrapper': '' })
+
+    movePointerTo(POINT.onContent, overlay)
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS * 3)
+    })
+
+    expect(active.state().isPeekOpen).toBe(true)
+  })
+
+  it('retracts after the grace period once the pointer moves to content', () => {
+    active = renderPeek(true)
+    openPeek(active)
+
+    movePointerTo(POINT.onContent)
+    expect(active.state().isPeekOpen).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS)
+    })
+    expect(active.state().isPeekOpen).toBe(false)
+    // Stays mounted so the fade-out can play.
+    expect(active.state().isPeekActive).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_DURATION_MS)
+    })
+    expect(active.state().isPeekActive).toBe(false)
+  })
+
+  it('stays open while crossing the gap between the toggle and the card', () => {
+    active = renderPeek(true)
+    openPeek(active)
+
+    movePointerTo(POINT.inGap)
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS * 2)
+    })
+
+    expect(active.state().isPeekOpen).toBe(true)
+  })
+
+  it('cancels a pending retraction when the pointer returns', () => {
+    active = renderPeek(true)
+    openPeek(active)
+
+    movePointerTo(POINT.onContent)
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS - 20)
+    })
+    movePointerTo(POINT.inCard)
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS * 2)
+    })
+
+    expect(active.state().isPeekOpen).toBe(true)
+  })
+
+  it('does not open on hover while a modal is already open', () => {
+    active = renderPeek(true)
+    active.setDismissed(true)
+
+    openPeek(active)
+
+    expect(active.state().isPeekActive).toBe(false)
+  })
+
+  it('retracts when a modal opens, even with the pointer inside', () => {
+    active = renderPeek(true)
+    openPeek(active)
+    movePointerTo(POINT.inCard)
+
+    active.setDismissed(true)
+
+    expect(active.state().isPeekOpen).toBe(false)
+  })
+
+  it('keeps the peek open while the pointer is over a non-modal popper', async () => {
+    active = renderPeek(true)
+    openPeek(active)
+
+    const popper = await appendToBody('div', { 'data-radix-popper-content-wrapper': '' })
+    movePointerTo(POINT.onContent, popper)
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS * 2)
+    })
+
+    expect(active.state().isPeekOpen).toBe(true)
+  })
+
+  /**
+   * Regression: a modal's scrim is `fixed inset-0` and carries emcn's
+   * `data-native-surface-overlay` marker, so matching that marker made every pointer
+   * position read as "inside a popper" and pinned the card open for good. Only Radix's
+   * popper wrapper counts.
+   */
+  it('retracts even while a full-screen modal scrim is present', () => {
+    active = renderPeek(true)
+    openPeek(active)
+
+    const scrim = document.createElement('div')
+    scrim.setAttribute('data-native-surface-overlay', '')
+    appended.push(scrim)
+    document.body.appendChild(scrim)
+
+    movePointerTo(POINT.onContent, scrim)
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS)
+    })
+
+    expect(active.state().isPeekOpen).toBe(false)
+  })
+
+  it('leaves Escape to an open popper rather than retracting', async () => {
+    active = renderPeek(true)
+    openPeek(active)
+    // Radix nests the state-bearing content inside the wrapper; only an *open* one
+    // claims Escape, so a menu animating closed still lets the card retract.
+    const wrapper = await appendToBody('div', { 'data-radix-popper-content-wrapper': '' })
+    const content = document.createElement('div')
+    content.setAttribute('data-state', 'open')
+    wrapper.appendChild(content)
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+
+    expect(active.state().isPeekOpen).toBe(true)
+  })
+
+  it('retracts on Escape when a popper is only animating closed', async () => {
+    active = renderPeek(true)
+    openPeek(active)
+    const wrapper = await appendToBody('div', { 'data-radix-popper-content-wrapper': '' })
+    const content = document.createElement('div')
+    content.setAttribute('data-state', 'closed')
+    wrapper.appendChild(content)
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+
+    expect(active.state().isPeekOpen).toBe(false)
+  })
+
+  it('retracts on Escape', () => {
+    active = renderPeek(true)
+    openPeek(active)
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+
+    expect(active.state().isPeekOpen).toBe(false)
+  })
+
+  it('drops the peek immediately when it stops being enabled', () => {
+    active = renderPeek(true)
+    openPeek(active)
+
+    active.setEnabled(false)
+
+    expect(active.state().isPeekOpen).toBe(false)
+    expect(active.state().isPeekActive).toBe(false)
+  })
+
+  it('opens under reduced motion', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({ matches: true }) as unknown as typeof matchMedia
+    )
+    active = renderPeek(true)
+
+    act(() => {
+      active?.triggerEnter()
+      vi.advanceTimersByTime(OPEN_DELAY_MS)
+    })
+
+    expect(active.state().isPeekActive).toBe(true)
+    expect(active.state().isPeekOpen).toBe(true)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/use-sidebar-peek.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/use-sidebar-peek.test.tsx
@@ -300,6 +300,59 @@ describe('useSidebarPeek', () => {
     expect(active.state().isPeekActive).toBe(false)
   })
 
+  it('never mounts the card when a modal opens mid-dwell', () => {
+    active = renderPeek(true)
+
+    act(() => {
+      active?.triggerEnter()
+      vi.advanceTimersByTime(OPEN_DELAY_MS - 20)
+    })
+    active.setDismissed(true)
+    act(() => {
+      vi.advanceTimersByTime(OPEN_DELAY_MS * 2)
+    })
+
+    expect(active.state().isPeekActive).toBe(false)
+  })
+
+  it('drops an already-exiting card the instant a modal opens', () => {
+    active = renderPeek(true)
+    openPeek(active)
+    movePointerTo(POINT.onContent)
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS)
+    })
+    expect(active.state().isPeekActive).toBe(true)
+
+    active.setDismissed(true)
+
+    expect(active.state().isPeekActive).toBe(false)
+  })
+
+  it('snaps a card that is animating out back open on re-hover', () => {
+    active = renderPeek(true)
+    openPeek(active)
+    movePointerTo(POINT.onContent)
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_DELAY_MS)
+    })
+    // Mid-exit: mounted but no longer open.
+    expect(active.state().isPeekActive).toBe(true)
+    expect(active.state().isPeekOpen).toBe(false)
+
+    // Re-hover late in the exit window; the pending exit timer must not win.
+    act(() => {
+      vi.advanceTimersByTime(EXIT_DURATION_MS - 20)
+      active?.triggerEnter()
+    })
+    expect(active.state().isPeekOpen).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_DURATION_MS * 2)
+    })
+    expect(active.state().isPeekOpen).toBe(true)
+  })
+
   it('retracts when a modal opens, even with the pointer inside', () => {
     active = renderPeek(true)
     openPeek(active)

--- a/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/use-sidebar-peek.ts
+++ b/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/use-sidebar-peek.ts
@@ -145,29 +145,39 @@ export function useSidebarPeek(enabled: boolean, dismissed = false): SidebarPeek
     if (!enabled || dismissed) return
     clearTimer(closeTimerRef)
     clearTimer(openTimerRef)
+    // Still on screen and animating out: snap it back instead of waiting out another
+    // dwell, which the pending exit timer would win — unmounting the card and then
+    // re-mounting it, a visible flicker with the pointer never leaving the toggle.
+    if (phase === 'exiting') {
+      open()
+      return
+    }
     openTimerRef.current = setTimeout(() => {
       openTimerRef.current = null
       open()
     }, PEEK_OPEN_DELAY_MS)
-  }, [dismissed, enabled, open])
+  }, [dismissed, enabled, open, phase])
 
   const onTriggerLeave = useCallback(() => {
     clearTimer(openTimerRef)
   }, [])
 
-  /** Drop the card outright — no exit animation — once the peek stops being available. */
+  /**
+   * Drop the card outright — no exit animation — the moment the peek stops being
+   * available (⌘B, fullscreen) or a modal takes the screen.
+   *
+   * Unconditional rather than gated on the current phase, because every phase needs
+   * clearing: a pending dwell would otherwise fire and mount the card over the modal,
+   * and an in-flight exit would keep animating on top of it. Instant is also right
+   * visually — the modal's own scrim covers the card's position on the same frame.
+   */
   useEffect(() => {
-    if (enabled) return
+    if (enabled && !dismissed) return
     clearTimer(openTimerRef)
     clearTimer(closeTimerRef)
     clearTimer(exitTimerRef)
     setPhase('closed')
-  }, [enabled])
-
-  /** A modal is a destination and owns the screen, so the transient card yields to it. */
-  useEffect(() => {
-    if (dismissed && phase === 'open') close()
-  }, [close, dismissed, phase])
+  }, [dismissed, enabled])
 
   useEffect(() => {
     if (phase !== 'open') return

--- a/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/use-sidebar-peek.ts
+++ b/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/use-sidebar-peek.ts
@@ -1,0 +1,234 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/** Hover dwell before the card appears, so a cursor passing over the control doesn't trigger it. */
+export const PEEK_OPEN_DELAY_MS = 90
+
+/** Grace period after the pointer leaves, so a small overshoot doesn't retract the card. */
+export const PEEK_CLOSE_DELAY_MS = 180
+
+/** How long the card stays mounted while its exit animation runs. */
+export const PEEK_EXIT_DURATION_MS = 150
+
+/** Floor between pointer hit-tests, so a fast drag doesn't measure rects every event. */
+export const PEEK_POINTER_SAMPLE_MS = 16
+
+/**
+ * Slack around the trigger and the card when hit-testing the pointer. The trigger sits
+ * in the title-bar lane and the card starts below it, so a straight line between them
+ * crosses a few pixels belonging to neither.
+ */
+const PEEK_GAP_TOLERANCE_PX = 12
+
+/**
+ * A transient floating layer — the wrapper Radix puts around popper content, so this
+ * covers every menu, context menu, select, and popover the sidebar opens. Same
+ * predicate emcn's own modal uses for "is a floating layer open" (`modal.tsx`).
+ *
+ * The pointer over one of these counts as inside the peek — otherwise reaching for a
+ * context-menu item would retract the card underneath it.
+ *
+ * Deliberately NOT the broader `data-native-surface-overlay` marker: emcn stamps that
+ * on the modal *scrim* too, which is `fixed inset-0`, so a `:not([aria-modal])` filter
+ * cannot exclude it (Radix puts `aria-modal` on the content, a different node) and any
+ * open modal would match at every pointer position and pin the card open. Tooltips are
+ * `pointer-events-none`, so they are never an event target and need no entry here.
+ */
+const POPPER_SELECTOR = '[data-radix-popper-content-wrapper]'
+
+/**
+ * An *open* popper. The `data-state` filter ignores one animating closed, so pressing
+ * Escape during a menu's exit still reaches the card. Mirrors emcn `modal.tsx`.
+ */
+const OPEN_POPPER_SELECTOR = `${POPPER_SELECTOR} [data-state="open"]`
+
+type PeekPhase = 'closed' | 'open' | 'exiting'
+
+function clearTimer(ref: React.MutableRefObject<ReturnType<typeof setTimeout> | null>) {
+  if (ref.current) {
+    clearTimeout(ref.current)
+    ref.current = null
+  }
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+/**
+ * Whether a client point falls inside an element, padded outward by `pad`.
+ *
+ * Geometric rather than DOM containment on purpose: the trigger is wrapped in a
+ * tooltip whose subtree re-renders, and a containment check against a stale or
+ * detached node reads as "outside" and retracts the card from under the pointer.
+ * Coordinates cannot go stale.
+ */
+function containsPoint(element: Element | null, x: number, y: number, pad: number): boolean {
+  if (!element) return false
+  const rect = element.getBoundingClientRect()
+  return (
+    x >= rect.left - pad && x <= rect.right + pad && y >= rect.top - pad && y <= rect.bottom + pad
+  )
+}
+
+export interface SidebarPeekResult {
+  /** Card is mounted as a floating overlay — drives positioning, chrome, and the expanded width. */
+  isPeekActive: boolean
+  /** Card is settled open. Goes false first on exit, so the exit animation can play. */
+  isPeekOpen: boolean
+  /** Attach to the floating card so the pointer hit-test can recognise it. */
+  cardRef: React.RefObject<HTMLDivElement | null>
+  /**
+   * Attach to the control that opens the peek (the title-bar sidebar toggle). It
+   * counts as inside the peek once open, so travelling from the control into the
+   * card never reads as leaving.
+   */
+  triggerRef: React.RefObject<HTMLDivElement | null>
+  onTriggerEnter: () => void
+  onTriggerLeave: () => void
+}
+
+/**
+ * Drives the desktop sidebar's hover-peek: hovering the title-bar sidebar toggle
+ * floats the collapsed sidebar in over the content, and it retracts once the pointer
+ * leaves. Clicking that same control still docks the sidebar for good.
+ *
+ * The `exiting` phase keeps the card mounted for {@link PEEK_EXIT_DURATION_MS} so its
+ * exit animation can play; unmounting immediately would snap it away mid-animation.
+ *
+ * Retraction is detected from a document-level `pointermove` hit-test rather than
+ * `mouseleave`, because the menus and tooltips the sidebar opens live in body
+ * portals. A `mouseleave`-driven peek would retract the instant the pointer crossed
+ * into one of those, so {@link POPPER_SELECTOR} counts as inside.
+ *
+ * @param enabled Whether the peek is available at all (collapsed, on the desktop shell).
+ *   Also masks the returned flags, so a consumer never sees a stale open card for the
+ *   render in which the peek became unavailable.
+ * @param dismissed Force the card closed — a modal is open and owns the screen.
+ */
+export function useSidebarPeek(enabled: boolean, dismissed = false): SidebarPeekResult {
+  const cardRef = useRef<HTMLDivElement | null>(null)
+  const triggerRef = useRef<HTMLDivElement | null>(null)
+  const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const [phase, setPhase] = useState<PeekPhase>('closed')
+
+  const open = useCallback(() => {
+    clearTimer(closeTimerRef)
+    clearTimer(exitTimerRef)
+    setPhase('open')
+  }, [])
+
+  const close = useCallback(() => {
+    clearTimer(openTimerRef)
+    clearTimer(closeTimerRef)
+    clearTimer(exitTimerRef)
+    setPhase((current) => (current === 'open' ? 'exiting' : current))
+    exitTimerRef.current = setTimeout(
+      () => {
+        exitTimerRef.current = null
+        setPhase('closed')
+      },
+      prefersReducedMotion() ? 0 : PEEK_EXIT_DURATION_MS
+    )
+  }, [])
+
+  const onTriggerEnter = useCallback(() => {
+    // `dismissed` is checked here too, not just in the effect below: that effect only
+    // fires on the transition, so with a modal already open a hover would otherwise
+    // float the card over it.
+    if (!enabled || dismissed) return
+    clearTimer(closeTimerRef)
+    clearTimer(openTimerRef)
+    openTimerRef.current = setTimeout(() => {
+      openTimerRef.current = null
+      open()
+    }, PEEK_OPEN_DELAY_MS)
+  }, [dismissed, enabled, open])
+
+  const onTriggerLeave = useCallback(() => {
+    clearTimer(openTimerRef)
+  }, [])
+
+  /** Drop the card outright — no exit animation — once the peek stops being available. */
+  useEffect(() => {
+    if (enabled) return
+    clearTimer(openTimerRef)
+    clearTimer(closeTimerRef)
+    clearTimer(exitTimerRef)
+    setPhase('closed')
+  }, [enabled])
+
+  /** A modal is a destination and owns the screen, so the transient card yields to it. */
+  useEffect(() => {
+    if (dismissed && phase === 'open') close()
+  }, [close, dismissed, phase])
+
+  useEffect(() => {
+    if (phase !== 'open') return
+
+    let lastSampleAt = Number.NEGATIVE_INFINITY
+
+    const onPointerMove = (event: PointerEvent) => {
+      // Sampled on the event's own clock rather than a frame callback: rAF is
+      // throttled in an unfocused or occluded window, which would strand the card up.
+      if (event.timeStamp - lastSampleAt < PEEK_POINTER_SAMPLE_MS) return
+      lastSampleAt = event.timeStamp
+
+      // The tolerance bridges the few px of title-bar lane between the trigger's
+      // bottom edge and the card's top edge. Poppers are matched by DOM instead —
+      // they can be anchored anywhere on screen.
+      const target = event.target instanceof Element ? event.target : null
+      const inside =
+        containsPoint(cardRef.current, event.clientX, event.clientY, PEEK_GAP_TOLERANCE_PX) ||
+        containsPoint(triggerRef.current, event.clientX, event.clientY, PEEK_GAP_TOLERANCE_PX) ||
+        Boolean(target?.closest(POPPER_SELECTOR))
+      if (inside) {
+        clearTimer(closeTimerRef)
+        return
+      }
+      if (!closeTimerRef.current) {
+        closeTimerRef.current = setTimeout(() => {
+          closeTimerRef.current = null
+          close()
+        }, PEEK_CLOSE_DELAY_MS)
+      }
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      // An open popper owns Escape first — dismissing a context menu shouldn't also
+      // take the card out from under the pointer.
+      if (event.key === 'Escape' && !document.querySelector(OPEN_POPPER_SELECTOR)) close()
+    }
+
+    document.addEventListener('pointermove', onPointerMove, { passive: true })
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointermove', onPointerMove)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [close, phase])
+
+  useEffect(
+    () => () => {
+      clearTimer(openTimerRef)
+      clearTimer(closeTimerRef)
+      clearTimer(exitTimerRef)
+    },
+    []
+  )
+
+  return {
+    isPeekActive: phase !== 'closed' && enabled,
+    isPeekOpen: phase === 'open' && enabled,
+    cardRef,
+    triggerRef,
+    onTriggerEnter,
+    onTriggerLeave,
+  }
+}

--- a/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/workspace-chrome.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/workspace-chrome.tsx
@@ -195,9 +195,16 @@ export function WorkspaceChrome({
     })
   }, [])
 
-  useEffect(() => {
-    // Seed from the attribute the pre-paint script already wrote, so the peek is armed
-    // on the first hover instead of waiting for the async bridge below to resolve.
+  /**
+   * A layout effect, not a passive one: the seed below arms the peek, and a passive
+   * effect lands after paint — long enough for a `mouseenter` on the toggle to be
+   * dropped while the peek still reads disabled, with nothing to retry it until the
+   * pointer leaves and returns. Everything here is a cheap synchronous read plus a
+   * subscription; the bridge's `getState` stays async and blocks nothing.
+   */
+  useLayoutEffect(() => {
+    // Seed from the attribute the pre-paint script already wrote, rather than waiting
+    // for the async bridge below to resolve.
     const initial = document.documentElement.getAttribute('data-sim-desktop-title-bar')
     if (initial === 'inset' || initial === 'fullscreen') setTitleBarMode(initial)
 

--- a/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/workspace-chrome.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/workspace-chrome.tsx
@@ -1,12 +1,15 @@
 'use client'
 
-import { useEffect, useLayoutEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { cn } from '@sim/emcn'
 import { PanelLeft } from '@sim/emcn/icons'
 import { usePathname } from 'next/navigation'
 import { getDesktopBridge } from '@/lib/desktop'
+import { applyDesktopTitleBarMode, type DesktopTitleBarMode } from '@/app/_shell/desktop-title-bar'
+import { useSidebarPeek } from '@/app/workspace/[workspaceId]/components/workspace-chrome/use-sidebar-peek'
 import { Sidebar, SidebarTooltip } from '@/app/workspace/[workspaceId]/w/components/sidebar/sidebar'
 import { useFullscreenOriginStore } from '@/stores/fullscreen-origin'
+import { useSearchModalStore } from '@/stores/modals/search/store'
 import { useSidebarStore } from '@/stores/sidebar/store'
 
 const FULLSCREEN_SUFFIXES = ['/upgrade'] as const
@@ -14,6 +17,45 @@ const FULLSCREEN_SUFFIXES = ['/upgrade'] as const
 /** Slide timing for the fullscreen sidebar collapse and content shift. */
 const SLIDE_TRANSITION =
   'duration-[175ms] ease-[cubic-bezier(0.25,0.1,0.25,1)] motion-reduce:transition-none'
+
+/**
+ * The peek card's floating chrome.
+ *
+ * Every value is an existing token: `rounded-lg` is `--radius`, matching the content
+ * pane it floats beside; `--border` is that pane's border; `shadow-overlay` and
+ * `--z-modal` are what the app's other edge-anchored panels use. The card's fill is
+ * the sidebar's own `--surface-1`, so docked and floating are the same surface.
+ *
+ * `w-auto` shrink-wraps the inner shell, which `[data-peek]` has already put at the
+ * expanded width. It must not be a length: `width` cannot interpolate to or from
+ * `auto`, so entering and leaving the peek snap instead of animating — otherwise the
+ * card widens as it appears and leaves a shrinking ghost on retract.
+ */
+const PEEK_CARD_CHROME =
+  'absolute top-[var(--desktop-title-bar-height)] bottom-2 left-2 z-[var(--z-modal)] w-auto origin-top-left rounded-lg border border-[var(--border)] shadow-overlay'
+
+/**
+ * Peek card enter/exit — the popper idiom rather than a slide, since the card is
+ * anchored to the title-bar toggle and grows out of that corner exactly as emcn's
+ * Radix surfaces do (`dropdown-menu.tsx`: `fade-in-0 zoom-in-95`).
+ *
+ * Animations rather than transitions: an animation runs from mount, so the card needs
+ * no hidden "from" frame and no `requestAnimationFrame` to step into — rAF is throttled
+ * in an unfocused window, which would strand the card mounted-but-invisible.
+ *
+ * `duration-150` must match {@link PEEK_EXIT_DURATION_MS}.
+ */
+const PEEK_CARD_ENTER = cn(
+  PEEK_CARD_CHROME,
+  'animate-in fade-in-0 zoom-in-95 duration-150 ease-out motion-reduce:animate-none'
+)
+const PEEK_CARD_EXIT = cn(
+  PEEK_CARD_CHROME,
+  'pointer-events-none animate-out fade-out-0 zoom-out-95 fill-mode-forwards duration-150 ease-out motion-reduce:animate-none'
+)
+
+/** The docked rail: in flow, width-animated by the collapse toggle. */
+const SIDEBAR_SHELL_IN_FLOW = cn('transition-[width]', SLIDE_TRANSITION)
 
 interface WorkspaceChromeProps {
   children: React.ReactNode
@@ -44,6 +86,12 @@ function isFullscreenPath(pathname: string | null): boolean {
  *
  * On a direct load of a fullscreen route the wrapper mounts already collapsed,
  * so no slide plays (CSS transitions don't run on mount).
+ *
+ * On the macOS desktop shell, where collapsing hides the rail entirely, the same
+ * wrapper doubles as the hover-peek card: hovering the title-bar sidebar toggle
+ * takes it out of flow, floats it over the content inset from the window edge, and
+ * re-points `--sidebar-width` at the restore width. The sidebar is never re-mounted
+ * or duplicated for this — see {@link useSidebarPeek}.
  */
 export function WorkspaceChrome({
   children,
@@ -55,6 +103,20 @@ export function WorkspaceChrome({
   const isFullscreen = isFullscreenPath(pathname)
 
   const setOrigin = useFullscreenOriginStore((s) => s.setOrigin)
+
+  /**
+   * Which title-bar treatment the host is using. `inset` is the macOS desktop shell,
+   * where collapsing hides the rail entirely (`--sidebar-collapsed-width: 0`) — the
+   * only host where the hover-peek applies. `null` is the web app (icon rail).
+   */
+  const [titleBarMode, setTitleBarMode] = useState<DesktopTitleBarMode>(null)
+
+  /**
+   * The search palette is the one overlay reachable from the peeked card that renders
+   * a full-screen scrim, so the card yields to it. Read from the store rather than
+   * sniffed off the DOM — the store is the modal's own source of truth.
+   */
+  const isSearchModalOpen = useSearchModalStore((s) => s.isOpen)
 
   const storeIsCollapsed = useSidebarStore((s) => s.isCollapsed)
   const hasHydrated = useSidebarStore((s) => s._hasHydrated)
@@ -70,6 +132,15 @@ export function WorkspaceChrome({
    * client render identical to the server), then the store takes over.
    */
   const isCollapsed = hasHydrated ? storeIsCollapsed : initialSidebarCollapsed
+
+  /**
+   * The hover-peek only exists where collapsing leaves nothing behind — the macOS
+   * desktop shell. The web app keeps a 51px icon rail (with its own hover flyouts),
+   * and native fullscreen falls back to that same rail.
+   */
+  const peekEnabled = isCollapsed && !isFullscreen && titleBarMode === 'inset'
+  const { isPeekActive, isPeekOpen, cardRef, triggerRef, onTriggerEnter, onTriggerLeave } =
+    useSidebarPeek(peekEnabled, isSearchModalOpen)
 
   /**
    * Suppresses sidebar transitions across the initial hydration window. The
@@ -125,16 +196,20 @@ export function WorkspaceChrome({
   }, [])
 
   useEffect(() => {
+    // Seed from the attribute the pre-paint script already wrote, so the peek is armed
+    // on the first hover instead of waiting for the async bridge below to resolve.
+    const initial = document.documentElement.getAttribute('data-sim-desktop-title-bar')
+    if (initial === 'inset' || initial === 'fullscreen') setTitleBarMode(initial)
+
     const windowState = getDesktopBridge()?.windowState
     if (!windowState) return
 
     let disposed = false
     const applyWindowState = ({ isFullScreen }: { isFullScreen: boolean }) => {
       if (!disposed) {
-        document.documentElement.setAttribute(
-          'data-sim-desktop-title-bar',
-          isFullScreen ? 'fullscreen' : 'inset'
-        )
+        const mode: DesktopTitleBarMode = isFullScreen ? 'fullscreen' : 'inset'
+        applyDesktopTitleBarMode(document.documentElement, mode)
+        setTitleBarMode(mode)
       }
     }
     const unsubscribe = windowState.onStateChange(applyWindowState)
@@ -180,13 +255,19 @@ export function WorkspaceChrome({
         )}
       />
       <div
+        ref={cardRef}
         className={cn(
-          'sidebar-shell-outer shrink-0 overflow-hidden transition-[width]',
-          SLIDE_TRANSITION,
-          isFullscreen ? 'w-0' : 'w-[var(--sidebar-width)]'
+          'sidebar-shell-outer shrink-0 overflow-hidden',
+          isPeekActive
+            ? isPeekOpen
+              ? PEEK_CARD_ENTER
+              : PEEK_CARD_EXIT
+            : cn(isFullscreen ? 'w-0' : 'w-[var(--sidebar-width)]', SIDEBAR_SHELL_IN_FLOW)
         )}
         data-collapsed={isCollapsed || undefined}
-        aria-hidden={isFullscreen || undefined}
+        data-peek={isPeekActive || undefined}
+        /* Also hidden mid-exit, where the card is mounted but invisible. */
+        aria-hidden={isFullscreen || (isPeekActive && !isPeekOpen) || undefined}
         suppressHydrationWarning
       >
         <div
@@ -196,7 +277,7 @@ export function WorkspaceChrome({
             isFullscreen && '-translate-x-full'
           )}
         >
-          <Sidebar isCollapsed={isCollapsed} />
+          <Sidebar isCollapsed={isCollapsed} isPeeking={isPeekActive} />
         </div>
       </div>
       <div
@@ -213,21 +294,40 @@ export function WorkspaceChrome({
         </div>
       </div>
       {!isFullscreen && (
-        <SidebarTooltip
-          label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          enabled
-          side='bottom'
-          shortcut='⌘B'
+        /**
+         * The hover region lives on this wrapper, not the button: `SidebarTooltip`
+         * returns bare `children` when disabled, so suppressing the tooltip while
+         * peeking swaps the element tree and remounts the button. A ref on the
+         * button would go null mid-hover and retract the card; the wrapper never
+         * unmounts, so it stays a stable anchor for the pointer hit-test.
+         */
+        <div
+          ref={triggerRef}
+          onMouseEnter={onTriggerEnter}
+          onMouseLeave={onTriggerLeave}
+          className='absolute top-[var(--desktop-title-bar-control-offset)] left-[var(--desktop-title-bar-inset-x)] z-30 hidden size-[var(--desktop-title-bar-control-size)] [-webkit-app-region:no-drag] [[data-sim-desktop-title-bar=inset]_&]:block'
         >
-          <button
-            type='button'
-            onClick={toggleSidebar}
-            className='absolute top-[var(--desktop-title-bar-control-offset)] left-[var(--desktop-title-bar-inset-x)] z-30 hidden size-[var(--desktop-title-bar-control-size)] items-center justify-center rounded-lg transition-colors [-webkit-app-region:no-drag] hover-hover:bg-[var(--surface-active)] [[data-sim-desktop-title-bar=inset]_&]:flex'
-            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          <SidebarTooltip
+            label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            /* Gated on `peekEnabled`, not on the card being open: hovering always
+               opens the card, so a tooltip tied to visibility would flash for the
+               dwell and then vanish under it. When peek is armed the card IS the
+               affordance; when it isn't (expanded, or web), the tooltip behaves
+               exactly as before. Stable across a hover, so no remount mid-gesture. */
+            enabled={!peekEnabled}
+            side='bottom'
+            shortcut='⌘B'
           >
-            <PanelLeft className='size-[var(--desktop-title-bar-control-icon-size)] text-[var(--text-icon)]' />
-          </button>
-        </SidebarTooltip>
+            <button
+              type='button'
+              onClick={toggleSidebar}
+              className='flex size-full items-center justify-center rounded-lg transition-colors hover-hover:bg-[var(--surface-active)]'
+              aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            >
+              <PanelLeft className='size-[var(--desktop-title-bar-control-icon-size)] text-[var(--text-icon)]' />
+            </button>
+          </SidebarTooltip>
+        </div>
       )}
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/browser/browser.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/browser/browser.test.tsx
@@ -25,6 +25,8 @@ vi.mock('@sim/browser-protocol', () => ({
 }))
 
 vi.mock('@sim/emcn', () => ({
+  /** `SettingsResourceRow` composes its tile classes with `cn`. */
+  cn: (...classes: unknown[]) => classes.filter(Boolean).join(' '),
   Chip: ({
     children,
     disabled,
@@ -292,12 +294,21 @@ describe('Browser settings', () => {
     ])
   })
 
-  it('lists each data type inline as a standard settings row', async () => {
+  it('lists each data type as a standard settings row in one section', async () => {
     await render()
 
+    const section = container.querySelector('section[aria-label="Browsing data"]')
+    expect(section).not.toBeNull()
+
+    const labels = [...(section?.querySelectorAll('span') ?? [])].map((s) => s.textContent)
     for (const label of ['Cookies', 'Site data', 'Cached images and files']) {
-      expect(container.querySelector(`section[aria-label="${label}"]`)).not.toBeNull()
+      expect(labels).toContain(label)
     }
+    expect([...(section?.querySelectorAll('button') ?? [])].map((b) => b.textContent)).toEqual([
+      'Delete cookies',
+      'Delete site data',
+      'Delete cached images and files',
+    ])
   })
 
   it.each([

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/browser/browser.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/browser/browser.tsx
@@ -166,28 +166,25 @@ export function Browser() {
           </div>
         </SettingsSection>
 
-        {canClearData &&
-          DATA_ROWS.map((row) => (
-            <SettingsSection
-              key={row.kind}
-              label={row.label}
-              action={
-                <Chip disabled={clearPending} onClick={() => setConfirming(row)}>
-                  {row.action}
-                </Chip>
-              }
-            >
-              {null}
-            </SettingsSection>
-          ))}
-
         {canClearData && (
-          <p className='text-[var(--text-muted)] text-caption'>
-            {siteCount === 0
-              ? 'Nothing saved. Sites you sign into in the browser stay on this device.'
-              : `${siteCount} ${siteCount === 1 ? 'site is' : 'sites are'} signed in or holding cookies, saved on this device only.`}{' '}
-            Saved passwords are never deleted here.
-          </p>
+          <SettingsSection label='Browsing data'>
+            <div className='flex flex-col gap-3'>
+              {DATA_ROWS.map((row) => (
+                <div key={row.kind} className='flex items-center justify-between'>
+                  <Label>{row.label}</Label>
+                  <Chip disabled={clearPending} onClick={() => setConfirming(row)}>
+                    {row.action}
+                  </Chip>
+                </div>
+              ))}
+              <p className='text-[var(--text-muted)] text-caption'>
+                {siteCount === 0
+                  ? 'Nothing saved. Sites you sign into in the browser stay on this device.'
+                  : `${siteCount} ${siteCount === 1 ? 'site is' : 'sites are'} signed in or holding cookies, saved on this device only.`}{' '}
+                Saved passwords are never deleted here.
+              </p>
+            </div>
+          </SettingsSection>
         )}
       </SettingsPanel>
 

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/browser/components/passwords-view/passwords-view.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/browser/components/passwords-view/passwords-view.test.tsx
@@ -15,6 +15,8 @@ const { mockBridge, mockSearch, mockToast } = vi.hoisted(() => ({
 }))
 
 vi.mock('@sim/emcn', () => ({
+  /** `SettingsResourceRow` composes its tile classes with `cn`. */
+  cn: (...classes: unknown[]) => classes.filter(Boolean).join(' '),
   ArrowLeft: () => <span />,
   ArrowRight: () => <span />,
   ChipConfirmModal: ({

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/browser/components/passwords-view/passwords-view.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/browser/components/passwords-view/passwords-view.tsx
@@ -11,19 +11,16 @@ import { ArrowLeft, ArrowRight, ChipConfirmModal, Key, Plus, toast } from '@sim/
 import { getDesktopBridge } from '@/lib/desktop'
 import { ImportModal } from '@/app/workspace/[workspaceId]/settings/components/browser/components/import-modal/import-modal'
 import { PasswordDetail } from '@/app/workspace/[workspaceId]/settings/components/browser/components/password-detail/password-detail'
-import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state/settings-empty-state'
+import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
+import { SettingsResourceRow } from '@/app/workspace/[workspaceId]/settings/components/settings-resource-row'
 import { useSettingsSearch } from '@/app/workspace/[workspaceId]/settings/components/use-settings-search'
 
-/** The integrations page's responsive card grid and row chrome. */
+/** The integrations page's responsive card grid (see `integration-section.tsx`, `skills.tsx`). */
 const CARD_GRID = '-mx-2 grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-x-2 gap-y-0.5'
+/** Card hit area; the row chrome inside it comes from {@link SettingsResourceRow}. */
 const CARD_CLASSES =
-  'flex items-center gap-2.5 rounded-lg p-2 text-left transition-colors hover-hover:bg-[var(--surface-active)]'
-const CARD_TILE_CLASSES =
-  'flex size-full items-center justify-center overflow-hidden rounded-xl border border-[var(--border-1)] bg-[var(--bg)]'
-const CARD_TITLE_CLASSES = 'truncate text-[14px] text-[var(--text-body)]'
-const CARD_SUBTITLE_CLASSES = 'truncate text-[12px] text-[var(--text-muted)]'
-const CARD_ARROW_CLASSES = 'size-4 flex-shrink-0 text-[var(--text-icon)]'
+  'w-full rounded-lg p-2 text-left transition-colors hover-hover:bg-[var(--surface-active)]'
 
 const IMPORT_ERROR_MESSAGES: Record<BrowserImportError, string> = {
   'unsupported-platform': 'Importing from another browser is only supported on macOS.',
@@ -204,30 +201,23 @@ export function PasswordsView({ credentials, onChange, onBack, onImported }: Pas
                   className={CARD_CLASSES}
                   onClick={() => setSelectedId(credential.id)}
                 >
-                  <div className='size-9 flex-shrink-0'>
-                    <div className={CARD_TILE_CLASSES}>
-                      {credential.icon ? (
+                  <SettingsResourceRow
+                    icon={
+                      credential.icon ? (
                         // A `data:` URL copied from the source browser at
                         // import time — never a network request, which would
                         // disclose which sites the user has passwords for.
                         // Fills the tile like any other brand logo.
-                        <img
-                          src={credential.icon}
-                          alt=''
-                          className='size-full rounded-xl object-contain'
-                        />
+                        <img src={credential.icon} alt='' className='object-contain' />
                       ) : (
-                        <Key className='size-5 text-[var(--text-icon)]' />
-                      )}
-                    </div>
-                  </div>
-                  <div className='flex min-w-0 flex-1 flex-col'>
-                    <span className={CARD_TITLE_CLASSES}>{siteLabel(credential.origin)}</span>
-                    <span className={CARD_SUBTITLE_CLASSES}>
-                      {credential.username || 'No username'}
-                    </span>
-                  </div>
-                  <ArrowRight className={CARD_ARROW_CLASSES} />
+                        <Key />
+                      )
+                    }
+                    iconFill
+                    title={siteLabel(credential.origin)}
+                    description={credential.username || 'No username'}
+                    trailing={<ArrowRight className='size-4 text-[var(--text-icon)]' />}
+                  />
                 </button>
               ))}
             </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
@@ -666,7 +666,7 @@ export function SearchModal({
     <>
       <div
         className={cn(
-          'fixed inset-0 z-40 transition-opacity duration-100',
+          'fixed inset-0 z-[var(--z-modal)] transition-opacity duration-100',
           open ? 'opacity-100' : 'pointer-events-none opacity-0'
         )}
         onClick={handleOverlayClick}
@@ -679,7 +679,7 @@ export function SearchModal({
         aria-hidden={!open}
         aria-label='Search'
         className={cn(
-          '-translate-x-1/2 fixed top-[15%] z-50 w-[500px] rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] shadow-[var(--shadow-overlay)] dark:bg-[var(--surface-5)]',
+          '-translate-x-1/2 fixed top-[15%] z-[var(--z-modal)] w-[500px] rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] shadow-[var(--shadow-overlay)] dark:bg-[var(--surface-5)]',
           open ? 'visible opacity-100' : 'invisible opacity-0'
         )}
         style={{

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -362,9 +362,22 @@ interface SidebarProps {
    * so the rail's structure, labels, and width all read a single source.
    */
   isCollapsed: boolean
+  /**
+   * True while the sidebar is rendered as the desktop hover-peek card. The card shows
+   * the expanded layout even though the rail is collapsed, so this overrides
+   * {@link SidebarProps.isCollapsed} below — and separately suppresses the chrome the
+   * card already provides: it sits below the traffic-light lane, and drag-resize would
+   * fight the card's width.
+   */
+  isPeeking?: boolean
 }
 
-export const Sidebar = memo(function Sidebar({ isCollapsed }: SidebarProps) {
+export const Sidebar = memo(function Sidebar({
+  isCollapsed: isCollapsedProp,
+  isPeeking = false,
+}: SidebarProps) {
+  /** The peek card always renders the expanded layout, whatever the rail's state. */
+  const isCollapsed = isCollapsedProp && !isPeeking
   const params = useParams()
   const workspaceId = params.workspaceId as string
   const workflowId = params.workflowId as string | undefined
@@ -1279,11 +1292,20 @@ export const Sidebar = memo(function Sidebar({ isCollapsed }: SidebarProps) {
           onClick={handleSidebarClick}
         >
           <div className='flex h-full flex-col'>
+            {/* The peek card already sits below the lane; reserving it again doubles the offset. */}
+            {!isPeeking && (
+              <div
+                aria-hidden
+                className='desktop-window-drag-region desktop-workspace-window-drag-region h-[var(--desktop-title-bar-height)]'
+              />
+            )}
             <div
-              aria-hidden
-              className='desktop-window-drag-region desktop-workspace-window-drag-region h-[var(--desktop-title-bar-height)]'
-            />
-            <div className='relative flex flex-shrink-0 items-center px-2 pt-3 [[data-sim-desktop-title-bar=inset]_&]:pt-[var(--desktop-title-bar-height)]'>
+              className={cn(
+                'relative flex flex-shrink-0 items-center px-2 pt-3',
+                !isPeeking &&
+                  '[[data-sim-desktop-title-bar=inset]_&]:pt-[var(--desktop-title-bar-height)]'
+              )}
+            >
               <WorkspaceHeader
                 activeWorkspace={activeWorkspace}
                 workspaceId={workspaceId}
@@ -1753,19 +1775,23 @@ export const Sidebar = memo(function Sidebar({ isCollapsed }: SidebarProps) {
           </div>
         </aside>
 
-        <div
-          className={cn(
-            'absolute top-0 right-0 bottom-0 z-20 w-[8px] translate-x-1/2',
-            isCollapsed ? 'cursor-e-resize' : 'cursor-ew-resize'
-          )}
-          onPointerDown={isCollapsed ? undefined : handlePointerDown}
-          onClick={isCollapsed ? toggleCollapsed : undefined}
-          onKeyDown={handleEdgeKeyDown}
-          role={isCollapsed ? 'button' : 'separator'}
-          tabIndex={0}
-          aria-orientation={isCollapsed ? undefined : 'vertical'}
-          aria-label={isCollapsed ? 'Expand sidebar' : 'Resize sidebar'}
-        />
+        {/* Not on the peek card: the resize hook writes an inline `--sidebar-width` that
+            out-specifies the `[data-peek]` rule, stranding the card at a stale width. */}
+        {!isPeeking && (
+          <div
+            className={cn(
+              'absolute top-0 right-0 bottom-0 z-20 w-[8px] translate-x-1/2',
+              isCollapsed ? 'cursor-e-resize' : 'cursor-ew-resize'
+            )}
+            onPointerDown={isCollapsed ? undefined : handlePointerDown}
+            onClick={isCollapsed ? toggleCollapsed : undefined}
+            onKeyDown={handleEdgeKeyDown}
+            role={isCollapsed ? 'button' : 'separator'}
+            tabIndex={0}
+            aria-orientation={isCollapsed ? undefined : 'vertical'}
+            aria-label={isCollapsed ? 'Expand sidebar' : 'Resize sidebar'}
+          />
+        )}
       </div>
 
       <SearchModal

--- a/apps/sim/stores/sidebar/store.test.ts
+++ b/apps/sim/stores/sidebar/store.test.ts
@@ -1,11 +1,20 @@
 /**
  * @vitest-environment jsdom
  */
-import { afterEach, describe, expect, it } from 'vitest'
-import { readCollapsedCookie } from './store'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { SIDEBAR_WIDTH } from '@/stores/constants'
+import { readCollapsedCookie, useSidebarStore } from './store'
 
 function setCookie(value: string) {
   document.cookie = `sidebar_collapsed=${value}; path=/`
+}
+
+function widthVars() {
+  const style = document.documentElement.style
+  return {
+    width: style.getPropertyValue('--sidebar-width'),
+    expanded: style.getPropertyValue('--sidebar-expanded-width'),
+  }
 }
 
 afterEach(() => {
@@ -30,5 +39,58 @@ describe('readCollapsedCookie', () => {
 
   it('is false when the cookie is absent', () => {
     expect(readCollapsedCookie()).toBe(false)
+  })
+})
+
+describe('sidebar width CSS variables', () => {
+  beforeEach(() => {
+    document.documentElement.style.removeProperty('--sidebar-width')
+    document.documentElement.style.removeProperty('--sidebar-expanded-width')
+    useSidebarStore.setState({ isCollapsed: false, sidebarWidth: SIDEBAR_WIDTH.DEFAULT })
+  })
+
+  it('publishes both variables when the width changes while expanded', () => {
+    useSidebarStore.getState().setSidebarWidth(300)
+    expect(widthVars()).toEqual({ width: '300px', expanded: '300px' })
+  })
+
+  it('keeps the expanded variable at the restore width while collapsed', () => {
+    useSidebarStore.getState().setSidebarWidth(300)
+    useSidebarStore.getState().toggleCollapsed()
+
+    expect(useSidebarStore.getState().isCollapsed).toBe(true)
+    expect(widthVars()).toEqual({
+      width: `${SIDEBAR_WIDTH.COLLAPSED}px`,
+      expanded: '300px',
+    })
+  })
+
+  it('restores the collapsed width from the expanded variable on expand', () => {
+    useSidebarStore.getState().setSidebarWidth(300)
+    useSidebarStore.getState().toggleCollapsed()
+    useSidebarStore.getState().toggleCollapsed()
+
+    expect(widthVars()).toEqual({ width: '300px', expanded: '300px' })
+  })
+
+  it('holds the expanded width across a syncWidth while collapsed', () => {
+    useSidebarStore.getState().setSidebarWidth(300)
+    useSidebarStore.getState().toggleCollapsed()
+    document.documentElement.style.removeProperty('--sidebar-expanded-width')
+
+    useSidebarStore.getState().syncWidth()
+
+    expect(widthVars()).toEqual({
+      width: `${SIDEBAR_WIDTH.COLLAPSED}px`,
+      expanded: '300px',
+    })
+  })
+
+  it('clamps a below-minimum persisted width into the expanded variable', () => {
+    useSidebarStore.setState({ isCollapsed: true, sidebarWidth: 10 })
+
+    useSidebarStore.getState().syncWidth()
+
+    expect(widthVars().expanded).toBe(`${SIDEBAR_WIDTH.MIN}px`)
   })
 })

--- a/apps/sim/stores/sidebar/store.ts
+++ b/apps/sim/stores/sidebar/store.ts
@@ -18,10 +18,23 @@ function clampSidebarWidth(width: number): number {
   return Math.min(Math.max(width, SIDEBAR_WIDTH.MIN), max)
 }
 
-function applySidebarWidth(width: number) {
+/**
+ * Publishes both sidebar widths, owning the collapsed mapping so callers don't repeat it.
+ *
+ * `--sidebar-width` is the width the rail currently occupies (the collapsed width while
+ * collapsed), whereas `--sidebar-expanded-width` always holds the width to restore to.
+ * The desktop hover-peek needs the latter: it renders the sidebar at full width while
+ * the rail itself is still collapsed to zero.
+ */
+function applySidebarWidths(expandedWidth: number, collapsed: boolean) {
   if (typeof window === 'undefined') return
-  const value = Number.isFinite(width) ? width : SIDEBAR_WIDTH.DEFAULT
-  document.documentElement.style.setProperty('--sidebar-width', `${value}px`)
+  const expanded = Number.isFinite(expandedWidth) ? expandedWidth : SIDEBAR_WIDTH.DEFAULT
+  const root = document.documentElement
+  root.style.setProperty('--sidebar-expanded-width', `${expanded}px`)
+  root.style.setProperty(
+    '--sidebar-width',
+    `${collapsed ? getCollapsedSidebarWidth() : expanded}px`
+  )
 }
 
 /** Reads the host-specific collapsed width established by the pre-paint layout script. */
@@ -63,26 +76,21 @@ export const useSidebarStore = create<SidebarState>()(
         if (get().isCollapsed) return
         const clampedWidth = clampSidebarWidth(width)
         set({ sidebarWidth: clampedWidth })
-        applySidebarWidth(clampedWidth)
+        applySidebarWidths(clampedWidth, false)
       },
       toggleCollapsed: () => {
         const { isCollapsed, sidebarWidth } = get()
         const nextCollapsed = !isCollapsed
+        const expandedWidth = clampSidebarWidth(sidebarWidth)
         set({ isCollapsed: nextCollapsed })
         applyCollapsedCookie(nextCollapsed)
-        applySidebarWidth(
-          nextCollapsed ? getCollapsedSidebarWidth() : clampSidebarWidth(sidebarWidth)
-        )
+        applySidebarWidths(expandedWidth, nextCollapsed)
       },
       syncWidth: () => {
         const { isCollapsed, sidebarWidth } = get()
-        if (isCollapsed) {
-          applySidebarWidth(getCollapsedSidebarWidth())
-          return
-        }
         const clampedWidth = clampSidebarWidth(sidebarWidth)
-        if (clampedWidth !== sidebarWidth) set({ sidebarWidth: clampedWidth })
-        applySidebarWidth(clampedWidth)
+        if (!isCollapsed && clampedWidth !== sidebarWidth) set({ sidebarWidth: clampedWidth })
+        applySidebarWidths(clampedWidth, isCollapsed)
       },
       setHasHydrated: (hasHydrated) => set({ _hasHydrated: hasHydrated }),
     }),
@@ -99,10 +107,7 @@ export const useSidebarStore = create<SidebarState>()(
       onRehydrateStorage: () => (state) => {
         if (state) {
           state.setHasHydrated(true)
-          const width = state.isCollapsed
-            ? getCollapsedSidebarWidth()
-            : clampSidebarWidth(state.sidebarWidth)
-          applySidebarWidth(width)
+          applySidebarWidths(clampSidebarWidth(state.sidebarWidth), state.isCollapsed)
         }
       },
       /** Only width is persisted; collapse lives in the cookie. */


### PR DESCRIPTION
## What

On the macOS desktop shell the collapsed sidebar has **no width at all** (`--sidebar-collapsed-width: 0`), unlike web's 51px icon rail — so once collapsed the only ways back were ⌘B and the small title-bar toggle. Hovering that toggle now floats the sidebar in as a card over the content, inset from the window edge, retracting when the pointer leaves. Clicking the same control still docks it for good.

Web and macOS native fullscreen (which falls back to the icon rail) are untouched.

## How

The card **is** the existing `.sidebar-shell-outer`, re-styled — not a second surface. `<Sidebar>` is 1800 lines with scroll and expansion state, so it must never re-mount; keeping the same element in the same tree position guarantees that. One CSS rule re-points `--sidebar-width` at a new `--sidebar-expanded-width`, and the inner shell plus the aside follow with no per-element width overrides.

- **Chrome is all existing tokens**: `rounded-lg` (`--radius`, same 8px as the content pane it floats beside), `border-[var(--border)]` (byte-identical to that pane's), `shadow-overlay` and `z-[var(--z-modal)]` (what the app's other edge-anchored panels use). The fill is the sidebar's own `--surface-1`, so docked and floating are the same surface.
- **Enter/exit** use the popper idiom emcn's Radix surfaces already use (`fade-in-0 zoom-in-95`). These are keyframe *animations*, not transitions, deliberately: an animation runs from mount, so no hidden "from" frame and no `requestAnimationFrame` to step into — rAF is throttled in an unfocused window and would strand the card mounted-but-invisible.
- **`w-auto`, not a length**: `width` cannot interpolate to or from `auto`, so entering and leaving snap instead of animating. With a length the card widened as it appeared and left a 248px ghost shrinking to zero in flow on retract.
- **Retraction** is a document-level `pointermove` hit-test, not `mouseleave`: every menu the sidebar opens lives in a body portal, so `mouseleave` would retract the card the instant you reached for a menu item. The card and trigger are matched *geometrically* (coordinates can't go stale when the tooltip subtree re-renders); poppers are matched via the same predicate emcn's own modal uses.

## Also fixed

**Search palette migrated from raw `z-40`/`z-50` to `--z-modal`.** It was the one overlay the new card outranked, and the raw values also placed it *below* `--z-toast`, inverting the order `globals.css` documents. Fixing it at the root beat teaching the peek to dodge it.

**Settings drive-bys** — all pre-existing violations in files this PR already touches:
- `passwords-view`: two literal pixel text sizes → scale tokens (`text-sm`/`text-caption`), and its cards now route through `SettingsResourceRow` instead of four re-derived chrome constants (mirroring the established `custom-blocks` pattern).
- `browser`: three `{null}`-bodied `SettingsSection`s — the only such usage in the codebase — collapse into one section of real label+action rows.

## Testing

- 18 unit tests for the peek hook: hover dwell, geometric hit-test, popper-keeps-open, modal dismissal, the gap between trigger and card, Escape yielding to an open popper, reduced motion, and a regression test for the scrim bug below.
- 5 tests covering `--sidebar-expanded-width` across collapse/expand/resize/rehydrate.
- Verified live in the desktop app via CDP: card geometry `[8, 40, 250, 812]`, 8px radius, shadow on, `transform-origin` top-left, the 90ms dwell gate, and traversal from trigger into card without retracting.

**Not verified: the animation feel.** Background windows throttle both timers and CSS animations, and the harness could not reliably bring the Electron window frontmost, so every measurement of the enter/exit animation was invalid. Geometry and chrome were verified with real numbers; the fade/zoom needs a human eye.

## Review notes

Three real bugs were found and fixed during review, each with a test:
1. Moving from the trigger *into* the card retracted it — `SidebarTooltip` returns bare `children` when disabled, so suppressing the tooltip remounted the button and nulled the ref mid-hover. Fixed by anchoring the hover region to a stable wrapper and hit-testing geometrically.
2. An earlier attempt used `[data-native-surface-overlay]:not([aria-modal="true"])` — but emcn stamps that marker on the modal *scrim* and never sets `aria-modal` (Radix puts it on a different node), so the exclusion matched nothing and a `fixed inset-0` scrim would have pinned the card open permanently.
3. With a modal already open, hovering still opened the card over it, because the dismissal effect only fired on the transition.

`lint:check` fails repo-wide on `terminal-session.tsx` (`noFocusedTests` on xterm's `fit.fit()`) — verified pre-existing on clean `staging`, untouched here.