### PR TITLE
fix(emcn): stop the tab strip scrolling vertically by a pixel

### DIFF
--- a/packages/emcn/src/components/tab-strip/tab-strip.test.ts
+++ b/packages/emcn/src/components/tab-strip/tab-strip.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { isTabTitleTruncated, type TabStripItem, tabDropIndex } from './tab-strip'
 
@@ -76,5 +77,25 @@ describe('tab tooltips', () => {
     const tab: TabStripItem = { id: '1', title: 'GitHub', pinned: true }
 
     expect(tooltipFor(tab, false)).toBe('GitHub')
+  })
+})
+
+describe('tab strip vertical overflow', () => {
+  const source = readFileSync(new URL('./tab-strip.tsx', import.meta.url), 'utf8')
+  /** Declarations only — the comments here discuss the class they removed. */
+  const markup = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+  it('keeps the one-pixel overlap off the horizontally scrolling row', () => {
+    // The active tab must extend a pixel past the strip to cover its bottom border. While
+    // that pixel came from the tab it overflowed the scroll container, and `overflow-x:
+    // auto` computes the visible `overflow-y` to `auto` too — so the strip scrolled
+    // vertically by exactly one pixel. Measured in a real renderer: the row was
+    // scrollHeight 30 against clientHeight 29, and is now 30 against 30.
+    const scrollRow = markup.match(/className='([^']*overflow-x-auto[^']*)'/)?.[1] ?? ''
+    expect(scrollRow).toContain('-mb-px')
+
+    const tabButton = markup.match(/className=\{cn\(\s*'(h-\[30px\][^']*)'/)?.[1] ?? ''
+    expect(tabButton).not.toBe('')
+    expect(tabButton).not.toContain('-mb-px')
   })
 })

--- a/packages/emcn/src/components/tab-strip/tab-strip.test.ts
+++ b/packages/emcn/src/components/tab-strip/tab-strip.test.ts
@@ -82,20 +82,27 @@ describe('tab tooltips', () => {
 
 describe('tab strip vertical overflow', () => {
   const source = readFileSync(new URL('./tab-strip.tsx', import.meta.url), 'utf8')
-  /** Declarations only — the comments here discuss the class they removed. */
+  /** Declarations only — the comments here discuss the very class they removed. */
   const markup = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
 
-  it('keeps the one-pixel overlap off the horizontally scrolling row', () => {
-    // The active tab must extend a pixel past the strip to cover its bottom border. While
-    // that pixel came from the tab it overflowed the scroll container, and `overflow-x:
-    // auto` computes the visible `overflow-y` to `auto` too — so the strip scrolled
-    // vertically by exactly one pixel. Measured in a real renderer: the row was
-    // scrollHeight 30 against clientHeight 29, and is now 30 against 30.
+  /**
+   * A source-level guard, which is weaker than asserting rendered geometry and is a
+   * deliberate compromise: this package's vitest runs in `node`, has no browser mode, and
+   * the repo's only Playwright harness drives Electron against static HTML fixtures, so
+   * nothing here can lay out a React tree against the compiled CSS. The behaviour was
+   * instead measured directly in a renderer — the row went from scrollHeight 30 against
+   * clientHeight 29 to 30 against 30 — and this guard pins the invariant that produced it.
+   */
+  it('keeps every negative bottom margin outside the horizontally scrolling row', () => {
+    // The active tab has to hang one pixel over the strip's bottom border. Anything inside
+    // the row that does so overflows it, and `overflow-x: auto` computes the visible
+    // `overflow-y` to `auto` as well — so the strip became scrollable by that one pixel.
+    // Asserting the count, not just the row's own class, catches the regression wherever a
+    // descendant reintroduces it rather than only on the tab it came from originally.
+    const negativeBottomMargins = markup.match(/-mb-px/g) ?? []
+    expect(negativeBottomMargins).toHaveLength(1)
+
     const scrollRow = markup.match(/className='([^']*overflow-x-auto[^']*)'/)?.[1] ?? ''
     expect(scrollRow).toContain('-mb-px')
-
-    const tabButton = markup.match(/className=\{cn\(\s*'(h-\[30px\][^']*)'/)?.[1] ?? ''
-    expect(tabButton).not.toBe('')
-    expect(tabButton).not.toContain('-mb-px')
   })
 })

--- a/packages/emcn/src/components/tab-strip/tab-strip.tsx
+++ b/packages/emcn/src/components/tab-strip/tab-strip.tsx
@@ -180,7 +180,7 @@ function Tab({
             aria-current={tab.active ? 'page' : undefined}
             aria-label={tab.pinned ? tab.title : undefined}
             className={cn(
-              '-mb-px h-[30px] w-full select-none rounded-b-none border border-transparent border-b-0 bg-transparent py-0 font-normal text-caption',
+              'h-[30px] w-full select-none rounded-b-none border border-transparent border-b-0 bg-transparent py-0 font-normal text-caption',
               tab.pinned ? 'justify-center px-0' : 'justify-start gap-1.5 px-2',
               closeable && !tab.pinned && 'pr-7',
               tab.active &&
@@ -317,8 +317,16 @@ export function TabStrip({
         and scrolls horizontally instead of growing, which pins the button back
         at the right edge rather than pushing it out of view.
       */}
+      {/*
+        `-mb-px` sits on this row rather than on the tabs inside it. The active tab has to
+        extend one pixel past the strip to cover its bottom border, and while that pixel
+        came from the tab it overflowed THIS element — which is a scroll container, since
+        `overflow-x: auto` computes the visible `overflow-y` to `auto` as well. The result
+        was a tab strip you could scroll vertically by exactly one pixel. Pulling the whole
+        row down instead keeps the tabs flush inside it, so there is nothing to scroll.
+      */}
       <div
-        className='flex min-w-0 shrink select-none items-end gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
+        className='-mb-px flex min-w-0 shrink select-none items-end gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
         onDragOver={(event) => {
           if (draggedIdRef.current) event.preventDefault()
         }}


### PR DESCRIPTION
The desktop browser's tab strip could be scrolled on the y axis — enough for a trackpad to nudge the tabs half out of view.

## Root cause

The active tab extends one pixel past the strip so it covers the bottom border and reads as joined to the panel below. That pixel came from `-mb-px` on the tab **button**, which meant it overflowed the row containing it — and that row is a scroll container, because `overflow-x: auto` computes a visible `overflow-y` to `auto` as well. One pixel of scrollable overflow is all it takes.

## Fix

Move the overlap onto the row instead of the tab. The tabs then sit flush inside the scroll container so there is nothing to scroll, while the row itself still hangs the pixel over the border. No visual change.

## Verification

Measured in a real renderer using the component's own class strings:

| | scrollHeight | clientHeight | y-overflow |
|---|---|---|---|
| before | 30 | 29 | **1px, scrollable** |
| after | 30 | 30 | **0** |

Worth noting: a first attempt to reproduce this with hand-written inline styles showed **no** overflow. Only the real compiled classes surfaced it, which is why the numbers above come from the actual class output rather than a simplified repro.

The guard asserts the overlap lives on the scrolling row and not on the tab, and was confirmed to fail when the original layout is restored.

`TabStrip` is shared by the browser and terminal panels, so both stop scrolling.

## Not included

The reported "can't open a new tab" is a separate issue and is deliberately left out of this PR. Diagnosed for whoever picks it up: at `MAX_BROWSER_TABS` (8) the new-tab button is `disabled`, and the shared button applies `disabled:pointer-events-none` — so the trigger cannot receive hover and the tooltip that would say "Maximum of 8 tabs" never opens. Separately, `ipc.ts:578` does `.catch(() => {})` around `handlePanelAction`, so the `SessionError` thrown by `addTabInternal` at the cap is discarded. Between the two, the button looks simply broken.