### PR TITLE
feat(admin): add send-password-reset-email toggle to create user modal

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/add-user-modal.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/add-user-modal.test.tsx
@@ -7,7 +7,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
-const { addUserMutation, mockMutate, mockReset } = vi.hoisted(() => ({
+const {
+  addUserMutation,
+  mockMutate,
+  mockReset,
+  mockResetPassword,
+  mockToast,
+  resetPasswordMutation,
+} = vi.hoisted(() => ({
   addUserMutation: {
     current: {
       isPending: false,
@@ -16,6 +23,9 @@ const { addUserMutation, mockMutate, mockReset } = vi.hoisted(() => ({
   },
   mockMutate: vi.fn(),
   mockReset: vi.fn(),
+  mockResetPassword: vi.fn(),
+  mockToast: { success: vi.fn(), error: vi.fn() },
+  resetPasswordMutation: { current: { isPending: false } },
 }))
 
 vi.mock('@sim/emcn', () => ({
@@ -58,6 +68,29 @@ vi.mock('@sim/emcn', () => ({
       </button>
     </footer>
   ),
+  Label: ({ htmlFor, children }: { htmlFor?: string; children: ReactNode }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+  Switch: ({
+    id,
+    checked,
+    onCheckedChange,
+    disabled,
+  }: {
+    id?: string
+    checked: boolean
+    onCheckedChange: (checked: boolean) => void
+    disabled?: boolean
+  }) => (
+    <input
+      id={id}
+      type='checkbox'
+      checked={checked}
+      disabled={disabled}
+      onChange={(event) => onCheckedChange(event.target.checked)}
+    />
+  ),
+  toast: mockToast,
   ChipModalField: ({
     type,
     inputType,
@@ -114,6 +147,18 @@ vi.mock('@/hooks/queries/admin-users', () => ({
   }),
 }))
 
+vi.mock('@/hooks/queries/user-profile', () => ({
+  useResetPassword: () => ({
+    mutateAsync: mockResetPassword,
+    isPending: resetPasswordMutation.current.isPending,
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/core/utils/urls', () => ({
+  getBaseUrl: () => 'https://sim.test',
+}))
+
 import { AddUserModal } from '@/app/workspace/[workspaceId]/settings/components/admin/add-user-modal'
 import type { AddUserInput, AdminUser } from '@/hooks/queries/admin-users'
 
@@ -157,6 +202,38 @@ async function changeField(label: string, value: string) {
   })
 }
 
+/** Resolves a switch through its `<label for>` association, mirroring a real click on the label. */
+async function toggleField(label: string) {
+  const labelElement = [...container.querySelectorAll('label')].find(
+    (candidate) => candidate.textContent === label
+  )
+  if (!labelElement?.htmlFor) throw new Error(`No label "${label}" bound to a control`)
+  const element = document.getElementById(labelElement.htmlFor) as HTMLInputElement | null
+  if (!element) throw new Error(`Label "${label}" points at a missing control`)
+  const checkedSetter = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(element),
+    'checked'
+  )?.set
+  if (!checkedSetter) throw new Error(`Field labelled "${label}" has no checked setter`)
+  await act(async () => {
+    checkedSetter.call(element, !element.checked)
+    element.dispatchEvent(new Event('click', { bubbles: true }))
+    element.dispatchEvent(new Event('change', { bubbles: true }))
+  })
+}
+
+/**
+ * Mirrors query-core's mutate-scoped callback contract: `onSuccess`'s return value is
+ * discarded (an async callback is never awaited) and `onSettled` follows synchronously.
+ */
+function succeedWithCreatedUser(
+  _input: AddUserInput,
+  options: { onSuccess: (user: AdminUser) => void | Promise<void>; onSettled: () => void }
+) {
+  options.onSuccess(CREATED_USER)
+  options.onSettled()
+}
+
 function buttonLabelled(text: string): HTMLButtonElement {
   const button = [...container.querySelectorAll('button')].find(
     (candidate) => candidate.textContent === text
@@ -179,6 +256,11 @@ describe('AddUserModal', () => {
     onCreated = vi.fn()
     onOpenChange = vi.fn()
     addUserMutation.current = { isPending: false, error: null }
+    resetPasswordMutation.current = { isPending: false }
+    mockResetPassword.mockResolvedValue({ success: true })
+    // vi.clearAllMocks() does not drop implementations, so re-arm the default (a
+    // request that never settles) rather than inheriting the previous test's.
+    mockMutate.mockImplementation(() => {})
   })
 
   afterEach(() => {
@@ -202,11 +284,7 @@ describe('AddUserModal', () => {
   })
 
   it('creates a verified credential user and returns it to the admin view', async () => {
-    mockMutate.mockImplementation(
-      (_input: AddUserInput, options: { onSuccess: (user: AdminUser) => void }) => {
-        options.onSuccess(CREATED_USER)
-      }
-    )
+    mockMutate.mockImplementation(succeedWithCreatedUser)
     await renderModal()
     await fillRequiredFields()
 
@@ -227,6 +305,57 @@ describe('AddUserModal', () => {
     )
     expect(onOpenChange).toHaveBeenCalledWith(false)
     expect(onCreated).toHaveBeenCalledWith(CREATED_USER)
+    expect(mockResetPassword).not.toHaveBeenCalled()
+  })
+
+  it('sends a password reset email when the toggle is on', async () => {
+    mockMutate.mockImplementation(succeedWithCreatedUser)
+    await renderModal()
+    await fillRequiredFields()
+    await toggleField('Send password reset email')
+
+    await act(async () => {
+      buttonLabelled('Add user').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockResetPassword).toHaveBeenCalledWith({
+      email: 'writer@synthetics.example.com',
+      redirectTo: 'https://sim.test/reset-password',
+    })
+    expect(mockToast.success).toHaveBeenCalled()
+    expect(onCreated).toHaveBeenCalledWith(CREATED_USER)
+  })
+
+  it('keeps the submit path locked while the reset email is still in flight', async () => {
+    resetPasswordMutation.current = { isPending: true }
+    await renderModal()
+    await fillRequiredFields()
+
+    expect(buttonLabelled('Adding...').disabled).toBe(true)
+    expect(buttonLabelled('Close').disabled).toBe(true)
+    expect(buttonLabelled('Cancel').disabled).toBe(true)
+  })
+
+  it('still reports the created user when the reset email fails', async () => {
+    mockResetPassword.mockRejectedValue(new Error('SMTP unavailable'))
+    mockMutate.mockImplementation(succeedWithCreatedUser)
+    await renderModal()
+    await fillRequiredFields()
+    await toggleField('Send password reset email')
+
+    await act(async () => {
+      buttonLabelled('Add user').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockToast.error).toHaveBeenCalledWith(expect.stringContaining('SMTP unavailable'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(onCreated).toHaveBeenCalledWith(CREATED_USER)
   })
 
   it('ignores repeated submissions before the pending state renders', async () => {
@@ -245,11 +374,7 @@ describe('AddUserModal', () => {
   })
 
   it('supports unverified accounts without exposing a platform-role control', async () => {
-    mockMutate.mockImplementation(
-      (_input: AddUserInput, options: { onSuccess: (user: AdminUser) => void }) => {
-        options.onSuccess(CREATED_USER)
-      }
-    )
+    mockMutate.mockImplementation(succeedWithCreatedUser)
     await renderModal()
     await fillRequiredFields()
     await changeField('Email status', 'unverified')

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/add-user-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/add-user-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import {
   ChipModal,
   ChipModalBody,
@@ -8,10 +8,15 @@ import {
   ChipModalField,
   ChipModalFooter,
   ChipModalHeader,
+  Label,
+  Switch,
+  toast,
 } from '@sim/emcn'
 import { getErrorMessage } from '@sim/utils/errors'
 import { isValidEmailSyntax } from '@sim/utils/string'
+import { getBaseUrl } from '@/lib/core/utils/urls'
 import { type AdminUser, useAddUser } from '@/hooks/queries/admin-users'
+import { useResetPassword } from '@/hooks/queries/user-profile'
 
 const EMAIL_STATUS_OPTIONS = [
   { value: 'verified', label: 'Verified' },
@@ -26,12 +31,15 @@ interface AddUserModalProps {
 
 export function AddUserModal({ open, onOpenChange, onCreated }: AddUserModalProps) {
   const addUser = useAddUser()
+  const resetPassword = useResetPassword()
+  const resetEmailToggleId = useId()
   const submissionInFlightRef = useRef(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [emailVerified, setEmailVerified] = useState(true)
+  const [sendResetEmail, setSendResetEmail] = useState(false)
 
   const normalizedName = name.trim()
   const normalizedEmail = email.trim().toLowerCase()
@@ -42,7 +50,7 @@ export function AddUserModal({ open, onOpenChange, onCreated }: AddUserModalProp
     password.length > 0 && password.length < 8
       ? 'Password must be at least 8 characters'
       : undefined
-  const isSubmissionPending = isSubmitting || addUser.isPending
+  const isSubmissionPending = isSubmitting || addUser.isPending || resetPassword.isPending
   const canSubmit =
     normalizedName.length > 0 &&
     isValidEmailSyntax(normalizedEmail) &&
@@ -54,7 +62,9 @@ export function AddUserModal({ open, onOpenChange, onCreated }: AddUserModalProp
     setEmail('')
     setPassword('')
     setEmailVerified(true)
+    setSendResetEmail(false)
     addUser.reset()
+    resetPassword.reset()
   }
 
   const handleClose = () => {
@@ -76,7 +86,20 @@ export function AddUserModal({ open, onOpenChange, onCreated }: AddUserModalProp
         emailVerified,
       },
       {
-        onSuccess: (user) => {
+        onSuccess: async (user) => {
+          if (sendResetEmail) {
+            try {
+              await resetPassword.mutateAsync({
+                email: normalizedEmail,
+                redirectTo: `${getBaseUrl()}/reset-password`,
+              })
+              toast.success(`Password reset email sent to ${normalizedEmail}`)
+            } catch (error) {
+              toast.error(
+                `User created, but the password reset email failed to send: ${getErrorMessage(error, 'Unknown error')}`
+              )
+            }
+          }
           reset()
           onOpenChange(false)
           onCreated(user)
@@ -160,6 +183,18 @@ export function AddUserModal({ open, onOpenChange, onCreated }: AddUserModalProp
           disabled={isSubmissionPending}
           required
         />
+        <div className='flex items-center justify-between px-2'>
+          <Label htmlFor={resetEmailToggleId}>Send password reset email</Label>
+          <Switch
+            id={resetEmailToggleId}
+            checked={sendResetEmail}
+            disabled={isSubmissionPending}
+            onCheckedChange={(checked) => {
+              setSendResetEmail(checked)
+              addUser.reset()
+            }}
+          />
+        </div>
         <ChipModalError>
           {addUser.error ? getErrorMessage(addUser.error, 'Failed to add user') : null}
         </ChipModalError>


### PR DESCRIPTION
## Summary
- Add a "Send password reset email" toggle to the admin create-user modal
- On success it hits the same `/api/auth/forget-password` contract as the login form's "Forgot password", so the user gets the identical email and reset page
- Toggle defaults off; password stays required
- If the account is created but the email fails, the user is still reported to the admin view and a toast explains the email failure

## Type of Change
- [x] New feature

## Testing
Tested via unit tests (8 cases, incl. toggle off/on and the email-failure path). `bun run lint`, `type-check`, `check:api-validation:strict`, `check:react-query`, and the full ship audit suite pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
