### PR TITLE
improvement(ci): move CodeQL off default setup onto Blacksmith

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,27 @@
+name: Sim CodeQL config
+
+# Trims the extraction surface. CodeQL parses every matching file into a
+# database before a single query runs, and that phase dominates runtime on a
+# ~12.7k-file JS/TS tree. Test and fixture code is not attacker-reachable, so
+# excluding it costs no real coverage.
+#
+# paths-ignore applies to analysis. The workflow's `on.pull_request.paths`
+# filter is separate and decides whether the run happens at all.
+paths-ignore:
+  - '**/*.test.ts'
+  - '**/*.test.tsx'
+  - '**/*.test.js'
+  - '**/*.spec.ts'
+  - '**/*.spec.tsx'
+  - '**/__tests__/**'
+  - '**/__mocks__/**'
+  - '**/__fixtures__/**'
+  - '**/test/**'
+  - '**/tests/**'
+  - '**/testing/**'
+  - '**/e2e/**'
+  - '**/*.d.ts'
+  - '**/node_modules/**'
+  - '**/dist/**'
+  - '**/.next/**'
+  - 'apps/docs/content/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -16,10 +16,16 @@ paths-ignore:
   - '**/__tests__/**'
   - '**/__mocks__/**'
   - '**/__fixtures__/**'
-  - '**/test/**'
-  - '**/tests/**'
-  - '**/testing/**'
   - '**/e2e/**'
+  # Deliberately no '**/test/**' or '**/tests/**'. A directory named `test` is a
+  # routable Next.js path segment, not necessarily test code: those globs
+  # excluded the real endpoint
+  # apps/sim/app/api/organizations/[id]/data-drains/[drainId]/test/route.ts,
+  # which authorizes, decrypts destination credentials, and makes an outbound
+  # request. CodeQL's paths-ignore has no `!` negation to carve it back out
+  # ("The filter pattern characters ?, +, [, ], and ! are not supported and will
+  # be matched literally"), and the globs only covered 76 of 12,716 files, so
+  # the naming convention above is the safer filter.
   - '**/*.d.ts'
   - '**/node_modules/**'
   - '**/dist/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,8 +22,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main, staging]
-    # Draft PRs are excluded via the job-level `if`, not here: `types` would
-    # also have to re-list the default event types to keep synchronize working.
+    # `ready_for_review` is not a default activity type, so it has to be listed
+    # alongside the defaults it replaces. Without it, a PR opened as a draft and
+    # then marked ready is skipped by the job-level draft guard and never
+    # rescanned until the next push.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '**/*.ts'
       - '**/*.tsx'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,91 @@
+name: CodeQL
+
+# Advanced setup, replacing the repo-settings "default setup".
+#
+# Default setup pinned every scan to a 4-vCPU GitHub-hosted runner with no
+# cancel-in-progress, which put PR scans at 30-125 min and re-ran them on every
+# push (PR #6183 burned six overlapping runs). None of that is configurable from
+# the settings UI, so the config moves into the repo.
+#
+# Before enabling this, disable default setup or the two will both run:
+#   gh api -X PATCH repos/:owner/:repo/code-scanning/default-setup -f state=not-configured
+#
+# The runs-on expression is the same CI_PROVIDER escape hatch as ci.yml and must
+# change together with it.
+
+on:
+  # Pushes to main are infrequent (merges only), so a full scan per push is
+  # affordable and is what GitHub recommends pairing with the PR trigger:
+  # "Scanning code when someone pushes a change, and whenever a pull request is
+  # created, prevents developers from introducing new vulnerabilities."
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, staging]
+    # Draft PRs are excluded via the job-level `if`, not here: `types` would
+    # also have to re-list the default event types to keep synchronize working.
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/*.mjs'
+      - '**/*.cjs'
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/codeql/**'
+  schedule:
+    # Safety net behind the push trigger, and the thing that keeps the
+    # default-branch alert view fresh when main is quiet. Only fires once this
+    # file is on the default branch — schedule events ignore other branches.
+    - cron: '17 8 * * *'
+  workflow_dispatch:
+
+# Scheduled main scans must run to completion — only PR pushes supersede.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-latest' }}
+    timeout-minutes: 60
+    if: github.event.pull_request.draft != true
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # One entry covers both JS and TS — `javascript`, `typescript` and
+        # `javascript-typescript` all resolve to the same extractor
+        # (github/codeql-action src/languages/builtin.json), so the three
+        # entries default setup listed were one analysis, not three.
+        # `javascript-typescript` is the documented spelling. Python dropped:
+        # 7 files in the tree.
+        language: [javascript-typescript, actions]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
CodeQL was running via GitHub Advanced Security **default setup** — no workflow file, so no control over runner, triggers, or concurrency. Result: PR scans of 30–125 min on a 4-vCPU GitHub-hosted runner, re-running on every push. PR #6183 alone burned six overlapping runs (94/96/100/100/125/93 min).

This replaces it with advanced setup. **Default setup has already been disabled** — the two cannot both be active.

## Changes

- **Blacksmith 8-vCPU** via the same `CI_PROVIDER` escape-hatch expression as `ci.yml`
- **`cancel-in-progress` scoped to `pull_request`**, mirroring `ci.yml:31`, so push and scheduled scans still run to completion
- **Triggers**: push to `main` + PR to `main`/`staging` + nightly safety net + `workflow_dispatch`
- **`paths` filter** so doc/config-only PRs skip the run entirely
- **`paths-ignore` config** dropping tests/mocks/fixtures: 12,716 → 11,128 extracted files
- **`languages: [javascript-typescript, actions]`** — python dropped (7 files in the tree)
- Draft-PR skip, `persist-credentials: false`, SHA-pinned actions, `timeout-minutes: 60`

## On the language list

Default setup listed `javascript`, `javascript-typescript` and `typescript`. Those are **aliases of one extractor** (`github/codeql-action` → `src/languages/builtin.json`), so it was always a single analysis, not three — the logs show `Extracting javascript` once. Not a source of the slowness.

## Prior art

Modelled on how comparable OSS repos configure this. Notably, none of n8n, cal.com, supabase, twenty, PostHog, medusa, next.js or trigger.dev commit a CodeQL workflow at all. Among those that do:

| | Trigger | Runner | Languages | cancel-in-progress |
|---|---|---|---|---|
| elastic/kibana | PR (paths, non-draft, gated) + nightly | self-hosted | `javascript` | gated instead |
| getsentry/sentry | PR (paths, `!tests/**`) + weekly | ubuntu-latest | js, python | yes |
| immich-app/immich | push + PR + weekly | ubuntu-latest | js, python | yes |
| directus/directus | nightly only | ubuntu-latest | `javascript` | — |
| prisma/prisma | weekly only | ubuntu-latest | `javascript` | — |
| nodejs/node | nightly only | ubuntu-slim | cpp, js, python | — |

Kibana is the closest analogue (large TS tree) and solves it the same way: dedicated runner + aggressive `paths-ignore`.

Not adopted: kibana's `CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES: true`. It is the largest single speedup available, but a GitHub code search returns 4 hits worldwide (kibana + a fork), it is undocumented, and it weakens type-based taint tracking. Available as an escape hatch if runtimes are still unacceptable.

## Verification owed

- [ ] Confirm actual runtime on this PR (expectation ~10–20 min, unproven)
- [ ] Confirm no SOC2/Vanta control requires the Python language or the previous cadence