### PR TITLE
fix(executor): escape resolved references in while/doWhile loop conditions

### DIFF
--- a/apps/sim/executor/orchestrators/loop.test.ts
+++ b/apps/sim/executor/orchestrators/loop.test.ts
@@ -308,6 +308,62 @@ describe('LoopOrchestrator', () => {
     )
   })
 
+  describe('while condition reference interpolation', () => {
+    async function evaluateWhileConditionFor(condition: string, resolved: unknown) {
+      const resolver = { resolveSingleReference: vi.fn().mockResolvedValue(resolved) }
+      const orchestrator = new LoopOrchestrator(
+        { loopConfigs: new Map(), parallelConfigs: new Map(), nodes: new Map() } as any,
+        createState(),
+        resolver as any
+      )
+      const ctx = createContext({
+        iteration: 0,
+        currentIterationOutputs: new Map(),
+        allIterationOutputs: [],
+        loopType: 'while',
+        condition,
+      })
+
+      await orchestrator.evaluateInitialCondition(ctx, 'loop-1')
+
+      return mockExecuteInIsolatedVM.mock.calls[0][0].code as string
+    }
+
+    it('does not let a quote in a resolved value escape into expression position', async () => {
+      const payload = 'z" ) && Boolean( "INJ".length === 3 ) && Boolean( "never'
+
+      const code = await evaluateWhileConditionFor('<start.input> === "never"', payload)
+
+      expect(new Function(code)()).toBe(false)
+      expect(code).toBe(`return Boolean(${JSON.stringify(payload)} === "never")`)
+    })
+
+    it('escapes backslashes and newlines so the condition stays compilable', async () => {
+      const code = await evaluateWhileConditionFor('<start.input> === "x"', 'a\\"\nb')
+
+      expect(() => new Function(code)).not.toThrow()
+      expect(new Function(code)()).toBe(false)
+    })
+
+    it('escapes line separators that are legal in JSON but not in every JS host', async () => {
+      const code = await evaluateWhileConditionFor('<start.input> === "x"', 'a\u2028b\u2029c')
+
+      expect(code).not.toMatch(/[\u2028\u2029]/)
+      expect(new Function(code)()).toBe(false)
+    })
+
+    it.each([
+      ['TRUE', 'return Boolean(true)'],
+      [' false ', 'return Boolean(false)'],
+      [7, 'return Boolean(7)'],
+      [true, 'return Boolean(true)'],
+      [null, 'return Boolean(null)'],
+      [{ a: 1 }, 'return Boolean({"a":1})'],
+    ])('serializes %o as a literal operand', async (resolved, expected) => {
+      expect(await evaluateWhileConditionFor('<start.input>', resolved)).toBe(expected)
+    })
+  })
+
   it('exits doWhile loops when the configured iteration cap is reached', async () => {
     const { orchestrator } = createOrchestrator()
     const ctx = createContext({

--- a/apps/sim/executor/orchestrators/loop.ts
+++ b/apps/sim/executor/orchestrators/loop.ts
@@ -38,6 +38,42 @@ const logger = createLogger('LoopOrchestrator')
 
 const LOOP_CONDITION_TIMEOUT_MS = 5000
 
+/**
+ * Serializes a resolved reference value into a JavaScript literal for the loop
+ * condition expression.
+ *
+ * The result is concatenated into source that is compiled and run in the
+ * execution isolate, so every value must be emitted as a self-contained literal.
+ * Interpolating a string without escaping would let a `"` in the resolved data
+ * terminate the literal and continue in expression position.
+ */
+function formatConditionOperand(resolved: unknown): string {
+  if (typeof resolved === 'boolean' || typeof resolved === 'number') {
+    return String(resolved)
+  }
+
+  if (typeof resolved === 'string') {
+    const lower = resolved.toLowerCase().trim()
+    if (lower === 'true' || lower === 'false') {
+      return lower
+    }
+  }
+
+  return toJsLiteral(resolved)
+}
+
+/**
+ * JSON-serializes a value and escapes the code points that are valid inside a
+ * JSON string but historically hazardous inside a JavaScript source literal.
+ */
+function toJsLiteral(value: unknown): string {
+  const serialized = JSON.stringify(value)
+  if (serialized === undefined) {
+    return 'undefined'
+  }
+  return serialized.replace(/\u2028/g, String.raw`\u2028`).replace(/\u2029/g, String.raw`\u2029`)
+}
+
 async function replaceLoopConditionReferences(
   condition: string,
   replacer: (match: string) => Promise<string>
@@ -724,17 +760,7 @@ export class LoopOrchestrator {
           resolvedType: resolved === null ? 'null' : typeof resolved,
         })
         if (resolved !== undefined) {
-          if (typeof resolved === 'boolean' || typeof resolved === 'number') {
-            return String(resolved)
-          }
-          if (typeof resolved === 'string') {
-            const lower = resolved.toLowerCase().trim()
-            if (lower === 'true' || lower === 'false') {
-              return lower
-            }
-            return `"${resolved}"`
-          }
-          return JSON.stringify(resolved)
+          return formatConditionOperand(resolved)
         }
         return match
       })


### PR DESCRIPTION
## Summary
- Loop conditions inlined each resolved `<reference>` as a bare double-quoted literal, then compiled the result in the execution isolate — a quote anywhere in the referenced value terminated the literal and ran the rest as JavaScript. Reachable by an external caller on any deployed workflow with a data-driven while condition; no workflow authorship needed.
- Serialize condition operands as proper JS literals (`JSON.stringify` plus U+2028/U+2029 escaping) instead of hand-quoting, matching the escaping the condition block already does via `stringifyForCondition`.
- The number / boolean / `"true"` / `"false"` / object / `null` branches are untouched, so output is byte-identical for every value that didn't already produce broken code.
- Scoped deliberately to the escaping fix. The unbounded-iteration and error-swallowing items from the report are left for separate follow-up: once injection is closed the runaway-loop primitive is no longer externally reachable, and both changes carry regression risk for currently-working workflows that this one does not.

## Type of Change
- [x] Bug fix

## Testing
- New tests cover the injection payload (asserting the generated code evaluates to `false` and the operand is a proper literal), backslash/newline/line-separator escaping, and the full coercion table.
- Reverted the fix and confirmed the injection tests go red — the PoC payload evaluated to `true` against the old code.
- Differential harness comparing old vs new formatting across every BMP code point, realistic workflow values, and 60k fuzz strings over 7 condition templates: **1,753,381 condition evaluations, 0 cases where behavior changed without the old code being uncompilable or corrupted**. Non-string types (`NaN`, `Infinity`, `-0`, `1e21`, nested objects): 0 differences.
- `loop.test.ts` 20/20; full `executor/` suite passing apart from failures unrelated to these files.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)