### PR TITLE
fix(providers): name the header phase on streaming OpenAI requests

### DIFF
--- a/apps/sim/providers/openai/core.transport-phase.test.ts
+++ b/apps/sim/providers/openai/core.transport-phase.test.ts
@@ -198,6 +198,20 @@ describe('OpenAI transport phase annotation', () => {
     expect(error.message.match(/phase=/g)).toHaveLength(1)
   })
 
+  /**
+   * Streaming calls the request helper directly and never reaches `postResponses`, so a
+   * header stall on a chat or SSE run used to surface as the bare runtime string with no
+   * phase, elapsed time, or request id.
+   */
+  it('names the header phase on a streaming request too', async () => {
+    const error = await run(vi.fn().mockRejectedValue(timeoutError()), {
+      stream: true,
+    }).catch((e) => e)
+
+    expect(error.message).toContain('phase=awaiting-response-headers')
+    expect(error.message).toMatch(/elapsedMs=\d+/)
+  })
+
   it('leaves a healthy response entirely unaffected', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/apps/sim/providers/openai/core.ts
+++ b/apps/sim/providers/openai/core.ts
@@ -410,6 +410,29 @@ export async function executeResponsesProviderRequest(
 
   let reasoningSummariesUnavailable = false
 
+  /**
+   * The single point every Responses request leaves through, so a stall waiting for
+   * headers is named on the streaming paths too — they call
+   * {@link fetchResponsesWithSummaryFallback} directly and never reach `postResponses`,
+   * which is where the annotation used to live.
+   */
+  const postOnce = async (
+    payload: Record<string, unknown>,
+    abortSignal: AbortSignal | undefined,
+    startedAt: number
+  ): Promise<Response> => {
+    try {
+      return await fetchImpl(config.endpoint, {
+        method: 'POST',
+        headers: config.headers,
+        body: JSON.stringify(payload),
+        signal: abortSignal,
+      })
+    } catch (error) {
+      throw annotateTransportFailure(error, 'awaiting-response-headers', startedAt)
+    }
+  }
+
   const fetchResponsesWithSummaryFallback = async (
     requestedBody: Record<string, unknown>,
     startedAt: number,
@@ -418,12 +441,7 @@ export async function executeResponsesProviderRequest(
     const body = reasoningSummariesUnavailable
       ? (stripReasoningSummary(requestedBody) ?? requestedBody)
       : requestedBody
-    const response = await fetchImpl(config.endpoint, {
-      method: 'POST',
-      headers: config.headers,
-      body: JSON.stringify(body),
-      signal: abortSignal,
-    })
+    const response = await postOnce(body, abortSignal, startedAt)
     if (response.ok) return response
 
     const message = await parseErrorResponse(response, startedAt)
@@ -439,12 +457,7 @@ export async function executeResponsesProviderRequest(
       `${config.providerLabel} rejected reasoning summaries (organization not verified); retrying without summary`,
       { model: config.modelName }
     )
-    const retryResponse = await fetchImpl(config.endpoint, {
-      method: 'POST',
-      headers: config.headers,
-      body: JSON.stringify(strippedBody),
-      signal: abortSignal,
-    })
+    const retryResponse = await postOnce(strippedBody, abortSignal, startedAt)
     if (!retryResponse.ok) {
       const retryMessage = await parseErrorResponse(retryResponse, startedAt)
       throw new Error(
@@ -459,12 +472,7 @@ export async function executeResponsesProviderRequest(
   ): Promise<OpenAI.Responses.Response> => {
     const startedAt = Date.now()
 
-    let response: Response
-    try {
-      response = await fetchResponsesWithSummaryFallback(body, startedAt)
-    } catch (error) {
-      throw annotateTransportFailure(error, 'awaiting-response-headers', startedAt)
-    }
+    const response = await fetchResponsesWithSummaryFallback(body, startedAt)
 
     const responseMeta = { ...describeResponse(response), ttfbMs: Date.now() - startedAt }
 


### PR DESCRIPTION
## Summary
- Streaming requests call `fetchResponsesWithSummaryFallback` directly and never reach `postResponses`, which is where #6283 put the header-phase annotation — so a chat or SSE run that stalled waiting for headers still surfaced the bare runtime `TimeoutError: The operation timed out.` with no phase, elapsed time, or request id
- Moved the annotation down to the one place every Responses request actually leaves through, so streaming and non-streaming are named identically
- Net simplification: the two duplicated `fetchImpl` blocks collapse into a single `postOnce` helper, and `postResponses` loses its now-redundant try/catch

Caught by Greptile on #6283. Non-streaming was already covered (webhook, scheduled, async, and sync-API runs are all non-streaming), so this closes the gap for chat, SSE, and streaming-mode API calls.

## Type of Change
- [x] Bug fix

## Testing
Added a test that a streaming request whose fetch rejects with a `TimeoutError` carries `phase=awaiting-response-headers` and `elapsedMs`. Verified it fails without the fix (along with the existing non-streaming header test), then passes with it.

Providers + agent-handler suites: 109 files / 1416 tests passing. Typecheck, lint, and `check:api-validation` clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)