### PR TITLE
fix(utils): return original input from date formatters on invalid dates

### DIFF
--- a/packages/utils/src/formatting.test.ts
+++ b/packages/utils/src/formatting.test.ts
@@ -68,6 +68,10 @@ describe('formatAbsoluteDate', () => {
     expect(result).toMatch(/May/)
     expect(result).toMatch(/2023/)
   })
+
+  it('returns the original input for an unparseable date', () => {
+    expect(formatAbsoluteDate('not-a-date')).toBe('not-a-date')
+  })
 })
 
 describe('formatTime', () => {
@@ -99,9 +103,10 @@ describe('formatCompactTimestamp', () => {
     expect(result).toMatch(/^\d{2}-\d{2} \d{2}:\d{2}$/)
   })
 
-  it('returns a formatted string even for invalid dates (no throw)', () => {
+  it('returns the original input for invalid dates instead of a NaN string', () => {
     const result = formatCompactTimestamp('not-a-date')
-    expect(typeof result).toBe('string')
+    expect(result).toBe('not-a-date')
+    expect(result).not.toContain('NaN')
   })
 })
 

--- a/packages/utils/src/formatting.ts
+++ b/packages/utils/src/formatting.ts
@@ -104,6 +104,11 @@ export function formatDate(date: Date): string {
  */
 export function formatAbsoluteDate(dateString: string): string {
   const date = new Date(dateString)
+  // An unparseable string yields an Invalid Date whose formatters return
+  // "Invalid Date"; fall back to the original input instead.
+  if (Number.isNaN(date.getTime())) {
+    return dateString
+  }
   return date.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
@@ -150,6 +155,11 @@ export function formatTimeWithSeconds(date: Date, includeTimezone = true): strin
 export function formatCompactTimestamp(iso: string): string {
   try {
     const d = new Date(iso)
+    // Invalid dates do not throw; their getters return NaN, so the catch
+    // below never fires. Guard explicitly and fall back to the input string.
+    if (Number.isNaN(d.getTime())) {
+      return iso
+    }
     const mm = String(d.getMonth() + 1).padStart(2, '0')
     const dd = String(d.getDate()).padStart(2, '0')
     const hh = String(d.getHours()).padStart(2, '0')

--- a/packages/utils/src/formatting.ts
+++ b/packages/utils/src/formatting.ts
@@ -100,7 +100,8 @@ export function formatDate(date: Date): string {
 /**
  * Formats a date string to absolute format for tooltip display
  * @param dateString - ISO date string to format
- * @returns A formatted date string (e.g., "Jan 22, 2026, 01:30 PM")
+ * @returns A formatted date string (e.g., "Jan 22, 2026, 01:30 PM"), or the
+ * original `dateString` unchanged when it cannot be parsed into a valid date
  */
 export function formatAbsoluteDate(dateString: string): string {
   const date = new Date(dateString)
@@ -150,7 +151,8 @@ export function formatTimeWithSeconds(date: Date, includeTimezone = true): strin
 /**
  * Format an ISO timestamp into a compact format for UI display
  * @param iso - ISO timestamp string
- * @returns A formatted string in "MM-DD HH:mm" format
+ * @returns A formatted string in "MM-DD HH:mm" format, or the original `iso`
+ * string unchanged when it cannot be parsed into a valid date
  */
 export function formatCompactTimestamp(iso: string): string {
   try {


### PR DESCRIPTION
## Summary

`formatCompactTimestamp` and `formatAbsoluteDate` in `packages/utils/src/formatting.ts` build their output from `Date` getters. An unparseable string produces an Invalid Date whose getters return `NaN` rather than throwing, so `formatCompactTimestamp` returned `"NaN-NaN NaN:NaN"` (its `try/catch` fallback never ran, since nothing throws) and `formatAbsoluteDate` returned the literal `"Invalid Date"`.

Both now check `Number.isNaN(date.getTime())` up front and fall back to the original input string, which is what the existing `catch` was already meant to do. Valid dates are unaffected.

## Type of Change
- [x] Bug fix

## Testing

Verified both functions against valid and invalid inputs. Updated the existing `formatCompactTimestamp` invalid-date test to assert the returned value (it previously only checked `typeof result === 'string'`, so the `"NaN-NaN NaN:NaN"` output slipped through), and added a matching invalid-date test for `formatAbsoluteDate`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the Contributor License Agreement (CLA)
