### PR TITLE
fix(billing): stop the false unbilled-charge error on zero-cost runs

### DIFF
--- a/apps/sim/lib/logs/execution/logger.test.ts
+++ b/apps/sim/lib/logs/execution/logger.test.ts
@@ -15,6 +15,28 @@ import type { SerializableExecutionState } from '@/executor/execution/types'
 
 afterAll(resetDbChainMock)
 
+/** Flat logger whose withMetadata() children share one spy set, so log level is assertable. */
+const { mockLogger } = vi.hoisted(() => {
+  const mockLogger: Record<string, ReturnType<typeof vi.fn>> = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+  }
+  mockLogger.child = vi.fn(() => mockLogger)
+  mockLogger.withMetadata = vi.fn(() => mockLogger)
+  return { mockLogger }
+})
+
+vi.mock('@sim/logger', () => ({
+  createLogger: vi.fn(() => mockLogger),
+  logger: mockLogger,
+  runWithRequestContext: vi.fn(<T>(_ctx: unknown, fn: () => T): T => fn()),
+  getRequestContext: vi.fn(() => undefined),
+}))
+
 // Mock billing modules
 vi.mock('@/lib/billing/core/subscription', () => ({
   getHighestPriorityPersonalSubscription: vi.fn(() => Promise.resolve(null)),
@@ -1011,6 +1033,36 @@ describe('recordExecutionUsage boundary-delta reconciliation', () => {
 
     expect(recorded).toBe(0)
     expect(recordUsage).not.toHaveBeenCalled()
+  })
+
+  const unbilledErrorCalls = () =>
+    mockLogger.error.mock.calls.filter((call) =>
+      String(call[0]).includes('Failed to record execution usage to usage_log ledger')
+    )
+
+  test('a structurally zero-cost run without billing context logs no unbilled-charge error', async () => {
+    mockDb([])
+
+    const recorded = await logger.recordExecutionUsage(
+      'workflow-1',
+      costSummary({ baseExecutionCharge: 0 }),
+      'api',
+      'exec-1',
+      'user-1'
+    )
+
+    expect(recorded).toBe(0)
+    expect(recordUsage).not.toHaveBeenCalled()
+    expect(unbilledErrorCalls()).toHaveLength(0)
+  })
+
+  test('a genuine ledger write failure still logs the unbilled-charge error', async () => {
+    vi.mocked(recordUsage).mockRejectedValueOnce(new Error('ledger insert failed'))
+
+    const recorded = await run(costSummary(), [])
+
+    expect(recorded).toBe(0)
+    expect(unbilledErrorCalls()).toHaveLength(1)
   })
 
   test('retry with everything already billed records nothing (idempotent)', async () => {

--- a/apps/sim/lib/logs/execution/logger.ts
+++ b/apps/sim/lib/logs/execution/logger.ts
@@ -1547,12 +1547,6 @@ export class ExecutionLogger implements IExecutionLoggerService {
         return 0
       }
 
-      if (workflowRecord.workspaceId && !billingContext) {
-        throw new Error('Billing attribution is required for workspace execution usage')
-      }
-      const resolvedBillingContext =
-        billingContext ?? deriveBillingContext(userId, await getHighestPrioritySubscription(userId))
-
       // Build the run's *cumulative* target ledger lines from the cost summary.
       // The usage_log is then reconciled to these targets: at each completion
       // boundary (pause or terminal) we record only the increment versus what
@@ -1615,10 +1609,20 @@ export class ExecutionLogger implements IExecutionLoggerService {
         }
       }
 
+      // Bail before requiring billing attribution: a run with no billable target
+      // (e.g. a preprocessing-gated run that never executed) writes no ledger row
+      // either way, so demanding attribution here would raise a lost-revenue
+      // error for a charge that does not exist.
       if (targets.length === 0) {
         statsLog.debug('No cost to record')
         return 0
       }
+
+      if (workflowRecord.workspaceId && !billingContext) {
+        throw new Error('Billing attribution is required for workspace execution usage')
+      }
+      const resolvedBillingContext =
+        billingContext ?? deriveBillingContext(userId, await getHighestPrioritySubscription(userId))
 
       // Matches the billedBefore key resolution (toFixed(8)): a delta below this
       // is finer than the idempotency key can distinguish across boundaries, so


### PR DESCRIPTION
## Problem

Every usage-gated (blocked) execution emitted an ERROR-level log:

> Failed to record execution usage to usage_log ledger; charge may be unbilled

This is a 100% false positive on that path. It claims possible revenue loss on runs that never executed and have zero cost — exactly the line an engineer pages on. It misdirected a production investigation for hours. Across 5 days / 683 occurrences, `sum(totalCost) = 0` and `max(totalCost) = 0`.

## Mechanism (verified)

1. `apps/sim/lib/execution/preprocessing.ts` `logPreprocessingError` calls `session.safeCompleteWithError({ skipCost: true })` and passes **no** `billingAttribution`.
2. `skipCost: true` makes `logging-session.ts` build an all-zero `costSummary` (no base charge, no models, no charges).
3. `logger.ts` `recordExecutionUsage` required a billing context **before** building `targets[]`:
   ```ts
   if (workflowRecord.workspaceId && !billingContext) {
     throw new Error('Billing attribution is required for workspace execution usage')
   }
   ```
   The throw was caught by the surrounding `catch`, which logs the unbilled-charge ERROR — even though `targets[]` would have been empty and `recordUsage` would never have been called.

## Fix

Move the existing `if (targets.length === 0) return 0` early return **above** the attribution requirement. Pure reordering — no new predicate.

**No charge can be lost by this change.** When `targets.length === 0` there is nothing to insert into `usage_log`: both the old path (throw → catch → log → return 0) and the new path (return 0) record exactly zero. The only difference is the spurious ERROR. Every path with a non-zero target still requires `billingContext` and still throws when it is missing.

## Genuine under-billing still alerts

The ERROR log is **not** silenced. Any real ledger failure — a `recordUsage` insert failure, a transaction/advisory-lock failure, or missing billing attribution on a run that *does* have cost — still reaches the same `catch` and still logs at ERROR with the full `costSummary`. Alerting on this line remains valid; it is now specific.

## Tests

- `a structurally zero-cost run without billing context logs no unbilled-charge error` — **fails without the fix** (1 spurious ERROR call).
- `a genuine ledger write failure still logs the unbilled-charge error` — regression guard; **fails** if anyone downgrades or removes the ERROR (verified by temporarily switching it to `warn`).

The file's `@sim/logger` mock is overridden locally so `withMetadata()` children share one spy set, making log level assertable.

## Verification

- `bunx vitest run lib/logs/execution/logger.test.ts lib/logs/execution/logging-session.test.ts` — 98 passed
- `bunx tsc --noEmit -p apps/sim/tsconfig.json` — clean
- `bun run lint` — clean