### PR TITLE
improvement(emcn): share one emails/domains chip input across share and deploy modals

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/share-modal/share-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/share-modal/share-modal.tsx
@@ -9,8 +9,6 @@ import {
   ChipModalField,
   ChipModalFooter,
   ChipModalHeader,
-  TagInput,
-  type TagItem,
 } from '@sim/emcn'
 import { Send } from '@sim/emcn/icons'
 import { generateShortId } from '@sim/utils/id'
@@ -18,7 +16,7 @@ import { GeneratedPasswordInput } from '@/components/ui'
 import type { ShareAuthType, ShareRecord } from '@/lib/api/contracts/public-shares'
 import { isSsoEnabled } from '@/lib/core/config/env-flags'
 import { getBaseUrl } from '@/lib/core/utils/urls'
-import { quickValidateEmail } from '@/lib/messaging/email/validation'
+import { validateAllowlistEntry } from '@/lib/messaging/email/validation'
 import { useFileShare, useUpsertFileShare } from '@/hooks/queries/public-shares'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
 
@@ -42,15 +40,12 @@ const ACCESS_LABELS: Record<AccessMode, string> = {
   sso: 'SSO',
 }
 
+/** Stable identity so the emails field's reconcile effect no-ops while unset. */
+const EMPTY_EMAILS: string[] = []
+
 function savedMode(share: ShareRecord | null): AccessMode {
   if (!share?.isActive) return 'private'
   return share.authType
-}
-
-/** True when an entry is a valid email or an `@domain` pattern. */
-function isValidEmailEntry(value: string): boolean {
-  const normalized = value.trim().toLowerCase()
-  return normalized.startsWith('@') || quickValidateEmail(normalized).isValid
 }
 
 export function ShareModal({
@@ -83,7 +78,7 @@ export function ShareModal({
   const [draftEmails, setDraftEmails] = useState<string[] | null>(null)
   const effectiveMode = draftMode ?? savedAccessMode
   const effectiveActive = effectiveMode !== 'private'
-  const effectiveEmails = draftEmails ?? saved?.allowedEmails ?? []
+  const effectiveEmails = draftEmails ?? saved?.allowedEmails ?? EMPTY_EMAILS
 
   // Org access-control may restrict which auth modes are allowed (`null` = all).
   // The route is the source of truth; this just hides disallowed options.
@@ -167,19 +162,6 @@ export function ShareModal({
     })
   }
 
-  const addEmail = (value: string): boolean => {
-    const normalized = value.trim().toLowerCase()
-    if (!normalized || effectiveEmails.includes(normalized) || !isValidEmailEntry(normalized)) {
-      return false
-    }
-    setDraftEmails([...effectiveEmails, normalized])
-    return true
-  }
-
-  const removeEmail = (_value: string, index: number) => {
-    setDraftEmails(effectiveEmails.filter((_, i) => i !== index))
-  }
-
   const accessHint = (() => {
     if (modeDisallowed) return 'This sharing method is disabled by an administrator.'
     if (enableBlockedByPolicy)
@@ -195,8 +177,6 @@ export function ShareModal({
       ? 'Save to make this file accessible to anyone with the link.'
       : 'Anyone with the link can view and download this file.'
   })()
-
-  const emailItems: TagItem[] = effectiveEmails.map((value) => ({ value, isValid: true }))
 
   return (
     <ChipModal open={open} onOpenChange={handleClose} size='sm' srTitle={`Share ${fileName}`}>
@@ -236,18 +216,15 @@ export function ShareModal({
         ) : null}
         {effectiveMode === 'email' || effectiveMode === 'sso' ? (
           <ChipModalField
-            type='custom'
+            type='emails'
             title='Allowed emails'
-            hint='Add specific emails or whole domains (@example.com).'
-          >
-            <TagInput
-              items={emailItems}
-              onAdd={addEmail}
-              onRemove={removeEmail}
-              placeholder='Enter emails or domains'
-              placeholderWithTags='Add email'
-            />
-          </ChipModalField>
+            value={effectiveEmails}
+            onChange={setDraftEmails}
+            validate={validateAllowlistEntry}
+            allowDomains
+            placeholder='Enter emails or domains'
+            placeholderWithTags='Add email or domain'
+          />
         ) : null}
         {effectiveMode !== 'private' && shareUrl ? (
           <ChipModalField type='copy' title='Link' value={shareUrl} copyLabel='Copy link' />

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/output-select/output-select.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/output-select/output-select.tsx
@@ -2,7 +2,7 @@
 
 import type React from 'react'
 import { useMemo } from 'react'
-import { Combobox, type ComboboxOptionGroup, cn } from '@sim/emcn'
+import { ChipCombobox, Combobox, type ComboboxOptionGroup, cn } from '@sim/emcn'
 import { RepeatIcon, SplitIcon } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import {
@@ -64,6 +64,12 @@ interface OutputSelectProps {
   align?: 'start' | 'end' | 'center'
   /** Maximum height of the dropdown content in pixels */
   maxHeight?: number
+  /**
+   * Trigger chrome. `'sm'` is the compact pill used in inline toolbars;
+   * `'md'` is the 30px chip field, for stacking with `ChipInput` in a form.
+   * @default 'sm'
+   */
+  size?: 'sm' | 'md'
   /** Additional class names to apply to the combobox trigger */
   className?: string
 }
@@ -87,6 +93,7 @@ export function OutputSelect({
   valueMode = 'id',
   align = 'start',
   maxHeight = 200,
+  size = 'sm',
   className,
 }: OutputSelectProps) {
   const blocks = useWorkflowStore((state) => state.blocks)
@@ -299,10 +306,12 @@ export function OutputSelect({
       .filter((v): v is string => v !== null)
   }, [selectedOutputs, workflowOutputs, valueMode])
 
+  const Trigger = size === 'md' ? ChipCombobox : Combobox
+
   return (
-    <Combobox
-      size='sm'
-      className={cn('!py-0.5 w-fit min-w-[100px] rounded-md px-2.5', className)}
+    <Trigger
+      size={size}
+      className={cn('min-w-[100px]', size === 'sm' && '!py-0.5 w-fit rounded-md px-2.5', className)}
       groups={comboboxGroups}
       options={[]}
       multiSelect

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
@@ -5,6 +5,7 @@ import {
   ButtonGroup,
   ButtonGroupItem,
   ChipConfirmModal,
+  ChipEmailsInput,
   ChipInput,
   cn,
   Input,
@@ -12,19 +13,16 @@ import {
   Loader,
   Skeleton,
   Switch,
-  TagInput,
-  type TagItem,
   Textarea,
   Tooltip,
 } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
-import { normalizeEmail } from '@sim/utils/string'
 import { AlertTriangle, Check } from 'lucide-react'
 import { GeneratedPasswordInput } from '@/components/ui'
 import { isSsoEnabled } from '@/lib/core/config/env-flags'
 import { getBaseUrl, getEmailDomain } from '@/lib/core/utils/urls'
-import { quickValidateEmail } from '@/lib/messaging/email/validation'
+import { validateAllowlistEntry } from '@/lib/messaging/email/validation'
 import { OutputSelect } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/output-select/output-select'
 import {
   type AuthType,
@@ -339,7 +337,7 @@ export function ChatDeploy({
         id='chat-deploy-form'
         ref={formRef}
         onSubmit={handleSubmit}
-        className='-mx-1 space-y-4 overflow-y-auto px-1'
+        className='-mx-1 space-y-4 px-1'
       >
         {errors.general && (
           <div className='flex items-center gap-2 rounded-md border border-[color-mix(in_srgb,var(--text-error)_20%,transparent)] bg-[color-mix(in_srgb,var(--text-error)_10%,transparent)] px-3 py-2 text-[var(--text-error)] text-small'>
@@ -388,6 +386,7 @@ export function ChatDeploy({
               onOutputSelect={(values) => updateField('selectedOutputBlocks', values)}
               placeholder='Select which block outputs to use'
               disabled={chatSubmitting}
+              size='md'
               className='w-full'
             />
             {errors.outputBlocks && (
@@ -693,12 +692,7 @@ function AuthSelector({
   hasExistingPassword = false,
   error,
 }: AuthSelectorProps) {
-  const [emailError, setEmailError] = useState('')
-  const [invalidEmailItems, setInvalidEmailItems] = useState<TagItem[]>([])
   const revealPasswordMutation = useRevealChatPassword()
-
-  const emailsRef = useRef(emails)
-  const invalidEmailItemsRef = useRef(invalidEmailItems)
 
   /**
    * Editing or regenerating the password clears a failed reveal. The mutation
@@ -708,60 +702,6 @@ function AuthSelector({
   const handlePasswordChange = (value: string) => {
     if (revealPasswordMutation.isError) revealPasswordMutation.reset()
     onPasswordChange(value)
-  }
-
-  useEffect(() => {
-    emailsRef.current = emails
-  }, [emails])
-
-  const addEmail = (email: string): boolean => {
-    if (!email.trim()) return false
-
-    const normalized = normalizeEmail(email)
-    const isDomainPattern = normalized.startsWith('@')
-    const validation = quickValidateEmail(normalized)
-    const isValid = validation.isValid || isDomainPattern
-
-    if (
-      emailsRef.current.includes(normalized) ||
-      invalidEmailItemsRef.current.some((item) => item.value === normalized)
-    ) {
-      return false
-    }
-
-    if (isValid) {
-      setEmailError('')
-      emailsRef.current = [...emailsRef.current, normalized]
-      onEmailsChange(emailsRef.current)
-    } else {
-      invalidEmailItemsRef.current = [
-        ...invalidEmailItemsRef.current,
-        { value: normalized, isValid, error: validation.reason ?? 'Invalid email format' },
-      ]
-      setInvalidEmailItems(invalidEmailItemsRef.current)
-    }
-
-    return isValid
-  }
-
-  const emailItems = [
-    ...emails.map((email) => ({ value: email, isValid: true })),
-    ...invalidEmailItems,
-  ]
-
-  const handleRemoveEmailItem = (_value: string, index: number) => {
-    const itemToRemove = emailItems[index]
-    if (!itemToRemove) return
-
-    if (itemToRemove.isValid) {
-      emailsRef.current = emailsRef.current.filter((e) => e !== itemToRemove.value)
-      onEmailsChange(emailsRef.current)
-    } else {
-      invalidEmailItemsRef.current = invalidEmailItemsRef.current.filter(
-        (item) => item.value !== itemToRemove.value
-      )
-      setInvalidEmailItems(invalidEmailItemsRef.current)
-    }
   }
 
   const { config: permissionConfig } = usePermissionConfig()
@@ -835,22 +775,15 @@ function AuthSelector({
           <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
             {authType === 'email' ? 'Allowed emails' : 'Allowed SSO emails'}
           </Label>
-          <TagInput
-            items={emailItems}
-            onAdd={(value) => addEmail(value)}
-            onRemove={handleRemoveEmailItem}
-            placeholder='Enter emails or domains (@example.com)'
-            placeholderWithTags='Add email'
+          <ChipEmailsInput
+            value={emails}
+            onChange={onEmailsChange}
+            validate={validateAllowlistEntry}
+            allowDomains
+            placeholder='Enter emails or domains'
+            placeholderWithTags='Add email or domain'
             disabled={disabled}
           />
-          {emailError && (
-            <p className='mt-[6.5px] text-[var(--text-error)] text-caption'>{emailError}</p>
-          )}
-          <p className='mt-[6.5px] text-[var(--text-secondary)] text-xs'>
-            {authType === 'email'
-              ? 'Add specific emails or entire domains (@example.com)'
-              : 'Add emails or domains that can access via SSO'}
-          </p>
         </div>
       )}
 

--- a/apps/sim/lib/messaging/email/validation.test.ts
+++ b/apps/sim/lib/messaging/email/validation.test.ts
@@ -1,5 +1,6 @@
+import { isValidEmailSyntax } from '@sim/utils/string'
 import { describe, expect, it } from 'vitest'
-import { quickValidateEmail } from '@/lib/messaging/email/validation'
+import { quickValidateEmail, validateAllowlistEntry } from '@/lib/messaging/email/validation'
 
 describe('quickValidateEmail', () => {
   it.concurrent('should validate a correct email', () => {
@@ -143,5 +144,57 @@ describe('quickValidateEmail', () => {
     const result = quickValidateEmail('user@mail.subdomain.example.com')
     expect(result.isValid).toBe(true)
     expect(result.checks.domain).toBe(true)
+  })
+})
+
+describe('isValidEmailSyntax', () => {
+  it.concurrent('should only accept a bare domain when allowDomains is set', () => {
+    expect(isValidEmailSyntax('@example.com')).toBe(false)
+    expect(isValidEmailSyntax('@example.com', true)).toBe(true)
+  })
+
+  it.concurrent('should accept single-label domains, which self-hosted deployments use', () => {
+    expect(isValidEmailSyntax('@intranet', true)).toBe(true)
+    expect(isValidEmailSyntax('@localhost', true)).toBe(true)
+  })
+
+  it.concurrent('should reject bare domains the old startsWith("@") check let through', () => {
+    for (const entry of ['@', '@-bad.com', '@bad-.com', '@example.com.', '@exa mple.com']) {
+      expect(isValidEmailSyntax(entry, true)).toBe(false)
+    }
+  })
+
+  it.concurrent('should enforce the 254-character cap', () => {
+    const at254 = `${'a'.repeat(242)}@example.com`
+    const at255 = `${'a'.repeat(243)}@example.com`
+    expect(at254).toHaveLength(254)
+    expect(at255).toHaveLength(255)
+    expect(isValidEmailSyntax(at254)).toBe(true)
+    expect(isValidEmailSyntax(at255)).toBe(false)
+  })
+
+  it.concurrent('should enforce the 63-character DNS label limit on bare domains', () => {
+    expect(isValidEmailSyntax(`@${'a'.repeat(63)}.com`, true)).toBe(true)
+    expect(isValidEmailSyntax(`@${'a'.repeat(64)}.com`, true)).toBe(false)
+  })
+})
+
+describe('validateAllowlistEntry', () => {
+  it.concurrent('should accept a valid address', () => {
+    expect(validateAllowlistEntry('user@example.com')).toBeNull()
+  })
+
+  it.concurrent('should waive address-level policy for bare domain entries', () => {
+    expect(validateAllowlistEntry('@mailinator.com')).toBeNull()
+    expect(validateAllowlistEntry('user@mailinator.com')).toBe(
+      'Disposable email addresses are not allowed'
+    )
+  })
+
+  it.concurrent('should surface the underlying rejection reason', () => {
+    expect(validateAllowlistEntry('notanemail')).toBe('Invalid email format')
+    expect(validateAllowlistEntry('user..name@example.com')).toBe(
+      'Email contains suspicious patterns'
+    )
   })
 })

--- a/apps/sim/lib/messaging/email/validation.ts
+++ b/apps/sim/lib/messaging/email/validation.ts
@@ -1,3 +1,5 @@
+import { isValidEmailSyntax } from '@sim/utils/string'
+
 export interface EmailValidationResult {
   isValid: boolean
   reason?: string
@@ -39,15 +41,6 @@ const DISPOSABLE_DOMAINS = new Set([
 ])
 
 /**
- * Validates email syntax using RFC 5322 compliant regex
- */
-function validateEmailSyntax(email: string): boolean {
-  const emailRegex =
-    /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
-  return emailRegex.test(email) && email.length <= 254
-}
-
-/**
  * Checks if email is from a known disposable email provider
  */
 function isDisposableEmail(email: string): boolean {
@@ -78,7 +71,7 @@ export function quickValidateEmail(email: string): EmailValidationResult {
     disposable: false,
   }
 
-  checks.syntax = validateEmailSyntax(email)
+  checks.syntax = isValidEmailSyntax(email)
   if (!checks.syntax) {
     return {
       isValid: false,
@@ -136,9 +129,9 @@ export function quickValidateEmail(email: string): EmailValidationResult {
 
 /**
  * App-level policy for a single access-allowlist entry, applied on top of the
- * syntax gate in `ChipEmailsInput`. A bare `@domain` entry carries no local
- * part, so the address-level checks (disposable providers, suspicious patterns)
- * only apply to full addresses.
+ * caller's format gate. A bare `@domain` entry carries no local part, so the
+ * address-level checks (disposable providers, suspicious patterns) only apply
+ * to full addresses.
  *
  * @returns the rejection reason, or `null` when the entry is accepted.
  */

--- a/apps/sim/lib/messaging/email/validation.ts
+++ b/apps/sim/lib/messaging/email/validation.ts
@@ -133,3 +133,17 @@ export function quickValidateEmail(email: string): EmailValidationResult {
     checks,
   }
 }
+
+/**
+ * App-level policy for a single access-allowlist entry, applied on top of the
+ * syntax gate in `ChipEmailsInput`. A bare `@domain` entry carries no local
+ * part, so the address-level checks (disposable providers, suspicious patterns)
+ * only apply to full addresses.
+ *
+ * @returns the rejection reason, or `null` when the entry is accepted.
+ */
+export function validateAllowlistEntry(entry: string): string | null {
+  if (entry.startsWith('@')) return null
+  const result = quickValidateEmail(entry)
+  return result.isValid ? null : (result.reason ?? 'Invalid email')
+}

--- a/packages/emcn/src/components/chip-emails-input/chip-emails-input.tsx
+++ b/packages/emcn/src/components/chip-emails-input/chip-emails-input.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import * as React from 'react'
+import { normalizeEmail } from '@sim/utils/string'
+import { TagInput, type TagItem } from '../tag-input/tag-input'
+
+/**
+ * Generic RFC 5322 email syntax gate. This is deliberately format-only —
+ * app-specific policy (disposable domains, MX/DNS, membership rules) is the
+ * consumer's concern and flows through the `validate` prop, keeping that logic
+ * in the app rather than the design system.
+ */
+const EMAIL_SYNTAX_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+
+/**
+ * Bare `@domain.tld` pattern, accepted only when the consumer opts in via
+ * `allowDomains` — for allowlists that grant access to a whole domain.
+ */
+const EMAIL_DOMAIN_SYNTAX_REGEX =
+  /^@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/
+
+function isValidEmailSyntax(email: string, allowDomains: boolean): boolean {
+  if (email.length > 254) return false
+  return EMAIL_SYNTAX_REGEX.test(email) || (allowDomains && EMAIL_DOMAIN_SYNTAX_REGEX.test(email))
+}
+
+/**
+ * Derives the post-first-chip placeholder from the initial placeholder so
+ * consumers don't have to spell both. Tries an `'Enter <noun>s'` →
+ * `'Add <noun>'` singularize; falls back to a generic `'Add another'`.
+ */
+function derivePlaceholderWithTags(placeholder: string): string {
+  const match = placeholder.match(/^Enter\s+(.+?)s?$/i)
+  if (match) return `Add ${match[1]}`
+  return 'Add another'
+}
+
+export interface ChipEmailsInputProps {
+  /** Current list of accepted entries. */
+  value: string[]
+  /** Called with the next list when valid items are added or removed. */
+  onChange: (next: string[]) => void
+  /**
+   * Optional domain-level validator. Runs AFTER the internal format check
+   * passes. Return an error message to reject the entry (added as an invalid
+   * chip whose reason shows in a tooltip on hover); return `null` to accept.
+   */
+  validate?: (email: string) => string | null
+  /**
+   * Also accept a bare `@domain.tld` entry alongside full addresses, for
+   * allowlists that grant access to an entire domain.
+   * @default false
+   */
+  allowDomains?: boolean
+  /** Placeholder shown when no chips exist. Defaults to `'Enter emails'`. */
+  placeholder?: string
+  /**
+   * Placeholder shown once at least one chip exists. Defaults to a singularized
+   * form of {@link ChipEmailsInputProps.placeholder}; pass this when that
+   * derivation reads awkwardly.
+   */
+  placeholderWithTags?: string
+  /**
+   * Chip surface. `'block'` is the taller multi-row form variant.
+   * @default 'block'
+   */
+  variant?: 'default' | 'block'
+  /** Disables the input and hides the per-chip remove buttons. */
+  disabled?: boolean
+  /** Focus the input when the component mounts. */
+  autoFocus?: boolean
+  /** HTML `id` for the inner input, for label association. */
+  id?: string
+}
+
+/**
+ * Canonical multi-email chip input. Owns the chip lifecycle (valid + invalid
+ * items, dedupe, lowercase normalization, format validation, paste, Backspace,
+ * per-chip error tooltips) and lifts only the accepted list up via `onChange`.
+ * Each rejected entry carries its rejection reason on the chip itself.
+ *
+ * Inside a `ChipModal`, prefer `ChipModalField type='emails'`, which wraps this
+ * with the canonical label/hint/error row. Use this component directly only in
+ * surfaces that own their own field chrome.
+ */
+export function ChipEmailsInput({
+  value,
+  onChange,
+  validate,
+  allowDomains = false,
+  placeholder = 'Enter emails',
+  placeholderWithTags,
+  variant = 'block',
+  disabled,
+  autoFocus,
+  id,
+}: ChipEmailsInputProps) {
+  const [items, setItems] = React.useState<TagItem[]>(() =>
+    value.map((v) => ({ value: v, isValid: true }))
+  )
+
+  /**
+   * Synchronous mirror of `items`. Pasting multiple values calls `handleAdd`
+   * once per value within a single event, before React re-renders — reading
+   * the `items` state there would make every call see the same stale array
+   * and each add overwrite the previous one (only the last pasted email
+   * survives). All reads and writes go through the ref so consecutive adds
+   * compose; `commitItems` keeps state and ref in lockstep.
+   */
+  const itemsRef = React.useRef<TagItem[]>(items)
+
+  const commitItems = React.useCallback((next: TagItem[]) => {
+    itemsRef.current = next
+    setItems(next)
+  }, [])
+
+  /**
+   * Reconcile internal `items` with the consumer's `value` when the latter
+   * changes externally (programmatic clear, partial-failure reseed, etc.).
+   * When our own `onChange` is the source of the update, the valid items in
+   * `items` already match `value` and this is a no-op.
+   */
+  React.useEffect(() => {
+    const prevValid = itemsRef.current.filter((item) => item.isValid).map((item) => item.value)
+    if (prevValid.length === value.length && prevValid.every((v, idx) => v === value[idx])) {
+      return
+    }
+    itemsRef.current = value.map((v) => ({ value: v, isValid: true }))
+    setItems(itemsRef.current)
+  }, [value])
+
+  const handleAdd = React.useCallback(
+    (raw: string): boolean => {
+      const email = normalizeEmail(raw)
+      if (!email) return false
+      const current = itemsRef.current
+      if (current.some((item) => item.value === email)) return false
+
+      if (!isValidEmailSyntax(email, allowDomains)) {
+        commitItems([
+          ...current,
+          {
+            value: email,
+            isValid: false,
+            error: allowDomains ? 'Invalid email or domain' : 'Invalid email format',
+          },
+        ])
+        return false
+      }
+
+      const reason = validate?.(email)
+      if (reason) {
+        commitItems([...current, { value: email, isValid: false, error: reason }])
+        return false
+      }
+
+      const next = [...current, { value: email, isValid: true }]
+      commitItems(next)
+      onChange(next.filter((item) => item.isValid).map((item) => item.value))
+      return true
+    },
+    [validate, onChange, commitItems, allowDomains]
+  )
+
+  const handleRemove = React.useCallback(
+    (_removed: string, index: number) => {
+      const current = itemsRef.current
+      const wasValid = current[index]?.isValid ?? false
+      const next = current.filter((_, i) => i !== index)
+      commitItems(next)
+      if (wasValid) {
+        onChange(next.filter((item) => item.isValid).map((item) => item.value))
+      }
+    },
+    [onChange, commitItems]
+  )
+
+  return (
+    <TagInput
+      variant={variant}
+      items={items}
+      onAdd={handleAdd}
+      onRemove={handleRemove}
+      placeholder={placeholder}
+      placeholderWithTags={placeholderWithTags ?? derivePlaceholderWithTags(placeholder)}
+      disabled={disabled}
+      autoFocus={autoFocus}
+      id={id}
+    />
+  )
+}
+
+ChipEmailsInput.displayName = 'ChipEmailsInput'

--- a/packages/emcn/src/components/chip-emails-input/chip-emails-input.tsx
+++ b/packages/emcn/src/components/chip-emails-input/chip-emails-input.tsx
@@ -1,39 +1,26 @@
 'use client'
 
 import * as React from 'react'
-import { normalizeEmail } from '@sim/utils/string'
+import { isValidEmailSyntax, normalizeEmail } from '@sim/utils/string'
 import { TagInput, type TagItem } from '../tag-input/tag-input'
 
-/**
- * Generic RFC 5322 email syntax gate. This is deliberately format-only —
- * app-specific policy (disposable domains, MX/DNS, membership rules) is the
- * consumer's concern and flows through the `validate` prop, keeping that logic
- * in the app rather than the design system.
- */
-const EMAIL_SYNTAX_REGEX =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
-
-/**
- * Bare `@domain.tld` pattern, accepted only when the consumer opts in via
- * `allowDomains` — for allowlists that grant access to a whole domain.
- */
-const EMAIL_DOMAIN_SYNTAX_REGEX =
-  /^@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/
-
-function isValidEmailSyntax(email: string, allowDomains: boolean): boolean {
-  if (email.length > 254) return false
-  return EMAIL_SYNTAX_REGEX.test(email) || (allowDomains && EMAIL_DOMAIN_SYNTAX_REGEX.test(email))
-}
+const ENTER_PREFIX = 'enter'
 
 /**
  * Derives the post-first-chip placeholder from the initial placeholder so
  * consumers don't have to spell both. Tries an `'Enter <noun>s'` →
  * `'Add <noun>'` singularize; falls back to a generic `'Add another'`.
+ *
+ * Deliberately string ops rather than a regex — `/^Enter\s+(.+?)s?$/` has
+ * polynomial backtracking on whitespace-heavy input (CodeQL js/redos).
  */
 function derivePlaceholderWithTags(placeholder: string): string {
-  const match = placeholder.match(/^Enter\s+(.+?)s?$/i)
-  if (match) return `Add ${match[1]}`
-  return 'Add another'
+  const rest = placeholder.slice(ENTER_PREFIX.length)
+  const noun = rest.trim()
+  const startsWithEnter = placeholder.slice(0, ENTER_PREFIX.length).toLowerCase() === ENTER_PREFIX
+  if (!startsWithEnter || rest === noun || !noun) return 'Add another'
+  const singular = noun.toLowerCase().endsWith('s') ? noun.slice(0, -1) : noun
+  return `Add ${singular}`
 }
 
 export interface ChipEmailsInputProps {

--- a/packages/emcn/src/components/chip-modal/chip-modal.tsx
+++ b/packages/emcn/src/components/chip-modal/chip-modal.tsx
@@ -47,26 +47,13 @@ import { Chip, type ChipProps } from '../chip/chip'
 import { chipContentIconClass, chipContentLabelClass } from '../chip/chip-chrome'
 import { ChipCopyInput } from '../chip-copy-input/chip-copy-input'
 import { ChipDropdown, type ChipDropdownOption } from '../chip-dropdown/chip-dropdown'
+import { ChipEmailsInput, type ChipEmailsInputProps } from '../chip-emails-input/chip-emails-input'
 import { ChipInput } from '../chip-input/chip-input'
 import { ChipSwitch } from '../chip-switch/chip-switch'
 import { ChipTextarea } from '../chip-textarea/chip-textarea'
 import { Label } from '../label/label'
 import { Modal, ModalContent } from '../modal/modal'
-import { TagInput, type TagItem } from '../tag-input/tag-input'
 import { Tooltip } from '../tooltip/tooltip'
-
-/**
- * Generic RFC 5322 email syntax gate for the `type='emails'` field. This is
- * deliberately format-only — app-specific policy (disposable domains, MX/DNS,
- * membership rules) is the consumer's concern and flows through the field's
- * `validate` prop, keeping that logic in the app rather than the design system.
- */
-const EMAIL_SYNTAX_REGEX =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
-
-function isValidEmailSyntax(email: string): boolean {
-  return EMAIL_SYNTAX_REGEX.test(email) && email.length <= 254
-}
 
 /**
  * The modal's hairline divider — used by the header and footer edges, and
@@ -524,29 +511,23 @@ interface ChipModalFileFieldProps extends ChipModalFieldBaseProps {
   loading?: boolean
 }
 
-export interface ChipModalEmailsFieldProps extends ChipModalFieldBaseProps {
+/**
+ * The emails field is a thin row wrapper over {@link ChipEmailsInput} — the
+ * control's own props (`value`, `onChange`, `validate`, `allowDomains`,
+ * `placeholder`, …) pass straight through, so they are declared in one place.
+ * `variant` is not forwarded: the field always uses the tall `block` chip
+ * surface so it stacks as a peer with `textarea` fields.
+ */
+export interface ChipModalEmailsFieldProps
+  extends ChipModalFieldBaseProps,
+    Omit<ChipEmailsInputProps, 'variant' | 'id'> {
   type: 'emails'
-  /** Current list of valid email addresses. */
-  value: string[]
-  /** Called with the next list when valid items are added or removed. */
-  onChange: (next: string[]) => void
-  /**
-   * Optional domain-level validator. Runs AFTER the field's internal format
-   * check passes. Return an error message to reject the email (added as an
-   * invalid chip whose reason shows in a tooltip on hover); return `null`
-   * to accept.
-   */
-  validate?: (email: string) => string | null
   /**
    * External error (e.g. server-side submit failure), rendered in the inline
    * banner below the field. Per-email rejection reasons are shown on the
    * invalid chips themselves, not here.
    */
   error?: React.ReactNode
-  /** Auto-focus the input when the field mounts. */
-  autoFocus?: boolean
-  /** Placeholder shown when no chips exist. Defaults to `'Enter emails'`. */
-  placeholder?: string
 }
 
 /**
@@ -742,119 +723,27 @@ function renderChipModalControl(
 }
 
 /**
- * Derives the post-first-chip placeholder from the initial placeholder so
- * consumers don't have to spell both. Tries an `'Enter <noun>s'` →
- * `'Add <noun>'` singularize; falls back to a generic `'Add another'`.
- */
-function derivePlaceholderWithTags(placeholder: string): string {
-  const match = placeholder.match(/^Enter\s+(.+?)s?$/i)
-  if (match) return `Add ${match[1]}`
-  return 'Add another'
-}
-
-/**
- * Internal renderer for {@link ChipModalField} `type='emails'`. Owns the
- * chip lifecycle (valid + invalid items, dedupe, per-chip error tooltips)
- * and lifts only the valid email list up to the consumer via `onChange`.
- * Each rejected entry carries its rejection reason on the chip itself,
- * surfaced as a tooltip; the inline banner is reserved for the consumer's
- * `error` (e.g. server-side submit failures).
+ * Internal renderer for {@link ChipModalField} `type='emails'`. Delegates the
+ * chip lifecycle to {@link ChipEmailsInput} and adds only the field-level
+ * error banner — per-entry rejection reasons are shown on the chips
+ * themselves, so this banner is reserved for the consumer's `error` (e.g. a
+ * server-side submit failure).
  */
 function ChipModalEmailsControl({
-  value,
-  onChange,
-  validate,
+  type: _type,
+  title: _title,
+  required: _required,
+  hint: _hint,
+  flush: _flush,
+  className: _className,
   error,
-  autoFocus,
-  placeholder = 'Enter emails',
-  disabled,
-  id,
   errorId,
+  id,
+  ...emailsProps
 }: ChipModalEmailsFieldProps & { id: string; errorId: string }) {
-  const [items, setItems] = React.useState<TagItem[]>([])
-
-  /**
-   * Synchronous mirror of `items`. Pasting multiple values calls `handleAdd`
-   * once per value within a single event, before React re-renders — reading
-   * the `items` state there would make every call see the same stale array
-   * and each add overwrite the previous one (only the last pasted email
-   * survives). All reads and writes go through the ref so consecutive adds
-   * compose; `commitItems` keeps state and ref in lockstep.
-   */
-  const itemsRef = React.useRef<TagItem[]>(items)
-
-  const commitItems = React.useCallback((next: TagItem[]) => {
-    itemsRef.current = next
-    setItems(next)
-  }, [])
-
-  /**
-   * Reconcile internal `items` with the consumer's `value` when the latter
-   * changes externally (programmatic clear, partial-failure reseed, etc.).
-   * When our own `onChange` is the source of the update, the valid items in
-   * `items` already match `value` and this is a no-op.
-   */
-  React.useEffect(() => {
-    const prevValid = itemsRef.current.filter((item) => item.isValid).map((item) => item.value)
-    if (prevValid.length === value.length && prevValid.every((v, idx) => v === value[idx])) {
-      return
-    }
-    itemsRef.current = value.map((v) => ({ value: v, isValid: true }))
-    setItems(itemsRef.current)
-  }, [value])
-
-  const handleAdd = React.useCallback(
-    (raw: string): boolean => {
-      const email = raw.trim().toLowerCase()
-      if (!email) return false
-      const current = itemsRef.current
-      if (current.some((item) => item.value === email)) return false
-
-      if (!isValidEmailSyntax(email)) {
-        commitItems([...current, { value: email, isValid: false, error: 'Invalid email format' }])
-        return false
-      }
-
-      const reason = validate?.(email)
-      if (reason) {
-        commitItems([...current, { value: email, isValid: false, error: reason }])
-        return false
-      }
-
-      const next = [...current, { value: email, isValid: true }]
-      commitItems(next)
-      onChange(next.filter((item) => item.isValid).map((item) => item.value))
-      return true
-    },
-    [validate, onChange, commitItems]
-  )
-
-  const handleRemove = React.useCallback(
-    (_removed: string, index: number) => {
-      const current = itemsRef.current
-      const wasValid = current[index]?.isValid ?? false
-      const next = current.filter((_, i) => i !== index)
-      commitItems(next)
-      if (wasValid) {
-        onChange(next.filter((item) => item.isValid).map((item) => item.value))
-      }
-    },
-    [onChange, commitItems]
-  )
-
   return (
     <>
-      <TagInput
-        variant='block'
-        items={items}
-        onAdd={handleAdd}
-        onRemove={handleRemove}
-        placeholder={placeholder}
-        placeholderWithTags={derivePlaceholderWithTags(placeholder)}
-        disabled={disabled}
-        autoFocus={autoFocus}
-        id={id}
-      />
+      <ChipEmailsInput id={id} {...emailsProps} />
       {error && (
         <p id={errorId} role='alert' className={CHIP_MODAL_FIELD_ERROR_CLASS}>
           {error}

--- a/packages/emcn/src/components/chip-modal/chip-modal.tsx
+++ b/packages/emcn/src/components/chip-modal/chip-modal.tsx
@@ -730,20 +730,31 @@ function renderChipModalControl(
  * server-side submit failure).
  */
 function ChipModalEmailsControl({
-  type: _type,
-  title: _title,
-  required: _required,
-  hint: _hint,
-  flush: _flush,
-  className: _className,
+  value,
+  onChange,
+  validate,
+  allowDomains,
+  placeholder,
+  placeholderWithTags,
+  autoFocus,
+  disabled,
   error,
   errorId,
   id,
-  ...emailsProps
 }: ChipModalEmailsFieldProps & { id: string; errorId: string }) {
   return (
     <>
-      <ChipEmailsInput id={id} {...emailsProps} />
+      <ChipEmailsInput
+        id={id}
+        value={value}
+        onChange={onChange}
+        validate={validate}
+        allowDomains={allowDomains}
+        placeholder={placeholder}
+        placeholderWithTags={placeholderWithTags}
+        autoFocus={autoFocus}
+        disabled={disabled}
+      />
       {error && (
         <p id={errorId} role='alert' className={CHIP_MODAL_FIELD_ERROR_CLASS}>
           {error}

--- a/packages/emcn/src/components/index.ts
+++ b/packages/emcn/src/components/index.ts
@@ -41,6 +41,10 @@ export {
   type ChipDropdownOption,
   type ChipDropdownProps,
 } from './chip-dropdown/chip-dropdown'
+export {
+  ChipEmailsInput,
+  type ChipEmailsInputProps,
+} from './chip-emails-input/chip-emails-input'
 export { ChipInput, type ChipInputProps } from './chip-input/chip-input'
 export {
   type ChipConfirmAction,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -34,6 +34,7 @@ export type { BackoffOptions } from './retry.js'
 export { backoffWithJitter, parseRetryAfter } from './retry.js'
 export { normalizeSSODomain } from './sso-domain.js'
 export {
+  isValidEmailSyntax,
   normalizeEmail,
   sanitizeForJsonb,
   sanitizeValueForJsonb,

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -47,6 +47,32 @@ export function normalizeEmail(email: string): string {
 }
 
 /**
+ * RFC 5322-shaped syntax gate for a full address. Format only — domain
+ * reputation, MX/DNS, and membership policy are the caller's concern.
+ */
+const EMAIL_SYNTAX_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+
+/**
+ * Bare `@domain` pattern, for allowlists that grant access to a whole domain.
+ * Single-label domains (`@intranet`) are allowed — self-hosted deployments use
+ * them — but a lone `@` and malformed labels are not.
+ */
+const EMAIL_DOMAIN_SYNTAX_REGEX =
+  /^@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+
+/**
+ * Format-only email syntax check, capped at the RFC 5321 length limit.
+ *
+ * @param allowDomains - also accept a bare `@domain` entry, for allowlists that
+ * grant access to an entire domain rather than a single address.
+ */
+export function isValidEmailSyntax(email: string, allowDomains = false): boolean {
+  if (email.length > 254) return false
+  return EMAIL_SYNTAX_REGEX.test(email) || (allowDomains && EMAIL_DOMAIN_SYNTAX_REGEX.test(email))
+}
+
+/**
  * Matches UTF-16 code units that Postgres JSONB rejects: unpaired surrogate
  * halves (e.g. produced by `slice()` cutting an astral character like 𝐀 in
  * half) and the NUL character, which jsonb cannot store at all.


### PR DESCRIPTION
## Summary
- Extract the emails chip lifecycle out of `ChipModalField type='emails'` into a standalone `ChipEmailsInput` — dedupe, normalize, format gate, paste, per-chip error tooltips — with an `allowDomains` opt-in for bare `@domain.tld` entries
- Point the file share modal and the deploy modal's Chat tab at it, deleting both hand-rolled `TagInput` implementations (add/remove/validate handlers, `TagItem` mapping, ref mirrors, and the dead `emailError` state that could only ever be `''`)
- Move the shared allowlist policy into `validateAllowlistEntry`, so disposable-domain/suspicious-pattern checks stay in the app and the design system stays format-only
- Drop the "Add specific emails or whole domains (@example.com)" hint text from both modals
- Give `OutputSelect` a `size` prop; the deploy modal's Chat tab uses the 30px chip trigger so Output lines up with the Title field above it. Other call sites (API tab, chat panel toolbar) keep the compact pill
- Drop `overflow-y-auto` from the chat deploy form — with `overflow-x` still `visible`, CSS promoted it to `auto`, which is where the stray horizontal scrollbar came from. `ModalBody` already owns the vertical scroll, so the class bought nothing

## Type of Change
- [x] Bug fix
- [x] Improvement

## Testing
`bun run lint:check` (23/23), `tsc --noEmit`, `check:api-validation`, and the 1644 workspace tests all pass. Not yet verified in a running browser.

Note: the emails field in both modals is now the taller `block` chip surface (the same one the workspace invite modal uses) rather than the previous single-row input.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)