### PR TITLE
chore(deps): bump undici to 7.29.0 to close 5 security advisories

### DIFF
--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -231,7 +231,7 @@
     "tldts": "7.0.30",
     "twilio": "5.9.0",
     "typebox": "1.1.38",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "unpdf": "1.4.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "y-protocols": "1.0.7",

--- a/bun.lock
+++ b/bun.lock
@@ -336,7 +336,7 @@
         "tldts": "7.0.30",
         "twilio": "5.9.0",
         "typebox": "1.1.38",
-        "undici": "7.28.0",
+        "undici": "7.29.0",
         "unpdf": "1.4.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "y-protocols": "1.0.7",
@@ -4392,7 +4392,7 @@
 
     "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
 


### PR DESCRIPTION
## Summary
- Bump `undici` 7.28.0 → 7.29.0 in `apps/sim`, closing all 5 open Dependabot alerts (GHSA-4cwx-7wf7-3272 high, plus 4 moderate)
- Dropped the stale nested `undici@7.28.0` lockfile pins for `cheerio`, `e2b`, and `@electron/get` so the whole 7.x tree dedupes onto 7.29.0 — the only remaining 7.x copy in `node_modules` is 7.29.0

## Notes
- Fixes cross-user info disclosure via degenerate/whitespace `Cache-Control` directives, CRLF injection via blob body `type`, retry-interceptor response desync, and `setCookie` attribute injection
- `node-gyp` still resolves `undici@6.28.0` (build-only transitive of `@electron/rebuild`, not flagged); a flat override would force it off its `^6` range, so it was left alone
- We use undici directly in `lib/core/security/input-validation.server.ts` (SSRF-guarded `request`); we don't use `setCookie` or the retry/cache interceptors, so no behavioral surface changed

## Type of Change
- [x] Bug fix (security dependency update)

## Testing
- `bun install --frozen-lockfile` passes; verified `node_modules/undici` is 7.29.0 with no nested 7.28.0 copies
- `bun run type-check` clean
- `vitest run lib/core/security/` — 775 tests pass
- `bun run lint` clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)