### PR TITLE
improvement(seo): noindex landing OG image endpoints via X-Robots-Tag

### DIFF
--- a/apps/sim/app/(landing)/og-utils.tsx
+++ b/apps/sim/app/(landing)/og-utils.tsx
@@ -159,6 +159,13 @@ export async function createLandingOgImage({
     </div>,
     {
       ...size,
+      /**
+       * These endpoints are social-card assets, not destinations. `noindex`
+       * keeps them out of search results while leaving them fetchable, so
+       * unfurl bots (which ignore the header) still render previews — unlike a
+       * robots.txt `Disallow`, which would block the fetch itself.
+       */
+      headers: { 'X-Robots-Tag': 'noindex' },
       fonts: [
         ...(regularFontData
           ? [


### PR DESCRIPTION
## Summary
- Sets `X-Robots-Tag: noindex` on the shared landing OG image helper, covering all five `models`/`integrations` `opengraph-image` endpoints
- Keeps those social-card assets out of search results while leaving them fetchable, so Slack/LinkedIn/Facebook unfurls still render
- Replaces a proposed `robots.txt` `Disallow` for the same paths, which would have blocked the fetch itself and broken previews

## Context
An external SEO recommendation asked for six new `robots.txt` rules. Checked each against GSC and the codebase:

| Proposed rule | Verdict |
|---|---|
| `Disallow: /api/og?*` | Dead route; already covered by `Disallow: /api/` |
| `Disallow: /favicon.ico?*` | No crawl or index problem to solve |
| `Disallow: /*?*tag=` | **Harmful.** `/blog?tag=*` already serves `noindex, follow` + canonical to `/blog`. A robots block stops Google seeing the noindex, freezing ~890 impressions/qtr of tag URLs in the index instead of dropping them |
| `Disallow: /*/tags*` | **Harmful.** `/blog/tags` and `/library/tags` are listed in `sitemap.ts` as intentional hub pages |
| `Disallow: /models/*/opengraph-image` | Real intent, wrong mechanism — shipped here as `X-Robots-Tag` instead |
| `Disallow: /integrations/*/opengraph-image` | Same |

`robots.ts` is unchanged.

## Type of Change
- [x] Improvement

## Testing
Typecheck clean. Verified live that `/blog?tag=n8n` already returns `noindex, follow` with a canonical to `/blog`, and that all five landing OG routes go through `createLandingOgImage`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)