### PR TITLE
fix(setup): launch the docker app the CLI is actually pointed at

### DIFF
--- a/scripts/setup/docker.ts
+++ b/scripts/setup/docker.ts
@@ -24,29 +24,34 @@ function installed(): boolean {
   return Bun.which('docker') !== null
 }
 
-function currentDockerContext(): string | null {
+/**
+ * Whether the docker CLI is currently pointed at OrbStack. `DOCKER_HOST` wins
+ * over the active context when set, so it is the only signal worth reading in
+ * that case; otherwise the active context is authoritative, since OrbStack
+ * registers and selects a context named `orbstack`.
+ */
+function orbstackSelected(): boolean {
+  const host = process.env.DOCKER_HOST
+  if (host) return host.includes('.orbstack/')
   const result = spawnSync('docker', ['context', 'show'], { encoding: 'utf8' })
-  return result.status === 0 ? result.stdout.trim() : null
+  return result.status === 0 && result.stdout.trim() === 'orbstack'
 }
 
 /**
- * Which GUI app owns the `docker` CLI on this Mac. Docker Desktop and OrbStack
- * both install a `docker` binary, so presence of the CLI alone doesn't tell us
- * which app to relaunch. Prefer the docker CLI's own active context — it's
- * accurate regardless of where the app bundle lives, and authoritative when
- * both apps are installed but only one is the active context. Only fall back
- * to checking the well-known `.app` install path when the context command
- * gives no answer at all.
+ * Which GUI app owns the `docker` CLI on this Mac. Both apps install a `docker`
+ * binary, so CLI presence alone doesn't say which one to launch. An explicit
+ * OrbStack selection wins; otherwise prefer whichever app is actually
+ * installed, which also covers CLIs too old for `docker context show`.
  */
 function macDockerApp(): typeof ORBSTACK_APP | typeof DOCKER_DESKTOP_APP {
-  const context = currentDockerContext()
-  if (context !== null) return context === 'orbstack' ? ORBSTACK_APP : DOCKER_DESKTOP_APP
+  if (orbstackSelected()) return ORBSTACK_APP
+  if (existsSync(DOCKER_DESKTOP_APP.path)) return DOCKER_DESKTOP_APP
   return existsSync(ORBSTACK_APP.path) ? ORBSTACK_APP : DOCKER_DESKTOP_APP
 }
 
 /**
- * Returns whether the Docker daemon is available, offering to launch Docker
- * Desktop (macOS) when it's installed but stopped. Never installs anything.
+ * Returns whether the Docker daemon is available, offering to launch the
+ * installed docker app (macOS) when it's stopped. Never installs anything.
  * With required=true, unavailability is a SetupError instead of false.
  */
 export async function ensureDocker(required: boolean): Promise<boolean> {

--- a/scripts/setup/docker.ts
+++ b/scripts/setup/docker.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { SetupError } from './errors.ts'
 import { waitFor } from './probes.ts'
 import * as p from './prompter.ts'
@@ -9,6 +10,10 @@ const INSTALL_HINTS = [
   `or OrbStack (lighter on macOS): ${theme.command('brew install orbstack')}`,
 ]
 
+/** macOS GUI docker providers we know how to launch via `open -a`. */
+const ORBSTACK_APP = { name: 'OrbStack', path: '/Applications/OrbStack.app' } as const
+const DOCKER_DESKTOP_APP = { name: 'Docker', path: '/Applications/Docker.app' } as const
+
 function daemonUp(): boolean {
   return spawnSync('docker', ['info'], { stdio: 'ignore' }).status === 0
 }
@@ -17,6 +22,24 @@ function installed(): boolean {
   // Bun.which resolves PATH cross-platform (incl. PATHEXT on Windows); `which`
   // is not a standard Windows command.
   return Bun.which('docker') !== null
+}
+
+function currentDockerContext(): string | null {
+  const result = spawnSync('docker', ['context', 'show'], { encoding: 'utf8' })
+  return result.status === 0 ? result.stdout.trim() : null
+}
+
+/**
+ * Which GUI app owns the `docker` CLI on this Mac. Docker Desktop and OrbStack
+ * both install a `docker` binary, so presence of the CLI alone doesn't tell us
+ * which app to relaunch. Prefer the docker CLI's own active context — it's
+ * accurate regardless of where the app bundle lives — and fall back to
+ * checking the well-known `.app` install paths when the context doesn't say.
+ */
+function macDockerApp(): typeof ORBSTACK_APP | typeof DOCKER_DESKTOP_APP {
+  if (currentDockerContext() === 'orbstack') return ORBSTACK_APP
+  if (existsSync(ORBSTACK_APP.path)) return ORBSTACK_APP
+  return DOCKER_DESKTOP_APP
 }
 
 /**
@@ -41,27 +64,31 @@ export async function ensureDocker(required: boolean): Promise<boolean> {
     return false
   }
 
+  const app = macDockerApp()
+
   const launch = await p.confirm({
-    message: 'Docker is installed but not running — start Docker Desktop now?',
+    message: `Docker is installed but not running — start ${app.name} now?`,
     initialValue: true,
   })
   if (!launch) {
     if (required) {
       throw new SetupError('Docker is required for this mode.', [
-        'start Docker Desktop, then re-run the wizard',
+        `start ${app.name}, then re-run the wizard`,
       ])
     }
     return false
   }
 
-  spawnSync('open', ['-a', 'Docker'], { stdio: 'ignore' })
+  spawnSync('open', ['-a', app.name], { stdio: 'ignore' })
   const spin = p.spinner()
-  spin.start('Waiting for the Docker daemon…')
+  spin.start(`Waiting for the Docker daemon (${app.name})…`)
   const up = await waitFor(async () => daemonUp(), 90_000, 2000)
   spin.stop(up ? 'Docker is running' : `${glyph.fail} daemon did not come up`)
   if (!up) {
-    throw new SetupError('Docker Desktop did not start within 90s.', [
-      'first-ever launch needs a GUI license acceptance — open Docker Desktop manually once, then re-run',
+    throw new SetupError(`${app.name} did not start within 90s.`, [
+      app === ORBSTACK_APP
+        ? 'open OrbStack manually once to finish its first-run setup, then re-run'
+        : 'first-ever launch needs a GUI license acceptance — open Docker Desktop manually once, then re-run',
     ])
   }
   return true

--- a/scripts/setup/docker.ts
+++ b/scripts/setup/docker.ts
@@ -88,6 +88,17 @@ function startDockerApp({ app, explicit }: DockerChoice): DockerApp | null {
 }
 
 /**
+ * A launch that failed after the user opted into it. Callers passing
+ * required=false have a non-Docker path to offer, so the reason is worth
+ * surfacing but must not abort the wizard.
+ */
+function launchFailed(required: boolean, message: string, hints: string[]): boolean {
+  if (required) throw new SetupError(message, hints)
+  p.log.warn([message, ...hints].join('\n'))
+  return false
+}
+
+/**
  * Returns whether the Docker daemon is available, offering to launch the
  * installed docker app (macOS) when it's stopped. Never installs anything.
  * With required=true, unavailability is a SetupError instead of false.
@@ -126,13 +137,12 @@ export async function ensureDocker(required: boolean): Promise<boolean> {
 
   const app = startDockerApp(choice)
   if (!app) {
-    if (choice.explicit) {
-      throw new SetupError('The docker CLI is pointed at OrbStack, which is not installed.', [
-        `reinstall it: ${theme.command('brew install orbstack')}`,
-        `or point the CLI elsewhere: unset DOCKER_HOST / ${theme.command('docker context use <name>')}`,
-      ])
-    }
-    throw new SetupError('No docker app is installed.', INSTALL_HINTS)
+    return choice.explicit
+      ? launchFailed(required, 'The docker CLI is pointed at OrbStack, which is not installed.', [
+          `reinstall it: ${theme.command('brew install orbstack')}`,
+          `or point the CLI elsewhere: unset DOCKER_HOST and DOCKER_CONTEXT, then ${theme.command('docker context use <name>')}`,
+        ])
+      : launchFailed(required, 'No docker app is installed.', INSTALL_HINTS)
   }
 
   const spin = p.spinner()
@@ -140,7 +150,7 @@ export async function ensureDocker(required: boolean): Promise<boolean> {
   const up = await waitFor(async () => daemonUp(), 90_000, 2000)
   spin.stop(up ? 'Docker is running' : `${glyph.fail} daemon did not come up`)
   if (!up) {
-    throw new SetupError(`${app.name} did not start within 90s.`, [
+    return launchFailed(required, `${app.name} did not start within 90s.`, [
       app === ORBSTACK_APP
         ? 'open OrbStack manually once to finish its first-run setup, then re-run'
         : 'first-ever launch needs a GUI license acceptance — open Docker Desktop manually once, then re-run',

--- a/scripts/setup/docker.ts
+++ b/scripts/setup/docker.ts
@@ -33,13 +33,15 @@ function currentDockerContext(): string | null {
  * Which GUI app owns the `docker` CLI on this Mac. Docker Desktop and OrbStack
  * both install a `docker` binary, so presence of the CLI alone doesn't tell us
  * which app to relaunch. Prefer the docker CLI's own active context — it's
- * accurate regardless of where the app bundle lives — and fall back to
- * checking the well-known `.app` install paths when the context doesn't say.
+ * accurate regardless of where the app bundle lives, and authoritative when
+ * both apps are installed but only one is the active context. Only fall back
+ * to checking the well-known `.app` install path when the context command
+ * gives no answer at all.
  */
 function macDockerApp(): typeof ORBSTACK_APP | typeof DOCKER_DESKTOP_APP {
-  if (currentDockerContext() === 'orbstack') return ORBSTACK_APP
-  if (existsSync(ORBSTACK_APP.path)) return ORBSTACK_APP
-  return DOCKER_DESKTOP_APP
+  const context = currentDockerContext()
+  if (context !== null) return context === 'orbstack' ? ORBSTACK_APP : DOCKER_DESKTOP_APP
+  return existsSync(ORBSTACK_APP.path) ? ORBSTACK_APP : DOCKER_DESKTOP_APP
 }
 
 /**

--- a/scripts/setup/docker.ts
+++ b/scripts/setup/docker.ts
@@ -25,9 +25,8 @@ function daemonUp(): boolean {
   return spawnSync('docker', ['info'], { stdio: 'ignore' }).status === 0
 }
 
+/** Uses `Bun.which` rather than `which`, which is not a standard Windows command. */
 function installed(): boolean {
-  // Bun.which resolves PATH cross-platform (incl. PATHEXT on Windows); `which`
-  // is not a standard Windows command.
   return Bun.which('docker') !== null
 }
 
@@ -44,32 +43,48 @@ function orbstackSelected(): boolean {
   return result.status === 0 && result.stdout.trim() === 'orbstack'
 }
 
-/**
- * Whether macOS can launch this app. The well-known directories cover every
- * normal install without spawning anything; LaunchServices is the authority
- * for the rest, since a Homebrew `--appdir` can put the bundle anywhere and
- * `open -a` would still find it there.
- */
 function appInstalled(app: DockerApp): boolean {
-  if (APP_DIRS.some((dir) => existsSync(join(dir, app.bundle)))) return true
-  const lookup = spawnSync('osascript', ['-e', `path to application "${app.name}"`], {
-    stdio: 'ignore',
-  })
-  return lookup.status === 0
+  return APP_DIRS.some((dir) => existsSync(join(dir, app.bundle)))
+}
+
+interface DockerChoice {
+  app: DockerApp
+  /** The CLI names this provider, so no other app can bring its daemon up. */
+  explicit: boolean
 }
 
 /**
- * Which GUI app owns the `docker` CLI on this Mac. Both apps install a `docker`
- * binary, so CLI presence alone doesn't say which one to launch. An explicit
- * OrbStack selection wins, but only when OrbStack is still installed — a
- * context or `DOCKER_HOST` left behind by an uninstall would otherwise pick an
- * app that can never come up. Otherwise fall back to whichever app is present,
- * which also covers CLIs too old for `docker context show`.
+ * Which app to offer to start. Both providers install a `docker` binary, so CLI
+ * presence alone doesn't say which one to launch. An OrbStack selection is
+ * explicit; anything else is a guess the launch is allowed to correct, which is
+ * why the install probe here doesn't have to be exhaustive.
  */
-function macDockerApp(): DockerApp {
-  if (orbstackSelected() && appInstalled(ORBSTACK_APP)) return ORBSTACK_APP
-  if (appInstalled(DOCKER_DESKTOP_APP)) return DOCKER_DESKTOP_APP
-  return appInstalled(ORBSTACK_APP) ? ORBSTACK_APP : DOCKER_DESKTOP_APP
+function macDockerApp(): DockerChoice {
+  if (orbstackSelected()) return { app: ORBSTACK_APP, explicit: true }
+  const orbstackOnly = appInstalled(ORBSTACK_APP) && !appInstalled(DOCKER_DESKTOP_APP)
+  return { app: orbstackOnly ? ORBSTACK_APP : DOCKER_DESKTOP_APP, explicit: false }
+}
+
+/**
+ * Starts a provider. `open` exits non-zero when macOS knows no such app, which
+ * settles installation authoritatively and without a dialog — it resolves the
+ * name the same way the launch does, so the two cannot disagree.
+ */
+function openApp(app: DockerApp): boolean {
+  return spawnSync('open', ['-a', app.name], { stdio: 'ignore' }).status === 0
+}
+
+/**
+ * Starts the chosen provider, retrying with the other one when the choice was
+ * only a guess. An explicit OrbStack selection is never redirected: `docker
+ * info` would still be addressing OrbStack's socket, so Docker Desktop cannot
+ * satisfy it however successfully it starts.
+ */
+function startDockerApp({ app, explicit }: DockerChoice): DockerApp | null {
+  if (openApp(app)) return app
+  if (explicit) return null
+  const other = app === ORBSTACK_APP ? DOCKER_DESKTOP_APP : ORBSTACK_APP
+  return openApp(other) ? other : null
 }
 
 /**
@@ -94,22 +109,32 @@ export async function ensureDocker(required: boolean): Promise<boolean> {
     return false
   }
 
-  const app = macDockerApp()
+  const choice = macDockerApp()
 
   const launch = await p.confirm({
-    message: `Docker is installed but not running — start ${app.name} now?`,
+    message: `Docker is installed but not running — start ${choice.app.name} now?`,
     initialValue: true,
   })
   if (!launch) {
     if (required) {
       throw new SetupError('Docker is required for this mode.', [
-        `start ${app.name}, then re-run the wizard`,
+        `start ${choice.app.name}, then re-run the wizard`,
       ])
     }
     return false
   }
 
-  spawnSync('open', ['-a', app.name], { stdio: 'ignore' })
+  const app = startDockerApp(choice)
+  if (!app) {
+    if (choice.explicit) {
+      throw new SetupError('The docker CLI is pointed at OrbStack, which is not installed.', [
+        `reinstall it: ${theme.command('brew install orbstack')}`,
+        `or point the CLI elsewhere: unset DOCKER_HOST / ${theme.command('docker context use <name>')}`,
+      ])
+    }
+    throw new SetupError('No docker app is installed.', INSTALL_HINTS)
+  }
+
   const spin = p.spinner()
   spin.start(`Waiting for the Docker daemon (${app.name})…`)
   const up = await waitFor(async () => daemonUp(), 90_000, 2000)

--- a/scripts/setup/docker.ts
+++ b/scripts/setup/docker.ts
@@ -44,8 +44,18 @@ function orbstackSelected(): boolean {
   return result.status === 0 && result.stdout.trim() === 'orbstack'
 }
 
+/**
+ * Whether macOS can launch this app. The well-known directories cover every
+ * normal install without spawning anything; LaunchServices is the authority
+ * for the rest, since a Homebrew `--appdir` can put the bundle anywhere and
+ * `open -a` would still find it there.
+ */
 function appInstalled(app: DockerApp): boolean {
-  return APP_DIRS.some((dir) => existsSync(join(dir, app.bundle)))
+  if (APP_DIRS.some((dir) => existsSync(join(dir, app.bundle)))) return true
+  const lookup = spawnSync('osascript', ['-e', `path to application "${app.name}"`], {
+    stdio: 'ignore',
+  })
+  return lookup.status === 0
 }
 
 /**

--- a/scripts/setup/docker.ts
+++ b/scripts/setup/docker.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import { SetupError } from './errors.ts'
 import { waitFor } from './probes.ts'
 import * as p from './prompter.ts'
@@ -11,8 +13,13 @@ const INSTALL_HINTS = [
 ]
 
 /** macOS GUI docker providers we know how to launch via `open -a`. */
-const ORBSTACK_APP = { name: 'OrbStack', path: '/Applications/OrbStack.app' } as const
-const DOCKER_DESKTOP_APP = { name: 'Docker', path: '/Applications/Docker.app' } as const
+const ORBSTACK_APP = { name: 'OrbStack', bundle: 'OrbStack.app' } as const
+const DOCKER_DESKTOP_APP = { name: 'Docker', bundle: 'Docker.app' } as const
+
+type DockerApp = typeof ORBSTACK_APP | typeof DOCKER_DESKTOP_APP
+
+/** Homebrew casks honour `--appdir`, so a user-local install is not unusual. */
+const APP_DIRS = ['/Applications', join(homedir(), 'Applications')]
 
 function daemonUp(): boolean {
   return spawnSync('docker', ['info'], { stdio: 'ignore' }).status === 0
@@ -37,16 +44,22 @@ function orbstackSelected(): boolean {
   return result.status === 0 && result.stdout.trim() === 'orbstack'
 }
 
+function appInstalled(app: DockerApp): boolean {
+  return APP_DIRS.some((dir) => existsSync(join(dir, app.bundle)))
+}
+
 /**
  * Which GUI app owns the `docker` CLI on this Mac. Both apps install a `docker`
  * binary, so CLI presence alone doesn't say which one to launch. An explicit
- * OrbStack selection wins; otherwise prefer whichever app is actually
- * installed, which also covers CLIs too old for `docker context show`.
+ * OrbStack selection wins, but only when OrbStack is still installed — a
+ * context or `DOCKER_HOST` left behind by an uninstall would otherwise pick an
+ * app that can never come up. Otherwise fall back to whichever app is present,
+ * which also covers CLIs too old for `docker context show`.
  */
-function macDockerApp(): typeof ORBSTACK_APP | typeof DOCKER_DESKTOP_APP {
-  if (orbstackSelected()) return ORBSTACK_APP
-  if (existsSync(DOCKER_DESKTOP_APP.path)) return DOCKER_DESKTOP_APP
-  return existsSync(ORBSTACK_APP.path) ? ORBSTACK_APP : DOCKER_DESKTOP_APP
+function macDockerApp(): DockerApp {
+  if (orbstackSelected() && appInstalled(ORBSTACK_APP)) return ORBSTACK_APP
+  if (appInstalled(DOCKER_DESKTOP_APP)) return DOCKER_DESKTOP_APP
+  return appInstalled(ORBSTACK_APP) ? ORBSTACK_APP : DOCKER_DESKTOP_APP
 }
 
 /**

--- a/scripts/setup/docker.ts
+++ b/scripts/setup/docker.ts
@@ -12,6 +12,16 @@ const INSTALL_HINTS = [
   `or OrbStack (lighter on macOS): ${theme.command('brew install orbstack')}`,
 ]
 
+/**
+ * Reaching this means the docker CLI exists but neither GUI app does, which is
+ * also what a colima or Rancher Desktop user looks like — telling them to
+ * install Docker Desktop would be advice for a problem they don't have.
+ */
+const NO_APP_HINTS = [
+  ...INSTALL_HINTS,
+  `or start your existing runtime its own way, e.g. ${theme.command('colima start')}`,
+]
+
 /** macOS GUI docker providers we know how to launch via `open -a`. */
 const ORBSTACK_APP = { name: 'OrbStack', bundle: 'OrbStack.app' } as const
 const DOCKER_DESKTOP_APP = { name: 'Docker', bundle: 'Docker.app' } as const
@@ -142,7 +152,7 @@ export async function ensureDocker(required: boolean): Promise<boolean> {
           `reinstall it: ${theme.command('brew install orbstack')}`,
           `or point the CLI elsewhere: unset DOCKER_HOST and DOCKER_CONTEXT, then ${theme.command('docker context use <name>')}`,
         ])
-      : launchFailed(required, 'No docker app is installed.', INSTALL_HINTS)
+      : launchFailed(required, 'Found the docker CLI, but no app to start.', NO_APP_HINTS)
   }
 
   const spin = p.spinner()


### PR DESCRIPTION
## Summary

Carries over #6250 by @BohdanVilischuk (commits cherry-picked, authorship preserved) and adds a follow-up fix. Full credit for finding and fixing this goes to them.

- `bun run setup` only knew how to relaunch Docker Desktop, so OrbStack users got `open -a Docker` against an app they don't have, a 90s wait, then an error about Docker Desktop's license screen. The wizard now detects which app owns the `docker` CLI and launches, prompts, and errors with the right name.
- Follow-up: detection only fell back to the installed app bundle when `docker context show` failed outright. An OrbStack-only Mac sitting on the `default` context (OrbStack symlinks `/var/run/docker.sock`; also anyone who ran `docker context use default`) still resolved to Docker Desktop — the same hang the fix exists to remove. An explicit OrbStack selection is now the only positive context signal; otherwise we pick whichever app is actually installed, which also covers CLIs too old for `docker context show`.
- Follow-up: read `DOCKER_HOST` first. It overrides the active context, so the context name isn't authoritative while it's set.

Docker Desktop stays the tiebreak when both apps are installed and nothing points at OrbStack, matching today's behavior. Non-macOS paths are untouched.

## Type of Change
- [x] Bug fix

## Testing

Verified the resolver against a real Docker Desktop install (context `desktop-linux`) plus shimmed `docker` binaries covering every branch:

| Signal | Resolves to |
|---|---|
| no `DOCKER_HOST`, context `desktop-linux` | Docker |
| `DOCKER_HOST=unix://…/.orbstack/run/docker.sock` | OrbStack |
| `DOCKER_HOST=tcp://…` (remote daemon) | Docker |
| `DOCKER_CONTEXT=orbstack` | OrbStack |
| context `orbstack` | OrbStack |
| context `default`, Docker.app installed | Docker |
| `docker context show` exits non-zero (old CLI) | falls back to installed app |

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)