### PR TITLE
fix(demo): exempt landing routes from COEP so the Cal.com booker loads on soft nav

### DIFF
--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -36,6 +36,38 @@ const minimalRegistryAlias: Record<string, string> = useMinimalRegistry
     }
   : {}
 
+/**
+ * Marketing routes (`app/(landing)/**`, plus the root) exempted from COEP.
+ *
+ * COEP is a *document* header and is inherited across client-side `<Link>`
+ * navigations, so `/demo`'s own exemption only applies on a direct load. Any
+ * landing page left isolated soft-navigates into `/demo` still credentialless,
+ * where the Cal.com booker iframe loads uncredentialed and hangs forever.
+ * Every route under `app/(landing)` must be listed here.
+ */
+const LANDING_ROUTES = [
+  'blog',
+  'careers',
+  'changelog',
+  'comparisons',
+  'contact',
+  'demo',
+  'enterprise',
+  'files',
+  'integrations',
+  'knowledge',
+  'library',
+  'logs',
+  'models',
+  'pricing',
+  'privacy',
+  'scheduled-tasks',
+  'solutions',
+  'tables',
+  'terms',
+  'workflows',
+] as const
+
 const nextConfig: NextConfig = {
   devIndicators: false,
   poweredByHeader: false,
@@ -255,17 +287,27 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        // Exclude Vercel internal resources and static assets from strict COEP, Google Drive Picker
+        // Exclude Vercel internal resources and static assets from strict COOP, Google Drive Picker
         // and the /demo Cal.com booking embed to prevent 'refused to connect' / slow-load issues
         source: '/((?!_next|_vercel|api|favicon.ico|w/.*|workspace/.*|api/tools/drive|demo).*)',
         headers: [
           {
-            key: 'Cross-Origin-Embedder-Policy',
-            value: 'credentialless',
-          },
-          {
             key: 'Cross-Origin-Opener-Policy',
             value: 'same-origin',
+          },
+        ],
+      },
+      {
+        // COEP stays on by default - a new route is cross-origin isolated unless
+        // it is named here. The exemptions are the app surfaces that embed
+        // credentialed third parties (Drive Picker, Vercel resources) and the
+        // marketing surface, which must opt out wholesale: see LANDING_ROUTES.
+        // The trailing `|$` exempts the root path.
+        source: `/((?!_next|_vercel|api|favicon.ico|w/.*|workspace/.*|api/tools/drive|${LANDING_ROUTES.join('|')}|$).*)`,
+        headers: [
+          {
+            key: 'Cross-Origin-Embedder-Policy',
+            value: 'credentialless',
           },
         ],
       },


### PR DESCRIPTION
## Summary
- `/demo`'s Cal.com booker hung on an infinite spinner when reached by clicking "Request a demo" from any landing page — it only worked on a direct load or refresh
- COEP is a *document* header and is inherited across client-side `<Link>` navigations, so `/demo`'s existing `unsafe-none` exemption (#5335) never applied on a soft nav; the booker iframe loaded `credentialless` and stalled on its storage-access handshake
- COEP stays on by default — a new route is still cross-origin isolated unless named in the new `LANDING_ROUTES` list, which exempts the marketing surface (`app/(landing)/**`) wholesale since every landing page can soft-nav into `/demo`
- Split COEP off the old combined rule so COOP is untouched: landing keeps `same-origin`, `/demo` keeps `same-origin-allow-popups`

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Reproduced on prod: from `/?home`, clicking "Request a demo" leaves `crossOriginIsolated: true` on `/demo` (navigation entry still `/?home`), and `<cal-inline>` never reaches `loading="done"` — iframe stuck at `height: 100%`.

Verified on the patched build: `/` and `/pricing` serve no COEP (browser default `unsafe-none`), `/demo` `unsafe-none`, `/login` still `credentialless`; COOP unchanged on all four. Same soft-nav path now gives `crossOriginIsolated: false` and the embed reaches `loading="done"` with the iframe resolving to 592px — calendar renders and slots are selectable.

Route patterns validated against Next's bundled `path-to-regexp`: all 23 landing paths exempt, all 15 isolated routes still strict, no path receiving two conflicting values for either header. `LANDING_ROUTES` verified at exact parity with the `app/(landing)` directory listing.

`bun run lint` clean; all 11 audit checks pass (`check:boundaries`, `check:api-validation:strict`, `check:utils`, `check:zustand-v5`, `check:react-query`, `check:client-boundary`, `check:bare-icons`, `check:icon-paths`, `check:realtime-prune`, `skills:check`, `agent-stream-docs:check`). No migrations touched.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)