### PR TITLE
fix(uploads): set Content-Type once on presigned PUTs; document x-goog-meta-folderid for GCS CORS

### DIFF
--- a/apps/docs/content/docs/en/platform/self-hosting/object-storage.mdx
+++ b/apps/docs/content/docs/en/platform/self-hosting/object-storage.mdx
@@ -245,6 +245,7 @@ cat > /tmp/cors.json <<'EOF'
       "x-goog-meta-purpose",
       "x-goog-meta-userid",
       "x-goog-meta-workspaceid",
+      "x-goog-meta-folderid",
       "x-goog-meta-workflowid",
       "x-goog-meta-executionid"
     ],

--- a/apps/sim/lib/uploads/client/direct-upload.test.ts
+++ b/apps/sim/lib/uploads/client/direct-upload.test.ts
@@ -82,6 +82,47 @@ describe('runUploadStrategy', () => {
     expect(MockXHR.instances[0].open).toHaveBeenCalledWith('PUT', 'https://s3/presigned')
   })
 
+  it('sets Content-Type exactly once when uploadHeaders already carry it (GCS signed uploads)', async () => {
+    const file = makeFile(1024)
+
+    await runUploadStrategy({
+      file,
+      workspaceId: 'ws-1',
+      context: 'workspace',
+      presignedOverride: presigned({
+        uploadHeaders: {
+          'Content-Type': 'application/octet-stream',
+          'x-goog-meta-workspaceid': 'ws-1',
+        },
+      }),
+    })
+
+    const calls = MockXHR.instances[0].setRequestHeader.mock.calls
+    const contentTypeCalls = calls.filter(
+      ([k]: [string, string]) => k.toLowerCase() === 'content-type'
+    )
+    expect(contentTypeCalls).toHaveLength(1)
+    expect(contentTypeCalls[0][1]).toBe('application/octet-stream')
+    expect(calls.some(([k]: [string, string]) => k === 'x-goog-meta-workspaceid')).toBe(true)
+  })
+
+  it('falls back to the file content type when uploadHeaders omit Content-Type', async () => {
+    const file = makeFile(1024)
+
+    await runUploadStrategy({
+      file,
+      workspaceId: 'ws-1',
+      context: 'workspace',
+      presignedOverride: presigned({ uploadHeaders: { 'x-ms-blob-type': 'BlockBlob' } }),
+    })
+
+    const calls = MockXHR.instances[0].setRequestHeader.mock.calls
+    const contentTypeCalls = calls.filter(
+      ([k]: [string, string]) => k.toLowerCase() === 'content-type'
+    )
+    expect(contentTypeCalls).toHaveLength(1)
+  })
+
   it('throws FALLBACK_REQUIRED when server signals no cloud storage', async () => {
     const file = makeFile(ONE_MB)
 

--- a/apps/sim/lib/uploads/client/direct-upload.ts
+++ b/apps/sim/lib/uploads/client/direct-upload.ts
@@ -292,7 +292,15 @@ const uploadViaPresignedPut = (opts: UploadViaPutOptions): Promise<void> => {
     })
 
     xhr.open('PUT', presignedUrl)
-    xhr.setRequestHeader('Content-Type', getFileContentType(file))
+    // XHR appends on repeated setRequestHeader calls, so when the server's
+    // signed headers already carry Content-Type (GCS), setting it here too
+    // produces a doubled value ("x, x") that breaks the URL signature.
+    const providesContentType =
+      uploadHeaders &&
+      Object.keys(uploadHeaders).some((key) => key.toLowerCase() === 'content-type')
+    if (!providesContentType) {
+      xhr.setRequestHeader('Content-Type', getFileContentType(file))
+    }
     if (uploadHeaders) {
       for (const [key, value] of Object.entries(uploadHeaders)) {
         xhr.setRequestHeader(key, value)

--- a/apps/sim/lib/uploads/client/direct-upload.ts
+++ b/apps/sim/lib/uploads/client/direct-upload.ts
@@ -292,9 +292,6 @@ const uploadViaPresignedPut = (opts: UploadViaPutOptions): Promise<void> => {
     })
 
     xhr.open('PUT', presignedUrl)
-    // XHR appends on repeated setRequestHeader calls, so when the server's
-    // signed headers already carry Content-Type (GCS), setting it here too
-    // produces a doubled value ("x, x") that breaks the URL signature.
     const providesContentType =
       uploadHeaders &&
       Object.keys(uploadHeaders).some((key) => key.toLowerCase() === 'content-type')


### PR DESCRIPTION
## Summary
- **Single-shot GCS uploads failed V4 signature verification (403).** `XMLHttpRequest.setRequestHeader` appends on repeated calls (values join with a comma), and GCS is the only storage provider whose signed `uploadHeaders` include `Content-Type` — so the browser sent `Content-Type: x, x` while the URL was signed for the single value. Per Google's canonical-request rules, headers canonicalize to a comma-separated value that must match what was signed exactly, so the doubled value 403s. The client now sets its default `Content-Type` only when the server's signed headers don't already carry one (case-insensitive check); S3/Azure behavior is unchanged, and multipart part PUTs were never affected (part URLs don't sign Content-Type).
- **GCS CORS docs were missing `x-goog-meta-folderid`.** Workspace uploads sign a `folderId` metadata header, and GCS matches preflight `Access-Control-Request-Headers` against the CORS `responseHeader` list exactly (no wildcards) — so the missing entry blocked browser uploads into folders. Added to the documented list; a sweep of every metadata key passed to presigned-upload generation confirms the list is now complete (originalname, uploadedat, purpose, userid, workspaceid, workflowid, executionid, folderid).

## Type of Change
- [x] Bug fix

## Testing
- Two regression tests on the presigned PUT path: signed `Content-Type` present → header set exactly once with the signed value; absent (S3/Azure shape) → client default set exactly once
- Both failure modes verified against Google's documentation (canonical-request header rules → 403 on mismatch; CORS `responseHeader` governs preflight allow-headers with exact matching)
- Full uploads suite passes (202 tests), typecheck clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
