### PR TITLE
fix(files): stop the embedded chat view being collaborative (streaming regressions)

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
@@ -720,7 +720,6 @@ function EmbeddedFile({
         streamIsIncremental={streamIsIncremental}
         disableStreamingAutoScroll={disableStreamingAutoScroll}
         previewContextKey={previewContextKey}
-        collaborative
       />
     </div>
   )


### PR DESCRIPTION
## Summary
Making the embedded `/chat` resource `FileViewer` collaborative (#6095) violated the editor's core invariant that **collaboration and agent-streaming are disjoint surfaces** (`rich-markdown-editor.tsx:791` — *'collaboration is enabled only on the Files page, which never streams'*). The embedded view **is** a streaming surface, which caused three regressions:

1. **Copilot streaming showed only a chunk, didn't stream in.** `collaborationEnabled` latches true at mount for a settled file → the streaming reconcile loop early-returns (`:797`) → `streamingContent` never applies. (Refresh mid-stream works because `streamingAtMountRef` is then true → collab off.)
2. **Editor stuck read-only after a stream.** `isEditable` gates on `collabReady` (synced+seeded); the seed races the copilot write, so readiness can time out → read-only fallback.
3. **Files loaded much slower.** Collab files render empty and block on a socket→seed round-trip (`:296`) + a redundant second blob read, discarding the already-fetched markdown.

## Fix
Revert the embedded view to non-collaborative (remove the one `collaborative` prop). This restores the disjoint-surfaces invariant — the well-tested pre-#6095 behavior. The `/chat` panel is a copilot streaming/preview surface, not a multi-user collaborative one; the two-window live-caret case #6095 targeted never worked in a single tab anyway (Files and chat are separate routes). **The Files-page collaborative editor is unchanged.**

Fixes Issues 1 & 3 fully, and Issue 2 for the embedded view (renders fetched markdown instantly, no seed round-trip). Issue 2 on the Files page is tracked separately (inherent to the collab seed design; needs a measured fix).

## Type of Change
- [x] Bug fix (regression)

## Testing
tsc clean, lint clean, 499 editor/collab tests pass. Traced the non-collab path: streaming reconcile runs, `collabReady` starts true so editing works post-stream, `initialContent` parses fetched markdown immediately. Pending live re-test on dev.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)