### PR TITLE
fix(observability): attach the real cause at three error-swallowing sites

### DIFF
--- a/apps/sim/lib/logs/execution/logger.test.ts
+++ b/apps/sim/lib/logs/execution/logger.test.ts
@@ -16,7 +16,7 @@ import type { SerializableExecutionState } from '@/executor/execution/types'
 afterAll(resetDbChainMock)
 
 /** Flat logger whose withMetadata() children share one spy set, so log level is assertable. */
-const { mockLogger } = vi.hoisted(() => {
+const { mockLogger, statsLogErrorMock } = vi.hoisted(() => {
   const mockLogger: Record<string, ReturnType<typeof vi.fn>> = {
     info: vi.fn(),
     warn: vi.fn(),
@@ -27,7 +27,7 @@ const { mockLogger } = vi.hoisted(() => {
   }
   mockLogger.child = vi.fn(() => mockLogger)
   mockLogger.withMetadata = vi.fn(() => mockLogger)
-  return { mockLogger }
+  return { mockLogger, statsLogErrorMock: mockLogger.error }
 })
 
 vi.mock('@sim/logger', () => ({
@@ -1229,5 +1229,33 @@ describe('recordExecutionUsage boundary-delta reconciliation', () => {
     expect(recordUsage).toHaveBeenCalledTimes(1)
     // The ledger INSERT participates in the locked transaction.
     expect(vi.mocked(recordUsage).mock.calls[0][0]).toHaveProperty('tx')
+  })
+
+  test('reports the driver cause and SQLSTATE when the ledger write fails', async () => {
+    const driver = Object.assign(new Error('cannot execute INSERT in a read-only transaction'), {
+      code: '25006',
+    })
+    vi.mocked(recordUsage).mockRejectedValueOnce(
+      new Error('Failed query: insert into "usage_log"\nparams: user-1', { cause: driver })
+    )
+
+    await run(
+      costSummary({
+        models: {
+          'gpt-4o': { input: 0, output: 0, total: 1, tokens: { input: 0, output: 0, total: 0 } },
+        },
+      }),
+      []
+    )
+
+    expect(statsLogErrorMock).toHaveBeenCalledWith(
+      'Failed to record execution usage to usage_log ledger; charge may be unbilled',
+      expect.objectContaining({
+        cause: expect.objectContaining({
+          code: '25006',
+          message: 'cannot execute INSERT in a read-only transaction',
+        }),
+      })
+    )
   })
 })

--- a/apps/sim/lib/logs/execution/logger.ts
+++ b/apps/sim/lib/logs/execution/logger.ts
@@ -10,7 +10,7 @@ import {
   workspace,
 } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
-import { getErrorMessage } from '@sim/utils/errors'
+import { describeError, getErrorMessage } from '@sim/utils/errors'
 import { generateId } from '@sim/utils/id'
 import { and, eq, inArray, sql } from 'drizzle-orm'
 import { checkUsageStatus as checkResolvedUsageStatus } from '@/lib/billing/calculations/usage-monitor'
@@ -1768,7 +1768,7 @@ export class ExecutionLogger implements IExecutionLoggerService {
       statsLog.error(
         'Failed to record execution usage to usage_log ledger; charge may be unbilled',
         {
-          error,
+          cause: describeError(error),
           actorUserId,
           costSummary,
         }

--- a/apps/sim/lib/logs/execution/trace-secret-projection.test.ts
+++ b/apps/sim/lib/logs/execution/trace-secret-projection.test.ts
@@ -4,9 +4,19 @@
 import { createHash } from 'node:crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { materializeLargeValueRefMock, storeLargeValueMock } = vi.hoisted(() => ({
+const { materializeLargeValueRefMock, storeLargeValueMock, warnMock } = vi.hoisted(() => ({
   materializeLargeValueRefMock: vi.fn(),
   storeLargeValueMock: vi.fn(),
+  warnMock: vi.fn(),
+}))
+
+vi.mock('@sim/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: warnMock,
+    error: vi.fn(),
+  }),
 }))
 
 vi.mock('@/lib/execution/payloads/store', () => ({
@@ -23,6 +33,8 @@ import {
   type ResolvedSecretTraceMatch,
   ResolvedSecretTraceRegistry,
 } from '@/executor/utils/resolved-secret-trace-registry'
+
+const MAX_CONTENT_NODES = 100_000
 
 const STORE = {
   workspaceId: 'workspace-1',
@@ -436,6 +448,25 @@ describe('projectTraceSpansForSecrets', () => {
 
     expect(result[0]).not.toHaveProperty('output')
     expect(source[0].output).toEqual({ apiKey: '[REDACTED]' })
+  })
+
+  it('names the invariant that forced the structural fallback', async () => {
+    const source = [createSpan({ output: { apiKey: '[REDACTED]' } })]
+
+    await enforceTraceSpanSecretInvariant(source, {
+      registry: createRegistry([{ plaintext: 'E', replacement: '{{X}}' }]),
+      store: STORE,
+    })
+
+    expect(warnMock).toHaveBeenCalledWith(
+      'Trace secret invariant failed; retaining structural spans only',
+      {
+        failure: {
+          name: 'TraceSecretProjectionError',
+          reason: expect.any(String),
+        },
+      }
+    )
   })
 
   it('fails the final invariant closed when provenance is incomplete', async () => {
@@ -1147,6 +1178,64 @@ describe('projectTraceSpansForSecrets', () => {
     }
 
     expect(result[0].output).toEqual({ token: '{{API_SECRET}}' })
+  })
+
+  it('names the invariant that forced content to be omitted', async () => {
+    const output: Record<string, unknown> = { token: 'top-secret' }
+    output.self = output
+
+    const [result] = await projectTraceSpansForSecrets([createSpan({ output })], {
+      registry: createRegistry([{ plaintext: 'top-secret', replacement: '{{API_SECRET}}' }]),
+      store: STORE,
+    })
+
+    expect(result).not.toHaveProperty('output')
+    expect(warnMock).toHaveBeenCalledWith('Omitting trace content that could not be sanitized', {
+      failure: {
+        name: 'TraceSecretProjectionError',
+        reason: 'Trace content could not be sanitized',
+      },
+    })
+  })
+
+  it('withholds the message of a failure raised outside the projection module', async () => {
+    const descriptorSpy = vi.spyOn(Object, 'getOwnPropertyDescriptor').mockImplementation(() => {
+      throw new SyntaxError('Unexpected token in "sk-live-top-secret"')
+    })
+
+    try {
+      await projectTraceSpansForSecrets([createSpan({ output: { token: 'top-secret' } })], {
+        registry: createRegistry([{ plaintext: 'top-secret', replacement: '{{API_SECRET}}' }]),
+        store: STORE,
+      })
+    } finally {
+      descriptorSpy.mockRestore()
+    }
+
+    expect(warnMock).toHaveBeenCalledWith('Omitting trace content that could not be sanitized', {
+      failure: { name: 'SyntaxError' },
+    })
+  })
+
+  it('names the invariant that forced the whole-tree structural fallback', async () => {
+    const source = Array(MAX_CONTENT_NODES + 1).fill(
+      createSpan({ output: { token: 'top-secret' } })
+    )
+
+    await projectTraceSpansForSecrets(source, {
+      registry: createRegistry([{ plaintext: 'top-secret', replacement: '{{API_SECRET}}' }]),
+      store: STORE,
+    })
+
+    expect(warnMock).toHaveBeenCalledWith(
+      'Trace secret projection failed; retaining structural spans only',
+      {
+        failure: {
+          name: 'TraceSecretProjectionError',
+          reason: 'Trace structure array exceeds the projection limit',
+        },
+      }
+    )
   })
 
   it('uses bounded structural fallback when matcher construction fails', async () => {

--- a/apps/sim/lib/logs/execution/trace-secret-projection.ts
+++ b/apps/sim/lib/logs/execution/trace-secret-projection.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@sim/logger'
+import { toError } from '@sim/utils/errors'
 import { isPlainRecord, omit } from '@sim/utils/object'
 import {
   isLargeArrayManifest,
@@ -125,6 +126,21 @@ class TraceSecretProjectionError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'TraceSecretProjectionError'
+  }
+}
+
+/**
+ * Diagnostic payload for a projection fallback.
+ *
+ * Every {@link TraceSecretProjectionError} message is a fixed literal describing
+ * which invariant fired, so it is safe to log. Any other failure originates
+ * outside this module and may embed trace content (a JSON parse error quotes the
+ * text it choked on), so only its name is reported.
+ */
+function describeProjectionFailure(error: unknown): { name: string; reason?: string } {
+  return {
+    name: toError(error).name,
+    ...(error instanceof TraceSecretProjectionError ? { reason: error.message } : {}),
   }
 }
 
@@ -786,8 +802,10 @@ async function sanitizeContentField(
 ): Promise<unknown | typeof OMIT> {
   try {
     return await sanitizeMaterializedValue(value, context)
-  } catch {
-    logger.warn('Omitting trace content that could not be sanitized')
+  } catch (error) {
+    logger.warn('Omitting trace content that could not be sanitized', {
+      failure: describeProjectionFailure(error),
+    })
     return OMIT
   }
 }
@@ -1182,8 +1200,10 @@ function projectBoundedTraceSpans(
 function structuralOnlyTraceSpans(traceSpans: TraceSpan[]): TraceSpan[] {
   try {
     return projectBoundedTraceSpans(traceSpans, structuralOnlySpan)
-  } catch {
-    logger.warn('Trace structure could not be safely traversed; omitting projected spans')
+  } catch (error) {
+    logger.warn('Trace structure could not be safely traversed; omitting projected spans', {
+      failure: describeProjectionFailure(error),
+    })
     return []
   }
 }
@@ -1522,8 +1542,10 @@ export async function enforceTraceSpanSecretInvariant(
 
     await assertPostTransformTraceSpansAreSafe(traceSpans, matcher, options.store)
     return traceSpans
-  } catch {
-    logger.warn('Trace secret invariant failed; retaining structural spans only')
+  } catch (error) {
+    logger.warn('Trace secret invariant failed; retaining structural spans only', {
+      failure: describeProjectionFailure(error),
+    })
     return structuralOnlyTraceSpans(traceSpans)
   }
 }
@@ -1560,8 +1582,10 @@ export async function projectTraceSpansForSecrets(
     }
     assertTraceSpansContentIsSafe(projected, context)
     return projected
-  } catch {
-    logger.warn('Trace secret projection failed; retaining structural spans only')
+  } catch (error) {
+    logger.warn('Trace secret projection failed; retaining structural spans only', {
+      failure: describeProjectionFailure(error),
+    })
     return structuralOnlyTraceSpans(traceSpans)
   }
 }

--- a/apps/sim/lib/uploads/contexts/workspace/fetch-external-url.test.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/fetch-external-url.test.ts
@@ -9,6 +9,13 @@
  * the module graph is fresh or reused.
  */
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }))
+
+vi.mock('@sim/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: warnMock, error: vi.fn() }),
+}))
+
 import * as inputValidation from '@/lib/core/security/input-validation.server'
 import {
   ExternalUrlValidationError,
@@ -198,6 +205,33 @@ describe('fetchExternalUrlToWorkspace', () => {
 
     expect(result.buffer.toString()).toBe('bytes')
     expect(result.savedWorkspaceFile).toBeUndefined()
+  })
+
+  it('logs the driver cause and SQLSTATE behind a swallowed workspace save error', async () => {
+    const driver = Object.assign(
+      new Error('cannot execute SELECT FOR UPDATE in a read-only transaction'),
+      { code: '25006' }
+    )
+    secureFetchWithPinnedIPSpy.mockResolvedValue(makeResponse('bytes', 'text/plain'))
+    uploadWorkspaceFileSpy.mockRejectedValueOnce(
+      new Error('Failed to upload file: storage accounting failed', { cause: driver })
+    )
+
+    await fetchExternalUrlToWorkspace({
+      url: 'https://example.com/file.txt',
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    })
+
+    expect(warnMock).toHaveBeenCalledWith(
+      'Failed to save fetched URL to workspace storage',
+      expect.objectContaining({
+        cause: expect.objectContaining({
+          code: '25006',
+          message: 'cannot execute SELECT FOR UPDATE in a read-only transaction',
+        }),
+      })
+    )
   })
 
   it('forwards custom headers to the fetch', async () => {

--- a/apps/sim/lib/uploads/contexts/workspace/fetch-external-url.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/fetch-external-url.ts
@@ -1,6 +1,7 @@
 import type { Buffer } from 'buffer'
 import path from 'path'
 import { createLogger } from '@sim/logger'
+import { describeError } from '@sim/utils/errors'
 import {
   secureFetchWithPinnedIP,
   validateUrlWithDNS,
@@ -134,7 +135,7 @@ export async function fetchExternalUrlToWorkspace(
         logger.warn('Failed to save fetched URL to workspace storage', {
           workspaceId,
           filename,
-          saveError,
+          cause: describeError(saveError),
         })
       }
     } else if (permission === null) {

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
@@ -7,7 +7,12 @@ import { randomBytes } from 'crypto'
 import { db } from '@sim/db'
 import { workspaceFiles } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
-import { getErrorMessage, getPostgresConstraintName, getPostgresErrorCode } from '@sim/utils/errors'
+import {
+  describeError,
+  getErrorMessage,
+  getPostgresConstraintName,
+  getPostgresErrorCode,
+} from '@sim/utils/errors'
 import { generateShortId } from '@sim/utils/id'
 import { and, eq, isNotNull, isNull, or, sql } from 'drizzle-orm'
 import type { ShareRecord } from '@/lib/api/contracts/public-shares'
@@ -446,15 +451,18 @@ export async function uploadWorkspaceFile(
         )
         continue
       }
-      logger.error(`Failed to upload workspace file ${fileName}:`, error)
-      throw new Error(`Failed to upload file: ${getErrorMessage(error, 'Unknown error')}`)
+      logger.error(`Failed to upload workspace file ${fileName}:`, {
+        cause: describeError(error),
+      })
+      throw new Error(`Failed to upload file: ${getErrorMessage(error, 'Unknown error')}`, {
+        cause: error,
+      })
     }
   }
 
-  logger.error(
-    `Failed to upload workspace file after ${MAX_UPLOAD_UNIQUE_RETRIES} attempts`,
-    lastError
-  )
+  logger.error(`Failed to upload workspace file after ${MAX_UPLOAD_UNIQUE_RETRIES} attempts`, {
+    cause: describeError(lastError),
+  })
   throw new FileConflictError(fileName)
 }
 

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-storage-accounting.test.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-storage-accounting.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 import { dbChainMockFns, resetDbChainMock } from '@sim/testing'
+import { describeError } from '@sim/utils/errors'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -157,6 +158,32 @@ describe('workspace file metadata and storage accounting', () => {
     expect(dbChainMockFns.transaction.mock.invocationCallOrder[0]).toBeLessThan(
       mockDeleteFile.mock.invocationCallOrder[0]
     )
+  })
+
+  it('preserves the driver cause so the SQLSTATE survives the upload wrapper', async () => {
+    const driver = Object.assign(
+      new Error('cannot execute SELECT FOR UPDATE in a read-only transaction'),
+      { code: '25006' }
+    )
+    dbChainMockFns.returning.mockResolvedValueOnce([FILE_ROW])
+    mockIncrementStorageUsageForBillingContextInTx.mockRejectedValueOnce(
+      new Error(
+        'Failed query: select "storage_used_bytes" from "workspace" where id = $1 limit $2 for update\nparams: ws-1,1',
+        { cause: driver }
+      )
+    )
+
+    const thrown = await uploadWorkspaceFile(
+      FILE_ROW.workspaceId,
+      FILE_ROW.userId,
+      Buffer.from('hello'),
+      FILE_ROW.originalName,
+      FILE_ROW.contentType
+    ).catch((error: unknown) => error)
+
+    const described = describeError(thrown)
+    expect(described.code).toBe('25006')
+    expect(described.message).toBe('cannot execute SELECT FOR UPDATE in a read-only transaction')
   })
 
   it('keeps an ordinary workspace upload on the legacy untracked path', async () => {

--- a/packages/utils/src/errors.test.ts
+++ b/packages/utils/src/errors.test.ts
@@ -102,6 +102,30 @@ describe('describeError', () => {
     ])
   })
 
+  it('redacts driver-appended bound parameter values from every reported message', () => {
+    const driver = Object.assign(
+      new Error('cannot execute SELECT FOR UPDATE in a read-only transaction'),
+      {
+        code: '25006',
+      }
+    )
+    const wrapped = new Error(
+      'Failed query: select "storage_used_bytes" from "workspace" where id = $1 limit $2 for update\nparams: ws-secret-id,1',
+      { cause: driver }
+    )
+    const described = describeError(wrapped)
+    expect(described.code).toBe('25006')
+    expect(described.causeChain?.[0]).toBe(
+      'Error: Failed query: select "storage_used_bytes" from "workspace" where id = $1 limit $2 for update\nparams: [redacted]'
+    )
+    expect(JSON.stringify(described)).not.toContain('ws-secret-id')
+  })
+
+  it('redacts bound parameter values from an unwrapped driver error message', () => {
+    const described = describeError(new Error('Failed query: select 1\nparams: ws-secret-id'))
+    expect(described.message).toBe('Failed query: select 1\nparams: [redacted]')
+  })
+
   it('always returns the cause for unclassified errors (AbortError)', () => {
     const aborted = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' })
     expect(describeError(aborted)).toEqual({

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -60,6 +60,10 @@ export interface DescribedError {
  *
  * Loggers do not serialize the non-enumerable `Error.prototype.cause`, so pass
  * the result as an explicit structured field rather than the raw error.
+ *
+ * Bound parameter values are stripped from every reported message: Drizzle's
+ * `DrizzleQueryError` appends `\nparams: <values>` to the failing SQL, and those
+ * values are user data that must never reach logs.
  */
 export function describeError(error: unknown): DescribedError {
   const chain: Error[] = []
@@ -73,7 +77,7 @@ export function describeError(error: unknown): DescribedError {
 
   if (chain.length === 0) {
     const normalized = toError(error)
-    return { name: normalized.name, message: normalized.message }
+    return { name: normalized.name, message: redactBoundParameters(normalized.message) }
   }
 
   const deepest = chain[chain.length - 1] as Error & Record<string, unknown>
@@ -85,12 +89,20 @@ export function describeError(error: unknown): DescribedError {
 
   return {
     name: deepest.name,
-    message: deepest.message,
+    message: redactBoundParameters(deepest.message),
     ...(code ? { code } : {}),
     ...(errno ? { errno } : {}),
     ...(syscall ? { syscall } : {}),
-    ...(chain.length > 1 ? { causeChain: chain.map((e) => `${e.name}: ${e.message}`) } : {}),
+    ...(chain.length > 1
+      ? { causeChain: chain.map((e) => `${e.name}: ${redactBoundParameters(e.message)}`) }
+      : {}),
   }
+}
+
+/** Replaces a driver-appended `params: <values>` tail with a redaction marker. */
+function redactBoundParameters(message: string): string {
+  const index = message.indexOf('\nparams:')
+  return index === -1 ? message : `${message.slice(0, index)}\nparams: [redacted]`
 }
 
 /**


### PR DESCRIPTION
## Problem

Three log sites discard the underlying error. All three were hit in production and each independently blocked root-cause analysis.

## Sites

**1. `lib/logs/execution/trace-secret-projection.ts`** — four bare `catch {}` blocks fell back to structural-only spans with no reason attached, across ~30 distinct throw sites (node/depth/array limits, cyclic content, non-plain prototypes, accessor properties, ref-fetch failures, budget exceeded). Now each reports which invariant fired.

Security: every `TraceSecretProjectionError` message is a compile-time literal (the `${label}` interpolations are all static constants), so logging it is safe. Any *other* failure originates outside the module and could quote trace content — a `SyntaxError` from `JSON.parse` embeds the text it choked on — so those are reported by `name` only. `describeProjectionFailure` enforces the split.

`structuralOnlySpan` still strips `errorMessage`, deliberately. It is a block's error text and routinely embeds resolved secret values (a provider error echoing a URL or header). The structural fallback exists precisely because projection/matching failed, so no redaction can be trusted on that path — retaining it would leak plaintext exactly when redaction is known broken.

**2. `ExecutionLogger`** — `"Failed to record execution usage to usage_log ledger; charge may be unbilled"` logged `"error":{}`. `Error.message`/`stack` are non-enumerable, so `Object.assign(entry, { error })` + `JSON.stringify` in the production logger yields `{}`. Now logs `describeError(error)`.

**3. `WorkspaceFileStorage` / `FetchExternalUrl`** — same `saveError:{}` problem, plus `uploadWorkspaceFile` rethrew `new Error(...)` **without** a cause, so Drizzle's `Failed query:` wrapper — and with it the Postgres SQLSTATE — was unrecoverable. All 137 prod occurrences were the same `select ... from "workspace" where id = $1 limit $2 for update` in `lib/billing/storage/tracking.ts`. The rethrow now chains `{ cause: error }` and both sites log `describeError`, which reports the deepest link's `code`. If the leading hypothesis (`SELECT ... FOR UPDATE` routed to a read replica) is right, the next occurrence logs SQLSTATE `25006` and settles it. That hypothesis is **not** proven here — this change only makes it observable.

## What is now logged

Error names, messages, and driver codes/SQLSTATE. No user data, no secret plaintext, no query parameter values. `describeError` additionally strips the `\nparams: <values>` tail that `DrizzleQueryError` appends to its message, closing a pre-existing leak for every existing caller.

## Tests

7 new tests, one per behavior; all verified failing with the source changes stashed.