### PR TITLE
fix(docker): upgrade bun to 1.3.14 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.13-alpine
+FROM oven/bun:1.3.14-alpine
 
 # Install necessary packages for development
 RUN apk add --no-cache \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -652,7 +652,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       # Docker Compose and Kubernetes must run the same background jobs on the
       # same schedules; this fails the build if the two drift apart. The script

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -251,7 +251,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/apps/sim/scripts/pi-sandbox-packages.ts
+++ b/apps/sim/scripts/pi-sandbox-packages.ts
@@ -14,7 +14,7 @@
  */
 
 /** Bun version mirrored from the root packageManager field. */
-export const PI_BUN_VERSION = '1.3.13'
+export const PI_BUN_VERSION = '1.3.14'
 
 /** Exact global package versions mirrored from package.json and bun.lock. */
 export const PI_GLOBAL_NPM_PACKAGES = [

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Debian-based Bun with Node.js 24
 # ========================================
-FROM oven/bun:1.3.13-slim AS base
+FROM oven/bun:1.3.14-slim AS base
 
 # Install Node.js 24 (Active LTS) and common dependencies once in base stage.
 # Node runs only the isolated-vm sandbox worker (the app itself runs under Bun);

--- a/docker/db.Dockerfile
+++ b/docker/db.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Alpine Linux with Bun
 # ========================================
-FROM oven/bun:1.3.13-alpine AS base
+FROM oven/bun:1.3.14-alpine AS base
 
 # ========================================
 # Dependencies Stage: Install Dependencies

--- a/docker/realtime.Dockerfile
+++ b/docker/realtime.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Alpine Linux with Bun
 # ========================================
-FROM oven/bun:1.3.13-alpine AS base
+FROM oven/bun:1.3.14-alpine AS base
 
 RUN apk add --no-cache libc6-compat curl
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simstudio",
-  "packageManager": "bun@1.3.13",
+  "packageManager": "bun@1.3.14",
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- **Staging is currently down.** Bun 1.3.13 cannot load Next 16.3.0's compiled server runtime, so every app-page render throws and `/api/health` returns 500. This bumps Bun to **1.3.14**, which fixes it.
- The app container runs the Next server under Bun (`oven/bun:1.3.13-slim`, `CMD ["bun", "apps/sim/bootstrap.js"]`), so the failure is at runtime, not build time:

```
⨯ Error: Failed to load external module
  next/dist/compiled/next-server/app-page-turbo.runtime.prod.js:
  TypeError: Expected CommonJS module to have a function wrapper.
  If you weren't messing around with Bun's internals, this is a bug in Bun
```

- Isolated to **Bun, not Next**, by loading that exact module inside the real container images:

| | Bun 1.3.13 | Bun 1.3.14 |
|---|---|---|
| Next 16.2.12 | loads (why staging was fine before) | loads |
| Next 16.3.0 | **CJS wrapper error** | **loads** |

Only one cell fails. Bun 1.3.14 is the current stable and already contains the fix, so this bumps every pin rather than reverting #6235 — a revert would only defer the same latent Bun bug to the next framework upgrade.

- Bumps all 13 pins: `docker/app.Dockerfile`, `docker/db.Dockerfile`, `docker/realtime.Dockerfile`, `package.json` `packageManager`, and `bun-version` in `ci.yml`, `test-build.yml`, `desktop-e2e.yml`, `desktop-release.yml`, `docs-embeddings.yml`, `helm.yml`, `migrations.yml`, `publish-cli.yml`, `publish-ts-sdk.yml`.

## Incident detail
- First error at **01:52:56 UTC**, ~2.5 min into deploy `d-8SLBY3ZXK` (the image carrying #6235). 745 occurrences, zero before that timestamp.
- Both ALB targets `unhealthy` / `Target.ResponseCodeMismatch` on the only target group serving traffic. **CodeDeploy reported `Succeeded`** and no rollback fired.
- **Production was never affected** (5/5 tasks healthy, zero occurrences) — it deploys from `main`.

## Why no gate caught it
Local dev machines run Bun 1.3.14, while the container and CI pinned 1.3.13 — so every local check (build, dev, 18k tests, typecheck) ran on the version *without* the bug. CI pins 1.3.13 but only **builds** the image; nothing boots a container and probes `/api/health`, so CI went green on an image that could not serve a page. **A container smoke test in CI would have caught this** and is worth adding as a follow-up.

## Type of Change
- [x] Bug fix (production/staging outage)

## Testing
- Reproduced and verified the fix at the root cause by loading `app-page-turbo.runtime.prod.js` in `oven/bun:1.3.13-slim` (fails) vs `oven/bun:1.3.14-slim` (loads) — see matrix above.
- Bun 1.3.14 is already the version this repo's full verification suite runs on locally (builds, 18366/18367 tests, 23-package typecheck all pass on it).
- A full image build on Bun 1.3.14 with an `/api/health` probe is running; I'll post the result here before merge.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)