### PR TITLE
fix(landing): restore homepage view tracking

### DIFF
--- a/apps/sim/app/(landing)/landing.test.tsx
+++ b/apps/sim/app/(landing)/landing.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment node
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@sim/emcn', () => ({
+  cn: (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/app/(landing)/components', () => ({
+  Cta: () => null,
+  Features: () => null,
+  Hero: () => null,
+  HomeStructuredData: () => null,
+  Mothership: () => null,
+  ProductDemo: () => null,
+}))
+
+vi.mock('@/app/(landing)/components/landing-layout', () => ({
+  LANDING_SECTION_RHYTHM: 'gap-test',
+}))
+
+vi.mock('@/app/(landing)/landing-analytics', () => ({
+  LandingAnalytics: () => <span>landing-analytics-marker</span>,
+}))
+
+import Landing from '@/app/(landing)/landing'
+
+describe('Landing', () => {
+  it('mounts the landing page analytics tracker exactly once', () => {
+    const markup = renderToStaticMarkup(<Landing />)
+
+    expect(markup.match(/landing-analytics-marker/g)).toHaveLength(1)
+  })
+})

--- a/apps/sim/app/(landing)/landing.tsx
+++ b/apps/sim/app/(landing)/landing.tsx
@@ -8,6 +8,7 @@ import {
   ProductDemo,
 } from '@/app/(landing)/components'
 import { LANDING_SECTION_RHYTHM } from '@/app/(landing)/components/landing-layout'
+import { LandingAnalytics } from '@/app/(landing)/landing-analytics'
 
 /**
  * Landing page root - owns the section order and the `<main>` content region.
@@ -26,6 +27,7 @@ import { LANDING_SECTION_RHYTHM } from '@/app/(landing)/components/landing-layou
 export default function Landing() {
   return (
     <main id='main-content' className={cn('flex flex-col', LANDING_SECTION_RHYTHM)}>
+      <LandingAnalytics />
       <HomeStructuredData />
       <Hero />
       <ProductDemo />


### PR DESCRIPTION
## Summary
- remount the landing analytics tracker on the homepage
- add regression coverage for the tracker composition

## Type of Change
- [x] Bug fix

## Testing
- `bun run test 'app/(landing)/landing.test.tsx'`
- `bun run lint`
- full ship audit suite

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)