### PR TITLE
improvement(landing): rewrite hero subheading for target keywords

### DIFF
--- a/apps/sim/app/(landing)/components/hero/components/hero-header/hero-header.tsx
+++ b/apps/sim/app/(landing)/components/hero/components/hero-header/hero-header.tsx
@@ -5,7 +5,8 @@ import { HeroCta } from '@/app/(landing)/components/hero-cta'
 import { LANDING_HERO_CTA_GAP } from '@/app/(landing)/components/landing-layout'
 
 interface LandingHeroHeaderProps {
-  description: string
+  /** A single paragraph, or an array of paragraphs rendered stacked within the same measure. */
+  description: string | string[]
   eyebrow?: ReactNode
   heading: ReactNode
   headingId: string
@@ -33,9 +34,22 @@ export function LandingHeroHeader({
           {heading}
         </h1>
 
-        <p className='w-full min-w-0 max-w-[58ch] text-pretty text-[var(--text-muted)] text-base leading-[1.5]'>
-          {description}
-        </p>
+        {Array.isArray(description) ? (
+          <div className='flex w-full min-w-0 max-w-[58ch] flex-col gap-3'>
+            {description.map((paragraph) => (
+              <p
+                key={paragraph}
+                className='text-pretty text-[var(--text-muted)] text-base leading-[1.5]'
+              >
+                {paragraph}
+              </p>
+            ))}
+          </div>
+        ) : (
+          <p className='w-full min-w-0 max-w-[58ch] text-pretty text-[var(--text-muted)] text-base leading-[1.5]'>
+            {description}
+          </p>
+        )}
 
         <div className={cn('max-sm:w-full', LANDING_HERO_CTA_GAP)}>
           <HeroCta />

--- a/apps/sim/app/(landing)/components/hero/hero.tsx
+++ b/apps/sim/app/(landing)/components/hero/hero.tsx
@@ -90,7 +90,10 @@ export function Hero() {
             and Managing AI Agents.
           </>
         }
-        description='Open source, with 1,000+ integrations and every major LLM. Build, deploy, and manage agents visually, conversationally, or with code.'
+        description={[
+          'Sim is an AI agent and workflow builder for teams creating agents that automate real work. Design workflows visually, describe what you need in natural language, or use code for complete control.',
+          'Connect your agents to 1,000+ integrations and every major LLM, then deploy, monitor, and improve them from one collaborative workspace.',
+        ]}
       />
 
       <div


### PR DESCRIPTION
## Summary
Rewrites the landing hero subheading with the SEO/GEO copy from the latest audit. The single line

> Open source, with 1,000+ integrations and every major LLM. Build, deploy, and manage agents visually, conversationally, or with code.

becomes two paragraphs:

> Sim is an AI agent and workflow builder for teams creating agents that automate real work. Design workflows visually, describe what you need in natural language, or use code for complete control.
>
> Connect your agents to 1,000+ integrations and every major LLM, then deploy, monitor, and improve them from one collaborative workspace.

This leads by naming **Sim** (pulling the brand into the first 150 visible characters of the hero, alongside "AI Workspace" / "AI Agents" already in the H1) and works the priority keywords (`ai agent builder`, `ai workflow builder`, `ai workspace`) into visible, server-rendered copy.

The other five items from the audit (title tag, meta description, H1, product-demo paragraph, mothership H2) were already shipped in a prior landing SEO pass and already match the suggested wording, so this PR is only the outstanding hero delta.

### Implementation
- `hero.tsx` passes the new two-paragraph `description` as a `string[]`.
- `LandingHeroHeader` `description` prop widened `string` → `string | string[]`. A **string** still renders the exact same single `<p>` (so `/workflows` and the other solutions heroes are byte-identical); an **array** renders stacked `<p>`s at `gap-3` within the same `58ch` measure.

## Type of Change
- [x] Other: landing-page copy / SEO

## Testing
Verified against a local dev build of the `(landing)` route:
- Server-rendered HTML contains both new paragraphs; the old line is gone; H1 unchanged.
- No console errors; **zero horizontal overflow** at 1280 / 1024 / 768 / 390.
- Desktop + mobile screenshots confirm the two-paragraph hero reads well; CTA row and right-side stat unmoved.
- `/workflows` solutions hero still renders its single-paragraph string path unchanged.
- `biome check` clean on both files; `tsc --noEmit` passes for `apps/sim`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing (copy-only change; no unit-testable logic)
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the Contributor License Agreement (CLA)

## Screenshots/Videos
Verified locally at 1280 and 390 widths (two stacked paragraphs, clean gap, no overflow). Happy to attach if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgSoC2yCfeDkSpZqafWoPA