### PR TITLE
fix(deps): revert next to 16.2.12, its 16.3.0 optimizer deletes live code

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,7 +31,7 @@
     "fumadocs-openapi": "10.8.1",
     "fumadocs-ui": "16.8.5",
     "lucide-react": "^0.511.0",
-    "next": "16.3.0",
+    "next": "16.2.12",
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/apps/sim/app/api/credentials/route.ts
+++ b/apps/sim/app/api/credentials/route.ts
@@ -133,15 +133,24 @@ async function findExistingCredentialBySourceWith(
   return null
 }
 
+/**
+ * `return await` is load-bearing, not redundant. Next 16.3.0's Turbopack
+ * optimizer models a bare `return <asyncCall>()` tail call as returning the
+ * promise object, then propagates that always-truthy fact through the caller's
+ * `await`. It concludes `if (existingCredential)` is always taken and — because
+ * every branch inside that block returns — deletes the entire create path from
+ * the emitted bundle, so a first-time create throws on `existingCredential.id`.
+ * Awaiting here makes the optimizer model the resolved value instead.
+ */
 async function findExistingCredentialBySource(params: ExistingCredentialSourceParams) {
-  return findExistingCredentialBySourceWith(db, params)
+  return await findExistingCredentialBySourceWith(db, params)
 }
 
 async function findExistingCredentialBySourceTx(
   tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
   params: ExistingCredentialSourceParams
 ) {
-  return findExistingCredentialBySourceWith(tx, params)
+  return await findExistingCredentialBySourceWith(tx, params)
 }
 
 export const GET = withRouteHandler(async (request: NextRequest) => {

--- a/apps/sim/lib/copilot/async-runs/repository.ts
+++ b/apps/sim/lib/copilot/async-runs/repository.ts
@@ -29,9 +29,18 @@ const WORKFLOW_EXECUTION_CLAIM_PREFIX = 'workflow:'
 // can evaluate modules before instrumentation-node.ts finishes).
 const getAsyncRunsTracer = () => trace.getTracer('sim-copilot-async-runs', '1.0.0')
 
-// Wrap an async DB op in a client-kind span with canonical `db.*` attrs.
-// Cancellation is routed through `markSpanForError` so aborts record the
-// exception event but don't paint spans red.
+/**
+ * Wrap an async DB op in a client-kind span with canonical `db.*` attrs.
+ * Cancellation is routed through `markSpanForError` so aborts record the
+ * exception event but don't paint spans red.
+ *
+ * Every caller writes `return await withDbSpan(...)`. The `await` is
+ * load-bearing, not redundant: Next 16.3.0's Turbopack optimizer models a bare
+ * `return <asyncCall>()` tail call as returning the promise object, then
+ * propagates that always-truthy fact through the caller's `await`. It deleted
+ * the entire insert path from `upsertAsyncToolCall` in the shipped bundle
+ * because `if (existing) return existing` looked always-taken.
+ */
 async function withDbSpan<T>(
   name: string,
   op: string,
@@ -74,7 +83,7 @@ export interface CreateRunSegmentInput {
 }
 
 export async function createRunSegment(input: CreateRunSegmentInput) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsCreateRunSegment,
     'INSERT',
     'copilot_runs',
@@ -122,7 +131,7 @@ export async function updateRunStatus(
     requestContext?: Record<string, unknown>
   } = {}
 ) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsUpdateRunStatus,
     'UPDATE',
     'copilot_runs',
@@ -150,7 +159,7 @@ export async function updateRunStatus(
 }
 
 async function getLatestRunForExecution(executionId: string) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsGetLatestForExecution,
     'SELECT',
     'copilot_runs',
@@ -183,7 +192,7 @@ export async function getLatestRunForStream(streamId: string, userId?: string) {
 }
 
 export async function getRunSegment(runId: string) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsGetRunSegment,
     'SELECT',
     'copilot_runs',
@@ -213,7 +222,7 @@ async function createRunCheckpoint(input: {
   agentState: Record<string, unknown>
   providerRequest: Record<string, unknown>
 }) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsCreateRunCheckpoint,
     'INSERT',
     'copilot_run_checkpoints',
@@ -247,7 +256,7 @@ export async function upsertAsyncToolCall(input: {
   status?: CopilotAsyncToolStatus
   sealedContext?: AsyncCompletionData
 }) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsUpsertAsyncToolCall,
     'UPSERT',
     'copilot_async_tool_calls',
@@ -296,7 +305,7 @@ export async function upsertAsyncToolCall(input: {
 }
 
 export async function getAsyncToolCall(toolCallId: string) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsGetAsyncToolCall,
     'SELECT',
     'copilot_async_tool_calls',
@@ -324,7 +333,7 @@ async function markAsyncToolStatus(
   } = {},
   expectedStatuses?: CopilotAsyncToolStatus[]
 ) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsMarkAsyncToolStatus,
     'UPDATE',
     'copilot_async_tool_calls',
@@ -382,7 +391,7 @@ export function getClaimedWorkflowExecutionId(claimedBy: string | null | undefin
 
 export async function claimWorkflowToolExecution(toolCallId: string, executionId: string) {
   const claimedBy = `${WORKFLOW_EXECUTION_CLAIM_PREFIX}${executionId}`
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsMarkAsyncToolStatus,
     'UPDATE',
     'copilot_async_tool_calls',
@@ -426,7 +435,7 @@ export async function claimWorkflowToolExecution(toolCallId: string, executionId
 
 export async function releaseWorkflowToolExecutionClaim(toolCallId: string, executionId: string) {
   const claimedBy = `${WORKFLOW_EXECUTION_CLAIM_PREFIX}${executionId}`
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsReleaseClaim,
     'UPDATE',
     'copilot_async_tool_calls',
@@ -464,7 +473,7 @@ export async function releaseWorkflowToolExecutionClaim(toolCallId: string, exec
  * cannot click, type, submit, or navigate twice.
  */
 export async function claimPendingAsyncToolCall(toolCallId: string, claimedBy: string) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsMarkAsyncToolStatus,
     'UPDATE',
     'copilot_async_tool_calls',
@@ -545,7 +554,7 @@ export async function replaceTerminalAsyncToolCallResult(input: {
   result: AsyncCompletionData | null
   error: string | null
 }) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsMarkAsyncToolStatus,
     'UPDATE',
     'copilot_async_tool_calls',
@@ -588,7 +597,7 @@ export async function recordToolPermissionDecision(
   toolCallId: string,
   decision: CopilotToolPermissionDecision
 ) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsMarkAsyncToolStatus,
     'UPDATE',
     'copilot_async_tool_calls',
@@ -619,7 +628,7 @@ export async function recordToolPermissionDecision(
 }
 
 async function listAsyncToolCallsForRun(runId: string) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsListForRun,
     'SELECT',
     'copilot_async_tool_calls',
@@ -635,7 +644,7 @@ async function listAsyncToolCallsForRun(runId: string) {
 
 export async function getAsyncToolCalls(toolCallIds: string[]) {
   if (toolCallIds.length === 0) return []
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsGetMany,
     'SELECT',
     'copilot_async_tool_calls',
@@ -649,7 +658,7 @@ export async function getAsyncToolCalls(toolCallIds: string[]) {
 }
 
 export async function claimCompletedAsyncToolCall(toolCallId: string, workerId: string) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsClaimCompleted,
     'UPDATE',
     'copilot_async_tool_calls',
@@ -679,7 +688,7 @@ export async function claimCompletedAsyncToolCall(toolCallId: string, workerId: 
 }
 
 async function releaseCompletedAsyncToolClaim(toolCallId: string, workerId: string) {
-  return withDbSpan(
+  return await withDbSpan(
     TraceSpan.CopilotAsyncRunsReleaseClaim,
     'UPDATE',
     'copilot_async_tool_calls',

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -219,15 +219,16 @@ const nextConfig: NextConfig = {
      * it lives. Restoring across commits is separately undocumented-as-supported
      * (vercel/next.js#87283 reports stale HTML from a cache built elsewhere).
      *
-     * The explicit pin is load-bearing: 16.3.0 flipped this default to true for
-     * stable (vercel/next.js#94616), so dropping it re-enables the slower cache.
+     * Keep the explicit pin even while we sit on 16.2.12: 16.3.0 flips this
+     * default to true for stable (vercel/next.js#94616), so dropping it would
+     * silently re-enable the slower cache the next time we take that bump.
      */
     turbopackFileSystemCacheForBuild: false,
     /**
      * TypeScript 7 ships no JavaScript compiler API until 7.1, so Next's default
      * checker cannot load it — this shells out to the project-local `tsc` instead.
      * Pinned because the failure mode is not slower type checking but none at all:
-     * 16.2.12 skipped the stage silently in 138ms.
+     * without it 16.2.12 skips the stage silently in 138ms.
      */
     useTypeScriptCli: true,
     preloadEntriesOnStart: false,

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -193,7 +193,7 @@
     "mongodb": "6.19.0",
     "mysql2": "3.14.3",
     "neo4j-driver": "6.0.1",
-    "next": "16.3.0",
+    "next": "16.2.12",
     "next-mdx-remote": "^6.0.0",
     "next-runtime-env": "3.3.0",
     "next-themes": "^0.4.6",

--- a/bun.lock
+++ b/bun.lock
@@ -21,10 +21,10 @@
         "turbo": "2.9.14",
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.3.0",
-        "@next/swc-darwin-x64": "16.3.0",
-        "@next/swc-linux-arm64-gnu": "16.3.0",
-        "@next/swc-linux-x64-gnu": "16.3.0",
+        "@next/swc-darwin-arm64": "16.2.12",
+        "@next/swc-darwin-x64": "16.2.12",
+        "@next/swc-linux-arm64-gnu": "16.2.12",
+        "@next/swc-linux-x64-gnu": "16.2.12",
       },
     },
     "apps/desktop": {
@@ -76,7 +76,7 @@
         "fumadocs-openapi": "10.8.1",
         "fumadocs-ui": "16.8.5",
         "lucide-react": "^0.511.0",
-        "next": "16.3.0",
+        "next": "16.2.12",
         "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -299,7 +299,7 @@
         "mongodb": "6.19.0",
         "mysql2": "3.14.3",
         "neo4j-driver": "6.0.1",
-        "next": "16.3.0",
+        "next": "16.2.12",
         "next-mdx-remote": "^6.0.0",
         "next-runtime-env": "3.3.0",
         "next-themes": "^0.4.6",
@@ -490,7 +490,7 @@
         "framer-motion": "^12.5.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.511.0",
-        "next": "16.3.0",
+        "next": "16.2.12",
         "prismjs": "^1.30.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -698,12 +698,12 @@
     "isolated-vm",
   ],
   "overrides": {
-    "@next/env": "16.3.0",
+    "@next/env": "16.2.12",
     "drizzle-orm": "^0.45.2",
     "e2b": "^2.36.1",
     "mermaid": "11.15.0",
     "minimatch": "^10.2.5",
-    "next": "16.3.0",
+    "next": "16.2.12",
     "postgres": "^3.4.5",
     "react": "19.2.4",
     "react-dom": "19.2.4",
@@ -1370,15 +1370,23 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
-    "@next/env": ["@next/env@16.3.0", "", {}, "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw=="],
+    "@next/env": ["@next/env@16.2.12", "", {}, "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA=="],
+
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.12", "", { "os": "linux", "cpu": "x64" }, "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg=="],
+
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.12", "", { "os": "linux", "cpu": "x64" }, "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w=="],
+
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA=="],
+
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.12", "", { "os": "win32", "cpu": "x64" }, "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
@@ -3618,7 +3626,7 @@
 
     "neo4j-driver-core": ["neo4j-driver-core@6.0.1", "", {}, "sha512-5I2KxICAvcHxnWdJyDqwu8PBAQvWVTlQH2ve3VQmtVdJScPqWhpXN1PiX5IIl+cRF3pFpz9GQF53B5n6s0QQUQ=="],
 
-    "next": ["next@16.3.0", "", { "dependencies": { "@next/env": "16.3.0", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.23", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0", "@next/swc-darwin-x64": "16.3.0", "@next/swc-linux-arm64-gnu": "16.3.0", "@next/swc-linux-arm64-musl": "16.3.0", "@next/swc-linux-x64-gnu": "16.3.0", "@next/swc-linux-x64-musl": "16.3.0", "@next/swc-win32-arm64-msvc": "16.3.0", "@next/swc-win32-x64-msvc": "16.3.0", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A=="],
+    "next": ["next@16.2.12", "", { "dependencies": { "@next/env": "16.2.12", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.12", "@next/swc-darwin-x64": "16.2.12", "@next/swc-linux-arm64-gnu": "16.2.12", "@next/swc-linux-arm64-musl": "16.2.12", "@next/swc-linux-x64-gnu": "16.2.12", "@next/swc-linux-x64-musl": "16.2.12", "@next/swc-win32-arm64-msvc": "16.2.12", "@next/swc-win32-x64-msvc": "16.2.12", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw=="],
 
     "next-mdx-remote": ["next-mdx-remote@6.0.0", "", { "dependencies": { "@babel/code-frame": "^7.23.5", "@mdx-js/mdx": "^3.0.1", "@mdx-js/react": "^3.0.1", "unist-util-remove": "^4.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.1", "vfile-matter": "^5.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ=="],
 
@@ -5154,6 +5162,10 @@
 
     "neo4j-driver-bolt-connection/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
+    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "next/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "node-gyp/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
@@ -5587,6 +5599,54 @@
     "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "next/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "next/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "next/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "next/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "next/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "next/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "next/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "next/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "next/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
   "overrides": {
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "next": "16.3.0",
-    "@next/env": "16.3.0",
+    "next": "16.2.12",
+    "@next/env": "16.2.12",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.5",
     "minimatch": "^10.2.5",
@@ -89,10 +89,10 @@
     "e2b": "^2.36.1"
   },
   "optionalDependencies": {
-    "@next/swc-darwin-arm64": "16.3.0",
-    "@next/swc-darwin-x64": "16.3.0",
-    "@next/swc-linux-arm64-gnu": "16.3.0",
-    "@next/swc-linux-x64-gnu": "16.3.0"
+    "@next/swc-darwin-arm64": "16.2.12",
+    "@next/swc-darwin-x64": "16.2.12",
+    "@next/swc-linux-arm64-gnu": "16.2.12",
+    "@next/swc-linux-x64-gnu": "16.2.12"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0-beta.5",

--- a/packages/emcn/package.json
+++ b/packages/emcn/package.json
@@ -84,7 +84,7 @@
     "framer-motion": "^12.5.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.511.0",
-    "next": "16.3.0",
+    "next": "16.2.12",
     "prismjs": "^1.30.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION
## Summary
- Reverts `next` 16.3.0 -> 16.2.12 across the root overrides, `@next/swc-*` optional deps, `apps/sim`, `apps/docs`, and `packages/emcn`. Keeps the TypeScript toolchain cleanup from the original bump (`@typescript/native-preview` dropped, `useTypeScriptCli` pinned).
- 16.3.0's Turbopack optimizer treats a bare `return <asyncCall>()` tail call inside an `async` function as returning the promise object, then carries that always-truthy fact through the caller's `await`. Where the result feeds an `if (x)` whose every branch returns, it decides the branch is always taken and **deletes everything after it** from the emitted bundle.
- Two sites shipped to production that way:
  - `POST /api/credentials` lost the whole create path (transaction, org locks, insert, audit, 201). New credentials 500'd with `TypeError: null is not an object (evaluating 'K.id')` — this is the prod canary failure.
  - `upsertAsyncToolCall` collapsed to `async () => await getAsyncToolCall(id)`. The insert is gone; it returns `null` for every new async copilot tool call. Silent — no error, no failed request, no canary.
- Both sites also hardened with `return await`, which defeats the miscompile in a minimal reproduction.

## Scope
Built the same commit on 16.2.12 and 16.3.0 and diffed 71,266 distinctive source string literals across `.next/server` and `.next/static`. Exactly two literals disappeared — the two above; the client bundle lost none. That scan cannot see dropped branches containing no distinctive string, which is why the version goes back rather than patching the two sites and calling it done.

## Type of Change
- [x] Bug fix

## Testing
- Minimal Next app reproducing the shape: tail deleted on 16.3.0, present on 16.2.12, identical source. `return await`, dropping the wrapper, `!== null`, and hoisting to a nullable `let` each fix it.
- `apps/sim/app/api/credentials/route.test.ts` passes (6/6).
- Biome clean on the changed files.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)