### PR TITLE
chore(gitignore): ignore the repo-root uploads spill directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,14 @@ i18n.cache
 # Python (apps/pii tests/tooling)
 __pycache__/
 .pytest_cache/
+
+# Local file-upload spill directory. `UPLOAD_DIR_SERVER` is
+# `join(process.cwd(), 'uploads')`, so it follows the cwd rather than a fixed
+# root: under `turbo run test` the cwd is apps/sim and `apps/sim/.gitignore`'s
+# `/uploads` catches it, but running vitest from the repo root drops ~40
+# `uploads/execution/**/large-value-*.json` files here instead.
+#
+# Anchored deliberately. An unanchored `uploads/` would also match
+# `apps/sim/lib/uploads/` — 61 files of tracked source — and silently ignore
+# anything added there later.
+/uploads


### PR DESCRIPTION
## Summary
- Running the test suite from the repo root leaves ~40 untracked `uploads/execution/**/large-value-*.json` artifacts; nothing ignored them
- `UPLOAD_DIR_SERVER` is `join(process.cwd(), 'uploads')`, so it follows the cwd — under `turbo run test` the cwd is `apps/sim` and that package's `/uploads` rule catches it, but a repo-root invocation escapes it
- Added an **anchored** `/uploads` to the root `.gitignore`. Unanchored `uploads/` would also match `apps/sim/lib/uploads/` — 61 files of tracked source — and silently ignore anything added there later

## Type of Change
- [x] Bug fix

## Testing
Verified both directions: `git check-ignore` confirms the artifact path is now ignored, and confirms `apps/sim/lib/uploads/core/setup.server.ts` is still **not** ignored. `bun run lint` clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)