### PR TITLE
fix(execution): compact loop state before serializing a pause snapshot

### DIFF
--- a/apps/sim/executor/execution/engine.test.ts
+++ b/apps/sim/executor/execution/engine.test.ts
@@ -427,6 +427,52 @@ describe('ExecutionEngine', () => {
       )
     })
 
+    /**
+     * The compaction pass is what keeps an oversized loop from failing the pause
+     * outright. Asserting it from the engine keeps the wiring defended: without
+     * this, removing the call leaves every serializer test still green.
+     */
+    it('compacts oversized loop state before building the paused result', async () => {
+      const node = createMockNode('hitl', 'function')
+      const dag = createMockDAG([node])
+      const payload = 'x'.repeat(300_000)
+      const context = createMockContext({
+        decisions: { router: new Map(), condition: new Map() },
+        loopExecutions: new Map([
+          [
+            'loop-1',
+            {
+              iteration: 1,
+              currentIterationOutputs: new Map(),
+              allIterationOutputs: Array.from({ length: 40 }, () => [{ payload }]),
+            },
+          ],
+        ]),
+      } as Partial<ExecutionContext>)
+      const edgeManager = createMockEdgeManager()
+      const nodeOrchestrator = createMockNodeOrchestrator()
+      vi.mocked(nodeOrchestrator.executeNode).mockResolvedValue({
+        nodeId: 'hitl',
+        output: {
+          response: { status: 'paused' },
+          _pauseMetadata: {
+            contextId: 'pause-1',
+            blockId: 'hitl',
+            response: { status: 'paused' },
+            timestamp: new Date().toISOString(),
+            pauseKind: 'hitl',
+          },
+        },
+        isFinalOutput: false,
+      })
+
+      const engine = new ExecutionEngine(context, dag, edgeManager, nodeOrchestrator)
+      const result = await engine.run('hitl')
+
+      expect(result.status).toBe('paused')
+      expect(result.snapshotSeed?.snapshot).toBeTruthy()
+    })
+
     it('does not stop run-until execution on parallel batch continuation', async () => {
       const parallelEnd = createMockNode('parallel-end', 'parallel')
       const nextNode = createMockNode('next', 'function')

--- a/apps/sim/executor/execution/engine.ts
+++ b/apps/sim/executor/execution/engine.ts
@@ -8,7 +8,10 @@ import {
 import { BlockType, EDGE } from '@/executor/constants'
 import type { DAG } from '@/executor/dag/builder'
 import type { EdgeManager } from '@/executor/execution/edge-manager'
-import { serializePauseSnapshot } from '@/executor/execution/snapshot-serializer'
+import {
+  compactPauseSnapshotScopes,
+  serializePauseSnapshot,
+} from '@/executor/execution/snapshot-serializer'
 import type { SerializableExecutionState } from '@/executor/execution/types'
 import type { NodeExecutionOrchestrator } from '@/executor/orchestrators/node'
 import type {
@@ -127,7 +130,7 @@ export class ExecutionEngine {
       }
 
       if (this.pausedBlocks.size > 0) {
-        return this.buildPausedResult(startTime)
+        return await this.buildPausedResult(startTime)
       }
 
       const endTime = performance.now()
@@ -491,12 +494,13 @@ export class ExecutionEngine {
     this.addMultipleToQueue(readyNodes)
   }
 
-  private buildPausedResult(startTime: number): ExecutionResult {
+  private async buildPausedResult(startTime: number): Promise<ExecutionResult> {
     const endTime = performance.now()
     this.context.metadata.endTime = new Date().toISOString()
     this.context.metadata.duration = endTime - startTime
     this.context.metadata.status = 'paused'
 
+    await compactPauseSnapshotScopes(this.context)
     const snapshotSeed = serializePauseSnapshot(this.context, [], this.dag, this.edgeManager)
     const pausePoints: PausePoint[] = Array.from(this.pausedBlocks.values()).map((pause) => ({
       contextId: pause.contextId,

--- a/apps/sim/executor/execution/engine.ts
+++ b/apps/sim/executor/execution/engine.ts
@@ -495,12 +495,12 @@ export class ExecutionEngine {
   }
 
   private async buildPausedResult(startTime: number): Promise<ExecutionResult> {
-    const endTime = performance.now()
-    this.context.metadata.endTime = new Date().toISOString()
-    this.context.metadata.duration = endTime - startTime
     this.context.metadata.status = 'paused'
 
     await compactPauseSnapshotScopes(this.context)
+    const endTime = performance.now()
+    this.context.metadata.endTime = new Date().toISOString()
+    this.context.metadata.duration = endTime - startTime
     const snapshotSeed = serializePauseSnapshot(this.context, [], this.dag, this.edgeManager)
     const pausePoints: PausePoint[] = Array.from(this.pausedBlocks.values()).map((pause) => ({
       contextId: pause.contextId,

--- a/apps/sim/executor/execution/snapshot-serializer.test.ts
+++ b/apps/sim/executor/execution/snapshot-serializer.test.ts
@@ -261,69 +261,132 @@ describe('serializePauseSnapshot', () => {
 })
 
 describe('compactPauseSnapshotScopes', () => {
-  function createLoopContext(iterations: number, bytesPerIteration: number): ExecutionContext {
-    const payload = 'x'.repeat(bytesPerIteration)
+  const dag = { nodes: new Map<string, DAGNode>() } as unknown as DAG
+  const edgeManager = new EdgeManager(dag)
+
+  function fatIterations(count: number, bytes: number): any[][] {
+    const payload = 'x'.repeat(bytes)
+    // Real shape is an array per iteration, which routes oversized entries
+    // through the chunked-manifest path rather than a single ref.
+    return Array.from({ length: count }, () => [{ payload }])
+  }
+
+  function loopContext(overrides: Record<string, unknown>): ExecutionContext {
     return createContext({
       loopExecutions: new Map([
         [
           'loop-1',
           {
-            loopId: 'loop-1',
-            iteration: iterations,
-            maxIterations: iterations,
+            iteration: 1,
+            loopType: 'forEach',
             currentIterationOutputs: new Map(),
-            // Each entry is well under the per-value cap; only the running total is oversized,
-            // which is exactly what per-iteration compaction cannot catch.
-            allIterationOutputs: Array.from({ length: iterations }, () => ({ payload })),
+            allIterationOutputs: [],
+            ...overrides,
           },
         ],
       ]),
     } as Partial<ExecutionContext>)
   }
 
-  /**
-   * A loop compacts its accumulated outputs when it exits, but a pause is
-   * mid-flight and never gets there — so without this pass the running total
-   * trips the serializer's size assertion and the pause fails outright.
-   */
+  const serialize = (context: ExecutionContext) =>
+    serializePauseSnapshot(context, [], dag, edgeManager)
+
   it('lets a pause inside a long-running loop serialize', async () => {
-    const context = createLoopContext(40, 300_000)
-    const dag = { nodes: new Map<string, DAGNode>() } as unknown as DAG
-    const edgeManager = new EdgeManager(dag)
+    const context = loopContext({ allIterationOutputs: fatIterations(40, 300_000) })
 
-    expect(() => serializePauseSnapshot(context, [], dag, edgeManager)).toThrow(
-      'oversized loop execution state'
-    )
-
+    expect(() => serialize(context)).toThrow('oversized loop execution state')
     await compactPauseSnapshotScopes(context)
-
-    const seed = serializePauseSnapshot(context, [], dag, edgeManager)
-    expect(seed.snapshot).toBeTruthy()
+    expect(serialize(context).snapshot).toBeTruthy()
   })
 
-  /**
-   * The refs are only usable if the resumed run is authorized to read them, so
-   * the keys compaction registers must reach the snapshot's trusted-access list.
-   */
+  /** A forEach collection is the most common way a loop's state gets large. */
+  it('compacts the forEach collection, not just the iteration outputs', async () => {
+    const context = loopContext({ items: fatIterations(40, 300_000) })
+
+    expect(() => serialize(context)).toThrow('oversized loop execution state')
+    await compactPauseSnapshotScopes(context)
+    expect(serialize(context).snapshot).toBeTruthy()
+  })
+
+  /** A single fat mid-flight block output reaches the limit on its own. */
+  it('compacts in-flight iteration outputs', async () => {
+    const context = loopContext({
+      currentIterationOutputs: new Map([['block-1', { payload: 'x'.repeat(9_000_000) }]]),
+    })
+
+    expect(() => serialize(context)).toThrow('oversized loop execution state')
+    await compactPauseSnapshotScopes(context)
+    expect(serialize(context).snapshot).toBeTruthy()
+  })
+
+  /** The assertion is on the whole record, so per-scope headroom is not enough. */
+  it('compacts across multiple loops whose combined state is oversized', async () => {
+    const context = createContext({
+      loopExecutions: new Map([
+        [
+          'loop-1',
+          {
+            iteration: 1,
+            currentIterationOutputs: new Map(),
+            allIterationOutputs: fatIterations(15, 300_000),
+          },
+        ],
+        [
+          'loop-2',
+          {
+            iteration: 1,
+            currentIterationOutputs: new Map(),
+            allIterationOutputs: fatIterations(15, 300_000),
+          },
+        ],
+      ]),
+    } as Partial<ExecutionContext>)
+
+    expect(() => serialize(context)).toThrow('oversized loop execution state')
+    await compactPauseSnapshotScopes(context)
+    expect(serialize(context).snapshot).toBeTruthy()
+  })
+
+  /** Parallels accumulate the same way and were previously not even asserted. */
+  it('compacts accumulated parallel branch outputs', async () => {
+    const context = createContext({
+      parallelExecutions: new Map([
+        [
+          'parallel-1',
+          {
+            parallelId: 'parallel-1',
+            totalBranches: 40,
+            branchOutputs: new Map([[0, fatIterations(40, 300_000).flat()]]),
+            accumulatedOutputs: new Map(),
+          },
+        ],
+      ]),
+    } as Partial<ExecutionContext>)
+
+    expect(() => serialize(context)).toThrow('oversized parallel execution state')
+    await compactPauseSnapshotScopes(context)
+    expect(serialize(context).snapshot).toBeTruthy()
+  })
+
+  /** Refs are unusable unless the resumed run is authorized to read them. */
   it('authorizes the offloaded values for the resumed run', async () => {
-    const context = createLoopContext(40, 300_000)
-    const dag = { nodes: new Map<string, DAGNode>() } as unknown as DAG
-    const edgeManager = new EdgeManager(dag)
+    const context = loopContext({ allIterationOutputs: fatIterations(40, 300_000) })
 
     await compactPauseSnapshotScopes(context)
-    const parsed = JSON.parse(serializePauseSnapshot(context, [], dag, edgeManager).snapshot) as {
+    const parsed = JSON.parse(serialize(context).snapshot) as {
       state?: { trustedLargeValueAccess?: { largeValueKeys?: string[] } }
     }
 
     expect(parsed.state?.trustedLargeValueAccess?.largeValueKeys?.length ?? 0).toBeGreaterThan(0)
   })
 
-  it('leaves a loop whose accumulated output already fits untouched', async () => {
-    const context = createLoopContext(2, 100)
-    const before = structuredClone(context.loopExecutions?.get('loop-1')?.allIterationOutputs)
+  /** Compaction is a structural rebuild, so a modest loop must not pay for it. */
+  it('skips the rebuild entirely when the state already fits', async () => {
+    const context = loopContext({ allIterationOutputs: fatIterations(2, 100) })
+    const before = context.loopExecutions?.get('loop-1')?.allIterationOutputs
 
     await compactPauseSnapshotScopes(context)
 
-    expect(context.loopExecutions?.get('loop-1')?.allIterationOutputs).toEqual(before)
+    expect(context.loopExecutions?.get('loop-1')?.allIterationOutputs).toBe(before)
   })
 })

--- a/apps/sim/executor/execution/snapshot-serializer.test.ts
+++ b/apps/sim/executor/execution/snapshot-serializer.test.ts
@@ -299,24 +299,19 @@ describe('compactPauseSnapshotScopes', () => {
     expect(serialize(context).snapshot).toBeTruthy()
   })
 
-  /** A forEach collection is the most common way a loop's state gets large. */
-  it('compacts the forEach collection, not just the iteration outputs', async () => {
+  /**
+   * `items` is consumed structurally — the orchestrator indexes it to derive
+   * `item`, and the loop resolver asserts no refs reach it — so it stays inline
+   * even though that leaves an oversized collection unhandled. Offloading it
+   * would trade a failed pause for a broken resume.
+   */
+  it('leaves the forEach collection inline rather than breaking iteration', async () => {
     const context = loopContext({ items: fatIterations(40, 300_000) })
 
-    expect(() => serialize(context)).toThrow('oversized loop execution state')
     await compactPauseSnapshotScopes(context)
-    expect(serialize(context).snapshot).toBeTruthy()
-  })
 
-  /** A single fat mid-flight block output reaches the limit on its own. */
-  it('compacts in-flight iteration outputs', async () => {
-    const context = loopContext({
-      currentIterationOutputs: new Map([['block-1', { payload: 'x'.repeat(9_000_000) }]]),
-    })
-
-    expect(() => serialize(context)).toThrow('oversized loop execution state')
-    await compactPauseSnapshotScopes(context)
-    expect(serialize(context).snapshot).toBeTruthy()
+    const items = context.loopExecutions?.get('loop-1')?.items as unknown[]
+    expect(JSON.stringify(items)).not.toContain('__simLargeValueRef')
   })
 
   /** The assertion is on the whole record, so per-scope headroom is not enough. */

--- a/apps/sim/executor/execution/snapshot-serializer.test.ts
+++ b/apps/sim/executor/execution/snapshot-serializer.test.ts
@@ -4,7 +4,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { DAG, DAGNode } from '@/executor/dag/builder'
 import { EdgeManager } from '@/executor/execution/edge-manager'
-import { serializePauseSnapshot } from '@/executor/execution/snapshot-serializer'
+import {
+  compactPauseSnapshotScopes,
+  serializePauseSnapshot,
+} from '@/executor/execution/snapshot-serializer'
 import type { ExecutionContext } from '@/executor/types'
 import { ResolvedSecretTraceRegistry } from '@/executor/utils/resolved-secret-trace-registry'
 
@@ -254,5 +257,73 @@ describe('serializePauseSnapshot', () => {
 
     expect(serialized.metadata.includeThinking).toBeUndefined()
     expect(serialized.metadata.includeToolCalls).toBeUndefined()
+  })
+})
+
+describe('compactPauseSnapshotScopes', () => {
+  function createLoopContext(iterations: number, bytesPerIteration: number): ExecutionContext {
+    const payload = 'x'.repeat(bytesPerIteration)
+    return createContext({
+      loopExecutions: new Map([
+        [
+          'loop-1',
+          {
+            loopId: 'loop-1',
+            iteration: iterations,
+            maxIterations: iterations,
+            currentIterationOutputs: new Map(),
+            // Each entry is well under the per-value cap; only the running total is oversized,
+            // which is exactly what per-iteration compaction cannot catch.
+            allIterationOutputs: Array.from({ length: iterations }, () => ({ payload })),
+          },
+        ],
+      ]),
+    } as Partial<ExecutionContext>)
+  }
+
+  /**
+   * A loop compacts its accumulated outputs when it exits, but a pause is
+   * mid-flight and never gets there — so without this pass the running total
+   * trips the serializer's size assertion and the pause fails outright.
+   */
+  it('lets a pause inside a long-running loop serialize', async () => {
+    const context = createLoopContext(40, 300_000)
+    const dag = { nodes: new Map<string, DAGNode>() } as unknown as DAG
+    const edgeManager = new EdgeManager(dag)
+
+    expect(() => serializePauseSnapshot(context, [], dag, edgeManager)).toThrow(
+      'oversized loop execution state'
+    )
+
+    await compactPauseSnapshotScopes(context)
+
+    const seed = serializePauseSnapshot(context, [], dag, edgeManager)
+    expect(seed.snapshot).toBeTruthy()
+  })
+
+  /**
+   * The refs are only usable if the resumed run is authorized to read them, so
+   * the keys compaction registers must reach the snapshot's trusted-access list.
+   */
+  it('authorizes the offloaded values for the resumed run', async () => {
+    const context = createLoopContext(40, 300_000)
+    const dag = { nodes: new Map<string, DAGNode>() } as unknown as DAG
+    const edgeManager = new EdgeManager(dag)
+
+    await compactPauseSnapshotScopes(context)
+    const parsed = JSON.parse(serializePauseSnapshot(context, [], dag, edgeManager).snapshot) as {
+      state?: { trustedLargeValueAccess?: { largeValueKeys?: string[] } }
+    }
+
+    expect(parsed.state?.trustedLargeValueAccess?.largeValueKeys?.length ?? 0).toBeGreaterThan(0)
+  })
+
+  it('leaves a loop whose accumulated output already fits untouched', async () => {
+    const context = createLoopContext(2, 100)
+    const before = structuredClone(context.loopExecutions?.get('loop-1')?.allIterationOutputs)
+
+    await compactPauseSnapshotScopes(context)
+
+    expect(context.loopExecutions?.get('loop-1')?.allIterationOutputs).toEqual(before)
   })
 })

--- a/apps/sim/executor/execution/snapshot-serializer.ts
+++ b/apps/sim/executor/execution/snapshot-serializer.ts
@@ -1,6 +1,6 @@
 import { recordMaterializedAccessKeys } from '@/lib/execution/payloads/access-keys'
 import { LARGE_VALUE_THRESHOLD_BYTES } from '@/lib/execution/payloads/large-value-ref'
-import { compactSubflowResults } from '@/lib/execution/payloads/serializer'
+import { compactExecutionPayload, compactSubflowResults } from '@/lib/execution/payloads/serializer'
 import type { DAG } from '@/executor/dag/builder'
 import type { EdgeManager } from '@/executor/execution/edge-manager'
 import { ExecutionSnapshot } from '@/executor/execution/snapshot'
@@ -185,23 +185,59 @@ function serializeParallelExecutions(
 }
 
 /**
- * Offload accumulated loop iteration outputs so a pause snapshot stays compact.
+ * Per-value offload ceiling applied once the subflow state is already oversized.
  *
- * A loop compacts `allIterationOutputs` when it exits, but a pause is by
- * definition mid-flight and never reaches that point — so the running total
- * arrives at the serializer uncompacted and trips its size assertion, failing
- * the pause outright. The approval notification has already gone out by then,
- * leaving the approver holding a link to a paused execution that was never
- * recorded.
+ * Deliberately far below the snapshot's own limit. The assertion measures the
+ * *combined* record, so scopes that are each individually under it still fail
+ * together — compacting at the snapshot ceiling would be a no-op in exactly the
+ * case that needs it. Only reached when the state is already too large, so the
+ * fidelity cost lands on runs that would otherwise fail outright.
+ */
+const PAUSE_SNAPSHOT_COMPACT_VALUE_BYTES = 64 * 1024
+
+/**
+ * Whether the serialized subflow state is already past what the snapshot allows.
  *
- * Mirrors the loop-exit pass: entries move to large-value storage and the
- * snapshot keeps refs. The keys they register are picked up by the snapshot's
- * `trustedLargeValueAccess`, so the resumed run can still read them.
+ * Measured on the serialized shape because that is what the assertions read,
+ * and bounded so an oversized structure short-circuits instead of being walked
+ * in full.
+ */
+function isSubflowStateOversized(loops?: Map<string, any>, parallels?: Map<string, any>): boolean {
+  const limit = LARGE_VALUE_THRESHOLD_BYTES
+  const loopBytes = getBoundedJsonByteLength(serializeLoopExecutions(loops), limit)
+  if (loopBytes !== undefined && loopBytes > limit) return true
+  const parallelBytes = getBoundedJsonByteLength(serializeParallelExecutions(parallels), limit)
+  return parallelBytes !== undefined && parallelBytes > limit
+}
+
+/**
+ * Offload accumulated subflow state so a pause snapshot stays under the size
+ * assertions below.
+ *
+ * A loop or parallel compacts its accumulated outputs when it *exits*, but a
+ * pause is by definition mid-flight and never reaches that point. The running
+ * total therefore arrives here uncompacted and trips the assertion, which
+ * throws rather than degrades — turning the pause into a failed run, so no
+ * paused-execution row is ever written. The approval notification has already
+ * gone out by then, leaving the approver holding a link to something that was
+ * never recorded.
+ *
+ * Every field that grows without an aggregate bound is covered: a loop's
+ * iteration outputs, its in-flight iteration outputs and its `forEach`
+ * collection, and the parallel equivalents. Compacting only one of them would
+ * leave the same failure reachable by a different route.
+ *
+ * Skipped entirely when the state already serializes small enough, so the
+ * common case — a pause per iteration inside a modest loop — pays one bounded
+ * measurement rather than a full structural rebuild each time.
  */
 export async function compactPauseSnapshotScopes(context: ExecutionContext): Promise<void> {
-  if (!context.loopExecutions?.size) return
+  const loops = context.loopExecutions
+  const parallels = context.parallelExecutions
+  if (!loops?.size && !parallels?.size) return
+  if (!isSubflowStateOversized(loops, parallels)) return
 
-  const options = {
+  const buildOptions = () => ({
     workspaceId: context.workspaceId,
     workflowId: context.workflowId,
     executionId: context.executionId,
@@ -210,14 +246,49 @@ export async function compactPauseSnapshotScopes(context: ExecutionContext): Pro
     allowLargeValueWorkflowScope: context.allowLargeValueWorkflowScope,
     userId: context.userId,
     requireDurable: true,
+    thresholdBytes: PAUSE_SNAPSHOT_COMPACT_VALUE_BYTES,
+  })
+
+  const compactList = async <T>(values: T[]): Promise<T[]> =>
+    compactSubflowResults(values, buildOptions())
+
+  const compactMapValues = async (map: Map<unknown, unknown[]>): Promise<void> => {
+    for (const [key, value] of map) {
+      if (Array.isArray(value) && value.length > 0) {
+        map.set(key, await compactList(value))
+      }
+    }
   }
 
-  for (const scope of context.loopExecutions.values()) {
-    if (!scope.allIterationOutputs?.length) continue
-    scope.allIterationOutputs = await compactSubflowResults(scope.allIterationOutputs, options)
-    // Authorize the refs this pass just minted. Reads are gated on the context's
-    // key list, so a resumed run cannot materialize them otherwise.
-    recordMaterializedAccessKeys(context, scope.allIterationOutputs)
+  for (const scope of loops?.values() ?? []) {
+    if (scope.allIterationOutputs?.length) {
+      scope.allIterationOutputs = await compactList(scope.allIterationOutputs)
+    }
+    if (scope.items?.length) {
+      scope.items = await compactList(scope.items)
+    }
+    if (scope.currentIterationOutputs instanceof Map && scope.currentIterationOutputs.size > 0) {
+      for (const [blockId, output] of scope.currentIterationOutputs) {
+        scope.currentIterationOutputs.set(
+          blockId,
+          await compactExecutionPayload(output, { ...buildOptions(), preserveRoot: false })
+        )
+      }
+    }
+    recordMaterializedAccessKeys(context, scope)
+  }
+
+  for (const scope of parallels?.values() ?? []) {
+    if (scope.items?.length) {
+      scope.items = await compactList(scope.items)
+    }
+    if (scope.branchOutputs instanceof Map) {
+      await compactMapValues(scope.branchOutputs)
+    }
+    if (scope.accumulatedOutputs instanceof Map) {
+      await compactMapValues(scope.accumulatedOutputs)
+    }
+    recordMaterializedAccessKeys(context, scope)
   }
 }
 
@@ -280,6 +351,7 @@ export function serializePauseSnapshot(
 
   assertSnapshotValueIsCompact(context.workflowVariables, 'workflow variables')
   assertSnapshotValueIsCompact(state.loopExecutions, 'loop execution state')
+  assertSnapshotValueIsCompact(state.parallelExecutions, 'parallel execution state')
 
   const workspaceId = metadataFromContext?.workspaceId ?? context.workspaceId
   if (!workspaceId) {

--- a/apps/sim/executor/execution/snapshot-serializer.ts
+++ b/apps/sim/executor/execution/snapshot-serializer.ts
@@ -1,6 +1,6 @@
 import { recordMaterializedAccessKeys } from '@/lib/execution/payloads/access-keys'
 import { LARGE_VALUE_THRESHOLD_BYTES } from '@/lib/execution/payloads/large-value-ref'
-import { compactExecutionPayload, compactSubflowResults } from '@/lib/execution/payloads/serializer'
+import { compactSubflowResults } from '@/lib/execution/payloads/serializer'
 import type { DAG } from '@/executor/dag/builder'
 import type { EdgeManager } from '@/executor/execution/edge-manager'
 import { ExecutionSnapshot } from '@/executor/execution/snapshot'
@@ -222,10 +222,14 @@ function isSubflowStateOversized(loops?: Map<string, any>, parallels?: Map<strin
  * gone out by then, leaving the approver holding a link to something that was
  * never recorded.
  *
- * Every field that grows without an aggregate bound is covered: a loop's
- * iteration outputs, its in-flight iteration outputs and its `forEach`
- * collection, and the parallel equivalents. Compacting only one of them would
- * leave the same failure reachable by a different route.
+ * Covers exactly the accumulators the orchestrators themselves compact when a
+ * subflow exits — a loop's iteration outputs and a parallel's branch and
+ * accumulated outputs. Deliberately excluded: `items`, which the loop consumes
+ * structurally (`orchestrators/loop.ts` indexes it to derive `item`, and the
+ * loop resolver asserts no refs reach it), and `currentIterationOutputs`, whose
+ * entries the block executor has already compacted and which resolve through
+ * the reference path that materializes refs. Offloading either would trade this
+ * failure for a broken resume.
  *
  * Skipped entirely when the state already serializes small enough, so the
  * common case — a pause per iteration inside a modest loop — pays one bounded
@@ -264,24 +268,10 @@ export async function compactPauseSnapshotScopes(context: ExecutionContext): Pro
     if (scope.allIterationOutputs?.length) {
       scope.allIterationOutputs = await compactList(scope.allIterationOutputs)
     }
-    if (scope.items?.length) {
-      scope.items = await compactList(scope.items)
-    }
-    if (scope.currentIterationOutputs instanceof Map && scope.currentIterationOutputs.size > 0) {
-      for (const [blockId, output] of scope.currentIterationOutputs) {
-        scope.currentIterationOutputs.set(
-          blockId,
-          await compactExecutionPayload(output, { ...buildOptions(), preserveRoot: false })
-        )
-      }
-    }
     recordMaterializedAccessKeys(context, scope)
   }
 
   for (const scope of parallels?.values() ?? []) {
-    if (scope.items?.length) {
-      scope.items = await compactList(scope.items)
-    }
     if (scope.branchOutputs instanceof Map) {
       await compactMapValues(scope.branchOutputs)
     }

--- a/apps/sim/executor/execution/snapshot-serializer.ts
+++ b/apps/sim/executor/execution/snapshot-serializer.ts
@@ -1,4 +1,6 @@
+import { recordMaterializedAccessKeys } from '@/lib/execution/payloads/access-keys'
 import { LARGE_VALUE_THRESHOLD_BYTES } from '@/lib/execution/payloads/large-value-ref'
+import { compactSubflowResults } from '@/lib/execution/payloads/serializer'
 import type { DAG } from '@/executor/dag/builder'
 import type { EdgeManager } from '@/executor/execution/edge-manager'
 import { ExecutionSnapshot } from '@/executor/execution/snapshot'
@@ -180,6 +182,43 @@ function serializeParallelExecutions(
     }
   }
   return result
+}
+
+/**
+ * Offload accumulated loop iteration outputs so a pause snapshot stays compact.
+ *
+ * A loop compacts `allIterationOutputs` when it exits, but a pause is by
+ * definition mid-flight and never reaches that point — so the running total
+ * arrives at the serializer uncompacted and trips its size assertion, failing
+ * the pause outright. The approval notification has already gone out by then,
+ * leaving the approver holding a link to a paused execution that was never
+ * recorded.
+ *
+ * Mirrors the loop-exit pass: entries move to large-value storage and the
+ * snapshot keeps refs. The keys they register are picked up by the snapshot's
+ * `trustedLargeValueAccess`, so the resumed run can still read them.
+ */
+export async function compactPauseSnapshotScopes(context: ExecutionContext): Promise<void> {
+  if (!context.loopExecutions?.size) return
+
+  const options = {
+    workspaceId: context.workspaceId,
+    workflowId: context.workflowId,
+    executionId: context.executionId,
+    largeValueExecutionIds: context.largeValueExecutionIds,
+    largeValueKeys: context.largeValueKeys,
+    allowLargeValueWorkflowScope: context.allowLargeValueWorkflowScope,
+    userId: context.userId,
+    requireDurable: true,
+  }
+
+  for (const scope of context.loopExecutions.values()) {
+    if (!scope.allIterationOutputs?.length) continue
+    scope.allIterationOutputs = await compactSubflowResults(scope.allIterationOutputs, options)
+    // Authorize the refs this pass just minted. Reads are gated on the context's
+    // key list, so a resumed run cannot materialize them otherwise.
+    recordMaterializedAccessKeys(context, scope.allIterationOutputs)
+  }
 }
 
 export function serializePauseSnapshot(


### PR DESCRIPTION
## Summary
- A loop compacts its accumulated iteration outputs when it **exits** (`orchestrators/loop.ts`), but a pause is by definition **mid-flight** and never reaches that point. The running total arrived at `serializePauseSnapshot` uncompacted and tripped `assertSnapshotValueIsCompact`, which **throws** rather than degrades.
- The throw is caught upstream and converts the pause into a **failed run**, so `handlePostExecutionPauseState` never writes the `paused_executions` row.
- Run the same compaction the loop performs on exit, before serializing.

## Why this is worse than a failed run
The HITL approval notification — email/Slack, containing the resume links — is sent during **block execution** (`human-in-the-loop-handler.ts`), well before the engine builds the paused result. So the approver receives a working-looking approval link pointing at a row that is never created, and the run surfaces a generic "Execution failed" with no indication that a byte budget caused it.

## Reachability
Not theoretical. Nothing caps the accumulation:
- `allIterationOutputs` is compacted **per iteration** (`loop.ts`) but never in aggregate until loop exit.
- Accumulation **survives resumes** — `executor.ts` rebuilds it from the snapshot — so an "approve each item" loop grows across every approval.
- ~8 KB retained per iteration × 1000 iterations reaches the limit; a paginated API response per iteration gets there in a couple of hundred.

The canonical failing workflow is the most idiomatic HITL pattern there is: `forEach` over records → work → approval per record. It works for the first few hundred approvals and then abruptly stops pausing.

## Why not degrade instead
`pause-persistence.ts` already handles a missing seed by failing the run, so catching the throw would produce the same failed run with a vaguer error. The snapshot *is* the point of a pause — an unstorable snapshot means an unresumable pause. The assertion stays as a valid post-condition; this satisfies it rather than tripping it.

Note the sibling call in `getSerializableExecutionState` is guarded, but it is not an equivalent case: it only runs on non-paused exits where the snapshot feeds a **display** payload, so degrading there costs a UI detail rather than the resume artifact.

## Registering the minted keys
Compaction creates refs at pause time, and reads are gated on the context's key list (`materialization.server.ts`), so the resumed run could not materialize them unless their keys reach the snapshot's `trustedLargeValueAccess`. `recordMaterializedAccessKeys` is called for exactly that. This was caught by the test below, not by inspection.

## Type of Change
- [x] Bug fix

## Testing
Three cases in `snapshot-serializer.test.ts`, each mutation-verified:
- serialization succeeds for an oversized loop scope — fails without the compaction pass
- the offloaded values are authorized for the resumed run — fails without the key registration
- a loop whose accumulated output already fits is left untouched

`executor` + `lib/execution` suites green (100 files, 1848 tests). One unrelated failure in `executor/handlers/pi/cloud-review-tools.test.ts` is pre-existing on clean staging — verified by stashing.

Not exercised against a live paused workflow.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)