### PR TITLE
fix(chat): invalidate deployment queries after a chat mutation

### DIFF
--- a/apps/sim/hooks/queries/chats.test.tsx
+++ b/apps/sim/hooks/queries/chats.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, type ReactNode } from 'react'
+import { sleep } from '@sim/utils/helpers'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createRoot, type Root } from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockRequestJson, mockInvalidateDeploymentQueries } = vi.hoisted(() => ({
+  mockRequestJson: vi.fn(),
+  mockInvalidateDeploymentQueries: vi.fn(),
+}))
+
+vi.mock('@/lib/api/client/request', () => ({
+  requestJson: mockRequestJson,
+}))
+
+vi.mock('@/hooks/queries/deployments', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks/queries/deployments')>()),
+  invalidateDeploymentQueries: mockInvalidateDeploymentQueries,
+}))
+
+import { useCreateChat, useUpdateChat } from '@/hooks/queries/chats'
+
+function renderHookWithClient<T>(useHook: () => T): { getResult: () => T } {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const container = document.createElement('div')
+  const root: Root = createRoot(container)
+  let result: T | undefined
+
+  function Probe() {
+    result = useHook()
+    return null
+  }
+
+  act(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>{(<Probe />) as ReactNode}</QueryClientProvider>
+    )
+  })
+
+  return {
+    getResult: () => {
+      if (result === undefined) throw new Error('Hook result is not ready')
+      return result
+    },
+  }
+}
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve()
+      await sleep(1)
+    }
+  })
+}
+
+const FORM_DATA = {
+  identifier: 'my-chat',
+  title: 'My chat',
+  description: '',
+  authType: 'public' as const,
+  password: '',
+  emails: [],
+  welcomeMessage: 'hi',
+  selectedOutputBlocks: [],
+  includeThinking: false,
+  includeToolCalls: false,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRequestJson.mockResolvedValue({ chatUrl: 'https://sim.ai/chat/my-chat', chatId: 'chat-1' })
+  mockInvalidateDeploymentQueries.mockResolvedValue(undefined)
+})
+
+describe('chat mutations invalidate the deployment boundary', () => {
+  /**
+   * PATCH /api/chat/manage/[id] calls performFullDeploy when the workflow has
+   * drifted, so a chat edit can mint a new deployment version. Invalidating only
+   * chatStatus/chatDetail left the deployment panel showing the previous version.
+   */
+  it('useUpdateChat invalidates every deployment query for the workflow', async () => {
+    const { getResult } = renderHookWithClient(() => useUpdateChat())
+
+    await act(async () => {
+      await getResult().mutateAsync({
+        chatId: 'chat-1',
+        workflowId: 'wf-1',
+        formData: FORM_DATA,
+      })
+    })
+    await flush()
+
+    expect(mockInvalidateDeploymentQueries).toHaveBeenCalledWith(expect.anything(), 'wf-1')
+  })
+
+  it('useCreateChat invalidates every deployment query for the workflow', async () => {
+    const { getResult } = renderHookWithClient(() => useCreateChat())
+
+    await act(async () => {
+      await getResult().mutateAsync({ workflowId: 'wf-1', formData: FORM_DATA })
+    })
+    await flush()
+
+    expect(mockInvalidateDeploymentQueries).toHaveBeenCalledWith(expect.anything(), 'wf-1')
+  })
+})

--- a/apps/sim/hooks/queries/chats.ts
+++ b/apps/sim/hooks/queries/chats.ts
@@ -20,7 +20,7 @@ import {
   verifyChatEmailOtpContract,
 } from '@/lib/api/contracts/chats'
 import type { OutputConfig } from '@/stores/chat/types'
-import { deploymentKeys } from './deployments'
+import { deploymentKeys, invalidateDeploymentQueries } from './deployments'
 
 const logger = createLogger('ChatMutations')
 
@@ -296,17 +296,8 @@ export function useCreateChat() {
         throwUserFriendlyIdentifierError(error)
       }
     },
-    onSettled: (_data, _error, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: deploymentKeys.chatStatus(variables.workflowId),
-      })
-      queryClient.invalidateQueries({
-        queryKey: deploymentKeys.info(variables.workflowId),
-      })
-      queryClient.invalidateQueries({
-        queryKey: deploymentKeys.versions(variables.workflowId),
-      })
-    },
+    onSettled: (_data, _error, variables) =>
+      invalidateDeploymentQueries(queryClient, variables.workflowId),
     onError: (error) => {
       logger.error('Failed to create chat', { error })
     },
@@ -342,11 +333,9 @@ export function useUpdateChat() {
     },
     onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
-        queryKey: deploymentKeys.chatStatus(variables.workflowId),
-      })
-      queryClient.invalidateQueries({
         queryKey: deploymentKeys.chatDetail(variables.chatId),
       })
+      return invalidateDeploymentQueries(queryClient, variables.workflowId)
     },
     onError: (error) => {
       logger.error('Failed to update chat', { error })


### PR DESCRIPTION
## Summary
- `PATCH /api/chat/manage/[id]` calls `performFullDeploy` when the workflow has drifted from its active deployment (`route.ts:183-190`), so editing a chat can mint a new deployment version.
- `useUpdateChat` invalidated only `chatStatus` and `chatDetail`, so `deploymentKeys.info` / `versions` / `deployedState` went stale. The deployment panel kept showing the previous version and a stale "needs redeployment" indicator until the 30s/5min `staleTime` expired or the window refocused.
- Both chat mutations now route through `invalidateDeploymentQueries`, the shared helper the rest of the deployment surface uses (`useUndeployWorkflow` follows the same pattern).
- That also picks up `deployedState`, which `useCreateChat`'s hand-rolled list omitted even though `performChatDeploy` replaces the deployed workflow state — so the deployed-state diff viewer could show stale content after deploying a chat.

## Failure scenario
Edit a chat's welcome message while the workflow draft has drifted → the PATCH redeploys to v4 → the deployment panel still shows v3 as latest, with the redeploy prompt still visible.

## Type of Change
- [x] Bug fix

## Testing
New `hooks/queries/chats.test.tsx` covers both mutations, following the `mcp.test.tsx` render-hook pattern. Verified to fail against the previous invalidation (reverting `useUpdateChat` turns the test red). 115 tests pass across `hooks/queries`; typecheck and lint clean.

Not exercised in a live browser — the assertion is on which query keys get invalidated.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)