### PR TITLE
fix(combobox): keep the dropdown open while dragging its scrollbar

### DIFF
--- a/packages/emcn/src/components/combobox/combobox.tsx
+++ b/packages/emcn/src/components/combobox/combobox.tsx
@@ -248,15 +248,16 @@ const Combobox = memo(
        * which a scrollbar drag left on `<body>`. Bound to `window` so a release
        * outside the popover still clears the flag; `pointercancel` is included
        * because a touch scroll gesture ends there instead of `pointerup`.
+       *
+       * Focus is only restored when the press actually stole it — a press inside the
+       * popover parks it on `<body>` or the `tabIndex={-1}` content, but option
+       * mousedown is prevented, so it often never left the input or the search box.
        */
       useEffect(() => {
         if (!editable) return
         const endPointerPress = () => {
           if (!pointerDownInsideRef.current) return
           pointerDownInsideRef.current = false
-          // Only restore focus if the press actually stole it: a press inside the
-          // popover parks focus on <body> or the `tabIndex={-1}` content, but option
-          // mousedown is prevented, so it often never left the input or search box.
           const active = document.activeElement
           const isTextEntry =
             active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement
@@ -360,7 +361,9 @@ const Combobox = memo(
       }, [groups, searchable, searchQuery])
 
       /**
-       * Handles selection of an option
+       * Handles selection of an option. In editable mode the input is blurred on
+       * purpose, so the pointer-press window is ended first — otherwise the `pointerup`
+       * that follows would hand focus back and reopen the dropdown.
        */
       const handleSelect = useCallback(
         (selectedValue: string, customOnSelect?: () => void, keepOpen?: boolean) => {
@@ -389,7 +392,6 @@ const Combobox = memo(
               setHighlightedIndex(-1)
               updateSearchQuery('')
               if (editable && inputRef.current) {
-                // The pointerup that follows must not hand focus back and reopen.
                 pointerDownInsideRef.current = false
                 inputRef.current.blur()
               }

--- a/packages/emcn/src/components/combobox/combobox.tsx
+++ b/packages/emcn/src/components/combobox/combobox.tsx
@@ -226,6 +226,13 @@ const Combobox = memo(
       const blurTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
       const internalInputRef = useRef<HTMLInputElement>(null)
       const inputRef = externalInputRef || internalInputRef
+      /**
+       * True while a pointer press that began inside the dropdown is still held.
+       * Grabbing the list's native scrollbar blurs the editable input and parks
+       * focus on `<body>` — which `handleBlur` would otherwise read as "focus
+       * left the combobox" and close the dropdown mid-drag.
+       */
+      const pointerDownInsideRef = useRef(false)
 
       const effectiveSelectedValue = selectedValue ?? value
 
@@ -235,6 +242,33 @@ const Combobox = memo(
           if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current)
         }
       }, [])
+
+      /**
+       * Releases the pointer-press window and restores focus to the editable input,
+       * which a scrollbar drag left on `<body>`. Bound to `window` so a release
+       * outside the popover still clears the flag; `pointercancel` is included
+       * because a touch scroll gesture ends there instead of `pointerup`.
+       */
+      useEffect(() => {
+        if (!editable) return
+        const endPointerPress = () => {
+          if (!pointerDownInsideRef.current) return
+          pointerDownInsideRef.current = false
+          // Only restore focus if the press actually stole it: a press inside the
+          // popover parks focus on <body> or the `tabIndex={-1}` content, but option
+          // mousedown is prevented, so it often never left the input or search box.
+          const active = document.activeElement
+          const isTextEntry =
+            active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement
+          if (!isTextEntry) inputRef.current?.focus({ preventScroll: true })
+        }
+        window.addEventListener('pointerup', endPointerPress)
+        window.addEventListener('pointercancel', endPointerPress)
+        return () => {
+          window.removeEventListener('pointerup', endPointerPress)
+          window.removeEventListener('pointercancel', endPointerPress)
+        }
+      }, [editable, inputRef])
 
       // Flatten groups into options if groups are provided
       const allOptions = useMemo(() => {
@@ -355,6 +389,8 @@ const Combobox = memo(
               setHighlightedIndex(-1)
               updateSearchQuery('')
               if (editable && inputRef.current) {
+                // The pointerup that follows must not hand focus back and reopen.
+                pointerDownInsideRef.current = false
                 inputRef.current.blur()
               }
             }
@@ -392,6 +428,7 @@ const Combobox = memo(
         if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current)
         // Delay to allow dropdown clicks
         blurTimeoutRef.current = setTimeout(() => {
+          if (pointerDownInsideRef.current) return
           const activeElement = document.activeElement
           // Check if focus is in the container, dropdown, or search input
           const isInContainer = containerRef.current?.contains(activeElement)
@@ -680,6 +717,9 @@ const Combobox = memo(
                 if (searchable && !editable) {
                   setTimeout(() => searchInputRef.current?.focus(), 0)
                 }
+              }}
+              onPointerDownCapture={() => {
+                if (editable) pointerDownInsideRef.current = true
               }}
               onInteractOutside={(e) => {
                 // If the user clicks the anchor/trigger while the popover is open,


### PR DESCRIPTION
## Summary
- Grabbing a combobox dropdown's scrollbar closed the dropdown mid-drag (e.g. the agent block's Model field). The editable input's `onBlur` starts a 150ms timer that closes the dropdown unless focus is still inside it — option rows dodge that by preventing default on mousedown, but the list's native scrollbar doesn't, so pressing it parked focus on `<body>` and the dropdown dismissed itself.
- Suppress that blur-close while a pointer press that started inside the popover is still held, and hand focus back to the input on release so typing and arrow keys keep working after a drag.
- Editable-only and behavior-only: no prop, API, or styling change. Every `Combobox`-backed picker (`ChipCombobox`, `ChipSelect`, credential/tool/file selectors) inherits the fix.

## Type of Change
- [x] Bug fix

## Testing
Typecheck and lint pass. Not yet verified in the browser — worth a click-test on the Model dropdown (and a spot-check in Firefox/Safari, whose scrollbars behave differently).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)