### PR TITLE
refactor(chat): clean up the deployed chat surface

### DIFF
--- a/apps/sim/app/(interfaces)/chat/[identifier]/chat.tsx
+++ b/apps/sim/app/(interfaces)/chat/[identifier]/chat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type RefObject, useCallback, useMemo, useRef, useState } from 'react'
 import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
 import {
@@ -25,6 +25,8 @@ import { useDeployedChatConfig } from '@/hooks/queries/chats'
 import { useGitHubStars } from '@/hooks/queries/github-stars'
 
 const logger = createLogger('ChatClient')
+
+const NEAR_BOTTOM_THRESHOLD_PX = 100
 
 interface ChatRequestFile {
   name: string
@@ -87,13 +89,11 @@ export default function ChatClient({ identifier }: { identifier: string }) {
   const { isStreamingResponse, abortControllerRef, stopStreaming, handleStreamedResponse } =
     useChatStreaming()
 
-  const NEAR_BOTTOM_THRESHOLD_PX = 100
-
   /**
    * ChatGPT-style scroll. Without `force`, no-ops when the user has scrolled away.
    * With `force` (jump button), re-pins to bottom.
    */
-  const scrollToBottom = useCallback((options?: { behavior?: ScrollBehavior; force?: boolean }) => {
+  const scrollToBottom = (options?: { behavior?: ScrollBehavior; force?: boolean }) => {
     const behavior = options?.behavior ?? 'smooth'
     const force = options?.force === true
     if (!force && !stickToBottomRef.current) return
@@ -112,52 +112,46 @@ export default function ChatClient({ identifier }: { identifier: string }) {
       },
       behavior === 'smooth' ? 400 : 50
     )
-  }, [])
+  }
 
-  const scrollToMessage = useCallback(
-    (messageId: string, scrollToShowOnlyMessage = false) => {
-      const messageElement = document.querySelector(`[data-message-id="${messageId}"]`)
-      if (messageElement && messagesContainerRef.current) {
-        const container = messagesContainerRef.current
-        const containerRect = container.getBoundingClientRect()
-        const messageRect = messageElement.getBoundingClientRect()
+  const scrollToMessage = (messageId: string) => {
+    const messageElement = document.querySelector(`[data-message-id="${messageId}"]`)
+    if (!messageElement || !messagesContainerRef.current) return
 
-        if (scrollToShowOnlyMessage) {
-          const scrollTop = container.scrollTop + messageRect.top - containerRect.top
-
-          container.scrollTo({
-            top: scrollTop,
-            behavior: 'smooth',
-          })
-        } else {
-          const scrollTop = container.scrollTop + messageRect.top - containerRect.top - 80
-
-          container.scrollTo({
-            top: scrollTop,
-            behavior: 'smooth',
-          })
-        }
-      }
-    },
-    [messagesContainerRef]
-  )
-
-  useEffect(() => {
     const container = messagesContainerRef.current
-    if (!container) return
+    const containerRect = container.getBoundingClientRect()
+    const messageRect = messageElement.getBoundingClientRect()
+
+    container.scrollTo({
+      top: container.scrollTop + messageRect.top - containerRect.top,
+      behavior: 'smooth',
+    })
+  }
+
+  /**
+   * Attaches on mount via a ref callback rather than an effect: the container
+   * renders only after the auth/loading early returns, so an effect would need
+   * unrelated render values as a stand-in for "the node exists yet".
+   */
+  const attachMessagesContainer = useCallback((node: HTMLDivElement | null) => {
+    messagesContainerRef.current = node
+    if (!node) return
 
     const handleScroll = () => {
       if (ignoreScrollRef.current) return
-      const { scrollTop, scrollHeight, clientHeight } = container
+      const { scrollTop, scrollHeight, clientHeight } = node
       const distanceFromBottom = scrollHeight - scrollTop - clientHeight
       const nearBottom = distanceFromBottom <= NEAR_BOTTOM_THRESHOLD_PX
       stickToBottomRef.current = nearBottom
       setShowScrollButton(!nearBottom)
     }
 
-    container.addEventListener('scroll', handleScroll, { passive: true })
-    return () => container.removeEventListener('scroll', handleScroll)
-  }, [chatConfig, authRequired])
+    node.addEventListener('scroll', handleScroll, { passive: true })
+    return () => {
+      node.removeEventListener('scroll', handleScroll)
+      messagesContainerRef.current = null
+    }
+  }, [])
 
   const handleSendMessage = async (
     messageToSend: string,
@@ -199,7 +193,7 @@ export default function ChatClient({ identifier }: { identifier: string }) {
     setIsLoading(true)
 
     setTimeout(() => {
-      scrollToMessage(userMessage.id, true)
+      scrollToMessage(userMessage.id)
     }, 100)
 
     // One AbortController for fetch + SSE body reads so Stop cancels server work too.
@@ -314,7 +308,7 @@ export default function ChatClient({ identifier }: { identifier: string }) {
   }
 
   return (
-    <div className='light desktop-title-bar-page fixed inset-0 z-[100] flex flex-col bg-[var(--bg)] text-[var(--text-primary)]'>
+    <div className='light desktop-title-bar-page fixed inset-0 z-[var(--z-dropdown)] flex flex-col bg-[var(--bg)] text-[var(--text-primary)]'>
       <DesktopTitleBarLane />
       <ChatHeader chatConfig={chatConfig} starCount={starCount} />
 
@@ -322,10 +316,9 @@ export default function ChatClient({ identifier }: { identifier: string }) {
         messages={displayMessages}
         isLoading={isLoading}
         showScrollButton={showScrollButton}
-        messagesContainerRef={messagesContainerRef as RefObject<HTMLDivElement>}
+        messagesContainerRef={attachMessagesContainer}
         messagesEndRef={messagesEndRef as RefObject<HTMLDivElement>}
         scrollToBottom={() => scrollToBottom({ behavior: 'smooth', force: true })}
-        scrollToMessage={scrollToMessage}
         chatConfig={chatConfig}
       />
 

--- a/apps/sim/app/(interfaces)/chat/[identifier]/loading.tsx
+++ b/apps/sim/app/(interfaces)/chat/[identifier]/loading.tsx
@@ -3,7 +3,7 @@ import { DesktopTitleBarLane } from '@/app/_shell/desktop-title-bar'
 
 export default function ChatLoading() {
   return (
-    <div className='light desktop-title-bar-page fixed inset-0 z-[100] flex flex-col bg-[var(--bg)] text-[var(--text-primary)]'>
+    <div className='light desktop-title-bar-page fixed inset-0 z-[var(--z-dropdown)] flex flex-col bg-[var(--bg)] text-[var(--text-primary)]'>
       <DesktopTitleBarLane />
       <div className='border-[var(--border-1)] border-b px-4 py-3'>
         <div className='mx-auto flex max-w-3xl items-center justify-between'>

--- a/apps/sim/app/(interfaces)/chat/components/auth/email/email-auth.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/auth/email/email-auth.tsx
@@ -35,7 +35,7 @@ export default function EmailAuth({ identifier }: EmailAuthProps) {
   const [email, setEmail] = useState('')
   const [authError, setAuthError] = useState<string | null>(null)
   const [emailErrors, setEmailErrors] = useState<string[]>([])
-  const [showEmailValidationError, setShowEmailValidationError] = useState(false)
+  const hasEmailError = emailErrors.length > 0
 
   const [showOtpVerification, setShowOtpVerification] = useState(false)
   const [otpValue, setOtpValue] = useState('')
@@ -53,15 +53,12 @@ export default function EmailAuth({ identifier }: EmailAuthProps) {
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newEmail = e.target.value
     setEmail(newEmail)
-    const errors = validateEmailField(newEmail)
-    setEmailErrors(errors)
-    setShowEmailValidationError(false)
+    setEmailErrors([])
   }
 
   const handleSendOtp = async () => {
     const emailValidationErrors = validateEmailField(email)
     setEmailErrors(emailValidationErrors)
-    setShowEmailValidationError(emailValidationErrors.length > 0)
 
     if (emailValidationErrors.length > 0) {
       return
@@ -75,7 +72,6 @@ export default function EmailAuth({ identifier }: EmailAuthProps) {
     } catch (error) {
       logger.error('Error sending OTP:', error)
       setEmailErrors([toError(error).message || 'Failed to send verification code'])
-      setShowEmailValidationError(true)
     }
   }
 
@@ -149,12 +145,10 @@ export default function EmailAuth({ identifier }: EmailAuthProps) {
                     value={email}
                     onChange={handleEmailChange}
                     className={cn(
-                      showEmailValidationError &&
-                        emailErrors.length > 0 &&
-                        'border-[var(--text-error)] focus:border-[var(--text-error)]'
+                      hasEmailError && 'border-[var(--text-error)] focus:border-[var(--text-error)]'
                     )}
                   />
-                  {showEmailValidationError && emailErrors.length > 0 && (
+                  {hasEmailError && (
                     <div className='mt-1 space-y-1 text-[var(--text-error)] text-xs'>
                       {emailErrors.map((error) => (
                         <p key={error}>{error}</p>

--- a/apps/sim/app/(interfaces)/chat/components/auth/password/password-auth.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/auth/password/password-auth.tsx
@@ -17,21 +17,19 @@ interface PasswordAuthProps {
 export default function PasswordAuth({ identifier }: PasswordAuthProps) {
   const [password, setPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
-  const [showValidationError, setShowValidationError] = useState(false)
   const [passwordErrors, setPasswordErrors] = useState<string[]>([])
+  const hasPasswordError = passwordErrors.length > 0
   const authenticate = useChatPasswordAuth(identifier)
 
   const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newPassword = e.target.value
     setPassword(newPassword)
-    setShowValidationError(false)
     setPasswordErrors([])
   }
 
   const handleAuthenticate = async () => {
     if (!password.trim()) {
       setPasswordErrors(['Password is required'])
-      setShowValidationError(true)
       return
     }
 
@@ -41,7 +39,6 @@ export default function PasswordAuth({ identifier }: PasswordAuthProps) {
     } catch (error) {
       logger.error('Authentication error:', error)
       setPasswordErrors([toError(error).message || 'Invalid password. Please try again.'])
-      setShowValidationError(true)
     }
   }
 
@@ -84,15 +81,14 @@ export default function PasswordAuth({ identifier }: PasswordAuthProps) {
                     onChange={handlePasswordChange}
                     className={cn(
                       'pr-10',
-                      showValidationError &&
-                        passwordErrors.length > 0 &&
+                      hasPasswordError &&
                         'border-[var(--text-error)] focus:border-[var(--text-error)]'
                     )}
                   />
                   <button
                     type='button'
                     onClick={() => setShowPassword(!showPassword)}
-                    className='-translate-y-1/2 absolute top-1/2 right-3 text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+                    className='-translate-y-1/2 absolute top-1/2 right-3 text-[var(--text-muted)] hover-hover:text-[var(--text-primary)]'
                     aria-label={showPassword ? 'Hide password' : 'Show password'}
                   >
                     {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
@@ -101,9 +97,7 @@ export default function PasswordAuth({ identifier }: PasswordAuthProps) {
                 <div
                   className={cn(
                     'absolute right-0 left-0 z-10 grid transition-[grid-template-rows] duration-200 ease-out',
-                    showValidationError && passwordErrors.length > 0
-                      ? 'grid-rows-[1fr]'
-                      : 'grid-rows-[0fr]'
+                    hasPasswordError ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
                   )}
                   aria-live='polite'
                 >

--- a/apps/sim/app/(interfaces)/chat/components/header/header.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/header/header.tsx
@@ -52,7 +52,7 @@ export function ChatHeader({ chatConfig, starCount }: ChatHeaderProps) {
             href='https://github.com/simstudioai/sim'
             target='_blank'
             rel='noopener noreferrer'
-            className='flex items-center gap-2 text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]'
+            className='flex items-center gap-2 text-[var(--text-muted)] transition-colors hover-hover:text-[var(--text-primary)]'
             aria-label={`GitHub repository - ${starCount} stars`}
           >
             <GithubIcon className='size-[16px]' aria-hidden='true' />

--- a/apps/sim/app/(interfaces)/chat/components/input/input.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/input/input.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import type React from 'react'
-import { useCallback, useLayoutEffect, useRef, useState } from 'react'
-import { Badge, Button, cn, handleKeyboardActivation, Tooltip } from '@sim/emcn'
+import { useLayoutEffect, useRef, useState } from 'react'
+import { Badge, Button, cn, Tooltip } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
 import { ArrowUp, Paperclip, X } from 'lucide-react'
@@ -96,201 +96,190 @@ export const ChatInput: React.FC<{
     }
   }
 
-  const handleRemoveFile = useCallback((fileId: string) => {
+  const handleRemoveFile = (fileId: string) => {
     setAttachedFiles((prev) => prev.filter((f) => f.id !== fileId))
-  }, [])
+  }
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = () => {
     if (isStreaming) return
     if (!inputValue.trim() && attachedFiles.length === 0) return
     onSubmit?.(inputValue.trim(), attachedFiles)
     setInputValue('')
     setAttachedFiles([])
     setUploadErrors([])
-  }, [isStreaming, inputValue, attachedFiles, onSubmit])
+  }
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-        e.preventDefault()
-        handleSubmit()
-      }
-    },
-    [handleSubmit]
-  )
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
 
-  const focusTextarea = useCallback(() => {
-    textareaRef.current?.focus()
-  }, [])
-
-  const handleContainerClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+  const handleContainerClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if ((e.target as HTMLElement).closest('button')) return
     textareaRef.current?.focus()
-  }, [])
+  }
 
   const canSubmit = (inputValue.trim().length > 0 || attachedFiles.length > 0) && !isStreaming
 
   return (
-    <Tooltip.Provider>
-      <div className='fixed right-0 bottom-0 left-0 flex w-full items-center justify-center bg-gradient-to-t from-[var(--bg)] to-transparent px-4 pb-4 md:px-0 md:pb-4'>
-        <div className='w-full max-w-3xl md:max-w-[748px]'>
-          {uploadErrors.length > 0 && (
-            <div className='mb-3 flex flex-col gap-2'>
-              {uploadErrors.map((error, idx) => (
-                <Badge key={`${error}-${idx}`} variant='red' size='lg' dot className='max-w-full'>
-                  {error}
-                </Badge>
+    <div className='fixed right-0 bottom-0 left-0 flex w-full items-center justify-center bg-gradient-to-t from-[var(--bg)] to-transparent px-4 pb-4 md:px-0 md:pb-4'>
+      <div className='w-full max-w-3xl md:max-w-[748px]'>
+        {uploadErrors.length > 0 && (
+          <div className='mb-3 flex flex-col gap-2'>
+            {uploadErrors.map((error, idx) => (
+              <Badge key={`${error}-${idx}`} variant='red' size='lg' dot className='max-w-full'>
+                {error}
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        <div
+          role='group'
+          aria-label='Chat message input'
+          onClick={handleContainerClick}
+          className={cn(
+            'relative z-10 cursor-text rounded-2xl border border-[var(--border-1)] bg-[var(--surface-2)] px-2.5 py-2',
+            isDragOver && 'border-purple-500'
+          )}
+          onDragEnter={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            if (!isStreaming) setDragCounter((prev) => prev + 1)
+          }}
+          onDragOver={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            if (!isStreaming) e.dataTransfer.dropEffect = 'copy'
+          }}
+          onDragLeave={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setDragCounter((prev) => Math.max(0, prev - 1))
+          }}
+          onDrop={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setDragCounter(0)
+            if (!isStreaming) handleFileSelect(e.dataTransfer.files)
+          }}
+        >
+          {attachedFiles.length > 0 && (
+            <div className='mb-1.5 flex flex-wrap gap-1.5'>
+              {attachedFiles.map((file) => (
+                <Tooltip.Root key={file.id}>
+                  <Tooltip.Trigger asChild>
+                    <div className='group relative size-[56px] flex-shrink-0 cursor-pointer overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-[var(--surface-3)]'>
+                      {file.dataUrl ? (
+                        <img
+                          src={file.dataUrl}
+                          alt={file.name}
+                          className='h-full w-full object-cover'
+                        />
+                      ) : (
+                        <div className='flex h-full w-full flex-col items-center justify-center gap-0.5 text-[var(--text-muted)]'>
+                          <Paperclip className='size-[18px]' />
+                          <span className='max-w-[48px] truncate px-[2px] text-[9px]'>
+                            {file.name.split('.').pop()}
+                          </span>
+                        </div>
+                      )}
+                      <Button
+                        variant='ghost'
+                        aria-label={`Remove ${file.name}`}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleRemoveFile(file.id)
+                        }}
+                        className='absolute top-[2px] right-[2px] size-[16px] rounded-full bg-black/60 p-0 text-white opacity-0 hover-hover:text-white group-hover:opacity-100'
+                      >
+                        <X className='size-[10px]' />
+                      </Button>
+                    </div>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content side='top'>
+                    <p className='max-w-[200px] truncate'>{file.name}</p>
+                  </Tooltip.Content>
+                </Tooltip.Root>
               ))}
             </div>
           )}
 
-          <div
-            role='group'
-            aria-label='Chat message input'
-            onClick={handleContainerClick}
-            onKeyDown={(event) => {
-              if (event.target !== event.currentTarget) return
-              handleKeyboardActivation(event, focusTextarea)
-            }}
-            className={cn(
-              'relative z-10 cursor-text rounded-2xl border border-[var(--border-1)] bg-[var(--surface-2)] px-2.5 py-2',
-              isDragOver && 'border-purple-500'
-            )}
-            onDragEnter={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              if (!isStreaming) setDragCounter((prev) => prev + 1)
-            }}
-            onDragOver={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              if (!isStreaming) e.dataTransfer.dropEffect = 'copy'
-            }}
-            onDragLeave={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              setDragCounter((prev) => Math.max(0, prev - 1))
-            }}
-            onDrop={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              setDragCounter(0)
-              if (!isStreaming) handleFileSelect(e.dataTransfer.files)
-            }}
-          >
-            {attachedFiles.length > 0 && (
-              <div className='mb-1.5 flex flex-wrap gap-1.5'>
-                {attachedFiles.map((file) => (
-                  <Tooltip.Root key={file.id}>
-                    <Tooltip.Trigger asChild>
-                      <div className='group relative size-[56px] flex-shrink-0 cursor-pointer overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-[var(--surface-3)]'>
-                        {file.dataUrl ? (
-                          <img
-                            src={file.dataUrl}
-                            alt={file.name}
-                            className='h-full w-full object-cover'
-                          />
-                        ) : (
-                          <div className='flex h-full w-full flex-col items-center justify-center gap-0.5 text-[var(--text-muted)]'>
-                            <Paperclip className='size-[18px]' />
-                            <span className='max-w-[48px] truncate px-[2px] text-[9px]'>
-                              {file.name.split('.').pop()}
-                            </span>
-                          </div>
-                        )}
-                        <Button
-                          variant='ghost'
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleRemoveFile(file.id)
-                          }}
-                          className='absolute top-[2px] right-[2px] size-[16px] rounded-full bg-black/60 p-0 text-white opacity-0 hover-hover:text-white group-hover:opacity-100'
-                        >
-                          <X className='size-[10px]' />
-                        </Button>
-                      </div>
-                    </Tooltip.Trigger>
-                    <Tooltip.Content side='top'>
-                      <p className='max-w-[200px] truncate'>{file.name}</p>
-                    </Tooltip.Content>
-                  </Tooltip.Root>
-                ))}
-              </div>
-            )}
+          <textarea
+            ref={textareaRef}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={isDragOver ? 'Drop files here...' : 'Enter a message...'}
+            rows={1}
+            className='m-0 h-auto min-h-[24px] w-full resize-none overflow-y-auto overflow-x-hidden border-0 bg-transparent p-1 text-[15px] text-[var(--text-primary)] leading-[24px] caret-[var(--text-primary)] outline-none [-ms-overflow-style:none] [scrollbar-width:none] placeholder:text-[var(--text-muted)] focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-scrollbar]:hidden'
+          />
 
-            <textarea
-              ref={textareaRef}
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={isDragOver ? 'Drop files here...' : 'Enter a message...'}
-              rows={1}
-              className='m-0 h-auto min-h-[24px] w-full resize-none overflow-y-auto overflow-x-hidden border-0 bg-transparent p-1 text-[15px] text-[var(--text-primary)] leading-[24px] caret-[var(--text-primary)] outline-none [-ms-overflow-style:none] [scrollbar-width:none] placeholder:text-[var(--text-muted)] focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-scrollbar]:hidden'
-            />
-
-            <div className='flex items-center justify-between'>
-              <div>
-                <Tooltip.Root>
-                  <Tooltip.Trigger asChild>
-                    <Button
-                      variant='quiet'
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={isStreaming || attachedFiles.length >= 15}
-                      className='size-[28px] rounded-full p-0'
-                    >
-                      <Paperclip className='size-[16px]' strokeWidth={2} />
-                    </Button>
-                  </Tooltip.Trigger>
-                  <Tooltip.Content side='top'>
-                    <p>Attach files</p>
-                  </Tooltip.Content>
-                </Tooltip.Root>
-
-                <input
-                  ref={fileInputRef}
-                  type='file'
-                  multiple
-                  accept={CHAT_ACCEPT_ATTRIBUTE}
-                  onChange={(e) => {
-                    handleFileSelect(e.target.files)
-                    if (fileInputRef.current) fileInputRef.current.value = ''
-                  }}
-                  className='hidden'
-                  disabled={isStreaming}
-                />
-              </div>
-
-              <div className='flex items-center gap-1.5'>
-                {isStreaming ? (
+          <div className='flex items-center justify-between'>
+            <div>
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
                   <Button
-                    variant='primary'
-                    onClick={onStopStreaming}
-                    className='size-[28px] rounded-full p-0'
-                    title='Stop generation'
-                  >
-                    <svg
-                      className='block size-[14px] fill-current'
-                      viewBox='0 0 24 24'
-                      xmlns='http://www.w3.org/2000/svg'
-                    >
-                      <rect x='4' y='4' width='16' height='16' rx='3' ry='3' />
-                    </svg>
-                  </Button>
-                ) : (
-                  <Button
-                    variant='primary'
-                    onClick={handleSubmit}
-                    disabled={!canSubmit}
+                    variant='quiet'
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={isStreaming || attachedFiles.length >= 15}
                     className='size-[28px] rounded-full p-0'
                   >
-                    <ArrowUp className='block size-[16px]' strokeWidth={2.25} />
+                    <Paperclip className='size-[16px]' strokeWidth={2} />
                   </Button>
-                )}
-              </div>
+                </Tooltip.Trigger>
+                <Tooltip.Content side='top'>
+                  <p>Attach files</p>
+                </Tooltip.Content>
+              </Tooltip.Root>
+
+              <input
+                ref={fileInputRef}
+                type='file'
+                multiple
+                accept={CHAT_ACCEPT_ATTRIBUTE}
+                onChange={(e) => {
+                  handleFileSelect(e.target.files)
+                  if (fileInputRef.current) fileInputRef.current.value = ''
+                }}
+                className='hidden'
+                disabled={isStreaming}
+              />
+            </div>
+
+            <div className='flex items-center gap-1.5'>
+              {isStreaming ? (
+                <Button
+                  variant='primary'
+                  onClick={onStopStreaming}
+                  className='size-[28px] rounded-full p-0'
+                  aria-label='Stop generation'
+                >
+                  <svg
+                    className='block size-[14px] fill-current'
+                    viewBox='0 0 24 24'
+                    xmlns='http://www.w3.org/2000/svg'
+                  >
+                    <rect x='4' y='4' width='16' height='16' rx='3' ry='3' />
+                  </svg>
+                </Button>
+              ) : (
+                <Button
+                  variant='primary'
+                  onClick={handleSubmit}
+                  disabled={!canSubmit}
+                  aria-label='Send message'
+                  className='size-[28px] rounded-full p-0'
+                >
+                  <ArrowUp className='block size-[16px]' strokeWidth={2.25} />
+                </Button>
+              )}
             </div>
           </div>
         </div>
       </div>
-    </Tooltip.Provider>
+    </div>
   )
 }

--- a/apps/sim/app/(interfaces)/chat/components/loading-state/loading-state.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/loading-state/loading-state.tsx
@@ -3,7 +3,7 @@ import { DesktopTitleBarLane } from '@/app/_shell/desktop-title-bar'
 
 export function ChatLoadingState() {
   return (
-    <div className='light desktop-title-bar-page fixed inset-0 z-[100] flex flex-col bg-[var(--bg)]'>
+    <div className='light desktop-title-bar-page fixed inset-0 z-[var(--z-dropdown)] flex flex-col bg-[var(--bg)]'>
       <DesktopTitleBarLane />
       <div className='flex flex-1 items-center justify-center px-4'>
         <div className='w-full max-w-[410px]'>

--- a/apps/sim/app/(interfaces)/chat/components/message-container/message-container.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/message-container/message-container.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { memo, type RefObject } from 'react'
+import type { Ref, RefObject } from 'react'
 import { Button } from '@sim/emcn'
 import { ArrowDown } from 'lucide-react'
 import {
@@ -12,28 +12,25 @@ interface ChatMessageContainerProps {
   messages: ChatMessage[]
   isLoading: boolean
   showScrollButton: boolean
-  messagesContainerRef: RefObject<HTMLDivElement>
+  messagesContainerRef: Ref<HTMLDivElement>
   messagesEndRef: RefObject<HTMLDivElement>
   scrollToBottom: () => void
-  scrollToMessage?: (messageId: string) => void
   chatConfig: {
     description?: string
   } | null
 }
 
-export const ChatMessageContainer = memo(function ChatMessageContainer({
+export function ChatMessageContainer({
   messages,
   isLoading,
   showScrollButton,
   messagesContainerRef,
   messagesEndRef,
   scrollToBottom,
-  scrollToMessage,
   chatConfig,
 }: ChatMessageContainerProps) {
   return (
     <div className='relative flex flex-1 flex-col overflow-hidden'>
-      {/* Scrollable Messages Area */}
       <div
         ref={messagesContainerRef}
         className='absolute inset-0 touch-pan-y overflow-y-auto overscroll-auto scroll-smooth'
@@ -54,7 +51,6 @@ export const ChatMessageContainer = memo(function ChatMessageContainer({
             messages.map((message) => <ClientChatMessage key={message.id} message={message} />)
           )}
 
-          {/* Loading indicator (shows only when executing) */}
           {isLoading && (
             <div className='px-4 py-5'>
               <div className='mx-auto max-w-3xl'>
@@ -69,18 +65,16 @@ export const ChatMessageContainer = memo(function ChatMessageContainer({
             </div>
           )}
 
-          {/* End of messages marker for scrolling */}
           <div ref={messagesEndRef} />
         </div>
       </div>
 
-      {/* Scroll to bottom button - appears when user scrolls up */}
       {showScrollButton && (
         <div className='-translate-x-1/2 absolute bottom-16 left-1/2 z-20 transform'>
           <Button
             onClick={scrollToBottom}
             size='sm'
-            className='gap-1 rounded-full px-3 py-1 shadow-lg'
+            className='gap-1 rounded-full px-3 py-1 shadow-medium'
           >
             <ArrowDown className='size-3.5' />
             <span className='sr-only'>Scroll to bottom</span>
@@ -89,4 +83,4 @@ export const ChatMessageContainer = memo(function ChatMessageContainer({
       )}
     </div>
   )
-})
+}

--- a/apps/sim/app/(interfaces)/chat/components/message/components/file-download.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/message/components/file-download.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Button, cn, Download, Loader } from '@sim/emcn'
+import { Button, Download, Loader } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
 import { sleep } from '@sim/utils/helpers'
 import { Music } from 'lucide-react'
@@ -76,7 +76,6 @@ async function triggerDownload(url: string, filename: string): Promise<void> {
 
 export function ChatFileDownload({ file }: ChatFileDownloadProps) {
   const [isDownloading, setIsDownloading] = useState(false)
-  const [isHovered, setIsHovered] = useState(false)
 
   const handleDownload = async () => {
     if (isDownloading) return
@@ -113,10 +112,8 @@ export function ChatFileDownload({ file }: ChatFileDownloadProps) {
     <Button
       variant='default'
       onClick={handleDownload}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
       disabled={isDownloading}
-      className='flex h-auto w-[200px] items-center gap-2 rounded-lg px-3 py-2'
+      className='group flex h-auto w-[200px] items-center gap-2 rounded-lg px-3 py-2'
     >
       <div className='flex size-8 flex-shrink-0 items-center justify-center'>{renderIcon()}</div>
       <div className='min-w-0 flex-1 text-left'>
@@ -127,9 +124,7 @@ export function ChatFileDownload({ file }: ChatFileDownloadProps) {
         {isDownloading ? (
           <Loader className='size-3.5' animate />
         ) : (
-          <Download
-            className={cn('size-3.5 transition-opacity', isHovered ? 'opacity-100' : 'opacity-0')}
-          />
+          <Download className='size-3.5 opacity-0 transition-opacity group-hover:opacity-100' />
         )}
       </div>
     </Button>

--- a/apps/sim/app/(interfaces)/chat/components/message/components/markdown-renderer.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/message/components/markdown-renderer.tsx
@@ -53,25 +53,13 @@ const COMPONENTS = {
   ),
 
   ul: ({ children }: React.HTMLAttributes<HTMLUListElement>) => (
-    <ul
-      className='mt-1 mb-1 space-y-1 pl-6 font-sans text-[var(--text-primary)]'
-      style={{ listStyleType: 'disc' }}
-    >
-      {children}
-    </ul>
+    <ul className='mt-1 mb-1 space-y-1 pl-6 font-sans text-[var(--text-primary)]'>{children}</ul>
   ),
   ol: ({ children }: React.HTMLAttributes<HTMLOListElement>) => (
-    <ol
-      className='mt-1 mb-1 space-y-1 pl-6 font-sans text-[var(--text-primary)]'
-      style={{ listStyleType: 'decimal' }}
-    >
-      {children}
-    </ol>
+    <ol className='mt-1 mb-1 space-y-1 pl-6 font-sans text-[var(--text-primary)]'>{children}</ol>
   ),
   li: ({ children }: React.LiHTMLAttributes<HTMLLIElement>) => (
-    <li className='font-sans text-[var(--text-primary)]' style={{ display: 'list-item' }}>
-      {children}
-    </li>
+    <li className='list-item font-sans text-[var(--text-primary)]'>{children}</li>
   ),
 
   pre: ({ children }: HTMLAttributes<HTMLPreElement>) => {
@@ -142,7 +130,7 @@ const COMPONENTS = {
     <tbody className='divide-y divide-[var(--divider)] bg-[var(--surface-2)]'>{children}</tbody>
   ),
   tr: ({ children }: React.HTMLAttributes<HTMLTableRowElement>) => (
-    <tr className='border-[var(--divider)] border-b transition-colors hover:bg-[var(--surface-hover)]'>
+    <tr className='border-[var(--divider)] border-b transition-colors hover-hover:bg-[var(--surface-hover)]'>
       {children}
     </tr>
   ),

--- a/apps/sim/app/(interfaces)/chat/components/message/components/markdown-renderer.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/message/components/markdown-renderer.tsx
@@ -53,10 +53,14 @@ const COMPONENTS = {
   ),
 
   ul: ({ children }: React.HTMLAttributes<HTMLUListElement>) => (
-    <ul className='mt-1 mb-1 space-y-1 pl-6 font-sans text-[var(--text-primary)]'>{children}</ul>
+    <ul className='mt-1 mb-1 list-disc space-y-1 pl-6 font-sans text-[var(--text-primary)]'>
+      {children}
+    </ul>
   ),
   ol: ({ children }: React.HTMLAttributes<HTMLOListElement>) => (
-    <ol className='mt-1 mb-1 space-y-1 pl-6 font-sans text-[var(--text-primary)]'>{children}</ol>
+    <ol className='mt-1 mb-1 list-decimal space-y-1 pl-6 font-sans text-[var(--text-primary)]'>
+      {children}
+    </ol>
   ),
   li: ({ children }: React.LiHTMLAttributes<HTMLLIElement>) => (
     <li className='list-item font-sans text-[var(--text-primary)]'>{children}</li>

--- a/apps/sim/app/(interfaces)/chat/components/message/message.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/message/message.tsx
@@ -1,16 +1,13 @@
 'use client'
 
 import { memo, useState } from 'react'
-import { Button, cn, Duplicate, Tooltip } from '@sim/emcn'
-import { Check, File as FileIcon, FileText, Image as ImageIcon } from 'lucide-react'
+import { Button, Check, cn, Duplicate, handleKeyboardActivation, Tooltip } from '@sim/emcn'
+import { File as FileIcon, FileText, Image as ImageIcon } from 'lucide-react'
 import {
   AgentStreamThinkingChrome,
   AgentStreamToolCallsChrome,
 } from '@/components/agent-stream/agent-stream-chrome'
-import type {
-  AgentStreamToolCall,
-  AgentStreamToolStatus,
-} from '@/components/agent-stream/tool-call-lifecycle'
+import type { AgentStreamToolCall } from '@/components/agent-stream/tool-call-lifecycle'
 import {
   ChatFileDownload,
   ChatFileDownloadAll,
@@ -34,9 +31,6 @@ export interface ChatFile {
   type: string
   context?: string
 }
-
-/** Lifecycle status for a tool chip (agent-events-v1). No args/results. */
-export type ChatToolCallStatus = AgentStreamToolStatus
 
 /** Chat surface tool chip — the shared lifecycle chip plus its block id. */
 export interface ChatToolCall extends AgentStreamToolCall {
@@ -106,224 +100,200 @@ function openAttachmentPreview(name: string, dataUrl: string): void {
   setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000)
 }
 
-function toolCallsFingerprint(toolCalls: ChatToolCall[] | undefined): string {
-  if (!toolCalls?.length) return ''
-  return toolCalls.map((t) => `${t.key}:${t.status}`).join('|')
-}
+export const ClientChatMessage = memo(function ClientChatMessage({
+  message,
+}: {
+  message: ChatMessage
+}) {
+  const [isCopied, setIsCopied] = useState(false)
 
-export const ClientChatMessage = memo(
-  function ClientChatMessage({ message }: { message: ChatMessage }) {
-    const [isCopied, setIsCopied] = useState(false)
+  const isJsonObject = typeof message.content === 'object' && message.content !== null
 
-    const isJsonObject = typeof message.content === 'object' && message.content !== null
+  // Answer text is streamed separately from thinking / tool lifecycle events.
+  const cleanTextContent = message.content
+  const hasThinking = typeof message.thinking === 'string' && message.thinking.length > 0
+  const hasToolCalls = Array.isArray(message.toolCalls) && message.toolCalls.length > 0
 
-    // Answer text is streamed separately from thinking / tool lifecycle events.
-    const cleanTextContent = message.content
-    const hasThinking = typeof message.thinking === 'string' && message.thinking.length > 0
-    const hasToolCalls = Array.isArray(message.toolCalls) && message.toolCalls.length > 0
+  const content =
+    message.type === 'user' ? (
+      <div className='px-4 py-5' data-message-id={message.id}>
+        <div className='mx-auto max-w-3xl'>
+          {message.attachments && message.attachments.length > 0 && (
+            <div className='mb-2 flex justify-end'>
+              <div className='flex flex-wrap gap-2'>
+                {message.attachments.map((attachment) => {
+                  const isImage = attachment.type.startsWith('image/')
+                  const getFileIcon = (type: string) => {
+                    if (type.includes('pdf'))
+                      return <FileText className='size-5 text-[var(--text-muted)] md:size-6' />
+                    if (type.startsWith('image/'))
+                      return <ImageIcon className='size-5 text-[var(--text-muted)] md:size-6' />
+                    if (type.includes('text') || type.includes('json'))
+                      return <FileText className='size-5 text-[var(--text-muted)] md:size-6' />
+                    return <FileIcon className='size-5 text-[var(--text-muted)] md:size-6' />
+                  }
+                  const formatFileSize = (bytes?: number) => {
+                    if (!bytes || bytes === 0) return ''
+                    const k = 1024
+                    const sizes = ['B', 'KB', 'MB', 'GB']
+                    const i = Math.floor(Math.log(bytes) / Math.log(k))
+                    return `${Math.round((bytes / k ** i) * 10) / 10} ${sizes[i]}`
+                  }
 
-    const content =
-      message.type === 'user' ? (
-        <div className='px-4 py-5' data-message-id={message.id}>
-          <div className='mx-auto max-w-3xl'>
-            {/* File attachments displayed above the message */}
-            {message.attachments && message.attachments.length > 0 && (
-              <div className='mb-2 flex justify-end'>
-                <div className='flex flex-wrap gap-2'>
-                  {message.attachments.map((attachment) => {
-                    const isImage = attachment.type.startsWith('image/')
-                    const getFileIcon = (type: string) => {
-                      if (type.includes('pdf'))
-                        return <FileText className='size-5 text-[var(--text-muted)] md:size-6' />
-                      if (type.startsWith('image/'))
-                        return <ImageIcon className='size-5 text-[var(--text-muted)] md:size-6' />
-                      if (type.includes('text') || type.includes('json'))
-                        return <FileText className='size-5 text-[var(--text-muted)] md:size-6' />
-                      return <FileIcon className='size-5 text-[var(--text-muted)] md:size-6' />
-                    }
-                    const formatFileSize = (bytes?: number) => {
-                      if (!bytes || bytes === 0) return ''
-                      const k = 1024
-                      const sizes = ['B', 'KB', 'MB', 'GB']
-                      const i = Math.floor(Math.log(bytes) / Math.log(k))
-                      return `${Math.round((bytes / k ** i) * 10) / 10} ${sizes[i]}`
-                    }
+                  const isInteractive =
+                    !!attachment.dataUrl?.trim() && attachment.dataUrl.startsWith('data:')
 
-                    const isInteractive =
-                      !!attachment.dataUrl?.trim() && attachment.dataUrl.startsWith('data:')
+                  const handleOpenPreview = () => {
+                    const validDataUrl = attachment.dataUrl?.trim()
+                    if (!validDataUrl?.startsWith('data:')) return
+                    openAttachmentPreview(attachment.name, validDataUrl)
+                  }
 
-                    const handleOpenPreview = () => {
-                      const validDataUrl = attachment.dataUrl?.trim()
-                      if (!validDataUrl?.startsWith('data:')) return
-                      openAttachmentPreview(attachment.name, validDataUrl)
-                    }
+                  return (
+                    <div
+                      key={attachment.id}
+                      role={isInteractive ? 'button' : undefined}
+                      aria-disabled={!isInteractive}
+                      tabIndex={isInteractive ? 0 : undefined}
+                      className={cn(
+                        'relative overflow-hidden rounded-2xl border border-[var(--border-1)] bg-[var(--surface-2)]',
+                        isInteractive && 'cursor-pointer',
+                        isImage
+                          ? 'size-16 md:size-20'
+                          : 'flex h-16 min-w-[140px] max-w-[220px] items-center gap-2 px-3 md:h-20 md:min-w-[160px] md:max-w-[240px]'
+                      )}
+                      onClick={(e) => {
+                        if (!isInteractive) return
+                        e.preventDefault()
+                        e.stopPropagation()
+                        handleOpenPreview()
+                      }}
+                      onKeyDown={(e) => {
+                        if (!isInteractive) return
+                        handleKeyboardActivation(e, handleOpenPreview, { stopPropagation: true })
+                      }}
+                    >
+                      {isImage &&
+                      attachment.dataUrl?.trim() &&
+                      attachment.dataUrl.startsWith('data:') ? (
+                        <img
+                          src={attachment.dataUrl}
+                          alt={attachment.name}
+                          className='size-full object-cover'
+                        />
+                      ) : (
+                        <>
+                          <div className='flex size-10 flex-shrink-0 items-center justify-center rounded bg-[var(--surface-3)] md:size-12'>
+                            {getFileIcon(attachment.type)}
+                          </div>
+                          <div className='min-w-0 flex-1'>
+                            <div className='truncate font-medium text-[var(--text-primary)] text-xs md:text-sm'>
+                              {attachment.name}
+                            </div>
+                            {attachment.size && (
+                              <div className='text-[var(--text-muted)] text-micro md:text-xs'>
+                                {formatFileSize(attachment.size)}
+                              </div>
+                            )}
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
 
-                    return (
-                      <div
-                        key={attachment.id}
-                        role={isInteractive ? 'button' : undefined}
-                        aria-disabled={!isInteractive}
-                        tabIndex={isInteractive ? 0 : undefined}
-                        className={cn(
-                          'relative overflow-hidden rounded-2xl border border-[var(--border-1)] bg-[var(--surface-2)]',
-                          isInteractive && 'cursor-pointer',
-                          isImage
-                            ? 'size-16 md:size-20'
-                            : 'flex h-16 min-w-[140px] max-w-[220px] items-center gap-2 px-3 md:h-20 md:min-w-[160px] md:max-w-[240px]'
-                        )}
-                        onClick={(e) => {
-                          if (!isInteractive) return
-                          e.preventDefault()
-                          e.stopPropagation()
-                          handleOpenPreview()
-                        }}
-                        onKeyDown={(e) => {
-                          if (!isInteractive) return
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            handleOpenPreview()
-                          }
+          {/* `Sent N file(s)` is a placeholder for attachment-only sends, not user text. */}
+          {message.content && !String(message.content).startsWith('Sent') && (
+            <div className='flex justify-end'>
+              <div className='max-w-[80%] rounded-3xl bg-[var(--surface-3)] px-4 py-3'>
+                <div className='whitespace-pre-wrap break-words text-[var(--text-primary)] text-base leading-relaxed'>
+                  {isJsonObject ? (
+                    <pre>{JSON.stringify(message.content, null, 2)}</pre>
+                  ) : (
+                    <span>{message.content as string}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    ) : (
+      <div className='px-4 pt-5 pb-2' data-message-id={message.id}>
+        <div className='mx-auto max-w-3xl'>
+          <div className='flex flex-col space-y-3'>
+            <div>
+              {hasThinking && (
+                <AgentStreamThinkingChrome
+                  thinking={message.thinking!}
+                  isStreaming={message.isThinkingStreaming}
+                />
+              )}
+              {hasToolCalls && (
+                <AgentStreamToolCallsChrome
+                  toolCalls={message.toolCalls!}
+                  isStreaming={message.isToolStreaming}
+                />
+              )}
+              <div className='break-words text-base'>
+                {isJsonObject ? (
+                  <pre className='text-[var(--text-primary)]'>
+                    {JSON.stringify(cleanTextContent, null, 2)}
+                  </pre>
+                ) : (
+                  <MarkdownRenderer content={cleanTextContent as string} />
+                )}
+              </div>
+            </div>
+            {message.files && message.files.length > 0 && (
+              <div className='flex flex-wrap gap-2'>
+                {message.files.map((file) => (
+                  <ChatFileDownload key={file.id} file={file} />
+                ))}
+              </div>
+            )}
+            {message.type === 'assistant' && !isJsonObject && !message.isInitialMessage && (
+              <div className='flex items-center justify-start space-x-2'>
+                {!message.isStreaming && (
+                  <Tooltip.Root>
+                    <Tooltip.Trigger asChild>
+                      <Button
+                        variant='ghost-secondary'
+                        className='p-0'
+                        onClick={() => {
+                          const contentToCopy =
+                            typeof cleanTextContent === 'string'
+                              ? cleanTextContent
+                              : JSON.stringify(cleanTextContent, null, 2)
+                          navigator.clipboard.writeText(contentToCopy)
+                          setIsCopied(true)
+                          setTimeout(() => setIsCopied(false), 2000)
                         }}
                       >
-                        {isImage &&
-                        attachment.dataUrl?.trim() &&
-                        attachment.dataUrl.startsWith('data:') ? (
-                          <img
-                            src={attachment.dataUrl}
-                            alt={attachment.name}
-                            className='size-full object-cover'
-                          />
+                        {isCopied ? (
+                          <Check className='size-3' strokeWidth={2} />
                         ) : (
-                          <>
-                            <div className='flex size-10 flex-shrink-0 items-center justify-center rounded bg-[var(--surface-3)] md:size-12'>
-                              {getFileIcon(attachment.type)}
-                            </div>
-                            <div className='min-w-0 flex-1'>
-                              <div className='truncate font-medium text-[var(--text-primary)] text-xs md:text-sm'>
-                                {attachment.name}
-                              </div>
-                              {attachment.size && (
-                                <div className='text-[var(--text-muted)] text-micro md:text-xs'>
-                                  {formatFileSize(attachment.size)}
-                                </div>
-                              )}
-                            </div>
-                          </>
+                          <Duplicate className='size-3' />
                         )}
-                      </div>
-                    )
-                  })}
-                </div>
-              </div>
-            )}
-
-            {/* Only render message bubble if there's actual text content (not just file count message) */}
-            {message.content && !String(message.content).startsWith('Sent') && (
-              <div className='flex justify-end'>
-                <div className='max-w-[80%] rounded-3xl bg-[var(--surface-3)] px-4 py-3'>
-                  <div className='whitespace-pre-wrap break-words text-[var(--text-primary)] text-base leading-relaxed'>
-                    {isJsonObject ? (
-                      <pre>{JSON.stringify(message.content, null, 2)}</pre>
-                    ) : (
-                      <span>{message.content as string}</span>
-                    )}
-                  </div>
-                </div>
+                      </Button>
+                    </Tooltip.Trigger>
+                    <Tooltip.Content side='top' align='center' sideOffset={5}>
+                      {isCopied ? 'Copied!' : 'Copy to clipboard'}
+                    </Tooltip.Content>
+                  </Tooltip.Root>
+                )}
+                {!message.isStreaming && message.files && (
+                  <ChatFileDownloadAll files={message.files} />
+                )}
               </div>
             )}
           </div>
         </div>
-      ) : (
-        <div className='px-4 pt-5 pb-2' data-message-id={message.id}>
-          <div className='mx-auto max-w-3xl'>
-            <div className='flex flex-col space-y-3'>
-              <div>
-                {hasThinking && (
-                  <AgentStreamThinkingChrome
-                    thinking={message.thinking!}
-                    isStreaming={message.isThinkingStreaming}
-                  />
-                )}
-                {hasToolCalls && (
-                  <AgentStreamToolCallsChrome
-                    toolCalls={message.toolCalls!}
-                    isStreaming={message.isToolStreaming}
-                  />
-                )}
-                <div className='break-words text-base'>
-                  {isJsonObject ? (
-                    <pre className='text-[var(--text-primary)]'>
-                      {JSON.stringify(cleanTextContent, null, 2)}
-                    </pre>
-                  ) : (
-                    <MarkdownRenderer content={cleanTextContent as string} />
-                  )}
-                </div>
-              </div>
-              {message.files && message.files.length > 0 && (
-                <div className='flex flex-wrap gap-2'>
-                  {message.files.map((file) => (
-                    <ChatFileDownload key={file.id} file={file} />
-                  ))}
-                </div>
-              )}
-              {message.type === 'assistant' && !isJsonObject && !message.isInitialMessage && (
-                <div className='flex items-center justify-start space-x-2'>
-                  {/* Copy Button - Only show when not streaming */}
-                  {!message.isStreaming && (
-                    <Tooltip.Root delayDuration={300}>
-                      <Tooltip.Trigger asChild>
-                        <Button
-                          variant='ghost-secondary'
-                          className='p-0'
-                          onClick={() => {
-                            const contentToCopy =
-                              typeof cleanTextContent === 'string'
-                                ? cleanTextContent
-                                : JSON.stringify(cleanTextContent, null, 2)
-                            navigator.clipboard.writeText(contentToCopy)
-                            setIsCopied(true)
-                            setTimeout(() => setIsCopied(false), 2000)
-                          }}
-                        >
-                          {isCopied ? (
-                            <Check className='size-3' strokeWidth={2} />
-                          ) : (
-                            <Duplicate className='size-3' />
-                          )}
-                        </Button>
-                      </Tooltip.Trigger>
-                      <Tooltip.Content side='top' align='center' sideOffset={5}>
-                        {isCopied ? 'Copied!' : 'Copy to clipboard'}
-                      </Tooltip.Content>
-                    </Tooltip.Root>
-                  )}
-                  {/* Download All Button - Only show when there are files */}
-                  {!message.isStreaming && message.files && (
-                    <ChatFileDownloadAll files={message.files} />
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      )
-
-    return <Tooltip.Provider>{content}</Tooltip.Provider>
-  },
-  (prevProps, nextProps) => {
-    return (
-      prevProps.message.id === nextProps.message.id &&
-      prevProps.message.content === nextProps.message.content &&
-      prevProps.message.thinking === nextProps.message.thinking &&
-      prevProps.message.isStreaming === nextProps.message.isStreaming &&
-      prevProps.message.isThinkingStreaming === nextProps.message.isThinkingStreaming &&
-      prevProps.message.isToolStreaming === nextProps.message.isToolStreaming &&
-      toolCallsFingerprint(prevProps.message.toolCalls) ===
-        toolCallsFingerprint(nextProps.message.toolCalls) &&
-      prevProps.message.isInitialMessage === nextProps.message.isInitialMessage &&
-      prevProps.message.files?.length === nextProps.message.files?.length
+      </div>
     )
-  }
-)
+
+  return <>{content}</>
+})

--- a/apps/sim/app/(interfaces)/chat/constants.ts
+++ b/apps/sim/app/(interfaces)/chat/constants.ts
@@ -1,15 +1,6 @@
 export const CHAT_ERROR_MESSAGES = {
   GENERIC_ERROR: 'Sorry, there was an error processing your message. Please try again.',
-  NETWORK_ERROR: 'Unable to connect to the server. Please check your connection and try again.',
-  TIMEOUT_ERROR: 'Request timed out. Please try again.',
-  AUTH_REQUIRED_PASSWORD: 'This chat requires a password to access.',
-  AUTH_REQUIRED_EMAIL: 'Please provide your email to access this chat.',
   CHAT_UNAVAILABLE: 'This chat is currently unavailable. Please try again later.',
-  NO_CHAT_TRIGGER:
-    'No Chat trigger configured for this workflow. Add a Chat Trigger block to enable chat.',
-  USAGE_LIMIT_EXCEEDED: 'Usage limit exceeded. Please upgrade your plan to continue using chat.',
 } as const
 
-export const CHAT_REQUEST_TIMEOUT_MS = 300000 // 5 minutes (same as in chat.tsx)
-
-export type ChatErrorType = keyof typeof CHAT_ERROR_MESSAGES
+export const CHAT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000

--- a/apps/sim/app/api/speech/token/route.ts
+++ b/apps/sim/app/api/speech/token/route.ts
@@ -60,8 +60,8 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     }
     const actorUserId = session.user.id
     /**
-     * Editor voice accepts only a workspace the caller belongs to, preventing
-     * client-supplied IDs from misattributing or bypassing member usage.
+     * Accepts only a workspace the caller belongs to, preventing client-supplied
+     * IDs from misattributing or bypassing member usage.
      */
     const requestedWorkspaceId =
       body.success && typeof body.data.workspaceId === 'string' ? body.data.workspaceId : undefined
@@ -70,8 +70,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       if (permission) workspaceId = requestedWorkspaceId
     }
     /**
-     * Editor voice is workspace-scoped so every charge has a payer and member
-     * cap attribution.
+     * Workspace-scoped so every charge has a payer and member cap attribution.
      */
     if (!workspaceId) {
       return NextResponse.json({ error: 'Workspace context is required.' }, { status: 400 })

--- a/apps/sim/hooks/queries/chats.ts
+++ b/apps/sim/hooks/queries/chats.ts
@@ -29,8 +29,6 @@ const logger = createLogger('ChatMutations')
  */
 export const chatKeys = {
   all: ['chats'] as const,
-  status: deploymentKeys.chatStatus,
-  detail: deploymentKeys.chatDetail,
   configs: () => [...chatKeys.all, 'config'] as const,
   config: (identifier?: string) => [...chatKeys.configs(), identifier ?? ''] as const,
 }

--- a/apps/sim/hooks/use-speech-to-text.ts
+++ b/apps/sim/hooks/use-speech-to-text.ts
@@ -16,8 +16,6 @@ import {
 
 const logger = createLogger('useSpeechToText')
 
-export type PermissionState = 'prompt' | 'granted' | 'denied'
-
 interface UseSpeechToTextProps {
   onTranscript: (text: string) => void
   /**
@@ -25,7 +23,6 @@ interface UseSpeechToTextProps {
    * whether it was a per-member cap (which only an org admin can raise).
    */
   onUsageLimitExceeded?: (message?: string, isMemberLimit?: boolean) => void
-  language?: string
   /** Attributes the voice-input cost to this workspace for per-member usage. */
   workspaceId?: string
 }
@@ -33,7 +30,6 @@ interface UseSpeechToTextProps {
 interface UseSpeechToTextReturn {
   isListening: boolean
   isSupported: boolean
-  permissionState: PermissionState
   toggleListening: () => void
   resetTranscript: () => void
 }
@@ -41,16 +37,13 @@ interface UseSpeechToTextReturn {
 export function useSpeechToText({
   onTranscript,
   onUsageLimitExceeded,
-  language,
   workspaceId,
 }: UseSpeechToTextProps): UseSpeechToTextReturn {
   const [isListening, setIsListening] = useState(false)
   const [isSupported, setIsSupported] = useState(false)
-  const [permissionState, setPermissionState] = useState<PermissionState>('prompt')
 
   const onTranscriptRef = useRef(onTranscript)
   const onUsageLimitExceededRef = useRef(onUsageLimitExceeded)
-  const languageRef = useRef(language)
   const workspaceIdRef = useRef(workspaceId)
   const mountedRef = useRef(true)
   const startingRef = useRef(false)
@@ -69,7 +62,6 @@ export function useSpeechToText({
 
   onTranscriptRef.current = onTranscript
   onUsageLimitExceededRef.current = onUsageLimitExceeded
-  languageRef.current = language
   workspaceIdRef.current = workspaceId
 
   useEffect(() => {
@@ -206,7 +198,6 @@ export function useSpeechToText({
         return false
       }
 
-      setPermissionState('granted')
       streamRef.current = stream
 
       const params = new URLSearchParams({
@@ -216,9 +207,6 @@ export function useSpeechToText({
         commit_strategy: 'vad',
         vad_silence_threshold_secs: '1.0',
       })
-      if (languageRef.current) {
-        params.set('language_code', languageRef.current)
-      }
 
       const ws = new WebSocket(`${ELEVENLABS_WS_URL}?${params.toString()}`)
       wsRef.current = ws
@@ -305,9 +293,6 @@ export function useSpeechToText({
     } catch (error) {
       logger.error('Failed to start speech streaming', error)
       cleanup()
-      if (error instanceof DOMException && error.name === 'NotAllowedError') {
-        setPermissionState('denied')
-      }
       return false
     } finally {
       startingRef.current = false
@@ -396,7 +381,6 @@ export function useSpeechToText({
   return {
     isListening,
     isSupported,
-    permissionState,
     toggleListening,
     resetTranscript,
   }

--- a/apps/sim/lib/core/rate-limiter/route-helpers.ts
+++ b/apps/sim/lib/core/rate-limiter/route-helpers.ts
@@ -90,23 +90,6 @@ export async function enforceWorkspaceRateLimit(
 }
 
 /**
- * Apply a per-deployed-chat token bucket. Use for endpoints an anonymous public
- * chat visitor can reach: the chat id is server-held state, so this bounds spend
- * per chat regardless of how many source addresses the traffic claims.
- */
-export async function enforceChatRateLimit(
-  bucketName: string,
-  chatId: string,
-  config: TokenBucketConfig = DEFAULT_USER_ROUTE_LIMIT
-): Promise<NextResponse | null> {
-  const key = `route:${bucketName}:chat:${chatId}`
-  const { allowed, resetAt } = await rateLimiter.checkRateLimitDirect(key, config)
-  if (allowed) return null
-  logger.warn('Chat rate limit exceeded', { bucket: bucketName, chatId })
-  return buildRateLimitResponse(resetAt)
-}
-
-/**
  * Apply a per-user limit when a userId is present, else fall back to per-IP.
  * Use for routes whose auth path may legitimately resolve without a userId
  * (e.g. internal JWT calls with `requireWorkflowId: false`) so missing-userId


### PR DESCRIPTION
## Summary
Eight-angle cleanup pass (effects, state, memo, callback, React Query, url-state, emcn, comments) run over the **full contents** of the deployed chat surface and the speech code that survived the voice-mode removal — not just a diff.

**Dead code**
- `enforceChatRateLimit` — added for the TTS relay in #6212, orphaned when #6215 deleted that route. Zero consumers.
- `ChatToolCallStatus`, `ChatErrorType`, and six unused `CHAT_ERROR_MESSAGES` keys (only `GENERIC_ERROR` and `CHAT_UNAVAILABLE` are read).
- `scrollToMessage` was declared and destructured by `ChatMessageContainer` but never used in its body. Removing the prop also made the `scrollToShowOnlyMessage` branch unreachable, since the one caller passed `true`.
- `permissionState` and the `language` prop on `useSpeechToText` — both write-only across the repo.
- The image branch in `ChatFileDownload`'s `renderIcon` returned the same `DefaultFileIcon` at the same size as the fallback.
- `chatKeys.status`/`detail` — aliases nothing imported, and misleading since they root under `['deployments', …]` rather than `chatKeys.all`.

**Redundant state**
- `password-auth` and `email-auth` each kept a boolean in lockstep with `errors.length > 0`; `email-auth` also validated on every keystroke and then immediately hid the result.
- `file-download` tracked hover in state to drive one opacity class → `group-hover`. Verified emcn `Button` sets no `group` class of its own.

**Memoization**
- `ChatMessageContainer`'s `memo()` could never bail: `chat.tsx` passes an inline arrow for `scrollToBottom` and `displayMessages` is a fresh array. Four of the five things that re-render `ChatClient` are its props anyway, so the memo is dropped rather than propped up.
- `ClientChatMessage` **keeps** its memo — it blocks markdown re-parsing during streaming — but loses the custom comparator, which compared proxies (a `key:status` fingerprint, `files` by length) and ignored `attachments` and `type` entirely. Default shallow compare on its single prop is simpler and stricter.
- Six `useCallback`s whose consumers are native DOM handlers or inline arrows.

**Effects**
- The scroll listener attached in an effect keyed on `[chatConfig, authRequired]` — values it never reads, standing in for "the container has mounted". Now a ref callback, so it no longer re-attaches on every config refetch.

**Design system / a11y**
- `z-[100]` → `z-[var(--z-dropdown)]` (identical value), `shadow-lg` → `shadow-medium`, inline list styles → Tailwind, `hover:` → `hover-hover:` on touch-reachable targets, `Check` sourced from emcn alongside its `Duplicate` pair.
- Accessible names on the remove-attachment, stop, and send buttons — all previously announced as just "button".
- Dropped a keyboard handler on a `role='group'` div with no `tabIndex` (so `target === currentTarget` was unreachable), plus the `Tooltip.Provider` wrappers and `delayDuration`, which emcn documents as no-op passthroughs.

## Needs a visual check
The scroll-listener change is the one behavioral risk. Please verify on a deployed chat: scroll up mid-conversation → jump-to-bottom button appears; click it → re-pins and hides; stream a reply while scrolled away → does not auto-follow.

`shadow-lg` → `shadow-medium` is a small deliberate shadow change on the jump-to-bottom pill.

## Deliberately not included
- **`useSpeechToText` fetching server state in an effect** into `useState` — should become a `useQuery`, but its only consumer is the workspace home input, and the render path is hydration-sensitive. Wants its own PR.
- **A real missing-invalidation bug**: `useUpdateChat` doesn't invalidate `deploymentKeys.info`/`versions`/`deployedState`, though the PATCH can trigger a redeploy (`api/chat/manage/[id]/route.ts` calls `performFullDeploy`). `useCreateChat` invalidates for exactly this reason. Left out because it changes deployment-panel behavior I can't verify here — worth its own PR.
- Visual-risk items needing design sign-off: `border-purple-500` drag state, `text-purple-500` audio icon, off-scale `text-sm`/`text-lg`, the stop glyph → emcn `Square`, and consolidating the two chat auth screens onto the shared `(auth)/components` kit (which would shrink headings 40px → 32px).

## Type of Change
- [x] Refactor / dead code removal

## Testing
1153 tests pass across chat, speech, settings, hooks and rate-limiter. Typecheck clean on `apps/sim`. Lint warnings in scope unchanged from staging's baseline (2). No behavior change intended except the two items called out above.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)