### PR TITLE
fix(tooltip): stop text blurring for ~150ms every time a tooltip appears

### DIFF
--- a/packages/emcn/src/components/tooltip/tooltip.tsx
+++ b/packages/emcn/src/components/tooltip/tooltip.tsx
@@ -11,13 +11,18 @@ const EDGE_THRESHOLD = 360
 const MIN_FRAME_MS = 16
 
 /**
- * How much of the gap between the smoothed and the instantaneous pointer velocity
- * is closed per pointer event. This is what softens the velocity flourish — the
- * transform itself is never handed to a CSS transition, because a compositor-
- * interpolated fractional scale forces the tooltip's rasterized text to be
- * resampled, which reads as a blur until the interpolation settles.
+ * Exponential time constant for smoothing the pointer velocity that drives the
+ * flourish, in ms. The flourish is deliberately never handed to a CSS transition:
+ * Chrome only re-rasters a layer at its new scale when the scale changes via
+ * script, not when a declarative animation interpolates it, so a transitioned
+ * fractional scale leaves the tooltip's text resampled from a stale bitmap until
+ * the animation settles — which is what read as a blur on every appear.
+ *
+ * Smoothing here replaces the smoothing that transition used to provide. ~3x the
+ * time constant is where the value has effectively settled, so 50ms reproduces
+ * the feel of the 150ms ease-out it stands in for.
  */
-const VELOCITY_SMOOTHING = 0.35
+const VELOCITY_TIME_CONSTANT_MS = 50
 
 /**
  * Resolved position and motion of a floating tooltip. `x`/`y` are whole-pixel
@@ -146,14 +151,19 @@ export function useFloatingTooltip(canShow: (target: HTMLElement) => boolean): {
         if (!canShowRef.current(event.currentTarget)) return
         const now = performance.now()
         const previous = lastPointerRef.current
-        const elapsed = previous ? Math.max(now - previous.time, MIN_FRAME_MS) : MIN_FRAME_MS
-        const instantX = previous ? ((event.clientX - previous.x) / elapsed) * MIN_FRAME_MS : 0
-        const instantY = previous ? ((event.clientY - previous.y) / elapsed) * MIN_FRAME_MS : 0
+        const delta = previous ? Math.max(now - previous.time, 1) : MIN_FRAME_MS
+        const perFrame = Math.max(delta, MIN_FRAME_MS)
+        const instantX = previous ? ((event.clientX - previous.x) / perFrame) * MIN_FRAME_MS : 0
+        const instantY = previous ? ((event.clientY - previous.y) / perFrame) * MIN_FRAME_MS : 0
 
+        /**
+         * Derived from the real elapsed time rather than applied per event, so a
+         * 120Hz pointer and a 60Hz one settle over the same wall-clock duration.
+         */
+        const smoothing = 1 - Math.exp(-delta / VELOCITY_TIME_CONSTANT_MS)
         const velocity = velocityRef.current
-        velocity.x += (instantX - velocity.x) * VELOCITY_SMOOTHING
-        velocity.magnitude +=
-          (Math.hypot(instantX, instantY) - velocity.magnitude) * VELOCITY_SMOOTHING
+        velocity.x += (instantX - velocity.x) * smoothing
+        velocity.magnitude += (Math.hypot(instantX, instantY) - velocity.magnitude) * smoothing
 
         lastPointerRef.current = { x: event.clientX, y: event.clientY, time: now }
         apply(event.clientX, event.clientY, {

--- a/packages/emcn/src/components/tooltip/tooltip.tsx
+++ b/packages/emcn/src/components/tooltip/tooltip.tsx
@@ -119,16 +119,28 @@ export function useFloatingTooltip(canShow: (target: HTMLElement) => boolean): {
       )
     }
 
-    const showNeutral = (clientX: number, clientY: number) => {
+    /** Reveals the tooltip at the pointer, seeding velocity tracking from it. */
+    const showFromPointer = (clientX: number, clientY: number) => {
       reset()
       lastPointerRef.current = { x: clientX, y: clientY, time: performance.now() }
+      apply(clientX, clientY, NEUTRAL_MOTION)
+    }
+
+    /**
+     * Reveals the tooltip anchored to an element's box rather than the pointer.
+     * Velocity tracking stays cleared: seeding it from the box would make the next
+     * `pointermove` read the box-to-cursor delta as velocity and spike the flourish
+     * when the pointer already happens to be over the trigger.
+     */
+    const showFromElement = (clientX: number, clientY: number) => {
+      reset()
       apply(clientX, clientY, NEUTRAL_MOTION)
     }
 
     return {
       onPointerEnter: (event) => {
         if (!canShowRef.current(event.currentTarget)) return
-        showNeutral(event.clientX, event.clientY)
+        showFromPointer(event.clientX, event.clientY)
       },
       onPointerMove: (event) => {
         if (!canShowRef.current(event.currentTarget)) return
@@ -157,7 +169,7 @@ export function useFloatingTooltip(canShow: (target: HTMLElement) => boolean): {
         if (!canShowRef.current(target)) return
         if (!isFocusVisible(target)) return
         const rect = target.getBoundingClientRect()
-        showNeutral(rect.left + rect.width / 2, rect.bottom)
+        showFromElement(rect.left + rect.width / 2, rect.bottom)
       },
       onBlur: hide,
     }

--- a/packages/emcn/src/components/tooltip/tooltip.tsx
+++ b/packages/emcn/src/components/tooltip/tooltip.tsx
@@ -8,18 +8,47 @@ import { cn } from '../../lib/cn'
 const TOOLTIP_OFFSET = 16
 const EDGE_GUTTER = 16
 const EDGE_THRESHOLD = 360
+const MIN_FRAME_MS = 16
 
 /**
- * Resolved position of a floating tooltip. `x`/`y` are whole-pixel viewport
- * coordinates the tooltip anchors to; `alignX`/`alignY` flip the tooltip away
- * from the nearest viewport edge.
+ * How much of the gap between the smoothed and the instantaneous pointer velocity
+ * is closed per pointer event. This is what softens the velocity flourish — the
+ * transform itself is never handed to a CSS transition, because a compositor-
+ * interpolated fractional scale forces the tooltip's rasterized text to be
+ * resampled, which reads as a blur until the interpolation settles.
+ */
+const VELOCITY_SMOOTHING = 0.35
+
+/**
+ * Resolved position and motion of a floating tooltip. `x`/`y` are whole-pixel
+ * viewport coordinates the tooltip anchors to; `alignX`/`alignY` flip the tooltip
+ * away from the nearest viewport edge; `skew`/`scale*` add the velocity-reactive
+ * flourish while the pointer is moving.
  */
 export interface FloatingTooltipState {
   visible: boolean
   x: number
   y: number
+  skew: number
+  scaleX: number
+  scaleY: number
   alignX: 'left' | 'right'
   alignY: 'above' | 'below'
+}
+
+/** Velocity-derived flourish applied to the tooltip on a given frame. */
+interface TooltipMotion {
+  skew: number
+  scaleX: number
+  scaleY: number
+}
+
+const NEUTRAL_MOTION: TooltipMotion = { skew: 0, scaleX: 1, scaleY: 1 }
+
+interface PointerSnapshot {
+  x: number
+  y: number
+  time: number
 }
 
 /**
@@ -39,6 +68,7 @@ const HIDDEN_STATE: FloatingTooltipState = {
   visible: false,
   x: 0,
   y: 0,
+  ...NEUTRAL_MOTION,
   alignX: 'left',
   alignY: 'below',
 }
@@ -57,32 +87,68 @@ export function useFloatingTooltip(canShow: (target: HTMLElement) => boolean): {
   const canShowRef = React.useRef(canShow)
   canShowRef.current = canShow
 
+  const lastPointerRef = React.useRef<PointerSnapshot | null>(null)
+  const velocityRef = React.useRef({ x: 0, magnitude: 0 })
   const [state, setState] = React.useState<FloatingTooltipState>(HIDDEN_STATE)
 
   const handlers = React.useMemo<FloatingTooltipHandlers>(() => {
-    const hide = () => setState((current) => (current.visible ? HIDDEN_STATE : current))
+    const reset = () => {
+      lastPointerRef.current = null
+      velocityRef.current.x = 0
+      velocityRef.current.magnitude = 0
+    }
 
-    const show = (clientX: number, clientY: number) => {
-      const next = getTooltipPosition(clientX, clientY)
+    const hide = () => {
+      reset()
+      setState((current) => (current.visible ? HIDDEN_STATE : current))
+    }
+
+    const apply = (clientX: number, clientY: number, motion: TooltipMotion) => {
+      const next = { ...getTooltipPosition(clientX, clientY), ...motion }
       setState((current) =>
         current.visible &&
         current.x === next.x &&
         current.y === next.y &&
         current.alignX === next.alignX &&
-        current.alignY === next.alignY
+        current.alignY === next.alignY &&
+        current.skew === next.skew &&
+        current.scaleX === next.scaleX &&
+        current.scaleY === next.scaleY
           ? current
           : { visible: true, ...next }
       )
     }
 
+    const showNeutral = (clientX: number, clientY: number) => {
+      reset()
+      lastPointerRef.current = { x: clientX, y: clientY, time: performance.now() }
+      apply(clientX, clientY, NEUTRAL_MOTION)
+    }
+
     return {
       onPointerEnter: (event) => {
         if (!canShowRef.current(event.currentTarget)) return
-        show(event.clientX, event.clientY)
+        showNeutral(event.clientX, event.clientY)
       },
       onPointerMove: (event) => {
         if (!canShowRef.current(event.currentTarget)) return
-        show(event.clientX, event.clientY)
+        const now = performance.now()
+        const previous = lastPointerRef.current
+        const elapsed = previous ? Math.max(now - previous.time, MIN_FRAME_MS) : MIN_FRAME_MS
+        const instantX = previous ? ((event.clientX - previous.x) / elapsed) * MIN_FRAME_MS : 0
+        const instantY = previous ? ((event.clientY - previous.y) / elapsed) * MIN_FRAME_MS : 0
+
+        const velocity = velocityRef.current
+        velocity.x += (instantX - velocity.x) * VELOCITY_SMOOTHING
+        velocity.magnitude +=
+          (Math.hypot(instantX, instantY) - velocity.magnitude) * VELOCITY_SMOOTHING
+
+        lastPointerRef.current = { x: event.clientX, y: event.clientY, time: now }
+        apply(event.clientX, event.clientY, {
+          skew: quantize(clamp(velocity.x * 0.11, -6, 6)),
+          scaleX: quantize(1 + Math.min(0.035, velocity.magnitude / 1100)),
+          scaleY: quantize(1 - Math.min(0.02, velocity.magnitude / 1500)),
+        })
       },
       onPointerLeave: hide,
       onPointerDown: hide,
@@ -91,7 +157,7 @@ export function useFloatingTooltip(canShow: (target: HTMLElement) => boolean): {
         if (!canShowRef.current(target)) return
         if (!isFocusVisible(target)) return
         const rect = target.getBoundingClientRect()
-        show(rect.left + rect.width / 2, rect.bottom)
+        showNeutral(rect.left + rect.width / 2, rect.bottom)
       },
       onBlur: hide,
     }
@@ -160,6 +226,14 @@ export function clamp(value: number, min: number, max: number): number {
 }
 
 /**
+ * Rounds a flourish value to 3 decimals so pointer jitter below the visible
+ * threshold settles to a stable number instead of re-rendering every consumer.
+ */
+function quantize(value: number): number {
+  return Math.round(value * 1000) / 1000
+}
+
+/**
  * Whether an element currently matches `:focus-visible` (keyboard focus, not focus produced by a
  * mouse click). Used to keep the tooltip from re-appearing/repositioning when the trigger is
  * clicked. Falls back to `true` where the selector can't be queried.
@@ -211,11 +285,16 @@ export const FloatingTooltip = React.memo(function FloatingTooltip({
       aria-hidden={role ? undefined : 'true'}
       data-native-surface-overlay=''
       className={cn(
-        'pointer-events-none fixed top-0 left-0 z-[var(--z-tooltip)] w-fit max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border border-[var(--border)] bg-[var(--bg)] px-2 py-1.5 text-[var(--text-body)] text-caption opacity-100 shadow-sm transition-[opacity,transform] duration-150 ease-out',
+        'pointer-events-none fixed top-0 left-0 z-[var(--z-tooltip)] w-fit max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border border-[var(--border)] bg-[var(--bg)] px-2 py-1.5 text-[var(--text-body)] text-caption opacity-100 shadow-sm transition-[opacity,translate] duration-150 ease-out',
         'motion-reduce:transition-none',
         className
       )}
-      style={{ transform: getTooltipTranslate(state, offset) }}
+      style={{
+        translate: getTooltipTranslate(state, offset),
+        scale: `${state.scaleX} ${state.scaleY}`,
+        transform: `skew(${state.skew}deg)`,
+        transformOrigin: state.alignX === 'left' ? '12px 12px' : 'calc(100% - 12px) 12px',
+      }}
     >
       {children ?? <span className='block whitespace-normal break-words text-left'>{label}</span>}
     </div>,
@@ -242,11 +321,17 @@ function getTooltipPosition(
   }
 }
 
+/**
+ * Value for the `translate` CSS property. Kept off the `transform` property so the
+ * velocity flourish (`scale` + `transform: skew()`) can stay out of the transition
+ * list while the tooltip's position still eases toward the cursor.
+ */
 function getTooltipTranslate(state: FloatingTooltipState, offset: number): string {
-  const xOffset = state.alignX === 'left' ? `${offset}px` : `calc(-100% - ${offset}px)`
-  const yOffset = state.alignY === 'below' ? `${offset}px` : `calc(-100% - ${offset}px)`
+  const x = state.alignX === 'left' ? `${state.x + offset}px` : `calc(${state.x - offset}px - 100%)`
+  const y =
+    state.alignY === 'below' ? `${state.y + offset}px` : `calc(${state.y - offset}px - 100%)`
 
-  return `translate3d(${state.x}px, ${state.y}px, 0) translate(${xOffset}, ${yOffset})`
+  return `${x} ${y}`
 }
 
 /**

--- a/packages/emcn/src/components/tooltip/tooltip.tsx
+++ b/packages/emcn/src/components/tooltip/tooltip.tsx
@@ -8,29 +8,18 @@ import { cn } from '../../lib/cn'
 const TOOLTIP_OFFSET = 16
 const EDGE_GUTTER = 16
 const EDGE_THRESHOLD = 360
-const MIN_FRAME_MS = 16
 
 /**
- * Resolved position and motion of a floating tooltip. `x`/`y` are viewport
+ * Resolved position of a floating tooltip. `x`/`y` are whole-pixel viewport
  * coordinates the tooltip anchors to; `alignX`/`alignY` flip the tooltip away
- * from the nearest viewport edge; `skew`/`scale*` add the velocity-reactive
- * flourish while the pointer is moving.
+ * from the nearest viewport edge.
  */
 export interface FloatingTooltipState {
   visible: boolean
   x: number
   y: number
-  skew: number
-  scaleX: number
-  scaleY: number
   alignX: 'left' | 'right'
   alignY: 'above' | 'below'
-}
-
-interface PointerSnapshot {
-  x: number
-  y: number
-  time: number
 }
 
 /**
@@ -50,9 +39,6 @@ const HIDDEN_STATE: FloatingTooltipState = {
   visible: false,
   x: 0,
   y: 0,
-  skew: 0,
-  scaleX: 1,
-  scaleY: 1,
   alignX: 'left',
   alignY: 'below',
 }
@@ -71,48 +57,32 @@ export function useFloatingTooltip(canShow: (target: HTMLElement) => boolean): {
   const canShowRef = React.useRef(canShow)
   canShowRef.current = canShow
 
-  const lastPointerRef = React.useRef<PointerSnapshot | null>(null)
   const [state, setState] = React.useState<FloatingTooltipState>(HIDDEN_STATE)
 
   const handlers = React.useMemo<FloatingTooltipHandlers>(() => {
-    const hide = () => {
-      lastPointerRef.current = null
-      setState((current) => (current.visible ? HIDDEN_STATE : current))
-    }
+    const hide = () => setState((current) => (current.visible ? HIDDEN_STATE : current))
 
-    const showStatic = (clientX: number, clientY: number) => {
-      lastPointerRef.current = { x: clientX, y: clientY, time: performance.now() }
-      setState({
-        visible: true,
-        ...getTooltipPosition(clientX, clientY),
-        skew: 0,
-        scaleX: 1,
-        scaleY: 1,
-      })
+    const show = (clientX: number, clientY: number) => {
+      const next = getTooltipPosition(clientX, clientY)
+      setState((current) =>
+        current.visible &&
+        current.x === next.x &&
+        current.y === next.y &&
+        current.alignX === next.alignX &&
+        current.alignY === next.alignY
+          ? current
+          : { visible: true, ...next }
+      )
     }
 
     return {
       onPointerEnter: (event) => {
         if (!canShowRef.current(event.currentTarget)) return
-        showStatic(event.clientX, event.clientY)
+        show(event.clientX, event.clientY)
       },
       onPointerMove: (event) => {
         if (!canShowRef.current(event.currentTarget)) return
-        const now = performance.now()
-        const previous = lastPointerRef.current
-        const elapsed = previous ? Math.max(now - previous.time, MIN_FRAME_MS) : MIN_FRAME_MS
-        const velocityX = previous ? ((event.clientX - previous.x) / elapsed) * MIN_FRAME_MS : 0
-        const velocityY = previous ? ((event.clientY - previous.y) / elapsed) * MIN_FRAME_MS : 0
-        const velocity = Math.hypot(velocityX, velocityY)
-
-        lastPointerRef.current = { x: event.clientX, y: event.clientY, time: now }
-        setState({
-          visible: true,
-          ...getTooltipPosition(event.clientX, event.clientY),
-          skew: clamp(velocityX * 0.11, -6, 6),
-          scaleX: 1 + Math.min(0.035, velocity / 1100),
-          scaleY: 1 - Math.min(0.02, velocity / 1500),
-        })
+        show(event.clientX, event.clientY)
       },
       onPointerLeave: hide,
       onPointerDown: hide,
@@ -121,14 +91,7 @@ export function useFloatingTooltip(canShow: (target: HTMLElement) => boolean): {
         if (!canShowRef.current(target)) return
         if (!isFocusVisible(target)) return
         const rect = target.getBoundingClientRect()
-        lastPointerRef.current = null
-        setState({
-          visible: true,
-          ...getTooltipPosition(rect.left + rect.width / 2, rect.bottom),
-          skew: 0,
-          scaleX: 1,
-          scaleY: 1,
-        })
+        show(rect.left + rect.width / 2, rect.bottom)
       },
       onBlur: hide,
     }
@@ -248,14 +211,11 @@ export const FloatingTooltip = React.memo(function FloatingTooltip({
       aria-hidden={role ? undefined : 'true'}
       data-native-surface-overlay=''
       className={cn(
-        'pointer-events-none fixed top-0 left-0 z-[var(--z-tooltip)] w-fit max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border border-[var(--border)] bg-[var(--bg)] px-2 py-1.5 text-[var(--text-body)] text-caption opacity-100 shadow-sm transition-[opacity,filter,transform] duration-150 ease-out',
+        'pointer-events-none fixed top-0 left-0 z-[var(--z-tooltip)] w-fit max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border border-[var(--border)] bg-[var(--bg)] px-2 py-1.5 text-[var(--text-body)] text-caption opacity-100 shadow-sm transition-[opacity,transform] duration-150 ease-out',
         'motion-reduce:transition-none',
         className
       )}
-      style={{
-        transform: `${getTooltipTranslate(state, offset)} skew(${state.skew}deg) scale(${state.scaleX}, ${state.scaleY})`,
-        transformOrigin: state.alignX === 'left' ? '12px 12px' : 'calc(100% - 12px) 12px',
-      }}
+      style={{ transform: getTooltipTranslate(state, offset) }}
     >
       {children ?? <span className='block whitespace-normal break-words text-left'>{label}</span>}
     </div>,
@@ -268,15 +228,15 @@ function getTooltipPosition(
   clientY: number
 ): Pick<FloatingTooltipState, 'x' | 'y' | 'alignX' | 'alignY'> {
   if (typeof window === 'undefined') {
-    return { x: clientX, y: clientY, alignX: 'left', alignY: 'below' }
+    return { x: Math.round(clientX), y: Math.round(clientY), alignX: 'left', alignY: 'below' }
   }
 
   const alignX = window.innerWidth - clientX < EDGE_THRESHOLD ? 'right' : 'left'
   const alignY = window.innerHeight - clientY < EDGE_THRESHOLD / 2 ? 'above' : 'below'
 
   return {
-    x: clamp(clientX, EDGE_GUTTER, window.innerWidth - EDGE_GUTTER),
-    y: clamp(clientY, EDGE_GUTTER, window.innerHeight - EDGE_GUTTER),
+    x: Math.round(clamp(clientX, EDGE_GUTTER, window.innerWidth - EDGE_GUTTER)),
+    y: Math.round(clamp(clientY, EDGE_GUTTER, window.innerHeight - EDGE_GUTTER)),
     alignX,
     alignY,
   }


### PR DESCRIPTION
## Summary
- Every tooltip rendered blurry for ~150ms on appear, then snapped crisp
- Cause: the bubble handed a fractional `scale()` + `skew()` to a 150ms CSS transition. Chrome promotes it to a compositor layer, rasterizes the text **once** at the pre-transition scale, then resamples that bitmap for the duration — text stays soft until the transition ends and the layer re-rasterizes at 1:1
- It fired on every single appear: a pointer entering a trigger is by definition moving, so the first `pointermove` after `pointerenter` always set a non-zero skew and a fractional scale
- The flourish itself was never the problem — letting the **compositor interpolate** it was. So it's kept, just driven differently:
  - Split the transform across the individual `translate`, `scale`, and `transform: skew()` properties, and transition only `translate`. Position still eases toward the cursor; the flourish is a static value on every frame, so each frame rasterizes at its own scale
  - Smooth the pointer velocity in JS (low-pass filter) to replace the smoothing the CSS transition used to provide, so the squish still ramps instead of snapping between raw per-event velocities
  - Quantize the flourish to 3 decimals so sub-visible jitter settles instead of re-rendering every consumer
- Round tooltip position to whole pixels — `clientX`/`clientY` are fractional on HiDPI/zoomed displays, parking the bubble on a subpixel boundary
- Drop the dead `filter` from the transition list; nothing ever set a filter (leftover from an older blur-in animation)
- Skip the state update when nothing resolved differently, so pointer jitter no longer re-renders every `Tooltip.Trigger`/`Content` consumer on each mouse move

Net effect: same cursor-following trail, same velocity squish, without the compositor resampling the text.

## Type of Change
- [x] Bug fix

## Testing
`tsc` clean on `apps/sim`, `packages/emcn`, `packages/workflow-renderer`, `apps/desktop`, `apps/realtime`. Existing tests that render tooltip consumers pass (19/19). No tests or stories cover the tooltip directly.

Still needs a visual check on real GPU compositing — the artifact can't be captured headlessly, since screenshot capture forces the re-rasterization that makes the transient state look crisp by construction.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)