### PR TITLE
fix(emcn): normalize MoreHorizontal and TerminalWindow geometry

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -693,7 +693,7 @@ export const Panel = memo(function Panel() {
               <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
                 <DropdownMenuTrigger asChild>
                   <Button className='size-[30px] rounded-[5px]'>
-                    <MoreHorizontal />
+                    <MoreHorizontal className='size-[14px]' />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align='start' side='bottom' sideOffset={8}>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -271,7 +271,7 @@ const SidebarChatItem = memo(function SidebarChatItem({
                 isMenuOpen && 'opacity-100'
               )}
             >
-              <MoreHorizontal className='size-[9px] text-[var(--text-icon)]' />
+              <MoreHorizontal className='size-[14px] text-[var(--text-icon)]' />
             </button>
           </div>
         )}
@@ -1612,7 +1612,7 @@ export const Sidebar = memo(function Sidebar({
                                       {isImporting || isCreatingFolder ? (
                                         <Loader className='h-[16px] w-[16px]' animate />
                                       ) : (
-                                        <MoreHorizontal className='size-[9px]' />
+                                        <MoreHorizontal className='size-[14px]' />
                                       )}
                                     </Button>
                                   </DropdownMenuTrigger>

--- a/packages/emcn/src/icons/more-horizontal.tsx
+++ b/packages/emcn/src/icons/more-horizontal.tsx
@@ -2,31 +2,32 @@ import type { SVGProps } from 'react'
 
 /**
  * MoreHorizontal icon component (three horizontal dots)
+ *
+ * The exact transpose of {@link MoreVertical} about (10.25, 9.75) — same radius,
+ * same stroke, same 6-unit spacing. The two are the same glyph rotated 90deg and
+ * appear in the same overflow-menu role, so they must match by construction
+ * rather than by coincidence.
+ *
  * @param props - SVG properties including className, fill, etc.
  */
 export function MoreHorizontal(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
-      width='12'
-      height='3'
-      viewBox='0 0 12 3'
+      width='24'
+      height='24'
+      viewBox='-1 -2 24 24'
       fill='none'
+      stroke='currentColor'
+      strokeWidth='1.55'
+      strokeLinecap='round'
+      strokeLinejoin='round'
       xmlns='http://www.w3.org/2000/svg'
       aria-hidden='true'
       {...props}
     >
-      <path
-        d='M10.64 2.72C10.46 2.72 10.29 2.68 10.122 2.61C9.96 2.54 9.81 2.44 9.68 2.32C9.56 2.19 9.46 2.04 9.39 1.88C9.32 1.71 9.28 1.54 9.28 1.36C9.28 1.18 9.32 1 9.39 0.84C9.45 0.67 9.55 0.52 9.68 0.4C9.81 0.27 9.96 0.17 10.12 0.1C10.286 0.04 10.46 5.74e-05 10.641 7.02e-08C11 0 11.35 0.14 11.6 0.4C11.86 0.65 12 1 12 1.36C12 1.72 11.86 2.06 11.6 2.32C11.35 2.57 11 2.72 10.64 2.72Z'
-        fill='currentColor'
-      />
-      <path
-        d='M6 2.72C6.75 2.72 7.36 2.11 7.36 1.36C7.36 0.61 6.75 0 6 0C5.25 0 4.64 0.61 4.64 1.36C4.64 2.11 5.25 2.72 6 2.72Z'
-        fill='currentColor'
-      />
-      <path
-        d='M1.36 2.72C2.11 2.72 2.72 2.11 2.72 1.36C2.72 0.61 2.11 0 1.36 0C0.61 0 0 0.61 0 1.36C0 2.11 0.61 2.72 1.36 2.72Z'
-        fill='currentColor'
-      />
+      <circle cx='4.25' cy='9.75' r='0.75' />
+      <circle cx='10.25' cy='9.75' r='0.75' />
+      <circle cx='16.25' cy='9.75' r='0.75' />
     </svg>
   )
 }

--- a/packages/emcn/src/icons/terminal-window.tsx
+++ b/packages/emcn/src/icons/terminal-window.tsx
@@ -2,26 +2,33 @@ import type { SVGProps } from 'react'
 
 /**
  * Terminal window icon component
+ *
+ * Redrawn on the house geometry (24-box, 1.55 stroke, round joins) so it sits at
+ * the weight of the icons it shares the resource registry tab strip with. The
+ * original character is kept: a window with a title bar and three chrome dots.
+ *
  * @param props - SVG properties including className, fill, etc.
  */
 export function TerminalWindow(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
-      width='16'
-      height='14'
-      viewBox='0 0 16 14'
+      width='24'
+      height='24'
+      viewBox='-1 -2 24 24'
       fill='none'
+      stroke='currentColor'
+      strokeWidth='1.55'
+      strokeLinecap='round'
+      strokeLinejoin='round'
       xmlns='http://www.w3.org/2000/svg'
       aria-hidden='true'
       {...props}
     >
-      <path
-        d='M3 0C1.34 0 0 1.34 0 3V11C0 12.66 1.34 14 3 14H13C14.66 14 16 12.66 16 11V3C16 1.34 14.66 0 13 0H3ZM1 3C1 1.9 1.9 1 3 1H13C14.1 1 15 1.9 15 3V4H1V3ZM1 5H15V11C15 12.1 14.1 13 13 13H3C1.9 13 1 12.1 1 11V5Z'
-        fill='currentColor'
-      />
-      <circle cx='3.5' cy='2.5' r='0.75' fill='currentColor' />
-      <circle cx='5.75' cy='2.5' r='0.75' fill='currentColor' />
-      <circle cx='8' cy='2.5' r='0.75' fill='currentColor' />
+      <path d='M3.75 2.75H16.75A2 2 0 0 1 18.75 4.75V14.75A2 2 0 0 1 16.75 16.75H3.75A2 2 0 0 1 1.75 14.75V4.75A2 2 0 0 1 3.75 2.75Z' />
+      <path d='M1.75 6.75H18.75' />
+      <circle cx='4.5' cy='4.75' r='0.5' />
+      <circle cx='7' cy='4.75' r='0.5' />
+      <circle cx='9.5' cy='4.75' r='0.5' />
     </svg>
   )
 }


### PR DESCRIPTION
The sidebar row's `...` renders visibly oversized. Root cause: `MoreVertical` was migrated to the house geometry and **`MoreHorizontal` was left behind**.

| | viewBox | build | dot Ø | span |
|---|---|---|---|---|
| `MoreVertical` | `-1 -2 24 24` | stroke `1.55` | 1.78px | 8.78px |
| `MoreHorizontal` **(before)** | `0 0 12 3` | **fill** | **3.17px** | **14.00px** |
| `MoreHorizontal` **(after)** | `-1 -2 24 24` | stroke `1.55` | 1.78px | **8.80px** |

*(measured at `size-[14px]`)*

They are the same glyph rotated 90°, in the same overflow-menu role. Because `12×3` is far wider than tall, a **square** size class scales by `14/12` and the dots stretch edge-to-edge, while every neighbour on that row sits well inside (`Folder` 9.7px, `ChevronRight` 9.4px, `Lock` 11.2px).

Redrawn as the **exact transpose of `MoreVertical`** about `(10.25, 9.75)` — same radius, same stroke, same 6-unit spacing. Both now measure **8.80px**, mirrored (`8.8×1.8` vs `1.8×8.8`).

## `TerminalWindow` — same class, found by the sweep

`RESOURCE_REGISTRY` renders ten icons side by side as tabs at `size-[14px]`:

```
Library 12.05  Task 12.05  Workflow 12.05  Connections 11.20
Database 11.20  Globe 10.30            <- all stroke 0.90
TerminalWindow 14.00  FILL  viewBox 0 0 16 14   <- lone outlier
```

Redrawn on the 24-box keeping its character (window + title bar + three chrome dots): now **10.85px**, and the strip is uniform at 10.30–12.05px / 0.90px stroke.

## Call-site changes that must ship with the viewBox change

- **`panel.tsx:696`** passed **no size** inside `<Button className='size-[30px]'>`. `Button` has no `[&_svg]:size-*`, so the icon renders at its intrinsic size — it would have jumped `12×3 → 24×24` inside a 30px button. Now explicitly `size-[14px]`.
- **`sidebar.tsx:274` and `:1615`** used `size-[9px]` — **compensations for the oversized glyph** (9px against a 12-wide box yields a ~9px span). Against the 24-box they would render **5.64px**, so they move to `size-[14px]` → **8.78px**, exactly `MoreVertical`.

Every other site was verified: 8 more `MoreHorizontal` sites already pass a square size; the two unsized ones sit inside `DropdownMenuItemAction`, which force-sizes `[&_svg]:size-[16px]`. All 6 `TerminalWindow` sites resolve to square sizes (3 explicit, 3 via caller `className` — `resource-tabs` `size-[14px]`, `recently-deleted` `size-5`, `ContextMentionIcon` `size-[12px]`/`size-[14px]`). **No aspect-ratio (`h-[N] w-[M]`) sizing anywhere in either call graph, so nothing letterboxes.**

## How this was found

All 168 icon components were measured by **rendering each at 20× and scanning the alpha channel for its true ink bounding box**, rather than estimating from path coordinates. Median span is **11.45px** at `size-[14px]`. Both redraws were rendered against their real neighbours and visually checked before committing.

## Verified not bugs

- `Sim`, `Wordmark`, `Blimp` — brand marks; `Play` — deliberately filled (`PlayOutline` is the stroke variant)
- `BubbleChatClose`/`Preview` — both `0 0 14 14` filled at 12.6px, but they only ever toggle against *each other*
- `DocumentAttachment` — 13.55px, but **zero call sites** (exported from the barrel, unused)
- The remaining >12.5px icons are all standard `0 0 24 24` / `0.90` stroke — that's glyph shape, not geometry

## Checks

`biome` clean · `type-check --force` 23/23 (0 cached) · no test references either icon; the 5 sidebar collection errors are **pre-existing** — a pristine `origin/staging` worktree reproduces the same 5 with zero changes applied.