### PR TITLE
improvement(tables): fire the live-rows signal on async delete, run cancel, and column run

### DIFF
--- a/apps/sim/app/api/table/[tableId]/cancel-runs/route.ts
+++ b/apps/sim/app/api/table/[tableId]/cancel-runs/route.ts
@@ -56,10 +56,11 @@ export const POST = withRouteHandler(async (request: NextRequest, { params }: Ro
       } cancelled=${cancelled}`
     )
 
-    // Cancelling clears each affected row's exec state in the DB. The `dispatch: cancelled` events drop
-    // the run overlay, but the client then renders the row's authoritative DB state — so refetch the grid
-    // to pick up the cleared cells. Only when something was actually cancelled.
-    if (cancelled > 0) signalTableRowsChanged(tableId)
+    // Cancelling clears/tombstones affected rows' exec state in the DB. The `dispatch: cancelled` events
+    // drop the run overlay, but the client then renders the row's authoritative DB state — so refetch the
+    // grid to pick up the cleared cells. Unconditional: `cancelled` counts dispatches, but tombstone row
+    // writes can happen even when that is 0, and a stale-but-harmless refetch beats a missed one.
+    signalTableRowsChanged(tableId)
 
     return NextResponse.json({ success: true, data: { cancelled } })
   } catch (error) {

--- a/apps/sim/app/api/table/[tableId]/cancel-runs/route.ts
+++ b/apps/sim/app/api/table/[tableId]/cancel-runs/route.ts
@@ -5,6 +5,7 @@ import { parseRequest } from '@/lib/api/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { signalTableRowsChanged } from '@/lib/table/events'
 import { cancelWorkflowGroupRuns } from '@/lib/table/workflow-columns'
 import { accessError, checkAccess, tableFilterError } from '@/app/api/table/utils'
 
@@ -54,6 +55,11 @@ export const POST = withRouteHandler(async (request: NextRequest, { params }: Ro
         rowId ? ` rowId=${rowId}` : ''
       } cancelled=${cancelled}`
     )
+
+    // Cancelling clears each affected row's exec state in the DB. The `dispatch: cancelled` events drop
+    // the run overlay, but the client then renders the row's authoritative DB state — so refetch the grid
+    // to pick up the cleared cells. Only when something was actually cancelled.
+    if (cancelled > 0) signalTableRowsChanged(tableId)
 
     return NextResponse.json({ success: true, data: { cancelled } })
   } catch (error) {

--- a/apps/sim/app/api/table/[tableId]/columns/run/route.ts
+++ b/apps/sim/app/api/table/[tableId]/columns/run/route.ts
@@ -5,6 +5,7 @@ import { parseRequest } from '@/lib/api/server'
 import { checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { signalTableRowsChanged } from '@/lib/table/events'
 import { runWorkflowColumn } from '@/lib/table/workflow-columns'
 import { accessError, checkAccess, tableFilterError } from '@/app/api/table/utils'
 
@@ -46,6 +47,11 @@ export const POST = withRouteHandler(async (request: NextRequest, { params }: Ro
       requestId,
       triggeredByUserId: auth.userId,
     })
+
+    // Starting a run clears the target group's cells to pending (`bulkClearWorkflowGroupCells`) — a DB
+    // row change. The `dispatch: dispatching` events drive the run overlay, but the cleared cell values
+    // come from the rows query, so refetch the grid. Only when a dispatch was actually created.
+    if (dispatchId) signalTableRowsChanged(tableId)
 
     return NextResponse.json({ success: true, data: { dispatchId } })
   } catch (error) {

--- a/apps/sim/app/api/table/[tableId]/columns/run/route.ts
+++ b/apps/sim/app/api/table/[tableId]/columns/run/route.ts
@@ -50,8 +50,10 @@ export const POST = withRouteHandler(async (request: NextRequest, { params }: Ro
 
     // Starting a run clears the target group's cells to pending (`bulkClearWorkflowGroupCells`) — a DB
     // row change. The `dispatch: dispatching` events drive the run overlay, but the cleared cell values
-    // come from the rows query, so refetch the grid. Only when a dispatch was actually created.
-    if (dispatchId) signalTableRowsChanged(tableId)
+    // come from the rows query, so refetch the grid. Unconditional: the bulk clear can run even on a path
+    // that then returns a null `dispatchId` (dispatch cancelled post-clear), and a stale-but-harmless
+    // refetch beats a missed one.
+    signalTableRowsChanged(tableId)
 
     return NextResponse.json({ success: true, data: { dispatchId } })
   } catch (error) {

--- a/apps/sim/lib/table/delete-runner.test.ts
+++ b/apps/sim/lib/table/delete-runner.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TableLockedError } from '@/lib/table/mutation-locks'
 
 const {
   mockGetTableById,
@@ -120,6 +121,18 @@ describe('runTableDelete', () => {
     expect(mockMarkJobReady).not.toHaveBeenCalled()
     // Even though the run was cancelled before completion, the first page WAS deleted — the `finally`
     // must still refetch the grid so open editors don't keep showing those deleted rows.
+    expect(mockSignalTableRowsChanged).toHaveBeenCalledWith('tbl_1')
+  })
+
+  it('signals a grid refetch when a page throws a mid-page lock after committing rows', async () => {
+    mockSelectRowIdPage.mockResolvedValueOnce(['a', 'b'])
+    // `deletePageByIds` commits in internal batches, so a lock landing mid-page can persist earlier
+    // batches and THEN throw — it returns no count. The grid must still be refetched.
+    mockDeletePageByIds.mockRejectedValueOnce(new TableLockedError('delete'))
+
+    await expect(runTableDelete(basePayload())).resolves.toBeUndefined()
+
+    expect(mockMarkJobCanceled).toHaveBeenCalledWith('tbl_1', 'job_1')
     expect(mockSignalTableRowsChanged).toHaveBeenCalledWith('tbl_1')
   })
 

--- a/apps/sim/lib/table/delete-runner.test.ts
+++ b/apps/sim/lib/table/delete-runner.test.ts
@@ -13,6 +13,7 @@ const {
   mockMarkJobFailed,
   mockMarkJobCanceled,
   mockAppendTableEvent,
+  mockSignalTableRowsChanged,
   mockBuildFilterClause,
 } = vi.hoisted(() => ({
   mockGetTableById: vi.fn(),
@@ -24,6 +25,7 @@ const {
   mockMarkJobFailed: vi.fn(),
   mockMarkJobCanceled: vi.fn(),
   mockAppendTableEvent: vi.fn(),
+  mockSignalTableRowsChanged: vi.fn(),
   mockBuildFilterClause: vi.fn(),
 }))
 
@@ -41,7 +43,10 @@ vi.mock('@/lib/table/rows/ordering', () => ({
   selectRowIdPage: mockSelectRowIdPage,
   deletePageByIds: mockDeletePageByIds,
 }))
-vi.mock('@/lib/table/events', () => ({ appendTableEvent: mockAppendTableEvent }))
+vi.mock('@/lib/table/events', () => ({
+  appendTableEvent: mockAppendTableEvent,
+  signalTableRowsChanged: mockSignalTableRowsChanged,
+}))
 vi.mock('@/lib/table/sql', () => ({ buildFilterClause: mockBuildFilterClause }))
 vi.mock('@/lib/table/constants', () => ({
   TABLE_LIMITS: { DELETE_PAGE_SIZE: 2 },
@@ -141,6 +146,9 @@ describe('runTableDelete', () => {
     expect(mockAppendTableEvent).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'job', type: 'delete', status: 'ready', progress: 3 })
     )
+    // The live grid must be told rows changed so deleted rows drop out of every open editor —
+    // the `job` progress event only drives the delete meter, not the rows query.
+    expect(mockSignalTableRowsChanged).toHaveBeenCalledWith('tbl_1')
   })
 
   it('stops once maxRows is reached and caps the final page fetch to the remaining budget', async () => {

--- a/apps/sim/lib/table/delete-runner.test.ts
+++ b/apps/sim/lib/table/delete-runner.test.ts
@@ -94,6 +94,8 @@ describe('runTableDelete', () => {
     expect(mockAppendTableEvent).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'job', type: 'delete', status: 'canceled' })
     )
+    // Nothing was deleted, so the grid must NOT be needlessly refetched.
+    expect(mockSignalTableRowsChanged).not.toHaveBeenCalled()
   })
 
   it('stops mid-run when the delete lock is enabled between pages', async () => {
@@ -116,6 +118,9 @@ describe('runTableDelete', () => {
     )
     expect(mockMarkJobCanceled).toHaveBeenCalledWith('tbl_1', 'job_1')
     expect(mockMarkJobReady).not.toHaveBeenCalled()
+    // Even though the run was cancelled before completion, the first page WAS deleted — the `finally`
+    // must still refetch the grid so open editors don't keep showing those deleted rows.
+    expect(mockSignalTableRowsChanged).toHaveBeenCalledWith('tbl_1')
   })
 
   it('deletes every matching page then marks the job ready', async () => {

--- a/apps/sim/lib/table/delete-runner.ts
+++ b/apps/sim/lib/table/delete-runner.ts
@@ -159,16 +159,13 @@ export async function runTableDelete(payload: TableDeletePayload): Promise<void>
 
       const toDelete = excluded.size > 0 ? page.filter((id) => !excluded.has(id)) : page
       if (toDelete.length > 0) {
+        // Mark BEFORE the call, not from its return: `deletePageByIds` commits in internal batches, so a
+        // mid-page lock can persist earlier batches and THEN throw — the catch below returns without a
+        // count. Setting this up front guarantees the `finally` grid refetch fires whether the call
+        // returns or throws. (An attempt that ends up committing nothing only over-refetches — harmless.)
+        deletedAny = true
         try {
-          const deleted = await deletePageByIds(
-            tableId,
-            workspaceId,
-            toDelete,
-            pageProof,
-            revalidate
-          )
-          processed += deleted
-          if (deleted > 0) deletedAny = true
+          processed += await deletePageByIds(tableId, workspaceId, toDelete, pageProof, revalidate)
         } catch (err) {
           if (!(err instanceof TableLockedError)) throw err
           // A lock landed between batches. Batches already committed stay

--- a/apps/sim/lib/table/delete-runner.ts
+++ b/apps/sim/lib/table/delete-runner.ts
@@ -65,6 +65,12 @@ export async function runTableDelete(payload: TableDeletePayload): Promise<void>
   const requestId = generateId().slice(0, 8)
   const budget = maxRows ?? Number.POSITIVE_INFINITY
 
+  // Whether any row was actually deleted this run. Signalled in `finally` so open editors refetch the
+  // grid on EVERY exit path — normal completion, a cancel/supersede between batches, a mid-batch lock,
+  // or a rethrown error after a partial delete — not only the throttled/`ready` paths (which a cancel
+  // landing after a committed batch would bypass, leaving deleted rows on screen).
+  let deletedAny = false
+
   try {
     const table = await getTableById(tableId, { includeArchived: true })
     if (!table) throw new Error(`Delete target table ${tableId} not found`)
@@ -154,7 +160,15 @@ export async function runTableDelete(payload: TableDeletePayload): Promise<void>
       const toDelete = excluded.size > 0 ? page.filter((id) => !excluded.has(id)) : page
       if (toDelete.length > 0) {
         try {
-          processed += await deletePageByIds(tableId, workspaceId, toDelete, pageProof, revalidate)
+          const deleted = await deletePageByIds(
+            tableId,
+            workspaceId,
+            toDelete,
+            pageProof,
+            revalidate
+          )
+          processed += deleted
+          if (deleted > 0) deletedAny = true
         } catch (err) {
           if (!(err instanceof TableLockedError)) throw err
           // A lock landed between batches. Batches already committed stay
@@ -179,7 +193,8 @@ export async function runTableDelete(payload: TableDeletePayload): Promise<void>
           progress: processed,
         })
         // Refetch the live grid as rows drop out (throttled with the progress event above) — the `job`
-        // event only drives the progress meter, not the rows query.
+        // event only drives the progress meter, not the rows query. The `finally` below guarantees a
+        // final refetch on every exit, so a cancel after the last un-throttled batch can't leave stale rows.
         signalTableRowsChanged(tableId)
       }
     }
@@ -197,9 +212,6 @@ export async function runTableDelete(payload: TableDeletePayload): Promise<void>
         status: 'ready',
         progress: processed,
       })
-      // Final grid refetch so the deleted rows are gone in every open editor (the last progress
-      // signal above may predate the tail batch).
-      signalTableRowsChanged(tableId)
       logger.info(`[${requestId}] Delete complete`, { tableId, rows: processed })
     } else {
       logger.info(
@@ -223,6 +235,10 @@ export async function runTableDelete(payload: TableDeletePayload): Promise<void>
     const error = cause ? toError(cause) : toError(err)
     logger.error(`[${requestId}] Delete failed for table ${tableId}:`, error)
     throw error
+  } finally {
+    // Guaranteed final grid refetch on every exit — completion, cancel/supersede, mid-batch lock, or a
+    // rethrown error — whenever this run deleted anything, so no open editor keeps showing deleted rows.
+    if (deletedAny) signalTableRowsChanged(tableId)
   }
 }
 

--- a/apps/sim/lib/table/delete-runner.ts
+++ b/apps/sim/lib/table/delete-runner.ts
@@ -4,7 +4,7 @@ import { generateId } from '@sim/utils/id'
 import { truncate } from '@sim/utils/string'
 import type { Filter, TableDefinition } from '@/lib/table'
 import { TABLE_LIMITS, USER_TABLE_ROWS_SQL_NAME } from '@/lib/table/constants'
-import { appendTableEvent } from '@/lib/table/events'
+import { appendTableEvent, signalTableRowsChanged } from '@/lib/table/events'
 import {
   getJobProgress,
   markJobCanceled,
@@ -178,6 +178,9 @@ export async function runTableDelete(payload: TableDeletePayload): Promise<void>
           status: 'running',
           progress: processed,
         })
+        // Refetch the live grid as rows drop out (throttled with the progress event above) — the `job`
+        // event only drives the progress meter, not the rows query.
+        signalTableRowsChanged(tableId)
       }
     }
 
@@ -194,6 +197,9 @@ export async function runTableDelete(payload: TableDeletePayload): Promise<void>
         status: 'ready',
         progress: processed,
       })
+      // Final grid refetch so the deleted rows are gone in every open editor (the last progress
+      // signal above may predate the tail batch).
+      signalTableRowsChanged(tableId)
       logger.info(`[${requestId}] Delete complete`, { tableId, rows: processed })
     } else {
       logger.info(


### PR DESCRIPTION
## Summary
- Three table operations mutate row data but emitted no live `rows` signal, so open editors' grids stayed stale until a manual refresh (enrichment *results* already stream live via `cell` events — these are the bulk paths that emit no per-cell event):
  - **Async row delete** (`runTableDelete`): signals as rows drop (throttled with the existing progress event) and once on completion — the `job` event only drives the delete meter, not the rows query. Covers the delete-async route and copilot bulk-delete (shared runner).
  - **Cancel runs** (`cancel-runs`): clearing exec state; the `dispatch: cancelled` events drop the overlay but the client then renders authoritative DB state, so refetch. Only when something was cancelled.
  - **Run column** (`columns/run`): starting a run bulk-clears cells to pending; refetch so the cleared cells show. Only when a dispatch was created.
- Guarded so no signal fires on a no-op/failure; adds a delete-runner test asserting the completion signal.

## Type of Change
- [x] Bug fix / integration follow-up

## Testing
Tested manually; delete-runner unit tests updated and passing; tsc + biome + api-validation green.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
