### PR TITLE
fix(settings): add bottom padding to settings sidebar

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/settings-sidebar/settings-sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/settings-sidebar/settings-sidebar.tsx
@@ -307,7 +307,7 @@ export function SettingsSidebar({
       <div
         ref={isCollapsed ? undefined : scrollContainerRef}
         className={cn(
-          'flex flex-1 flex-col overflow-y-auto overflow-x-hidden border-t pt-1.5 transition-colors duration-150',
+          'flex flex-1 flex-col overflow-y-auto overflow-x-hidden border-t pt-1.5 pb-2 transition-colors duration-150',
           !hasOverflowTop && 'border-transparent'
         )}
       >

--- a/apps/sim/components/settings/settings-sidebar.tsx
+++ b/apps/sim/components/settings/settings-sidebar.tsx
@@ -126,7 +126,7 @@ export function SettingsSidebar<Section extends SettingsSection>({
       <div
         ref={isCollapsed ? undefined : scrollContainerRef}
         className={cn(
-          'flex flex-1 flex-col overflow-y-auto overflow-x-hidden border-t py-1.5 transition-colors duration-150',
+          'flex flex-1 flex-col overflow-y-auto overflow-x-hidden border-t pt-1.5 pb-2 transition-colors duration-150',
           !hasOverflowTop && 'border-transparent'
         )}
       >


### PR DESCRIPTION
## Summary
- The settings sidebar's nav list ended flush against the bottom of the sidebar column — the last item had zero bottom gutter (reported by Emir)
- Root cause: on the settings route the sidebar renders scroll region + nothing after it, while the non-settings branch has a footer block (`pt-[9px] pb-2`) supplying the bottom gutter. The scroll container's `pt-1.5` was copy-pasted from that branch, where the missing `pb` is fine because the footer follows it
- Added `pb-2` to the settings scroll container, matching the non-settings footer exactly
- Also normalized the standalone settings shell (account / org / self-host planes) from `py-1.5` to `pt-1.5 pb-2` — it was 6px, 2px off the workspace sidebar and off its own content pane's `p-[8px]` inset

## Type of Change
- [x] Bug fix

## Testing
Measured the box model in Chromium and WebKit with Playwright: gap from the last nav chip to the sidebar's bottom edge goes 0px -> 8px when the list overflows, and is unchanged (no-op) when it doesn't. Confirmed the padding lands inside the scrollable area (`scrollHeight` 764 -> 772, `clientHeight` unchanged) rather than being clipped.

Checked for regressions: neither settings sidebar computes `hasOverflowBottom`, so no bottom-border/fade state can flip; the `hasOverflowBottom` logic in `sidebar.tsx` is bound to the untouched non-settings container. No CSS selector targets these containers' padding. The desktop hover-peek card renders this component with `isCollapsed=false` and stretches rather than being fixed-height, so the padding adds scrollable space instead of clipping — it now clears the card's `rounded-lg` bottom corners. No tests or snapshots reference these classNames.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
