### PR TITLE
fix(search): restore cmd+k autofocus on the search input

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
@@ -105,7 +105,6 @@ export function SearchModal({
   const atomicBrowserOcclusion = supportsAtomicBrowserPanelOcclusion()
   const nativeSurfaceReady = useNativeSurfaceOcclusionReady(open, 'modal')
   const visuallyOpen = open && nativeSurfaceReady
-  const focusReady = atomicBrowserOcclusion ? visuallyOpen : open
   const [retainNativeSurfaceOcclusion, setRetainNativeSurfaceOcclusion] = useState(open)
   const nativeSurfaceOcclusionActive =
     open || (atomicBrowserOcclusion && retainNativeSurfaceOcclusion)
@@ -326,8 +325,12 @@ export function SearchModal({
     if (open) setSearch('')
   }
 
+  /**
+   * Focus only once the dialog is actually visible: `.focus()` is a no-op while
+   * the surface still carries `invisible`, and nothing re-focuses afterwards.
+   */
   useEffect(() => {
-    if (!focusReady || !inputRef.current) return
+    if (!visuallyOpen || !inputRef.current) return
     const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
       window.HTMLInputElement.prototype,
       'value'
@@ -337,7 +340,7 @@ export function SearchModal({
       inputRef.current.dispatchEvent(new Event('input', { bubbles: true }))
     }
     inputRef.current.focus()
-  }, [focusReady])
+  }, [visuallyOpen])
 
   const deferredSearch = useDeferredValue(search)
   const deferredSearchRef = useRef(deferredSearch)


### PR DESCRIPTION
## Summary
- Cmd+K opened the search palette without focusing the input, so you had to click it before typing
- Regressed in #6196 (`5ab5f2c7e`): the dialog's visibility gate moved to `visuallyOpen` (`open && nativeSurfaceReady`), but the focus effect stayed on a separate `focusReady` gate that is just `open` off the desktop app
- `nativeSurfaceReady` starts `false` and only flips inside a `useLayoutEffect`, so the focus effect ran in the commit where the panel still carried `invisible` — `.focus()` on a `visibility: hidden` element is a silent no-op, and nothing re-focused it afterwards
- Fix is one gate: focus off `visuallyOpen`, so it runs on the first commit where the panel is actually visible. Desktop (atomic browser panel occlusion) already waited for that same signal, so its behavior is unchanged

## Type of Change
- [x] Bug fix

## Testing
Typecheck and lint pass. **Not yet verified in a running browser** — needs a manual Cmd+K check before merge.

No unit test: the failure depends on `visibility: hidden` making an element unfocusable, which jsdom does not model (it applies no Tailwind CSS), so a test here would pass with or without the fix.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)