### PR TITLE
test(tables): cover the views realtime signal

### DIFF
--- a/apps/sim/lib/table/events.test.ts
+++ b/apps/sim/lib/table/events.test.ts
@@ -11,7 +11,12 @@ beforeAll(() => {
 afterAll(resetEnvMock)
 
 import type { TableEvent } from '@/lib/table/events'
-import { appendTableEvent, getLatestTableEventId, readTableEventsSince } from '@/lib/table/events'
+import {
+  appendTableEvent,
+  getLatestTableEventId,
+  readTableEventsSince,
+  signalTableViewsChanged,
+} from '@/lib/table/events'
 
 /** Module-level memory buffer can't be reset without vi.resetModules — use a
  *  unique tableId per test to avoid cross-test bleed. */
@@ -72,6 +77,26 @@ describe('getLatestTableEventId (memory buffer)', () => {
     if (result.status === 'ok') {
       expect(result.events).toHaveLength(1)
       expect(result.events[0].eventId).toBe(latest + 1)
+    }
+  })
+})
+
+describe('signalTableViewsChanged', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('appends a single views event carrying the tableId', async () => {
+    const tableId = uniqueTableId()
+    // The memory-buffer append is synchronous, so the fire-and-forget signal is
+    // observable immediately without awaiting the (unreturned) append promise.
+    signalTableViewsChanged(tableId)
+
+    const result = await readTableEventsSince(tableId, 0)
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') {
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].event).toEqual({ kind: 'views', tableId })
     }
   })
 })

--- a/apps/sim/lib/table/views/service.test.ts
+++ b/apps/sim/lib/table/views/service.test.ts
@@ -1,9 +1,25 @@
 /**
  * @vitest-environment node
  */
-import { describe, expect, it } from 'vitest'
+import { tableViews } from '@sim/db/schema'
+import { dbChainMockFns, queueTableRows, resetDbChainMock } from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ColumnDefinition, TableViewConfig } from '@/lib/table/types'
-import { normalizeStoredViewConfig, pruneViewConfig } from '@/lib/table/views/service'
+
+const { mockSignalTableViewsChanged } = vi.hoisted(() => ({
+  mockSignalTableViewsChanged: vi.fn(),
+}))
+vi.mock('@/lib/table/events', () => ({
+  signalTableViewsChanged: mockSignalTableViewsChanged,
+}))
+
+import {
+  createTableView,
+  deleteTableView,
+  normalizeStoredViewConfig,
+  pruneViewConfig,
+  updateTableView,
+} from '@/lib/table/views/service'
 
 const columns: ColumnDefinition[] = [
   { id: 'col_a', name: 'Name', type: 'text' },
@@ -82,5 +98,89 @@ describe('normalizeStoredViewConfig', () => {
   it('drops an unconvertible legacy filter rather than surfacing it broken', () => {
     const out = normalizeStoredViewConfig({ filter: { $bogus: [{ nested: true }] } })
     expect(out.filter).toBeNull()
+  })
+})
+
+describe('table-view mutations signal collaborators', () => {
+  const columns: ColumnDefinition[] = []
+  const viewRow = {
+    id: 'view-1',
+    tableId: 'table-1',
+    workspaceId: 'ws-1',
+    name: 'My View',
+    config: {},
+    isDefault: false,
+    createdBy: 'user-1',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDbChainMock()
+  })
+
+  it('createTableView signals the table after inserting', async () => {
+    dbChainMockFns.returning.mockResolvedValueOnce([viewRow])
+
+    await createTableView({
+      tableId: 'table-1',
+      workspaceId: 'ws-1',
+      name: 'My View',
+      config: {},
+      userId: 'user-1',
+      columns,
+    })
+
+    expect(mockSignalTableViewsChanged).toHaveBeenCalledTimes(1)
+    expect(mockSignalTableViewsChanged).toHaveBeenCalledWith('table-1')
+  })
+
+  it('updateTableView signals when the target view exists', async () => {
+    queueTableRows(tableViews, [{ id: 'view-1' }]) // the in-transaction existence pre-check
+    dbChainMockFns.returning.mockResolvedValueOnce([viewRow]) // the update returning
+
+    const result = await updateTableView({
+      viewId: 'view-1',
+      tableId: 'table-1',
+      name: 'Renamed',
+      columns,
+    })
+
+    expect(result).not.toBeNull()
+    expect(mockSignalTableViewsChanged).toHaveBeenCalledTimes(1)
+    expect(mockSignalTableViewsChanged).toHaveBeenCalledWith('table-1')
+  })
+
+  it('updateTableView does NOT signal a no-op update on a missing view', async () => {
+    // No queued existence row → the pre-check finds nothing → returns null before any write.
+    const result = await updateTableView({
+      viewId: 'missing',
+      tableId: 'table-1',
+      name: 'Renamed',
+      columns,
+    })
+
+    expect(result).toBeNull()
+    expect(mockSignalTableViewsChanged).not.toHaveBeenCalled()
+  })
+
+  it('deleteTableView signals when a row was actually deleted', async () => {
+    dbChainMockFns.returning.mockResolvedValueOnce([{ id: 'view-1' }])
+
+    const deleted = await deleteTableView('view-1', 'table-1')
+
+    expect(deleted).toBe(true)
+    expect(mockSignalTableViewsChanged).toHaveBeenCalledTimes(1)
+    expect(mockSignalTableViewsChanged).toHaveBeenCalledWith('table-1')
+  })
+
+  it('deleteTableView does NOT signal when nothing was deleted', async () => {
+    dbChainMockFns.returning.mockResolvedValueOnce([])
+
+    const deleted = await deleteTableView('missing', 'table-1')
+
+    expect(deleted).toBe(false)
+    expect(mockSignalTableViewsChanged).not.toHaveBeenCalled()
   })
 })

--- a/packages/testing/src/mocks/schema.mock.ts
+++ b/packages/testing/src/mocks/schema.mock.ts
@@ -1136,6 +1136,17 @@ export const schemaMock = {
     updatedAt: 'updatedAt',
     completedAt: 'completedAt',
   },
+  tableViews: {
+    id: 'id',
+    tableId: 'tableId',
+    workspaceId: 'workspaceId',
+    name: 'name',
+    config: 'config',
+    isDefault: 'isDefault',
+    createdBy: 'createdBy',
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt',
+  },
   tableRowExecutions: {
     tableId: 'tableId',
     rowId: 'rowId',


### PR DESCRIPTION
## Summary
- Follow-up test coverage for the views-realtime wiring merged in #6100 (was missing dedicated tests).
- `events.test.ts`: `signalTableViewsChanged` appends a single `views` event carrying the tableId, verified through the real in-memory event buffer.
- `views/service.test.ts`: `createTableView`/`updateTableView`/`deleteTableView` emit the signal on **real success**, and **do not** on a no-op — a PATCH/DELETE targeting a missing view changes nothing, so it must not signal collaborators. Mirrors `delete-runner.test.ts`'s signal-path coverage; drives the DB via the shared `dbChainMock`.
- Adds `tableViews` to the comprehensive `@sim/db/schema` test mock so the service tests can queue the in-transaction existence-check row (the mock is meant to be comprehensive; it was simply missing this table).

## Type of Change
- [x] Test coverage

## Testing
tsc clean, lint clean, 618 table tests pass (36 files) including the 6 new cases. The client event-stream handler is intentionally not unit-tested — consistent with all 8 sibling event kinds (cell/dispatch/job/schema/metadata/definition/edit/usageLimitReached), which have no handler tests; it's a one-line type-checked invalidation.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)