### PR TITLE
fix(docs): point the service-account guides at the real connect flow

### DIFF
--- a/apps/docs/content/docs/en/integrations/airtable-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/airtable-service-account.mdx
@@ -69,12 +69,12 @@ Enterprise organizations can enable "Block API access to organization-owned base
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Airtable Service Account" and click it, then click **Add to Sim** and choose **Add personal access token**
+    Search for "Airtable" and open it, then click **Add to Sim** and choose **Add personal access token**
 
-    {/* TODO(screenshot): Integrations page with "Airtable Service Account" in the service list */}
+    {/* TODO(screenshot): Airtable integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the **Personal access token**, and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/asana-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/asana-service-account.mdx
@@ -73,12 +73,12 @@ If you're not on an Enterprise plan, a personal access token works identically o
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Asana Service Account" and click it, then click **Add to Sim** and choose **Add access token**
+    Search for "Asana" and open it, then click **Add to Sim** and choose **Add access token**
 
-    {/* TODO(screenshot): Integrations page with "Asana Service Account" in the service list */}
+    {/* TODO(screenshot): Asana integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the token — service account token or personal access token, both work in the same field — and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/attio-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/attio-service-account.mdx
@@ -61,12 +61,12 @@ The API key is bearer credentials for your Attio workspace. Treat it like a pass
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Attio Service Account" and click it, then click **Add to Sim** and choose **Add API key**
+    Search for "Attio" and open it, then click **Add to Sim** and choose **Add API key**
 
-    {/* TODO(screenshot): Integrations page with "Attio Service Account" in the service list */}
+    {/* TODO(screenshot): Attio integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the API key and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/calcom-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/calcom-service-account.mdx
@@ -45,12 +45,12 @@ The API key carries the full privileges of the user who created it — there is 
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Cal.com Service Account" and click it, then click **Add to Sim** and choose **Add API key**
+    Search for "Cal.com" and open it, then click **Add to Sim** and choose **Add API key**
 
-    {/* TODO(screenshot): Integrations page with "Cal.com Service Account" in the service list */}
+    {/* TODO(screenshot): Cal.com integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the API key, and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/clickup-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/clickup-service-account.mdx
@@ -45,12 +45,12 @@ The API token carries the creating user's full access to every workspace they be
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "ClickUp Service Account" and click it, then click **Add to Sim** and choose **Add API token**
+    Search for "ClickUp" and open it, then click **Add to Sim** and choose **Add API token**
 
-    {/* TODO(screenshot): Integrations page with "ClickUp Service Account" in the service list */}
+    {/* TODO(screenshot): ClickUp integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the API token (`pk_...`) and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/google-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/google-service-account.mdx
@@ -140,15 +140,15 @@ Once Google Cloud and Workspace are configured, add the service account as a cre
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Google Service Account" and click **Connect**
+    Search for "Google Drive" and open it — any Google integration works, since they share one service account — then click **Add to Sim** and choose **Add service account**
 
     <div className="flex justify-center">
       <Image
         src="/static/credentials/integrations-service-account.png"
-        alt="Integrations page showing Google Service Account"
+        alt="Google Drive integration page with the service-account connect option"
         width={800}
         height={150}
         className="my-4"
@@ -171,7 +171,7 @@ Once Google Cloud and Workspace are configured, add the service account as a cre
     Give the credential a display name (the service account email is used by default)
   </Step>
   <Step>
-    Click **Save**
+    Click **Add service account**
   </Step>
 </Steps>
 

--- a/apps/docs/content/docs/en/integrations/hubspot-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/hubspot-service-account.mdx
@@ -97,12 +97,12 @@ The access token is bearer credentials for your entire portal, limited only by i
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "HubSpot Service Account" and click it, then click **Add to Sim** and choose **Add private app token**
+    Search for "HubSpot" and open it, then click **Add to Sim** and choose **Add private app token**
 
-    {/* TODO(screenshot): Integrations page with "HubSpot Service Account" in the service list */}
+    {/* TODO(screenshot): HubSpot integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the **Private app access token**, and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/linear-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/linear-service-account.mdx
@@ -45,12 +45,12 @@ The API key carries the creating user's full access to your Linear workspace. Tr
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Linear Service Account" and click it, then click **Add to Sim** and choose **Add API key**
+    Search for "Linear" and open it, then click **Add to Sim** and choose **Add API key**
 
-    {/* TODO(screenshot): Integrations page with "Linear Service Account" in the service list */}
+    {/* TODO(screenshot): Linear integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the API key (`lin_api_...`) and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/monday-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/monday-service-account.mdx
@@ -61,12 +61,12 @@ There is no scope picker: personal API tokens carry **all** API permission scope
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "monday.com Service Account" and click it, then click **Add to Sim** and choose **Add API token**
+    Search for "Monday" and open it, then click **Add to Sim** and choose **Add API token**
 
-    {/* TODO(screenshot): Integrations page with "monday.com Service Account" in the service list */}
+    {/* TODO(screenshot): Monday integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the API token and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/notion-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/notion-service-account.mdx
@@ -78,12 +78,12 @@ A valid secret with no page connections validates fine in Sim but returns `404 o
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Notion Service Account" and click it, then click **Add to Sim** and choose **Add integration secret**
+    Search for "Notion" and open it, then click **Add to Sim** and choose **Add integration secret**
 
-    {/* TODO(screenshot): Integrations page with "Notion Service Account" in the service list */}
+    {/* TODO(screenshot): Notion integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the **Internal integration secret**, and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/shopify-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/shopify-service-account.mdx
@@ -72,12 +72,12 @@ Use the permanent `.myshopify.com` domain — for example, `your-store.myshopify
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Shopify Service Account" and click it, then click **Add to Sim** and choose **Add admin API token**
+    Search for "Shopify" and open it, then click **Add to Sim** and choose **Add admin API token**
 
-    {/* TODO(screenshot): Integrations page with "Shopify Service Account" in the service list */}
+    {/* TODO(screenshot): Shopify integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the Admin API access token, enter the store domain (e.g. `your-store.myshopify.com`), and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/trello-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/trello-service-account.mdx
@@ -58,12 +58,12 @@ Newer Trello tokens start with `ATTA`; older ones are 64-character hex strings. 
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Trello Service Account" and click it, then click **Add to Sim** and choose **Add API token**
+    Search for "Trello" and open it, then click **Add to Sim** and choose **Add API token**
 
-    {/* TODO(screenshot): Integrations page with "Trello Service Account" in the service list */}
+    {/* TODO(screenshot): Trello integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the API token, and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/wealthbox-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/wealthbox-service-account.mdx
@@ -43,12 +43,12 @@ The token carries the full permissions of the user who created it — there is n
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Wealthbox Service Account" and click it, then click **Add to Sim** and choose **Add access token**
+    Search for "Wealthbox" and open it, then click **Add to Sim** and choose **Add access token**
 
-    {/* TODO(screenshot): Integrations page with "Wealthbox Service Account" in the service list */}
+    {/* TODO(screenshot): Wealthbox integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the API access token, and optionally set a display name and description

--- a/apps/docs/content/docs/en/integrations/webflow-service-account.mdx
+++ b/apps/docs/content/docs/en/integrations/webflow-service-account.mdx
@@ -52,12 +52,12 @@ Site tokens expire after **365 consecutive days of inactivity**. Any API call re
 
 <Steps>
   <Step>
-    Open your workspace **Settings** and go to the **Integrations** tab
+    Open **Integrations** from your workspace sidebar
   </Step>
   <Step>
-    Search for "Webflow Service Account" and click it, then click **Add to Sim** and choose **Add site token**
+    Search for "Webflow" and open it, then click **Add to Sim** and choose **Add site token**
 
-    {/* TODO(screenshot): Integrations page with "Webflow Service Account" in the service list */}
+    {/* TODO(screenshot): Webflow integration page with the service-account connect option */}
   </Step>
   <Step>
     Paste the site API token and optionally set a display name and description

--- a/apps/sim/lib/credentials/token-service-accounts/descriptors.ts
+++ b/apps/sim/lib/credentials/token-service-accounts/descriptors.ts
@@ -344,7 +344,7 @@ export const TOKEN_SERVICE_ACCOUNT_DESCRIPTORS: Record<
     helpText:
       'Trial accounts cannot use the Wealthbox API; contact Wealthbox support if API Access is missing from your Settings.',
     invalidCredentialsHelp:
-      "Wealthbox rejected this token. Sim's Wealthbox tools authenticate with a Bearer header, so a token Wealthbox only accepts over its ACCESS_TOKEN header is refused here even though it is valid. Check that the token is active in Wealthbox under Settings, and that the account is not on an expired trial.",
+      'Wealthbox rejected this token. Check that it is still active under API Access in your Wealthbox settings, and that the account is not on an expired trial. If the same token works elsewhere, note that Sim authenticates with a Bearer header — a token Wealthbox accepts only over its ACCESS_TOKEN header is refused here.',
   },
   [PIPEDRIVE_SERVICE_ACCOUNT_PROVIDER_ID]: {
     providerId: PIPEDRIVE_SERVICE_ACCOUNT_PROVIDER_ID,

--- a/apps/sim/lib/credentials/token-service-accounts/descriptors.ts
+++ b/apps/sim/lib/credentials/token-service-accounts/descriptors.ts
@@ -343,6 +343,8 @@ export const TOKEN_SERVICE_ACCOUNT_DESCRIPTORS: Record<
     docsUrl: 'https://docs.sim.ai/integrations/wealthbox-service-account',
     helpText:
       'Trial accounts cannot use the Wealthbox API; contact Wealthbox support if API Access is missing from your Settings.',
+    invalidCredentialsHelp:
+      "Wealthbox rejected this token. Sim's Wealthbox tools authenticate with a Bearer header, so a token Wealthbox only accepts over its ACCESS_TOKEN header is refused here even though it is valid. Check that the token is active in Wealthbox under Settings, and that the account is not on an expired trial.",
   },
   [PIPEDRIVE_SERVICE_ACCOUNT_PROVIDER_ID]: {
     providerId: PIPEDRIVE_SERVICE_ACCOUNT_PROVIDER_ID,


### PR DESCRIPTION
## Summary
- 14 of 20 service-account guides sent admins to a workspace **Settings → Integrations** tab that **does not exist**. Integrations is a top-level workspace route (`sidebar.tsx` → `/workspace/{id}/integrations`), and `components/settings/navigation.ts` has no integrations section at all
- The same 14 told them to search the catalog for `"<Service> Service Account"` — a name no entry has. The catalog is block-derived, so entries are `Airtable`, `Monday`, `Wealthbox`; search matches name + description only, so those strings matched **nothing**
- Both steps now match the 6 guides that were already correct (Box, Zoho Desk, Zoom, Salesforce, Pipedrive, Atlassian). All 20 now describe one flow
- Google needed a third fix the original audit missed — see below
- Adds `invalidCredentialsHelp` for Wealthbox

These were the first two things an admin hit, and they hit them before reaching anything provider-specific.

## Verified against the code, not assumed
Every claim was checked against the actual UI rather than taken from the audit that raised them:
- `components/settings/navigation.ts` — zero occurrences of "integration"; the workspace sections are `teammates | secrets | byok | sandboxes | custom-tools | mcp | workflow-mcp-servers | api-keys | inbox | recently-deleted | forks | custom-blocks | self-host`
- `lib/integrations/integrations.json` — 233 entries, none containing "Service Account". The only "Service" names are `Jira Service Management` and `ServiceNow`
- `integrations.tsx` search is a lowercased substring over name + description
- The per-guide connect labels (`Add API token`, `Add integration secret`, …) were already correct — they come from `connectNoun`, and they are **untouched**

## Google (3 edits)
Its final step said `Click **Save**`, but the modal's primary button is `Add {connectNoun}`, and Google falls back to `'service account'` (`service-account-provider-ids.ts`) — so it reads **Add service account**, never "Save". Google also has no catalog entry of its own (`CANONICAL_SERVICE_ACCOUNT_SLUGS` maps `google-service-account` → `google-drive`), so the search now points at Google Drive with a note that any Google integration works.

## Wealthbox error copy
Its validator deliberately rejects a token that works only over Wealthbox's documented `ACCESS_TOKEN` header, because Sim's tools authenticate with `Bearer`. The distinguishing reason went to the **server log**; the user saw only *"Double-check it in Wealthbox and try again."* Now the modal names the real cause instead of leaving someone re-pasting a valid token.

**Not fixed here:** whether that Bearer-only limitation should change at all. Wealthbox documents `ACCESS_TOKEN` for personal tokens and `Bearer` for OAuth, but never says Bearer is *rejected* for personal tokens, and probing the live API with a bogus token returns an identical 401 for every header shape — inconclusive. The fix would touch 12 files with 4 silent-failure paths (notably the `authStyle` allowlist in `app/api/auth/oauth/utils.ts`, and 4 selector routes whose token helper structurally cannot carry `authStyle`), and those 10 call sites serve the working OAuth path too. That needs one real Wealthbox token to settle, not a speculative change to request signing.

## Type of Change
- [x] Bug fix
- [x] Documentation

## Testing
`bun run lint`, `turbo run type-check` (23/23), and the credentials suites (287 tests) all pass. Verified no `"* Service Account"` search string and no `Settings → Integrations` reference remains anywhere under `apps/docs/content/docs/en/`, and that all 20 guides now use the canonical step 1.

Not browser-verified — the claims are checked against the navigation, catalog and modal source rather than by clicking through.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)