### PR TITLE
fix(knowledge): align document tag provenance selections with the serialized request

### DIFF
--- a/apps/sim/app/api/knowledge/secret-provenance.ts
+++ b/apps/sim/app/api/knowledge/secret-provenance.ts
@@ -19,13 +19,13 @@ import {
   importKnowledgePersistedResponseSecretProvenance,
   type KnowledgeDocumentSourceValue,
   type KnowledgeDocumentWriteSecretProvenance,
-  parseKnowledgeDocumentTagProvenanceTargets,
 } from '@/lib/knowledge/secret-provenance'
 import {
   knowledgeDocumentContentSelectionKey,
   knowledgeDocumentFilenameSelectionKey,
   knowledgeDocumentTagNameSelectionKey,
   knowledgeDocumentTagValueSelectionKey,
+  parseKnowledgeDocumentTagProvenanceTargets,
 } from '@/lib/knowledge/secret-provenance-selection'
 import { ResolvedSecretTraceRegistry } from '@/executor/utils/resolved-secret-trace-registry'
 

--- a/apps/sim/lib/knowledge/secret-provenance-selection.ts
+++ b/apps/sim/lib/knowledge/secret-provenance-selection.ts
@@ -1,3 +1,34 @@
+export interface KnowledgeDocumentTagProvenanceTarget {
+  tagName: string
+  value: unknown
+}
+
+/**
+ * Parses only tag entries that can causally contribute a persisted tag value. Both the tool that
+ * builds the request selections and the route that builds the write targets read this one parser,
+ * so their counts can never diverge.
+ */
+export function parseKnowledgeDocumentTagProvenanceTargets(
+  documentTagsData: string | undefined
+): KnowledgeDocumentTagProvenanceTarget[] {
+  if (!documentTagsData) return []
+  try {
+    const parsed: unknown = JSON.parse(documentTagsData)
+    if (!Array.isArray(parsed)) return []
+    return parsed.flatMap((candidate) => {
+      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return []
+      const record = candidate as Record<string, unknown>
+      const tagName = typeof record.tagName === 'string' ? record.tagName.trim() : ''
+      if (!tagName || record.value === undefined || record.value === null || record.value === '') {
+        return []
+      }
+      return [{ tagName, value: record.value }]
+    })
+  } catch {
+    return []
+  }
+}
+
 export function knowledgeDocumentFilenameSelectionKey(documentIndex: number): string {
   return `document-filename:${documentIndex}`
 }

--- a/apps/sim/lib/knowledge/secret-provenance.ts
+++ b/apps/sim/lib/knowledge/secret-provenance.ts
@@ -56,33 +56,6 @@ export interface KnowledgeDocumentWriteSecretProvenance {
   }[]
 }
 
-interface KnowledgeDocumentTagProvenanceTarget {
-  tagName: string
-  value: unknown
-}
-
-/** Parses only tag entries that can causally contribute a persisted tag value. */
-export function parseKnowledgeDocumentTagProvenanceTargets(
-  documentTagsData: string | undefined
-): KnowledgeDocumentTagProvenanceTarget[] {
-  if (!documentTagsData) return []
-  try {
-    const parsed: unknown = JSON.parse(documentTagsData)
-    if (!Array.isArray(parsed)) return []
-    return parsed.flatMap((candidate) => {
-      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return []
-      const record = candidate as Record<string, unknown>
-      const tagName = typeof record.tagName === 'string' ? record.tagName.trim() : ''
-      if (!tagName || record.value === undefined || record.value === null || record.value === '') {
-        return []
-      }
-      return [{ tagName, value: record.value }]
-    })
-  } catch {
-    return []
-  }
-}
-
 export type KnowledgeDocumentMetadataField = Exclude<
   keyof KnowledgeDocumentSourceValue,
   'fileUrl' | 'contentHash'

--- a/apps/sim/tools/knowledge/secret-provenance.test.ts
+++ b/apps/sim/tools/knowledge/secret-provenance.test.ts
@@ -25,12 +25,12 @@ function serverSelectionKeys(documentTags: unknown): string[] {
   ]
 }
 
-const EMPTY_STRINGIFYING_TAG_VALUES: readonly [string, unknown][] = [
+const EMPTY_STRINGIFYING_TAG_VALUES = [
   ['empty array', []],
   ['array of null', [null]],
   ['array of undefined', [undefined]],
   ['object stringifying to empty', { toString: () => '' }],
-]
+] as const
 
 describe('selectKnowledgeDocumentWriteSecretProvenance', () => {
   it.each(EMPTY_STRINGIFYING_TAG_VALUES)(

--- a/apps/sim/tools/knowledge/secret-provenance.test.ts
+++ b/apps/sim/tools/knowledge/secret-provenance.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  knowledgeDocumentContentSelectionKey,
+  knowledgeDocumentFilenameSelectionKey,
+  knowledgeDocumentTagNameSelectionKey,
+  knowledgeDocumentTagValueSelectionKey,
+  parseKnowledgeDocumentTagProvenanceTargets,
+} from '@/lib/knowledge/secret-provenance-selection'
+import { selectKnowledgeDocumentWriteSecretProvenance } from '@/tools/knowledge/secret-provenance'
+import { formatDocumentTagsForAPI, parseDocumentTags } from '@/tools/shared/tags'
+
+/** Mirrors the selection keys the knowledge write route derives from the serialized request body. */
+function serverSelectionKeys(documentTags: unknown): string[] {
+  const { documentTagsData } = formatDocumentTagsForAPI(parseDocumentTags(documentTags))
+  return [
+    knowledgeDocumentFilenameSelectionKey(0),
+    knowledgeDocumentContentSelectionKey(0),
+    ...parseKnowledgeDocumentTagProvenanceTargets(documentTagsData).flatMap((_tag, tagIndex) => [
+      knowledgeDocumentTagNameSelectionKey(0, tagIndex),
+      knowledgeDocumentTagValueSelectionKey(0, tagIndex),
+    ]),
+  ]
+}
+
+const EMPTY_STRINGIFYING_TAG_VALUES: readonly [string, unknown][] = [
+  ['empty array', []],
+  ['array of null', [null]],
+  ['array of undefined', [undefined]],
+  ['object stringifying to empty', { toString: () => '' }],
+]
+
+describe('selectKnowledgeDocumentWriteSecretProvenance', () => {
+  it.each(EMPTY_STRINGIFYING_TAG_VALUES)(
+    'agrees with the server target count for a tag value that is a %s',
+    (_label, tagValue) => {
+      const documentTags = [
+        { tagName: 'kept', value: 'value' },
+        { tagName: 'dropped', value: tagValue },
+      ]
+      const selections = selectKnowledgeDocumentWriteSecretProvenance({
+        name: 'doc.md',
+        content: 'content',
+        documentTags,
+      })
+
+      expect(selections.map((selection) => selection.key)).toEqual(
+        serverSelectionKeys(documentTags)
+      )
+    }
+  )
+
+  it('keeps tags whose serialized value is non-empty', () => {
+    const documentTags = { alpha: 'one', beta: 2, gamma: false }
+    const selections = selectKnowledgeDocumentWriteSecretProvenance({
+      name: 'doc.md',
+      content: 'content',
+      documentTags,
+    })
+
+    expect(selections.map((selection) => selection.key)).toEqual(serverSelectionKeys(documentTags))
+    expect(selections).toHaveLength(8)
+  })
+})

--- a/apps/sim/tools/knowledge/secret-provenance.ts
+++ b/apps/sim/tools/knowledge/secret-provenance.ts
@@ -4,9 +4,10 @@ import {
   knowledgeDocumentFilenameSelectionKey,
   knowledgeDocumentTagNameSelectionKey,
   knowledgeDocumentTagValueSelectionKey,
+  parseKnowledgeDocumentTagProvenanceTargets,
 } from '@/lib/knowledge/secret-provenance-selection'
 import { inferDocumentFileInfo } from '@/tools/knowledge/types'
-import { parseDocumentTags } from '@/tools/shared/tags'
+import { formatDocumentTagsForAPI, parseDocumentTags } from '@/tools/shared/tags'
 
 /** Selects each causally independent persisted document field before request serialization. */
 export function selectKnowledgeDocumentWriteSecretProvenance(params: {
@@ -17,7 +18,9 @@ export function selectKnowledgeDocumentWriteSecretProvenance(params: {
   const name = typeof params.name === 'string' ? params.name.trim() : ''
   const content = typeof params.content === 'string' ? params.content.trim() : params.content
   const filename = inferDocumentFileInfo(name).filename
-  const tags = parseDocumentTags(params.documentTags)
+  const tags = parseKnowledgeDocumentTagProvenanceTargets(
+    formatDocumentTagsForAPI(parseDocumentTags(params.documentTags)).documentTagsData
+  )
 
   return [
     { key: knowledgeDocumentFilenameSelectionKey(0), value: filename },


### PR DESCRIPTION
## Problem

Same bug class as the `selectTableRowSecretProvenance` outage fixed in #6325: a private-provenance **producer** counting pre-serialization semantics while the **consumer** counts post-serialization.

Knowledge document writes (`knowledge_create_document`, `knowledge_upsert_document`):

- **Producer** — `selectKnowledgeDocumentWriteSecretProvenance` counted one name/value selection pair per `parseDocumentTags` entry. `parseDocumentTags` keeps an entry whose `value` is merely truthy, then coerces `value: String(entry.value)`.
- **Consumer** — `parseKnowledgeDocumentTagProvenanceTargets` builds targets from the serialized `documentTagsData` and drops entries where `value === ''`.
- `resolveKnowledgeWriteSecretProvenance` rejects the write with **HTTP 400** when `bundle.selections.length !== selectionKeys.length`.

So any tag value that is truthy before coercion but stringifies to empty — `[]`, `[null]`, `[undefined]`, an object whose `toString()` returns `''` — was counted by the tool and dropped by the route.

Reproduced by executing both parsers against `[{ tagName: 'kept', value: 'value' }, { tagName: 'dropped', value: [] }]`: the tool emitted 6 selection keys, the route derived 4.

Not observed in production logs — found by code-level audit.

## Semantics

Drop, matching the route. The functional write path agrees already: `resolveDocumentTags` skips any tag whose value fails its `hasValue` check, so an empty-stringifying tag never persists a value and has nothing to attribute provenance to.

## Fix

Following the `update_chunk` pattern (its selector mirrors its own body builder exactly), the producer now describes exactly what goes on the wire: it runs the same `formatDocumentTagsForAPI(parseDocumentTags(...))` the body builder runs, then feeds the resulting `documentTagsData` through the **same** target parser the route uses. `parseKnowledgeDocumentTagProvenanceTargets` moved from `lib/knowledge/secret-provenance.ts` (which pulls in `@sim/db`) to the db-free `lib/knowledge/secret-provenance-selection.ts` both sides already import, so there is one parser, not two rules that can drift.

## Tests

`apps/sim/tools/knowledge/secret-provenance.test.ts` asserts the tool's selection keys equal the route-derived target keys for each divergent value, plus a non-divergent case.

Verified red before the fix (`expected 6 keys to equal 4`), green after.

## Audit of the other provenance producer/consumer pairs

| Pair | Status |
| --- | --- |
| knowledge document tags | **fixed here** |
| table rows (`selectTableRowSecretProvenance` ↔ `createTableWriteProvenanceTargets`) | Aligned since #6325. Residual theoretical gap: the producer filters only `undefined`, but `JSON.stringify` also drops function- and symbol-valued keys, which the consumer's `Object.entries` over the parsed row would then not see. Not reachable from JSON-sourced tool params — left alone. |
| workspace files (`file_write`, `file_append`) | Fixed arity `['content']` on both sides. |
| memory (`memory_add`) | Fixed arity `1` on both sides. |
| knowledge chunks (`upload_chunk`, `update_chunk`) | Fixed arity; `update_chunk`'s conditional producer mirrors both its body builder and the route's `validatedData.content === undefined` check. |
| workflow executor | Fixed arity `1` on both sides. |

## Checks

- `bunx tsc --noEmit -p tsconfig.json` — clean
- `bun run lint` — clean (9 pre-existing unrelated warnings)
- `app/api/knowledge/secret-provenance.test.ts` + new test — 14 passed
- `tools/knowledge/knowledge.test.ts` fails identically on a clean checkout (postcss/tailwind env issue), unrelated
