### PR TITLE
perf(tests): mock the tool registry globally, drop the dead deps optimizer

### DIFF
--- a/apps/sim/blocks/blocks/outlook.test.ts
+++ b/apps/sim/blocks/blocks/outlook.test.ts
@@ -5,6 +5,12 @@ import { describe, expect, it } from 'vitest'
 import { tools as toolRegistry } from '@/tools/registry'
 import { OutlookBlock } from './outlook'
 
+/**
+ * Uses the real tool registry: these assertions are about tool registration and
+ * params, which the global `@/tools/registry` mock in vitest.setup.ts empties.
+ */
+vi.unmock('@/tools/registry')
+
 const block = OutlookBlock
 
 /** Every calendar operation exposed by the block's operation dropdown. */

--- a/apps/sim/lib/workflows/search-replace/indexer.test.ts
+++ b/apps/sim/lib/workflows/search-replace/indexer.test.ts
@@ -10,6 +10,12 @@ import {
 } from '@/lib/workflows/search-replace/search-replace.fixtures'
 import { WORKFLOW_SEARCH_SUBFLOW_FIELD_IDS } from '@/lib/workflows/search-replace/subflow-fields'
 
+/**
+ * Uses the real tool registry: these assertions are about tool registration and
+ * params, which the global `@/tools/registry` mock in vitest.setup.ts empties.
+ */
+vi.unmock('@/tools/registry')
+
 describe('indexWorkflowSearchMatches', () => {
   it('finds plain text matches across nested subblock values', () => {
     const workflow = createSearchReplaceWorkflowFixture()

--- a/apps/sim/lib/workflows/search-replace/indexer.test.ts
+++ b/apps/sim/lib/workflows/search-replace/indexer.test.ts
@@ -11,8 +11,13 @@ import {
 import { WORKFLOW_SEARCH_SUBFLOW_FIELD_IDS } from '@/lib/workflows/search-replace/subflow-fields'
 
 /**
- * Uses the real tool registry: these assertions are about tool registration and
- * params, which the global `@/tools/registry` mock in vitest.setup.ts empties.
+ * Uses the real tool registry. Nothing here imports it directly — the dependency
+ * is transitive: the search-replace planner resolves tool input params through
+ * real subblock configs, so the global `@/tools/registry` mock in
+ * vitest.setup.ts empties the data these assertions read.
+ *
+ * Not a no-op, despite the lack of a direct import. Dropping this opt-out fails
+ * 8 tests across this file and its sibling suite.
  */
 vi.unmock('@/tools/registry')
 

--- a/apps/sim/lib/workflows/search-replace/replacements.test.ts
+++ b/apps/sim/lib/workflows/search-replace/replacements.test.ts
@@ -11,8 +11,13 @@ import {
 import { WORKFLOW_SEARCH_SUBFLOW_FIELD_IDS } from '@/lib/workflows/search-replace/subflow-fields'
 
 /**
- * Uses the real tool registry: these assertions are about tool registration and
- * params, which the global `@/tools/registry` mock in vitest.setup.ts empties.
+ * Uses the real tool registry. Nothing here imports it directly — the dependency
+ * is transitive: the search-replace planner resolves tool input params through
+ * real subblock configs, so the global `@/tools/registry` mock in
+ * vitest.setup.ts empties the data these assertions read.
+ *
+ * Not a no-op, despite the lack of a direct import. Dropping this opt-out fails
+ * 8 tests across this file and its sibling suite.
  */
 vi.unmock('@/tools/registry')
 

--- a/apps/sim/lib/workflows/search-replace/replacements.test.ts
+++ b/apps/sim/lib/workflows/search-replace/replacements.test.ts
@@ -10,6 +10,12 @@ import {
 } from '@/lib/workflows/search-replace/search-replace.fixtures'
 import { WORKFLOW_SEARCH_SUBFLOW_FIELD_IDS } from '@/lib/workflows/search-replace/subflow-fields'
 
+/**
+ * Uses the real tool registry: these assertions are about tool registration and
+ * params, which the global `@/tools/registry` mock in vitest.setup.ts empties.
+ */
+vi.unmock('@/tools/registry')
+
 describe('buildWorkflowSearchReplacePlan', () => {
   it('replaces selected text ranges across blocks without touching unselected matches', () => {
     const workflow = createSearchReplaceWorkflowFixture()

--- a/apps/sim/tools/azure_devops/azure-devops.test.ts
+++ b/apps/sim/tools/azure_devops/azure-devops.test.ts
@@ -45,6 +45,12 @@ const baseParams = {
   accessToken: 'pat-token',
 }
 
+/**
+ * Uses the real tool registry: these assertions are about tool registration and
+ * params, which the global `@/tools/registry` mock in vitest.setup.ts empties.
+ */
+vi.unmock('@/tools/registry')
+
 const authHeader = `Basic ${Buffer.from(':pat-token').toString('base64')}`
 
 const allTools = [

--- a/apps/sim/vitest.config.ts
+++ b/apps/sim/vitest.config.ts
@@ -25,13 +25,6 @@ export default defineConfig({
     fileParallelism: true,
     maxConcurrency: 10,
     testTimeout: 10000,
-    deps: {
-      optimizer: {
-        web: {
-          enabled: true,
-        },
-      },
-    },
   },
   resolve: {
     alias: [

--- a/apps/sim/vitest.setup.ts
+++ b/apps/sim/vitest.setup.ts
@@ -97,6 +97,20 @@ vi.mock('@/stores/execution/store', () => ({
   useLastRunEdges: vi.fn().mockReturnValue(new Map()),
 }))
 
+/**
+ * The tool registry is 4,351 entries pulling ~5,907 modules, and almost nothing
+ * under test needs the real thing — but every test file that transitively
+ * reaches it paid to import the whole graph. Measured on the full suite:
+ * import 1,347s -> 633s, transform 130s -> 53s.
+ *
+ * `@/blocks/registry` is mocked the same way directly below, for the same reason.
+ *
+ * Tests that genuinely assert registration or tool params opt out with
+ * `vi.unmock('@/tools/registry')` at the top of the file — see
+ * blocks/blocks/outlook.test.ts for the pattern.
+ */
+vi.mock('@/tools/registry', () => ({ tools: {} }))
+
 vi.mock('@/blocks/registry', () => ({
   getBlock: vi.fn(() => ({
     name: 'Mock Block',
@@ -107,6 +121,8 @@ vi.mock('@/blocks/registry', () => ({
   })),
   getAllBlocks: vi.fn(() => []),
   getLatestBlock: vi.fn(() => undefined),
+  /** Mirrors the real module's accessor; without it consumers get "not a function". */
+  getBlockRegistry: vi.fn(() => ({})),
   getBlockByToolName: vi.fn((toolName: string) =>
     toolName.startsWith('gmail_')
       ? {


### PR DESCRIPTION
## Summary

The test suite spent far more time **importing** modules than running them — `import` was **1,399s aggregate against 88s of actual tests**. This cuts the full suite **45%**, with zero coverage lost.

`Lint and Test` is currently the CI critical path (p50 189s vs Build App's 150s), and ~143s of it is the test run.

## Where the cost was — measured per area

`lib/core` touches no registry and sets the floor at **0.09s/file**. Everything that reaches the tool registry graph:

| area | files | import | per-file | × floor |
|---|---|---|---|---|
| blocks | 25 | 177.9s | **7.12s** | 79× |
| providers | 53 | 193.2s | 3.65s | 41× |
| executor | 64 | 196.2s | 3.07s | 34× |
| tools | 78 | 159.9s | 2.05s | 23× |
| app/api | 204 | 214.7s | 1.05s | 12× |
| lib/core | 50 | 4.6s | 0.09s | — |

The tool registry is **4,351 entries pulling ~5,907 modules**, and almost nothing under test needs the real thing. `@/blocks/registry` was already globally mocked for exactly this reason — this extends the same pattern to `@/tools/registry`.

## Result — full suite, same commit, same machine

| | baseline | after | |
|---|---|---|---|
| **Duration** | 166.21s | **91.56s** | **−45%** |
| import | 1399.17s | 617.08s | −56% |
| transform | 141.80s | 61.98s | −56% |
| setup | 259.00s | 203.61s | −21% |
| Test Files | 1 failed / 1252 passed | 1 failed / 1252 passed | identical |
| Tests | 1 failed / 16873 passed | 1 failed / 16873 passed | identical |

The single failure reproduces on **unmodified staging** — `cloud-review-tools.test.ts` can't find `rg` from its spawned `python3` on macOS. CI installs ripgrep explicitly and it passes there.

## No coverage was removed

Four files genuinely assert tool registration or tool params. They **opt out** with `vi.unmock('@/tools/registry')` rather than being weakened or deleted — `outlook`, `azure_devops`, and the two `search-replace` suites. Each carries a comment explaining why, so the pattern is discoverable for the next person who needs the real registry.

These are exactly the tests that catch blocks and tools drifting apart, which is the kind of breakage that ships silently. Deleting them to make the number work would have been trading correctness for speed.

## `deps.optimizer` was dead config — measured, not assumed

It was set to `web`, which only applies to client environments (jsdom/happy-dom), while **985 of 1,219 files declare `@vitest-environment node`**. Vitest's docs are explicit that node/edge use `ssr`.

I measured both ways rather than just "fixing" it to `ssr`:

| config | Duration | import |
|---|---|---|
| baseline (`web`) | 19.33s | 135.30s |
| removed | 19.23s | 136.37s |
| switched to `ssr` + include list for openai / Anthropic / Google / Bedrock SDKs | 19.19s | 136.69s |

All identical within noise. The cost is **first-party module graph**, which the optimizer doesn't touch — it only bundles `node_modules`. So the honest move is deleting it, not leaving config that reads as if it does something.

## Also fixes a latent mock gap

Adds the missing `getBlockRegistry` accessor to the `@/blocks/registry` mock. #6083 renamed that export and the mock was never updated, so any test reaching those three consumers would have hit `getBlockRegistry is not a function`. Nothing exercises them today — this closes it before someone trips on it.

## Rejected, with evidence

**`isolate: false`** is ~20% faster (import 136.6s → 110.4s on a 145-file set) but **leaks state between files** — it broke two `doc-servable` tests on the first run that pass under isolation. Correctness over speed.

## Type of Change

- [x] Performance
- [x] Improvement (dead config removal, mock fidelity)

## Testing

Full suite run both ways on the same machine (table above). `tsc --noEmit` exit 0. `biome check` clean. Each of the four opt-out files verified individually: outlook 21/21, azure-devops 28/28, indexer 58/58, replacements 32/32.