### PR TITLE
fix(logger): stop a server-side jsdom window from silencing all logging in production

### DIFF
--- a/packages/logger/src/index.test.ts
+++ b/packages/logger/src/index.test.ts
@@ -46,6 +46,36 @@ describe('Logger', () => {
     })
   })
 
+  describe('browser suppression in production', () => {
+    const realProcess = globalThis.process
+
+    afterEach(() => {
+      Reflect.deleteProperty(globalThis, 'window')
+      globalThis.process = realProcess
+    })
+
+    test('should keep logging when the server installs a DOM', () => {
+      globalThis.process = {
+        ...realProcess,
+        env: { ...realProcess.env, NODE_ENV: 'production' },
+      } as typeof realProcess
+      Object.assign(globalThis, { window: { document: {} } })
+
+      createLogger('Test').error('server still logs')
+
+      expect(consoleErrorSpy).toHaveBeenCalled()
+    })
+
+    test('should stay silent in a real browser', () => {
+      globalThis.process = { env: { NODE_ENV: 'production' } } as typeof realProcess
+      Object.assign(globalThis, { window: { document: {} } })
+
+      createLogger('Test').error('browser stays quiet')
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    })
+  })
+
   describe('LogLevel enum', () => {
     test('should have correct log levels', () => {
       expect(LogLevel.DEBUG).toBe('DEBUG')

--- a/packages/logger/src/index.test.ts
+++ b/packages/logger/src/index.test.ts
@@ -67,7 +67,7 @@ describe('Logger', () => {
     })
 
     test('should stay silent in a real browser', () => {
-      globalThis.process = { env: { NODE_ENV: 'production' } } as typeof realProcess
+      globalThis.process = { env: { NODE_ENV: 'production' } } as unknown as typeof realProcess
       Object.assign(globalThis, { window: { document: {} } })
 
       createLogger('Test').error('browser stays quiet')

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -48,6 +48,21 @@ const getNodeEnv = (): string => {
   return 'development'
 }
 
+/**
+ * True only in a real browser.
+ *
+ * Server code can legitimately install a DOM — `ensureDomForTipTap` in the
+ * collab-doc converter mounts a jsdom `window` so TipTap runs headless — so the
+ * presence of `window` alone does not mean the browser. Node always exposes
+ * `process.versions.node` and a browser never does, which keeps a server-side
+ * DOM from silencing the logger for the rest of the process's life.
+ */
+const isBrowserRuntime = (): boolean => {
+  if (typeof (globalThis as { window?: unknown }).window === 'undefined') return false
+  const runtime = (globalThis as { process?: { versions?: { node?: unknown } } }).process
+  return typeof runtime?.versions?.node !== 'string'
+}
+
 const getLogLevel = (): string | undefined => {
   if (typeof process !== 'undefined' && process.env) {
     return process.env.LOG_LEVEL
@@ -201,10 +216,7 @@ export class Logger {
   private shouldLog(level: LogLevel): boolean {
     if (!this.config.enabled) return false
 
-    if (
-      getNodeEnv() === 'production' &&
-      typeof (globalThis as { window?: unknown }).window !== 'undefined'
-    ) {
+    if (getNodeEnv() === 'production' && isBrowserRuntime()) {
       return false
     }
 


### PR DESCRIPTION
## Summary
- `shouldLog()` treated `typeof window !== 'undefined'` as "we are in a browser" and, in production, returned `false` for **every level** — permanently, process-wide, with no diagnostic
- `ensureDomForTipTap()` (`apps/sim/lib/collab-doc/converter.ts:68`) assigns `globalThis.window = jsdomWindow` so TipTap can run headless. The first collab-markdown request a task serves therefore kills that task's structured logging for the rest of its life
- `jsdom` is a **production** dependency and `next.config.ts` explicitly traces it into the standalone output for `/api/internal/file-doc/{seed,merge,persist}`, so this is live in prod. This is the only non-test `window` assignment in the repo
- Fixed by testing for a real browser instead: Node always exposes `process.versions.node`, a browser never does. The original intent — suppress logging in the browser in production — is preserved

## Evidence
This is the cause of the recurring multi-hour structured-logging blackouts:
- Structured logs went from ~30k/30min to **exactly zero** while all five ECS tasks kept emitting 400–1,100 raw lines/30min — the processes were alive and `console.*` worked; only `@sim/logger` was silent
- Tasks went dark **staggered**, one at a time over ~15 minutes — the signature of a per-process latch, not a global event
- It self-recovered only when five brand-new task IDs appeared (a deploy). A restart cannot fix bad log data; it does clear a latched global
- Task `a5989f51` served file-doc traffic at 15:00 and went dark at 15:08

## Type of Change
- [x] Bug fix

## Testing
Two regression tests, both directions:
- `should keep logging when the server installs a DOM` — **red before** the fix, green after
- `should stay silent in a real browser` — passes **both** before and after, proving the guard's original behavior is intact and this is not simply removing it

27/27 passing.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)