### PR TITLE
feat(copilot): identify current workspace in workspace lists

### DIFF
--- a/apps/sim/lib/copilot/tools/handlers/workflow/queries.test.ts
+++ b/apps/sim/lib/copilot/tools/handlers/workflow/queries.test.ts
@@ -17,7 +17,10 @@ vi.mock('@/lib/workspaces/utils', () => ({
   listUserWorkspaces: listUserWorkspacesMock,
 }))
 
-import { executeGetBlockOutputs, executeListUserWorkspaces } from './queries'
+import {
+  executeGetBlockOutputs,
+  executeListUserWorkspaces,
+} from '@/lib/copilot/tools/handlers/workflow/queries'
 
 describe('executeListUserWorkspaces', () => {
   beforeEach(() => {

--- a/apps/sim/lib/copilot/tools/handlers/workflow/queries.test.ts
+++ b/apps/sim/lib/copilot/tools/handlers/workflow/queries.test.ts
@@ -2,8 +2,9 @@ import { getErrorMessage } from '@sim/utils/errors'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ExecutionContext } from '@/lib/copilot/request/types'
 
-const { executeWorkflowUseCaseMock } = vi.hoisted(() => ({
+const { executeWorkflowUseCaseMock, listUserWorkspacesMock } = vi.hoisted(() => ({
   executeWorkflowUseCaseMock: vi.fn(),
+  listUserWorkspacesMock: vi.fn(),
 }))
 
 vi.mock('@/lib/copilot/application/execute-workflow-use-case', () => ({
@@ -12,7 +13,51 @@ vi.mock('@/lib/copilot/application/execute-workflow-use-case', () => ({
     getErrorMessage(error, 'Workflow operation failed'),
 }))
 
-import { executeGetBlockOutputs } from './queries'
+vi.mock('@/lib/workspaces/utils', () => ({
+  listUserWorkspaces: listUserWorkspacesMock,
+}))
+
+import { executeGetBlockOutputs, executeListUserWorkspaces } from './queries'
+
+describe('executeListUserWorkspaces', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('marks the current workspace in the accessible workspace list', async () => {
+    listUserWorkspacesMock.mockResolvedValue([
+      { workspaceId: 'workspace-1', workspaceName: 'One', role: 'owner' },
+      { workspaceId: 'workspace-2', workspaceName: 'Two', role: 'read' },
+    ])
+
+    const result = await executeListUserWorkspaces({
+      userId: 'user-1',
+      workflowId: 'workflow-1',
+      workspaceId: 'workspace-2',
+    })
+
+    expect(listUserWorkspacesMock).toHaveBeenCalledWith('user-1')
+    expect(result).toEqual({
+      success: true,
+      output: {
+        workspaces: [
+          {
+            workspaceId: 'workspace-1',
+            workspaceName: 'One',
+            role: 'owner',
+            isCurrent: false,
+          },
+          {
+            workspaceId: 'workspace-2',
+            workspaceName: 'Two',
+            role: 'read',
+            isCurrent: true,
+          },
+        ],
+      },
+    })
+  })
+})
 
 describe('executeGetBlockOutputs', () => {
   beforeEach(() => {

--- a/apps/sim/lib/copilot/tools/handlers/workflow/queries.ts
+++ b/apps/sim/lib/copilot/tools/handlers/workflow/queries.ts
@@ -34,7 +34,10 @@ export async function executeListUserWorkspaces(
   context: ExecutionContext
 ): Promise<ToolCallResult> {
   try {
-    const workspaces = await listUserWorkspaces(context.userId)
+    const workspaces = (await listUserWorkspaces(context.userId)).map((workspace) => ({
+      ...workspace,
+      isCurrent: workspace.workspaceId === context.workspaceId,
+    }))
 
     return { success: true, output: { workspaces } }
   } catch (error) {


### PR DESCRIPTION
## Summary

`list_user_workspaces` now identifies the request's current workspace while preserving each accessible workspace's ID, name, and effective role. The handler adds `isCurrent` by comparing each result with the existing tool execution context; unscoped executions return `false` for every workspace.

This keeps workspace discovery as an on-demand tool call and adds no runtime-context plumbing.

Related: simstudioai/mothership#393

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

- `bun --cwd apps/sim test lib/copilot/tools/handlers/workflow/queries.test.ts lib/copilot/tools/tool-display.test.ts` — 74 tests passed
- `bun run check:api-validation`
- `bun run scripts/sync-tool-catalog.ts --check --input=../mothership/copilot/contracts/tool-catalog-v1.json`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

Not applicable — tool result only.

## Post-Deploy Monitoring & Validation

For the first 24 hours, the Copilot owner should watch `list_user_workspaces` calls for missing or multiple current-workspace markers. Healthy scoped calls return exactly one `isCurrent: true`; unscoped calls return none. Roll back the focused handler commit if current-workspace marking is incorrect.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
