### PR TITLE
fix(setup): detect OrbStack vs Docker Desktop before relaunching the daemon

### DIFF
--- a/scripts/setup/docker.ts
+++ b/scripts/setup/docker.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { SetupError } from './errors.ts'
 import { waitFor } from './probes.ts'
 import * as p from './prompter.ts'
@@ -9,6 +10,10 @@ const INSTALL_HINTS = [
   `or OrbStack (lighter on macOS): ${theme.command('brew install orbstack')}`,
 ]
 
+/** macOS GUI docker providers we know how to launch via `open -a`. */
+const ORBSTACK_APP = { name: 'OrbStack', path: '/Applications/OrbStack.app' } as const
+const DOCKER_DESKTOP_APP = { name: 'Docker', path: '/Applications/Docker.app' } as const
+
 function daemonUp(): boolean {
   return spawnSync('docker', ['info'], { stdio: 'ignore' }).status === 0
 }
@@ -17,6 +22,24 @@ function installed(): boolean {
   // Bun.which resolves PATH cross-platform (incl. PATHEXT on Windows); `which`
   // is not a standard Windows command.
   return Bun.which('docker') !== null
+}
+
+function currentDockerContext(): string | null {
+  const result = spawnSync('docker', ['context', 'show'], { encoding: 'utf8' })
+  return result.status === 0 ? result.stdout.trim() : null
+}
+
+/**
+ * Which GUI app owns the `docker` CLI on this Mac. Docker Desktop and OrbStack
+ * both install a `docker` binary, so presence of the CLI alone doesn't tell us
+ * which app to relaunch. Prefer the docker CLI's own active context — it's
+ * accurate regardless of where the app bundle lives — and fall back to
+ * checking the well-known `.app` install paths when the context doesn't say.
+ */
+function macDockerApp(): typeof ORBSTACK_APP | typeof DOCKER_DESKTOP_APP {
+  if (currentDockerContext() === 'orbstack') return ORBSTACK_APP
+  if (existsSync(ORBSTACK_APP.path)) return ORBSTACK_APP
+  return DOCKER_DESKTOP_APP
 }
 
 /**
@@ -41,27 +64,31 @@ export async function ensureDocker(required: boolean): Promise<boolean> {
     return false
   }
 
+  const app = macDockerApp()
+
   const launch = await p.confirm({
-    message: 'Docker is installed but not running — start Docker Desktop now?',
+    message: `Docker is installed but not running — start ${app.name} now?`,
     initialValue: true,
   })
   if (!launch) {
     if (required) {
       throw new SetupError('Docker is required for this mode.', [
-        'start Docker Desktop, then re-run the wizard',
+        `start ${app.name}, then re-run the wizard`,
       ])
     }
     return false
   }
 
-  spawnSync('open', ['-a', 'Docker'], { stdio: 'ignore' })
+  spawnSync('open', ['-a', app.name], { stdio: 'ignore' })
   const spin = p.spinner()
-  spin.start('Waiting for the Docker daemon…')
+  spin.start(`Waiting for the Docker daemon (${app.name})…`)
   const up = await waitFor(async () => daemonUp(), 90_000, 2000)
   spin.stop(up ? 'Docker is running' : `${glyph.fail} daemon did not come up`)
   if (!up) {
-    throw new SetupError('Docker Desktop did not start within 90s.', [
-      'first-ever launch needs a GUI license acceptance — open Docker Desktop manually once, then re-run',
+    throw new SetupError(`${app.name} did not start within 90s.`, [
+      app === ORBSTACK_APP
+        ? 'open OrbStack manually once to finish its first-run setup, then re-run'
+        : 'first-ever launch needs a GUI license acceptance — open Docker Desktop manually once, then re-run',
     ])
   }
   return true

--- a/scripts/setup/docker.ts
+++ b/scripts/setup/docker.ts
@@ -33,13 +33,15 @@ function currentDockerContext(): string | null {
  * Which GUI app owns the `docker` CLI on this Mac. Docker Desktop and OrbStack
  * both install a `docker` binary, so presence of the CLI alone doesn't tell us
  * which app to relaunch. Prefer the docker CLI's own active context — it's
- * accurate regardless of where the app bundle lives — and fall back to
- * checking the well-known `.app` install paths when the context doesn't say.
+ * accurate regardless of where the app bundle lives, and authoritative when
+ * both apps are installed but only one is the active context. Only fall back
+ * to checking the well-known `.app` install path when the context command
+ * gives no answer at all.
  */
 function macDockerApp(): typeof ORBSTACK_APP | typeof DOCKER_DESKTOP_APP {
-  if (currentDockerContext() === 'orbstack') return ORBSTACK_APP
-  if (existsSync(ORBSTACK_APP.path)) return ORBSTACK_APP
-  return DOCKER_DESKTOP_APP
+  const context = currentDockerContext()
+  if (context !== null) return context === 'orbstack' ? ORBSTACK_APP : DOCKER_DESKTOP_APP
+  return existsSync(ORBSTACK_APP.path) ? ORBSTACK_APP : DOCKER_DESKTOP_APP
 }
 
 /**


### PR DESCRIPTION
## Summary

The setup wizard (`bun run setup`) only knew how to relaunch Docker
Desktop when Docker wasn't running. If you use OrbStack instead, it
tried to open an app that isn't installed, waited 90 seconds, then
failed with a confusing error about Docker Desktop's license screen —
even though Docker itself works fine through OrbStack.

## Why this matters
OrbStack is a common, lighter-weight alternative to Docker Desktop on
macOS (this repo's own setup script even suggests installing it).
Anyone using it currently hits a dead end in the setup wizard instead
of a working local environment.

## What changed
The wizard now checks which Docker app is actually installed —
OrbStack or Docker Desktop — and launches and refers to the right one.
OrbStack users get a working "start Docker for me" prompt instead of
an error pointing them at an app they don't have.

Fixes #(issue)

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How has this been tested? What should reviewers focus on?

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
