### PR TITLE
fix(providers): bound a non-streaming request with an explicit 10-minute deadline

### DIFF
--- a/apps/sim/providers/openai/core.deadline.test.ts
+++ b/apps/sim/providers/openai/core.deadline.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment node
+ *
+ * A non-streaming generation is silent on the wire until it finishes, so nothing but an
+ * explicit deadline can bound it. A streaming one emits continuously and must NOT carry
+ * a total deadline, or a long answer still arriving normally gets cut off.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { executeResponsesProviderRequest } from '@/providers/openai/core'
+import { PROVIDER_REQUEST_TIMEOUT_MS } from '@/providers/timeouts'
+import type { ProviderRequest } from '@/providers/types'
+
+vi.mock('@/providers', () => ({ MAX_TOOL_ITERATIONS: 5 }))
+
+vi.mock('@/providers/utils', () => ({
+  isFunctionToolCall: () => false,
+  calculateCost: () => ({ input: 0, output: 0, total: 0 }),
+  sumToolCosts: () => 0,
+  enforceStrictSchema: (schema: unknown) => schema,
+  prepareToolExecution: () => ({ toolParams: {}, executionParams: {} }),
+  prepareToolsWithUsageControl: (tools: unknown[]) => ({
+    tools,
+    toolChoice: undefined,
+    forcedTools: [],
+    hasFilteredTools: false,
+  }),
+  trackForcedToolUsage: () => ({ hasUsedForcedTool: false, usedForcedTools: [] }),
+  supportsReasoningEffort: () => false,
+}))
+
+const COMPLETED = {
+  id: 'resp_1',
+  status: 'completed',
+  output: [{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'ok' }] }],
+  usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+}
+
+describe('provider request deadline', () => {
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never
+
+  beforeEach(() => vi.clearAllMocks())
+
+  function run(fetchMock: unknown, request: Partial<ProviderRequest> = {}) {
+    return executeResponsesProviderRequest(
+      { apiKey: 'k', model: 'gpt-5.5', messages: [{ role: 'user', content: 'hi' }], ...request },
+      {
+        providerId: 'openai',
+        providerLabel: 'OpenAI',
+        modelName: 'gpt-5.5',
+        endpoint: 'https://api.openai.com/v1/responses',
+        headers: { Authorization: 'Bearer k' },
+        logger,
+        fetch: fetchMock as typeof fetch,
+      }
+    )
+  }
+
+  function okResponse() {
+    return { ok: true, status: 200, headers: new Headers(), json: () => Promise.resolve(COMPLETED) }
+  }
+
+  /** Ten minutes, matching the OpenAI client's own documented default. */
+  it('matches the vendor default rather than inventing a number', () => {
+    expect(PROVIDER_REQUEST_TIMEOUT_MS).toBe(600_000)
+  })
+
+  it('arms a deadline on a non-streaming request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse())
+    await run(fetchMock)
+
+    const signal = fetchMock.mock.calls[0][1].signal as AbortSignal
+    expect(signal).toBeInstanceOf(AbortSignal)
+    expect(signal.aborted).toBe(false)
+  })
+
+  /**
+   * The runtime's idle timer already bounds a stalled stream correctly. A total deadline
+   * here would kill a long answer that is still arriving.
+   */
+  it('does not arm a deadline on a streaming request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse())
+    await run(fetchMock, { stream: true }).catch(() => {})
+
+    const streamCall = fetchMock.mock.calls.find(
+      (c) => JSON.parse(c[1].body as string).stream === true
+    )
+    expect(streamCall).toBeDefined()
+    expect(streamCall?.[1].signal).toBeUndefined()
+  })
+
+  /** A user pressing Stop must still win over the deadline. */
+  it('preserves the caller signal alongside the deadline', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn().mockResolvedValue(okResponse())
+    await run(fetchMock, { abortSignal: controller.signal })
+
+    const signal = fetchMock.mock.calls[0][1].signal as AbortSignal
+    expect(signal.aborted).toBe(false)
+    controller.abort()
+    expect(signal.aborted).toBe(true)
+  })
+})

--- a/apps/sim/providers/openai/core.ts
+++ b/apps/sim/providers/openai/core.ts
@@ -17,6 +17,7 @@ import {
 import { executeProviderTool } from '@/providers/runtime-context'
 import { createStreamingExecution } from '@/providers/streaming-execution'
 import { isAbortError, parseToolArguments } from '@/providers/streaming-tool-loop-shared'
+import { PROVIDER_REQUEST_TIMEOUT_MS } from '@/providers/timeouts'
 import { adaptOpenAIChatToolSchema } from '@/providers/tool-schema-adapter'
 import type { Message, ProviderRequest, ProviderResponse, TimeSegment } from '@/providers/types'
 import { ProviderError } from '@/providers/types'
@@ -411,6 +412,26 @@ export async function executeResponsesProviderRequest(
   let reasoningSummariesUnavailable = false
 
   /**
+   * Bounds a non-streaming request, and deliberately leaves a streaming one alone.
+   *
+   * A non-streaming generation is silent on the wire until it completes, so there is no
+   * liveness signal an idle timer could act on — the deadline has to be explicit. A
+   * streaming response emits continuously, which is precisely what the runtime's idle
+   * timer is built for, and a total deadline there would cut off a long answer that is
+   * still arriving normally.
+   *
+   * The caller's own signal is preserved: a user pressing Stop must still win.
+   */
+  const withRequestDeadline = (
+    abortSignal: AbortSignal | undefined,
+    streaming: boolean
+  ): AbortSignal | undefined => {
+    if (streaming) return abortSignal
+    const deadline = AbortSignal.timeout(PROVIDER_REQUEST_TIMEOUT_MS)
+    return abortSignal ? AbortSignal.any([abortSignal, deadline]) : deadline
+  }
+
+  /**
    * The single point every Responses request leaves through, so a stall waiting for
    * headers is named on the streaming paths too — they call
    * {@link fetchResponsesWithSummaryFallback} directly and never reach `postResponses`,
@@ -426,7 +447,7 @@ export async function executeResponsesProviderRequest(
         method: 'POST',
         headers: config.headers,
         body: JSON.stringify(payload),
-        signal: abortSignal,
+        signal: withRequestDeadline(abortSignal, payload.stream === true),
       })
     } catch (error) {
       throw annotateTransportFailure(error, 'awaiting-response-headers', startedAt)

--- a/apps/sim/providers/timeouts.ts
+++ b/apps/sim/providers/timeouts.ts
@@ -1,0 +1,14 @@
+/**
+ * Deadline for a single non-streaming provider request, matching the OpenAI client's own
+ * documented default (`node_modules/openai/client.d.ts`: `[opts.timeout=10 minutes]`).
+ *
+ * Without an explicit value the request inherits whatever the runtime imposes — under Bun
+ * that is an undocumented ~300s idle timer, half the vendor's default and chosen by nobody.
+ * Measured production failures at 295.8s and 278.9s were generations still in progress, not
+ * stalled connections.
+ *
+ * Deliberately its own module rather than the `@/providers` barrel: that barrel is replaced
+ * wholesale by `vi.mock` in 21 test files, so an export added there resolves to `undefined`
+ * in all of them.
+ */
+export const PROVIDER_REQUEST_TIMEOUT_MS = 600_000


### PR DESCRIPTION
## Summary
Sim sets **no** request timeout on provider calls, so every one inherits whatever the runtime imposes. Under Bun that is an undocumented **~300s idle timer** — half of OpenAI's own documented default, chosen by nobody, and not configurable.

This sets an explicit **600,000 ms** deadline on non-streaming provider requests, matching the vendor default verbatim: `node_modules/openai/client.d.ts:179` — `[opts.timeout=10 minutes]`.

## Why 600s and not a number I made up
It is the OpenAI client's own default, in the SDK version this repo vendors. Both measured production failures — **295,823 ms** and **278,920 ms**, on gpt-5.4 and gpt-5.6-luna — were generations still in progress, not stalled connections. Both would have completed under the vendor default.

This is not hypothetical or one customer: four models across two providers (OpenAI and Gemini), and the Gemini case recurs on the same workflow roughly daily for at least two weeks.

## Streaming is deliberately excluded
I measured Bun's default with a raw-TCP probe on 1.3.14, the production version:

```
trickle (a byte every 10s): COMPLETED after 330,054ms
silent  (zero bytes):       TimeoutError after 300,015ms
```

The timer is **idle-based** — any received byte resets it. So a streaming response, which emits continuously, is already bounded correctly by the runtime, and a *total* deadline there would cut off a long answer still arriving normally. The carve-out keys on `payload.stream === true`, i.e. the request's own semantics.

Caveat recorded honestly: the probe is HTTP/1.1 plaintext to localhost, and production is h2 over TLS. It explains the mechanism but does **not** explain why the two production failures fired *early* (4.2s and 21.1s before 300s). Leading hypothesis is that Bun's idle timer is connection-anchored and not reset on reuse of a pooled h2 connection, which would predict exactly those margins. Unproven. It does not change this fix — the runtime timer is demonstrably not anchored to our request, which is the reason to arm our own.

## No regressions
- The caller's `abortSignal` is preserved via `AbortSignal.any`, so a user pressing Stop still wins.
- `AbortSignal.timeout` aborts with a `TimeoutError`, which the existing phase annotation already classifies — diagnostics keep working unchanged.
- The constant lives in its own `providers/timeouts.ts` rather than the `@/providers` barrel. That barrel is replaced wholesale by `vi.mock` in **21** test files, so an export added there resolves to `undefined` in all of them. I hit this: the first version broke 30 tests across 4 files.

## Type of Change
- [x] Bug fix

## Testing
4 tests: the constant matches the vendor default, a deadline is armed on non-streaming, **no** deadline on streaming, and the caller signal still aborts. Each verified fail-detectable by breaking it and watching it go red.

Providers + agent-handler suites: 110 files / 1420 tests passing. Typecheck, lint, and `check:api-validation` clean.

## Follow-up
A survey of default timeout and retry policy across all 25 providers is running. Sim also performs **zero** retries on the OpenAI path, where the vendor client does 2 with exponential backoff on 408/409/429/5xx and connection errors — including retrying timeouts. That gap is bigger day-to-day than this one and is the natural next PR.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)