### PR TITLE
feat(tables): propagate shared saved-view changes to collaborators live

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/hooks/use-table-event-stream.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/hooks/use-table-event-stream.ts
@@ -406,6 +406,12 @@ export function useTableEventStream({
           else if (entry.event?.kind === 'definition') {
             void queryClient.invalidateQueries({ queryKey: tableKeys.detail(tableId), exact: true })
           }
+          // A collaborator changed the table's shared saved views (create/rename/delete/
+          // re-save): refetch the views list alone. Views are presentation state layered on
+          // the already-loaded table, so no rows/definition refetch is needed.
+          else if (entry.event?.kind === 'views') {
+            void queryClient.invalidateQueries({ queryKey: tableKeys.views(tableId) })
+          }
         } catch (err) {
           logger.warn('Failed to parse table event', { tableId, err })
         }

--- a/apps/sim/lib/table/events.ts
+++ b/apps/sim/lib/table/events.ts
@@ -147,6 +147,16 @@ export type TableEvent =
       tableId: string
       reason: 'locks'
     }
+  | {
+      /** A user created, renamed, deleted, or re-saved a shared saved view (a named
+       *  filter/sort/layout preset). Views are table-wide collaborative state — every
+       *  reader of the table sees every view — so peers refetch the views list to pick
+       *  up the change live. Value-less, same refetch-in-own-format rationale as
+       *  {@link kind} `edit`; no rows/definition refetch, since a view is presentation
+       *  state layered on top of the already-loaded table. */
+      kind: 'views'
+      tableId: string
+    }
 
 export interface TableEventEntry {
   eventId: number
@@ -201,6 +211,15 @@ export function signalTableSchemaChanged(tableId: string): void {
  */
 export function signalTableMetadataChanged(tableId: string): void {
   void appendTableEvent({ kind: 'metadata', tableId })
+}
+
+/**
+ * Signal collaborators that a user changed the table's shared saved views (created,
+ * renamed, deleted, or re-saved one) so they refetch the views list live. Fire-and-forget
+ * for the same reason as {@link signalTableRowsChanged}.
+ */
+export function signalTableViewsChanged(tableId: string): void {
+  void appendTableEvent({ kind: 'views', tableId })
 }
 
 /**

--- a/apps/sim/lib/table/views/service.ts
+++ b/apps/sim/lib/table/views/service.ts
@@ -16,6 +16,7 @@ import { generateId } from '@sim/utils/id'
 import { and, asc, eq, ne, sql } from 'drizzle-orm'
 import { getColumnId } from '@/lib/table/column-keys'
 import { NAME_PATTERN } from '@/lib/table/constants'
+import { signalTableViewsChanged } from '@/lib/table/events'
 import { filterRulesToPredicate, filterToRules } from '@/lib/table/query-builder/converters'
 import type {
   ColumnDefinition,
@@ -181,6 +182,8 @@ export async function createTableView(data: CreateTableViewData): Promise<TableV
     .returning()
 
   logger.info('Created table view', { tableId: data.tableId, viewId: row.id })
+  // Views are table-wide shared state, so every open reader refetches the list live.
+  signalTableViewsChanged(data.tableId)
   return toTableView(row, data.columns)
 }
 
@@ -252,6 +255,8 @@ export async function updateTableView(data: UpdateTableViewData): Promise<TableV
   // route maps it to 404 the same way `deleteTableView`'s `false` does.
   if (!row) return null
 
+  // Only signal a real update — a no-op PATCH on a missing view (row === null) changed nothing.
+  signalTableViewsChanged(data.tableId)
   return toTableView(row, data.columns)
 }
 
@@ -262,6 +267,10 @@ export async function deleteTableView(viewId: string, tableId: string): Promise<
     .where(and(eq(tableViews.id, viewId), eq(tableViews.tableId, tableId)))
     .returning({ id: tableViews.id })
 
-  if (deleted.length > 0) logger.info('Deleted table view', { tableId, viewId })
+  if (deleted.length > 0) {
+    logger.info('Deleted table view', { tableId, viewId })
+    // Only signal a real deletion — a missing view (nothing deleted) changed nothing.
+    signalTableViewsChanged(tableId)
+  }
   return deleted.length > 0
 }


### PR DESCRIPTION
## Summary
- Table **views** (named filter/sort/layout presets) are table-wide shared state — every reader of a table sees every view — but view create/update/delete had **no realtime signal**, so a collaborator only saw another user's view changes on their own staleTime/focus refetch. This closes the one table-mutation surface that wasn't wired into realtime.
- Adds a `views` table event kind + `signalTableViewsChanged`, emitted from the **views service** (`createTableView`/`updateTableView`/`deleteTableView`, on real success only — a no-op PATCH/DELETE on a missing view signals nothing).
- Adds a client handler that invalidates the **views query alone** (`tableKeys.views`) — no rows/definition refetch, since a view is presentation state layered on the already-loaded table.
- Mirrors exactly how row (`edit`), schema, metadata, and definition changes already propagate to collaborators.

## Context
Found during a wiring audit after merging staging into `realtime-rooms`: the new v2 table surface's views feature was the only mutating table surface not propagated live. Rows/schema/metadata/table-CRUD and the async background runners (import/update/backfill via `job` events) were already covered.

## Type of Change
- [x] New feature (realtime propagation for an existing surface)

## Testing
Tested manually. tsc clean, lint clean, `check:api-validation` passes (no route change), 61 table/events/views/hook tests pass. No dedicated wrapper test added — consistent with the sibling signals (edit/schema/metadata/definition), which are type-checked and trivial; the views service test deliberately avoids DB mocking.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)