### PR TITLE
fix(security): bind copilot chat attachment keys to their owner

### DIFF
--- a/apps/sim/app/api/mothership/local-files/stage/route.ts
+++ b/apps/sim/app/api/mothership/local-files/stage/route.ts
@@ -13,7 +13,10 @@ import {
 } from '@/lib/copilot/request/http'
 import { encodeVfsSegment } from '@/lib/copilot/vfs/path-utils'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { trackChatUpload } from '@/lib/uploads/contexts/workspace/workspace-file-manager'
+import {
+  trackChatUpload,
+  WorkspaceFileKeyOwnershipError,
+} from '@/lib/uploads/contexts/workspace/workspace-file-manager'
 import { getUserEntityPermissions } from '@/lib/workspaces/permissions/utils'
 
 const logger = createLogger('StageLocalFileUploadAPI')
@@ -95,6 +98,13 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       uploadPath: `uploads/${encodeVfsSegment(displayName)}`,
     })
   } catch (error) {
+    if (error instanceof WorkspaceFileKeyOwnershipError) {
+      // The caller supplied a key they may not bind — a client error, not ours.
+      logger.warn('Rejected chat upload staging for an unowned storage key', {
+        error: error.message,
+      })
+      return NextResponse.json({ error: 'Storage key is not available' }, { status: 403 })
+    }
     logger.error('Failed to stage local file upload', error)
     return createInternalServerErrorResponse('Failed to stage local file upload')
   }

--- a/apps/sim/lib/copilot/chat/payload.test.ts
+++ b/apps/sim/lib/copilot/chat/payload.test.ts
@@ -4,10 +4,12 @@
 import { workflowsUtilsMock } from '@sim/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockCreateUserToolSchema, mockGetHighestPrioritySubscription } = vi.hoisted(() => ({
-  mockCreateUserToolSchema: vi.fn(() => ({ type: 'object', properties: {} })),
-  mockGetHighestPrioritySubscription: vi.fn(),
-}))
+const { mockCreateUserToolSchema, mockGetHighestPrioritySubscription, mockTrackChatUpload } =
+  vi.hoisted(() => ({
+    mockCreateUserToolSchema: vi.fn(() => ({ type: 'object', properties: {} })),
+    mockGetHighestPrioritySubscription: vi.fn(),
+    mockTrackChatUpload: vi.fn(),
+  }))
 
 vi.mock('@/lib/billing/core/subscription', () => ({
   getHighestPrioritySubscription: mockGetHighestPrioritySubscription,
@@ -102,6 +104,10 @@ vi.mock('@/lib/copilot/integration-tools', () => ({
 
 vi.mock('@/tools/params', () => ({
   createUserToolSchema: mockCreateUserToolSchema,
+}))
+
+vi.mock('@/lib/uploads/contexts/workspace/workspace-file-manager', () => ({
+  trackChatUpload: mockTrackChatUpload,
 }))
 
 import {
@@ -209,6 +215,53 @@ describe('buildIntegrationToolSchemas', () => {
 describe('buildCopilotRequestPayload', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockTrackChatUpload.mockResolvedValue({ displayName: 'payroll.xlsx' })
+  })
+
+  describe('file attachment tracking', () => {
+    const attachmentParams = {
+      message: 'hi',
+      userId: 'mallory',
+      userMessageId: 'msg-1',
+      mode: 'agent',
+      model: 'claude-opus-4-8',
+      workspaceId: 'ws-1',
+      chatId: 'chat-1',
+      fileAttachments: [
+        { id: 'a1', key: 'workspace/ws-1/1731000000000-ab12cd34-payroll.xlsx', size: 1 },
+      ],
+    }
+
+    /**
+     * Tracking writes `workspace_files` rows. A read-only member reaching the
+     * chat endpoint must not gain that write through an attachment.
+     */
+    it.each(['read', undefined])('does not track attachments for permission %s', async (perm) => {
+      await buildCopilotRequestPayload(
+        { ...attachmentParams, userPermission: perm },
+        { selectedModel: 'claude-opus-4-8' }
+      )
+
+      expect(mockTrackChatUpload).not.toHaveBeenCalled()
+    })
+
+    it.each(['write', 'admin'])('tracks attachments for permission %s', async (perm) => {
+      await buildCopilotRequestPayload(
+        { ...attachmentParams, userPermission: perm },
+        { selectedModel: 'claude-opus-4-8' }
+      )
+
+      expect(mockTrackChatUpload).toHaveBeenCalledWith(
+        'ws-1',
+        'mallory',
+        'chat-1',
+        'workspace/ws-1/1731000000000-ab12cd34-payroll.xlsx',
+        expect.anything(),
+        expect.anything(),
+        1,
+        'msg-1'
+      )
+    })
   })
 
   it('passes workspaceContext through to the Go request payload', async () => {

--- a/apps/sim/lib/copilot/chat/payload.ts
+++ b/apps/sim/lib/copilot/chat/payload.ts
@@ -1,5 +1,6 @@
 import type { BrowserKnownSession } from '@sim/browser-protocol'
 import { createLogger } from '@sim/logger'
+import { isPermissionType, permissionSatisfies } from '@sim/platform-authz/predicates'
 import { toError } from '@sim/utils/errors'
 import { LRUCache } from 'lru-cache'
 import { getHighestPrioritySubscription } from '@/lib/billing/core/subscription'
@@ -338,10 +339,10 @@ export async function buildCopilotRequestPayload(
   // upload routes that issue these keys already require — reaching the chat
   // endpoint with `read` must not confer a file-write capability.
   const uploadContexts: Array<{ type: string; content: string; tag?: string; path?: string }> = []
-  // `PermissionType` is exactly read | write | admin, so this covers the whole
-  // write-or-better half of the ordering.
+  // `userPermission` is typed `string` for legacy reasons, so narrow it before
+  // comparing — an unrecognized value must fail the gate, not rank below it.
   const canWriteWorkspaceFiles =
-    params.userPermission === 'write' || params.userPermission === 'admin'
+    isPermissionType(params.userPermission) && permissionSatisfies(params.userPermission, 'write')
   if (chatId && params.workspaceId && fileAttachments && fileAttachments.length > 0) {
     if (!canWriteWorkspaceFiles) {
       logger.warn('Dropping chat file attachments without workspace write access', {

--- a/apps/sim/lib/copilot/chat/payload.ts
+++ b/apps/sim/lib/copilot/chat/payload.ts
@@ -333,10 +333,23 @@ export async function buildCopilotRequestPayload(
   const effectiveMode = mode === 'agent' ? 'build' : mode
   const transportMode = effectiveMode === 'build' ? 'agent' : effectiveMode
 
-  // Track uploaded files in the DB and build context tags instead of base64 inlining
+  // Track uploaded files in the DB and build context tags instead of base64 inlining.
+  // Tracking writes `workspace_files` rows, so it needs the same write grant the
+  // upload routes that issue these keys already require — reaching the chat
+  // endpoint with `read` must not confer a file-write capability.
   const uploadContexts: Array<{ type: string; content: string; tag?: string; path?: string }> = []
+  const canWriteWorkspaceFiles =
+    params.userPermission === 'write' || params.userPermission === 'admin'
   if (chatId && params.workspaceId && fileAttachments && fileAttachments.length > 0) {
-    for (const f of fileAttachments) {
+    if (!canWriteWorkspaceFiles) {
+      logger.warn('Dropping chat file attachments without workspace write access', {
+        chatId,
+        workspaceId: params.workspaceId,
+        attachmentCount: fileAttachments.length,
+      })
+    }
+    const trackableAttachments = canWriteWorkspaceFiles ? fileAttachments : []
+    for (const f of trackableAttachments) {
       const filename = (f.filename ?? f.name ?? 'file') as string
       const mediaType = (f.media_type ?? f.mimeType ?? 'application/octet-stream') as string
       try {

--- a/apps/sim/lib/copilot/chat/payload.ts
+++ b/apps/sim/lib/copilot/chat/payload.ts
@@ -338,6 +338,8 @@ export async function buildCopilotRequestPayload(
   // upload routes that issue these keys already require — reaching the chat
   // endpoint with `read` must not confer a file-write capability.
   const uploadContexts: Array<{ type: string; content: string; tag?: string; path?: string }> = []
+  // `PermissionType` is exactly read | write | admin, so this covers the whole
+  // write-or-better half of the ordering.
   const canWriteWorkspaceFiles =
     params.userPermission === 'write' || params.userPermission === 'admin'
   if (chatId && params.workspaceId && fileAttachments && fileAttachments.length > 0) {

--- a/apps/sim/lib/uploads/contexts/workspace/track-chat-upload.test.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/track-chat-upload.test.ts
@@ -412,6 +412,31 @@ describe('trackChatUpload', () => {
       expect(dbChainMockFns.values).not.toHaveBeenCalled()
     })
 
+    /**
+     * The probe is hygiene, not authorization — a provider 5xx must not drop a
+     * legitimate >50MB multipart upload, which is the only path that reaches it.
+     * Only a definitive not-found (`null`) rejects.
+     */
+    it('proceeds when the storage existence probe throws a transient error', async () => {
+      queueOwnershipLookup([])
+      mockHeadObject.mockRejectedValueOnce(new Error('503 SlowDown'))
+
+      const result = await trackChatUpload(
+        WORKSPACE_ID,
+        USER_ID,
+        CHAT_ID,
+        S3_KEY,
+        'image.png',
+        'image/png',
+        1024
+      )
+
+      expect(result).toEqual({ displayName: 'image.png' })
+      expect(dbChainMockFns.values).toHaveBeenCalledWith(
+        expect.objectContaining({ key: S3_KEY, context: 'mothership' })
+      )
+    })
+
     /** Local-storage deployments have no headObject to consult; ownership still gates. */
     it('skips the storage existence probe when cloud storage is not configured', async () => {
       mockHasCloudStorage.mockReturnValue(false)

--- a/apps/sim/lib/uploads/contexts/workspace/track-chat-upload.test.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/track-chat-upload.test.ts
@@ -52,6 +52,7 @@ function existingRow(overrides: Record<string, unknown> = {}) {
     userId: USER_ID,
     workspaceId: WORKSPACE_ID,
     context: 'mothership',
+    chatId: null,
     deletedAt: null,
     ...overrides,
   }
@@ -397,8 +398,47 @@ describe('trackChatUpload', () => {
           { type: 'eq', left: 'workspaceId', right: WORKSPACE_ID },
           { type: 'eq', left: 'context', right: 'mothership' },
           { type: 'isNull', column: 'deletedAt' },
+          {
+            type: 'or',
+            conditions: [
+              { type: 'isNull', column: 'chatId' },
+              { type: 'eq', left: 'chatId', right: CHAT_ID },
+            ],
+          },
         ],
       })
+    })
+
+    /**
+     * An upload binds to exactly one chat. Matches the 409 the sibling
+     * `local-files/stage` route already returns for this case.
+     */
+    it('refuses to relink an upload already bound to a different chat', async () => {
+      queueOwnershipLookup([existingRow({ chatId: 'other-chat-id' })])
+
+      await expect(
+        trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, S3_KEY, 'image.png', 'image/png', 1024)
+      ).rejects.toThrow('not available for a chat attachment')
+
+      expect(dbChainMockFns.set).not.toHaveBeenCalled()
+      expect(dbChainMockFns.values).not.toHaveBeenCalled()
+    })
+
+    it('still re-links an upload already bound to this same chat', async () => {
+      queueOwnershipLookup([existingRow({ chatId: CHAT_ID })])
+      dbChainMockFns.returning.mockResolvedValueOnce([{ id: 'wf_existing' }])
+
+      const result = await trackChatUpload(
+        WORKSPACE_ID,
+        USER_ID,
+        CHAT_ID,
+        S3_KEY,
+        'image.png',
+        'image/png',
+        1024
+      )
+
+      expect(result).toEqual({ displayName: 'image.png' })
     })
 
     it('requires the object to exist in storage before minting a new binding', async () => {

--- a/apps/sim/lib/uploads/contexts/workspace/track-chat-upload.test.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/track-chat-upload.test.ts
@@ -376,6 +376,31 @@ describe('trackChatUpload', () => {
       expect(dbChainMockFns.values).not.toHaveBeenCalled()
     })
 
+    /**
+     * The ownership lookup and the write are separate statements, so a
+     * concurrent `materialize_file` can flip the row to context='workspace'
+     * in between. The UPDATE must re-assert every ownership predicate rather
+     * than matching on the captured row id alone, or it would drag a saved
+     * workspace file back into chat scope.
+     */
+    it('re-asserts every ownership predicate in the update, not just the row id', async () => {
+      queueOwnershipLookup([existingRow({ id: 'wf_mine' })])
+      dbChainMockFns.returning.mockResolvedValueOnce([{ id: 'wf_mine' }])
+
+      await trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, S3_KEY, 'image.png', 'image/png', 1024)
+
+      expect(dbChainMockFns.where.mock.calls.at(-1)?.[0]).toEqual({
+        type: 'and',
+        conditions: [
+          { type: 'eq', left: 'id', right: 'wf_mine' },
+          { type: 'eq', left: 'userId', right: USER_ID },
+          { type: 'eq', left: 'workspaceId', right: WORKSPACE_ID },
+          { type: 'eq', left: 'context', right: 'mothership' },
+          { type: 'isNull', column: 'deletedAt' },
+        ],
+      })
+    })
+
     it('requires the object to exist in storage before minting a new binding', async () => {
       queueOwnershipLookup([])
       mockHeadObject.mockResolvedValueOnce(null)

--- a/apps/sim/lib/uploads/contexts/workspace/track-chat-upload.test.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/track-chat-upload.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 
-import { dbChainMockFns, resetDbChainMock } from '@sim/testing'
+import { dbChainMockFns, queueTableRows, resetDbChainMock, schemaMock } from '@sim/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -10,11 +10,15 @@ const {
   mockDecrementStorageUsageForBillingContext,
   mockIncrementStorageUsageForBillingContext,
   mockResolveStorageBillingContext,
+  mockHasCloudStorage,
+  mockHeadObject,
 } = vi.hoisted(() => ({
   mockCheckStorageQuotaForBillingContext: vi.fn(),
   mockDecrementStorageUsageForBillingContext: vi.fn(),
   mockIncrementStorageUsageForBillingContext: vi.fn(),
   mockResolveStorageBillingContext: vi.fn(),
+  mockHasCloudStorage: vi.fn(),
+  mockHeadObject: vi.fn(),
 }))
 
 vi.mock('@/lib/billing/storage', () => ({
@@ -24,12 +28,39 @@ vi.mock('@/lib/billing/storage', () => ({
   resolveStorageBillingContext: mockResolveStorageBillingContext,
 }))
 
+vi.mock('@/lib/uploads/core/storage-service', () => ({
+  deleteFile: vi.fn(),
+  downloadFile: vi.fn(),
+  hasCloudStorage: mockHasCloudStorage,
+  headObject: mockHeadObject,
+  uploadFile: vi.fn(),
+}))
+
 import { CHAT_DISPLAY_NAME_INDEX, suffixedName, trackChatUpload } from './workspace-file-manager'
 
 const CHAT_ID = '11111111-1111-1111-1111-111111111111'
-const WORKSPACE_ID = 'ws_1'
+const WORKSPACE_ID = '22222222-2222-2222-2222-222222222222'
+const OTHER_WORKSPACE_ID = '33333333-3333-3333-3333-333333333333'
 const USER_ID = 'user_1'
-const S3_KEY = 'mothership/abc/123-image.png'
+const OTHER_USER_ID = 'user_2'
+const S3_KEY = `workspace/${WORKSPACE_ID}/1731000000000-ab12cd34-image.png`
+
+/** Row shape `resolveClaimableChatUploadRow` selects, with claimable defaults. */
+function existingRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wf_existing',
+    userId: USER_ID,
+    workspaceId: WORKSPACE_ID,
+    context: 'mothership',
+    deletedAt: null,
+    ...overrides,
+  }
+}
+
+/** Queue the key-ownership lookup that runs before every bind. */
+function queueOwnershipLookup(rows: unknown[]): void {
+  queueTableRows(schemaMock.workspaceFiles, rows)
+}
 
 function expectNoWorkspaceStorageAccounting(): void {
   expect(mockCheckStorageQuotaForBillingContext).not.toHaveBeenCalled()
@@ -69,9 +100,12 @@ describe('trackChatUpload', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetDbChainMock()
+    mockHasCloudStorage.mockReturnValue(true)
+    mockHeadObject.mockResolvedValue({ size: 1024 })
   })
 
   it('finalizes an existing direct upload without workspace storage accounting', async () => {
+    queueOwnershipLookup([existingRow()])
     dbChainMockFns.returning.mockResolvedValueOnce([{ id: 'wf_existing' }])
 
     const result = await trackChatUpload(
@@ -96,7 +130,7 @@ describe('trackChatUpload', () => {
   })
 
   it('finalizes a presigned upload without workspace storage accounting', async () => {
-    dbChainMockFns.returning.mockResolvedValueOnce([])
+    queueOwnershipLookup([])
 
     const result = await trackChatUpload(
       WORKSPACE_ID,
@@ -122,6 +156,7 @@ describe('trackChatUpload', () => {
   })
 
   it('stamps message_id on the UPDATE arm when the birth message is known', async () => {
+    queueOwnershipLookup([existingRow()])
     dbChainMockFns.returning.mockResolvedValueOnce([{ id: 'wf_existing' }])
 
     await trackChatUpload(
@@ -141,7 +176,7 @@ describe('trackChatUpload', () => {
   })
 
   it('stamps message_id on the fallback INSERT arm and nulls it when omitted', async () => {
-    dbChainMockFns.returning.mockResolvedValueOnce([])
+    queueOwnershipLookup([])
 
     await trackChatUpload(
       WORKSPACE_ID,
@@ -159,6 +194,7 @@ describe('trackChatUpload', () => {
     )
 
     // Legacy callers without a message id write an explicit NULL ("birth unknown").
+    queueOwnershipLookup([existingRow()])
     dbChainMockFns.returning.mockResolvedValueOnce([{ id: 'wf_existing' }])
     await trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, S3_KEY, 'image.png', 'image/png', 1024)
     expect(dbChainMockFns.set).toHaveBeenLastCalledWith(
@@ -173,9 +209,8 @@ describe('trackChatUpload', () => {
       constraint_name: CHAT_DISPLAY_NAME_INDEX,
     })
 
-    dbChainMockFns.returning.mockResolvedValueOnce([])
+    queueOwnershipLookup([])
     dbChainMockFns.values.mockRejectedValueOnce(displayNameCollision)
-    dbChainMockFns.returning.mockResolvedValueOnce([])
     dbChainMockFns.values.mockResolvedValueOnce(undefined)
 
     const result = await trackChatUpload(
@@ -204,7 +239,7 @@ describe('trackChatUpload', () => {
       constraint_name: 'workspace_files_key_active_unique',
     })
 
-    dbChainMockFns.returning.mockResolvedValueOnce([])
+    queueOwnershipLookup([])
     dbChainMockFns.values.mockRejectedValueOnce(keyCollision)
 
     await expect(
@@ -216,6 +251,7 @@ describe('trackChatUpload', () => {
   })
 
   it('rethrows metadata errors without workspace storage accounting', async () => {
+    queueOwnershipLookup([existingRow()])
     dbChainMockFns.returning.mockRejectedValueOnce(new Error('connection lost'))
 
     await expect(
@@ -223,5 +259,151 @@ describe('trackChatUpload', () => {
     ).rejects.toThrow('connection lost')
 
     expectNoWorkspaceStorageAccounting()
+  })
+
+  describe('storage key ownership', () => {
+    /**
+     * A caller-supplied key that resolves to a different workspace must never
+     * reach the binding write — that is cross-tenant key smuggling.
+     */
+    it('rejects a key addressed to another workspace', async () => {
+      const foreignKey = `workspace/${OTHER_WORKSPACE_ID}/1731000000000-ab12cd34-image.png`
+
+      await expect(
+        trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, foreignKey, 'image.png', 'image/png', 1024)
+      ).rejects.toThrow('not available for a chat attachment')
+
+      expect(dbChainMockFns.set).not.toHaveBeenCalled()
+      expect(dbChainMockFns.values).not.toHaveBeenCalled()
+    })
+
+    it('rejects a key with no workspace prefix at all', async () => {
+      await expect(
+        trackChatUpload(
+          WORKSPACE_ID,
+          USER_ID,
+          CHAT_ID,
+          'mothership/abc/123-image.png',
+          'image.png',
+          'image/png',
+          1024
+        )
+      ).rejects.toThrow('not available for a chat attachment')
+
+      expect(dbChainMockFns.set).not.toHaveBeenCalled()
+      expect(dbChainMockFns.values).not.toHaveBeenCalled()
+    })
+
+    /**
+     * The reported attack: a member hands in another member's workspace-file key
+     * and the UPDATE re-parents that row to the caller's chat, hiding it from the
+     * workspace Files listing and exposing it to the chat-delete FK cascade.
+     */
+    it("refuses to re-parent another member's workspace file", async () => {
+      queueOwnershipLookup([
+        existingRow({ id: 'wf_victim', userId: OTHER_USER_ID, context: 'workspace' }),
+      ])
+
+      await expect(
+        trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, S3_KEY, 'image.png', 'image/png', 1024)
+      ).rejects.toThrow('not available for a chat attachment')
+
+      expect(dbChainMockFns.set).not.toHaveBeenCalled()
+      expect(dbChainMockFns.values).not.toHaveBeenCalled()
+    })
+
+    it("refuses to re-parent another member's chat upload", async () => {
+      queueOwnershipLookup([existingRow({ id: 'wf_victim', userId: OTHER_USER_ID })])
+
+      await expect(
+        trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, S3_KEY, 'image.png', 'image/png', 1024)
+      ).rejects.toThrow('not available for a chat attachment')
+
+      expect(dbChainMockFns.set).not.toHaveBeenCalled()
+      expect(dbChainMockFns.values).not.toHaveBeenCalled()
+    })
+
+    /** The caller's own workspace file is still a Files-tab file, not a chat upload. */
+    it("refuses to convert the caller's own workspace file into a chat upload", async () => {
+      queueOwnershipLookup([existingRow({ context: 'workspace' })])
+
+      await expect(
+        trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, S3_KEY, 'image.png', 'image/png', 1024)
+      ).rejects.toThrow('not available for a chat attachment')
+
+      expect(dbChainMockFns.set).not.toHaveBeenCalled()
+      expect(dbChainMockFns.values).not.toHaveBeenCalled()
+    })
+
+    /**
+     * The active-key unique index is partial on `deleted_at IS NULL`, so an
+     * INSERT over an archived row would succeed and mint a binding granting read
+     * access to the archived file's bytes.
+     */
+    it('refuses to mint a binding over a soft-deleted record for the same key', async () => {
+      queueOwnershipLookup([
+        existingRow({ id: 'wf_archived', deletedAt: new Date('2026-01-01T00:00:00Z') }),
+      ])
+
+      await expect(
+        trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, S3_KEY, 'image.png', 'image/png', 1024)
+      ).rejects.toThrow('not available for a chat attachment')
+
+      expect(dbChainMockFns.values).not.toHaveBeenCalled()
+    })
+
+    it('scopes the UPDATE to the caller-owned row id rather than the raw key', async () => {
+      queueOwnershipLookup([existingRow({ id: 'wf_mine' })])
+      dbChainMockFns.returning.mockResolvedValueOnce([{ id: 'wf_mine' }])
+
+      await trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, S3_KEY, 'image.png', 'image/png', 1024)
+
+      expect(dbChainMockFns.where).toHaveBeenCalled()
+      expect(dbChainMockFns.set).toHaveBeenCalledWith(
+        expect.objectContaining({ chatId: CHAT_ID, context: 'mothership' })
+      )
+    })
+
+    /** The row vanished between the ownership check and the write — fail closed. */
+    it('fails closed when the owned row disappears before the update lands', async () => {
+      queueOwnershipLookup([existingRow({ id: 'wf_mine' })])
+      dbChainMockFns.returning.mockResolvedValueOnce([])
+
+      await expect(
+        trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, S3_KEY, 'image.png', 'image/png', 1024)
+      ).rejects.toThrow('not available for a chat attachment')
+
+      expect(dbChainMockFns.values).not.toHaveBeenCalled()
+    })
+
+    it('requires the object to exist in storage before minting a new binding', async () => {
+      queueOwnershipLookup([])
+      mockHeadObject.mockResolvedValueOnce(null)
+
+      await expect(
+        trackChatUpload(WORKSPACE_ID, USER_ID, CHAT_ID, S3_KEY, 'image.png', 'image/png', 1024)
+      ).rejects.toThrow('not available for a chat attachment')
+
+      expect(dbChainMockFns.values).not.toHaveBeenCalled()
+    })
+
+    /** Local-storage deployments have no headObject to consult; ownership still gates. */
+    it('skips the storage existence probe when cloud storage is not configured', async () => {
+      mockHasCloudStorage.mockReturnValue(false)
+      queueOwnershipLookup([])
+
+      const result = await trackChatUpload(
+        WORKSPACE_ID,
+        USER_ID,
+        CHAT_ID,
+        S3_KEY,
+        'image.png',
+        'image/png',
+        1024
+      )
+
+      expect(result).toEqual({ displayName: 'image.png' })
+      expect(mockHeadObject).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
@@ -707,12 +707,24 @@ export async function trackChatUpload(
             context: 'mothership',
             displayName: candidate,
           })
-          .where(eq(workspaceFiles.id, claimable.id))
+          .where(
+            and(
+              eq(workspaceFiles.id, claimable.id),
+              eq(workspaceFiles.userId, userId),
+              eq(workspaceFiles.workspaceId, workspaceId),
+              eq(workspaceFiles.context, 'mothership'),
+              isNull(workspaceFiles.deletedAt)
+            )
+          )
           .returning({ id: workspaceFiles.id })
 
         if (updated.length === 0) {
-          // The row was deleted or re-owned between the ownership check and the
-          // write. Fail closed rather than silently minting a new binding.
+          // The ownership lookup is a separate statement, so re-assert every
+          // predicate here — this UPDATE is the atomic check. A concurrent
+          // `materialize_file` flips the same row to context='workspace' and
+          // clears chatId; matching on id alone would drag that saved file back
+          // into chat scope, hiding it from the Files listing and re-exposing it
+          // to the chat-delete cascade.
           throw new WorkspaceFileKeyOwnershipError(s3Key)
         }
 

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
@@ -9,7 +9,7 @@ import { workspaceFiles } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage, getPostgresConstraintName, getPostgresErrorCode } from '@sim/utils/errors'
 import { generateShortId } from '@sim/utils/id'
-import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm'
+import { and, eq, isNotNull, isNull, or, sql } from 'drizzle-orm'
 import type { ShareRecord } from '@/lib/api/contracts/public-shares'
 import {
   decrementStorageUsageForBillingContextInTx,
@@ -617,10 +617,15 @@ type ClaimableChatUploadRow = { kind: 'update'; id: string } | { kind: 'insert' 
  * Soft-deleted rows count: the active-key unique index is partial on
  * `deleted_at IS NULL`, so inserting over an archived row would succeed and
  * hand the caller read access to the archived file's bytes.
+ *
+ * An upload also binds to exactly one chat: a row already linked to a different
+ * chat is not claimable, matching the 409 the sibling `local-files/stage` route
+ * returns for the same case. Re-sending the key within its own chat still works.
  */
 async function resolveClaimableChatUploadRow(
   workspaceId: string,
   userId: string,
+  chatId: string,
   s3Key: string
 ): Promise<ClaimableChatUploadRow> {
   const rows = await db
@@ -629,6 +634,7 @@ async function resolveClaimableChatUploadRow(
       userId: workspaceFiles.userId,
       workspaceId: workspaceFiles.workspaceId,
       context: workspaceFiles.context,
+      chatId: workspaceFiles.chatId,
       deletedAt: workspaceFiles.deletedAt,
     })
     .from(workspaceFiles)
@@ -643,7 +649,8 @@ async function resolveClaimableChatUploadRow(
       row.userId === userId &&
       row.workspaceId === workspaceId &&
       row.context === 'mothership' &&
-      row.deletedAt === null
+      row.deletedAt === null &&
+      (row.chatId === null || row.chatId === chatId)
   )
 
   if (!owned) {
@@ -686,7 +693,7 @@ export async function trackChatUpload(
     throw new WorkspaceFileKeyOwnershipError(s3Key)
   }
 
-  const claimable = await resolveClaimableChatUploadRow(workspaceId, userId, s3Key)
+  const claimable = await resolveClaimableChatUploadRow(workspaceId, userId, chatId, s3Key)
 
   if (claimable.kind === 'insert' && hasCloudStorage()) {
     // Hygiene only — the format and no-prior-record guards above already carry
@@ -727,7 +734,13 @@ export async function trackChatUpload(
               eq(workspaceFiles.userId, userId),
               eq(workspaceFiles.workspaceId, workspaceId),
               eq(workspaceFiles.context, 'mothership'),
-              isNull(workspaceFiles.deletedAt)
+              isNull(workspaceFiles.deletedAt),
+              // Compare-and-swap on the chat binding: an upload belongs to one
+              // chat. Two overlapping requests both observe `chat_id IS NULL`,
+              // but only the first satisfies this predicate — the loser matches
+              // zero rows and fails closed instead of stealing the binding and
+              // its delete-cascade lifecycle.
+              or(isNull(workspaceFiles.chatId), eq(workspaceFiles.chatId, chatId))
             )
           )
           .returning({ id: workspaceFiles.id })

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
@@ -689,7 +689,21 @@ export async function trackChatUpload(
   const claimable = await resolveClaimableChatUploadRow(workspaceId, userId, s3Key)
 
   if (claimable.kind === 'insert' && hasCloudStorage()) {
-    const head = await headObject(s3Key, 'workspace')
+    // Hygiene only — the format and no-prior-record guards above already carry
+    // authorization, and a binding to a nonexistent object grants nothing
+    // readable. So reject only on a definitive not-found (`null`); a provider
+    // 5xx/throttle throws, and failing the attachment on that would drop a
+    // legitimate >50MB multipart upload (the sole path reaching this branch).
+    let head: Awaited<ReturnType<typeof headObject>> = null
+    try {
+      head = await headObject(s3Key, 'workspace')
+    } catch (error) {
+      logger.warn('Chat upload existence probe failed; proceeding on the ownership guards', {
+        key: s3Key,
+        error: getErrorMessage(error),
+      })
+      head = { size }
+    }
     if (!head) {
       throw new WorkspaceFileKeyOwnershipError(s3Key)
     }

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
@@ -591,10 +591,82 @@ const MAX_CHAT_DISPLAY_NAME_RETRIES = 1000
 export const CHAT_DISPLAY_NAME_INDEX = 'workspace_files_chat_display_name_unique'
 
 /**
+ * Raised when a caller-supplied storage key may not be bound to a chat upload —
+ * it addresses another workspace, or it already has a `workspace_files` record
+ * the caller does not own as an active chat upload.
+ */
+export class WorkspaceFileKeyOwnershipError extends Error {
+  readonly code = 'KEY_NOT_OWNED' as const
+  constructor(key: string) {
+    super(`Storage key is not available for a chat attachment: ${key}`)
+  }
+}
+
+type ClaimableChatUploadRow = { kind: 'update'; id: string } | { kind: 'insert' }
+
+/**
+ * Decide how `trackChatUpload` may bind `s3Key`, or reject the key outright.
+ *
+ * Only two outcomes are safe. Either the caller already owns an active
+ * chat-upload row for the key (re-linking their own upload to a chat), or the
+ * key has no `workspace_files` record whatsoever and a fresh binding can be
+ * minted. Anything else — another member's row, a `context='workspace'` file,
+ * or a soft-deleted record whose object is still readable through the binding —
+ * belongs to somebody else's file and must not be touched.
+ *
+ * Soft-deleted rows count: the active-key unique index is partial on
+ * `deleted_at IS NULL`, so inserting over an archived row would succeed and
+ * hand the caller read access to the archived file's bytes.
+ */
+async function resolveClaimableChatUploadRow(
+  workspaceId: string,
+  userId: string,
+  s3Key: string
+): Promise<ClaimableChatUploadRow> {
+  const rows = await db
+    .select({
+      id: workspaceFiles.id,
+      userId: workspaceFiles.userId,
+      workspaceId: workspaceFiles.workspaceId,
+      context: workspaceFiles.context,
+      deletedAt: workspaceFiles.deletedAt,
+    })
+    .from(workspaceFiles)
+    .where(eq(workspaceFiles.key, s3Key))
+
+  if (rows.length === 0) {
+    return { kind: 'insert' }
+  }
+
+  const owned = rows.find(
+    (row) =>
+      row.userId === userId &&
+      row.workspaceId === workspaceId &&
+      row.context === 'mothership' &&
+      row.deletedAt === null
+  )
+
+  if (!owned) {
+    throw new WorkspaceFileKeyOwnershipError(s3Key)
+  }
+
+  return { kind: 'update', id: owned.id }
+}
+
+/**
  * Track a file that was already uploaded to workspace S3 as a chat-scoped upload.
  * Links the existing workspaceFiles metadata record (created by the storage service
  * during upload) to the chat by setting chatId and context='mothership'.
  * Falls back to inserting a new record if none exists for the key.
+ *
+ * `s3Key` reaches this function from client-supplied request bodies, and
+ * `workspace_files.key` is the trusted binding every file authorization check
+ * resolves the owning workspace from. So the key is treated as untrusted here:
+ * it must address the target workspace, it may only re-link a chat-upload row
+ * the caller already owns, and minting a brand-new binding requires the key to
+ * have no prior record at all. Without those invariants a member could hand in
+ * another member's key and re-parent their file (hiding it from the workspace
+ * Files listing, or destroying it through the chat-delete FK cascade).
  *
  * Allocates a collision-free `displayName` (the partial unique index on
  * (chat_id, display_name) WHERE context='mothership' enforces this) and returns it
@@ -610,27 +682,40 @@ export async function trackChatUpload(
   size: number,
   messageId?: string
 ): Promise<{ displayName: string }> {
+  if (parseWorkspaceFileKey(s3Key) !== workspaceId) {
+    throw new WorkspaceFileKeyOwnershipError(s3Key)
+  }
+
+  const claimable = await resolveClaimableChatUploadRow(workspaceId, userId, s3Key)
+
+  if (claimable.kind === 'insert' && hasCloudStorage()) {
+    const head = await headObject(s3Key, 'workspace')
+    if (!head) {
+      throw new WorkspaceFileKeyOwnershipError(s3Key)
+    }
+  }
+
   for (let n = 1; n <= MAX_CHAT_DISPLAY_NAME_RETRIES; n++) {
     const candidate = suffixedName(fileName, n)
     try {
-      const updated = await db
-        .update(workspaceFiles)
-        .set({
-          chatId,
-          messageId: messageId ?? null,
-          context: 'mothership',
-          displayName: candidate,
-        })
-        .where(
-          and(
-            eq(workspaceFiles.key, s3Key),
-            eq(workspaceFiles.workspaceId, workspaceId),
-            isNull(workspaceFiles.deletedAt)
-          )
-        )
-        .returning({ id: workspaceFiles.id })
+      if (claimable.kind === 'update') {
+        const updated = await db
+          .update(workspaceFiles)
+          .set({
+            chatId,
+            messageId: messageId ?? null,
+            context: 'mothership',
+            displayName: candidate,
+          })
+          .where(eq(workspaceFiles.id, claimable.id))
+          .returning({ id: workspaceFiles.id })
 
-      if (updated.length > 0) {
+        if (updated.length === 0) {
+          // The row was deleted or re-owned between the ownership check and the
+          // write. Fail closed rather than silently minting a new binding.
+          throw new WorkspaceFileKeyOwnershipError(s3Key)
+        }
+
         logger.info(
           `Linked existing file record to chat: ${fileName} (display: ${candidate}) for chat ${chatId}`
         )


### PR DESCRIPTION
## Problem

`POST /api/copilot/chat` accepted a client-supplied `fileAttachments[].key` and passed it straight into `trackChatUpload()`, which wrote it into the `workspace_files` **ownership-binding row** with no permission check and no key-ownership validation.

`workspace_files.key` is the trusted binding that `verifyFileAccess()` and the whole workspace Files feature resolve authorization from. The sibling registration path (`POST /api/workspaces/[id]/files/register`) enforces the invariant explicitly; the copilot attachment path did not.

Net effect: a **read-only** workspace member could take any other member's workspace file, re-bind it to their own private copilot chat, and make it disappear from the workspace — a write/delete capability reached from a read-only grant.

The `UPDATE` matched on `(key, workspaceId, deletedAt IS NULL)` only. It set `context='mothership'`, which removes the row from every workspace-file query (Files tab, folders, download-by-id, restore), and re-parented `chatId` to the attacker's chat — where `copilot_chats.id ON DELETE CASCADE` hard-deletes the victim's row when that chat is deleted. When no active row matched, the `INSERT` branch minted a fresh binding claiming a foreign object for the caller's workspace.

## Fix

**`trackChatUpload`** — treat `s3Key` as untrusted, applying the invariants the direct-upload path already enforces:

- Reject keys that do not resolve to the target workspace (`parseWorkspaceFileKey`).
- Only two outcomes are claimable: the caller already owns an **active chat-upload row** for the key, or the key has **no `workspace_files` record at all**. Another member's row, a `context='workspace'` file, and soft-deleted records are all rejected. (Soft-deleted matters: the active-key unique index is partial on `deleted_at IS NULL`, so an `INSERT` over an archived row would succeed and grant read access to its bytes.)
- The `UPDATE` re-asserts **every** ownership predicate rather than trusting the row id captured by the lookup, so the statement itself is the atomic check. A concurrent `materialize_file` sets `context='workspace'` and clears `chatId` on the same row; an id-only predicate would drag that saved file back into chat scope.
- The binding is a **compare-and-swap** on `chat_id` (`IS NULL OR = target`). Two overlapping requests both observe an unbound row; only the first wins, and the loser fails closed instead of stealing the upload and its delete-cascade lifecycle. This also makes an upload bind to exactly one chat, matching the 409 the sibling `local-files/stage` route already returns.
- Verify the object exists in storage before minting a new binding. This is hygiene, not authorization, so only a **definitive** not-found rejects — `headObject` rethrows provider 5xx/throttles, and failing there would drop a legitimate >50MB multipart upload (the only path that reaches this branch).

**`buildCopilotRequestPayload`** — gate attachment tracking on write/admin via the shared `permissionSatisfies` predicate, the same grant `/api/files/presigned`, `/api/files/multipart` and `/api/files/upload` already require to issue these keys.

**`local-files/stage` route** — an ownership rejection is a client error; return 403 instead of 500.

## Backward compatibility

Audited explicitly for regressions to legitimate users:

- **All upload paths still work.** `insertFileMetadata` passes `context` through verbatim as `'mothership'` with `chatId` null, so presigned and the no-cloud-storage fallback land on the UPDATE branch; multipart persists no row and lands on INSERT. Its restore branch also clears `deleted_at`, so re-uploading revives a soft-deleted row before tracking sees it.
- **Key format.** All four live key-minting paths emit `workspace/{workspaceId}/…`. `sanitizeFileName` collapses names to `[A-Za-z0-9.\-_]` and never returns empty, so the pattern holds for unicode, spaces, long names and dotfiles. A pre-#1785 prefix-less format exists but is unreachable — `trackChatUpload` postdates it and every key is freshly minted in the same request.
- **No permission tier loses access.** Owners get `admin` via an explicit row; org owners/admins are derived admins; the route is session-only (no API-key principal). A `read` member cannot obtain a key in the first place, since all three upload routes already gate on write.
- **No client flow relinks a key across chats.** Drafts are scoped per `workspaceId:chatId` and cleared on submit; every queue/retry/abort-resume path replays under a pinned chat id; no UI attaches an already-uploaded file into a new chat; forking copies blobs to fresh keys.

## Tests

`bunx vitest run lib/uploads lib/copilot app/api/files app/api/mothership app/api/workspaces` — 1718 passed. Typecheck clean; `bun run check:api-validation` passes.

Fifteen new tests cover the ownership contract, the atomicity predicate, the chat compare-and-swap, and the transient-probe tolerance. Each was verified to fail against the unfixed code — reverting the manager turns the ownership/atomicity/CAS tests red, and reverting the gate turns the permission tests red.

**Not live-tested.** Recommended smoke before production: attach a small file and a >50MB file in a chat and confirm the model reads both, then `materialize_file` one and confirm it appears in Files and the chat still sends. That covers the UPDATE branch, the INSERT + `headObject` branch, and the materialize interaction.