### PR TITLE
feat(scripts): add a client-bundle measurement so regressions are visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "check:bare-icons": "bun run scripts/check-bare-icons.ts",
     "check:icon-paths": "bun run scripts/check-icon-paths.ts",
     "check:migrations": "bun run scripts/check-migrations-safety.ts",
+    "measure:bundle": "bun run scripts/measure-client-bundle.ts",
     "check:desktop-bridge": "bun run scripts/check-desktop-bridge-contract.ts --check",
     "check:desktop-ipc": "bun run scripts/check-desktop-ipc-contract.ts",
     "desktop-bridge-contract:update": "bun run scripts/check-desktop-bridge-contract.ts --update",

--- a/scripts/measure-client-bundle.ts
+++ b/scripts/measure-client-bundle.ts
@@ -1,0 +1,123 @@
+/**
+ * Reports the size of the client JavaScript a production build ships, so a
+ * bundle regression is something CI can see rather than something a user
+ * reports as a slow page.
+ *
+ * Nothing else measures this today. Turbopack's route table prints only
+ * `Revalidate`/`Expire` — no `First Load JS` — and it emits flat,
+ * content-hashed chunk names with no `app-build-manifest.json`, so there is no
+ * route -> chunk mapping to attribute bytes with. `@next/bundle-analyzer` is a
+ * webpack plugin and is not installed. This measures what is reliably
+ * available: the total client payload, plus the largest chunks so a jump can be
+ * traced to a culprit.
+ *
+ * Deliberately not per-route. A per-route number would need either a
+ * route->chunk manifest Turbopack does not emit, or a browser loading each
+ * route; inventing an attribution from flat chunk names would produce a
+ * confident number that is wrong.
+ *
+ * Usage:
+ *   bun run scripts/measure-client-bundle.ts                       # human-readable
+ *   bun run scripts/measure-client-bundle.ts --json                # machine-readable
+ *   bun run scripts/measure-client-bundle.ts --baseline b.json     # compare, fail on regression
+ *   bun run scripts/measure-client-bundle.ts --json > baseline.json
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const rootDir = path.resolve(path.dirname(__filename), '..')
+const chunkDir = path.join(rootDir, 'apps/sim/.next/static/chunks')
+
+/** Fraction a total may grow past the baseline before `--baseline` fails. */
+const REGRESSION_TOLERANCE = 0.02
+
+interface Chunk {
+  file: string
+  bytes: number
+}
+
+interface Report {
+  totalBytes: number
+  chunkCount: number
+  largest: Chunk[]
+}
+
+function walk(dir: string, acc: Chunk[] = []): Chunk[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      walk(full, acc)
+      continue
+    }
+    // `.map` files are excluded: they are never requested during page load, so
+    // counting them would let a source-map change masquerade as a bundle
+    // regression.
+    if (entry.isFile() && entry.name.endsWith('.js')) {
+      acc.push({ file: path.relative(chunkDir, full), bytes: fs.statSync(full).size })
+    }
+  }
+  return acc
+}
+
+function measure(): Report {
+  if (!fs.existsSync(chunkDir)) {
+    throw new Error(
+      `No build found at ${path.relative(rootDir, chunkDir)}. Run \`bun run build\` in apps/sim first.`
+    )
+  }
+  const chunks = walk(chunkDir)
+  if (chunks.length === 0) {
+    throw new Error(`No .js chunks under ${path.relative(rootDir, chunkDir)} — build looks empty.`)
+  }
+  return {
+    totalBytes: chunks.reduce((sum, c) => sum + c.bytes, 0),
+    chunkCount: chunks.length,
+    largest: [...chunks].sort((a, b) => b.bytes - a.bytes).slice(0, 15),
+  }
+}
+
+const mb = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(2)} MB`
+
+function main(): void {
+  const args = process.argv.slice(2)
+  const report = measure()
+
+  if (args.includes('--json')) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+    return
+  }
+
+  console.log(`Client JS: ${mb(report.totalBytes)} across ${report.chunkCount} chunks\n`)
+  console.log('Largest chunks:')
+  for (const c of report.largest) {
+    console.log(`  ${mb(c.bytes).padStart(9)}  ${c.file}`)
+  }
+
+  const baselineIdx = args.indexOf('--baseline')
+  if (baselineIdx === -1) return
+
+  const baselinePath = args[baselineIdx + 1]
+  if (!baselinePath) {
+    console.error('\n--baseline requires a path to a JSON report')
+    process.exit(1)
+  }
+  const baseline: Report = JSON.parse(fs.readFileSync(baselinePath, 'utf8'))
+  const delta = report.totalBytes - baseline.totalBytes
+  const pct = (delta / baseline.totalBytes) * 100
+  const sign = delta >= 0 ? '+' : ''
+  console.log(
+    `\nvs baseline: ${mb(baseline.totalBytes)} -> ${mb(report.totalBytes)} (${sign}${pct.toFixed(1)}%)`
+  )
+
+  if (delta > baseline.totalBytes * REGRESSION_TOLERANCE) {
+    console.error(
+      `\nClient JS grew more than ${(REGRESSION_TOLERANCE * 100).toFixed(0)}% over the baseline.`
+    )
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary

We ship JavaScript to users and **nothing measures it**. This adds `bun run measure:bundle`, and its first use already produced a decisive result: **the tool and block registries are ~52% of all client JS.**

## Why this didn't exist

Every instrument you'd reach for is missing:

| instrument | status |
|---|---|
| `First Load JS` in build output | **0 matches** — Turbopack's route table prints only Revalidate/Expire |
| `app-build-manifest.json` (route→chunk map) | not emitted |
| route-shaped `static/chunks/app/**` | absent — chunks are flat and content-hashed (`1ep92zb9a-584.js`) |
| `@next/bundle-analyzer` | not installed, and it's a webpack plugin |

So a bundle regression was invisible until someone noticed a slow page.

## What it measures

Total client JS plus the largest chunks. `--json` writes a baseline; `--baseline <file>` fails on a >2% regression, so it can become a CI gate once a baseline is agreed.

**Deliberately not per-route.** That needs either a manifest Turbopack doesn't emit, or a browser loading each route. Inventing an attribution from flat chunk names would produce a confident number that is wrong — worse than no number.

`.map` files are excluded, so a source-map change can't masquerade as a bundle regression.

## First result: the registry premise, measured

Two production builds — one normal, one with the existing `SIM_DEV_MINIMAL_REGISTRY` alias forced on:

| | client JS | chunks |
|---|---|---|
| baseline | **110.08 MB** | 553 |
| registries aliased away | **52.96 MB** | 553 |
| | **−57.12 MB (−51.9%)** | |

The four **15.52 MB** chunks in the baseline vanish completely — that's the registry graph duplicated across four entry points.

### How to read that number honestly

- It's an **upper bound for both registries together** (`@/tools/registry` *and* `@/blocks/registry-maps`), not tools alone, and not a promise. A metadata split would still ship `params`/`outputs` for referenced tools.
- It's **total client JS, not per-route First Load**. Users download the chunks their route needs, not all 110 MB. "52% of client JS" is **not** "52% faster page load."
- What it does establish: the registry is roughly half of everything we ship, **measured** rather than inferred from an import-graph tracer. The prior 11.8 MB/route figure came from a static tracer; this is a real build.

## Why this matters beyond one project

The registry split was scoped on an unverified premise. This makes the premise checkable, gives the work a before/after, and leaves behind a regression guard that outlives it.

## Type of Change

- [x] Improvement (tooling / observability)

## Testing

Run against two real production builds (numbers above). `biome check` clean. No dependencies added. `next.config.ts` was temporarily modified for the second build and restored — the diff is only the new script and its `package.json` entry.