### PR TITLE
fix(search): restore cross-field Cmd-K matches

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/utils.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/utils.test.ts
@@ -315,3 +315,34 @@ describe('filterAndCap', () => {
     expect(capped).toEqual(filterAndSort(items, id, 'item').slice(0, MAX_RESULTS_PER_GROUP))
   })
 })
+
+describe('filterAndSort — name vs. secondary text', () => {
+  const rows = [
+    { name: 'Leads', folder: 'Sales / EMEA' },
+    { name: 'Contacts', folder: 'Sales / AMER' },
+    { name: 'EMEA', folder: 'Archive' },
+  ]
+  const run = (search: string) =>
+    filterAndSort(
+      rows,
+      (r) => r.name,
+      search,
+      (r) => r.folder
+    ).map((r) => r.name)
+
+  it('matches a query spanning the name and the secondary text', () => {
+    expect(run('leads emea')).toEqual(['Leads'])
+  })
+
+  it('ranks a name match above a secondary-text match', () => {
+    expect(run('emea')).toEqual(['EMEA', 'Leads'])
+  })
+
+  it('still matches on secondary text alone', () => {
+    expect(run('amer')).toEqual(['Contacts'])
+  })
+
+  it('drops rows that match neither field nor the two joined', () => {
+    expect(run('zzz')).toEqual([])
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/utils.ts
@@ -244,9 +244,16 @@ const NAME_MATCH_TIER = 1_000_000
 
 /**
  * Ranks an item by its name first, falling back to secondary text (ids, aliases,
- * option labels) only when the name doesn't match — a name match always wins, so
- * an exact name hit isn't diluted by a long secondary string ("Agent" beats
- * "Pi Coding Agent" for the query "agent").
+ * option labels, folder paths) only when the name doesn't match — a name match
+ * always wins, so an exact name hit isn't diluted by a long secondary string
+ * ("Agent" beats "Pi Coding Agent" for the query "agent").
+ *
+ * When neither field matches alone the two are matched joined, so a query that
+ * spans both ("leads emea" for a `Leads` table in `EMEA`) still finds the row.
+ * That is last on purpose: matching the joined text would otherwise let a
+ * secondary hit masquerade as a name hit. Positions from the joined match do not
+ * index into either field, which is safe only because `filterAndSort` scores
+ * with them and discards them — never pass them to a highlighter.
  */
 function scoreItem(name: string, extra: string | undefined, search: string): FuzzyResult {
   const byName = fuzzyMatch(name, search)
@@ -255,7 +262,8 @@ function scoreItem(name: string, extra: string | undefined, search: string): Fuz
     return { matched: true, score: byName.score + NAME_MATCH_TIER, positions: byName.positions }
   }
   const byExtra = fuzzyMatch(extra, search)
-  return byExtra.matched ? byExtra : NO_MATCH
+  if (byExtra.matched) return byExtra
+  return fuzzyMatch(`${name} ${extra}`, search)
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #6192, fixing a regression Cursor Bugbot caught there after it merged.

#6192 moved folder paths out of the primary fuzzy haystack into `filterAndCap`'s `toExtra` parameter, so an exact name match could no longer be outranked by a folder that happened to fuzzy-match. That ranking fix was right, but `scoreItem` matches the name **or** the secondary text and never the two together — so a query spanning both stopped matching at all:

- `"leads emea"` for a `Leads` table in the `EMEA` folder → no results
- This affected workflows and files too, which had the concatenating behavior before #6192

## Fix

`scoreItem` now falls back to matching the two fields joined, but only when neither matches alone. Ordering matters: the joined attempt runs **last** so a secondary-text hit still cannot masquerade as a name hit, preserving the ranking #6192 established.

Positions from the joined match don't index into either field — safe here only because `filterAndSort` scores with them and discards them. Called that out in the TSDoc so nobody later feeds them to a highlighter.

## Type of Change
- [x] Bug fix

## Testing
- 4 new tests covering cross-field match, name-beats-secondary ranking, secondary-only match, and non-match
- Mutation-checked: reverting the fix turns the cross-field test red
- `tsc` and `bun run lint:check` pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)