### PR TITLE
fix(docs): stop the sidebar drifting when page content resizes

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -362,16 +362,33 @@ aside#nd-sidebar [data-radix-scroll-area-viewport] {
     min-height: var(--fd-docs-height) !important;
   }
 
-  /* Sidebar divider line — sticky within the docs layout box, so it ends where
-     the layout does instead of bleeding into (or past) the footer below it.
-     #nd-docs-layout is a CSS grid (see fumadocs' Container slot); a sticky
-     pseudo-element stays in normal flow, so without an explicit grid-area it
-     gets auto-placed into a real content cell and skews that cell's sizing.
-     Spanning the full grid keeps it purely decorative/overlaid instead. */
+  /* Pin the sidebar to the viewport instead of letting fumadocs' `sticky` do it.
+     A sticky box is bottom-limited by its containing block, and #nd-docs-layout
+     ends ~660px above the document bottom because the site footer is a sibling
+     of the layout, not a grid child. So across the whole footer the sidebar gets
+     pushed upward — and any content-height change while the reader is in that
+     zone (expanding an FAQ row, say) makes it visibly jump. A fixed box ignores
+     both the container's end and the document's height, so neither happens.
+
+     Safe because the grid columns are explicit (`0px 300px 1fr 268px 0px`), so
+     removing the placeholder from flow leaves its track intact. `left`/`width`
+     are restated because a fixed box no longer derives them from its grid cell,
+     and `top`/`height` already come from fumadocs' own utility classes. */
+  [data-sidebar-placeholder] {
+    position: fixed !important;
+    left: var(--sidebar-offset);
+    width: var(--fd-sidebar-width);
+  }
+
+  /* Sidebar divider line — pinned for the same reason, and to stay glued to the
+     sidebar's right edge. #nd-docs-layout is a CSS grid (see fumadocs' Container
+     slot); the pseudo-element spans the full grid so it reads as decorative
+     overlay rather than being auto-placed into a real content cell and skewing
+     that cell's sizing. */
   #nd-docs-layout::before {
     content: "";
     display: block;
-    position: sticky;
+    position: fixed;
     grid-row: 1 / -1;
     grid-column: 1 / -1;
     top: 92px; /* below navbar */
@@ -381,6 +398,14 @@ aside#nd-sidebar [data-radix-scroll-area-viewport] {
     background-color: var(--surface-active);
     pointer-events: none;
     z-index: 21;
+  }
+
+  /* The footer is opaque and now has to out-stack the pinned sidebar and its
+     divider (z-index 20 and 21), so it slides over them at the end of the page
+     rather than being drawn through. */
+  footer {
+    position: relative;
+    z-index: 22;
   }
 
   /* Hide fumadocs nav on desktop - we use custom navbar there */

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -380,17 +380,14 @@ aside#nd-sidebar [data-radix-scroll-area-viewport] {
     width: var(--fd-sidebar-width);
   }
 
-  /* Sidebar divider line — pinned for the same reason, and to stay glued to the
-     sidebar's right edge. #nd-docs-layout is a CSS grid (see fumadocs' Container
-     slot); the pseudo-element spans the full grid so it reads as decorative
-     overlay rather than being auto-placed into a real content cell and skewing
-     that cell's sizing. */
+  /* Sidebar divider line — pinned for the same reason, and so it stays glued to
+     the sidebar's right edge. Being fixed takes it out of #nd-docs-layout's grid
+     entirely, so it needs no grid placement and cannot skew a content cell; its
+     position comes from `left`/`top` alone. */
   #nd-docs-layout::before {
     content: "";
     display: block;
     position: fixed;
-    grid-row: 1 / -1;
-    grid-column: 1 / -1;
     top: 92px; /* below navbar */
     height: calc(100dvh - 92px);
     left: calc(var(--sidebar-offset) + var(--fd-sidebar-width));
@@ -398,14 +395,6 @@ aside#nd-sidebar [data-radix-scroll-area-viewport] {
     background-color: var(--surface-active);
     pointer-events: none;
     z-index: 21;
-  }
-
-  /* The footer is opaque and now has to out-stack the pinned sidebar and its
-     divider (z-index 20 and 21), so it slides over them at the end of the page
-     rather than being drawn through. */
-  footer {
-    position: relative;
-    z-index: 22;
   }
 
   /* Hide fumadocs nav on desktop - we use custom navbar there */

--- a/apps/docs/components/footer/footer.tsx
+++ b/apps/docs/components/footer/footer.tsx
@@ -130,9 +130,16 @@ function FooterColumn({ title, items }: { title: string; items: FooterItem[] }) 
   )
 }
 
+/**
+ * Site footer.
+ *
+ * `relative z-[22]` stacks it above the docs sidebar (z-20) and that sidebar's
+ * divider (z-21), both of which are pinned to the viewport, so the footer slides
+ * over them at the end of the page instead of being drawn through.
+ */
 export function Footer() {
   return (
-    <footer className='mt-[120px] w-full border-[var(--border)] border-t bg-[var(--bg)] max-sm:mt-16 max-lg:mt-[88px]'>
+    <footer className='relative z-[22] mt-[120px] w-full border-[var(--border)] border-t bg-[var(--bg)] max-sm:mt-16 max-lg:mt-[88px]'>
       <div className='mx-auto w-full max-w-[1460px] px-20 pt-16 pb-16 max-sm:px-5 max-lg:px-8 max-lg:pt-12 max-lg:pb-12'>
         <nav
           aria-label='Footer navigation'


### PR DESCRIPTION
## Summary
- The docs sidebar visibly jumped whenever page content resized — expanding an FAQ row moved it **16.8px** at a fixed scroll position, collapsing moved it back.
- Root cause: the sidebar used fumadocs' `sticky` positioning, and a sticky box is bottom-limited by its containing block. `#nd-docs-layout` ends ~660px above the document bottom because the site footer is a **sibling** of the layout, not a grid child. So across the entire footer the sidebar was pushed progressively upward, and any content-height change while the reader was in that zone moved it.
- Fix: pin the sidebar and its divider to the viewport. A fixed box ignores both the container's end and the document height, so neither the drift nor the jump can occur.

## Why this is safe
- The grid columns are explicit (`0px 300px 1fr 268px 0px`), so taking the placeholder out of flow leaves its track intact — the content column does not move.
- `left`/`width` are restated because a fixed box no longer derives them from its grid cell; `top`/`height` still come from fumadocs' own utility classes.
- The footer was already opaque (`bg-[var(--bg)]`) and now out-stacks the sidebar (z-20) and divider (z-21) at z-22, so it slides over them at the end of the page.
- Desktop-only (`min-width: 1024px`) — mobile is untouched.

## Testing
Measured with Playwright, before and after:

| | before | after |
|---|---|---|
| sidebar shift on FAQ expand | +16.8px | **0px** |
| sidebar shift on collapse | −16.8px | **0px** |
| content column left / width | — | unchanged (0 delta) |
| sidebar `top` at page bottom | 75.2 → drifting | **92px, held** |

Interaction regression suite, all passing: sidebar link navigates, sidebar folder expands, content link clickable (the naive `position: fixed` attempt broke this — a full-width fixed aside intercepted every click), FAQ toggles, ToC link clickable, language selector still hidden.

Verified `top: 92px` holds at the page bottom on the docs, API-reference, academy and integrations layouts, with zero page errors. Screenshots checked in light and dark at top/middle/bottom, plus mobile. Production build passes (4,281 static pages), typecheck and biome clean.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)