### PR TITLE
fix(scripts): make the specifier audit path-separator agnostic

### DIFF
--- a/scripts/check-import-specifiers.ts
+++ b/scripts/check-import-specifiers.ts
@@ -18,7 +18,7 @@
  * Usage: `bun run scripts/check-import-specifiers.ts [--verbose]`
  */
 import { readdirSync, readFileSync, statSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
+import { dirname, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
@@ -46,11 +46,16 @@ const REQUIRE_RE = /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g
  */
 const SUBPATH_REQUIRED = new Set(['@sim/utils'])
 
+/** Repo-relative path, always `/`-separated — `relative()` yields `\` on Windows. */
+function repoPath(absolute: string): string {
+  return relative(ROOT, absolute).replaceAll('\\', '/')
+}
+
 /** Only source a bundler compiles — see the "Deliberately NOT checked" note above. */
 function isCompiledSource(full: string, name: string): boolean {
   if (!/\.(ts|tsx)$/.test(name) || name.endsWith('.d.ts')) return false
   if (/\.(test|spec)\.tsx?$/.test(name)) return false
-  const rel = relative(ROOT, full)
+  const rel = repoPath(full)
   return !rel.startsWith('apps/sim/scripts/') && !rel.startsWith('apps/realtime/scripts/')
 }
 
@@ -78,7 +83,7 @@ function walk(dir: string, acc: string[] = []): string[] {
  * would otherwise make every specifier in the repo look generated.
  */
 function isGeneratedPath(absolute: string): boolean {
-  const rel = relative(ROOT, absolute)
+  const rel = repoPath(absolute)
   if (rel.startsWith('..')) return true
   return rel.split('/').some((segment) => segment.startsWith('.') || SKIP_DIRS.has(segment))
 }
@@ -160,7 +165,7 @@ for (const group of ['apps', 'packages']) {
 workspaces.sort((a, b) => b.dir.length - a.dir.length)
 
 function workspaceFor(file: string): Workspace | undefined {
-  return workspaces.find((w) => file.startsWith(`${w.dir}/`))
+  return workspaces.find((w) => file.startsWith(w.dir + sep))
 }
 
 /** Matched a tsconfig path, but every target is generated — distinct from missing (`null`). */
@@ -328,7 +333,7 @@ for (const file of files) {
         checked++
         if (!outcome.ok) {
           violations.push({
-            file: relative(ROOT, file),
+            file: repoPath(file),
             line: lineAt(at),
             specifier: spec,
             kind: 'unresolved',
@@ -340,7 +345,7 @@ for (const file of files) {
         const subs = packageExports(spec)
         const example = subs ? [...subs.keys()].find((k) => k !== '.') : undefined
         violations.push({
-          file: relative(ROOT, file),
+          file: repoPath(file),
           line: lineAt(at),
           specifier: spec,
           kind: 'bare-barrel',


### PR DESCRIPTION
## Summary

Follow-up to #6351. Cursor Bugbot raised this on that PR after it had already merged, so it lands separately.

`isGeneratedPath` split the repo-relative path on `/`, but `path.relative` returns backslashes on Windows — so `.source` and `node_modules` never matched a segment and generated output was treated as scannable source. The repo does support Windows development (`scripts/setup/*` branches on `win32`).

## The finding named one site; there were three

- **`isGeneratedPath`** — the reported one.
- **`isCompiledSource`** compared against `'apps/sim/scripts/'` with the same assumption, so the test/script exclusions silently stopped applying.
- **`workspaceFor`** matched `` `${w.dir}/` `` against an absolute path. On Windows that never matches, dropping every file out of its own workspace — which disables tsconfig `paths` resolution entirely rather than erroring, so `@/…` specifiers would be reported as unverifiable instead of being checked. That is the worst of the three: a guard that quietly stops guarding.

## Changes

All path comparisons go through a `repoPath()` helper that normalizes to `/`; `workspaceFor` uses `path.sep` against absolute paths. Reported paths use it too, so output is byte-identical on either platform.

`spec.split('/')` is deliberately left alone — import specifiers are always `/`-separated regardless of host.

## Type of Change
- [x] Bug fix

## Testing

- Simulated win32 separators through the same predicates:

```
"apps\docs\.source\server.ts"        -> generated: true
"apps\sim\lib\x.ts"                  -> generated: false
"packages\utils\node_modules\y.ts"   -> generated: true
scripts filter on "apps\sim\scripts" -> true
```

- posix behaviour unchanged: 37,437 first-party specifiers across 11,243 files still resolve clean
- `biome check` clean

No Windows machine was available to run this end-to-end, so the verification is at the predicate level rather than a real win32 run.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Relevant tests are passing
- [x] No new warnings introduced
