### PR TITLE
perf(tests): skip jest-dom in node-environment test files

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -177,7 +177,9 @@ jobs:
       - name: Install ripgrep
         run: command -v rg || (sudo apt-get update && sudo apt-get install -y ripgrep)
 
-      - name: Run tests with coverage
+      # Named for what it does: `bun run test` is `vitest run`, with no
+      # `--coverage`. See the Codecov note below.
+      - name: Run tests
         env:
           NODE_OPTIONS: '--no-warnings --max-old-space-size=8192'
           NEXT_PUBLIC_APP_URL: 'https://www.sim.ai'
@@ -199,6 +201,14 @@ jobs:
           fi
           echo "✅ Schema and migrations are in sync"
 
+      # DEAD PATH: nothing generates `apps/sim/coverage`. The test step runs
+      # `vitest run` without `--coverage`, and vitest.config.ts declares no
+      # coverage provider, so this uploads nothing and still reports success in
+      # ~1s (`fail_ci_if_error: false` hides it). `@vitest/coverage-v8` IS
+      # installed, so wiring it up is possible — but coverage instrumentation
+      # costs test time and nothing gates on the result today. Left in place
+      # pending a decision to either enable coverage or drop this step; do not
+      # read its green tick as "coverage was published".
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:

--- a/apps/sim/vitest.setup.ts
+++ b/apps/sim/vitest.setup.ts
@@ -17,7 +17,15 @@ import {
   workflowAuthzMock,
 } from '@sim/testing'
 import { afterAll, vi } from 'vitest'
-import '@testing-library/jest-dom/vitest'
+
+/**
+ * jest-dom only registers DOM matchers (`toBeVisible`, `toHaveTextContent`, …),
+ * so it is dead weight in a `node` environment — which is 985 of the 1,219 test
+ * files here. Loading it unconditionally made every one of them pay for it.
+ */
+if (typeof document !== 'undefined') {
+  await import('@testing-library/jest-dom/vitest')
+}
 
 setupGlobalFetchMock()
 setupGlobalStorageMocks()


### PR DESCRIPTION
## Summary

`Lint and Test` is now the CI critical path (184s vs Build App's 147s after #6080), and **143s of that 184s is the test suite**. This takes ~8% off it.

`vitest.setup.ts` loaded `@testing-library/jest-dom/vitest` unconditionally, so all **1,219** test files paid for it. jest-dom only registers DOM matchers (`toBeInTheDocument`, `toBeVisible`, …), which are useless without a document — and **985 of those files declare `@vitest-environment node`**.

## Where the time actually goes

From the CI run's own vitest summary (aggregate across workers, so it exceeds wall clock):

```
Duration 141.02s (transform 101.32s, setup 123.76s, import 686.00s, tests 55.18s, environment 15.07s)
```

**Actual test execution is 55s.** The rest is per-file overhead — and `setup` is the part a global setup file controls.

## Measured, same machine, full suite

| | Duration | setup (aggregate) |
|---|---|---|
| baseline | 179.47s | 367.13s |
| guarded | **165.78s** | **252.72s** |

**7.6% off the suite, 31% off aggregate setup.** On a node-only subset (50 files, n=3 each) it's **21%** — 2.75s → 2.16s median.

## Nothing loses a matcher

All **7** files that actually call a jest-dom matcher are explicitly `@vitest-environment jsdom`, so `typeof document !== 'undefined'` is true for exactly those. Verified by running them: 4 files / 7 tests pass.

Full suite is identical either way — 1225 files / 16184 tests pass. The one failure (`cloud-review-tools.test.ts`) **reproduces on unmodified staging**: its spawned `python3` can't find `rg` on macOS. CI installs ripgrep explicitly and it passes there.

## Two CI docs that claimed more than the code does

Same class as #6076, found while tracing this:

- The step was named **"Run tests with coverage"** but runs `bun run test` = `vitest run`, with **no `--coverage`** anywhere.
- The **Codecov upload reads `apps/sim/coverage`, which nothing generates** — `vitest.config.ts` declares no coverage provider. It uploads nothing and still reports success in ~1s because `fail_ci_if_error: false`. So its green tick has never meant coverage was published.

I annotated rather than deleted the Codecov step: `@vitest/coverage-v8` *is* installed, so enabling coverage is possible, but instrumentation costs test time and nothing gates on the result. **That's a call for you, not a side effect of a perf change** — happy to either wire it up or drop the step.

## Not addressed here

`import` is the real monster — **686s aggregate vs 55s of actual tests**. That's module graph cost per test file, the same root cause as the tool registry being 68–78% of every route's graph. `vitest.setup.ts` already globally mocks `@/blocks/registry`; doing the same for `@/tools/registry` could be large, but it would silently change behaviour for any test that needs real tools, across 1,219 files. Needs its own measured, scoped change.

## Type of Change

- [x] Performance
- [x] Improvement (CI documentation accuracy)

## Testing

Full suite run both ways on the same machine (numbers above); the 7 jest-dom-dependent files run explicitly; `actionlint` clean; `biome` clean.