### PR TITLE
fix(files): stop markdown reflow on open by matching placeholder wrapping to the editor

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -1198,10 +1198,12 @@ export function LoadedRichMarkdownEditor({
         }}
       />
       {showPlaceholder && placeholderHtml && (
-        // Instant read-only content while the collaborative doc seeds; the editor stays mounted-but-
-        // hidden below so it renders the seeded doc before the swap. Same layout box → no reflow.
+        // Instant read-only content while the collaborative doc seeds, swapped for the live editor
+        // once ready. The `ProseMirror` class is load-bearing: it gives the placeholder the same base
+        // text layout as the live editable (prosemirror-view sets `white-space: break-spaces` and
+        // disables ligatures), so a line wraps identically and never re-wraps on the swap.
         <div
-          className='rich-markdown-prose mx-auto w-full max-w-[48rem] px-8 py-6'
+          className='ProseMirror rich-markdown-prose mx-auto w-full max-w-[48rem] px-8 py-6'
           dangerouslySetInnerHTML={{ __html: placeholderHtml }}
         />
       )}


### PR DESCRIPTION
## Summary
- Fixes the flicker where a line's word-wrap shifts on first open/refresh of a markdown file (e.g. "…shook only a little" starts on one line, then "little" jumps down as the doc settles).
- **Root cause:** collaborative files render a static `placeholderHtml` while the Yjs doc seeds, then swap to the live TipTap editor. The placeholder was `.rich-markdown-prose` only (browser-default `white-space: normal`), but the live editable is `.ProseMirror.rich-markdown-prose`, and `prosemirror-view` sets `white-space: break-spaces` and disables ligatures on `.ProseMirror`. Different wrapping model → identical text wraps at a different point → the visible re-wrap on the swap.
- **Fix:** give the placeholder the same `ProseMirror` class as the live editable, so both share the exact base text layout and wrap identically. One class added; no width/scrollbar/font changes.

## Type of Change
- [x] Bug fix

## Testing
- Traced empirically, no guesswork: confirmed `prosemirror-view/style/prosemirror.css` sets `white-space: break-spaces` + `font-variant-ligatures: none` on `.ProseMirror`, and the placeholder lacked both. Both render sites already share width (`max-w-[48rem] px-8`), ruling out container width; ruled out scrollbar (macOS overlay scrollbars take no layout width) and font-swap (the bug repros on refresh with the font cached).
- Cross-checked prior art (TipTap docs/issues + inkeep/open-knowledge): inkeep's warm-HTML fallback avoids swap reflow precisely by reusing the live editor's exact classes — this mirrors that. No UX downside: the placeholder was already read-only; only its wrap model now matches the editor.
- Visual confirmation on staging recommended after deploy.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)