### PR TITLE
fix(security): validate cloud region/project inputs and bind vertex credentials to the executing workspace

### DIFF
--- a/apps/sim/executor/handlers/agent/agent-handler.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.ts
@@ -1173,11 +1173,12 @@ export class AgentBlockHandler implements BlockHandler {
       let finalApiKey: string | undefined = providerRequest.apiKey
 
       if (providerId === 'vertex' && providerRequest.vertexCredential) {
-        finalApiKey = await resolveVertexCredential(
-          providerRequest.vertexCredential,
-          ctx.userId,
-          'vertex-agent'
-        )
+        finalApiKey = await resolveVertexCredential({
+          credentialId: providerRequest.vertexCredential,
+          actingUserId: ctx.userId,
+          workspaceId: ctx.workspaceId,
+          callerLabel: 'vertex-agent',
+        })
       }
 
       const { blockData, blockNameMapping } = collectBlockData(ctx)

--- a/apps/sim/executor/handlers/evaluator/evaluator-handler.ts
+++ b/apps/sim/executor/handlers/evaluator/evaluator-handler.ts
@@ -135,11 +135,12 @@ export class EvaluatorBlockHandler implements BlockHandler {
 
     let finalApiKey: string | undefined = evaluatorConfig.apiKey
     if (providerId === 'vertex' && evaluatorConfig.vertexCredential) {
-      finalApiKey = await resolveVertexCredential(
-        evaluatorConfig.vertexCredential,
-        ctx.userId,
-        'vertex-evaluator'
-      )
+      finalApiKey = await resolveVertexCredential({
+        credentialId: evaluatorConfig.vertexCredential,
+        actingUserId: ctx.userId,
+        workspaceId: ctx.workspaceId,
+        callerLabel: 'vertex-evaluator',
+      })
     }
 
     try {

--- a/apps/sim/executor/handlers/router/router-handler.ts
+++ b/apps/sim/executor/handlers/router/router-handler.ts
@@ -99,11 +99,12 @@ export class RouterBlockHandler implements BlockHandler {
 
       let finalApiKey: string | undefined = routerConfig.apiKey
       if (providerId === 'vertex' && routerConfig.vertexCredential) {
-        finalApiKey = await resolveVertexCredential(
-          routerConfig.vertexCredential,
-          ctx.userId,
-          'vertex-router'
-        )
+        finalApiKey = await resolveVertexCredential({
+          credentialId: routerConfig.vertexCredential,
+          actingUserId: ctx.userId,
+          workspaceId: ctx.workspaceId,
+          callerLabel: 'vertex-router',
+        })
       }
 
       const providerRequest: Record<string, any> = {
@@ -239,11 +240,12 @@ export class RouterBlockHandler implements BlockHandler {
 
       let finalApiKey: string | undefined = routerConfig.apiKey
       if (providerId === 'vertex' && routerConfig.vertexCredential) {
-        finalApiKey = await resolveVertexCredential(
-          routerConfig.vertexCredential,
-          ctx.userId,
-          'vertex-router'
-        )
+        finalApiKey = await resolveVertexCredential({
+          credentialId: routerConfig.vertexCredential,
+          actingUserId: ctx.userId,
+          workspaceId: ctx.workspaceId,
+          callerLabel: 'vertex-router',
+        })
       }
 
       const providerRequest: Record<string, any> = {

--- a/apps/sim/executor/utils/vertex-credential.test.ts
+++ b/apps/sim/executor/utils/vertex-credential.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetCredentialActorContext, mockGetServiceAccountToken, mockRefreshTokenIfNeeded } =
+  vi.hoisted(() => ({
+    mockGetCredentialActorContext: vi.fn(),
+    mockGetServiceAccountToken: vi.fn(),
+    mockRefreshTokenIfNeeded: vi.fn(),
+  }))
+
+vi.mock('@/lib/credentials/access', () => ({
+  getCredentialActorContext: mockGetCredentialActorContext,
+}))
+vi.mock('@/app/api/auth/oauth/utils', () => ({
+  getServiceAccountToken: mockGetServiceAccountToken,
+  refreshTokenIfNeeded: mockRefreshTokenIfNeeded,
+}))
+
+import { resolveVertexCredential } from '@/executor/utils/vertex-credential'
+
+function actorContext(workspaceId: string) {
+  return {
+    credential: {
+      id: 'cred-b',
+      workspaceId,
+      type: 'service_account',
+      accountId: null,
+    },
+    member: { id: 'member-1' },
+    hasWorkspaceAccess: true,
+    canWriteWorkspace: true,
+    isAdmin: false,
+  }
+}
+
+describe('resolveVertexCredential workspace binding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServiceAccountToken.mockResolvedValue('gcp-access-token')
+  })
+
+  it('rejects a credential owned by a different workspace than the executing workflow', async () => {
+    mockGetCredentialActorContext.mockResolvedValue(actorContext('workspace-b'))
+
+    await expect(
+      resolveVertexCredential({
+        credentialId: 'cred-b',
+        actingUserId: 'user-1',
+        workspaceId: 'workspace-a',
+      })
+    ).rejects.toThrow('Credential is not accessible from this workflow workspace')
+
+    expect(mockGetServiceAccountToken).not.toHaveBeenCalled()
+  })
+
+  it('resolves a credential owned by the executing workspace', async () => {
+    mockGetCredentialActorContext.mockResolvedValue(actorContext('workspace-a'))
+
+    await expect(
+      resolveVertexCredential({
+        credentialId: 'cred-b',
+        actingUserId: 'user-1',
+        workspaceId: 'workspace-a',
+      })
+    ).resolves.toBe('gcp-access-token')
+  })
+
+  it('still enforces the user-to-credential check within the same workspace', async () => {
+    mockGetCredentialActorContext.mockResolvedValue({
+      ...actorContext('workspace-a'),
+      member: null,
+      isAdmin: false,
+    })
+
+    await expect(
+      resolveVertexCredential({
+        credentialId: 'cred-b',
+        actingUserId: 'user-1',
+        workspaceId: 'workspace-a',
+      })
+    ).rejects.toThrow('Not authorized to use this Vertex AI credential')
+  })
+
+  it('requires an authenticated acting user', async () => {
+    await expect(
+      resolveVertexCredential({
+        credentialId: 'cred-b',
+        actingUserId: undefined,
+        workspaceId: 'workspace-a',
+      })
+    ).rejects.toThrow('requires an authenticated user')
+  })
+})

--- a/apps/sim/executor/utils/vertex-credential.ts
+++ b/apps/sim/executor/utils/vertex-credential.ts
@@ -7,17 +7,27 @@ import { getServiceAccountToken, refreshTokenIfNeeded } from '@/app/api/auth/oau
 
 const logger = createLogger('VertexCredential')
 
+export interface ResolveVertexCredentialParams {
+  credentialId: string
+  actingUserId: string | undefined
+  /** Workspace of the executing workflow. The credential must belong to it. */
+  workspaceId: string | null | undefined
+  callerLabel?: string
+}
+
 /**
  * Resolves a Vertex AI OAuth credential to an access token.
- * Shared across agent, evaluator, and router handlers. Authorizes the executing
- * user against the credential first — workspace credentials are usable by their
- * members and by derived workspace admins, matching `authorizeCredentialUse`.
+ * Shared across agent, evaluator, and router handlers. Enforces the same two
+ * predicates as `authorizeCredentialUse`: the executing user must be a member
+ * (or derived workspace admin) of the credential, and the credential must belong
+ * to the workspace the workflow is executing in.
  */
-export async function resolveVertexCredential(
-  credentialId: string,
-  actingUserId: string | undefined,
-  callerLabel = 'vertex'
-): Promise<string> {
+export async function resolveVertexCredential({
+  credentialId,
+  actingUserId,
+  workspaceId,
+  callerLabel = 'vertex',
+}: ResolveVertexCredentialParams): Promise<string> {
   const requestId = `${callerLabel}-${Date.now()}`
 
   logger.info(`[${requestId}] Resolving Vertex AI credential: ${credentialId}`)
@@ -30,6 +40,13 @@ export async function resolveVertexCredential(
   const cred = access.credential
   if (!cred) {
     throw new Error(`Vertex AI credential not found: ${credentialId}`)
+  }
+  if (workspaceId && cred.workspaceId !== workspaceId) {
+    logger.warn(`[${requestId}] Vertex AI credential belongs to a different workspace`, {
+      credentialId,
+      executingWorkspaceId: workspaceId,
+    })
+    throw new Error('Credential is not accessible from this workflow workspace')
   }
   if (!access.hasWorkspaceAccess || (!access.member && !access.isAdmin)) {
     throw new Error('Not authorized to use this Vertex AI credential')

--- a/apps/sim/lib/core/security/input-validation.test.ts
+++ b/apps/sim/lib/core/security/input-validation.test.ts
@@ -9,6 +9,8 @@ import {
   validateExternalUrl,
   validateFileExtension,
   validateGoogleCalendarId,
+  validateGoogleCloudLocation,
+  validateGoogleCloudProject,
   validateHostname,
   validateImageUrl,
   validateInteger,
@@ -1558,6 +1560,91 @@ describe('validateAwsRegion', () => {
       const result = validateAwsRegion('', 'awsRegion')
       expect(result.error).toContain('awsRegion')
     })
+  })
+})
+
+describe('validateGoogleCloudLocation', () => {
+  describe('valid locations', () => {
+    it.concurrent.each([
+      'us-central1',
+      'us-east5',
+      'europe-west4',
+      'northamerica-northeast1',
+      'southamerica-east1',
+      'asia-northeast3',
+      'australia-southeast2',
+      'africa-south1',
+      'me-central2',
+      'global',
+    ])('should accept %s', (location) => {
+      const result = validateGoogleCloudLocation(location)
+      expect(result.isValid).toBe(true)
+      expect(result.sanitized).toBe(location)
+    })
+  })
+
+  describe('hostname injection', () => {
+    it.concurrent.each([
+      'attacker.example.com/x',
+      'us-central1/../attacker.tld',
+      'us-central1:8080',
+      'user@attacker.tld',
+      'us-central1?a=b',
+      'us-central1#frag',
+      'us central1',
+      'us-central1\n',
+      'US-CENTRAL1',
+      '../us-central1',
+    ])('should reject %j', (location) => {
+      const result = validateGoogleCloudLocation(location)
+      expect(result.isValid).toBe(false)
+    })
+  })
+
+  it.concurrent('should reject empty and missing values', () => {
+    expect(validateGoogleCloudLocation('').isValid).toBe(false)
+    expect(validateGoogleCloudLocation(null).isValid).toBe(false)
+    expect(validateGoogleCloudLocation(undefined).isValid).toBe(false)
+  })
+
+  it.concurrent('should name the parameter in the error', () => {
+    const result = validateGoogleCloudLocation('bad host', 'vertexLocation')
+    expect(result.error).toContain('vertexLocation')
+  })
+})
+
+describe('validateGoogleCloudProject', () => {
+  describe('valid projects', () => {
+    it.concurrent.each(['my-project', 'sim-prod-1', 'abcdef', '123456789012'])(
+      'should accept %s',
+      (project) => {
+        const result = validateGoogleCloudProject(project)
+        expect(result.isValid).toBe(true)
+        expect(result.sanitized).toBe(project)
+      }
+    )
+  })
+
+  describe('path injection and malformed ids', () => {
+    it.concurrent.each([
+      'my-project/../../other',
+      'my-project:alias',
+      'my project',
+      'My-Project',
+      '1project',
+      'my-project-',
+      'abc',
+      'a'.repeat(31),
+    ])('should reject %j', (project) => {
+      const result = validateGoogleCloudProject(project)
+      expect(result.isValid).toBe(false)
+    })
+  })
+
+  it.concurrent('should reject empty and missing values', () => {
+    expect(validateGoogleCloudProject('').isValid).toBe(false)
+    expect(validateGoogleCloudProject(null).isValid).toBe(false)
+    expect(validateGoogleCloudProject(undefined).isValid).toBe(false)
   })
 })
 

--- a/apps/sim/lib/core/security/input-validation.test.ts
+++ b/apps/sim/lib/core/security/input-validation.test.ts
@@ -1460,6 +1460,19 @@ describe('validateAwsRegion', () => {
     })
   })
 
+  describe('valid European Sovereign Cloud regions', () => {
+    it.concurrent('should accept eusc-de-east-1', () => {
+      const result = validateAwsRegion('eusc-de-east-1')
+      expect(result.isValid).toBe(true)
+      expect(result.sanitized).toBe('eusc-de-east-1')
+    })
+
+    it.concurrent('should reject a malformed eusc region', () => {
+      expect(validateAwsRegion('eusc-de-east').isValid).toBe(false)
+      expect(validateAwsRegion('eusc-deu-east-1').isValid).toBe(false)
+    })
+  })
+
   describe('valid China regions', () => {
     it.concurrent('should accept cn-north-1', () => {
       const result = validateAwsRegion('cn-north-1')

--- a/apps/sim/lib/core/security/input-validation.ts
+++ b/apps/sim/lib/core/security/input-validation.ts
@@ -898,6 +898,84 @@ export function validateAwsRegion(
 }
 
 /**
+ * Validates a Google Cloud location (region) identifier.
+ *
+ * Google SDKs interpolate this value directly into the API hostname
+ * (`https://{location}-aiplatform.googleapis.com/`), so an unvalidated value
+ * containing `/`, `:`, `@`, or whitespace can terminate the authority component
+ * and relocate the request — along with any attached credential — to an
+ * attacker-controlled host.
+ *
+ * Accepts `global` plus the documented `{geography}-{direction}{index}` region
+ * form (e.g. us-central1, europe-west4, northamerica-northeast1, me-central2).
+ *
+ * @param value - The location to validate
+ * @param paramName - Name of the parameter for error messages
+ * @returns ValidationResult
+ */
+export function validateGoogleCloudLocation(
+  value: string | null | undefined,
+  paramName = 'location'
+): ValidationResult {
+  if (value === null || value === undefined || value === '') {
+    return { isValid: false, error: `${paramName} is required` }
+  }
+
+  const googleLocationPattern =
+    /^(global|(africa|asia|australia|europe|me|northamerica|southamerica|us)-(central|east|north|northeast|northwest|south|southeast|southwest|west)\d{1,2})$/
+
+  if (!googleLocationPattern.test(value)) {
+    logger.warn('Invalid Google Cloud location format', {
+      paramName,
+      value: value.substring(0, 50),
+    })
+    return {
+      isValid: false,
+      error: `${paramName} must be a valid Google Cloud location (e.g., us-central1, europe-west4, global)`,
+    }
+  }
+
+  return { isValid: true, sanitized: value }
+}
+
+/**
+ * Validates a Google Cloud project identifier.
+ *
+ * Accepts either a project ID (6-30 chars, starts with a lowercase letter,
+ * lowercase letters/digits/hyphens, no trailing hyphen) or a numeric project
+ * number. This value is interpolated into the API URL path, so anything that
+ * could introduce path or authority separators is rejected.
+ *
+ * @param value - The project to validate
+ * @param paramName - Name of the parameter for error messages
+ * @returns ValidationResult
+ */
+export function validateGoogleCloudProject(
+  value: string | null | undefined,
+  paramName = 'project'
+): ValidationResult {
+  if (value === null || value === undefined || value === '') {
+    return { isValid: false, error: `${paramName} is required` }
+  }
+
+  const projectIdPattern = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/
+  const projectNumberPattern = /^\d{1,20}$/
+
+  if (!projectIdPattern.test(value) && !projectNumberPattern.test(value)) {
+    logger.warn('Invalid Google Cloud project format', {
+      paramName,
+      value: value.substring(0, 50),
+    })
+    return {
+      isValid: false,
+      error: `${paramName} must be a valid Google Cloud project ID or project number`,
+    }
+  }
+
+  return { isValid: true, sanitized: value }
+}
+
+/**
  * Validates an S3 bucket name according to AWS naming rules
  *
  * S3 bucket names must:

--- a/apps/sim/lib/core/security/input-validation.ts
+++ b/apps/sim/lib/core/security/input-validation.ts
@@ -856,6 +856,7 @@ export function validateAirtableId(
  * - ISO partitions: us-iso-east-1, us-iso-west-1, us-isob-east-1
  * - Mexico: mx-central-1
  * - EU Sovereign Cloud: eu-isoe-west-1
+ * - European Sovereign Cloud: eusc-de-east-1
  *
  * @param value - The AWS region to validate
  * @param paramName - Name of the parameter for error messages
@@ -881,7 +882,7 @@ export function validateAwsRegion(
   }
 
   const awsRegionPattern =
-    /^(eu-isoe|us-isob|us-iso|us-gov|af|ap|ca|cn|eu|il|me|mx|sa|us)-(central|north|northeast|northwest|south|southeast|southwest|east|west)-\d{1,2}$/
+    /^(eu-isoe|eusc-[a-z]{2}|us-isob|us-iso|us-gov|af|ap|ca|cn|eu|il|me|mx|sa|us)-(central|north|northeast|northwest|south|southeast|southwest|east|west)-\d{1,2}$/
 
   if (!awsRegionPattern.test(value)) {
     logger.warn('Invalid AWS region format', {

--- a/apps/sim/providers/bedrock/index.ts
+++ b/apps/sim/providers/bedrock/index.ts
@@ -17,6 +17,7 @@ import {
 import { createLogger } from '@sim/logger'
 import { getErrorMessage, toError } from '@sim/utils/errors'
 import { isRecordLike } from '@sim/utils/object'
+import { validateAwsRegion } from '@/lib/core/security/input-validation'
 import type { IterationToolCall, NormalizedBlockOutput, StreamingExecution } from '@/executor/types'
 import { MAX_TOOL_ITERATIONS } from '@/providers'
 import { buildBedrockMessageContent } from '@/providers/attachments'
@@ -124,6 +125,15 @@ export const bedrockProvider: ProviderConfig = {
     request: ProviderRequest
   ): Promise<ProviderResponse | StreamingExecution> => {
     const region = request.bedrockRegion || 'us-east-1'
+
+    // The AWS SDK interpolates the region into the Bedrock endpoint hostname, so an
+    // unvalidated value can redirect the signed request to an attacker-chosen host.
+    const regionValidation = validateAwsRegion(region, 'bedrockRegion')
+    if (!regionValidation.isValid) {
+      logger.warn('Blocked invalid Bedrock region', { error: regionValidation.error })
+      throw new Error(`Invalid Bedrock region: ${regionValidation.error}`)
+    }
+
     const bedrockModelId = getBedrockInferenceProfileId(request.model, region)
 
     logger.info('Bedrock request', {

--- a/apps/sim/providers/vertex/index.test.ts
+++ b/apps/sim/providers/vertex/index.test.ts
@@ -91,6 +91,12 @@ describe('vertexProvider location and project validation', () => {
     expect(mockExecuteGeminiRequest).toHaveBeenCalledTimes(1)
   })
 
+  it('normalizes a mixed-case location rather than rejecting it', async () => {
+    await vertexProvider.executeRequest(request({ vertexLocation: 'US-Central1' }))
+
+    expect(genAIArgs[0]).toMatchObject({ location: 'us-central1' })
+  })
+
   it('defaults to us-central1 when no location is supplied', async () => {
     await vertexProvider.executeRequest(request())
 

--- a/apps/sim/providers/vertex/index.test.ts
+++ b/apps/sim/providers/vertex/index.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProviderRequest } from '@/providers/types'
+
+const { mockGoogleGenAI, genAIArgs, mockExecuteGeminiRequest } = vi.hoisted(() => {
+  const genAIArgs: Array<Record<string, unknown>> = []
+  class MockGoogleGenAI {
+    constructor(opts: Record<string, unknown>) {
+      genAIArgs.push(opts)
+    }
+  }
+  return {
+    mockGoogleGenAI: MockGoogleGenAI,
+    genAIArgs,
+    mockExecuteGeminiRequest: vi.fn(),
+  }
+})
+
+vi.mock('@google/genai', () => ({ GoogleGenAI: mockGoogleGenAI }))
+vi.mock('google-auth-library', () => ({
+  OAuth2Client: class {
+    setCredentials() {}
+  },
+}))
+vi.mock('@/providers/gemini/core', () => ({ executeGeminiRequest: mockExecuteGeminiRequest }))
+vi.mock('@/providers/models', () => ({
+  getProviderModels: () => ['vertex/gemini-2.0-flash'],
+  getProviderDefaultModel: () => 'vertex/gemini-2.0-flash',
+}))
+vi.mock('@/lib/core/config/env', () => ({ env: {} }))
+
+import { vertexProvider } from '@/providers/vertex'
+
+function request(overrides: Partial<ProviderRequest> = {}): ProviderRequest {
+  return {
+    model: 'vertex/gemini-2.0-flash',
+    apiKey: 'ya29.canary-token',
+    vertexProject: 'pentest-proj',
+    messages: [],
+    ...overrides,
+  } as ProviderRequest
+}
+
+describe('vertexProvider location and project validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    genAIArgs.length = 0
+    mockExecuteGeminiRequest.mockResolvedValue({ content: 'ok' })
+  })
+
+  it('rejects a location that terminates the URL authority', async () => {
+    await expect(
+      vertexProvider.executeRequest(request({ vertexLocation: 'attacker.example.com/x' }))
+    ).rejects.toThrow(/Invalid Vertex AI location/)
+
+    expect(genAIArgs).toHaveLength(0)
+    expect(mockExecuteGeminiRequest).not.toHaveBeenCalled()
+  })
+
+  it.each(['us-central1:8080', 'user@attacker.tld', 'us-central1 attacker.tld', '../us-central1'])(
+    'rejects the malformed location %j without constructing a client',
+    async (vertexLocation) => {
+      await expect(vertexProvider.executeRequest(request({ vertexLocation }))).rejects.toThrow(
+        /Invalid Vertex AI location/
+      )
+      expect(genAIArgs).toHaveLength(0)
+    }
+  )
+
+  it('rejects a project that injects extra URL path segments', async () => {
+    await expect(
+      vertexProvider.executeRequest(
+        request({ vertexProject: 'proj/../../attacker', vertexLocation: 'us-central1' })
+      )
+    ).rejects.toThrow(/Invalid Vertex AI project/)
+
+    expect(genAIArgs).toHaveLength(0)
+  })
+
+  it('passes a valid location and project through to the SDK', async () => {
+    await vertexProvider.executeRequest(request({ vertexLocation: 'europe-west4' }))
+
+    expect(genAIArgs).toHaveLength(1)
+    expect(genAIArgs[0]).toMatchObject({
+      vertexai: true,
+      project: 'pentest-proj',
+      location: 'europe-west4',
+    })
+    expect(mockExecuteGeminiRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('defaults to us-central1 when no location is supplied', async () => {
+    await vertexProvider.executeRequest(request())
+
+    expect(genAIArgs[0]).toMatchObject({ location: 'us-central1' })
+  })
+})

--- a/apps/sim/providers/vertex/index.ts
+++ b/apps/sim/providers/vertex/index.ts
@@ -35,7 +35,13 @@ export const vertexProvider: ProviderConfig = {
     request: ProviderRequest
   ): Promise<ProviderResponse | StreamingExecution> => {
     const vertexProject = request.vertexProject || env.VERTEX_PROJECT
-    const vertexLocation = request.vertexLocation || env.VERTEX_LOCATION || 'us-central1'
+    // Hostnames are case-insensitive, so a mixed-case location reaches Google fine
+    // today. Normalize before validating rather than rejecting it as malformed.
+    const vertexLocation = (
+      request.vertexLocation ||
+      env.VERTEX_LOCATION ||
+      'us-central1'
+    ).toLowerCase()
 
     if (!vertexProject) {
       throw new Error(

--- a/apps/sim/providers/vertex/index.ts
+++ b/apps/sim/providers/vertex/index.ts
@@ -2,6 +2,10 @@ import { GoogleGenAI } from '@google/genai'
 import { createLogger } from '@sim/logger'
 import { OAuth2Client } from 'google-auth-library'
 import { env } from '@/lib/core/config/env'
+import {
+  validateGoogleCloudLocation,
+  validateGoogleCloudProject,
+} from '@/lib/core/security/input-validation'
 import type { StreamingExecution } from '@/executor/types'
 import { executeGeminiRequest } from '@/providers/gemini/core'
 import { getProviderDefaultModel, getProviderModels } from '@/providers/models'
@@ -37,6 +41,22 @@ export const vertexProvider: ProviderConfig = {
       throw new Error(
         'Vertex AI project is required. Please provide it via VERTEX_PROJECT environment variable or vertexProject parameter.'
       )
+    }
+
+    // The @google/genai SDK interpolates location into the API hostname and project
+    // into the URL path. Both must be validated before they reach the client, or a
+    // crafted value relocates the request — and the attached bearer token — to an
+    // arbitrary host.
+    const locationValidation = validateGoogleCloudLocation(vertexLocation, 'vertexLocation')
+    if (!locationValidation.isValid) {
+      logger.warn('Blocked invalid Vertex AI location', { error: locationValidation.error })
+      throw new Error(`Invalid Vertex AI location: ${locationValidation.error}`)
+    }
+
+    const projectValidation = validateGoogleCloudProject(vertexProject, 'vertexProject')
+    if (!projectValidation.isValid) {
+      logger.warn('Blocked invalid Vertex AI project', { error: projectValidation.error })
+      throw new Error(`Invalid Vertex AI project: ${projectValidation.error}`)
     }
 
     if (!request.apiKey) {


### PR DESCRIPTION
## Summary
- Validate `vertexLocation` before it reaches `@google/genai`. The SDK builds its base URL as `` `https://${location}-aiplatform.googleapis.com/` `` — a literal interpolation into the **hostname** — so `attacker.tld/x` terminates the authority and the auth client still attaches `Authorization: Bearer <workspace GCP token>` to the attacker's host. Runtime-confirmed against production via `POST /api/guardrails/validate`, which needs only a session cookie.
- Same treatment for the two siblings in the same bug class: `vertexProject` (interpolated into the URL path) and the Bedrock `region` (interpolated into the endpoint hostname, now using the pre-existing `validateAwsRegion`). `azureEndpoint` was already routed through the DNS-pinning SSRF guard and needed no change.
- Bind Vertex credential resolution to the executing workspace. `resolveVertexCredential` enforced only the user↔credential predicate; `authorizeCredentialUse` also enforces workflow-workspace↔credential. A credential held in workspace B could be pasted into a workflow in workspace A and consumed by A's principals — including on deployed runs, where `enforceCredentialAccess` is false and `ctx.userId` is the workflow owner rather than the trigger caller. Service-account credentials mint a `cloud-platform`-scoped token, so this handed A the use of B's GCP identity.

## Details

**Chokepoint.** Two new validators (`validateGoogleCloudLocation`, `validateGoogleCloudProject`) live next to the existing `validateAwsRegion` in the shared input-validation module and are applied in each provider's `executeRequest`. There is exactly one `vertexai: true` construction site in the repo, so every path — agent/router/evaluator/translate blocks, `/api/providers`, `/api/guardrails/validate` — goes through them. Nothing containing `/`, `:`, `@`, `?`, `#`, or whitespace can pass.

**Credential binding.** `getCredentialActorContext` resolves the workspace *from the credential row itself*, so it structurally cannot express the workflow-workspace predicate. `resolveVertexCredential` now takes the executing `workspaceId` (params object, since the arg list grew) and rejects a mismatch with the same message `credential-access.ts` uses. All four call sites pass `ctx.workspaceId`, already in scope at each. Routing through `authorizeCredentialUse` directly was the other option but it needs a `NextRequest` the executor does not have.

## Regression audit
- `ExecutionContext.workspaceId` is optional in the type, so the binding check is conditional — but `execution-core.ts:356` throws when execution metadata lacks a workspace, so it is always present on real runs. No bypass by omission.
- `credential.workspaceId` is `NOT NULL`, so there is no personal/unscoped credential the new check could wrongly reject.
- Custom-block children deliberately run under the **source** workspace (`childWorkspaceId = childWorkflow.workspaceId`) with `childUserId = loadUserId`; the new check follows that boundary rather than fighting it. Regular child workflows already go through `assertChildWorkflowInWorkspace`.
- Mixed-case locations like `US-Central1` work today (DNS is case-insensitive), so the provider lowercases before validating instead of rejecting input that currently succeeds. Second commit.
- Neither `providers/vertex` nor `providers/bedrock` is imported from any client module, so pulling in the validation module adds nothing to a client bundle. `check:client-boundary` passes.
- Legacy domain-scoped project ids (`google.com:my-project`) would be rejected by the project validator. They cannot be created anymore and none are expected here.

## Type of Change
- [x] Bug fix

## Testing
- `providers/vertex/index.test.ts` (new) — malicious locations and projects throw and **never construct the client**; valid values pass through; mixed case normalizes; the `us-central1` default still applies.
- `executor/utils/vertex-credential.test.ts` (new) — cross-workspace credential rejected before any token is minted; same-workspace still resolves; the user↔credential check still fires.
- `lib/core/security/input-validation.test.ts` — table-driven cases for both validators covering every authority-terminating character class.
- Each fix was reverted and the suites re-run to confirm they go red (7 failures) rather than passing vacuously.
- `tsc -p apps/sim --noEmit` clean, `bun run lint` clean, `bun run check:api-validation` passes, `check:client-boundary` passes. The one failing test in a wider run (`executor/handlers/pi/cloud-review-tools.test.ts`) fails identically on `origin/staging` and is unrelated.
- Not live-tested against a real Vertex deployment — verification is unit-level plus source trace.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)